### PR TITLE
Fix horizontal scrollbar in Right-To-Left mode

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -53,8 +53,10 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
@@ -183,7 +185,7 @@ fun HorizontalScrollbar(
 ) = Scrollbar(
     adapter,
     modifier,
-    reverseLayout,
+    reverseLayout xor (LocalLayoutDirection.current == LayoutDirection.Rtl),
     style,
     interactionSource,
     isVertical = false


### PR DESCRIPTION
We officially don't support RTL for now, as we haven't test it.

But this small fix will help others, if they want to implement/test it themselves.

Fixes https://kotlinlang.slack.com/archives/C01D6HTPATV/p1635449056107800

Test:
1. take the snippet from [here](https://github.com/JetBrains/compose-jb/tree/master/tutorials/Desktop_Components#scrollbars)
2. wrap it into:
```
CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
  App()
}
```