### PR TITLE
Fix disposing window in event callback

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
@@ -1,13 +1,18 @@
 package androidx.compose.ui.awt
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.window.density
+import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -16,6 +21,7 @@ import org.junit.Assume
 import org.junit.Test
 import java.awt.GraphicsEnvironment
 import java.awt.Dimension
+import java.awt.event.MouseEvent
 
 class ComposeWindowTest {
     @Test
@@ -92,6 +98,30 @@ class ComposeWindowTest {
             } finally {
                 window.dispose()
             }
+        }
+    }
+
+    @Test
+    fun `dispose window in event handler`() = runApplicationTest {
+        val window = ComposeWindow()
+        try {
+            window.size = Dimension(300, 400)
+            window.setContent {
+                Box(modifier = Modifier.fillMaxSize().background(Color.Blue).clickable {
+                    window.dispose()
+                })
+            }
+            window.isVisible = true
+            window.sendMouseEvent(MouseEvent.MOUSE_ENTERED, x = 100, y = 50)
+            awaitIdle()
+            window.sendMouseEvent(MouseEvent.MOUSE_MOVED, x = 100, y = 50)
+            awaitIdle()
+            window.sendMouseEvent(MouseEvent.MOUSE_PRESSED, x = 100, y = 50, modifiers = MouseEvent.BUTTON1_DOWN_MASK)
+            awaitIdle()
+            window.sendMouseEvent(MouseEvent.MOUSE_RELEASED, x = 100, y = 50)
+            awaitIdle()
+        } finally {
+            window.dispose()
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -121,7 +121,7 @@ class ComposeScene internal constructor(
 
     private fun invalidateIfNeeded() {
         hasPendingDraws = frameClock.hasAwaiters || list.any(SkiaBasedOwner::needRender)
-        if (hasPendingDraws && !isInvalidationDisabled) {
+        if (hasPendingDraws && !isInvalidationDisabled && !isClosed) {
             invalidate()
         }
     }


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1448

The sequence of calls:
```
mouseReleased
  window.dispose
    scene.dispose
  cancelRippleEffect
    scene.invalidate
      layer.needRedraw
```