### PR TITLE
Improve doc comment of ImageResources#loadImageBitmap()

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
@@ -22,12 +22,13 @@ import org.jetbrains.skia.Image
 import java.io.InputStream
 
 /**
- * Load and decode [ImageBitmap] from the given [inputStream]. [inputStream] should contain encoded
+ * Load and decode an [ImageBitmap] from the given [inputStream]. [inputStream] should contain an encoded
  * raster image in a format supported by Skia (BMP, GIF, HEIF, ICO, JPEG, PNG, WBMP, WebP)
  *
- * @param inputStream input stream to load an rater image. All bytes will be read from this
- * stream, but stream will not be closed after this method.
- * @return the decoded SVG image associated with the resource
+ * @param inputStream input stream to load a raster image from. All bytes will be read from this
+ * stream, but the stream will not be closed after this method.
+ * @return the image decoded from the stream
+ * @throws IllegalArgumentException if decoding the image fails
  */
 fun loadImageBitmap(inputStream: InputStream): ImageBitmap =
     Image.makeFromEncoded(inputStream.readAllBytes()).toComposeImageBitmap()


### PR DESCRIPTION
## Proposed Changes

I found the documentation of the desktop ImageResources#loadImageBitmap() not entirely correct, stating that it returns an SVG image while it returns an ImageBitmap. While fixing that, I noticed the doc comment could use some improvement concerning wording, so I tried to imporove that a bit. I also found it not to mention an exception it would throw when unable to decode an image from the input, so added that, too.

## Testing

Test: documentation changes only, should not change anything on the ability to build and pass tests

## Issues Fixed

Fixes: None (issue tracker disabled?)
