### PR TITLE
workaround default composable lambdas with typed parameters (for k/js and k/native)

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.backend.common.peek
 import org.jetbrains.kotlin.backend.common.pop
 import org.jetbrains.kotlin.backend.common.push
+import org.jetbrains.kotlin.backend.jvm.codegen.anyTypeArgument
 import org.jetbrains.kotlin.descriptors.ClassKind
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.IrStatement
@@ -601,6 +602,15 @@ class ComposerLambdaMemoization(
         )
 
         if (!collector.hasCaptures) {
+            if (!context.platform.isJvm() && hasTypeParameter(expression.type)) {
+                // This is a workaround
+                // for TypeParameters having initial parents (old IrFunctions before deepCopy).
+                // Otherwise it doesn't compile on k/js and k/native (can't find symbols).
+                // Ideally we will find a solution to remap symbols of TypeParameters in
+                // ComposableSingletons properties after ComposerParamTransformer
+                // (deepCopy in ComposerParamTransformer didn't help).
+                return wrapped
+            }
             return irGetComposableSingleton(
                 lambdaExpression = wrapped,
                 lambdaType = expression.type
@@ -608,6 +618,10 @@ class ComposerLambdaMemoization(
         } else {
             return wrapped
         }
+    }
+
+    private fun hasTypeParameter(type: IrType): Boolean {
+        return type.anyTypeArgument { true }
     }
 
     private fun irGetComposableSingleton(

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
@@ -428,7 +428,10 @@ class ComposerParamTransformer(
                     fn,
                     name = newName,
                     type = newType,
-                    isAssignable = param.defaultValue != null
+                    isAssignable = param.defaultValue != null,
+                    defaultValue = param.defaultValue?.copyWithNewTypeParams(
+                        source = this, target = fn
+                    )
                 )
             }
             fn.annotations = annotations.toList()


### PR DESCRIPTION
it removes compilation error.
The workaround is less optimized than jvm version.