### PR TITLE
Make MouseEvent.nativeEvent and KeyEvent.nativeKeyEvent as Any?

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.ui.awt.awtEvent
 import androidx.compose.ui.input.key.KeyEvent
 
 private fun Char.isPrintable(): Boolean {
@@ -27,5 +28,5 @@ private fun Char.isPrintable(): Boolean {
 }
 
 actual val KeyEvent.isTypedEvent: Boolean
-    get() = nativeKeyEvent.id == java.awt.event.KeyEvent.KEY_TYPED &&
-        nativeKeyEvent.keyChar.isPrintable()
+    get() = awtEvent.id == java.awt.event.KeyEvent.KEY_TYPED &&
+        awtEvent.keyChar.isPrintable()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.kt
@@ -1,0 +1,29 @@
+package androidx.compose.ui.awt
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerEvent
+
+
+// TODO(demin): new API, which is not merged to AOSP
+/**
+ * The original raw native event from AWT
+ */
+val PointerEvent.awtEvent: java.awt.event.MouseEvent get() {
+    require(nativeEvent is java.awt.event.MouseEvent) {
+        "nativeEvent was sent not by AWT. Make sure, that you use AWT backed API" +
+                " (from androidx.compose.ui.awt.* or from androidx.compose.ui.window.*)"
+    }
+    return nativeEvent
+}
+
+// TODO(demin): new API, which is not merged to AOSP
+/**
+ * The original raw native event from AWT
+ */
+val KeyEvent.awtEvent: java.awt.event.KeyEvent get() {
+    require(nativeKeyEvent is java.awt.event.KeyEvent) {
+        "nativeKeyEvent was sent not by AWT. Make sure, that you use AWT backed API" +
+                " (from androidx.compose.ui.awt.* or from androidx.compose.ui.window.*)"
+    }
+    return nativeKeyEvent
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/KeyEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/KeyEvent.desktop.kt
@@ -16,19 +16,20 @@
 
 package androidx.compose.ui.input.key
 
+import androidx.compose.ui.awt.awtEvent
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
 
 /**
  * The native desktop [KeyEvent][KeyEventAwt].
  */
-actual typealias NativeKeyEvent = java.awt.event.KeyEvent
+actual typealias NativeKeyEvent = Any
 
 /**
  * The key that was pressed.
  */
 actual val KeyEvent.key: Key
-    get() = Key(nativeKeyEvent.keyCode, nativeKeyEvent.keyLocation)
+    get() = Key(awtEvent.keyCode, awtEvent.keyLocation)
 
 /**
  * The UTF16 value corresponding to the key event that was pressed. The unicode character
@@ -47,13 +48,13 @@ actual val KeyEvent.key: Key
  * second from the low-surrogates range (\uDC00-\uDFFF).
  */
 actual val KeyEvent.utf16CodePoint: Int
-    get() = nativeKeyEvent.keyChar.code
+    get() = awtEvent.keyChar.code
 
 /**
  * The [type][KeyEventType] of key event.
  */
 actual val KeyEvent.type: KeyEventType
-    get() = when (nativeKeyEvent.id) {
+    get() = when (awtEvent.id) {
         KEY_PRESSED -> KeyEventType.KeyDown
         KEY_RELEASED -> KeyEventType.KeyUp
         else -> KeyEventType.Unknown
@@ -63,22 +64,22 @@ actual val KeyEvent.type: KeyEventType
  * Indicates whether the Alt key is pressed.
  */
 actual val KeyEvent.isAltPressed: Boolean
-    get() = nativeKeyEvent.isAltDown || nativeKeyEvent.isAltGraphDown
+    get() = awtEvent.isAltDown || awtEvent.isAltGraphDown
 
 /**
  * Indicates whether the Ctrl key is pressed.
  */
 actual val KeyEvent.isCtrlPressed: Boolean
-    get() = nativeKeyEvent.isControlDown
+    get() = awtEvent.isControlDown
 
 /**
  * Indicates whether the Meta key is pressed.
  */
 actual val KeyEvent.isMetaPressed: Boolean
-    get() = nativeKeyEvent.isMetaDown
+    get() = awtEvent.isMetaDown
 
 /**
  * Indicates whether the Shift key is pressed.
  */
 actual val KeyEvent.isShiftPressed: Boolean
-    get() = nativeKeyEvent.isShiftDown
+    get() = awtEvent.isShiftDown

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.desktop.kt
@@ -34,11 +34,22 @@ actual data class PointerEvent internal constructor(
      */
     actual val changes: List<PointerInputChange>,
 
+    // TODO(demin): new API, which is not merged to AOSP
     /**
-     * Original raw native event from AWT
+     * The original raw native event which is sent by the platform.
      */
-    val mouseEvent: MouseEvent?
+    val nativeEvent: Any?
 ) {
+    /**
+     * The original raw native event from AWT
+     */
+    @Deprecated(
+        "Use androidx.compose.ui.awt.awtEvent",
+        replaceWith = ReplaceWith("awtEvent", "androidx.compose.ui.awt.awtEvent"
+        )
+    )
+    val mouseEvent: MouseEvent? get() = nativeEvent as MouseEvent?
+
     internal actual constructor(
         changes: List<PointerInputChange>,
         internalPointerEvent: InternalPointerEvent?
@@ -53,7 +64,7 @@ actual data class PointerEvent internal constructor(
     /**
      * @param changes The changes.
      */
-    actual constructor(changes: List<PointerInputChange>) : this(changes, mouseEvent = null)
+    actual constructor(changes: List<PointerInputChange>) : this(changes, nativeEvent = null)
 
     actual var type: PointerEventType = PointerEventType.Unknown
         internal set

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopOwner.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopOwner.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.awtEvent
 import androidx.compose.ui.input.key.KeyInputModifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -31,7 +32,7 @@ internal actual fun sendKeyEvent(
     keyEvent: KeyEvent
 ): Boolean {
     when {
-        keyEvent.nativeKeyEvent.id == java.awt.event.KeyEvent.KEY_TYPED ->
+        keyEvent.awtEvent.id == java.awt.event.KeyEvent.KEY_TYPED ->
             platformInputService.charKeyPressed = true
         keyEvent.type == KeyEventType.KeyUp ->
             platformInputService.charKeyPressed = false


### PR DESCRIPTION
Also introduce extensions, which should be used by the users, if they need interop with AWT:
val PointerEvent.awtEvent: java.awt.event.MouseEvent
val KeyEvent.awtEvent: java.awt.event.KeyEvent

We don't yet support non-awt events, as we cast to it internally, but we can do it in the future, when we get rid of this casting.

Make https://github.com/JetBrains/compose-jb/issues/1348 irrelevant.
We can introduce new types in the future.

I don't want to mark it experimental because:
- these types can be used in libraries, it is better if make them backward compatible
- the current PR proposal covers all known cases for our future API
- this API looks pretty simple to write fallback, if we deprecate them someday