### PR TITLE
Fixed issue when AlertDialog not aligned to center.

### DIFF
--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.material
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.fillMaxSize
@@ -29,9 +29,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.rememberDialogState
 import androidx.compose.ui.window.Dialog as CoreDialog
 
@@ -180,12 +186,23 @@ object PopupAlertDialogProvider : AlertDialogProvider {
         content: @Composable () -> Unit
     ) {
         Popup(
-            alignment = Alignment.Center,
+            popupPositionProvider = object : PopupPositionProvider {
+                override fun calculatePosition(
+                    anchorBounds: IntRect,
+                    windowSize: IntSize,
+                    layoutDirection: LayoutDirection,
+                    popupContentSize: IntSize
+                ): IntOffset = IntOffset.Zero
+            },
             focusable = true,
             onDismissRequest = onDismissRequest,
         ) {
-            Box (
-                modifier = Modifier.fillMaxSize(),
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(onDismissRequest) {
+                        detectTapGestures(onPress = { onDismissRequest() })
+                    },
                 contentAlignment = Alignment.Center
             ) {
                 Surface(elevation = 24.dp) {

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -16,8 +16,10 @@
 
 package androidx.compose.material
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -182,8 +184,13 @@ object PopupAlertDialogProvider : AlertDialogProvider {
             focusable = true,
             onDismissRequest = onDismissRequest,
         ) {
-            Surface(elevation = 24.dp) {
-                content()
+            Box (
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Surface(elevation = 24.dp) {
+                    content()
+                }
             }
         }
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -185,17 +185,15 @@ private fun PopupLayout(
                     val width = constraints.maxWidth
                     val height = constraints.maxHeight
 
-                    val windowSize = IntSize(
-                        width = width,
-                        height = height
-                    )
+                    val windowRect = IntRect(0, 0, width, height)
+                    val anchorRect = if (parentBounds == IntRect.Zero) windowRect else parentBounds
 
                     layout(constraints.maxWidth, constraints.maxHeight) {
                         measurables.forEach {
                             val placeable = it.measure(constraints)
                             val position = popupPositionProvider.calculatePosition(
-                                anchorBounds = parentBounds,
-                                windowSize = windowSize,
+                                anchorBounds = anchorRect,
+                                windowSize = windowRect.size,
                                 layoutDirection = layoutDirection,
                                 popupContentSize = IntSize(placeable.width, placeable.height)
                             )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -185,15 +185,12 @@ private fun PopupLayout(
                     val width = constraints.maxWidth
                     val height = constraints.maxHeight
 
-                    val windowRect = IntRect(0, 0, width, height)
-                    val anchorRect = if (parentBounds == IntRect.Zero) windowRect else parentBounds
-
                     layout(constraints.maxWidth, constraints.maxHeight) {
                         measurables.forEach {
                             val placeable = it.measure(constraints)
                             val position = popupPositionProvider.calculatePosition(
-                                anchorBounds = anchorRect,
-                                windowSize = windowRect.size,
+                                anchorBounds = parentBounds,
+                                windowSize = IntSize(width, height),
                                 layoutDirection = layoutDirection,
                                 popupContentSize = IntSize(placeable.width, placeable.height)
                             )


### PR DESCRIPTION
 - when open AlertDialog in pure Window without any container with [Modifier.fillMaxSize()]
 see: https://github.com/JetBrains/compose-jb/issues/1268

Test: manual.