### PR TITLE
Re-enable a11y or Windows, add property to disable it

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeScene.desktop.kt
@@ -84,12 +84,7 @@ internal actual fun pointerInputEvent(
 internal actual fun makeAccessibilityController(
     skiaBasedOwner: SkiaBasedOwner,
     component: PlatformComponent
-): AccessibilityController? =
-    if (DesktopPlatform.Current == DesktopPlatform.MacOS) {
-        AccessibilityControllerImpl(skiaBasedOwner, component)
-    } else {
-        null
-    }
+): AccessibilityController? = AccessibilityControllerImpl(skiaBasedOwner, component)
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual val DefaultPointerButtons: PointerButtons = PointerButtons()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -101,9 +101,14 @@ internal class ComposeLayer {
 
     private val density get() = _component.density.density
 
+    private val a11yDisabled by lazy {
+        System.getProperty("compose.accessibility.enable") == "false" ||
+        System.getenv("COMPOSE_DISABLE_ACCESSIBILITY") != null
+    }
+
     fun makeAccessible(component: Component) = object : Accessible {
         override fun getAccessibleContext(): AccessibleContext? {
-            if (System.getenv("COMPOSE_DISABLE_ACCESSIBILITY") != null) return null
+            if (a11yDisabled) return null
             val controller =
                 scene.mainOwner?.accessibilityController as? AccessibilityControllerImpl
             val accessible = controller?.rootAccessible


### PR DESCRIPTION
A11y can be disabled with both `COMPOSE_DISABLE_ACCESSIBILITY` environment variable and `compose.accessibility.enable=false` system property