### PR TITLE
Provide density for AccessBridge, enable a11y for Windows

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeScene.desktop.kt
@@ -84,12 +84,7 @@ internal actual fun pointerInputEvent(
 internal actual fun makeAccessibilityController(
     skiaBasedOwner: SkiaBasedOwner,
     component: PlatformComponent
-): AccessibilityController? =
-    if (DesktopPlatform.Current == DesktopPlatform.MacOS) {
-        AccessibilityControllerImpl(skiaBasedOwner, component)
-    } else {
-        null
-    }
+): AccessibilityController = AccessibilityControllerImpl(skiaBasedOwner, component)
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual val DefaultPointerButtons: PointerButtons = PointerButtons()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
@@ -46,6 +46,8 @@ import java.awt.FontMetrics
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.event.FocusListener
+import java.awt.font.FontRenderContext
+import java.awt.geom.AffineTransform
 import java.util.Locale
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleAction
@@ -902,19 +904,31 @@ internal class ComposeAccessible(
             TODO("Not yet implemented")
         }
 
-        override fun getFont(): Font {
-            println("Not implemented: getFont")
-            TODO("Not yet implemented")
-        }
+        // Create dummy FontMetrics and FontRenderContext to provide density for Accessibility
+        // TODO("Properly implement font-related features if necessary")
+        override fun getFont(): Font? = null
 
-        override fun setFont(f: Font?) {
-            println("Not implemented: setFont")
-            TODO("Not yet implemented")
+        override fun setFont(f: Font?) {}
+
+        val _fontMetricsForA11y = object : FontMetrics(null) {
+            private val _fontRenderContext = FontRenderContext(
+                AffineTransform().apply {
+                    scale(
+                        density.density.toDouble(),
+                        density.density.toDouble()
+                    )
+                },
+                true,
+                true
+            )
+
+            override fun getFontRenderContext(): FontRenderContext {
+                return _fontRenderContext
+            }
         }
 
         override fun getFontMetrics(f: Font?): FontMetrics {
-            println("Not implemented: getFontMetrics")
-            TODO("Not yet implemented")
+            return _fontMetricsForA11y
         }
 
         override fun setEnabled(b: Boolean) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -521,7 +521,7 @@ internal expect fun pointerInputEvent(
 internal expect fun makeAccessibilityController(
     skiaBasedOwner: SkiaBasedOwner,
     component: PlatformComponent
-): AccessibilityController?
+): AccessibilityController
 
 internal expect val DefaultPointerButtons: PointerButtons
 internal expect val DefaultPointerKeyboardModifiers: PointerKeyboardModifiers


### PR DESCRIPTION
This fix will work after merging changes introduced in [JetBrainsRuntime/105](https://github.com/JetBrains/JetBrainsRuntime/pull/105) and upstreaming to OpenJDK