### PR TITLE
Desktop. Fix "DpSize is unspecified" when we set unspecified size for the window

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.isSpecified
-import androidx.compose.ui.unit.isUnspecified
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.density
@@ -65,19 +64,22 @@ internal fun ComposeWindow.setPositionSafely(
 internal fun Window.setSizeSafely(size: DpSize) {
     val screenBounds by lazy { graphicsConfiguration.bounds }
 
-    val width = if (size.width.isSpecified) {
+    val isWidthSpecified = size.isSpecified && size.width.isSpecified
+    val isHeightSpecified = size.isSpecified && size.height.isSpecified
+
+    val width = if (isWidthSpecified) {
         size.width.value.roundToInt().coerceAtLeast(0)
     } else {
         screenBounds.width
     }
 
-    val height = if (size.height.isSpecified) {
+    val height = if (isHeightSpecified) {
         size.height.value.roundToInt().coerceAtLeast(0)
     } else {
         screenBounds.height
     }
 
-    if (size.width.isUnspecified || size.height.isUnspecified) {
+    if (!isWidthSpecified || !isHeightSpecified) {
         preferredSize = Dimension(width, height)
         pack()
         // if we set null, getPreferredSize will return the default inner size determined by
@@ -86,8 +88,8 @@ internal fun Window.setSizeSafely(size: DpSize) {
     }
 
     setSize(
-        if (size.width.isSpecified) width else preferredSize.width,
-        if (size.height.isSpecified) height else preferredSize.height,
+        if (isWidthSpecified) width else preferredSize.width,
+        if (isHeightSpecified) height else preferredSize.height,
     )
 }
 


### PR DESCRIPTION
Regression after https://android-review.googlesource.com/c/platform/frameworks/support/+/1850178

Failing tests:
androidx.compose.ui.window.window.WindowStateTest#set window size by its content
androidx.compose.ui.window.window.WindowStateTest#set window size by its content when window is on the screen

Exception:
```
Exception in thread "AWT-EventQueue-0 @coroutine#2896" java.lang.IllegalStateException: DpSize is unspecified
	at androidx.compose.ui.unit.DpSize.getWidth-D9Ej5fM(Dp.kt:389)
	at androidx.compose.ui.util.Windows_desktopKt.setSizeSafely-6HolHcs(Windows.desktop.kt:68)
	at androidx.compose.ui.util.Windows_desktopKt.setSizeSafely-6HolHcs(Windows.desktop.kt:46)
	at androidx.compose.ui.window.Window_desktopKt$Window$5$1$8.invoke-EaSLcWc(Window.desktop.kt:179)
	at androidx.compose.ui.window.Window_desktopKt$Window$5$1$8.invoke(Window.desktop.kt:179)
	at androidx.compose.ui.util.ComponentUpdater$UpdateScope.set(ComponentUpdater.kt:45)
	at androidx.compose.ui.window.Window_desktopKt$Window$5$1.invoke(Window.desktop.kt:179)
	at androidx.compose.ui.window.Window_desktopKt$Window$5$1.invoke(Window.desktop.kt:171)
	at androidx.compose.ui.util.ComponentUpdater.update(ComponentUpdater.kt:27)
	at androidx.compose.ui.window.Window_desktopKt$Window$5.invoke(Window.desktop.kt:171)
	at androidx.compose.ui.window.Window_desktopKt$Window$5.invoke(Window.desktop.kt:137)
	at androidx.compose.ui.window.AwtWindow_desktopKt$AwtWindow$3.invoke(AwtWindow.desktop.kt:88)
	at androidx.compose.ui.window.AwtWindow_desktopKt$AwtWindow$3.invoke(AwtWindow.desktop.kt:87)
	at androidx.compose.ui.util.UpdateEffect_desktopKt$UpdateEffect$2$performUpdate$2.invoke(UpdateEffect.desktop.kt:58)
	at androidx.compose.ui.util.UpdateEffect_desktopKt$UpdateEffect$2$performUpdate$2.invoke(UpdateEffect.desktop.kt:54)
```

On Desktop we sometimes use these sizes for Window:
DpSize(Dp.Unspecified, Dp.Unspecified) - the window width/height will be determined by its content
DpSize(Dp.Unspecified, 200) - only the window width will be determined by its content
DpSize(200, Dp.Unspecified) - only the window height will be determined by its content

The other way to fix this issue - is to allow getting unspecified width/height of DpSize.
It is different from Size, because Size can't have only width/height unspecified, but DpSize can.

Test: ./gradlew jvmTest desktopTest -Pandroidx.compose.multiplatformEnabled=true
Change-Id: Iab583138ce0caf365f184b3926dd09fd46289f40