### PR TITLE
Fix height of an empty line

### DIFF
--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -304,6 +304,19 @@ class DesktopParagraphTest {
         Truth.assertThat(paragraphWithoutStyles.getLineBottom(1)).isNotEqualTo(secondLineBottom)
     }
 
+    @Test
+    fun `line heights`() {
+        val paragraph = simpleParagraph(
+            text = "aaa\n\naaa\n\n\naaa\n   \naaa",
+            style = TextStyle(fontSize = 50.sp)
+        )
+        val firstLineHeight = paragraph.getLineHeight(0)
+
+        for (i in 1 until paragraph.lineCount) {
+            Truth.assertThat(paragraph.getLineHeight(i)).isEqualTo(firstLineHeight)
+        }
+    }
+
     private fun simpleParagraph(
         text: String = "",
         style: TextStyle? = null,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -549,7 +549,7 @@ internal class ParagraphBuilder(
         )
 
         var pos = 0
-        val ps = textStyleToParagraphStyle(textStyle)
+        val ps = textStyleToParagraphStyle(textStyle, defaultStyle)
 
         if (maxLines != Int.MAX_VALUE) {
             ps.maxLinesCount = maxLines
@@ -729,8 +729,9 @@ internal class ParagraphBuilder(
         return null
     }
 
-    private fun textStyleToParagraphStyle(style: TextStyle): ParagraphStyle {
+    private fun textStyleToParagraphStyle(style: TextStyle, computedStyle: ComputedStyle): ParagraphStyle {
         val pStyle = ParagraphStyle()
+        pStyle.textStyle = makeSkTextStyle(computedStyle)
         style.textAlign?.let {
             pStyle.alignment = it.toSkAlignment()
         }


### PR DESCRIPTION
SkiaParagraph doesn't use span style to determine the height of the empty/blank line. It uses main style of the paragraph, which we haven't set.

Fixes https://github.com/JetBrains/compose-jb/issues/1781