### PR TITLE
Fix TestComposeWindow

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/TestComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/TestComposeWindow.desktop.kt
@@ -80,6 +80,7 @@ class TestComposeWindow(
 
     private fun onFrame() {
         canvas.clear(Color.Transparent.toArgb())
+        scene.flushEffects()
         scene.render(canvas, nanoTime())
     }
 
@@ -116,6 +117,7 @@ class TestComposeWindow(
     fun setContent(content: @Composable () -> Unit) {
         scene.constraints = Constraints(maxWidth = width, maxHeight = height)
         scene.setContent(content = content)
+        scene.flushEffects()
         scene.render(canvas, nanoTime = nanoTime())
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -328,6 +328,11 @@ class ComposeScene internal constructor(
         }
     }
 
+    // for TestComposeWindow backward compatibility
+    internal fun flushEffects() {
+        effectDispatcher.flush()
+    }
+
     private var focusedOwner: SkiaBasedOwner? = null
     private val hoveredOwner: SkiaBasedOwner?
         get() = list.lastOrNull { it.isHovered(pointLocation) } ?: list.lastOrNull()


### PR DESCRIPTION
ComposeScene doesn't flush LaunchedEffect's, but TestComposeWindow can't work without it, and can't work with Dispatchers.Unconfined