### PR TITLE
Fix dokka (attempt 2)

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/dokka/Dokka.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/dokka/Dokka.kt
@@ -37,6 +37,7 @@ object Dokka {
         return "dokka${formattedLangauage}Docs"
     }
 
+    @Suppress("UNUSED_PARAMETER")
     fun createDokkaTask(
         project: Project,
         hiddenPackages: List<String>,
@@ -76,8 +77,8 @@ object Dokka {
             task.description = "Generates $language documentation in the style of " +
                 "d.android.com.  Places docs in ${task.outputDirectory}"
             task.outputFormat = outputFormat
-            task.outlineRoot = "androidx/"
-            task.dacRoot = dacRoot
+//            task.outlineRoot = "androidx/"
+//            task.dacRoot = dacRoot
             task.moduleName = ""
             task.externalDocumentationLinks.add(guavaDocLink)
             task.externalDocumentationLinks.add(kotlinLangLink)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,7 @@ daggerCompiler = { module = "com.google.dagger:dagger-compiler", version.ref = "
 dexmakerMockito = { module = "com.linkedin.dexmaker:dexmaker-mockito", version.ref = "dexmaker" }
 dexmakerMockitoInline = { module = "com.linkedin.dexmaker:dexmaker-mockito-inline", version.ref = "dexmaker" }
 dexMemberList = { module = "com.jakewharton.dex:dex-member-list", version = "4.1.1" }
-dokkaGradlePluginz = { module = "org.jetbrains.dokka:dokka-android-gradle-plugin", version = "0.9.17-g014" }
+dokkaGradlePluginz = { module = "org.jetbrains.dokka:dokka-android-gradle-plugin", version = "0.9.18" }
 espressoContrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "espresso" }
 espressoCore = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 espressoIdlingNet = { module = "androidx.test.espresso.idling:idling-net", version.ref = "espresso" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,9 +9,6 @@ pluginManagement {
             mavenCentral()
             google()
             maven {
-                url("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-            }
-            maven {
                 url = "https://plugins.gradle.org/m2/"
             }
         }


### PR DESCRIPTION
> Could not resolve all files for configuration ':support:buildSrc:plugins:cacheableApi'.
   > Could not resolve org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17-g014.
     Required by:
         project :support:buildSrc:plugins
      > Could not resolve org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17-g014.
         > Could not get resource 'https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/dokka/dokka-android-gradle-plugin/0.9.17-g014/dokka-android-gradle-plugin-0.9.17-g014.pom'.
            > Could not GET 'https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/dokka/dokka-android-gradle-plugin/0.9.17-g014/dokka-android-gradle-plugin-0.9.17-g014.pom'.
