### PR TITLE
Hide top-level dialog from the taskbar

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -37,10 +37,14 @@ import javax.swing.JDialog
  * ComposeDialog is a dialog for building UI using Compose for Desktop.
  * ComposeDialog inherits javax.swing.JDialog.
  */
-class ComposeDialog(
-    owner: Window? = null,
-    modalityType: ModalityType = ModalityType.MODELESS
-) : JDialog(owner, modalityType) {
+class ComposeDialog : JDialog {
+    constructor(
+        owner: Window?,
+        modalityType: ModalityType = ModalityType.MODELESS
+    ) : super(owner, modalityType)
+
+    constructor() : super()
+
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated)
 
     init {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -43,6 +43,11 @@ class ComposeDialog : JDialog {
         modalityType: ModalityType = ModalityType.MODELESS
     ) : super(owner, modalityType)
 
+    @Deprecated("Use the constructor with setting owner explicitly")
+    constructor(
+        modalityType: ModalityType = ModalityType.MODELESS
+    ) : super(null, modalityType)
+
     constructor() : super()
 
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -141,7 +141,12 @@ fun Dialog(
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         create = {
-            ComposeDialog(owner, ModalityType.DOCUMENT_MODAL).apply {
+            val dialog = if (owner != null) {
+                ComposeDialog(owner, ModalityType.DOCUMENT_MODAL)
+            } else {
+                ComposeDialog()
+            }
+            dialog.apply {
                 // close state is controlled by DialogState.isOpen
                 defaultCloseOperation = JDialog.DO_NOTHING_ON_CLOSE
                 addWindowListener(object : WindowAdapter() {


### PR DESCRIPTION
Swing has a special constructor for that (without arguments). It says:
```
A shared, hidden frame will be set as the owner of the dialog.
```

We need exactly this as a default behaviour for top-level Dialog's. This will hide the icon in the taskbar. If the user need to show icon in the taskbar, Window is a better option.

If `SwingUtilities.getSharedOwnerFrame()` was public, I would just use it as a default value in the constructor, but instead we have to create a separate constructor and keep it consistent with `JDialog`, even if it is unusual API.

The reproducer:
```
import androidx.compose.ui.awt.ComposeDialog
import javax.swing.SwingUtilities

fun main() = SwingUtilities.invokeLater {
    val dialog = ComposeDialog()
    dialog.setSize(800, 600)
    dialog.isVisible = true
}
```

The icon shouldn't be in the taskbar now.

Old behavior:
![image](https://user-images.githubusercontent.com/5963351/152127666-46f17aa4-d2b6-4313-b315-abbffd0fb837.png)

New behavior:
![image](https://user-images.githubusercontent.com/5963351/152127706-8716218c-07f4-4dc7-ada1-4a1a802f88b8.png)

