### PR TITLE
Fix crash on key input if we have focused component that was destroyd when we scrolled LazyList

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/ModifiedFocusNode.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/ModifiedFocusNode.kt
@@ -43,6 +43,7 @@ internal class ModifiedFocusNode(
     override var modifier: FocusModifier
         get() = super.modifier
         set(value) {
+            clearFocusIfFocused()
             super.modifier = value
             value.focusNode = this
         }
@@ -82,6 +83,11 @@ internal class ModifiedFocusNode(
     }
 
     override fun detach() {
+        clearFocusIfFocused()
+        super.detach()
+    }
+
+    private fun clearFocusIfFocused() {
         when (focusState) {
             // If this node is focused, set the focus on the root layoutNode before removing it.
             Active, Captured -> {
@@ -113,7 +119,6 @@ internal class ModifiedFocusNode(
             // Do nothing, as the nextFocusNode is also Inactive.
             Inactive -> {}
         }
-        super.detach()
     }
 
     override fun findPreviousFocusWrapper() = this


### PR DESCRIPTION
LazyList internally uses ReusableContent, which reuses all created nodes after we need completely new composition.

Initial composition:
```
FocusModifier[hasChildFocused=true]
LayoutNode
  key 0
    ReusableContent // indicates that all child LayoutNode will be reused for the next new compositions (new compositions != recompositions)
      FocusModifier[isFocused=true] // won't be reused, as it is not a LayoutNode
      LayoutNode
```

Let's change key to 1:
```
FocusModifier[hasChildFocused=true] // reused
LayoutNode  // reused
  key 1 // change key, and recreate child composition, reusing previously created LayoutNode's
    ReusableContent
      FocusModifier[isFocused=false] // recreated
      LayoutNode // reused
```

This tree is inconsistent, as the root LayoutNode think that its child is focused. To fix that, we clear focus when we reuse LayoutNode, as we do on detach. To know if we reusing it, we just check if the new Modifier is applied to the node.

Fixes https://github.com/JetBrains/compose-jb/issues/937

Test 1:
```
import androidx.compose.foundation.background
import androidx.compose.foundation.focusable
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.size
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.runtime.ReusableContent
import androidx.compose.runtime.getValue
import androidx.compose.runtime.mutableStateOf
import androidx.compose.runtime.remember
import androidx.compose.runtime.setValue
import androidx.compose.ui.Modifier
import androidx.compose.ui.focus.FocusRequester
import androidx.compose.ui.focus.focusRequester
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.input.key.onKeyEvent
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication
import kotlinx.coroutines.delay

fun main() = singleWindowApplication {
    var num by remember { mutableStateOf(0) }
    val focusRequester = FocusRequester()

    ReusableContent(num) {
        Box(
            Modifier
                .focusRequester(focusRequester)
                .focusable()
                .size(300.dp)
                .background(Color.Red)
                .onKeyEvent {
                    println(it)
                    true
                }
        )
    }

    LaunchedEffect(Unit) {
        focusRequester.requestFocus()
        delay(2000)
        num++
    }
}
```

Test 2:
```
import androidx.compose.foundation.background
import androidx.compose.foundation.focusable
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.padding
import androidx.compose.foundation.layout.size
import androidx.compose.foundation.lazy.LazyColumn
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.ui.Modifier
import androidx.compose.ui.focus.FocusRequester
import androidx.compose.ui.focus.focusRequester
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.input.key.onKeyEvent
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication

fun main() = singleWindowApplication {
    LazyColumn {
        items(100) {
            val focusRequester = FocusRequester()

            Box(
                Modifier
                    .focusRequester(focusRequester)
                    .focusable()
                    .size(300.dp)
                    .padding(20.dp)
                    .background(Color.Red)
                    .onKeyEvent {
                        println(it)
                        true
                    }
            )

            if (it == 0) {
                LaunchedEffect(Unit) {
                    focusRequester.requestFocus()
                }
            }
        }
    }
}
```

Test: ./gradlew :compose:ui:ui:connectedCheck
Test: manual (see the snippets)