### PR TITLE
Exit event often doesn't fire when we exit the component

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
@@ -93,6 +93,7 @@ internal class HitPathTracker(private val rootCoordinates: LayoutCoordinates) {
             isInBounds
         )
         if (!changed) {
+            root.cleanUp(internalPointerEvent)
             return false
         }
         var dispatchHit = root.dispatchMainEventPass(
@@ -102,6 +103,7 @@ internal class HitPathTracker(private val rootCoordinates: LayoutCoordinates) {
             isInBounds
         )
         dispatchHit = root.dispatchFinalEventPass(internalPointerEvent) || dispatchHit
+        root.cleanUp(internalPointerEvent)
 
         return dispatchHit
     }
@@ -197,8 +199,14 @@ internal open class NodeParent {
         children.forEach {
             dispatched = it.dispatchFinalEventPass(internalPointerEvent) || dispatched
         }
-        cleanUpHits(internalPointerEvent)
         return dispatched
+    }
+
+    open fun cleanUp(internalPointerEvent: InternalPointerEvent) {
+        children.forEach {
+            it.cleanUp(internalPointerEvent)
+        }
+        cleanUpHits(internalPointerEvent)
     }
 
     /**
@@ -329,9 +337,12 @@ internal class Node(val pointerInputFilter: PointerInputFilter) : NodeParent() {
                 children.forEach { it.dispatchFinalEventPass(internalPointerEvent) }
             }
         }
-        cleanUpHits(internalPointerEvent)
-        clearCache()
         return result
+    }
+
+    override fun cleanUp(internalPointerEvent: InternalPointerEvent) {
+        super.cleanUp(internalPointerEvent)
+        clearCache()
     }
 
     /**

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseHoverFilterTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseHoverFilterTest.kt
@@ -167,6 +167,63 @@ class MouseHoverFilterTest {
         assertThat(exitCount2).isEqualTo(0)
     }
 
+    @Test
+    fun `don't send move with the same position`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var moveCount1 = 0
+        var enterCount1 = 0
+        var exitCount1 = 0
+        var moveCount2 = 0
+        var enterCount2 = 0
+        var exitCount2 = 0
+
+        scene.setContent {
+            Column {
+                Box(
+                    modifier = Modifier
+                        .pointerMove(
+                            onMove = { moveCount1++ },
+                            onEnter = { enterCount1++ },
+                            onExit = { exitCount1++ }
+                        )
+                        .size(10.dp, 10.dp)
+                )
+                Box(
+                    modifier = Modifier
+                        .pointerMove(
+                            onMove = { moveCount2++ },
+                            onEnter = { enterCount2++ },
+                            onExit = { exitCount2++ }
+                        )
+                        .size(10.dp, 10.dp)
+                )
+            }
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(5f, 5f))
+        assertThat(listOf(moveCount1, enterCount1, exitCount1)).isEqualTo(listOf(0, 1, 0))
+        assertThat(listOf(moveCount2, enterCount2, exitCount2)).isEqualTo(listOf(0, 0, 0))
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+        assertThat(listOf(moveCount1, enterCount1, exitCount1)).isEqualTo(listOf(0, 1, 0))
+        assertThat(listOf(moveCount2, enterCount2, exitCount2)).isEqualTo(listOf(0, 0, 0))
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+        assertThat(listOf(moveCount1, enterCount1, exitCount1)).isEqualTo(listOf(0, 1, 0))
+        assertThat(listOf(moveCount2, enterCount2, exitCount2)).isEqualTo(listOf(0, 0, 0))
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 15f))
+        assertThat(listOf(moveCount1, enterCount1, exitCount1)).isEqualTo(listOf(0, 1, 1))
+        assertThat(listOf(moveCount2, enterCount2, exitCount2)).isEqualTo(listOf(0, 1, 0))
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 15f))
+        assertThat(listOf(moveCount1, enterCount1, exitCount1)).isEqualTo(listOf(0, 1, 1))
+        assertThat(listOf(moveCount2, enterCount2, exitCount2)).isEqualTo(listOf(0, 1, 0))
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `send multiple move events with paused dispatcher`() {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -20,11 +20,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalPointerIconService
 import androidx.compose.ui.platform.TestComposeWindow
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,15 +36,17 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 @OptIn(ExperimentalComposeUiApi::class)
 class PointerIconTest {
-    private val window = TestComposeWindow(width = 100, height = 100, density = Density(1f))
-
     private val iconService = object : PointerIconService {
         override var current: PointerIcon = PointerIconDefaults.Default
     }
 
     @Test
-    fun basicTest() {
-        window.setContent {
+    fun basicTest() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f),
+    ).use { scene ->
+        scene.setContent {
             CompositionLocalProvider(
                 LocalPointerIconService provides iconService
             ) {
@@ -58,16 +63,20 @@ class PointerIconTest {
             }
         }
 
-        window.onMouseMoved(
-            x = 5,
-            y = 5
+        scene.sendPointerEvent(
+            PointerEventType.Move,
+            Offset(5f, 5f)
         )
         assertThat(iconService.current).isEqualTo(PointerIconDefaults.Text)
     }
 
     @Test
-    fun parentWins() {
-        window.setContent {
+    fun parentWins() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f),
+    ).use { scene ->
+        scene.setContent {
             CompositionLocalProvider(
                 LocalPointerIconService provides iconService
             ) {
@@ -85,22 +94,26 @@ class PointerIconTest {
             }
         }
 
-        window.onMouseMoved(
-            x = 5,
-            y = 5
+        scene.sendPointerEvent(
+            PointerEventType.Move,
+            Offset(5f, 5f)
         )
         assertThat(iconService.current).isEqualTo(PointerIconDefaults.Hand)
 
-        window.onMouseMoved(
-            x = 15,
-            y = 15
+        scene.sendPointerEvent(
+            PointerEventType.Move,
+            Offset(15f, 15f)
         )
         assertThat(iconService.current).isEqualTo(PointerIconDefaults.Hand)
     }
 
     @Test
-    fun childWins() {
-        window.setContent {
+    fun childWins() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f),
+    ).use { scene ->
+        scene.setContent {
             CompositionLocalProvider(
                 LocalPointerIconService provides iconService
             ) {
@@ -118,15 +131,15 @@ class PointerIconTest {
             }
         }
 
-        window.onMouseMoved(
-            x = 5,
-            y = 5
+        scene.sendPointerEvent(
+            PointerEventType.Move,
+            Offset(5f, 5f)
         )
         assertThat(iconService.current).isEqualTo(PointerIconDefaults.Text)
 
-        window.onMouseMoved(
-            x = 15,
-            y = 15
+        scene.sendPointerEvent(
+            PointerEventType.Move,
+            Offset(15f, 15f)
         )
         assertThat(iconService.current).isEqualTo(PointerIconDefaults.Hand)
     }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -283,13 +283,13 @@ class WindowInputEventTest {
 
         window.sendMouseEvent(MouseEvent.MOUSE_ENTERED, x = 100, y = 50)
         awaitIdle()
-        assertThat(onMoves.size).isEqualTo(1)  // there is a synthetic Move on the first layout
+        assertThat(onMoves.size).isEqualTo(0)
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)
 
         window.sendMouseEvent(MouseEvent.MOUSE_MOVED, x = 90, y = 50)
         awaitIdle()
-        assertThat(onMoves.size).isEqualTo(2)
+        assertThat(onMoves.size).isEqualTo(1)
         assertThat(onMoves.last()).isEqualTo(Offset(90 * density, 50 * density))
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)
@@ -298,7 +298,7 @@ class WindowInputEventTest {
         window.sendMouseEvent(MouseEvent.MOUSE_DRAGGED, x = 80, y = 50, modifiers = MouseEvent.BUTTON1_DOWN_MASK)
         window.sendMouseEvent(MouseEvent.MOUSE_RELEASED, x = 80, y = 50)
         awaitIdle()
-        assertThat(onMoves.size).isEqualTo(3)
+        assertThat(onMoves.size).isEqualTo(2)
         assertThat(onMoves.last()).isEqualTo(Offset(80 * density, 50 * density))
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -458,13 +458,12 @@ class ComposeScene internal constructor(
         // - move from outside to the window (owner != null, lastMouseMoveOwner == null): Enter
         // - move from the window to outside (owner == null, lastMouseMoveOwner != null): Exit
         // - move from one point of the window to another (owner == lastMouseMoveOwner): Move
-        // - move from one popup to another (owner != lastMouseMoveOwner): [Popup 1] Exit, [Popup 2] Enter, Move
+        // - move from one popup to another (owner != lastMouseMoveOwner): [Popup 1] Exit, [Popup 2] Enter
 
         if (owner != lastMouseMoveOwner) {
             lastMouseMoveOwner?.processPointerInput(event.copy(eventType = PointerEventType.Exit), isInBounds = false)
             owner?.processPointerInput(event.copy(eventType = PointerEventType.Enter))
-        }
-        if (event.eventType == PointerEventType.Move) {
+        } else if (event.eventType == PointerEventType.Move) {
             owner?.processPointerInput(event)
         }
 


### PR DESCRIPTION
Failing tests:
```
WindowInputEventTest.catch mouse move
PointerIconTest.childWins
```

The calling chain of `PointerIconTest.childWins` was:

```
Enter(5,5)
Move(5,5) - position is the same, so we don't pass the event
Move(15,15) - it should trigger Exit on the first component, but it haven't, because we skipped cleanup on the previeous event, and think that we still inside the component (isIn is true)
```

It is a regression after https://android-review.googlesource.com/c/platform/frameworks/support/+/1875581