### PR TITLE
Fix overflow in Identity collections (on Eclipse OpenJ9)

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayIntMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayIntMap.kt
@@ -170,10 +170,10 @@ internal class IdentityArrayIntMap {
         while (low <= high) {
             val mid = (low + high).ushr(1)
             val midVal = keys[mid]
-            val comparison = identityHashCode(midVal).toLong() - valueIdentity.toLong()
+            val midIdentity = identityHashCode(midVal)
             when {
-                comparison < 0 -> low = mid + 1
-                comparison > 0 -> high = mid - 1
+                midIdentity < valueIdentity -> low = mid + 1
+                midIdentity > valueIdentity -> high = mid - 1
                 midVal === key -> return mid
                 else -> return findExactIndex(mid, key, valueIdentity)
             }

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayIntMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayIntMap.kt
@@ -170,7 +170,7 @@ internal class IdentityArrayIntMap {
         while (low <= high) {
             val mid = (low + high).ushr(1)
             val midVal = keys[mid]
-            val comparison = identityHashCode(midVal) - valueIdentity
+            val comparison = identityHashCode(midVal).toLong() - valueIdentity.toLong()
             when {
                 comparison < 0 -> low = mid + 1
                 comparison > 0 -> high = mid - 1

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayMap.kt
@@ -148,7 +148,7 @@ internal class IdentityArrayMap<Key : Any, Value : Any?>(capacity: Int = 16) {
             val mid = (low + high).ushr(1)
             val midKey = keys[mid]
             val midKeyHash = identityHashCode(midKey)
-            val comparison = midKeyHash - keyIdentity
+            val comparison = midKeyHash.toLong() - keyIdentity.toLong()
             when {
                 comparison < 0 -> low = mid + 1
                 comparison > 0 -> high = mid - 1

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArrayMap.kt
@@ -148,10 +148,9 @@ internal class IdentityArrayMap<Key : Any, Value : Any?>(capacity: Int = 16) {
             val mid = (low + high).ushr(1)
             val midKey = keys[mid]
             val midKeyHash = identityHashCode(midKey)
-            val comparison = midKeyHash.toLong() - keyIdentity.toLong()
             when {
-                comparison < 0 -> low = mid + 1
-                comparison > 0 -> high = mid - 1
+                midKeyHash < keyIdentity -> low = mid + 1
+                midKeyHash > keyIdentity -> high = mid - 1
                 key === midKey -> return mid
                 else -> return findExactIndex(mid, key, keyIdentity)
             }

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArraySet.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArraySet.kt
@@ -172,7 +172,7 @@ internal class IdentityArraySet<T : Any> : Set<T> {
         while (low <= high) {
             val mid = (low + high).ushr(1)
             val midVal = get(mid)
-            val comparison = identityHashCode(midVal) - valueIdentity
+            val comparison = identityHashCode(midVal).toLong() - valueIdentity.toLong()
             when {
                 comparison < 0 -> low = mid + 1
                 comparison > 0 -> high = mid - 1

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArraySet.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityArraySet.kt
@@ -172,10 +172,10 @@ internal class IdentityArraySet<T : Any> : Set<T> {
         while (low <= high) {
             val mid = (low + high).ushr(1)
             val midVal = get(mid)
-            val comparison = identityHashCode(midVal).toLong() - valueIdentity.toLong()
+            val midIdentity = identityHashCode(midVal)
             when {
-                comparison < 0 -> low = mid + 1
-                comparison > 0 -> high = mid - 1
+                midIdentity < valueIdentity -> low = mid + 1
+                midIdentity > valueIdentity -> high = mid - 1
                 midVal === value -> return mid
                 else -> return findExactIndex(mid, value, valueIdentity)
             }

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityScopeMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityScopeMap.kt
@@ -253,10 +253,9 @@ internal class IdentityScopeMap<T : Any> {
             val mid = (low + high).ushr(1)
             val midValue = valueAt(mid)
             val midValHash = identityHashCode(midValue)
-            val comparison = midValHash.toLong() - valueIdentity.toLong()
             when {
-                comparison < 0 -> low = mid + 1
-                comparison > 0 -> high = mid - 1
+                midValHash < valueIdentity -> low = mid + 1
+                midValHash > valueIdentity -> high = mid - 1
                 value === midValue -> return mid
                 else -> return findExactIndex(mid, value, valueIdentity)
             }

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityScopeMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/collection/IdentityScopeMap.kt
@@ -253,7 +253,7 @@ internal class IdentityScopeMap<T : Any> {
             val mid = (low + high).ushr(1)
             val midValue = valueAt(mid)
             val midValHash = identityHashCode(midValue)
-            val comparison = midValHash - valueIdentity
+            val comparison = midValHash.toLong() - valueIdentity.toLong()
             when {
                 comparison < 0 -> low = mid + 1
                 comparison > 0 -> high = mid - 1


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/991

Eclipse OpenJ9 can return negative hashcodes (at least 15.0.2):
-1366493741
192407236

when we compare them, we can catch an overflow:
`-1366493741 - 1924072363` will be greater than 0

see https://github.com/eclipse-openj9/openj9/issues/3062

That leads to wrong behaviour of IdentityArraySet, and so of Recomposer:
```
alreadyComposed.add(composition)
println(alreadyComposed.contains(composition)) // will print `false`
```

The crash:
```
Caused by: java.lang.IllegalStateException: pending composition has not been applied
	at androidx.compose.runtime.CompositionImpl.drainPendingModificationsForCompositionLocked(Composition.kt:448)
	at androidx.compose.runtime.CompositionImpl.recompose(Composition.kt:635)
	at androidx.compose.runtime.Recomposer.performRecompose(Recomposer.kt:793)
	at androidx.compose.runtime.Recomposer.access$performRecompose(Recomposer.kt:106)
	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$2.invoke(Recomposer.kt:460)
	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$2.invoke(Recomposer.kt:426)
	at androidx.compose.desktop.examples.example1.TestClock.withFrameNanos(Main.jvm.kt:85)
	at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2.invokeSuspend(Recomposer.kt:426)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:853)
```

The reproducer:
```
import androidx.compose.runtime.AbstractApplier
import androidx.compose.runtime.Composable
import androidx.compose.runtime.Composition
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.runtime.MonotonicFrameClock
import androidx.compose.runtime.currentRecomposeScope
import androidx.compose.runtime.rememberCompositionContext
import androidx.compose.runtime.rememberUpdatedState
import androidx.compose.runtime.withRunningRecomposer
import kotlinx.coroutines.asCoroutineDispatcher
import kotlinx.coroutines.runBlocking
import kotlinx.coroutines.yield
import java.util.concurrent.Executors.newSingleThreadExecutor
import kotlin.random.Random

fun main() {
    runBlocking(newSingleThreadExecutor().asCoroutineDispatcher() + TestClock) {
        repeat(300) { num ->
            println("test $num")

            withRunningRecomposer {
                val composition = Composition(TestApplier, it)
                composition.setContent {
                    val scope = currentRecomposeScope
                    Test(Random.nextInt())
                    Test(Random.nextInt())
                    LaunchedEffect(Unit) {
                        scope.invalidate()
                    }
                }
                yield()
                yield()
            }
        }
    }
}

@Composable
fun Test(test: Int) {
    val latestContent = rememberUpdatedState(test)
    latestContent.value

    val parent = rememberCompositionContext()
    LaunchedEffect(Unit) {
        val composition1 = Composition(TestApplier, parent)
        composition1.setContent {
            latestContent.value
        }
        val composition2 = Composition(TestApplier, parent)
        composition2.setContent {
            latestContent.value
        }
    }
}

internal object TestApplier: AbstractApplier<Unit>(Unit) {
    override fun insertTopDown(index: Int, instance: Unit) = Unit
    override fun insertBottomUp(index: Int, instance: Unit) = Unit
    override fun remove(index: Int, count: Int) = Unit
    override fun move(from: Int, to: Int, count: Int) = Unit
    override fun onClear() = Unit
}

object TestClock : MonotonicFrameClock {
    override suspend fun <R> withFrameNanos(onFrame: (frameTimeNanos: Long) -> R): R {
        return onFrame(System.nanoTime())
    }
}
```

java --version:
```
openjdk 15.0.2 2021-01-19
OpenJDK Runtime Environment AdoptOpenJDK (build 15.0.2+7)
Eclipse OpenJ9 VM AdoptOpenJDK (build openj9-0.24.0, JRE 15 Linux amd64-64-Bit Compressed References 20210121_172 (JIT enabled, AOT enabled)
OpenJ9   - 345e1b09e
OMR      - 741e94ea8
JCL      - 863b523566 based on jdk-15.0.2+7)
```
OS: Ubuntu 20.0.4

Test: manual (see the reproducer)
Test: ./gradlew :compose:runtime:runtime:test (without the fix we have failing Identity*Test on this JDK)