### PR TITLE
Don't send synthetic Move before real Move event

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/PointerPositionUpdater.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/PointerPositionUpdater.skiko.kt
@@ -37,7 +37,9 @@ internal class PointerPositionUpdater(
     fun beforeEvent(event: PointerInputEvent) {
         if (isMoveEventMissing(lastEvent, event) || needUpdate) {
             needUpdate = false
-            lastEvent?.sendAsUpdate(pointersSource = event)
+            if (!event.isMove()) {
+                lastEvent?.sendAsUpdate(pointersSource = event)
+            }
         }
         lastEvent = event
     }


### PR DESCRIPTION
It is pointless and spam unnecessary events