### PR TITLE
Get rid of double exit/enter when we drag over hoverable component outside of window

### DIFF
--- a/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/input/pointer/MouseEventTest.kt
+++ b/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/input/pointer/MouseEventTest.kt
@@ -83,7 +83,7 @@ class MouseEventTest {
     }
 
     @Test
-    fun absentExitSent() {
+    fun dontSendExitWhenWePress() {
         // Sometimes the ACTION_HOVER_EXIT isn't sent when a touch event comes after a mouse event.
 
         val events = mutableListOf<PointerEventType>()
@@ -114,7 +114,7 @@ class MouseEventTest {
 
         assertThat(events).hasSize(4)
         assertThat(events[0]).isEqualTo(PointerEventType.Enter)
-        assertThat(events[1]).isEqualTo(PointerEventType.Exit)
+        assertThat(events[1]).isEqualTo(PointerEventType.Move)
         assertThat(events[2]).isEqualTo(PointerEventType.Press)
         assertThat(events[3]).isEqualTo(PointerEventType.Release)
     }
@@ -222,7 +222,7 @@ class MouseEventTest {
 
         rule.onNodeWithTag(tag).performMouseInput {
             moveTo(Offset.Zero)
-            exit()
+            exit(Offset(-1f, -1f))
         }
 
         assertThat(events).hasSize(2)

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
@@ -242,7 +242,6 @@ internal class Node(val pointerInputFilter: PointerInputFilter) : NodeParent() {
     private val relevantChanges: MutableMap<PointerId, PointerInputChange> = mutableMapOf()
     private var coordinates: LayoutCoordinates? = null
     private var pointerEvent: PointerEvent? = null
-    private var wasIn = false
     private var isIn = true
     private var hasEntered = false
 
@@ -393,9 +392,8 @@ internal class Node(val pointerInputFilter: PointerInputFilter) : NodeParent() {
                 event.type == PointerEventType.Exit
             ) {
                 event.type = when {
-                    !hasEntered && !wasIn && isIn -> PointerEventType.Enter
-                    // event.type == PointerEventType.Exit is a special case, where we should force the exit, not matter we are in or not
-                    hasEntered && (wasIn && !isIn || event.type == PointerEventType.Exit) ->  PointerEventType.Exit
+                    !hasEntered && isIn -> PointerEventType.Enter
+                    hasEntered && !isIn -> PointerEventType.Exit
                     else -> PointerEventType.Move
                 }
             }
@@ -457,8 +455,6 @@ internal class Node(val pointerInputFilter: PointerInputFilter) : NodeParent() {
         super.cleanUpHits(internalPointerEvent)
 
         val event = pointerEvent ?: return
-
-        wasIn = isIn
 
         event.changes.fastForEach { change ->
             // If the pointer is released and doesn't support hover OR

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
@@ -393,17 +393,15 @@ internal class Node(val pointerInputFilter: PointerInputFilter) : NodeParent() {
                 event.type == PointerEventType.Exit
             ) {
                 event.type = when {
-                    !hasEntered && !wasIn && isIn -> {
-                        hasEntered = true
-                        PointerEventType.Enter
-                    }
-                    hasEntered && (wasIn && !isIn || event.type == PointerEventType.Exit) -> {
-                        hasEntered = false
-                        PointerEventType.Exit
-                    }
+                    !hasEntered && !wasIn && isIn -> PointerEventType.Enter
+                    // event.type == PointerEventType.Exit is a special case, where we should force the exit, not matter we are in or not
+                    hasEntered && (wasIn && !isIn || event.type == PointerEventType.Exit) ->  PointerEventType.Exit
                     else -> PointerEventType.Move
                 }
             }
+
+            if (event.type == PointerEventType.Enter) hasEntered = true
+            if (event.type == PointerEventType.Exit) hasEntered = false
         }
         pointerEvent = event
     }


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1218

Reproducer:
```
import androidx.compose.foundation.background
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.foundation.layout.padding
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.Modifier
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.input.pointer.PointerEventType
import androidx.compose.ui.input.pointer.onPointerEvent
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication

@OptIn(ExperimentalComposeUiApi::class)
fun main() = singleWindowApplication {
    Box(
        Modifier
            .fillMaxSize()
            .padding(50.dp)
            .background(Color.Red)
            .onPointerEvent(PointerEventType.Exit) { println("EXIT") }
            .onPointerEvent(PointerEventType.Enter) { println("ENTER") }
    )
}
```

1. Press on the Red box
2. Move outside the box -> EXIT
3. Move outside the window -> EXIT
4. Move into the window -> ENTER  // hover is stuck here
5. Move into the box -> ENTER

Test: gradle compose:ui:ui:connectedCheck -Pandroidx.compose.multiplatformEnabled=false