### PR TITLE
Pass composition locals at the very top level of the Window/Dialog

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -71,11 +71,7 @@ class ComposeDialog(
      *
      * `null` if no composition locals should be provided.
      */
-    var compositionLocalContext: CompositionLocalContext?
-        get() = delegate.compositionLocalContext
-        set(value) {
-            delegate.compositionLocalContext = value
-        }
+    var compositionLocalContext: CompositionLocalContext? by delegate::compositionLocalContext
 
     /**
      * Composes the given composable into the ComposeDialog.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -16,6 +16,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.DialogWindowScope
@@ -63,6 +64,18 @@ class ComposeDialog(
         onKeyEvent = { false },
         content = content
     )
+
+    // TODO(CL) non-experimental new API. we can't remove it when we merge it into AOSP, we can just deprecate it.
+    /**
+     * Top-level composition locals, which will be provided for the Composable content, which is set by [setContent].
+     *
+     * `null` if no composition locals should be provided.
+     */
+    var compositionLocalContext: CompositionLocalContext?
+        get() = delegate.compositionLocalContext
+        set(value) {
+            delegate.compositionLocalContext = value
+        }
 
     /**
      * Composes the given composable into the ComposeDialog.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -236,11 +236,7 @@ internal class ComposeLayer {
         isDisposed = true
     }
 
-    var compositionLocalContext: CompositionLocalContext?
-        get() = scene.compositionLocalContext
-        set(value) {
-            scene.compositionLocalContext = value
-        }
+    var compositionLocalContext: CompositionLocalContext? by scene::compositionLocalContext
 
     fun setContent(
         onPreviewKeyEvent: (ComposeKeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
@@ -234,6 +235,12 @@ internal class ComposeLayer {
         _initContent = null
         isDisposed = true
     }
+
+    var compositionLocalContext: CompositionLocalContext?
+        get() = scene.compositionLocalContext
+        set(value) {
+            scene.compositionLocalContext = value
+        }
 
     fun setContent(
         onPreviewKeyEvent: (ComposeKeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -16,6 +16,8 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.FrameWindowScope
@@ -46,6 +48,18 @@ class ComposeWindow : JFrame() {
     override fun add(component: Component) = delegate.add(component)
 
     override fun remove(component: Component) = delegate.remove(component)
+
+    // TODO(CL) non-experimental new API. we can't remove it when we merge it into AOSP, we can just deprecate it.
+    /**
+     * Top-level composition locals, which will be provided for the Composable content, which is set by [setContent].
+     *
+     * `null` if no composition locals should be provided.
+     */
+    var compositionLocalContext: CompositionLocalContext?
+        get() = delegate.compositionLocalContext
+        set(value) {
+            delegate.compositionLocalContext = value
+        }
 
     /**
      * Composes the given composable into the ComposeWindow.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -55,11 +55,7 @@ class ComposeWindow : JFrame() {
      *
      * `null` if no composition locals should be provided.
      */
-    var compositionLocalContext: CompositionLocalContext?
-        get() = delegate.compositionLocalContext
-        set(value) {
-            delegate.compositionLocalContext = value
-        }
+    var compositionLocalContext: CompositionLocalContext? by delegate::compositionLocalContext
 
     /**
      * Composes the given composable into the ComposeWindow.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.LocalWindow
@@ -75,6 +76,12 @@ internal class ComposeWindowDelegate(private val window: Window) {
     fun remove(component: Component) {
         pane.remove(component)
     }
+
+    var compositionLocalContext: CompositionLocalContext?
+        get() = layer.compositionLocalContext
+        set(value) {
+            layer.compositionLocalContext = value
+        }
 
     fun setContent(
         onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -77,11 +77,7 @@ internal class ComposeWindowDelegate(private val window: Window) {
         pane.remove(component)
     }
 
-    var compositionLocalContext: CompositionLocalContext?
-        get() = layer.compositionLocalContext
-        set(value) {
-            layer.compositionLocalContext = value
-        }
+    var compositionLocalContext: CompositionLocalContext? by layer::compositionLocalContext
 
     fun setContent(
         onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -237,20 +237,20 @@ fun Dialog(
     update: (ComposeDialog) -> Unit = {},
     content: @Composable DialogWindowScope.() -> Unit
 ) {
-    val currentLocals by rememberUpdatedState(currentCompositionLocalContext)
+    val compositionLocalContext by rememberUpdatedState(currentCompositionLocalContext)
     AwtWindow(
         visible = visible,
         create = {
             create().apply {
-                setContent(onPreviewKeyEvent, onKeyEvent) {
-                    CompositionLocalProvider(currentLocals) {
-                        content()
-                    }
-                }
+                this.compositionLocalContext = compositionLocalContext
+                setContent(onPreviewKeyEvent, onKeyEvent, content)
             }
         },
         dispose = dispose,
-        update = update
+        update = {
+            it.compositionLocalContext = compositionLocalContext
+            update(it)
+        }
     )
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -354,20 +354,20 @@ fun Window(
     update: (ComposeWindow) -> Unit = {},
     content: @Composable FrameWindowScope.() -> Unit
 ) {
-    val currentLocals by rememberUpdatedState(currentCompositionLocalContext)
+    val compositionLocalContext by rememberUpdatedState(currentCompositionLocalContext)
     AwtWindow(
         visible = visible,
         create = {
             create().apply {
-                setContent(onPreviewKeyEvent, onKeyEvent) {
-                    CompositionLocalProvider(currentLocals) {
-                        content()
-                    }
-                }
+                this.compositionLocalContext = compositionLocalContext
+                setContent(onPreviewKeyEvent, onKeyEvent, content)
             }
         },
         dispose = dispose,
-        update = update
+        update = {
+            it.compositionLocalContext = compositionLocalContext
+            update(it)
+        }
     )
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -33,7 +33,6 @@ class ComposePanelTest {
                 frame.contentPane.add(composePanel)
                 frame.isUndecorated = true
 
-                frame.isVisible = true
                 assertThat(composePanel.preferredSize).isEqualTo(Dimension(234, 345))
 
                 frame.pack()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
@@ -27,7 +27,6 @@ class ComposeWindowTest {
             try {
                 window.preferredSize = Dimension(234, 345)
                 window.isUndecorated = true
-                window.isVisible = true
                 assertThat(window.preferredSize).isEqualTo(Dimension(234, 345))
                 window.pack()
                 assertThat(window.size).isEqualTo(Dimension(234, 345))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -485,6 +485,7 @@ class WindowTest {
         }
 
         awaitIdle()
+        assertThat(actualDensity).isNotNull()
         assertThat(actualDensity).isNotEqualTo(customDensity)
 
         exitApplication()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.LeakDetector
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
@@ -465,5 +467,26 @@ class WindowTest {
 
         assertThat(isApplicationEffectEnded).isTrue()
         assertThat(isWindowEffectEnded).isTrue()
+    }
+
+    @Test(timeout = 30000)
+    fun `Window should override density provided by application`() = runApplicationTest {
+        val customDensity = Density(3.14f)
+        var actualDensity: Density? = null
+
+        launchApplication {
+            if (isOpen) {
+                CompositionLocalProvider(LocalDensity provides customDensity) {
+                    Window(onCloseRequest = ::exitApplication) {
+                        actualDensity = LocalDensity.current
+                    }
+                }
+            }
+        }
+
+        awaitIdle()
+        assertThat(actualDensity).isNotEqualTo(customDensity)
+
+        exitApplication()
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -19,10 +19,14 @@ import androidx.compose.runtime.BroadcastFrameClock
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
@@ -237,6 +241,14 @@ class ComposeScene internal constructor(
         }
     }
 
+    // TODO(CL) non-experimental new API. we can't remove it when we merge it into AOSP, we can just deprecate it.
+    /**
+     * Top-level composition locals, which will be provided for the Composable content, which is set by [setContent].
+     *
+     * `null` if no composition locals should be provided.
+     */
+    var compositionLocalContext: CompositionLocalContext? by mutableStateOf(null)
+
     /**
      * Update the composition with the content described by the [content] composable. After this
      * has been called the changes to produce the initial composition has been calculated and
@@ -282,7 +294,7 @@ class ComposeScene internal constructor(
             onKeyEvent = onKeyEvent
         )
         attach(mainOwner)
-        composition = mainOwner.setContent(parentComposition ?: recomposer) {
+        composition = mainOwner.setContent(parentComposition ?: recomposer, { compositionLocalContext }) {
             CompositionLocalProvider(
                 LocalComposeScene provides this,
                 content = content

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Wrapper.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Wrapper.skiko.kt
@@ -18,7 +18,10 @@ package androidx.compose.ui.platform
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.node.LayoutNode
 
@@ -27,24 +30,37 @@ import androidx.compose.ui.node.LayoutNode
  *
  * @param parent The parent composition reference to coordinate scheduling of composition updates
  *        If null then default root composition will be used.
+ * @param getCompositionLocalContext getter for retrieving the top-level composition local context.
+ * Can be backed by `mutableStateOf` to dynamically change top-level locals.
  * @param content A `@Composable` function declaring the UI contents
  */
 @OptIn(ExperimentalComposeUiApi::class)
 internal fun SkiaBasedOwner.setContent(
     parent: CompositionContext,
+    getCompositionLocalContext: () -> CompositionLocalContext? = { null },
     content: @Composable () -> Unit
 ): Composition {
     val composition = Composition(DefaultUiApplier(root), parent)
     composition.setContent {
-        ProvideCommonCompositionLocals(
-            owner = this,
-            uriHandler = PlatformUriHandler(),
-            content = content
-        )
-        val owner = this
-        LaunchedEffect(this) { owner.accessibilityController?.syncLoop() }
+        getCompositionLocalContext().provide {
+            ProvideCommonCompositionLocals(
+                owner = this,
+                uriHandler = remember { PlatformUriHandler() },
+                content = content
+            )
+            LaunchedEffect(this) { accessibilityController?.syncLoop() }
+        }
     }
     return composition
+}
+
+@Composable
+private fun CompositionLocalContext?.provide(content: @Composable () -> Unit) {
+    if (this != null) {
+        CompositionLocalProvider(this, content = content)
+    } else {
+        content()
+    }
 }
 
 internal actual fun createSubcomposition(


### PR DESCRIPTION
Currently we pass them not at the top level:
```
composition.setContent {
    ProvideCommonCompositionLocals {
        CompositionLocalProvider(compositionLocalContext) { ... }
    }
}
```
And because of that, compositionLocalContext overrides all locals provided by ProvideCommonCompositionLocals. For example, in this code:
```
application {
  Window {
     Dialog {
     }
  }
}
```
application provides a value for default LocalDensity, and pass it down to Window, and Dialog. But Window and Dialog should provide their own density, as they know on which display they are open.

To fix that, we change order of the providing locals:
```
composition.setContent {
    CompositionLocalProvider(compositionLocalContext) {
       ProvideCommonCompositionLocals { ... }
    }
}
```

Fixes JetBrains/compose-jb#1329
Maybe fixes JetBrains/compose-jb#1376 (need to check)

Partially fixes:
JetBrains/compose-jb#1193
JetBrains/compose-jb#1223
JetBrains/compose-jb#990