### PR TITLE
Fix scrolling over Textfield

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/gestures/AndroidScrollable.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/gestures/AndroidScrollable.android.kt
@@ -20,5 +20,5 @@ import androidx.compose.ui.Modifier
 
 internal actual fun Modifier.mouseScrollable(
     orientation: Orientation,
-    onScroll: (Float) -> Unit
+    onScroll: (Float) -> Boolean
 ): Modifier = this

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -135,7 +135,8 @@ internal fun Modifier.scrollable(
                 enabled
             )
             .mouseScrollable(orientation) {
-                state.dispatchRawDelta(it.reverseIfNeeded())
+                val consumedDelta = state.dispatchRawDelta(it.reverseIfNeeded())
+                consumedDelta != 0f
             }
     }
 )
@@ -163,7 +164,7 @@ object ScrollableDefaults {
 //  (to differentiate mouse and touch)
 internal expect fun Modifier.mouseScrollable(
     orientation: Orientation,
-    onScroll: (Float) -> Unit
+    onScroll: (Float) -> Boolean
 ): Modifier
 
 @Suppress("ComposableModifierFactory")

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -45,7 +45,7 @@ internal val LocalMouseScrollConfig = compositionLocalOf { MouseScrollableConfig
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual fun Modifier.mouseScrollable(
     orientation: Orientation,
-    onScroll: (Float) -> Unit
+    onScroll: (Float) -> Boolean
 ): Modifier = composed {
     val density = LocalDensity.current
     val config = LocalMouseScrollConfig.current
@@ -58,7 +58,6 @@ internal actual fun Modifier.mouseScrollable(
             }
             val scrollOffset = config.offsetOf(event.delta, scrollBounds, density)
             onScroll(-scrollOffset)
-            true
         } else {
             false
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
@@ -47,6 +47,7 @@ import org.junit.Test
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
+
 @OptIn(
     ExperimentalTime::class,
     ExperimentalComposeUiApi::class,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
@@ -47,7 +47,6 @@ import org.junit.Test
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 
-
 @OptIn(
     ExperimentalTime::class,
     ExperimentalComposeUiApi::class,


### PR DESCRIPTION
Fixes JetBrains/compose-jb#26

Non-singleLine TextField is scrollable, that is why scrolling didn't work over it (we haven't supported nested scrollable's).

Another reproducer:
```
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.Column
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.foundation.layout.size
import androidx.compose.foundation.rememberScrollState
import androidx.compose.foundation.verticalScroll
import androidx.compose.material.Button
import androidx.compose.material.Text
import androidx.compose.ui.Modifier
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication

fun main() = singleWindowApplication {
    Box(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
        Column {
            Box(Modifier.size(100.dp).verticalScroll(rememberScrollState())) {
                Column {
                    repeat(10) {
                        Button({}) {}
                    }
                }
            }
            Column {
                repeat(20) {
                    Button({}) { Text("Button") }
                }
            }
        }
    }
}
```