### PR TITLE
Fix shortcuts when Caps is on (Linux)

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/KeyEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/KeyEvent.desktop.kt
@@ -17,6 +17,8 @@
 package androidx.compose.ui.input.key
 
 import androidx.compose.ui.awt.awtEvent
+import java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
+import java.awt.event.KeyEvent.KEY_LOCATION_UNKNOWN
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
 
@@ -29,7 +31,10 @@ actual typealias NativeKeyEvent = Any
  * The key that was pressed.
  */
 actual val KeyEvent.key: Key
-    get() = Key(awtEvent.keyCode, awtEvent.keyLocation)
+    get() = Key(awtEvent.keyCode, awtEvent.keyLocationForCompose)
+
+private val java.awt.event.KeyEvent.keyLocationForCompose get() =
+    if (keyLocation == KEY_LOCATION_UNKNOWN) KEY_LOCATION_STANDARD else keyLocation
 
 /**
  * The UTF16 value corresponding to the key event that was pressed. The unicode character


### PR DESCRIPTION
Fix shortcuts when Caps is on (Linux)

If Caps is on or it is not English layout, Linux sends LOCATION_UNKNOWN instead of LOCATION_STANDARD

Fixes https://github.com/JetBrains/compose-jb/issues/1457