### PR TITLE
Deprecate PointerEvent.awtEvent, KeyEvent.awtEvent

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.foundation.text
 
-import androidx.compose.ui.awt.awtEvent
+import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.input.key.KeyEvent
 
 private fun Char.isPrintable(): Boolean {
@@ -28,5 +28,5 @@ private fun Char.isPrintable(): Boolean {
 }
 
 actual val KeyEvent.isTypedEvent: Boolean
-    get() = awtEvent.id == java.awt.event.KeyEvent.KEY_TYPED &&
-        awtEvent.keyChar.isPrintable()
+    get() = awtEventOrNull?.id == java.awt.event.KeyEvent.KEY_TYPED &&
+        awtEventOrNull?.keyChar?.isPrintable() == true

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -28,7 +28,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.awtEvent
+import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.key.Key
@@ -202,7 +202,7 @@ object PopupAlertDialogProvider : AlertDialogProvider {
             focusable = true,
             onDismissRequest = onDismissRequest,
             onKeyEvent = {
-                if (it.awtEvent.keyCode == KeyEvent.VK_ESCAPE) {
+                if (it.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
                     onDismissRequest()
                     true
                 } else {

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -26,10 +26,8 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.awtEvent
+import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
@@ -103,7 +101,7 @@ fun DropdownMenu(
             onDismissRequest = onDismissRequest,
             popupPositionProvider = popupPositionProvider,
             onKeyEvent = {
-                if (it.awtEvent.keyCode == KeyEvent.VK_ESCAPE) {
+                if (it.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
                     onDismissRequest()
                     true
                 } else {
@@ -189,7 +187,7 @@ fun CursorDropdownMenu(
             onDismissRequest = onDismissRequest,
             popupPositionProvider = rememberCursorPositionProvider(),
             onKeyEvent = {
-                if (it.awtEvent.keyCode == KeyEvent.VK_ESCAPE) {
+                if (it.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
                     onDismissRequest()
                     true
                 } else {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.desktop.kt
@@ -3,27 +3,54 @@ package androidx.compose.ui.awt
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerEvent
 
-
-// TODO(demin): new API, which is not merged to AOSP
 /**
  * The original raw native event from AWT
  */
+@Deprecated("Use awtEventOrNull. `awtEvent` will be removed in Compose 1.3", replaceWith = ReplaceWith("awtEventOrNull"))
 val PointerEvent.awtEvent: java.awt.event.MouseEvent get() {
     require(nativeEvent is java.awt.event.MouseEvent) {
-        "nativeEvent was sent not by AWT. Make sure, that you use AWT backed API" +
+        "nativeEvent wasn't sent by AWT. Make sure, that you use AWT backed API" +
                 " (from androidx.compose.ui.awt.* or from androidx.compose.ui.window.*)"
     }
     return nativeEvent
 }
 
-// TODO(demin): new API, which is not merged to AOSP
 /**
  * The original raw native event from AWT
  */
+@Deprecated("Use awtEventOrNull. `awtEvent` will be removed in Compose 1.3", replaceWith = ReplaceWith("awtEventOrNull"))
 val KeyEvent.awtEvent: java.awt.event.KeyEvent get() {
     require(nativeKeyEvent is java.awt.event.KeyEvent) {
-        "nativeKeyEvent was sent not by AWT. Make sure, that you use AWT backed API" +
+        "nativeKeyEvent wasn't sent by AWT. Make sure, that you use AWT backed API" +
                 " (from androidx.compose.ui.awt.* or from androidx.compose.ui.window.*)"
     }
     return nativeKeyEvent
+}
+
+// TODO(demin): new API, which is not merged to AOSP
+/**
+ * The original raw native event from AWT.
+ *
+ * Null if:
+ * - the native event is sent by another framework (when Compose UI is embed into it)
+ * - there no native event (in tests, for example)
+ * - there was a synthetic move event sent by compose on relayout
+ * - there was a synthetic move event sent by compose when move is missing between two non-move events
+ */
+@Suppress("DEPRECATION")
+val PointerEvent.awtEventOrNull: java.awt.event.MouseEvent? get() {
+    if (nativeEvent is SyntheticMouseEvent) return null
+    return nativeEvent as? java.awt.event.MouseEvent
+}
+
+// TODO(demin): new API, which is not merged to AOSP
+/**
+ * The original raw native event from AWT.
+ *
+ * Null if:
+ * - the native event is sent by another framework (when Compose UI is embed into it)
+ * - there no native event (in tests, for example)
+ */
+val KeyEvent.awtEventOrNull: java.awt.event.KeyEvent? get() {
+    return nativeKeyEvent as? java.awt.event.KeyEvent
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -43,6 +43,7 @@ import java.awt.Component
 import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Graphics
+import java.awt.IllegalComponentStateException
 import java.awt.Point
 import java.awt.Toolkit
 import java.awt.Window
@@ -432,3 +433,9 @@ private val MouseEvent.isMacOsCtrlClick
                     ((modifiersEx and InputEvent.BUTTON1_DOWN_MASK) != 0) &&
                     ((modifiersEx and InputEvent.CTRL_DOWN_MASK) != 0)
             )
+
+
+@Deprecated("Will be removed in Compose 1.3")
+internal class SyntheticMouseEvent(
+    source: Component, id: Int, `when`: Long, modifiers: Int, x: Int, y: Int
+) : MouseEvent(source, id, `when`, modifiers, x, y, 0, false)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.AccessibilityControllerImpl
 import androidx.compose.ui.platform.DesktopPlatform
 import androidx.compose.ui.platform.PlatformComponent
-import androidx.compose.ui.platform.NativeEventFactory
 import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
@@ -96,7 +95,8 @@ internal class ComposeLayer {
         Dispatchers.Swing + coroutineExceptionHandler,
         _component,
         Density(1f),
-        _component::needRedraw
+        _component::needRedraw,
+        createSyntheticNativeMoveEvent = _component::createSyntheticMouseEvent,
     )
 
     private val density get() = _component.density.density
@@ -210,22 +210,19 @@ internal class ComposeLayer {
             windowInfo.isWindowFocused = window?.isFocused ?: false
         }
 
-        override val nativeEventFactory = object : NativeEventFactory {
-            override fun createMoveEvent(sourceEvent: Any?, positionSourceEvent: Any?): Any {
-                sourceEvent as MouseEvent
-                positionSourceEvent as MouseEvent
+        @Suppress("DEPRECATION")
+        fun createSyntheticMouseEvent(sourceEvent: Any?, positionSourceEvent: Any?): Any {
+            sourceEvent as MouseEvent
+            positionSourceEvent as MouseEvent
 
-                return MouseEvent(
-                    sourceEvent.source as Component,
-                    MouseEvent.MOUSE_MOVED,
-                    sourceEvent.`when`,
-                    sourceEvent.modifiersEx,
-                    positionSourceEvent.x,
-                    positionSourceEvent.y,
-                    0,
-                    false
-                )
-            }
+            return SyntheticMouseEvent(
+                sourceEvent.source as Component,
+                MouseEvent.MOUSE_MOVED,
+                sourceEvent.`when`,
+                sourceEvent.modifiersEx,
+                positionSourceEvent.x,
+                positionSourceEvent.y
+            )
         }
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/KeyEvent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/KeyEvent.desktop.kt
@@ -16,11 +16,12 @@
 
 package androidx.compose.ui.input.key
 
-import androidx.compose.ui.awt.awtEvent
+import androidx.compose.ui.awt.awtEventOrNull
 import java.awt.event.KeyEvent.KEY_LOCATION_STANDARD
 import java.awt.event.KeyEvent.KEY_LOCATION_UNKNOWN
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
+import java.awt.event.KeyEvent.VK_UNDEFINED
 
 /**
  * The native desktop [KeyEvent][KeyEventAwt].
@@ -31,7 +32,10 @@ actual typealias NativeKeyEvent = Any
  * The key that was pressed.
  */
 actual val KeyEvent.key: Key
-    get() = Key(awtEvent.keyCode, awtEvent.keyLocationForCompose)
+    get() = Key(
+        awtEventOrNull?.keyCode ?: VK_UNDEFINED,
+        awtEventOrNull?.keyLocationForCompose ?: KEY_LOCATION_STANDARD
+    )
 
 private val java.awt.event.KeyEvent.keyLocationForCompose get() =
     if (keyLocation == KEY_LOCATION_UNKNOWN) KEY_LOCATION_STANDARD else keyLocation
@@ -53,13 +57,13 @@ private val java.awt.event.KeyEvent.keyLocationForCompose get() =
  * second from the low-surrogates range (\uDC00-\uDFFF).
  */
 actual val KeyEvent.utf16CodePoint: Int
-    get() = awtEvent.keyChar.code
+    get() = awtEventOrNull?.keyChar?.code ?: 0
 
 /**
  * The [type][KeyEventType] of key event.
  */
 actual val KeyEvent.type: KeyEventType
-    get() = when (awtEvent.id) {
+    get() = when (awtEventOrNull?.id) {
         KEY_PRESSED -> KeyEventType.KeyDown
         KEY_RELEASED -> KeyEventType.KeyUp
         else -> KeyEventType.Unknown
@@ -69,22 +73,22 @@ actual val KeyEvent.type: KeyEventType
  * Indicates whether the Alt key is pressed.
  */
 actual val KeyEvent.isAltPressed: Boolean
-    get() = awtEvent.isAltDown || awtEvent.isAltGraphDown
+    get() = awtEventOrNull?.isAltDown == true || awtEventOrNull?.isAltGraphDown == true
 
 /**
  * Indicates whether the Ctrl key is pressed.
  */
 actual val KeyEvent.isCtrlPressed: Boolean
-    get() = awtEvent.isControlDown
+    get() = awtEventOrNull?.isControlDown == true
 
 /**
  * Indicates whether the Meta key is pressed.
  */
 actual val KeyEvent.isMetaPressed: Boolean
-    get() = awtEvent.isMetaDown
+    get() = awtEventOrNull?.isMetaDown == true
 
 /**
  * Indicates whether the Shift key is pressed.
  */
 actual val KeyEvent.isShiftPressed: Boolean
-    get() = awtEvent.isShiftDown
+    get() = awtEventOrNull?.isShiftDown == true

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopOwner.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopOwner.desktop.kt
@@ -17,7 +17,7 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.awt.awtEvent
+import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.input.key.KeyInputModifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -25,7 +25,6 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.AwtCursor
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerIconDefaults
-import java.awt.Cursor
 
 internal actual fun sendKeyEvent(
     platformInputService: PlatformInput,
@@ -33,7 +32,7 @@ internal actual fun sendKeyEvent(
     keyEvent: KeyEvent
 ): Boolean {
     when {
-        keyEvent.awtEvent.id == java.awt.event.KeyEvent.KEY_TYPED ->
+        keyEvent.awtEventOrNull?.id == java.awt.event.KeyEvent.KEY_TYPED ->
             platformInputService.charKeyPressed = true
         keyEvent.type == KeyEventType.KeyUp ->
             platformInputService.charKeyPressed = false

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
@@ -23,7 +23,6 @@ import java.awt.im.InputMethodRequests
 
 internal actual interface PlatformComponent : PlatformInputComponent, PlatformComponentWithCursor {
     actual val windowInfo: WindowInfo
-    actual val nativeEventFactory: NativeEventFactory
 }
 
 internal actual interface PlatformComponentWithCursor {
@@ -43,7 +42,4 @@ internal actual object DummyPlatformComponent : PlatformComponent {
     override val density: Density
         get() = Density(1f, 1f)
     override val windowInfo = WindowInfoImpl()
-    override val nativeEventFactory = object : NativeEventFactory {
-        override fun createMoveEvent(sourceEvent: Any?, positionSourceEvent: Any?): Any? = null
-    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformComponent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformComponent.skiko.kt
@@ -17,13 +17,8 @@ package androidx.compose.ui.platform
 
 internal expect interface PlatformComponent : PlatformInputComponent, PlatformComponentWithCursor {
     val windowInfo: WindowInfo
-    val nativeEventFactory: NativeEventFactory
 }
 
 internal expect interface PlatformComponentWithCursor
 
 internal expect object DummyPlatformComponent : PlatformComponent
-
-internal interface NativeEventFactory {
-    fun createMoveEvent(sourceEvent: Any?, positionSourceEvent: Any?): Any?
-}


### PR DESCRIPTION
Deprecate PointerEvent.awtEvent, KeyEvent.awtEvent

RelNote:
PointerEvent.awtEvent, KeyEvent.awtEvent are deprecated (will be removed in Compose MPP 1.3). Use PointerEvent.awtEventOrNull, KeyEvent.awtEventOrNull instead.
