### PR TITLE
Fix races when we resize window programmatically or manually

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -125,6 +125,14 @@ fun Dialog(
 
     val updater = remember(::ComponentUpdater)
 
+    // the state applied to the dialog. exist to avoid races between DialogState changes and the state stored inside the native dialog
+    val appliedState = remember {
+        object {
+            var size: DpSize? = null
+            var position: WindowPosition? = null
+        }
+    }
+
     Dialog(
         visible = visible,
         onPreviewKeyEvent = onPreviewKeyEvent,
@@ -141,10 +149,12 @@ fun Dialog(
                 addComponentListener(object : ComponentAdapter() {
                     override fun componentResized(e: ComponentEvent) {
                         currentState.size = DpSize(width.dp, height.dp)
+                        appliedState.size = currentState.size
                     }
 
                     override fun componentMoved(e: ComponentEvent) {
                         currentState.position = WindowPosition(x.dp, y.dp)
+                        appliedState.position = currentState.position
                     }
                 })
             }
@@ -159,8 +169,14 @@ fun Dialog(
                 set(currentResizable, dialog::setResizable)
                 set(currentEnabled, dialog::setEnabled)
                 set(currentFocusable, dialog::setFocusable)
-                set(state.size, dialog::setSizeSafely)
-                set(state.position, dialog::setPositionSafely)
+            }
+            if (state.size != appliedState.size) {
+                dialog.setSizeSafely(state.size)
+                appliedState.size = state.size
+            }
+            if (state.position != appliedState.position) {
+                dialog.setPositionSafely(state.position)
+                appliedState.position = state.position
             }
         },
         content = content

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -139,6 +139,16 @@ fun Window(
 
     val updater = remember(::ComponentUpdater)
 
+    // the state applied to the window. exist to avoid races between WindowState changes and the state stored inside the native window
+    val appliedState = remember {
+        object {
+            var size: DpSize? = null
+            var position: WindowPosition? = null
+            var placement: WindowPlacement? = null
+            var isMinimized: Boolean? = null
+        }
+    }
+
     Window(
         visible = visible,
         onPreviewKeyEvent = onPreviewKeyEvent,
@@ -155,6 +165,8 @@ fun Window(
                 addWindowStateListener {
                     currentState.placement = placement
                     currentState.isMinimized = isMinimized
+                    appliedState.placement = currentState.placement
+                    appliedState.isMinimized = currentState.isMinimized
                 }
                 addComponentListener(object : ComponentAdapter() {
                     override fun componentResized(e: ComponentEvent) {
@@ -163,10 +175,13 @@ fun Window(
                         // fire windowStateChanged, only componentResized
                         currentState.placement = placement
                         currentState.size = DpSize(width.dp, height.dp)
+                        appliedState.placement = currentState.placement
+                        appliedState.size = currentState.size
                     }
 
                     override fun componentMoved(e: ComponentEvent) {
                         currentState.position = WindowPosition(x.dp, y.dp)
+                        appliedState.position = currentState.position
                     }
                 })
             }
@@ -182,10 +197,22 @@ fun Window(
                 set(currentEnabled, window::setEnabled)
                 set(currentFocusable, window::setFocusable)
                 set(currentAlwaysOnTop, window::setAlwaysOnTop)
-                set(state.size, window::setSizeSafely)
-                set(state.position, window::setPositionSafely)
-                set(state.placement, window::placement::set)
-                set(state.isMinimized, window::isMinimized::set)
+            }
+            if (state.size != appliedState.size) {
+                window.setSizeSafely(state.size)
+                appliedState.size = state.size
+            }
+            if (state.position != appliedState.position) {
+                window.setPositionSafely(state.position)
+                appliedState.position = state.position
+            }
+            if (state.placement != appliedState.placement) {
+                window.placement = state.placement
+                appliedState.placement = state.placement
+            }
+            if (state.isMinimized != appliedState.isMinimized) {
+                window.isMinimized = state.isMinimized
+                appliedState.isMinimized = state.isMinimized
             }
         },
         content = content

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -270,7 +270,7 @@ class WindowStateTest {
     }
 
     @Test
-    fun `state position should be specified after attach`() = runApplicationTest {
+    fun `state position should be specified after attach`() = runApplicationTest(useDelay = isLinux) {
         val state = WindowState(size = DpSize(200.dp, 200.dp))
 
         launchApplication {


### PR DESCRIPTION
Prevent change window size/position/etc if we recompose in response to OS event
When OS fires event, for example during animation, or when user resizes the window, we called setSize with the reported size. This causes some glitches.

Probably fixes:
- https://github.com/JetBrains/compose-jb/issues/1040 (on Linux)
- resize jumps on Windows
- "flaky" tests on macOs

Also fix two flaky tests - one on macOs (key sending), one on Linux (because of the non-deterministic async event dispatching)