### PR TITLE
Disable default reaction on secondary clicks when we click on Button, move Slider, etc

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt
@@ -23,12 +23,14 @@ import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.changedToDown
 import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.consumeAllChanges
 import androidx.compose.ui.input.pointer.consumeDownChange
 import androidx.compose.ui.input.pointer.isOutOfBounds
+import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.positionChangeConsumed
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.unit.Density
@@ -240,10 +242,16 @@ suspend fun AwaitPointerEventScope.awaitFirstDown(
     } while (
         !event.changes.fastAll {
             if (requireUnconsumed) it.changedToDown() else it.changedToDownIgnoreConsumed()
-        }
+        } || !event.isPrimaryButton
     )
     return event.changes[0]
 }
+
+private val PointerEvent.isPrimaryButton: Boolean
+    get() {
+        val isMouse = changes.all { it.type == PointerType.Mouse }
+        return isMouse && buttons.isPrimaryPressed || !isMouse
+    }
 
 /**
  * Reads events until all pointers are up or the gesture was canceled. The gesture

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt
@@ -250,7 +250,7 @@ suspend fun AwaitPointerEventScope.awaitFirstDown(
 private val PointerEvent.isPrimaryButton: Boolean
     get() {
         val isMouse = changes.all { it.type == PointerType.Mouse }
-        return isMouse && buttons.isPrimaryPressed || !isMouse
+        return !isMouse || buttons.isPrimaryPressed
     }
 
 /**


### PR DESCRIPTION
This CL disable all non-left button interactions for clickable, draggable, etc.

Now we have these event API's:
- low-level awaitPointerEvent, which triggers on any event (no matter if it is left or right mouse button)
- medium-level awaitFirstDown, which triggers only on left mouse event. If we would trigger it on right click too, the user can't distinguish it if it was left or right click, because we don't provide this information in PointerInputChange. In the future we can add something like `filter: (PointerEvent) -> Unit = PrimaryButtonFilter` to awaitFirstDown, and to high-level API.
- high-level clickable, draggable, toggleable, which use awaitFirstDown under the hood
- high level mouseClickable, which provides info about which button was pressed. It doesn't use awaitFirstDown under the hood.

Fixes https://github.com/JetBrains/compose-jb/issues/832