### PR TITLE
Fixed a case where [event.modifiersEx] does not provide info about the pressed mouse button (AWT).

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -454,8 +454,9 @@ private fun ComposeScene.onMouseWheelEvent(
 @OptIn(ExperimentalComposeUiApi::class)
 private val MouseEvent.buttons get() = PointerButtons(
     // We should check [event.button] because of case where [event.modifiersEx] does not provide
-    // info about the pressed mouse button when using touchpad on MacOS 12 (AWT only)
-    // see: https://youtrack.jetbrains.com/issue/COMPOSE-36
+    // info about the pressed mouse button when using touchpad on MacOS 12 (AWT only).
+    // When the [Tap to click] feature is activated on Mac OS 12, half of all clicks are not
+    // handled because [event.modifiersEx] may not provide info about the pressed mouse button.
     isPrimaryPressed = ((modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
         || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON1))
         && !isMacOsCtrlClick,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -450,8 +450,12 @@ private fun ComposeScene.onMouseWheelEvent(
     )
 }
 
+
 @OptIn(ExperimentalComposeUiApi::class)
 private val MouseEvent.buttons get() = PointerButtons(
+    // We should check [event.button] because of case where [event.modifiersEx] does not provide
+    // info about the pressed mouse button when using touchpad on MacOS 12 (AWT only)
+    // see: https://youtrack.jetbrains.com/issue/COMPOSE-36
     isPrimaryPressed = ((modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
         || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON1))
         && !isMacOsCtrlClick,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -452,11 +452,18 @@ private fun ComposeScene.onMouseWheelEvent(
 
 @OptIn(ExperimentalComposeUiApi::class)
 private val MouseEvent.buttons get() = PointerButtons(
-    isPrimaryPressed = (modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0 && !isMacOsCtrlClick,
-    isSecondaryPressed = (modifiersEx and MouseEvent.BUTTON3_DOWN_MASK) != 0 || isMacOsCtrlClick,
-    isTertiaryPressed = (modifiersEx and MouseEvent.BUTTON2_DOWN_MASK) != 0,
-    isBackPressed = (modifiersEx and MouseEvent.getMaskForButton(4)) != 0,
-    isForwardPressed = (modifiersEx and MouseEvent.getMaskForButton(5)) != 0,
+    isPrimaryPressed = ((modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
+        || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON1))
+        && !isMacOsCtrlClick,
+    isSecondaryPressed = (modifiersEx and MouseEvent.BUTTON3_DOWN_MASK) != 0
+        || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON3)
+        || isMacOsCtrlClick,
+    isTertiaryPressed = (modifiersEx and MouseEvent.BUTTON2_DOWN_MASK) != 0
+        || (id == MouseEvent.MOUSE_PRESSED && button == MouseEvent.BUTTON2),
+    isBackPressed = (modifiersEx and MouseEvent.getMaskForButton(4)) != 0
+        || (id == MouseEvent.MOUSE_PRESSED && button == 4),
+    isForwardPressed = (modifiersEx and MouseEvent.getMaskForButton(5)) != 0
+        || (id == MouseEvent.MOUSE_PRESSED && button == 5),
 )
 
 @OptIn(ExperimentalComposeUiApi::class)


### PR DESCRIPTION
Test: manual.

Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-36
