### PR TITLE
Get rid of mousePressed from ComposeScene

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
@@ -94,6 +94,8 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIconDefaults
+import androidx.compose.ui.input.pointer.isBackPressed
+import androidx.compose.ui.input.pointer.isForwardPressed
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalUriHandler
@@ -389,6 +391,9 @@ private fun FrameWindowScope.ScrollableContent(scrollState: ScrollState) {
                             append("primary: ${buttons.isPrimaryPressed}\t")
                             append("secondary: ${buttons.isSecondaryPressed}\t")
                             append("tertiary: ${buttons.isTertiaryPressed}\t")
+                            append("primary: ${buttons.isPrimaryPressed}\t")
+                            append("back: ${buttons.isBackPressed}\t")
+                            append("forward: ${buttons.isForwardPressed}\t")
 
                             append("\n\nKeyboard modifiers pressed:\n")
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeScene.desktop.kt
@@ -16,11 +16,16 @@
 package androidx.compose.ui
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventData
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.areAnyPressed
+import androidx.compose.ui.input.pointer.indexOfFirstPressed
+import androidx.compose.ui.input.pointer.indexOfLastPressed
 import androidx.compose.ui.platform.AccessibilityController
 import androidx.compose.ui.platform.AccessibilityControllerImpl
 import androidx.compose.ui.platform.PlatformComponent
@@ -50,8 +55,9 @@ internal actual fun pointerInputEvent(
     timeMillis: Long,
     nativeEvent: Any?,
     type: PointerType,
-    isMousePressed: Boolean,
-    pointerId: Long
+    pointerId: Long,
+    buttons: PointerButtons,
+    keyboardModifiers: PointerKeyboardModifiers,
 ): PointerInputEvent {
     return PointerInputEvent(
         eventType,
@@ -62,10 +68,12 @@ internal actual fun pointerInputEvent(
                 timeMillis,
                 position,
                 position,
-                isMousePressed,
+                buttons.areAnyPressed,
                 type
             )
         ),
+        buttons,
+        keyboardModifiers,
         nativeEvent as MouseEvent?
     )
 }
