### PR TITLE
Fix race between ImageComposeScene and GlobalSnapshotManager

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
@@ -93,6 +93,8 @@ inline fun <R> ImageComposeScene.use(
  * Instead of calling [close] manually, you can use the helper function [use],
  * it will close scene for you.
  *
+ * [ImageComposeScene] doesn't support concurrent read/write access from different threads.
+ *
  * @param width The width of the content.
  * @param height The height of the content.
  * @param density Density of the content which will be used to convert [dp] units.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.desktop.kt
@@ -45,7 +45,10 @@ internal actual object GlobalSnapshotManager {
             val channel = Channel<Unit>(Channel.CONFLATED)
             CoroutineScope(Dispatchers.Swing).launch {
                 channel.consumeEach {
-                    Snapshot.sendApplyNotifications()
+                    // TODO(https://github.com/JetBrains/compose-jb/issues/1854) get rid of synchronized
+                    synchronized(GlobalSnapshotManager) {
+                        Snapshot.sendApplyNotifications()
+                    }
                 }
             }
             Snapshot.registerGlobalWriteObserver {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/CommandList.desktop.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/CommandList.desktop.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.ui.platform.synchronized
+
+internal class CommandList(
+    private var onNewCommand: () -> Unit
+) {
+    private val list = mutableListOf<() -> Unit>()
+    private val listCopy = mutableListOf<() -> Unit>()
+
+    val hasCommands: Boolean get() = synchronized(list) {
+        list.isNotEmpty()
+    }
+
+    fun add(command: () -> Unit) {
+        synchronized(list) {
+            list.add(command)
+        }
+        onNewCommand()
+    }
+
+    fun perform() {
+        synchronized(list) {
+            listCopy.addAll(list)
+            list.clear()
+        }
+        listCopy.forEach { it.invoke() }
+        listCopy.clear()
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -170,7 +170,7 @@ internal class SkiaBasedOwner(
     override val rootForTest = this
 
     override val snapshotObserver = OwnerSnapshotObserver { command ->
-        onDispatchCommand?.invoke(command)
+        dispatchSnapshotChanges?.invoke(command)
     }
     private val pointerInputEventProcessor = PointerInputEventProcessor(root)
     private val measureAndLayoutDelegate = MeasureAndLayoutDelegate(root)
@@ -225,7 +225,7 @@ internal class SkiaBasedOwner(
 
     var requestLayout: (() -> Unit)? = null
     var requestDraw: (() -> Unit)? = null
-    var onDispatchCommand: ((Command) -> Unit)? = null
+    var dispatchSnapshotChanges: ((Command) -> Unit)? = null
 
     private var needClearObservations = false
 


### PR DESCRIPTION
`ImageComposeScene`  uses `Dispatchers.Unconfined` by default, which executes callback in a thread, in which it is called. For our case it is callback which executed when we apply snapshot in `GlobalSnapshotManager`. It has a race with `render`/`sendPointerEvent` function. To avoid races, we now perform manual dispatching/execution.

Fixes https://github.com/JetBrains/compose-jb/issues/1392