### PR TITLE
compose plugin: fix compilation issue for k/js - 1306

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/FixComposableLambdaCalls.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/FixComposableLambdaCalls.kt
@@ -85,11 +85,11 @@ class FixComposableLambdaCalls(
         module.transformChildrenVoid(this)
     }
 
-    private fun IrType.hasComposer(): Boolean {
+    private fun IrType.hasComposerDirectly(): Boolean {
         if (this == composerType) return true
 
         return when (this) {
-            is IrSimpleType -> arguments.any { (it as? IrType)?.hasComposer() == true }
+            is IrSimpleType -> arguments.any { (it as? IrType) == composerType }
             else -> false
         }
     }
@@ -136,7 +136,7 @@ class FixComposableLambdaCalls(
 
         val dispatchReceiver = original.dispatchReceiver ?: return original
 
-        if (!dispatchReceiver.type.isFunction() || !dispatchReceiver.type.hasComposer()) {
+        if (!dispatchReceiver.type.isFunction() || !dispatchReceiver.type.hasComposerDirectly()) {
             return original
         }
 


### PR DESCRIPTION
https://github.com/JetBrains/compose-jb/issues/1306 

This fixes the compilation error only. The behaviour is likely broken (or this syntax is not supposed to be used with MutableState) - https://github.com/JetBrains/compose-jb/issues/1436