### PR TITLE
Cl 1705371 Fix build with gradle 7

### DIFF
--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXUiPlugin.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXUiPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.ClasspathNormalizer
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.findByType
@@ -280,6 +281,14 @@ class AndroidXUiPlugin : Plugin<Project> {
             val multiplatformExtension = checkNotNull(multiplatformExtension) {
                 "Unable to configureForMultiplatform() when " +
                     "multiplatformExtension is null (multiplatform plugin not enabled?)"
+            }
+
+            /**
+             * Temporary workaround for https://youtrack.jetbrains.com/issue/KT-46096
+             * Should be removed once the build switches to Kotlin 1.5
+             */
+            tasks.withType(org.gradle.jvm.tasks.Jar::class.java).configureEach { jar ->
+                jar.duplicatesStrategy = DuplicatesStrategy.INCLUDE
             }
 
             /*

--- a/buildSrc/src/main/kotlin/androidx/build/ComposeJvmTarget.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ComposeJvmTarget.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.build
+
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.compile.AbstractCompile
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.tasks.Jar
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmCompilation
+import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
+import org.jetbrains.kotlin.gradle.utils.addExtendsFromRelation
+import java.lang.reflect.Modifier
+import java.util.concurrent.Callable
+
+object ComposeJvmTarget {
+    /**
+     * Temporary workaround for fixing Compose Desktop build with Kotlin 1.4 and Gradle 7
+     * Intended to be used only in :compose:desktop:desktop and only until Compose project
+     * switches to Kotlin 1.5.0
+     *
+     * This is basically a copy
+     * org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget.withJava from Kotlin 1.5.0,
+     * which fixes java.lang.NoSuchMethodError, thrown by Gradle 7 with Kotlin 1.4
+     * (https://youtrack.jetbrains.com/issue/KTIJ-10018).
+     *
+     * There are a few changes from the original:
+     * some internal methods are copied or called using Java Reflection
+     */
+    @JvmStatic
+    fun withJava(target: KotlinJvmTarget) {
+        val project = target.project
+
+        project.plugins.apply(JavaPlugin::class.java)
+        val javaPluginConvention = project.convention.getPlugin(JavaPluginConvention::class.java)
+        setUpJavaSourceSets(target)
+
+        javaPluginConvention.sourceSets.all { javaSourceSet ->
+            val compilation = target.compilations.getByName(javaSourceSet.name)
+            val compileJavaTask = project.tasks.withType(AbstractCompile::class.java)
+                .named(javaSourceSet.compileJavaTaskName)
+
+            setupJavaSourceSetSourcesAndResources(project, javaSourceSet, compilation)
+
+            val javaClasses = project.files(compileJavaTask.map { it.destinationDir })
+
+            compilation.output.classesDirs.from(javaClasses)
+
+            (javaSourceSet.output.classesDirs as? ConfigurableFileCollection)?.from(
+                compilation.output.classesDirs.minus(javaClasses)
+            )
+
+            javaSourceSet.output.setResourcesDir(
+                Callable { compilation.output.resourcesDirProvider }
+            )
+
+            setupDependenciesCrossInclusionForJava(project, compilation, javaSourceSet)
+        }
+
+        // Eliminate the Java output configurations from dependency resolution
+        // to avoid ambiguity between them and the equivalent configurations
+        // created for the target:
+        listOf(
+            JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME,
+            JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME
+        ).forEach { outputConfigurationName ->
+            project.configurations.findByName(outputConfigurationName)?.isCanBeConsumed = false
+        }
+
+        disableJavaPluginTasks(project, javaPluginConvention, target)
+    }
+
+    private fun setupDependenciesCrossInclusionForJava(
+        project: Project,
+        compilation: KotlinJvmCompilation,
+        javaSourceSet: SourceSet
+    ) {
+        // Make sure Kotlin compilation dependencies appear in the Java source set classpaths:
+
+        listOfNotNull(
+            compilation.apiConfigurationName,
+            compilation.implementationConfigurationName,
+            compilation.compileOnlyConfigurationName
+        ).forEach { configurationName ->
+            project.addExtendsFromRelation(
+                javaSourceSet.compileClasspathConfigurationName,
+                configurationName
+            )
+        }
+
+        listOfNotNull(
+            compilation.apiConfigurationName,
+            compilation.implementationConfigurationName,
+            compilation.runtimeOnlyConfigurationName
+        ).forEach { configurationName ->
+            project.addExtendsFromRelation(
+                javaSourceSet.runtimeClasspathConfigurationName,
+                configurationName
+            )
+        }
+
+        // Add the Java source set dependencies to the Kotlin compilation
+        // compile & runtime configurations:
+        listOfNotNull(
+            javaSourceSet.compileOnlyConfigurationName,
+            javaSourceSet.apiConfigurationName
+                .takeIf { project.configurations.findByName(it) != null },
+            javaSourceSet.implementationConfigurationName
+        ).forEach { configurationName ->
+            project.addExtendsFromRelation(
+                compilation.compileDependencyConfigurationName,
+                configurationName
+            )
+        }
+
+        listOfNotNull(
+            javaSourceSet.runtimeOnlyConfigurationName,
+            javaSourceSet.apiConfigurationName
+                .takeIf { project.configurations.findByName(it) != null },
+            javaSourceSet.implementationConfigurationName
+        ).forEach { configurationName ->
+            project.addExtendsFromRelation(
+                compilation.runtimeDependencyConfigurationName,
+                configurationName
+            )
+        }
+    }
+
+    /**
+     * Calls AbstractKotlinPlugin.setUpJavaSourceSets(target, false) using reflection
+     */
+    private fun setUpJavaSourceSets(target: KotlinJvmTarget) {
+        val abstractKotlinPluginClass = Class.forName(ABSTRACT_KOTLIN_PLUGIN)
+            ?: error("Could not find '$ABSTRACT_KOTLIN_PLUGIN' class")
+        val companionField = abstractKotlinPluginClass.fields
+            .find { it.name == COMPANION && Modifier.isStatic(it.modifiers) }
+            ?: error("Could not find '$COMPANION' field")
+        val companionInstance = companionField.get(abstractKotlinPluginClass)!!
+        val companionClass = companionInstance.javaClass
+        val setUpJavaSourceSetsMethod = companionClass.methods.find {
+            it.name == SET_UP_JAVA_SOURCE_SETS && it.parameterCount == 2
+        } ?: error("Could not find '$SET_UP_JAVA_SOURCE_SETS' method")
+        setUpJavaSourceSetsMethod.invoke(companionInstance, target, false)
+    }
+
+    private fun disableJavaPluginTasks(
+        project: Project,
+        javaPluginConvention: JavaPluginConvention,
+        target: KotlinJvmTarget
+    ) {
+        // A 'normal' build should not do redundant job like running the tests twice or building two JARs,
+        // so disable some tasks and just make them depend on the others:
+        val targetJar = project.tasks.withType(Jar::class.java).named(target.artifactsTaskName)
+
+        val mainJarTaskName = javaPluginConvention.sourceSets.getByName("main").jarTaskName
+        project.tasks.withType(Jar::class.java).named(mainJarTaskName) { javaJar ->
+            (javaJar.source as? ConfigurableFileCollection)?.setFrom(targetJar.map { it.source })
+            javaJar.conventionMapping("archiveName") { targetJar.get().archiveFileName.get() }
+            javaJar.dependsOn(targetJar)
+            javaJar.enabled = false
+        }
+
+        project.tasks.withType(Test::class.java).named(JavaPlugin.TEST_TASK_NAME) { javaTestTask ->
+            javaTestTask.dependsOn(project.tasks.named(target.testTaskName))
+            javaTestTask.enabled = false
+        }
+    }
+
+    private fun setupJavaSourceSetSourcesAndResources(
+        project: Project,
+        javaSourceSet: SourceSet,
+        compilation: KotlinJvmCompilation
+    ) {
+        javaSourceSet.java.setSrcDirs(listOf("src/${compilation.defaultSourceSet.name}/java"))
+        compilation.defaultSourceSet.kotlin.srcDirs(javaSourceSet.java.sourceDirectories)
+
+        // To avoid confusion in the sources layout, remove the default Java source directories
+        // (like src/main/java, src/test/java) and instead add sibling directories to those where the Kotlin
+        // sources are placed (i.e. src/jvmMain/java, src/jvmTest/java):
+        javaSourceSet.resources.setSrcDirs(
+            compilation.defaultSourceSet.resources.sourceDirectories
+        )
+        compilation.defaultSourceSet.resources.srcDirs(javaSourceSet.resources.sourceDirectories)
+
+        // Resources processing is done with the Kotlin resource processing task:
+        val processJavaResourcesTask =
+            project.tasks.getByName(javaSourceSet.processResourcesTaskName)
+        processJavaResourcesTask.dependsOn(
+            project.tasks.getByName(compilation.processResourcesTaskName)
+        )
+        processJavaResourcesTask.enabled = false
+    }
+
+    private const val ABSTRACT_KOTLIN_PLUGIN =
+        "org.jetbrains.kotlin.gradle.plugin.AbstractKotlinPlugin"
+    private const val COMPANION = "Companion"
+    private const val SET_UP_JAVA_SOURCE_SETS = "setUpJavaSourceSets${'$'}kotlin_gradle_plugin"
+    private const val ARTIFACT_TASK_NAME = "jar"
+
+    private val KotlinTarget.testTaskName: String
+        get() = lowerCamelCaseName(name, "test")
+
+    private fun lowerCamelCaseName(vararg nameParts: String?): String {
+        val nonEmptyParts = nameParts.mapNotNull { it?.takeIf(String::isNotEmpty) }
+        return nonEmptyParts.drop(1).joinToString(
+            separator = "",
+            prefix = nonEmptyParts.firstOrNull().orEmpty(),
+            transform = String::capitalize
+        )
+    }
+}

