### PR TITLE
Pointer Icon fixes

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -80,8 +80,7 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
         if (pointerIconService == null) {
             Modifier
         } else {
-            var coordinates: LayoutCoordinates? = null
-            this.onGloballyPositioned { coordinates = it }.pointerInput(icon, overrideDescendants) {
+            this.pointerInput(icon, overrideDescendants) {
                 awaitPointerEventScope {
                     while (true) {
                         val pass = if (overrideDescendants)
@@ -90,12 +89,7 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                             PointerEventPass.Initial
                         val event = awaitPointerEvent(pass)
                         val isOutsideRelease = event.type == PointerEventType.Release &&
-                            coordinates?.size?.let {
-                                event.changes[0].isOutOfBounds(
-                                    it,
-                                    Size.Zero
-                                )
-                            } == true
+                            event.changes[0].isOutOfBounds(size, Size.Zero)
                         if (event.type != PointerEventType.Exit && !isOutsideRelease) {
                             pointerIconService.current = icon
                         }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -19,6 +19,9 @@ package androidx.compose.ui.input.pointer
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInParent
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalPointerIconService
 import androidx.compose.ui.platform.debugInspectorInfo
 
@@ -73,7 +76,8 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
         if (pointerIconService == null) {
             Modifier
         } else {
-            this.pointerInput(icon, overrideDescendants) {
+            var coordinates: LayoutCoordinates? = null
+            this.onGloballyPositioned { coordinates = it }.pointerInput(icon, overrideDescendants) {
                 awaitPointerEventScope {
                     while (true) {
                         val pass = if (overrideDescendants)
@@ -81,7 +85,9 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                         else
                             PointerEventPass.Initial
                         val event = awaitPointerEvent(pass)
-                        if (event.type != PointerEventType.Exit) {
+                        if (event.type != PointerEventType.Exit &&
+                            coordinates?.boundsInParent()?.contains(event.changes[0].position) == true
+                        ) {
                             pointerIconService.current = icon
                         }
                     }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -81,10 +81,8 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                         else
                             PointerEventPass.Initial
                         val event = awaitPointerEvent(pass)
-                        when (event.type) {
-                            PointerEventType.Enter, PointerEventType.Move -> {
-                                pointerIconService.current = icon
-                            }
+                        if (event.type != PointerEventType.Exit) {
+                            pointerIconService.current = icon
                         }
                     }
                 }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -85,9 +85,8 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                         else
                             PointerEventPass.Initial
                         val event = awaitPointerEvent(pass)
-                        if (event.type != PointerEventType.Exit &&
-                            coordinates?.boundsInParent()?.contains(event.changes[0].position) == true
-                        ) {
+                        val isOutsideRelease = event.type == PointerEventType.Release && coordinates?.boundsInParent()?.contains(event.changes[0].position) == false
+                        if (event.type != PointerEventType.Exit && !isOutsideRelease) {
                             pointerIconService.current = icon
                         }
                     }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.input.pointer
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -41,10 +42,13 @@ interface PointerIcon
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal expect val pointerIconDefault: PointerIcon
+
 @OptIn(ExperimentalComposeUiApi::class)
 internal expect val pointerIconCrosshair: PointerIcon
+
 @OptIn(ExperimentalComposeUiApi::class)
 internal expect val pointerIconText: PointerIcon
+
 @OptIn(ExperimentalComposeUiApi::class)
 internal expect val pointerIconHand: PointerIcon
 
@@ -85,7 +89,13 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                         else
                             PointerEventPass.Initial
                         val event = awaitPointerEvent(pass)
-                        val isOutsideRelease = event.type == PointerEventType.Release && coordinates?.boundsInParent()?.contains(event.changes[0].position) == false
+                        val isOutsideRelease = event.type == PointerEventType.Release &&
+                            coordinates?.size?.let {
+                                event.changes[0].isOutOfBounds(
+                                    it,
+                                    Size.Zero
+                                )
+                            } == true
                         if (event.type != PointerEventType.Exit && !isOutsideRelease) {
                             pointerIconService.current = icon
                         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -70,7 +70,7 @@ internal class ComposeLayer {
     private val _component = ComponentImpl()
     val component: SkiaLayer get() = _component
 
-    private val scene = ComposeScene(
+    internal val scene = ComposeScene(
         Dispatchers.Swing,
         _component,
         Density(1f),
@@ -123,11 +123,15 @@ internal class ComposeLayer {
         }
 
         override fun getInputMethodRequests() = currentInputMethodRequests
-        override var componentCursor: Cursor
-            get() = super.getCursor()
-            set(value) {
-                super.setCursor(value)
-            }
+        private var _desiredCursor: Cursor? = null
+        override var desiredCursor: Cursor
+            get() = _desiredCursor ?: super.getCursor()
+            set(value) { _desiredCursor = value }
+
+        override fun commitCursor() {
+            super.setCursor(_desiredCursor ?: Cursor(Cursor.DEFAULT_CURSOR))
+            _desiredCursor = null
+        }
 
         override fun enableInput(inputMethodRequests: InputMethodRequests) {
             currentInputMethodRequests = inputMethodRequests

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopOwner.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopOwner.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.AwtCursor
 import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.PointerIconDefaults
 import java.awt.Cursor
 
 internal actual fun sendKeyEvent(
@@ -41,7 +42,19 @@ internal actual fun sendKeyEvent(
     return keyInputModifier.processKeyInput(keyEvent)
 }
 
-private val defaultCursor = Cursor(Cursor.DEFAULT_CURSOR)
+internal actual fun commitPointerIcon(
+    containerCursor: PlatformComponentWithCursor?
+) {
+    containerCursor?.commitCursor()
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal actual fun getPointerIcon(
+    containerCursor: PlatformComponentWithCursor?
+): PointerIcon {
+    return containerCursor?.let { AwtCursor(it.desiredCursor) }
+        ?: PointerIconDefaults.Default
+}
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual fun setPointerIcon(
@@ -49,9 +62,8 @@ internal actual fun setPointerIcon(
     icon: PointerIcon?
 ) {
     when (icon) {
-        is AwtCursor -> containerCursor?.componentCursor = icon.cursor
-        else -> if (containerCursor?.componentCursor != defaultCursor) {
-            containerCursor?.componentCursor = defaultCursor
+        is AwtCursor -> {
+            containerCursor?.desiredCursor = icon.cursor
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
@@ -26,11 +26,13 @@ internal actual interface PlatformComponent : PlatformInputComponent, PlatformCo
 }
 
 internal actual interface PlatformComponentWithCursor {
-    var componentCursor: Cursor
+    var desiredCursor: Cursor
+    fun commitCursor()
 }
 
 internal actual object DummyPlatformComponent : PlatformComponent {
-    override var componentCursor: Cursor = Cursor(Cursor.CROSSHAIR_CURSOR)
+    override var desiredCursor: Cursor = Cursor(Cursor.CROSSHAIR_CURSOR)
+    override fun commitCursor() {}
     var enabledInput: InputMethodRequests? = null
     override fun enableInput(inputMethodRequests: InputMethodRequests) {
         enabledInput = inputMethodRequests

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/UndecoratedWindowResizer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/UndecoratedWindowResizer.desktop.kt
@@ -30,7 +30,7 @@ internal const val DefaultBorderThickness = 8
 
 internal class UndecoratedWindowResizer(
     private val window: Window,
-    layer: ComposeLayer,
+    private val layer: ComposeLayer,
     var enabled: Boolean = false,
     var borderThickness: Int = DefaultBorderThickness
 ) {
@@ -70,16 +70,18 @@ internal class UndecoratedWindowResizer(
         }
         val point = event.getPoint()
         sides = getSides(point)
+        fun setCursor(cursorType: Int) {
+            layer.scene.component.desiredCursor = Cursor(cursorType)
+        }
         when (sides) {
-            Side.Left.value -> window.setCursor(Cursor(Cursor.W_RESIZE_CURSOR))
-            Side.Top.value -> window.setCursor(Cursor(Cursor.N_RESIZE_CURSOR))
-            Side.Right.value -> window.setCursor(Cursor(Cursor.E_RESIZE_CURSOR))
-            Side.Bottom.value -> window.setCursor(Cursor(Cursor.S_RESIZE_CURSOR))
-            Corner.LeftTop.value -> window.setCursor(Cursor(Cursor.NW_RESIZE_CURSOR))
-            Corner.LeftBottom.value -> window.setCursor(Cursor(Cursor.SW_RESIZE_CURSOR))
-            Corner.RightTop.value -> window.setCursor(Cursor(Cursor.NE_RESIZE_CURSOR))
-            Corner.RightBottom.value -> window.setCursor(Cursor(Cursor.SE_RESIZE_CURSOR))
-            else -> window.setCursor(Cursor(Cursor.DEFAULT_CURSOR))
+            Side.Left.value -> setCursor(Cursor.W_RESIZE_CURSOR)
+            Side.Top.value -> setCursor(Cursor.N_RESIZE_CURSOR)
+            Side.Right.value -> setCursor(Cursor.E_RESIZE_CURSOR)
+            Side.Bottom.value -> setCursor(Cursor.S_RESIZE_CURSOR)
+            Corner.LeftTop.value -> setCursor(Cursor.NW_RESIZE_CURSOR)
+            Corner.LeftBottom.value -> setCursor(Cursor.SW_RESIZE_CURSOR)
+            Corner.RightTop.value -> setCursor(Cursor.NE_RESIZE_CURSOR)
+            Corner.RightBottom.value -> setCursor(Cursor.SE_RESIZE_CURSOR)
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -340,11 +340,8 @@ internal class SkiaBasedOwner(
         root.draw(canvas.asComposeCanvas())
     }
 
-    private var desiredPointerIcon: PointerIcon? = null
-
     internal fun processPointerInput(event: PointerInputEvent): ProcessResult {
         measureAndLayout()
-        desiredPointerIcon = null
         return pointerInputEventProcessor.process(
             event,
             this,
@@ -353,7 +350,7 @@ internal class SkiaBasedOwner(
                     it.position.y in 0f..root.height.toFloat()
             }
         ).also {
-            setPointerIcon(containerCursor, desiredPointerIcon)
+            commitPointerIcon(containerCursor)
         }
     }
 
@@ -389,8 +386,8 @@ internal class SkiaBasedOwner(
     override val pointerIconService: PointerIconService =
         object : PointerIconService {
             override var current: PointerIcon
-                get() = desiredPointerIcon ?: PointerIconDefaults.Default
-                set(value) { desiredPointerIcon = value }
+                get() = getPointerIcon(containerCursor)
+                set(value) { setPointerIcon(containerCursor, value) }
         }
 }
 
@@ -400,8 +397,17 @@ internal expect fun sendKeyEvent(
     keyEvent: KeyEvent
 ): Boolean
 
+internal expect fun commitPointerIcon(
+    containerCursor: PlatformComponentWithCursor?
+)
+
 @OptIn(ExperimentalComposeUiApi::class)
 internal expect fun setPointerIcon(
     containerCursor: PlatformComponentWithCursor?,
     icon: PointerIcon?
 )
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal expect fun getPointerIcon(
+    containerCursor: PlatformComponentWithCursor?
+): PointerIcon


### PR DESCRIPTION
- it fixes cursor blinks when mouse buttons are pressed
- it splits cursor setting in PlatformComponent into two parts: setting the desired cursor and committing cursors. Now code like UndecoratedWindowResizer could set the desired cursor without conflicts with Modifier.pointerHoverIcon