### PR TITLE
Fix initial cursor position in TextField for Rtl

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -270,8 +270,9 @@ internal class SkiaParagraph(
     override fun getHorizontalPosition(offset: Int, usePrimaryDirection: Boolean): Float {
         val prevBox = getBoxBackwardByOffset(offset)
         val nextBox = getBoxForwardByOffset(offset)
+        val isRtl = paragraphIntrinsics.textDirection == ResolvedTextDirection.Rtl
         return when {
-            prevBox == null && nextBox == null -> 0f
+            prevBox == null && nextBox == null -> if (isRtl) width else 0f
             prevBox == null -> nextBox!!.cursorHorizontalPosition(true)
             nextBox == null -> prevBox.cursorHorizontalPosition()
             nextBox.direction == prevBox.direction -> nextBox.cursorHorizontalPosition(true)


### PR DESCRIPTION
Resolves [#1950](https://github.com/JetBrains/compose-jb/issues/1950)
