### PR TITLE
Call exitProcess(0) in the end of `application` function

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -42,7 +43,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
-import java.awt.Window
+import kotlin.system.exitProcess
 
 /**
  * An entry point for the Compose application. See [awaitApplication] for more information.
@@ -54,30 +55,69 @@ import java.awt.Window
  * }
  * ```
  *
+ * After all windows are closed and all operations are completed, the application will end.
+ * Set [exitProcessOnExit] to `false`, if you need to execute some code after [application] block, otherwise the code after it
+ * won't be executed, as [application] will exit the process.
+ *
  * This entry point is a blocking operation (it blocks the current thread until application
  * finishes) and can't be called inside UI thread. To launch new application from UI thread (for
  * example, from some event listener), use `GlobalScope.launchApplication` instead.
  *
- * This function is equivalent of:
- * ```
- * runBlocking {
- *     awaitApplication {
+ * Application can launch background tasks using [LaunchedEffect]
+ * or create [Window], [Dialog], or [Tray] in a declarative Compose way:
  *
+ * ```
+ * fun main() = application {
+ *     val isSplashScreenShowing by remember { mutableStateOf(true) }
+ *
+ *     LaunchedEffect(Unit) {
+ *         delay(2000)
+ *         isSplashScreenShowing = false
+ *     }
+ *
+ *     if (isSplashScreenShowing) {
+ *         Window(title = "Splash") {}
+ *     } else {
+ *         Window(title = "App") {}
  *     }
  * }
  * ```
  *
+ * When there is no any active compositions, this function will end.
+ * Active composition is a composition that have active coroutine (for example, launched in
+ * [LaunchedEffect]) or that have child composition created inside [Window], [Dialog], or [Tray].
+ *
+ * Don't use any animation in this function
+ * (for example, [withFrameNanos] or [androidx.compose.animation.core.animateFloatAsState]),
+ * because underlying [MonotonicFrameClock] hasn't synchronized with any display, and produces
+ * frames as fast as possible.
+ *
+ * All animation's should be created inside Composable content of the
+ * [Window] / [Dialog] / [ComposePanel].
+ *
+ * @param exitProcessOnExit should `exitProcess(0)` be called after the application is closed.
+ * exitProcess speedup process exit (instant instead of 1-4sec).
+ * If `false`, the execution of the function will be unblocked after application is exited
+ * (when the last window is closed, and all [LaunchedEffect] are complete).
  * @see [awaitApplication]
  */
 fun application(
+    exitProcessOnExit: Boolean = true,
     content: @Composable ApplicationScope.() -> Unit
 ) {
-    if (System.getProperty("compose.application.configure.swing.globals") == "true") {
+    val configureSwingGlobals = System.getProperty("compose.application.configure.swing.globals") == "true"
+    if (configureSwingGlobals) {
         configureSwingGlobalsForCompose()
     }
 
     runBlocking {
-        awaitApplication(content = content)
+        awaitApplication {
+            content()
+        }
+    }
+
+    if (exitProcessOnExit) {
+        exitProcess(0)
     }
 }
 
@@ -120,7 +160,7 @@ fun CoroutineScope.launchApplication(
  *
  * ```
  * fun main() = runBlocking {
- *     withApplication {
+ *     awaitApplication {
  *         val isSplashScreenShowing by remember { mutableStateOf(true) }
  *
  *         LaunchedEffect(Unit) {
@@ -197,7 +237,14 @@ suspend fun awaitApplication(
     }
 }
 
+/**
+ * Scope used by [application], [awaitApplication], [launchApplication]
+ */
 interface ApplicationScope {
+    /**
+     * Close all windows created inside the application and cancel all launched effects
+     * (they launch via [LaunchedEffect] adn [rememberCoroutineScope].
+     */
     fun exitApplication()
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -230,6 +231,9 @@ fun Window(
  * }
  * ```
  *
+ * Set [exitProcessOnExit] to `false`, if you need to execute some code after [singleWindowApplication] block, otherwise the code after it
+ * won't be executed, as [singleWindowApplication] will exit the process.
+ *
  * @param state The state object to be used to control or observe the window's state
  * When size/position/status is changed by the user, state will be updated.
  * When size/position/status of the window is changed by the application (changing state),
@@ -262,6 +266,10 @@ fun Window(
  * @param onKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. While implementing this callback, return true to stop propagation of this event.
  * If you return false, the key event will be sent to this [onKeyEvent]'s parent.
+ * @param exitProcessOnExit should `exitProcess(0)` be called after the window is closed.
+ * exitProcess speedup process exit (instant instead of 1-4sec).
+ * If `false`, the execution of the function will be unblocked after application is exited
+ * (when the last window is closed, and all [LaunchedEffect] are complete).
  * @param content Content of the window
  */
 fun singleWindowApplication(
@@ -277,8 +285,9 @@ fun singleWindowApplication(
     alwaysOnTop: Boolean = false,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     onKeyEvent: (KeyEvent) -> Boolean = { false },
+    exitProcessOnExit: Boolean = true,
     content: @Composable FrameWindowScope.() -> Unit
-) = application {
+) = application(exitProcessOnExit = exitProcessOnExit) {
     Window(
         ::exitApplication,
         state,


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/749
(probably it is a GTK issue, we just bypass it)

Fixes https://github.com/JetBrains/compose-jb/issues/748
(now we exit instantly, not 3-5 seconds)

Exit process in the end of the application shouldn't mess with resource disposing, if users carefully dispose all resources in DisposableEffect.