### PR TITLE
Remove pointerId from ComposeScene

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -301,12 +301,11 @@ class WindowInputEventTest {
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)
 
-        // TODO(https://github.com/JetBrains/compose-jb/issues/1176) fix catching exit event
-//        window.sendMouseEvent(MouseEvent.MOUSE_EXITED, x = 900, y = 500)
-//        awaitIdle()
-//        assertThat(onMoves.size).isEqualTo(2)
-//        assertThat(onEnters).isEqualTo(1)
-//        assertThat(onExits).isEqualTo(1)
+        window.sendMouseEvent(MouseEvent.MOUSE_EXITED, x = 900, y = 500)
+        awaitIdle()
+        assertThat(onMoves.size).isEqualTo(2)
+        assertThat(onEnters).isEqualTo(1)
+        assertThat(onExits).isEqualTo(1)
 
         exitApplication()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -140,7 +140,6 @@ class ComposeScene internal constructor(
      */
     val roots: Set<RootForTest> get() = list
 
-    private var pointerId = 0L
     private var isMousePressed = false
 
     private val job = Job()
@@ -391,7 +390,7 @@ class ComposeScene internal constructor(
             PointerEventType.Release -> isMousePressed = false
         }
         val event = pointerInputEvent(
-            eventType, position, timeMillis, nativeEvent, type, isMousePressed, pointerId
+            eventType, position, timeMillis, nativeEvent, type, isMousePressed, pointerId = 0
         )
         when (eventType) {
             PointerEventType.Press -> onMousePressed(event)
@@ -463,7 +462,6 @@ class ComposeScene internal constructor(
         val owner = (mousePressOwner ?: hoveredOwner) ?: focusedOwner
         owner?.processPointerInput(event)
         mousePressOwner = null
-        pointerId += 1
     }
 
     private var pointLocation = Offset.Zero


### PR DESCRIPTION
pointerId was indroduced in https://android-review.googlesource.com/c/platform/frameworks/support/+/1402607, because double click didn't work (see https://jetbrains.slack.com/archives/GT449QBCK/p1597328095373000)

But it messes with hover and clicking multiple mouse buttons at the same time.

Double clicking still works after removing it:
```
import androidx.compose.foundation.ExperimentalFoundationApi
import androidx.compose.foundation.background
import androidx.compose.foundation.combinedClickable
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.size
import androidx.compose.ui.Modifier
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication

@OptIn(ExperimentalFoundationApi::class)
fun main() = singleWindowApplication {
    Box(
        Modifier
        .size(300.dp)
        .background(Color.Red)
            .combinedClickable(onDoubleClick = {
                println("onDoubleClick")
            }, onClick = {
                println("onClick")
            })
    ) {
    }
}
```

Fixes https://github.com/JetBrains/compose-jb/issues/1176

Test: ./gradlew jvmTest desktopTest -Pandroidx.compose.multiplatformEnabled=true
Test: manual (see the snippet)