### PR TITLE
Fix exception when we initialize a window with visible = false, undecorated = true

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/AwtWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/AwtWindow.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.node.Ref
 import androidx.compose.ui.util.UpdateEffect
+import androidx.compose.ui.util.makeDisplayable
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -73,19 +74,17 @@ fun <T : Window> AwtWindow(
 
     DisposableEffect(Unit) {
         windowRef.value = create()
-        // We should init a native window even if it is not yet visible.
-        // `pack` method makes window displayable, creates a native window, init graphic
-        // context, performs the first composition and runs effects
-        if (!currentVisible) {
-            window().pack()
-        }
         onDispose {
             dispose(window())
         }
     }
 
     UpdateEffect {
-        update(window())
+        val window = window()
+        update(window)
+        if (!window.isDisplayable) {
+            window.makeDisplayable()
+        }
     }
 
     val showJob = Ref<Job?>()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -769,6 +769,33 @@ class WindowStateTest {
         exitApplication()
     }
 
+    @Test
+    fun `start invisible undecorated window`() = runApplicationTest {
+        val receivedNumbers = mutableListOf<Int>()
+
+        val sendChannel = Channel<Int>(Channel.UNLIMITED)
+
+        launchApplication {
+            Window(onCloseRequest = ::exitApplication, visible = false, undecorated = true) {
+                LaunchedEffect(Unit) {
+                    sendChannel.consumeEach {
+                        receivedNumbers.add(it)
+                    }
+                }
+            }
+        }
+
+        sendChannel.send(1)
+        awaitIdle()
+        assertThat(receivedNumbers).isEqualTo(listOf(1))
+
+        sendChannel.send(2)
+        awaitIdle()
+        assertThat(receivedNumbers).isEqualTo(listOf(1, 2))
+
+        exitApplication()
+    }
+
     private val Window.contentSize
         get() = Dimension(
             size.width - insets.left - insets.right,


### PR DESCRIPTION
window.makeDisplayable() is a default behaviour now for any AWT window, which is called only after we set all properties for the window

Fixes https://github.com/JetBrains/compose-jb/issues/1652