### PR TITLE
Fix missing slider position synchronization on first click

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -251,6 +251,7 @@ private fun Scrollbar(
                     .scrollbarDrag(
                         interactionSource = interactionSource,
                         draggedInteraction = dragInteraction,
+                        onStarted = { sliderAdapter.rawPosition = sliderAdapter.position },
                         onDelta = { offset ->
                             sliderAdapter.rawPosition += if (isVertical) offset.y else offset.x
                         },
@@ -268,11 +269,13 @@ private fun Scrollbar(
 private fun Modifier.scrollbarDrag(
     interactionSource: MutableInteractionSource,
     draggedInteraction: MutableState<DragInteraction.Start?>,
+    onStarted: () -> Unit,
     onDelta: (Offset) -> Unit,
     onFinished: () -> Unit
 ): Modifier = composed {
     val currentInteractionSource by rememberUpdatedState(interactionSource)
     val currentDraggedInteraction by rememberUpdatedState(draggedInteraction)
+    val currentOnStarted by rememberUpdatedState(onStarted)
     val currentOnDelta by rememberUpdatedState(onDelta)
     val currentOnFinished by rememberUpdatedState(onFinished)
     pointerInput(Unit) {
@@ -282,6 +285,7 @@ private fun Modifier.scrollbarDrag(
                 val interaction = DragInteraction.Start()
                 currentInteractionSource.tryEmit(interaction)
                 currentDraggedInteraction.value = interaction
+                currentOnStarted.invoke()
                 val isSuccess = drag(down.id) { change ->
                     currentOnDelta.invoke(change.positionChange())
                     change.consumePositionChange()


### PR DESCRIPTION
When user scroll with macOS touchpad and then tries to move slider thumb - it glitches