### PR TITLE
Desktop. Deprecate TestComposeWindow in favor to ImageComposeScene

### DIFF
--- a/compose/desktop/desktop/src/jvmTest/kotlin/androidx/compose/desktop/ParagraphTest.kt
+++ b/compose/desktop/desktop/src/jvmTest/kotlin/androidx/compose/desktop/ParagraphTest.kt
@@ -26,10 +26,11 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.TestComposeWindow
 import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.renderComposeScene
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -46,7 +47,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@OptIn(InternalTestApi::class)
+@OptIn(ExperimentalComposeUiApi::class, InternalTestApi::class)
 class ParagraphTest {
     @get:Rule
     val screenshotRule = DesktopScreenshotTestRule("compose/ui/ui-desktop/paragraph")
@@ -79,9 +80,7 @@ class ParagraphTest {
     @Ignore
     @Test
     fun paragraphBasics() {
-        val window = TestComposeWindow(width = 1024, height = 768)
-
-        window.setContent {
+        val snapshot = renderComposeScene(width = 1024, height = 768) {
             ProvideTextStyle(TextStyle(fontFamily = fontFamily)) {
                 Column(Modifier.fillMaxSize().background(Color.White), Arrangement.SpaceEvenly) {
                     Text(
@@ -121,6 +120,6 @@ class ParagraphTest {
                 }
             }
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 }

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -21,14 +21,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.mouse.MouseScrollEvent
 import androidx.compose.ui.input.mouse.MouseScrollOrientation
 import androidx.compose.ui.input.mouse.MouseScrollUnit
-import androidx.compose.ui.platform.TestComposeWindow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,23 +41,20 @@ import kotlin.math.sqrt
 class DesktopScrollableTest {
     private val density = 2f
 
-    private fun window() = TestComposeWindow(
-        width = 100,
-        height = 100,
-        density = Density(density)
-    )
-
     private fun scrollLineLinux(bounds: Dp) = sqrt(bounds.value * density)
     private fun scrollLineWindows(bounds: Dp) = bounds.value * density / 20f
     private fun scrollLineMacOs() = density * 10f
     private fun scrollPage(bounds: Dp) = bounds.value * density
 
     @Test
-    fun `linux, scroll vertical`() {
-        val window = window()
+    fun `linux, scroll vertical`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(density)
+    ).use { scene ->
         val context = TestColumn()
 
-        window.setContent {
+        scene.setContent {
             CompositionLocalProvider(
                 LocalMouseScrollConfig provides MouseScrollableConfig.LinuxGnome
             ) {
@@ -71,29 +69,32 @@ class DesktopScrollableTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(context.offset).isWithin(0.1f).of(-3 * scrollLineLinux(20.dp))
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(context.offset).isWithin(0.1f).of(-6 * scrollLineLinux(20.dp))
     }
 
     @Test
-    fun `windows, scroll vertical`() {
-        val window = window()
+    fun `windows, scroll vertical`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(density)
+    ).use { scene ->
         val context = TestColumn()
 
-        window.setContent {
+        scene.setContent {
             CompositionLocalProvider(
                 LocalMouseScrollConfig provides MouseScrollableConfig.WindowsWinUI
             ) {
@@ -108,29 +109,32 @@ class DesktopScrollableTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(-2f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(-2f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(context.offset).isWithin(0.1f).of(2 * scrollLineWindows(20.dp))
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(4f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(4f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(context.offset).isWithin(0.1f).of(-2 * scrollLineWindows(20.dp))
     }
 
     @Test
-    fun `windows, scroll one page vertical`() {
-        val window = window()
+    fun `windows, scroll one page vertical`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(density)
+    ).use { scene ->
         val context = TestColumn()
 
-        window.setContent {
+        scene.setContent {
             CompositionLocalProvider(
                 LocalMouseScrollConfig provides MouseScrollableConfig.WindowsWinUI
             ) {
@@ -145,21 +149,24 @@ class DesktopScrollableTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Page(1f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Page(1f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(context.offset).isWithin(0.1f).of(-scrollPage(20.dp))
     }
 
     @Test
-    fun `macOS, scroll vertical`() {
-        val window = window()
+    fun `macOS, scroll vertical`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(density)
+    ).use { scene ->
         val context = TestColumn()
 
-        window.setContent {
+        scene.setContent {
             CompositionLocalProvider(
                 LocalMouseScrollConfig provides MouseScrollableConfig.MacOSCocoa
             ) {
@@ -174,21 +181,24 @@ class DesktopScrollableTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(-5.5f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(-5.5f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(context.offset).isWithin(0.1f).of(5.5f * scrollLineMacOs())
     }
 
     @Test
-    fun `scroll with different orientation`() {
-        val window = window()
+    fun `scroll with different orientation`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(density)
+    ).use { scene ->
         val column = TestColumn()
 
-        window.setContent {
+        scene.setContent {
             CompositionLocalProvider(
                 LocalMouseScrollConfig provides MouseScrollableConfig.LinuxGnome
             ) {
@@ -203,10 +213,10 @@ class DesktopScrollableTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(column.offset).isEqualTo(0f)

--- a/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopComposeTestRule.desktop.kt
+++ b/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopComposeTestRule.desktop.kt
@@ -82,7 +82,7 @@ class DesktopComposeTestRule : ComposeContentTestRule {
                 try {
                     base.evaluate()
                 } finally {
-                    runOnUiThread(scene::dispose)
+                    runOnUiThread(scene::close)
                 }
 
                 coroutineDispatcher.cleanupTestCoroutines()

--- a/compose/ui/ui-tooling/src/desktopMain/kotlin/androidx/compose/desktop/ui/tooling/preview/runtime/NonInteractivePreviewFacade.kt
+++ b/compose/ui/ui-tooling/src/desktopMain/kotlin/androidx/compose/desktop/ui/tooling/preview/runtime/NonInteractivePreviewFacade.kt
@@ -16,9 +16,9 @@
 
 package androidx.compose.desktop.ui.tooling.preview.runtime
 
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentComposer
-import androidx.compose.ui.platform.TestComposeWindow
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.renderComposeScene
 import androidx.compose.ui.tooling.CommonPreviewUtils
 import androidx.compose.ui.unit.Density
 
@@ -45,13 +45,13 @@ import androidx.compose.ui.unit.Density
 @Suppress("unused")
 internal class NonInteractivePreviewFacade {
     companion object {
+        @OptIn(ExperimentalComposeUiApi::class)
         @JvmStatic
         fun render(fqName: String, width: Int, height: Int, scale: Double?): ByteArray {
             val className = fqName.substringBeforeLast(".")
             val methodName = fqName.substringAfterLast(".")
             val density = scale?.let { Density(it.toFloat()) } ?: Density(1f)
-            val window = TestComposeWindow(width = width, height = height, density = density)
-            window.setContent @Composable {
+            return renderComposeScene(width = width, height = height, density = density) {
                 // We need to delay the reflection instantiation of the class until we are in the
                 // composable to ensure all the right initialization has happened and the Composable
                 // class loads correctly.
@@ -60,8 +60,7 @@ internal class NonInteractivePreviewFacade {
                     methodName,
                     currentComposer
                 )
-            }
-            return window.surface.makeImageSnapshot().encodeToData()!!.bytes
+            }.encodeToData()!!.bytes
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.mouse.MouseScrollOrientation
+import androidx.compose.ui.input.mouse.MouseScrollUnit
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.platform.setContent
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.skia.Image
+import org.jetbrains.skia.Surface
+import java.awt.event.MouseEvent
+import java.util.concurrent.TimeUnit.NANOSECONDS
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+/**
+ * Render Compose [content] into an [Image]
+ *
+ * @param width The width of the content.
+ * @param height The height of the content.
+ * @param density Density of the content which will be used to convert [dp] units.
+ * @param content Composable content which needed to be rendered.
+ */
+@ExperimentalComposeUiApi
+fun renderComposeScene(
+    width: Int,
+    height: Int,
+    density: Density = Density(1f),
+    content: @Composable () -> Unit
+): Image = ImageComposeScene(
+    width = width,
+    height = height,
+    density = density,
+    content = content
+).use { it.render() }
+
+/**
+ * Executes the given [block] function on this [ImageComposeScene] and then closes it down
+ * correctly whether an exception is thrown or not.
+ *
+ * @param block a function to process this [ImageComposeScene].
+ * @return the result of [block] function invoked on this [ImageComposeScene].
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+inline fun <R> ImageComposeScene.use(
+    block: (ImageComposeScene) -> R
+): R {
+    return try {
+        block(this)
+    } finally {
+        close()
+    }
+}
+
+/**
+ * A virtual container that encapsulates Compose UI content with ability to draw it into an image.
+ *
+ * To set content, use `content` parameter of the constructor, or [setContent] method.
+ *
+ * To draw content into an image, use [render] method.
+ *
+ * After [ImageComposeScene] will no longer needed, you should call [close] method, so all resources
+ * and subscriptions will be properly closed. Otherwise there can be a memory leak.
+ *
+ * Instead of calling [close] manually, you can use the helper function [use],
+ * it will close scene for you.
+ *
+ * @param width The width of the content.
+ * @param height The height of the content.
+ * @param density Density of the content which will be used to convert [dp] units.
+ * @param coroutineContext Context which will be used to launch effects ([LaunchedEffect],
+ * [rememberCoroutineScope]) and run recompositions.
+ * @param content Composable content which needed to be rendered.
+ */
+@ExperimentalComposeUiApi
+class ImageComposeScene(
+    width: Int,
+    height: Int,
+    density: Density = Density(1f),
+    coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+    content: @Composable () -> Unit = {},
+) {
+    private val surface = Surface.makeRasterN32Premul(width, height)
+
+    private val scene = ComposeScene(
+        density = density,
+        coroutineContext = coroutineContext
+    ).apply {
+        constraints = Constraints(maxWidth = surface.width, maxHeight = surface.height)
+        setContent(content = content)
+    }
+
+    /**
+     * Close all resources and subscriptions. Not calling this method when [ImageComposeScene] is no
+     * longer needed will cause a memory leak.
+     *
+     * All effects launched via [LaunchedEffect] or [rememberCoroutineScope] will be cancelled
+     * (but not immediately).
+     *
+     * After calling this method, you cannot call any other method of this [ImageComposeScene].
+     */
+    fun close(): Unit = scene.close()
+
+    /**
+     * All currently registered [RootForTest]s. After calling [setContent] the first root
+     * will be added. If there is an any [Popup] is present in the content, it will be added as
+     * another [RootForTest]
+     */
+    val roots: Set<RootForTest> get() = scene.roots
+
+    /**
+     * Constraints used to measure and layout content.
+     */
+    var constraints: Constraints
+        get() = scene.constraints
+        set(value) {
+            scene.constraints = value
+        }
+
+    /**
+     * Update the composition with the content described by the [content] composable. After this
+     * has been called the changes to produce the initial composition has been calculated and
+     * applied to the composition.
+     *
+     * Will throw an [IllegalStateException] if the composition has been disposed.
+     *
+     * @param content Content of the [ImageComposeScene]
+     */
+    fun setContent(content: @Composable () -> Unit): Unit =
+        scene.setContent(content = content)
+
+    /**
+     * Render the current content into an image. [nanoTime] will be used to drive all
+     * animations in the content (or any other code, which uses [withFrameNanos]
+     */
+    fun render(nanoTime: Long = 0): Image {
+        scene.render(surface.canvas, nanoTime)
+        return surface.makeImageSnapshot()
+    }
+
+    /**
+     * Render the current content into an image. [time] will be used to drive all
+     * animations in the content (or any other code, which uses [withFrameNanos]
+     */
+    @ExperimentalTime
+    fun render(time: Duration): Image =
+        render(time.toLong(NANOSECONDS))
+
+    /**
+     * Send pointer event to the content.
+     *
+     * @param eventType Indicates the primary reason that the event was sent.
+     * @param position The [Offset] of the current pointer event, relative to the content.
+     * @param timeMillis The time of the current pointer event, in milliseconds. The start (`0`) time
+     * is platform-dependent.
+     * @param type The device type that produced the event, such as [mouse][PointerType.Mouse],
+     * or [touch][PointerType.Touch].
+     * @param mouseEvent The original native event.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    fun sendPointerEvent(
+        eventType: PointerEventType,
+        position: Offset,
+        timeMillis: Long = System.nanoTime() / 1_000_000L,
+        type: PointerType = PointerType.Mouse,
+        mouseEvent: MouseEvent? = null
+    ): Unit = scene.sendPointerEvent(
+        eventType, position, timeMillis, type, mouseEvent
+    )
+
+    // TODO(demin): remove/change when we will have scroll event support in the common code
+    // TODO(demin): return Boolean (when it is consumed).
+    //  see ComposeLayer todo about AWTDebounceEventQueue
+    /**
+     * Send pointer scroll event to the content.
+     *
+     * @param position The [Offset] of the current pointer event, relative to the content
+     * @param delta Change of mouse scroll.
+     * Positive if scrolling down, negative if scrolling up.
+     * @param orientation Orientation in which scrolling event occurs.
+     * Up/down wheel scrolling causes events in vertical orientation.
+     * Left/right wheel scrolling causes events in horizontal orientation.
+     * @param timeMillis The time of the current pointer event, in milliseconds. The start (`0`) time
+     * is platform-dependent.
+     * @param type The device type that produced the event, such as [mouse][PointerType.Mouse],
+     * or [touch][PointerType.Touch].
+     * @param mouseEvent The original native event
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Suppress("UNUSED_PARAMETER")
+    @ExperimentalComposeUiApi // it is more experimental than ComposeScene itself
+    fun sendPointerScrollEvent(
+        position: Offset,
+        delta: MouseScrollUnit,
+        orientation: MouseScrollOrientation = MouseScrollOrientation.Vertical,
+        timeMillis: Long = System.nanoTime() / 1_000_000L,
+        type: PointerType = PointerType.Mouse,
+        mouseEvent: MouseEvent? = null,
+//        buttons: PointerButtons? = null,
+//        keyboardModifiers: PointerKeyboardModifiers? = null,
+    ): Unit = scene.sendPointerScrollEvent(
+        position, delta, orientation, timeMillis, type, mouseEvent
+    )
+
+    /**
+     * Send [KeyEvent] to the content.
+     * @return true if the event was consumed by the content
+     */
+    fun sendKeyEvent(event: KeyEvent): Boolean = scene.sendKeyEvent(event)
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
@@ -69,7 +69,7 @@ fun renderComposeScene(
  * @param block a function to process this [ImageComposeScene].
  * @return the result of [block] function invoked on this [ImageComposeScene].
  */
-@OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalComposeUiApi
 inline fun <R> ImageComposeScene.use(
     block: (ImageComposeScene) -> R
 ): R {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -199,7 +199,7 @@ internal class ComposeLayer {
 
     fun dispose() {
         check(!isDisposed)
-        scene.dispose()
+        scene.close()
         events.cancel()
         _component.dispose()
         _initContent = null

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/TestComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/TestComposeWindow.desktop.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -35,6 +36,11 @@ import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.FrameDispatcher
 import java.awt.Component
 import kotlin.coroutines.CoroutineContext
+
+@PublishedApi
+internal val EmptyDispatcher = object : CoroutineDispatcher() {
+    override fun dispatch(context: CoroutineContext, block: Runnable) = Unit
+}
 
 /**
  * A virtual window for testing purposes.
@@ -45,6 +51,13 @@ import kotlin.coroutines.CoroutineContext
  * dispatcher as coroutineContext (for example, Dispatchers.Swing)
  */
 @OptIn(ExperimentalComposeUiApi::class)
+@Deprecated(
+    "use ImageComposeScene",
+    replaceWith = ReplaceWith(
+        "ImageComposeScene",
+        "androidx.compose.ui.ImageComposeScene"
+    )
+)
 class TestComposeWindow(
     val width: Int,
     val height: Int,
@@ -88,7 +101,7 @@ class TestComposeWindow(
      * Clear-up all acquired resources and stop all pending work
      */
     fun dispose() {
-        scene.dispose()
+        scene.close()
         coroutineScope.cancel()
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
@@ -450,11 +450,11 @@ class ComposeSceneTest {
 
     private class TestException : RuntimeException()
 
-    // TODO(https://github.com/JetBrains/compose-jb/issues/1136): fix deadlock
+    // TODO(b/202967533): fix deadlock
     @ExperimentalComposeUiApi
     @Ignore(
         "This test never ends because of the deadlock" +
-            "(https://github.com/JetBrains/compose-jb/issues/1136)"
+            "(https://issuetracker.google.com/issues/202967533)"
     )
     @Test
     fun `focus management by keys`() {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.ExtendedFloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountBox
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.swing.Swing
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+
+@OptIn(
+    ExperimentalTime::class,
+    ExperimentalComposeUiApi::class,
+    ExperimentalCoroutinesApi::class,
+    InternalTestApi::class
+)
+class ImageComposeSceneTest {
+    @get:Rule
+    val screenshotRule = DesktopScreenshotTestRule("compose/ui/ui-desktop")
+
+    @Test
+    @Ignore // TODO(CL) remove before merging to AOSP. disabled because we don't have 'golden' fork
+    fun `render static ui`() {
+        val density = 2f
+        val image = renderComposeScene(
+            width = 100,
+            height = 200,
+            density = Density(density)
+        ) {
+            Box(Modifier.fillMaxSize().padding(1.dp).background(Color.Red))
+        }
+        screenshotRule.write(image)
+    }
+
+    @Test
+    @Ignore // TODO(CL) remove before merging to AOSP. disabled because we don't have 'golden' fork
+    fun `render animated ui`() {
+        ImageComposeScene(
+            width = 100,
+            height = 200
+        ).use { scene ->
+            var targetSize by mutableStateOf(0f)
+
+            scene.setContent {
+                val size by animateFloatAsState(
+                    targetSize,
+                    tween(durationMillis = 100_000, easing = LinearEasing)
+                )
+                Box(Modifier.size(size.dp, size.dp * 2).background(Color.Red))
+            }
+
+            targetSize = 100f
+            scene.render() // start animation
+
+            screenshotRule.write(scene.render(seconds(0)), "frame1")
+            screenshotRule.write(scene.render(seconds(10)), "frame2")
+            screenshotRule.write(scene.render(seconds(50)), "frame3")
+            screenshotRule.write(scene.render(seconds(100)), "frame4")
+        }
+    }
+
+    // TODO(b/202967533): fix deadlock
+    @Ignore(
+        "This test never ends because of the deadlock" +
+            "(https://issuetracker.google.com/issues/202967533)"
+    )
+    @Test
+    fun `run multiple ImageComposeScene`() {
+        for (i in 1..300) {
+            ImageComposeScene(800, 800).use {
+                it.setContent {
+                    Box(Modifier.fillMaxWidth()) {
+                        ExtendedFloatingActionButton(
+                            icon = { Icon(Icons.Filled.AccountBox, "") },
+                            text = {},
+                            onClick = {},
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(timeout = 5000)
+    fun `closing ImageComposeScene should not cancel coroutineContext's Job`() {
+        runBlocking(Dispatchers.Swing) {
+            val window = ImageComposeScene(100, 100, coroutineContext = coroutineContext)
+            window.close()
+        }
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseHoverFilterTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseHoverFilterTest.kt
@@ -19,12 +19,14 @@ package androidx.compose.ui.input.mouse
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.TestComposeWindow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,15 +35,17 @@ import org.junit.runners.JUnit4
 @OptIn(ExperimentalComposeUiApi::class)
 @RunWith(JUnit4::class)
 class MouseHoverFilterTest {
-    private val window = TestComposeWindow(width = 100, height = 100, density = Density(2f))
-
     @Test
-    fun `inside window`() {
+    fun `inside window`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var moveCount = 0
         var enterCount = 0
         var exitCount = 0
 
-        window.setContent {
+        scene.setContent {
             Box(
                 modifier = Modifier
                     .pointerMove(
@@ -58,42 +62,35 @@ class MouseHoverFilterTest {
                     .size(10.dp, 20.dp)
             )
         }
-        window.onMouseEntered(
-            x = 0,
-            y = 0
-        )
-        window.onMouseMoved(
-            x = 10,
-            y = 20
-        )
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(0f, 0f))
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 20f))
         assertThat(enterCount).isEqualTo(1)
         assertThat(exitCount).isEqualTo(0)
         assertThat(moveCount).isEqualTo(1)
 
-        window.onMouseMoved(
-            x = 10,
-            y = 15
-        )
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 15f))
         assertThat(enterCount).isEqualTo(1)
         assertThat(exitCount).isEqualTo(0)
         assertThat(moveCount).isEqualTo(2)
 
-        window.onMouseMoved(
-            x = 30,
-            y = 30
-        )
+        scene.sendPointerEvent(PointerEventType.Move, Offset(30f, 30f))
         assertThat(enterCount).isEqualTo(1)
         assertThat(exitCount).isEqualTo(1)
         assertThat(moveCount).isEqualTo(2)
     }
 
     @Test
-    fun `window enter`() {
+    fun `window enter`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var moveCount = 0
         var enterCount = 0
         var exitCount = 0
 
-        window.setContent {
+        scene.setContent {
             Box(
                 modifier = Modifier
                     .pointerMove(
@@ -111,15 +108,12 @@ class MouseHoverFilterTest {
             )
         }
 
-        window.onMouseEntered(
-            x = 10,
-            y = 20
-        )
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
         assertThat(enterCount).isEqualTo(1)
         assertThat(exitCount).isEqualTo(0)
         assertThat(moveCount).isEqualTo(0)
 
-        window.onMouseExited()
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(-1f, -1f))
         assertThat(enterCount).isEqualTo(1)
         assertThat(exitCount).isEqualTo(1)
         assertThat(moveCount).isEqualTo(0)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseScrollFilterTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseScrollFilterTest.kt
@@ -19,11 +19,13 @@ package androidx.compose.ui.input.mouse
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.TestComposeWindow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,14 +34,16 @@ import org.junit.runners.JUnit4
 @OptIn(ExperimentalComposeUiApi::class)
 @RunWith(JUnit4::class)
 class MouseScrollFilterTest {
-    private val window = TestComposeWindow(width = 100, height = 100, density = Density(2f))
-
     @Test
-    fun `inside box`() {
+    fun `inside box`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent: MouseScrollEvent? = null
         var actualBounds: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -51,10 +55,10 @@ class MouseScrollFilterTest {
             )
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(actualEvent?.delta).isEqualTo(MouseScrollUnit.Line(3f))
@@ -63,11 +67,15 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `outside box`() {
+    fun `outside box`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent: MouseScrollEvent? = null
         var actualBounds: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -79,10 +87,10 @@ class MouseScrollFilterTest {
             )
         }
 
-        window.onMouseScroll(
-            x = 20,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Vertical)
+        scene.sendPointerScrollEvent(
+            position = Offset(20f, 0f),
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Vertical
         )
 
         assertThat(actualEvent).isEqualTo(null)
@@ -90,13 +98,17 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `inside two overlapping boxes`() {
+    fun `inside two overlapping boxes`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent1: MouseScrollEvent? = null
         var actualBounds1: IntSize? = null
         var actualEvent2: MouseScrollEvent? = null
         var actualBounds2: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -117,10 +129,10 @@ class MouseScrollFilterTest {
             )
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(actualEvent1).isEqualTo(null)
@@ -131,11 +143,15 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `inside two overlapping boxes, top box doesn't handle scroll`() {
+    fun `inside two overlapping boxes, top box doesn't handle scroll`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent: MouseScrollEvent? = null
         var actualBounds: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -154,10 +170,10 @@ class MouseScrollFilterTest {
             )
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(actualEvent).isEqualTo(null)
@@ -165,11 +181,15 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `inside two overlapping boxes, top box doesn't have mouseScrollFilter`() {
+    fun `inside two overlapping boxes, top box doesn't have filter`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent: MouseScrollEvent? = null
         var actualBounds: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -185,10 +205,10 @@ class MouseScrollFilterTest {
             )
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(3f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(3f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(actualEvent?.delta).isEqualTo(MouseScrollUnit.Line(3f))
@@ -197,13 +217,17 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `inside two nested boxes`() {
+    fun `inside two nested boxes`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent1: MouseScrollEvent? = null
         var actualBounds1: IntSize? = null
         var actualEvent2: MouseScrollEvent? = null
         var actualBounds2: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -225,10 +249,10 @@ class MouseScrollFilterTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Line(-1f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Line(-1f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(actualEvent1).isEqualTo(null)
@@ -239,11 +263,15 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `inside two nested boxes, nested box doesn't handle scroll`() {
+    fun `inside two nested boxes, nested box doesn't handle scroll`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent: MouseScrollEvent? = null
         var actualBounds: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -263,10 +291,10 @@ class MouseScrollFilterTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Page(1f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Page(1f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(actualEvent?.delta).isEqualTo(MouseScrollUnit.Page(1f))
@@ -275,11 +303,15 @@ class MouseScrollFilterTest {
     }
 
     @Test
-    fun `inside two nested boxes, nested box doesn't have mouseScrollFilter`() {
+    fun `inside two nested boxes, nested box doesn't have mouseScrollFilter`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(2f)
+    ).use { scene ->
         var actualEvent: MouseScrollEvent? = null
         var actualBounds: IntSize? = null
 
-        window.setContent {
+        scene.setContent {
             Box(
                 Modifier
                     .mouseScrollFilter { event, bounds ->
@@ -296,10 +328,10 @@ class MouseScrollFilterTest {
             }
         }
 
-        window.onMouseScroll(
-            x = 0,
-            y = 0,
-            event = MouseScrollEvent(MouseScrollUnit.Page(1f), MouseScrollOrientation.Horizontal)
+        scene.sendPointerScrollEvent(
+            position = Offset.Zero,
+            delta = MouseScrollUnit.Page(1f),
+            orientation = MouseScrollOrientation.Horizontal
         )
 
         assertThat(actualEvent?.delta).isEqualTo(MouseScrollUnit.Page(1f))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import kotlin.random.Random
+
+@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
+class FlushCoroutineDispatcherTest {
+    @Test
+    fun `all tasks should run with flush`() = runBlockingTest {
+        pauseDispatcher()
+        val dispatcher = FlushCoroutineDispatcher(this)
+
+        val actualNumbers = mutableListOf<Int>()
+        launch(dispatcher) {
+            yield()
+            actualNumbers.add(1)
+            yield()
+            yield()
+            actualNumbers.add(2)
+            yield()
+            yield()
+            yield()
+            actualNumbers.add(3)
+        }
+
+        while (dispatcher.hasTasks()) {
+            dispatcher.flush()
+        }
+
+        assertEquals(listOf(1, 2, 3), actualNumbers)
+    }
+
+    @Test
+    fun `tasks should run even without flush`() = runBlockingTest {
+        pauseDispatcher()
+        val dispatcher = FlushCoroutineDispatcher(this)
+
+        val actualNumbers = mutableListOf<Int>()
+        launch(dispatcher) {
+            yield()
+            actualNumbers.add(1)
+            yield()
+            yield()
+            actualNumbers.add(2)
+            yield()
+            yield()
+            yield()
+            actualNumbers.add(3)
+        }
+
+        advanceUntilIdle()
+
+        assertEquals(listOf(1, 2, 3), actualNumbers)
+        assertFalse(dispatcher.hasTasks())
+    }
+
+    @Test
+    fun `flushing in another thread`() {
+        val actualNumbers = mutableListOf<Int>()
+        lateinit var dispatcher: FlushCoroutineDispatcher
+        val random = Random(123)
+
+        runBlocking(Dispatchers.Default) {
+            dispatcher = FlushCoroutineDispatcher(this)
+
+            val addJob = launch(dispatcher) {
+                repeat(10000) {
+                    actualNumbers.add(it)
+                    repeat(random.nextInt(5)) {
+                        yield()
+                    }
+                }
+            }
+
+            launch {
+                while (addJob.isActive) {
+                    dispatcher.flush()
+                    yield()
+                }
+            }
+        }
+
+        assertEquals((0 until 10000).toList(), actualNumbers)
+        assertFalse(dispatcher.hasTasks())
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicsLayerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicsLayerTest.kt
@@ -21,11 +21,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.renderComposeScene
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.unit.dp
 import org.junit.Rule
@@ -34,15 +36,14 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-@OptIn(InternalTestApi::class)
+@OptIn(InternalTestApi::class, ExperimentalComposeUiApi::class)
 class GraphicsLayerTest {
     @get:Rule
     val screenshotRule = DesktopScreenshotTestRule("compose/ui/ui-desktop/platform")
 
     @Test
     fun scale() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(
@@ -63,13 +64,12 @@ class GraphicsLayerTest {
                     .requiredSize(10f.dp, 10f.dp).background(Color.Blue)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun rotationZ() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(
@@ -91,14 +91,12 @@ class GraphicsLayerTest {
                     .requiredSize(10f.dp, 10f.dp).background(Color.Blue)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun rotationX() {
-        val window = TestComposeWindow(width = 40, height = 40)
-
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(rotationX = 45f)
@@ -114,13 +112,12 @@ class GraphicsLayerTest {
                     .requiredSize(10f.dp, 10f.dp).background(Color.Blue)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun rotationY() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(rotationY = 45f)
@@ -136,13 +133,12 @@ class GraphicsLayerTest {
                     .requiredSize(10f.dp, 10f.dp).background(Color.Blue)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun `nested layer transformations`() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(rotationZ = 45f, translationX = 10f)
@@ -155,13 +151,12 @@ class GraphicsLayerTest {
                 )
             }
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun clip() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(
@@ -226,13 +221,12 @@ class GraphicsLayerTest {
                 )
             }
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun alpha() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .padding(start = 5.dp)
@@ -278,13 +272,12 @@ class GraphicsLayerTest {
                     .background(Color.Blue)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun elevation() {
-        val window = TestComposeWindow(width = 40, height = 40)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 40, height = 40) {
             Box(
                 Modifier
                     .graphicsLayer(shadowElevation = 5f)
@@ -323,6 +316,6 @@ class GraphicsLayerTest {
                     .requiredSize(20f.dp, 20f.dp)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
@@ -75,7 +75,7 @@ internal class RenderingTestScope(
         }
 
     fun dispose() {
-        scene.dispose()
+        scene.close()
         frameDispatcher.cancel()
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/TestComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/TestComposeWindowTest.kt
@@ -28,19 +28,23 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.swing.Swing
 import org.junit.Test
 
+@Suppress("DEPRECATION")
 class TestComposeWindowTest {
     @Test
     fun `run multiple TestComposeWindow`() {
         for (i in 1..15) {
-            TestComposeWindow(800, 800).setContent {
-                Box(Modifier.fillMaxWidth()) {
-                    ExtendedFloatingActionButton(
-                        icon = { Icon(Icons.Filled.AccountBox, "") },
-                        text = {},
-                        onClick = {},
-                        modifier = Modifier.fillMaxWidth()
-                    )
+            TestComposeWindow(800, 800).apply {
+                setContent {
+                    Box(Modifier.fillMaxWidth()) {
+                        ExtendedFloatingActionButton(
+                            icon = { Icon(Icons.Filled.AccountBox, "") },
+                            text = {},
+                            onClick = {},
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
                 }
+                dispose()
             }
         }
     }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/res/DesktopSvgResourcesTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/res/DesktopSvgResourcesTest.kt
@@ -19,19 +19,20 @@ package androidx.compose.ui.res
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.isLinux
 import androidx.compose.ui.isWindows
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.TestComposeWindow
 import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.renderComposeScene
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.unit.dp
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(InternalTestApi::class)
+@OptIn(ExperimentalComposeUiApi::class, InternalTestApi::class)
 class DesktopSvgResourcesTest {
     @get:Rule
     val screenshotRule = DesktopScreenshotTestRule("compose/ui/ui-desktop/res")
@@ -40,65 +41,60 @@ class DesktopSvgResourcesTest {
     fun `load SVG with specified size`() {
         assumeTrue(isLinux || isWindows)
 
-        val window = TestComposeWindow(width = 200, height = 200)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 200, height = 200) {
             Image(
                 painterResource("androidx/compose/ui/res/star-size-100.svg"),
                 contentDescription = "Star"
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun `load SVG with unspecified size`() {
         assumeTrue(isLinux || isWindows)
 
-        val window = TestComposeWindow(width = 200, height = 200)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 200, height = 200) {
             Image(
                 painterResource("androidx/compose/ui/res/star-size-unspecified.svg"),
                 contentDescription = "Star"
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun `load SVG with unspecified viewbox`() {
         assumeTrue(isLinux || isWindows)
 
-        val window = TestComposeWindow(width = 200, height = 200)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 200, height = 200) {
             Image(
                 painterResource("androidx/compose/ui/res/star-viewbox-unspecified.svg"),
                 contentDescription = "Star"
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun `load SVG with custom size`() {
         assumeTrue(isLinux || isWindows)
 
-        val window = TestComposeWindow(width = 200, height = 200)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 200, height = 200) {
             Image(
                 painterResource("androidx/compose/ui/res/star-size-100.svg"),
                 contentDescription = "Star",
                 modifier = Modifier.size(50.dp)
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun `load SVG and fill bounds`() {
         assumeTrue(isLinux || isWindows)
 
-        val window = TestComposeWindow(width = 200, height = 300)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 200, height = 300) {
             Image(
                 painterResource("androidx/compose/ui/res/star-size-100.svg"),
                 contentDescription = "Star",
@@ -106,15 +102,14 @@ class DesktopSvgResourcesTest {
                 modifier = Modifier.fillMaxSize()
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 
     @Test
     fun `load SVG with unspecified viewbox and fill bounds`() {
         assumeTrue(isLinux || isWindows)
 
-        val window = TestComposeWindow(width = 200, height = 300)
-        window.setContent {
+        val snapshot = renderComposeScene(width = 200, height = 300) {
             Image(
                 painterResource("androidx/compose/ui/res/star-viewbox-unspecified.svg"),
                 contentDescription = "Star",
@@ -122,6 +117,6 @@ class DesktopSvgResourcesTest {
                 modifier = Modifier.fillMaxSize()
             )
         }
-        screenshotRule.snap(window.surface)
+        screenshotRule.write(snapshot)
     }
 }


### PR DESCRIPTION
This CL introduces ImageComposeScene - simplified version of ComposeScene, with drawing only into Image.

It is almost the same as the old TestComposeWindow, but with a different class and method names.

See examples of usage in ImageComposeSceneTest

I "renamed" TestComposeWindow to ImageComposeScene, because its name can confuse people:
1. because we had "Window" in the name, some people thought that it creates the real native window
2. "Test" in the name can mislead about the purpose of the class. The main purpose, of course - is to use it in screenshot tests, but we can also use it in PDF generation, for example.

Also, we introduce:
- renderComposeScene - one-liner function to draw Composable content into an image
- ImageComposeScene.use - similar to AutoClosable.use to disposing created resources. We don't inherit AutoCloseable, because we want to move ImageComposeScene into skikoMain. For now, common code doesn't have Closeable, but in the future it can (https://github.com/Kotlin/kotlinx-io/blob/c5bba0114e33c2afd8e4b1ab214aad94ee416d00/core/commonMain/src/kotlinx/io/Closeable.common.kt#L7), so I renamed `dispose` method to `close`

Also I have fixed a race when we call ComposeScene.render from another thread and use TestCoroutineDispatcher or Dispatcher.Unconfined (see FlushCoroutineDispatcher and ComposeScene).
The race was between:
```
[Swing thread] GlobalSnapshotManager -> sendApplyNotifications -> (ComposeScene.recomposer) awaitWorkAvailable, ..., parentFrameClock.withFrameNanos
```
and
```
[Test thread] ComposeScene.render -> sendApplyNotifications, ..., frameClock.sendFrame
```
In the Swing thread recomposer still don't wait for the frame, but in test thread we already send it.
To make sure that recomposer waiting for the frame, we had `dispatcher.flush`.
But it don't wait for the already running tasks (in our case - for sendApplyNotifications to finish in Swing thread).
In this CL we fix that, adding a synchronization point - we don't exit `flush` if there are still performing tasks.

Test: ./gradlew jvmTest desktopTest -Pandroidx.compose.multiplatformEnabled=true
Test: manual ./gradlew :compose:desktop:desktop:desktop-samples:run1 -Pandroidx.compose.multiplatformEnabled=true

Change-Id: I48d2769fd2eaff53e391371aea9ed37964b6afc3