--- a/compose/desktop/desktop/build.gradle
+++ b/compose/desktop/desktop/build.gradle
@@ -19,6 +19,7 @@ import androidx.build.LibraryType
 import androidx.build.LibraryVersions
 import androidx.build.RunApiTasks
 import androidx.build.SupportConfigKt
+import androidx.build.ComposeJvmTarget
 
 import static androidx.build.AndroidXPlugin.BUILD_ON_SERVER_TASK
 import static androidx.build.dependencies.DependenciesKt.*
@@ -34,9 +35,9 @@ dependencies {
 }
 
 kotlin {
-    jvm() {
-        withJava()
-    }
+    // Replace with jvm() { withJava() }
+    // Once the build switches to Kotlin 1.5
+    ComposeJvmTarget.withJava(jvm())
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
Original CL: https://android-review.googlesource.com/c/platform/frameworks/support/+/1705371

Currently, Androidx project uses Gradle 7 and Kotlin 1.4.32
There are some incompatibilities between the two, which only
affect multiplatform build of Compose Desktop.

There are two issues breaking Compose Desktop build:
1. https://youtrack.jetbrains.com/issue/KT-46096
   Gradle 7 removed 'compile' and 'runtime'
   configurations, which were referred in
   `KotlinJvmTarget.withJava` method, leading
   to the NoSuchMethodError.
   Only `:compose:desktop:desktop` module is affected.
   The module does not contain Java code, but `withJava`
   is necessary for configuring publishing correctly.

   This change adds a workaround by copying the fixed
   `withJava` implementation from Kotlin 1.5.
   The change affects only `:compose:desktop:desktop`,
   which is configured only with the property
   `-Pandroidx.compose.multiplatformEnabled=true`.

2. https://youtrack.jetbrains.com/issue/KT-46165
   Gradle 7 started to throw an exception on duplicate
   entry, when `Jar.duplicateStrategy` is not set.
   This affects `*SourcesJar` task of Android MPP source sets
   only when Multiplatform plugin is used.

   This change works around the issue by setting
   `duplicatesStrategy` to `INCLUDE`, but only when
   multiplatform build is enabled and only for subprojects,
   that use the Kotlin multiplatform plugin.

Both workarounds do not affect the build when
`androidx.compose.multiplatformEnabled` is set to `false`,
which is the default, so they should not affect
Android Compose builds in any way.
The changes are proposed as a temporary workarounds,
until Kotlin 1.5 is used to build Compose.
Once it happens, this commit will be reverted.

Test: tested multiplatform publishing manually.
Non multiplatform builds are not affected.

Signed-off-by: Alexey Tsvetkov <alexey.tsvetkov@jetbrains.com>
Change-Id: I2783b4ee833357dfaa14ccd93ae2b0cef6a0bde6

## Proposed Changes

  -
  -
  -

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
