### PR TITLE
Fix closing a wrong window

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -240,6 +241,7 @@ suspend fun awaitApplication(
 /**
  * Scope used by [application], [awaitApplication], [launchApplication]
  */
+@Stable
 interface ApplicationScope {
     /**
      * Close all windows created inside the application and cancel all launched effects

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -262,6 +263,7 @@ fun Dialog(
 /**
  * Receiver scope which is used by [androidx.compose.ui.window.Dialog].
  */
+@Stable
 interface DialogWindowScope : WindowScope {
     /**
      * [ComposeDialog] that was created inside [androidx.compose.ui.window.Dialog].

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -381,6 +382,7 @@ fun Window(
 /**
  * Receiver scope which is used by [androidx.compose.ui.window.Window].
  */
+@Stable
 interface FrameWindowScope : WindowScope {
     /**
      * [ComposeWindow] that was created inside [androidx.compose.ui.window.Window].

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowScope.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowScope.kt
@@ -16,12 +16,14 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.runtime.Stable
 import java.awt.Window
 
 /**
  * Receiver scope which is used by [androidx.compose.ui.window.Window] and
  * [androidx.compose.ui.window.Dialog].
  */
+@Stable
 interface WindowScope {
     /**
      * [Window] that was created inside [androidx.compose.ui.window.Window]


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1487

Marking Stable seems fixes the issue. Stable adds some guaranties for the compiler.

All requirements, described in the comment for Stable are satisfied.