@@ -74,3 +82,12 @@ internal actual fun makeAccessibilityController(
     skiaBasedOwner: SkiaBasedOwner,
     component: PlatformComponent
 ): AccessibilityController = AccessibilityControllerImpl(skiaBasedOwner, component)
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual val DefaultPointerButtons: PointerButtons = PointerButtons()
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual val DefaultPointerKeyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers()
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual val PrimaryPressedPointerButtons: PointerButtons = PointerButtons(isPrimaryPressed = true)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.mouse.MouseScrollOrientation
 import androidx.compose.ui.input.mouse.MouseScrollUnit
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.platform.setContent
@@ -185,6 +187,9 @@ class ImageComposeScene(
      * is platform-dependent.
      * @param type The device type that produced the event, such as [mouse][PointerType.Mouse],
      * or [touch][PointerType.Touch].
+     * @param buttons Contains the state of pointer buttons (e.g. mouse and stylus buttons).
+     * @param keyboardModifiers Contains the state of modifier keys, such as Shift, Control, and Alt, as well as the state
+     * of the lock keys, such as Caps Lock and Num Lock.
      * @param mouseEvent The original native event.
      */
     @OptIn(ExperimentalComposeUiApi::class)
@@ -193,9 +198,11 @@ class ImageComposeScene(
         position: Offset,
         timeMillis: Long = System.nanoTime() / 1_000_000L,
         type: PointerType = PointerType.Mouse,
+        buttons: PointerButtons? = null,
+        keyboardModifiers: PointerKeyboardModifiers? = null,
         mouseEvent: MouseEvent? = null
     ): Unit = scene.sendPointerEvent(
-        eventType, position, timeMillis, type, mouseEvent
+        eventType, position, timeMillis, type, buttons, keyboardModifiers, mouseEvent
     )
 
     // TODO(demin): remove/change when we will have scroll event support in the common code
@@ -214,6 +221,9 @@ class ImageComposeScene(
      * is platform-dependent.
      * @param type The device type that produced the event, such as [mouse][PointerType.Mouse],
      * or [touch][PointerType.Touch].
+     * @param buttons Contains the state of pointer buttons (e.g. mouse and stylus buttons).
+     * @param keyboardModifiers Contains the state of modifier keys, such as Shift, Control, and Alt, as well as the state
+     * of the lock keys, such as Caps Lock and Num Lock.
      * @param mouseEvent The original native event
      */
     @OptIn(ExperimentalComposeUiApi::class)
@@ -225,11 +235,11 @@ class ImageComposeScene(
         orientation: MouseScrollOrientation = MouseScrollOrientation.Vertical,
         timeMillis: Long = System.nanoTime() / 1_000_000L,
         type: PointerType = PointerType.Mouse,
+        buttons: PointerButtons? = null,
+        keyboardModifiers: PointerKeyboardModifiers? = null,
         mouseEvent: MouseEvent? = null,
-//        buttons: PointerButtons? = null,
-//        keyboardModifiers: PointerKeyboardModifiers? = null,
     ): Unit = scene.sendPointerScrollEvent(
-        position, delta, orientation, timeMillis, type, mouseEvent
+        position, delta, orientation, timeMillis, type, buttons, keyboardModifiers, mouseEvent
     )
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/InternalPointerEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/InternalPointerEvent.desktop.kt
@@ -21,6 +21,8 @@ import java.awt.event.MouseEvent
 internal actual class InternalPointerEvent constructor(
     val type: PointerEventType,
     actual val changes: Map<PointerId, PointerInputChange>,
+    val buttons: PointerButtons,
+    val keyboardModifiers: PointerKeyboardModifiers,
     val mouseEvent: MouseEvent?
 ) {
     actual constructor(
@@ -29,6 +31,8 @@ internal actual class InternalPointerEvent constructor(
     ) : this(
         pointerInputEvent.eventType,
         changes,
+        pointerInputEvent.buttons,
+        pointerInputEvent.keyboardModifiers,
         pointerInputEvent.mouseEvent
     )
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.desktop.kt
@@ -16,14 +16,55 @@
 
 package androidx.compose.ui.input.pointer
 
-import androidx.compose.ui.platform.DesktopPlatform
-import java.awt.event.InputEvent
-import java.awt.event.KeyEvent
+import androidx.compose.ui.ExperimentalComposeUiApi
 import java.awt.event.MouseEvent
-import java.awt.Toolkit
 
 internal actual typealias NativePointerButtons = Int
 internal actual typealias NativePointerKeyboardModifiers = Int
+
+@ExperimentalComposeUiApi
+fun PointerButtons(
+    isPrimaryPressed: Boolean = false,
+    isSecondaryPressed: Boolean = false,
+    isTertiaryPressed: Boolean = false,
+    isBackPressed: Boolean = false,
+    isForwardPressed: Boolean = false
+): PointerButtons {
+    var res = 0
+    if (isPrimaryPressed) res = res or ButtonMasks.Primary
+    if (isSecondaryPressed) res = res or ButtonMasks.Secondary
+    if (isTertiaryPressed) res = res or ButtonMasks.Tertiary
+    if (isBackPressed) res = res or ButtonMasks.Back
+    if (isForwardPressed) res = res or ButtonMasks.Forward
+    return PointerButtons(res)
+}
+
+@ExperimentalComposeUiApi
+fun PointerKeyboardModifiers(
+    isCtrlPressed: Boolean = false,
+    isMetaPressed: Boolean = false,
+    isAltPressed: Boolean = false,
+    isShiftPressed: Boolean = false,
+    isAltGraphPressed: Boolean = false,
+    isSymPressed: Boolean = false,
+    isFunctionPressed: Boolean = false,
+    isCapsLockOn: Boolean = false,
+    isScrollLockOn: Boolean = false,
+    isNumLockOn: Boolean = false,
+): PointerKeyboardModifiers {
+    var res = 0
+    if (isCtrlPressed) res = res or KeyboardModifierMasks.CtrlPressed
+    if (isMetaPressed) res = res or KeyboardModifierMasks.MetaPressed
+    if (isAltPressed) res = res or KeyboardModifierMasks.AltPressed
+    if (isShiftPressed) res = res or KeyboardModifierMasks.ShiftPressed
+    if (isAltGraphPressed) res = res or KeyboardModifierMasks.AltGraphPressed
+    if (isSymPressed) res = res or KeyboardModifierMasks.SymPressed
+    if (isFunctionPressed) res = res or KeyboardModifierMasks.FunctionPressed
+    if (isCapsLockOn) res = res or KeyboardModifierMasks.CapsLockOn
+    if (isScrollLockOn) res = res or KeyboardModifierMasks.ScrollLockOn
+    if (isNumLockOn) res = res or KeyboardModifierMasks.NumLockOn
+    return PointerKeyboardModifiers(res)
+}
 
 /**
  * Describes a pointer input change event that has occurred at a particular point in time.
@@ -33,6 +74,10 @@ actual data class PointerEvent internal constructor(
      * The changes.
      */
     actual val changes: List<PointerInputChange>,
+
+    actual val buttons: PointerButtons,
+
+    actual val keyboardModifiers: PointerKeyboardModifiers,
 
     // TODO(demin): new API, which is not merged to AOSP
     /**
@@ -53,100 +98,63 @@ actual data class PointerEvent internal constructor(
     internal actual constructor(
         changes: List<PointerInputChange>,
         internalPointerEvent: InternalPointerEvent?
-    ) : this(changes, internalPointerEvent?.mouseEvent) {
+    ) : this(
+        changes,
+        internalPointerEvent?.buttons ?: PointerButtons(0),
+        internalPointerEvent?.keyboardModifiers ?: PointerKeyboardModifiers(0),
+        internalPointerEvent?.mouseEvent
+    ) {
         this.type = internalPointerEvent?.type ?: PointerEventType.Unknown
     }
-
-    actual val buttons = PointerButtons(mouseEvent?.modifiersEx ?: 0)
-
-    actual val keyboardModifiers = createPointerKeyboardModifiers(mouseEvent?.modifiersEx ?: 0)
 
     /**
      * @param changes The changes.
      */
-    actual constructor(changes: List<PointerInputChange>) : this(changes, nativeEvent = null)
+    actual constructor(changes: List<PointerInputChange>) : this(
+        changes,
+        buttons = PointerButtons(0),
+        keyboardModifiers = PointerKeyboardModifiers(0),
+        nativeEvent = null
+    )
 
     actual var type: PointerEventType = PointerEventType.Unknown
         internal set
-
-    private fun createPointerKeyboardModifiers(modifiersEx: Int): PointerKeyboardModifiers {
-        val toolkit = Toolkit.getDefaultToolkit()
-        val capsLockBits = toolkit.getMaskForLockingKeyState(KeyEvent.VK_CAPS_LOCK, CapsLockMask)
-        val numLockBits = toolkit.getMaskForLockingKeyState(KeyEvent.VK_NUM_LOCK, NumLockMask)
-        val scrollLockBits =
-            toolkit.getMaskForLockingKeyState(KeyEvent.VK_SCROLL_LOCK, ScrollLockMask)
-
-        val packed = (modifiersEx and ClearMask) or capsLockBits or numLockBits or scrollLockBits
-        return PointerKeyboardModifiers(packed)
-    }
 }
 
-private fun Toolkit.getMaskForLockingKeyState(event: Int, mask: Int): Int {
-    return try {
-        if (getLockingKeyState(event)) {
-            mask
-        } else {
-            0
-        }
-    } catch (_: Exception) {
-        0
-    }
+private object ButtonMasks {
+    const val Primary = 1 shl 0
+    const val Secondary = 1 shl 1
+    const val Tertiary = 1 shl 2
+    const val Back = 1 shl 3
+    const val Forward = 1 shl 4
 }
 
-/**
- * Coopt the BUTTON1_DOWN_MASK for caps lock state in PointerKeyboardModifiers
- */
-private const val CapsLockMask = InputEvent.BUTTON1_DOWN_MASK
-/**
- * Coopt the BUTTON2_DOWN_MASK for scroll lock state in PointerKeyboardModifiers
- */
-private const val ScrollLockMask = InputEvent.BUTTON2_DOWN_MASK
-/**
- * Coopt the BUTTON3_DOWN_MASK for num lock state in PointerKeyboardModifiers
- */
-private const val NumLockMask = InputEvent.BUTTON3_DOWN_MASK
-
-/**
- * Clear mask for all coopted values. We don't want button state to interfere with keyboard
- * state.
- */
-private const val ClearMask = (
-    InputEvent.BUTTON1_DOWN_MASK or
-        InputEvent.BUTTON2_DOWN_MASK or
-        InputEvent.BUTTON3_DOWN_MASK
-    ).inv()
-
-private val PointerButtons.isMacOsCtrlClick
-    get() = (
-        DesktopPlatform.Current == DesktopPlatform.MacOS &&
-            ((packedValue and InputEvent.BUTTON1_DOWN_MASK) != 0) &&
-            ((packedValue and InputEvent.CTRL_DOWN_MASK) != 0)
-        )
-
+private object KeyboardModifierMasks {
+    const val CtrlPressed = 1 shl 0
+    const val MetaPressed = 1 shl 1
+    const val AltPressed = 1 shl 2
+    const val AltGraphPressed = 1 shl 3
+    const val SymPressed = 1 shl 4
+    const val ShiftPressed = 1 shl 5
+    const val FunctionPressed = 1 shl 6
+    const val CapsLockOn = 1 shl 7
+    const val ScrollLockOn = 1 shl 8
+    const val NumLockOn = 1 shl 9
+}
 actual val PointerButtons.isPrimaryPressed
-    get() = (packedValue and InputEvent.BUTTON1_DOWN_MASK) != 0 && !isMacOsCtrlClick
+    get() = (packedValue and ButtonMasks.Primary) != 0
 
 actual val PointerButtons.isSecondaryPressed: Boolean
-    get() = ((packedValue and InputEvent.BUTTON3_DOWN_MASK) != 0) || isMacOsCtrlClick
+    get() = ((packedValue and ButtonMasks.Secondary) != 0)
 
 actual val PointerButtons.isTertiaryPressed: Boolean
-    get() = (packedValue and InputEvent.BUTTON2_DOWN_MASK) != 0
-
-/**
- * Bit mask for back button.
- */
-private const val BackMask = 1 shl 14
-
-/**
- * Bit mask for forward button.
- */
-private const val ForwardMask = 1 shl 15
+    get() = (packedValue and ButtonMasks.Tertiary) != 0
 
 actual val PointerButtons.isBackPressed: Boolean
-    get() = packedValue and BackMask != 0
+    get() = packedValue and ButtonMasks.Back != 0
 
 actual val PointerButtons.isForwardPressed: Boolean
-    get() = packedValue and ForwardMask != 0
+    get() = packedValue and ButtonMasks.Forward != 0
 
 actual fun PointerButtons.isPressed(buttonIndex: Int): Boolean =
     when (buttonIndex) {
@@ -158,11 +166,8 @@ actual fun PointerButtons.isPressed(buttonIndex: Int): Boolean =
         else -> false
     }
 
-private const val AnyButtonMask =
-    InputEvent.BUTTON1_DOWN_MASK or InputEvent.BUTTON2_DOWN_MASK or InputEvent.BUTTON3_DOWN_MASK
-
 actual val PointerButtons.areAnyPressed: Boolean
-    get() = (packedValue and AnyButtonMask) != 0
+    get() = isPrimaryPressed || isSecondaryPressed || isTertiaryPressed || isBackPressed || isForwardPressed
 
 actual fun PointerButtons.indexOfFirstPressed(): Int = when {
     isPrimaryPressed -> 0
@@ -183,31 +188,31 @@ actual fun PointerButtons.indexOfLastPressed(): Int = when {
 }
 
 actual val PointerKeyboardModifiers.isCtrlPressed: Boolean
-    get() = (packedValue and InputEvent.CTRL_DOWN_MASK) != 0
+    get() = (packedValue and KeyboardModifierMasks.CtrlPressed) != 0
 
 actual val PointerKeyboardModifiers.isMetaPressed: Boolean
-    get() = (packedValue and InputEvent.META_DOWN_MASK) != 0
+    get() = (packedValue and KeyboardModifierMasks.MetaPressed) != 0
 
 actual val PointerKeyboardModifiers.isAltPressed: Boolean
-    get() = (packedValue and InputEvent.ALT_DOWN_MASK) != 0
+    get() = (packedValue and KeyboardModifierMasks.AltPressed) != 0
 
 actual val PointerKeyboardModifiers.isAltGraphPressed: Boolean
-    get() = (packedValue and InputEvent.ALT_GRAPH_DOWN_MASK) != 0
+    get() = (packedValue and KeyboardModifierMasks.AltGraphPressed) != 0
 
 actual val PointerKeyboardModifiers.isSymPressed: Boolean
-    get() = false
+    get() = (packedValue and KeyboardModifierMasks.SymPressed) != 0
 
 actual val PointerKeyboardModifiers.isShiftPressed: Boolean
-    get() = (packedValue and InputEvent.SHIFT_DOWN_MASK) != 0
+    get() = (packedValue and KeyboardModifierMasks.ShiftPressed) != 0
 
 actual val PointerKeyboardModifiers.isFunctionPressed: Boolean
-    get() = false
+    get() = (packedValue and KeyboardModifierMasks.FunctionPressed) != 0
 
 actual val PointerKeyboardModifiers.isCapsLockOn: Boolean
-    get() = (packedValue and CapsLockMask) != 0
+    get() = (packedValue and KeyboardModifierMasks.CapsLockOn) != 0
 
 actual val PointerKeyboardModifiers.isScrollLockOn: Boolean
-    get() = (packedValue and ScrollLockMask) != 0
+    get() = (packedValue and KeyboardModifierMasks.ScrollLockOn) != 0
 
 actual val PointerKeyboardModifiers.isNumLockOn: Boolean
-    get() = (packedValue and NumLockMask) != 0
+    get() = (packedValue and KeyboardModifierMasks.NumLockOn) != 0

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.desktop.kt
@@ -22,5 +22,7 @@ internal actual class PointerInputEvent(
     val eventType: PointerEventType,
     actual val uptime: Long,
     actual val pointers: List<PointerInputEventData>,
+    val buttons: PointerButtons = PointerButtons(0),
+    val keyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers(0),
     val mouseEvent: MouseEvent? = null
 )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -227,13 +227,13 @@ class WindowInputEventTest {
         awaitIdle()
         assertThat(events.size).isEqualTo(0)
 
-        window.sendMouseEvent(MouseEvent.MOUSE_PRESSED, x = 100, y = 50)
+        window.sendMouseEvent(MouseEvent.MOUSE_PRESSED, x = 100, y = 50, modifiers = MouseEvent.BUTTON1_DOWN_MASK)
         awaitIdle()
         assertThat(events.size).isEqualTo(1)
         assertThat(events.last().pressed).isEqualTo(true)
         assertThat(events.last().position).isEqualTo(Offset(100 * density, 50 * density))
 
-        window.sendMouseEvent(MouseEvent.MOUSE_DRAGGED, x = 90, y = 40)
+        window.sendMouseEvent(MouseEvent.MOUSE_DRAGGED, x = 90, y = 40, modifiers = MouseEvent.BUTTON1_DOWN_MASK)
         awaitIdle()
         assertThat(events.size).isEqualTo(2)
         assertThat(events.last().pressed).isEqualTo(true)
@@ -292,8 +292,8 @@ class WindowInputEventTest {
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)
 
-        window.sendMouseEvent(MouseEvent.MOUSE_PRESSED, x = 90, y = 50)
-        window.sendMouseEvent(MouseEvent.MOUSE_DRAGGED, x = 80, y = 50)
+        window.sendMouseEvent(MouseEvent.MOUSE_PRESSED, x = 90, y = 50, modifiers = MouseEvent.BUTTON1_DOWN_MASK)
+        window.sendMouseEvent(MouseEvent.MOUSE_DRAGGED, x = 80, y = 50, modifiers = MouseEvent.BUTTON1_DOWN_MASK)
         window.sendMouseEvent(MouseEvent.MOUSE_RELEASED, x = 80, y = 50)
         awaitIdle()
         assertThat(onMoves.size).isEqualTo(2)


### PR DESCRIPTION
mousePressed is unreliable on Windows (we can miss the release event), and doesn't work well with multiple buttons.

After this fix, mouseClickable only reacts to the first pressed button. Right button click doesn't trigger callback, if there is already left mouse button is pressed.

`Clickable` shouldn't be able to handle these cases. If users would want simultaneously handle multiple buttons, they have to use low-level api:
```
Modifier.pointerInput(Unit) {
    while (true) {
        val event = awaitPointerEventScope { awaitPointerEvent() }

        if (event.type == PointerEventType.Press && event.buttons.isPrimaryPressed) {
            // do something
        } else if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed) {
            // do something
        }
    }
}
```
(it is verbose, there is a field for improvement)

Also pass PointerButtons and PointerKeyboardModifiers to ComposeScene, instead of reading them from AWT event.

Test: ./gradlew jvmTest desktopTest -Pandroidx.compose.multiplatformEnabled=true
Test: the snippet from https://github.com/JetBrains/compose-jb/issues/1149, because changed the code for that fix