### PR TITLE
Memory leak of ComposeWindow/ComposeLayer after window.dispose

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -42,7 +42,6 @@ class ComposeDialog(
     modalityType: ModalityType = ModalityType.MODELESS
 ) : JDialog(owner, modalityType) {
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated)
-    internal val layer get() = delegate.layer
 
     init {
         contentPane.add(delegate.pane)
@@ -78,7 +77,7 @@ class ComposeDialog(
      * Handler to catch uncaught exceptions during rendering frames, handling events, or processing background Compose operations.
      */
     @ExperimentalComposeUiApi
-    var exceptionHandler: WindowExceptionHandler? by layer::exceptionHandler
+    var exceptionHandler: WindowExceptionHandler? by delegate::exceptionHandler
 
     /**
      * Composes the given composable into the ComposeDialog.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -45,7 +45,6 @@ class ComposeWindow(
     graphicsConfiguration: GraphicsConfiguration? = null
 ) : JFrame(graphicsConfiguration) {
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated)
-    internal val layer get() = delegate.layer
 
     init {
         contentPane.add(delegate.pane)
@@ -67,7 +66,7 @@ class ComposeWindow(
      * Handler to catch uncaught exceptions during rendering frames, handling events, or processing background Compose operations.
      */
     @ExperimentalComposeUiApi
-    var exceptionHandler: WindowExceptionHandler? by layer::exceptionHandler
+    var exceptionHandler: WindowExceptionHandler? by delegate::exceptionHandler
 
     /**
      * Composes the given composable into the ComposeWindow.
@@ -159,11 +158,7 @@ class ComposeWindow(
     /**
      * `true` if the window is in fullscreen mode, `false` otherwise
      */
-    private var isFullscreen: Boolean
-        get() = layer.component.fullscreen
-        set(value) {
-            layer.component.fullscreen = value
-        }
+    private var isFullscreen: Boolean by delegate::fullscreen
 
     /**
      * `true` if the window is maximized to fill all available screen space, `false` otherwise


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1688

After the fix we still have `ComposeWindow` leak (I think we can't fix that outside of JDK):
![image](https://user-images.githubusercontent.com/5963351/149177851-bcb90872-cc09-45c0-a8fc-169a811b5bf0.png)

but don't have `ComposeLayer` leak:
![image](https://user-images.githubusercontent.com/5963351/149177830-60aba4ac-e418-4ee6-aa52-2742d844f25c.png)

Which is fine, because `ComposeLayer` is big, and `ComposeWindow` isn't. `ComposeLayer` can hold the whole composition tree and objects created by it (theoretically). `ComposeWindow` can hold only some AWT or our classes. Native resources are disposed by "dispose" method.