### PR TITLE
Fix painterResource Experimental warning

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
@@ -50,11 +50,20 @@ import org.xml.sax.InputSource
  * @param loader  resources loader
  * @return [Painter] used for drawing the loaded resource
  */
-@Composable
 @OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun painterResource(
+    resourcePath: String
+): Painter = painterResource(
+    resourcePath,
+    ResourceLoader.Default
+)
+
+@ExperimentalComposeUiApi
+@Composable
 fun painterResource(
     resourcePath: String,
-    loader: ResourceLoader = ResourceLoader.Default
+    loader: ResourceLoader
 ): Painter = when (resourcePath.substringAfterLast(".")) {
     "svg" -> rememberSvgResource(resourcePath, loader)
     "xml" -> rememberVectorXmlResource(resourcePath, loader)


### PR DESCRIPTION
Now there is no warning:
![image](https://user-images.githubusercontent.com/5963351/144215815-f455a495-4af7-4a83-afc1-9a4a83c67443.png)
