### PR TITLE
Fix selection of last line

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/MultiWidgetSelectionDelegate.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/MultiWidgetSelectionDelegate.kt
@@ -153,8 +153,7 @@ internal fun getTextSelectionInfo(
         textLayoutResult.multiParagraph.width.toFloat(),
         textLayoutResult.multiParagraph.height.toFloat()
     )
-println(startHandlePosition)
-println(bounds)
+
     val isSelected =
         SelectionMode.Vertical.isSelected(bounds, startHandlePosition, endHandlePosition)
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/MultiWidgetSelectionDelegate.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/MultiWidgetSelectionDelegate.kt
@@ -150,10 +150,11 @@ internal fun getTextSelectionInfo(
     val bounds = Rect(
         0.0f,
         0.0f,
-        textLayoutResult.size.width.toFloat(),
-        textLayoutResult.size.height.toFloat()
+        textLayoutResult.multiParagraph.width.toFloat(),
+        textLayoutResult.multiParagraph.height.toFloat()
     )
-
+println(startHandlePosition)
+println(bounds)
     val isSelected =
         SelectionMode.Vertical.isSelected(bounds, startHandlePosition, endHandlePosition)
 


### PR DESCRIPTION
Another attempt to fix https://github.com/JetBrains/compose-jb/issues/1403

Before, bounds was clipped by the outer Box (i.e. by window bounds),
so when we check if the selection handle is out of the box, it returns that it is, but in reality, it is still inside the text.

P.S. 
If we would wrap the Text to scrollable Box, the bounds are correct - it returns bounds of the scrollable content. Before the fix, and after the fix.

startHandlePosition/endHandlePosition are not in the window/viewport coordinates, it is relative to the topLeft corner of the Text. I.e. if we scroll the text by 2000px, startHandlePosition would be more than 2000px