### PR TITLE
Experimental Modifier.onPointerEvent

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
@@ -96,6 +96,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIconDefaults
 import androidx.compose.ui.input.pointer.isBackPressed
 import androidx.compose.ui.input.pointer.isForwardPressed
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalUriHandler
@@ -349,25 +350,18 @@ private fun FrameWindowScope.ScrollableContent(scrollState: ScrollState) {
                     "   }\n" +
                     "}",
                 fontFamily = italicFont,
-                modifier = Modifier.padding(10.dp).pointerInput(Unit) {
-                    awaitPointerEventScope {
-                        while (true) {
-                            val event = awaitPointerEvent()
-                            val position = event.changes.first().position
-                            when (event.type) {
-                                PointerEventType.Move -> {
-                                    overText = "Move position: $position"
-                                }
-                                PointerEventType.Enter -> {
-                                    overText = "Over enter"
-                                }
-                                PointerEventType.Exit -> {
-                                    overText = "Over exit"
-                                }
-                            }
-                        }
+                modifier = Modifier
+                    .padding(10.dp)
+                    .onPointerEvent(PointerEventType.Move) {
+                        val position = it.changes.first().position
+                        overText = "Move position: $position"
                     }
-                }
+                    .onPointerEvent(PointerEventType.Enter) {
+                        overText = "Over enter"
+                    }
+                    .onPointerEvent(PointerEventType.Exit) {
+                        overText = "Over exit"
+                    }
             )
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.desktop.kt
@@ -1,0 +1,23 @@
+package androidx.compose.ui.input.pointer
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+
+/**
+ * Call [onEvent] when a [PointerEvent] with type [eventType] is reported to the specified input [pass].
+ */
+@ExperimentalComposeUiApi
+fun Modifier.onPointerEvent(
+    eventType: PointerEventType,
+    pass: PointerEventPass = PointerEventPass.Main,
+    onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
+) = pointerInput(eventType, pass, onEvent) {
+    awaitPointerEventScope {
+        while (true) {
+            val event = awaitPointerEvent(pass)
+            if (event.type == eventType) {
+                onEvent(event)
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current low-level pointerInput is too complex for the user, and high-level clickable, draggable, etc don't work properly with mouse.

This is an attempt to introduce easy to use mid-level API.

Experimental for now, and desktop-only, if during upstream we decide to change/remove it.

By discussion (https://jetbrains.slack.com/archives/G017NLN12D8/p1633440526243500?thread_ts=1631004192.064700&cid=G017NLN12D8)