### PR TITLE
Fixed NPE when selecting text and moving over popup.

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -142,7 +142,6 @@ class ComposeScene internal constructor(
 
     private var pointerId = 0L
     private var isMousePressed = false
-    private var wasMouseDragEvent = false
 
     private val job = Job()
     private val coroutineScope = CoroutineScope(coroutineContext + job)
@@ -397,9 +396,12 @@ class ComposeScene internal constructor(
             PointerEventType.Press -> onMousePressed(event)
             PointerEventType.Release -> onMouseReleased(event)
             PointerEventType.Move -> {
-                wasMouseDragEvent = isMousePressed
                 pointLocation = position
-                hoveredOwner?.processPointerInput(event)
+                if (isMousePressed) {
+                    mousePressOwner?.processPointerInput(event)
+                } else {
+                    hoveredOwner?.processPointerInput(event)
+                }
             }
             PointerEventType.Enter -> hoveredOwner?.processPointerInput(event)
             PointerEventType.Exit -> hoveredOwner?.processPointerInput(event)
@@ -457,13 +459,9 @@ class ComposeScene internal constructor(
     }
 
     private fun onMouseReleased(event: PointerInputEvent) {
-        if (wasMouseDragEvent) {
-            wasMouseDragEvent = false
-            mousePressOwner?.processPointerInput(event)
-            mousePressOwner = null
-        } else {
-            (hoveredOwner ?: focusedOwner)?.processPointerInput(event)
-        }
+        val owner = (mousePressOwner ?: hoveredOwner) ?: focusedOwner
+        owner?.processPointerInput(event)
+        mousePressOwner = null
         pointerId += 1
     }
 


### PR DESCRIPTION
 - fixed NPE when clicking back on a TextField after releasing the mouse button over a Popup during selection
see: https://github.com/JetBrains/compose-jb/issues/1149

Why NPE occurs in this case:
You started a drag event on one [SkiaBasedOwner] and finished a drag event on another [SkiaBasedOwner], so the text selection did not receive a MouseRelease event to complete the selection, and when you moved the freed cursor to the text you started the selection on, you will get an NPE because the event is no longer [Drag] but [Move].

To avoid such situations, we need to make sure that the [Drag] mouse event ends on the [SkiaBasedOwner] on which it started.

In this PR we check that the event is a drag and the mouse release event is always sent to the [SkiaBasedOwner] that the drag event started on.

Test: manual.
