### PR TITLE
Hoverable. Send enter/exit undispatched

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Hoverable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Hoverable.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.debugInspectorInfo
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
@@ -98,8 +99,16 @@ fun Modifier.hoverable(
                         while (currentContext.isActive) {
                             val event = awaitPointerEvent()
                             when (event.type) {
-                                PointerEventType.Enter -> outerScope.launch { emitEnter() }
-                                PointerEventType.Exit -> outerScope.launch { emitExit() }
+                                PointerEventType.Enter -> outerScope.launch(
+                                    start = CoroutineStart.UNDISPATCHED
+                                ) {
+                                    emitEnter()
+                                }
+                                PointerEventType.Exit -> outerScope.launch(
+                                    start = CoroutineStart.UNDISPATCHED
+                                ) {
+                                    emitExit()
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
`launch` will dispatch hover state changing to the next coroutine frame, which can lead to some UI glitches

See, for example scroll of hoverable elements:
https://github.com/JetBrains/compose-jb/issues/1480

The CL won't completely fix this issue though. To completely fix the issue we need multiple fixes on Desktop/Android side.