### PR TITLE
Revert "Remove pointerId from ComposeScene"

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -301,11 +301,12 @@ class WindowInputEventTest {
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)
 
-        window.sendMouseEvent(MouseEvent.MOUSE_EXITED, x = 900, y = 500)
-        awaitIdle()
-        assertThat(onMoves.size).isEqualTo(2)
-        assertThat(onEnters).isEqualTo(1)
-        assertThat(onExits).isEqualTo(1)
+        // TODO(https://github.com/JetBrains/compose-jb/issues/1176) fix catching exit event
+//        window.sendMouseEvent(MouseEvent.MOUSE_EXITED, x = 900, y = 500)
+//        awaitIdle()
+//        assertThat(onMoves.size).isEqualTo(2)
+//        assertThat(onEnters).isEqualTo(1)
+//        assertThat(onExits).isEqualTo(1)
 
         exitApplication()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -140,6 +140,7 @@ class ComposeScene internal constructor(
      */
     val roots: Set<RootForTest> get() = list
 
+    private var pointerId = 0L
     private var isMousePressed = false
 
     private val job = Job()
@@ -390,7 +391,7 @@ class ComposeScene internal constructor(
             PointerEventType.Release -> isMousePressed = false
         }
         val event = pointerInputEvent(
-            eventType, position, timeMillis, nativeEvent, type, isMousePressed, pointerId = 0
+            eventType, position, timeMillis, nativeEvent, type, isMousePressed, pointerId
         )
         when (eventType) {
             PointerEventType.Press -> onMousePressed(event)
@@ -462,6 +463,7 @@ class ComposeScene internal constructor(
         val owner = (mousePressOwner ?: hoveredOwner) ?: focusedOwner
         owner?.processPointerInput(event)
         mousePressOwner = null
+        pointerId += 1
     }
 
     private var pointLocation = Offset.Zero


### PR DESCRIPTION
I was wrong, we need it. Scrollbar behaves weird in some situations.

Will fix another way in the next PR.