### PR TITLE
Hide cursor if window isn't focused

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldCursor.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldCursor.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.isUnspecified
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -44,7 +45,8 @@ internal fun Modifier.cursor(
 ) = if (enabled) composed {
     val cursorAlpha = remember { Animatable(1f) }
     val isBrushSpecified = !(cursorBrush is SolidColor && cursorBrush.value.isUnspecified)
-    if (state.hasFocus && value.selection.collapsed && isBrushSpecified) {
+    val isWindowFocused = LocalWindowInfo.current.isWindowFocused
+    if (state.hasFocus && value.selection.collapsed && isBrushSpecified && isWindowFocused) {
         LaunchedEffect(cursorBrush, value.annotatedString, value.selection) {
             cursorAlpha.animateTo(0f, cursorAnimationSpec)
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.AccessibilityControllerImpl
 import androidx.compose.ui.platform.PlatformComponent
+import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.window.density
@@ -40,6 +41,7 @@ import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Graphics
 import java.awt.Point
+import java.awt.Window
 import java.awt.event.FocusEvent
 import java.awt.event.InputMethodEvent
 import java.awt.event.InputMethodListener
@@ -49,9 +51,12 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseMotionAdapter
 import java.awt.event.MouseWheelEvent
+import java.awt.event.WindowEvent
+import java.awt.event.WindowFocusListener
 import java.awt.im.InputMethodRequests
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleContext
+import javax.swing.SwingUtilities
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 
 internal class ComposeLayer {
@@ -89,11 +94,27 @@ internal class ComposeLayer {
         SkiaLayer(externalAccessibleFactory = ::makeAccessible), Accessible, PlatformComponent {
         var currentInputMethodRequests: InputMethodRequests? = null
 
+        private var window: Window? = null
+        private var windowListener = object : WindowFocusListener {
+            override fun windowGainedFocus(e: WindowEvent) = refreshWindowFocus()
+            override fun windowLostFocus(e: WindowEvent) = refreshWindowFocus()
+        }
+
         override fun addNotify() {
             super.addNotify()
             resetDensity()
             initContent()
             updateSceneSize()
+            window = SwingUtilities.getWindowAncestor(this)
+            window?.addWindowFocusListener(windowListener)
+            refreshWindowFocus()
+        }
+
+        override fun removeNotify() {
+            window?.removeWindowFocusListener(windowListener)
+            window = null
+            refreshWindowFocus()
+            super.removeNotify()
         }
 
         override fun paint(g: Graphics) {
@@ -150,6 +171,12 @@ internal class ComposeLayer {
                 this@ComposeLayer.scene.density = density
                 updateSceneSize()
             }
+        }
+
+        override val windowInfo = WindowInfoImpl()
+
+        private fun refreshWindowFocus() {
+            windowInfo.isWindowFocused = window?.isFocused ?: false
         }
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
@@ -21,7 +21,9 @@ import java.awt.Cursor
 import java.awt.Point
 import java.awt.im.InputMethodRequests
 
-internal actual interface PlatformComponent : PlatformInputComponent, PlatformComponentWithCursor
+internal actual interface PlatformComponent : PlatformInputComponent, PlatformComponentWithCursor {
+    actual val windowInfo: WindowInfo
+}
 
 internal actual interface PlatformComponentWithCursor {
     var componentCursor: Cursor
@@ -37,4 +39,5 @@ internal actual object DummyPlatformComponent : PlatformComponent {
     override val locationOnScreen = Point(0, 0)
     override val density: Density
         get() = Density(1f, 1f)
+    override val windowInfo = WindowInfoImpl()
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -170,6 +170,7 @@ private fun PopupLayout(
     val (owner, composition) = remember {
         val owner = SkiaBasedOwner(
             platformInputService = scene.platformInputService,
+            windowInfo = scene.component.windowInfo,
             density = density,
             isPopup = true,
             isFocusable = focusable,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -78,7 +78,7 @@ internal val LocalComposeScene = staticCompositionLocalOf<ComposeScene> {
  */
 class ComposeScene internal constructor(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
-    private val component: PlatformComponent,
+    internal val component: PlatformComponent,
     density: Density,
     private val invalidate: () -> Unit
 ) {
@@ -289,6 +289,7 @@ class ComposeScene internal constructor(
         mainOwner?.dispose()
         val mainOwner = SkiaBasedOwner(
             platformInputService,
+            component.windowInfo,
             density,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformComponent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformComponent.skiko.kt
@@ -15,7 +15,9 @@
  */
 package androidx.compose.ui.platform
 
-internal expect interface PlatformComponent : PlatformInputComponent, PlatformComponentWithCursor
+internal expect interface PlatformComponent : PlatformInputComponent, PlatformComponentWithCursor {
+    val windowInfo: WindowInfo
+}
 
 internal expect interface PlatformComponentWithCursor
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -88,6 +88,7 @@ private typealias Command = () -> Unit
 )
 internal class SkiaBasedOwner(
     private val platformInputService: PlatformInput,
+    override val windowInfo: WindowInfo,
     density: Density = Density(1f, 1f),
     val isPopup: Boolean = false,
     val isFocusable: Boolean = true,
@@ -137,11 +138,6 @@ internal class SkiaBasedOwner(
     )
     override val inputModeManager: InputModeManager
         get() = _inputModeManager
-
-    // TODO: set/clear _windowInfo.isWindowFocused when the window gains/loses focus.
-    private val _windowInfo: WindowInfoImpl = WindowInfoImpl()
-    override val windowInfo: WindowInfo
-        get() = _windowInfo
 
     // TODO(b/177931787) : Consider creating a KeyInputManager like we have for FocusManager so
     //  that this common logic can be used by all owners.


### PR DESCRIPTION
All desktop platforms do it, and it is an user friendly behavior, as it indicates - there is no active text field, in which we currently type.

Also implement LocalWindowInfo.current