### PR TITLE
Fix DropdownMenu positioning and size when it contains too many items.

### DIFF
--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -231,7 +231,7 @@ private data class DesktopDropdownMenuPositionProvider(
         
         // Desktop specific vertical position checking
         val aboveAnchor = anchorBounds.top + contentOffsetY
-        val belowAnchor = windowSize.height - anchorBounds.bottom + contentOffsetY
+        val belowAnchor = windowSize.height - anchorBounds.bottom - contentOffsetY
 
         if (belowAnchor >= aboveAnchor) {
             y = anchorBounds.bottom + contentOffsetY

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -22,16 +22,23 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.rememberCursorPositionProvider
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 
 /**
  * A Material Design [dropdown menu](https://material.io/components/menus#dropdown-menu).
@@ -80,7 +87,7 @@ fun DropdownMenu(
     if (expandedStates.currentState || expandedStates.targetState) {
         val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
         val density = LocalDensity.current
-        val popupPositionProvider = DropdownMenuPositionProvider(
+        val popupPositionProvider = DesktopDropdownMenuPositionProvider(
             offset,
             density
         ) { parentBounds, menuBounds ->
@@ -178,5 +185,62 @@ fun CursorDropdownMenu(
                 content = content
             )
         }
+    }
+}
+
+@Immutable
+private data class DesktopDropdownMenuPositionProvider(
+    val contentOffset: DpOffset,
+    val density: Density,
+    val onPositionCalculated: (IntRect, IntRect) -> Unit = { _, _ -> }
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset {
+        // The min margin above and below the menu, relative to the screen.
+        val verticalMargin = with(density) { MenuVerticalMargin.roundToPx() }
+        // The content offset specified using the dropdown offset parameter.
+        val contentOffsetX = with(density) { contentOffset.x.roundToPx() }
+        val contentOffsetY = with(density) { contentOffset.y.roundToPx() }
+
+        // Compute horizontal position.
+        val toRight = anchorBounds.left + contentOffsetX
+        val toLeft = anchorBounds.right - contentOffsetX - popupContentSize.width
+        val toDisplayRight = windowSize.width - popupContentSize.width
+        val toDisplayLeft = 0
+        val x = if (layoutDirection == LayoutDirection.Ltr) {
+            sequenceOf(toRight, toLeft, toDisplayRight)
+        } else {
+            sequenceOf(toLeft, toRight, toDisplayLeft)
+        }.firstOrNull {
+            it >= 0 && it + popupContentSize.width <= windowSize.width
+        } ?: toLeft
+
+        // Compute vertical position.
+        val toBottom = maxOf(anchorBounds.bottom + contentOffsetY, verticalMargin)
+        val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
+        val toCenter = anchorBounds.top - popupContentSize.height / 2
+        val toDisplayBottom = windowSize.height - popupContentSize.height - verticalMargin
+        var y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
+            it >= verticalMargin &&
+                it + popupContentSize.height <= windowSize.height - verticalMargin
+        } ?: toTop
+        
+        // Desktop specific vertical position checking
+        val aboveAnchor = anchorBounds.top + contentOffsetY
+        val belowAnchor = windowSize.height - anchorBounds.bottom + contentOffsetY
+
+        if (belowAnchor >= aboveAnchor) {
+            y = anchorBounds.bottom + contentOffsetY
+        }
+
+        onPositionCalculated(
+            anchorBounds,
+            IntRect(x, y, x + popupContentSize.width, y + popupContentSize.height)
+        )
+        return IntOffset(x, y)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import java.awt.MouseInfo
 import javax.swing.SwingUtilities.convertPointFromScreen
+import kotlin.math.max
 
 /**
  * Opens a popup with the given content.
@@ -194,8 +195,8 @@ private fun PopupLayout(
                     )
 
                     val layoutConstrants = constraints.copy(
-                        maxHeight = height - parentBounds.height,
-                        maxWidth = width - parentBounds.width
+                        maxHeight = max(height - position.y, position.y),
+                        maxWidth = max(width - position.x, position.x),
                     )
 
                     layout(constraints.maxWidth, constraints.maxHeight) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -186,19 +186,21 @@ private fun PopupLayout(
                 measurePolicy = { measurables, constraints ->
                     val width = constraints.maxWidth
                     val height = constraints.maxHeight
+                    var position = popupPositionProvider.calculatePosition(
+                        anchorBounds = parentBounds,
+                        windowSize = IntSize(width, height),
+                        layoutDirection = layoutDirection,
+                        popupContentSize = IntSize.Zero
+                    )
+
+                    val layoutConstrants = constraints.copy(
+                        maxHeight = height - parentBounds.height,
+                        maxWidth = width - parentBounds.width
+                    )
 
                     layout(constraints.maxWidth, constraints.maxHeight) {
                         measurables.forEach {
-                            var position = popupPositionProvider.calculatePosition(
-                                anchorBounds = parentBounds,
-                                windowSize = IntSize(width, height),
-                                layoutDirection = layoutDirection,
-                                popupContentSize = IntSize.Zero
-                            )
-                            // Vertically constraints correction
-                            val placeable = it.measure(constraints.copy(
-                                maxHeight = height - position.y
-                            ))
+                            val placeable = it.measure(layoutConstrants)
                             position = popupPositionProvider.calculatePosition(
                                 anchorBounds = parentBounds,
                                 windowSize = IntSize(width, height),

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.SkiaBasedOwner
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.setContent
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
@@ -188,14 +189,22 @@ private fun PopupLayout(
 
                     layout(constraints.maxWidth, constraints.maxHeight) {
                         measurables.forEach {
-                            val placeable = it.measure(constraints)
-                            val position = popupPositionProvider.calculatePosition(
+                            var position = popupPositionProvider.calculatePosition(
+                                anchorBounds = parentBounds,
+                                windowSize = IntSize(width, height),
+                                layoutDirection = layoutDirection,
+                                popupContentSize = IntSize.Zero
+                            )
+                            // Vertically constraints correction
+                            val placeable = it.measure(constraints.copy(
+                                maxHeight = height - position.y
+                            ))
+                            position = popupPositionProvider.calculatePosition(
                                 anchorBounds = parentBounds,
                                 windowSize = IntSize(width, height),
                                 layoutDirection = layoutDirection,
                                 popupContentSize = IntSize(placeable.width, placeable.height)
                             )
-
                             popupBounds = IntRect(
                                 position,
                                 IntSize(placeable.width, placeable.height)


### PR DESCRIPTION
 - added DesktopDropdownMenuPositionProvider to avoid incorrect size and position of DropdownMenu with many items
 see: https://github.com/JetBrains/compose-jb/issues/1388

Test: manual.
