### PR TITLE
Desktop. Fix NPE inside SkiaLayer (outlineCache.outline!!)

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/SkiaLayerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/SkiaLayerTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.RenderEffect
@@ -28,6 +29,8 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.round
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import kotlin.math.PI
@@ -310,6 +313,58 @@ class SkiaLayerTest {
 
         assertEquals(IntOffset(0 + 60, 0 + 7), matrix.map(Offset(0f, 0f)).round())
         assertEquals(IntOffset(-10 * 4 + 60, 100 * 2 + 7), matrix.map(Offset(100f, 10f)).round())
+    }
+
+    @Test
+    fun `is in layer`() {
+        layer.resize(IntSize(0, 0))
+        layer.updateProperties(
+            clip = false
+        )
+
+        assertTrue(layer.isInLayer(Offset(-1f, -1f)))
+        assertTrue(layer.isInLayer(Offset(0f, 0f)))
+        assertTrue(layer.isInLayer(Offset(1f, 1f)))
+
+        layer.resize(IntSize(0, 0))
+        layer.updateProperties(
+            clip = true
+        )
+
+        assertFalse(layer.isInLayer(Offset(-1f, -1f)))
+        assertFalse(layer.isInLayer(Offset(0f, 0f)))
+        assertFalse(layer.isInLayer(Offset(1f, 1f)))
+
+        layer.resize(IntSize(0, 0))
+        layer.updateProperties(
+            clip = true,
+            shape = CircleShape
+        )
+
+        assertFalse(layer.isInLayer(Offset(-1f, -1f)))
+        assertFalse(layer.isInLayer(Offset(0f, 0f)))
+        assertFalse(layer.isInLayer(Offset(1f, 1f)))
+
+        layer.resize(IntSize(1, 2))
+        layer.updateProperties(
+            clip = true
+        )
+
+        assertFalse(layer.isInLayer(Offset(-1f, -1f)))
+        assertTrue(layer.isInLayer(Offset(0f, 0f)))
+        assertTrue(layer.isInLayer(Offset(0f, 1f)))
+        assertFalse(layer.isInLayer(Offset(0f, 2f)))
+        assertFalse(layer.isInLayer(Offset(1f, 0f)))
+
+        layer.resize(IntSize(100, 200))
+        layer.updateProperties(
+            clip = true,
+            shape = CircleShape
+        )
+
+        assertFalse(layer.isInLayer(Offset(5f, 5f)))
+        assertFalse(layer.isInLayer(Offset(95f, 195f)))
+        assertTrue(layer.isInLayer(Offset(50f, 100f)))
     }
 
     private fun TestSkiaLayer() = SkiaLayer(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/OutlineCache.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/OutlineCache.skiko.kt
@@ -38,7 +38,7 @@ internal class OutlineCache(
         set(value) {
             if (value != field) {
                 field = value
-                update()
+                outline = createOutline()
             }
         }
 
@@ -46,7 +46,7 @@ internal class OutlineCache(
         set(value) {
             if (value != field) {
                 field = value
-                update()
+                outline = createOutline()
             }
         }
 
@@ -54,7 +54,7 @@ internal class OutlineCache(
         set(value) {
             if (value != field) {
                 field = value
-                update()
+                outline = createOutline()
             }
         }
 
@@ -62,19 +62,13 @@ internal class OutlineCache(
         set(value) {
             if (value != field) {
                 field = value
-                update()
+                outline = createOutline()
             }
         }
 
-    var outline: Outline? = null
+    var outline: Outline = createOutline()
         private set
 
-    private fun update() {
-        outline = if (size != IntSize.Zero) {
-            val floatSize = size.toSize()
-            shape.createOutline(floatSize, layoutDirection, density)
-        } else {
-            null
-        }
-    }
+    private fun createOutline() =
+        shape.createOutline(size.toSize(), layoutDirection, density)
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
@@ -131,7 +131,7 @@ internal class SkiaLayer(
             return 0f <= x && x < size.width && 0f <= y && y < size.height
         }
 
-        return isInOutline(outlineCache.outline!!, x, y)
+        return isInOutline(outlineCache.outline, x, y)
     }
 
     private fun getMatrix(inverse: Boolean): Matrix {


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1173

Regression after https://android-review.googlesource.com/c/platform/frameworks/support/+/1729414.
But the bug was in the old code, not in the new code. We don't create an outline for zero-sized layer.

Test: ./gradlew jvmTest desktopTest -Pandroidx.compose.multiplatformEnabled=true
Change-Id: Ic3b7c8f92d24cdb234f93f3ebae0d2124d2cc8fa