### PR TITLE
Remove "androidx.annotation:annotation" from desktop dependencies

### DIFF
--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -91,13 +91,14 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(libs.kotlinStdlib)
                 api(libs.kotlinStdlibCommon)
 
-                implementation("androidx.annotation:annotation:1.1.0")
+                compileOnly("androidx.annotation:annotation:1.1.0")
             }
 
             androidMain.dependencies {
                 api("androidx.activity:activity:1.2.0")
                 implementation "androidx.activity:activity-compose:1.3.0"
                 api("androidx.test.ext:junit:1.1.2")
+                implementation("androidx.annotation:annotation:1.1.0")
 
                 implementation(project(":compose:runtime:runtime-saveable"))
                 implementation("androidx.lifecycle:lifecycle-common:2.3.0")

--- a/compose/ui/ui-tooling-preview/build.gradle
+++ b/compose/ui/ui-tooling-preview/build.gradle
@@ -49,8 +49,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         sourceSets {
             commonMain.dependencies {
                 implementation(libs.kotlinStdlibCommon)
-                api("androidx.annotation:annotation:1.2.0")
                 api(project(":compose:runtime:runtime"))
+            }
+
+            androidMain.dependencies {
+                api("androidx.annotation:annotation:1.2.0")
             }
 
             androidMain.dependsOn(jvmMain)


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1186

Now we don't need `google()` repository, if we only need desktop target

Tested it on  0.0.0-feature-material3-build460