### PR TITLE
Fix tintColor in rememberVectorPainter if we try to draw it in the same Composable frame

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/graphics/vector/VectorPainter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/graphics/vector/VectorPainter.kt
@@ -76,21 +76,26 @@ fun rememberVectorPainter(
     val vpWidth = if (viewportWidth.isNaN()) widthPx else viewportWidth
     val vpHeight = if (viewportHeight.isNaN()) heightPx else viewportHeight
 
+    val intrinsicColorFilter = remember(tintColor, tintBlendMode) {
+        if (tintColor != Color.Unspecified) {
+            ColorFilter.tint(tintColor, tintBlendMode)
+        } else {
+            null
+        }
+    }
+
     val painter = remember { VectorPainter() }.apply {
         // This assignment is thread safe as the internal Size parameter is
         // backed by a mutableState object
         size = Size(widthPx, heightPx)
+        this.intrinsicColorFilter = intrinsicColorFilter
         RenderVector(name, vpWidth, vpHeight, content)
     }
     SideEffect {
         // Initialize the intrinsic color filter if a tint color is provided on the
         // vector itself. Note this tint can be overridden by an explicit ColorFilter
         // provided on the Modifier.paint call
-        painter.intrinsicColorFilter = if (tintColor != Color.Unspecified) {
-            ColorFilter.tint(tintColor, tintBlendMode)
-        } else {
-            null
-        }
+        painter.intrinsicColorFilter = intrinsicColorFilter
     }
     return painter
 }


### PR DESCRIPTION
SideEffect usually called when Recomposer performs all Composables.
So `intrinsicColorFilter` will not be applied if we try to draw ImageVector immediately after we create VectorPainter:

```
import androidx.compose.foundation.Image
import androidx.compose.material.icons.Icons
import androidx.compose.material.icons.filled.Menu
import androidx.compose.runtime.Composable
import androidx.compose.runtime.remember
import androidx.compose.ui.geometry.Size
import androidx.compose.ui.graphics.Canvas
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.graphics.ImageBitmap
import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
import androidx.compose.ui.graphics.vector.ImageVector
import androidx.compose.ui.graphics.vector.RenderVectorGroup
import androidx.compose.ui.unit.Density
import androidx.compose.ui.unit.LayoutDirection
import androidx.compose.ui.window.Window
import androidx.compose.ui.window.application

fun main() {
    application {
        Window(onCloseRequest = ::exitApplication) {
            Test()
        }
    }
}

@Composable
fun Test() {
    val icon = rememberVectorPainter(Icons.Default.Menu, tintColor = Color(0xFF2CA4E1))

    val bitmap = remember {
        val bitmap = ImageBitmap(100, 100)
        val canvas = Canvas(bitmap)
        CanvasDrawScope().draw(Density(1f), LayoutDirection.Ltr, canvas, Size(100f, 100f)) {
            with(icon) {
                draw(Size(100f, 100f))
            }
        }
        bitmap
    }

    Image(bitmap, contentDescription = null)
}

@Composable
fun rememberVectorPainter(image: ImageVector, tintColor: Color) =
    androidx.compose.ui.graphics.vector.rememberVectorPainter(
        defaultWidth = image.defaultWidth,
        defaultHeight = image.defaultHeight,
        viewportWidth = image.viewportWidth,
        viewportHeight = image.viewportHeight,
        name = image.name,
        tintColor = tintColor,
        tintBlendMode = image.tintBlendMode,
        content = { _, _ -> RenderVectorGroup(group = image.root) }
    )
```

Fixes https://github.com/JetBrains/compose-jb/issues/1307

Test: manual. see the snippet. Without the fix we draw without color filter (with black color)