### PR TITLE
Fix backward selection of an empty line

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -738,7 +738,7 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
 internal fun merge(lhs: Selection?, rhs: Selection?): Selection? {
     return when {
         lhs == null -> rhs
-        rhs == null -> lhs
+        rhs == null || rhs.start == rhs.end -> lhs
         lhs.start == lhs.end -> lhs.copy(handlesCrossed = rhs.handlesCrossed).merge(rhs)
         else -> lhs.merge(rhs)
     }


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1473

The fix from https://github.com/JetBrains/androidx/pull/65 was not complete.

With two empty selections we still have an invalid merged selection.

If line selections are:
```
Selection(start=AnchorInfo(direction=Ltr, offset=4, selectableId=1), end=AnchorInfo(direction=Ltr, offset=4, selectableId=1), handlesCrossed=false)
Selection(start=AnchorInfo(direction=Ltr, offset=0, selectableId=2), end=AnchorInfo(direction=Ltr, offset=0, selectableId=2), handlesCrossed=false)
Selection(start=AnchorInfo(direction=Ltr, offset=8, selectableId=3), end=AnchorInfo(direction=Ltr, offset=0, selectableId=3), handlesCrossed=true)
```

then the merged selection is:
```
SELECTION Selection(start=AnchorInfo(direction=Ltr, offset=4, selectableId=1), end=AnchorInfo(direction=Ltr, offset=0, selectableId=3), handlesCrossed=false)
```

but it should be:
```
SELECTION Selection(start=AnchorInfo(direction=Ltr, offset=0, selectableId=3, end=AnchorInfo(direction=Ltr, offset=4, selectableId=1), handlesCrossed=true)
```

In this CL we don't add selection if it is empty