### PR TITLE
Fix selection of lines which end with \n

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -736,7 +736,12 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
 }
 
 internal fun merge(lhs: Selection?, rhs: Selection?): Selection? {
-    return lhs?.merge(rhs) ?: rhs
+    return when {
+        lhs == null -> rhs
+        rhs == null -> lhs
+        lhs.start == lhs.end -> lhs.copy(handlesCrossed = rhs.handlesCrossed).merge(rhs)
+        else -> lhs.merge(rhs)
+    }
 }
 
 internal expect fun isCopyKeyEvent(keyEvent: KeyEvent): Boolean


### PR DESCRIPTION
Regression after https://android-review.googlesource.com/c/platform/frameworks/support/+/1803456
That CL probably doesn't introduce a new bug, just reveal the old one.

When we selecting text between multiple lines, we can have a situation, when a line in between has an empty selection with a reverted handlesCrossed:
```
null
Selection(start=AnchorInfo(direction=Ltr, offset=27, selectableId=2), end=AnchorInfo(direction=Ltr, offset=27, selectableId=2), handlesCrossed=false)
Selection(start=AnchorInfo(direction=Ltr, offset=16, selectableId=3), end=AnchorInfo(direction=Ltr, offset=0, selectableId=3), handlesCrossed=true)
null
```

Merging these selections will result in:
```
Selection(start=AnchorInfo(direction=Ltr, offset=27, selectableId=2), end=AnchorInfo(direction=Ltr, offset=27, selectableId=2), handlesCrossed=false)
```

But it should be:
```
Selection(start=AnchorInfo(direction=Ltr, offset=16, selectableId=3), end=AnchorInfo(direction=Ltr, offset=27, selectableId=2), handlesCrossed=true)
```

Fixes https://github.com/JetBrains/compose-jb/issues/1234

Snippet to reproduce:
```
import androidx.compose.foundation.layout.Column
import androidx.compose.foundation.text.selection.SelectionContainer
import androidx.compose.material.Text
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.window.Window
import androidx.compose.ui.window.application

@OptIn(ExperimentalComposeUiApi::class)
fun main() = application {
    Window({}) {
        SelectionContainer {
            Column {
                Text("xxxxxxxxxxxxxxxxxxxxxxxxxx\n")
                Text("xxxxxxxxxxxxxxxxxxxxxxxxxx\n")
                Text("xxxxxxxxxxxxxxxxxxxxxxxxxx\n")
                Text("xxxxxxxxxxxxxxxxxxxxxxxxxx\n")
            }
        }
    }
}
```

1. select the third line from right to left
2. start moving cursor to the second line
3. when we reach the empty space, we starting to select the second line
4. Skia paragraph tells that in this empty space there are no symbols, so it returns the last index of the line (27):
```
Selection(start=AnchorInfo(direction=Ltr, offset=27, selectableId=2), end=AnchorInfo(direction=Ltr, offset=27, selectableId=2), handlesCrossed=false)
```

Test: ./gradlew compose:foundation:foundation:test
Test: ./gradlew compose:foundation:foundation:deskktopTest
Test: manual (see the snippet)