### PR TITLE
Fix size issues

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -92,6 +92,7 @@ internal class ComposeLayer {
             super.addNotify()
             resetDensity()
             initContent()
+            updateSceneSize()
         }
 
         override fun paint(g: Graphics) {
@@ -115,16 +116,16 @@ internal class ComposeLayer {
             currentInputMethodRequests = null
         }
 
-        override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
+        override fun doLayout() {
+            super.doLayout()
+            updateSceneSize()
+        }
+
+        private fun updateSceneSize() {
             this@ComposeLayer.scene.constraints = Constraints(
                 maxWidth = (width * density.density).toInt().coerceAtLeast(0),
                 maxHeight = (height * density.density).toInt().coerceAtLeast(0)
             )
-            super.setBounds(x, y, width, height)
-        }
-
-        override fun doLayout() {
-            super.doLayout()
             preferredSize = Dimension(
                 (this@ComposeLayer.scene.contentSize.width / density.density).toInt(),
                 (this@ComposeLayer.scene.contentSize.height / density.density).toInt()
@@ -139,7 +140,10 @@ internal class ComposeLayer {
 
         private fun resetDensity() {
             density = (this as SkiaLayer).density
-            this@ComposeLayer.scene.density = density
+            if (this@ComposeLayer.scene.density != density) {
+                this@ComposeLayer.scene.density = density
+                updateSceneSize()
+            }
         }
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -21,6 +21,7 @@ import org.jetbrains.skiko.ClipComponent
 import org.jetbrains.skiko.GraphicsApi
 import java.awt.Color
 import java.awt.Component
+import java.awt.Dimension
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities.isEventDispatchThread
 
@@ -47,7 +48,9 @@ class ComposePanel : JLayeredPane() {
         super.setBounds(x, y, width, height)
     }
 
-    override fun getPreferredSize() = layer?.component?.preferredSize
+    override fun getPreferredSize(): Dimension? {
+        return if (isPreferredSizeSet) super.getPreferredSize() else layer?.component?.preferredSize
+    }
 
     /**
      * Sets Compose content of the ComposePanel.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -58,7 +58,7 @@ internal class ComposeWindowDelegate(private val window: Window) {
             layer.component.requestFocus()
         }
 
-        override fun getPreferredSize() = layer.component.preferredSize
+        override fun getPreferredSize() = if (isPreferredSizeSet) super.getPreferredSize() else layer.component.preferredSize
     }
 
     private val clipMap = mutableMapOf<Component, ClipComponent>()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -57,7 +57,7 @@ fun Window.sendKeyEvent(
     modifiers: Int = 0
 ): Boolean {
     val event = KeyEvent(
-        focusOwner,
+        mostRecentFocusOwner, // just `focusOwner` is null if the window is minimized
         KeyEvent.KEY_PRESSED,
         0,
         modifiers,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -1,0 +1,65 @@
+package androidx.compose.ui.awt
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.swing.Swing
+import org.junit.Test
+import java.awt.Dimension
+import javax.swing.JFrame
+
+class ComposePanelTest {
+    @Test
+    fun `don't override user preferred size`() {
+        runBlocking(Dispatchers.Swing) {
+            val composePanel = ComposePanel()
+            composePanel.preferredSize = Dimension(234, 345)
+            assertThat(composePanel.preferredSize).isEqualTo(Dimension(234, 345))
+
+            val frame = JFrame()
+            try {
+                frame.contentPane.add(composePanel)
+                frame.isUndecorated = true
+
+                frame.isVisible = true
+                assertThat(composePanel.preferredSize).isEqualTo(Dimension(234, 345))
+
+                frame.pack()
+                assertThat(composePanel.size).isEqualTo(Dimension(234, 345))
+                assertThat(frame.size).isEqualTo(Dimension(234, 345))
+            } finally {
+                frame.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun `pack to Compose content`() {
+        runBlocking(Dispatchers.Swing) {
+            val composePanel = ComposePanel()
+            composePanel.setContent {
+                Box(Modifier.requiredSize(300.dp, 400.dp))
+            }
+
+            val frame = JFrame()
+            try {
+                frame.contentPane.add(composePanel)
+                frame.isUndecorated = true
+
+                frame.pack()
+                assertThat(composePanel.preferredSize).isEqualTo(Dimension(300, 400))
+                assertThat(frame.preferredSize).isEqualTo(Dimension(300, 400))
+
+                frame.isVisible = true
+                assertThat(composePanel.preferredSize).isEqualTo(Dimension(300, 400))
+                assertThat(frame.preferredSize).isEqualTo(Dimension(300, 400))
+            } finally {
+                frame.dispose()
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
@@ -1,0 +1,54 @@
+package androidx.compose.ui.awt
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.swing.Swing
+import org.junit.Test
+import java.awt.Dimension
+
+class ComposeWindowTest {
+    @Test
+    fun `don't override user preferred size`() {
+        runBlocking(Dispatchers.Swing) {
+            val window = ComposeWindow()
+            try {
+                window.preferredSize = Dimension(234, 345)
+                window.isUndecorated = true
+                window.isVisible = true
+                assertThat(window.preferredSize).isEqualTo(Dimension(234, 345))
+                window.pack()
+                assertThat(window.size).isEqualTo(Dimension(234, 345))
+            } finally {
+                window.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun `pack to Compose content`() {
+        runBlocking(Dispatchers.Swing) {
+            val window = ComposeWindow()
+            try {
+                window.setContent {
+                    Box(Modifier.requiredSize(300.dp, 400.dp))
+                }
+                window.isUndecorated = true
+
+                window.pack()
+                assertThat(window.preferredSize).isEqualTo(Dimension(300, 400))
+                assertThat(window.size).isEqualTo(Dimension(300, 400))
+
+                window.isVisible = true
+                assertThat(window.preferredSize).isEqualTo(Dimension(300, 400))
+                assertThat(window.size).isEqualTo(Dimension(300, 400))
+            } finally {
+                window.dispose()
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -313,7 +313,7 @@ class ComposeScene internal constructor(
             check(!isClosed) { "ComposeScene is closed" }
             val mainOwner = mainOwner ?: return IntSize.Zero
             mainOwner.measureAndLayout()
-            return IntSize(mainOwner.root.width, mainOwner.root.height)
+            return mainOwner.contentSize
         }
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -273,12 +273,21 @@ internal class SkiaBasedOwner(
         onNeedsRender?.invoke()
     }
 
+    var contentSize = IntSize.Zero
+        private set
+
     override fun measureAndLayout() {
         measureAndLayoutDelegate.updateRootConstraints(constraints)
         if (measureAndLayoutDelegate.measureAndLayout()) {
             requestDraw()
         }
         measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
+
+        // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
+        contentSize = IntSize(
+            root.children.maxOfOrNull { it.outerLayoutNodeWrapper.measuredWidth } ?: 0,
+            root.children.maxOfOrNull { it.outerLayoutNodeWrapper.measuredHeight } ?: 0,
+        )
     }
 
     override fun onRequestMeasure(layoutNode: LayoutNode) {


### PR DESCRIPTION
- fix overriding preferredSize by the user
- size of the content didn't change after density change
- fix pure Swing window.pack() (fix is inside ComposeScene/SkiaBasedOwner)