### PR TITLE
new API (in skikoMain): onCombinedClick and detectDragGestures with PointerFilter

### DIFF
--- a/compose/desktop/desktop/samples/build.gradle
+++ b/compose/desktop/desktop/samples/build.gradle
@@ -80,6 +80,15 @@ task run4(type: JavaExec) {
         compilation.runtimeDependencyFiles
 }
 
+task runMouseClicks(type: JavaExec) {
+    dependsOn(":compose:desktop:desktop:jar")
+    main = "androidx.compose.desktop.examples.mouseclicks.Main_jvmKt"
+    def compilation = kotlin.jvm().compilations["main"]
+    classpath =
+        compilation.output.allOutputs +
+        compilation.runtimeDependencyFiles
+}
+
 task runVsync(type: JavaExec) {
     dependsOn(":compose:desktop:desktop:jar")
     main = "androidx.compose.desktop.examples.vsynctest.Main_jvmKt"

--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/mouseclicks/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/mouseclicks/Main.jvm.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package androidx.compose.desktop.examples.mouseclicks
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.onDragGesture
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.onCombinedClick
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.isAltPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.singleWindowApplication
+
+@OptIn(ExperimentalFoundationApi::class)
+fun main() {
+    var isCtrlPressed: Boolean by mutableStateOf(false)
+
+    singleWindowApplication(
+        title = "Desktop Mouse Clicks",
+        state = WindowState(width = 512.dp, height = 425.dp),
+        onPreviewKeyEvent = {
+            isCtrlPressed = it.isCtrlPressed
+            false
+        }
+    ) {
+        var enabled by remember { mutableStateOf(true) }
+
+        Column {
+            Box(modifier = Modifier.fillMaxWidth().border(1.dp, Color.Black)) {
+                Row(modifier = Modifier.align(Alignment.Center)) {
+                    Checkbox(enabled, onCheckedChange = {
+                        enabled = it
+                    })
+                    Text("enabled all", modifier = Modifier.padding(top = 16.dp, start = 8.dp))
+                }
+            }
+
+
+            Row {
+                Column(modifier = Modifier.padding(25.dp)) {
+                    Text("combinedMouseClickable")
+
+                    Box(modifier = Modifier.size(100.dp).background(Color.LightGray)
+                        .onCombinedClick(
+                            enabled = enabled,
+                            onDoubleClick = {
+                                println("Simple LClick DoubleClick")
+                            },
+                            onLongClick = {
+                                println("Simple LClick LongPress")
+                            })
+                        {
+                            println("Simple LClick click")
+                        }
+                        .onCombinedClick(
+                            enabled = enabled,
+                            filter = {
+                                mouse {
+                                    button = PointerButton.Primary
+                                    keyboardModifiers = { isShiftPressed }
+                                }
+                            },
+                        ) {
+                            println("LClick + Shit")
+                        }
+                        .onCombinedClick(
+                            enabled = enabled,
+                            filter = {
+                                mouse {
+                                    button = PointerButton.Secondary
+                                    keyboardModifiers = { isAltPressed }
+                                }
+                            },
+                        ) {
+                            println("RClick + Alt")
+                        }
+                    ) {
+                        Text("LClick + Shit | RClick + Alt | Simple LClick & DoubleClick & LongPress")
+                    }
+                }
+
+                var isDragging by remember { mutableStateOf(false) }
+                val isDraggingCtrlPressed = isDragging && isCtrlPressed
+
+                println("Recomposing now")
+
+                Column(modifier = Modifier.padding(25.dp)) {
+                    Text("mouseDraggable")
+                    var offset1 by remember { mutableStateOf(Offset.Zero) }
+                    Box(modifier = Modifier.offset { IntOffset(offset1.x.toInt(), offset1.y.toInt()) }
+                        .size(100.dp).background(Color.Blue).pointerInput(Unit) {
+                            detectDragGestures(
+                                filter = { mouse { button = PointerButton.Secondary } },
+                                onDragStart = {
+                                    isDragging = true
+                                    println("Blue: Start, offset=$it")
+                                },
+                                onDragEnd = {
+                                    isDragging = false
+                                    println("Blue: End")
+                                },
+                                onDragCancel = {
+                                    isDragging = false
+                                }
+                            ) {
+                                offset1 += it * if (isDraggingCtrlPressed) 2.0f else 1.0f
+                            }
+                        }
+                    ) {
+                        Text("Use Right Mouse")
+                    }
+
+                    var offset2 by remember { mutableStateOf(Offset.Zero) }
+                    Box(
+                        modifier = Modifier.offset { IntOffset(offset2.x.toInt(), offset2.y.toInt()) }
+                            .size(100.dp).background(Color.Gray)
+                            .onDragGesture(
+                                enabled = enabled,
+                                onDragStart = { o ->
+                                    isDragging = true
+                                    println("Gray: Start, offset=$o")
+                                },
+                                onDragEnd = {
+                                    isDragging = false
+                                    println("Gray: End")
+                                },
+                                onDragCancel = {
+                                    isDragging = false
+                                }
+                            ) {
+                                offset2 += it * if (isDraggingCtrlPressed) 2.0f else 1.0f
+                            }) {
+                        Text("Use Left Mouse")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/CombinedClickTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/CombinedClickTest.kt
@@ -1,0 +1,427 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isAltPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.DefaultViewConfiguration
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
+class CombinedClickTest {
+
+    private fun testClick(
+        button: PointerButton
+    ) = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var clicksCount = 0
+
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .onCombinedClick(filter = {
+                        mouse {
+                            this.button = button
+                        }
+                    }) {
+                        clicksCount++
+                    }.size(10.dp, 20.dp)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), button = button)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), button = button)
+        assertThat(clicksCount).isEqualTo(1)
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), button = button)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(5f, 5f), button = button)
+        assertThat(clicksCount).isEqualTo(2)
+    }
+
+    @Test
+    fun primaryClicks() = testClick(button = PointerButton.Primary)
+
+    @Test
+    fun secondaryClicks() = testClick(button = PointerButton.Secondary)
+
+    @Test
+    fun tertiaryClicks() = testClick(button = PointerButton.Tertiary)
+
+    @Test
+    fun backClicks() = testClick(button = PointerButton.Back)
+
+    @Test
+    fun forwardClicks() = testClick(button = PointerButton.Forward)
+
+    private fun testDoubleClick(
+        button: PointerButton
+    ) = runBlocking {
+        val density = Density(1f)
+        val viewConfiguration = DefaultViewConfiguration(density)
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = density
+        ).use { scene ->
+            var clicksCount = 0
+            var doubleClickCount = 0
+
+            scene.setContent {
+                Box(
+                    modifier = Modifier
+                        .onCombinedClick(filter = {
+                            mouse { this.button = button }
+                        }, onDoubleClick = {
+                            doubleClickCount++
+                        }) {
+                            clicksCount++
+                        }.size(10.dp, 20.dp)
+                )
+            }
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+            scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), button = button)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), button = button)
+            delay(viewConfiguration.doubleTapTimeoutMillis * 2)
+            assertThat(clicksCount).isEqualTo(1)
+            assertThat(doubleClickCount).isEqualTo(0)
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+            scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), button = button)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(5f, 5f), button = button)
+            delay(viewConfiguration.doubleTapTimeoutMillis / 2)
+            scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), button = button)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(5f, 5f), button = button)
+            assertThat(clicksCount).isEqualTo(1)
+            assertThat(doubleClickCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun primaryDoubleClick() = testDoubleClick(button = PointerButton.Primary)
+
+    @Test
+    fun secondaryDoubleClick() = testDoubleClick(button = PointerButton.Secondary)
+
+    @Test
+    fun tertiaryDoubleClick() = testDoubleClick(button = PointerButton.Tertiary)
+
+    private fun testLongClick(button: PointerButton) = runBlocking {
+        val density = Density(1f)
+        val viewConfiguration = DefaultViewConfiguration(density)
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = density
+        ).use { scene ->
+            var clicksCount = 0
+            var longClickCount = 0
+
+            scene.setContent {
+                Box(
+                    modifier = Modifier
+                        .onCombinedClick(filter = {
+                            mouse { this.button = button }
+                        }, onLongClick = {
+                            longClickCount++
+                        }) {
+                            clicksCount++
+                        }.size(10.dp, 20.dp)
+                )
+            }
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+            scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), button = button)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), button = button)
+            assertThat(clicksCount).isEqualTo(1)
+            assertThat(longClickCount).isEqualTo(0)
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+            scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), button = button)
+            delay(viewConfiguration.longPressTimeoutMillis * 2)
+            assertThat(clicksCount).isEqualTo(1)
+            assertThat(longClickCount).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun primaryLongClick() = testLongClick(button = PointerButton.Primary)
+
+    @Test
+    fun secondaryLongClick() = testLongClick(button = PointerButton.Secondary)
+
+    @Test
+    fun tertiaryLongClick() = testLongClick(button = PointerButton.Tertiary)
+
+    @Test
+    fun `handles primary and secondary clicks`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var primaryClicks = 0
+        var secondaryClicks = 0
+
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .onCombinedClick(filter = { mouse { button = PointerButton.Primary } }) {
+                        primaryClicks++
+                    }
+                    .onCombinedClick(filter = { mouse { button = PointerButton.Secondary } }) {
+                        secondaryClicks++
+                    }
+                    .size(40.dp, 40.dp)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+        scene.sendPointerEvent(
+            PointerEventType.Press, Offset(0f, 0f),
+            button = PointerButton.Primary
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release, Offset(0f, 0f),
+            button = PointerButton.Primary
+        )
+
+        assertThat(primaryClicks).isEqualTo(1)
+        assertThat(secondaryClicks).isEqualTo(0)
+
+        scene.sendPointerEvent(
+            PointerEventType.Press, Offset(0f, 0f),
+            button = PointerButton.Secondary
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release, Offset(0f, 0f),
+            button = PointerButton.Secondary
+        )
+
+        assertThat(primaryClicks).isEqualTo(1)
+        assertThat(secondaryClicks).isEqualTo(1)
+    }
+
+    @Test
+    fun `handles primary click with alt keyModifier`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var genericClicks = 0
+        var withAltClicks = 0
+
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .combinedClickable {
+                        genericClicks++
+                    }
+                    .onCombinedClick(
+                        filter = {
+                            mouse {
+                                button = PointerButton.Primary
+                                keyboardModifiers = { isAltPressed }
+                            }
+                        }
+                    ) {
+                        withAltClicks++
+                    }
+                    .size(40.dp, 40.dp)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+        // With Alt pressed
+        scene.sendPointerEvent(
+            PointerEventType.Press, Offset(0f, 0f),
+            button = PointerButton.Primary,
+            keyboardModifiers = PointerKeyboardModifiers(isAltPressed = true)
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release, Offset(0f, 0f),
+            button = PointerButton.Primary,
+            keyboardModifiers = PointerKeyboardModifiers(isAltPressed = true)
+        )
+
+        assertThat(withAltClicks).isEqualTo(1)
+        assertThat(genericClicks).isEqualTo(0)
+
+        // Without Alt pressed (for generic click handler)
+        scene.sendPointerEvent(
+            PointerEventType.Press, Offset(0f, 0f),
+            button = PointerButton.Primary,
+            keyboardModifiers = PointerKeyboardModifiers(isAltPressed = false)
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release, Offset(0f, 0f),
+            button = PointerButton.Primary,
+            keyboardModifiers = PointerKeyboardModifiers(isAltPressed = false)
+        )
+        assertThat(withAltClicks).isEqualTo(1)
+        assertThat(genericClicks).isEqualTo(1)
+    }
+
+    @Test
+    fun `consume click`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var outerBoxClicks = 0
+        var innerBoxClicks = 0
+
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .combinedClickable {
+                        outerBoxClicks++
+                    }
+                    .size(40.dp, 40.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .combinedClickable {
+                            innerBoxClicks++
+                        }
+                        .size(10.dp, 20.dp)
+                )
+            }
+        }
+
+        val downButtons = PointerButtons(isPrimaryPressed = true)
+        val upButtons = PointerButtons(isPrimaryPressed = false)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), buttons = downButtons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), buttons = upButtons)
+        assertThat(outerBoxClicks).isEqualTo(0)
+        assertThat(innerBoxClicks).isEqualTo(1)
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(30f, 30f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(30f, 30f), buttons = downButtons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(30f, 30f), buttons = upButtons)
+        assertThat(outerBoxClicks).isEqualTo(1)
+        assertThat(innerBoxClicks).isEqualTo(1)
+    }
+
+    @Test
+    fun `don't handle consumed click by another click`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var outerBoxClicks = 0
+        var innerBoxClicks = 0
+
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .combinedClickable {
+                        outerBoxClicks++
+                    }
+                    .size(40.dp, 40.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .combinedClickable {
+                            innerBoxClicks++
+                        }
+                        .size(10.dp, 20.dp)
+                )
+            }
+        }
+
+        val downButtons = PointerButtons(isPrimaryPressed = true)
+        val upButtons = PointerButtons(isPrimaryPressed = false)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), buttons = downButtons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), buttons = upButtons)
+        assertThat(outerBoxClicks).isEqualTo(0)
+        assertThat(innerBoxClicks).isEqualTo(1)
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(30f, 30f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(30f, 30f), buttons = downButtons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(30f, 30f), buttons = upButtons)
+        assertThat(outerBoxClicks).isEqualTo(1)
+        assertThat(innerBoxClicks).isEqualTo(1)
+    }
+
+    @Test
+    fun `don't handle consumed click by pan`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+        density = Density(1f)
+    ).use { scene ->
+        var outerBoxTotalPan = Offset.Zero
+        var innerBoxClicks = 0
+
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .pointerInput(Unit) {
+                        detectTransformGestures { _, pan, _, _ ->
+                            outerBoxTotalPan += pan
+                        }
+                    }
+                    .size(80.dp, 80.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .combinedClickable {
+                            innerBoxClicks++
+                        }
+                        .size(50.dp, 50.dp)
+                )
+            }
+        }
+
+        val downButtons = PointerButtons(isPrimaryPressed = true)
+        val upButtons = PointerButtons(isPrimaryPressed = false)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(0f, 0f))
+        scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), buttons = downButtons)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 0f))
+        scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 0f), buttons = upButtons)
+        assertThat(outerBoxTotalPan).isEqualTo(Offset(20f, 0f))
+        assertThat(innerBoxClicks).isEqualTo(0)
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 0f), buttons = downButtons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 0f), buttons = upButtons)
+        assertThat(outerBoxTotalPan).isEqualTo(Offset(20f, 0f))
+        assertThat(innerBoxClicks).isEqualTo(1)
+    }
+}

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DragGestureTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DragGestureTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.platform.DefaultViewConfiguration
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import kotlin.math.ceil
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.Ignore
+import org.junit.Test
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
+class DragGestureTest {
+
+    @Test
+    fun `draggable by mouse primary button`() {
+        val density = Density(1f)
+        val viewConfiguration = DefaultViewConfiguration(density)
+
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = density
+        ).use { scene ->
+
+            var dragStartResult: Offset? = null
+            var dragCanceled = false
+            var dragEnded = false
+            var onDragCounter = 0
+            var dragOffset = Offset.Zero
+
+            scene.setContent {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp, 40.dp)
+                        .onDragGesture(
+                            enabled = true,
+                            onDragStart = { offset -> dragStartResult = offset },
+                            onDragCancel = { dragCanceled = true },
+                            onDragEnd = { dragEnded = true },
+                            onDrag = {
+                                dragOffset = it
+                                onDragCounter++
+                            }
+                        )
+                )
+            }
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+            scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), button = PointerButton.Primary)
+            scene.sendPointerEvent(
+                PointerEventType.Move,
+                Offset(5f + viewConfiguration.touchSlop, 5f)
+            )
+
+            assertEquals(Offset(5f, 5f), dragStartResult)
+            assertEquals(ceil(viewConfiguration.touchSlop), ceil(dragOffset.x))
+            assertEquals(1, onDragCounter)
+            assertEquals(0f, 0f)
+            assertFalse(dragCanceled)
+            assertFalse(dragEnded)
+
+            scene.sendPointerEvent(
+                PointerEventType.Move,
+                Offset(5f + viewConfiguration.touchSlop, 15f)
+            )
+            assertEquals(0f, dragOffset.x)
+            assertEquals(10f, dragOffset.y)
+            assertEquals(2, onDragCounter)
+            assertFalse(dragCanceled)
+            assertFalse(dragEnded)
+
+            scene.sendPointerEvent(
+                PointerEventType.Move,
+                Offset(5f + viewConfiguration.touchSlop, 25f)
+            )
+            assertEquals(0f, dragOffset.x)
+            assertEquals(10f, dragOffset.y)
+            assertEquals(3, onDragCounter)
+            assertFalse(dragCanceled)
+            assertFalse(dragEnded)
+
+            scene.sendPointerEvent(
+                eventType = PointerEventType.Release,
+                position = Offset(viewConfiguration.touchSlop, 15f),
+                button = PointerButton.Primary,
+            )
+            assertEquals(-5f, dragOffset.x)
+            assertEquals(-10f, dragOffset.y)
+            assertTrue(dragEnded)
+            assertFalse(dragCanceled)
+            assertEquals(4, onDragCounter)
+        }
+    }
+
+    @Test
+    @Ignore // remove Ignore if needed later when startDragOnLongPress mode supported
+    fun `draggable by mouse OnLongPress primary button`() = runBlocking {
+        val density = Density(1f)
+        val viewConfiguration = DefaultViewConfiguration(density)
+
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = density
+        ).use { scene ->
+
+            var dragStartResult: Offset? = null
+            var dragCanceled = false
+            var dragEnded = false
+            var onDragCounter = 0
+            var dragOffset = Offset.Zero
+
+            scene.setContent {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp, 40.dp)
+                        .onDragGesture(
+                            enabled = true,
+                            onDragStart = { offset -> dragStartResult = offset },
+                            onDragCancel = { dragCanceled = true },
+                            onDragEnd = { dragEnded = true },
+                            onDrag = {
+                                dragOffset = it
+                                onDragCounter++
+                            }
+                        )
+                )
+            }
+
+            val downButtons = PointerButtons(isPrimaryPressed = true)
+            scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+            scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), buttons = downButtons)
+
+            delay(viewConfiguration.longPressTimeoutMillis * 2)
+
+            assertEquals(
+                Offset(5f, 5f),
+                dragStartResult
+            )
+            assertEquals(0, onDragCounter)
+            assertEquals(0f, 0f)
+            assertFalse(dragCanceled)
+            assertFalse(dragEnded)
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 10f), buttons = downButtons)
+            assertEquals(0f, dragOffset.x)
+            assertEquals(5f, dragOffset.y)
+            assertEquals(1, onDragCounter)
+            assertFalse(dragCanceled)
+            assertFalse(dragEnded)
+
+            scene.sendPointerEvent(PointerEventType.Move, Offset(15f, 10f), buttons = downButtons)
+            assertEquals(10f, dragOffset.x)
+            assertEquals(0f, dragOffset.y)
+            assertEquals(2, onDragCounter)
+            assertFalse(dragCanceled)
+            assertFalse(dragEnded)
+
+            scene.sendPointerEvent(PointerEventType.Release, Offset(5f, 5f))
+            assertEquals(-10f, dragOffset.x)
+            assertEquals(-5f, dragOffset.y)
+            assertTrue(dragEnded)
+            assertFalse(dragCanceled)
+            assertEquals(3, onDragCounter)
+        }
+    }
+}

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/ClicksHandlerScope.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/ClicksHandlerScope.kt
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalComposeUiApi::class)
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.gestures.GestureCancellationException
+import androidx.compose.foundation.gestures.PressGestureScope
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToDown
+import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.isOutOfBounds
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+
+internal class ClicksHandlerScope(
+    pointerInputScope: PointerInputScope,
+    val interactionSource: MutableInteractionSource,
+    val pressedInteraction: MutableState<PressInteraction.Press?>,
+    val filterState: State<(PointerEvent) -> Boolean>,
+    val onDoubleClick: State<(() -> Unit)?>,
+    val onLongClick: State<(() -> Unit)?>,
+    val onClick: State<() -> Unit>
+) : PointerInputScope by pointerInputScope {
+
+    private val pressScope = PressGestureScopeImpl(this)
+
+    private val longPressTimeout: Long
+        get() = if (onLongClick.value != null) {
+            viewConfiguration.longPressTimeoutMillis
+        } else {
+            Long.MAX_VALUE / 2
+        }
+
+    private fun CoroutineScope.handlePressInteraction(pressOffset: Offset) {
+        launch {
+            pressScope.handlePressInteraction(
+                pressPoint = pressOffset,
+                interactionSource = interactionSource,
+                pressedInteraction = pressedInteraction,
+                delayPressInteraction = mutableStateOf({ false })
+            )
+        }
+    }
+
+    suspend fun awaitEvents() {
+        coroutineScope {
+            awaitPointerEventScope {
+                pressScope.reset()
+
+                val firstPress = awaitPress().apply {
+                    changes.fastForEach { it.consume() }
+                }
+
+                handlePressInteraction(firstPress.changes[0].position)
+
+                var cancelled = false
+
+                // `firstRelease` will be null if either event is cancelled or it's timed out
+                // use `cancelled` flag to distinguish between two cases
+
+                val firstRelease = withTimeoutOrNull(longPressTimeout) {
+                    awaitReleaseOrCancelled().apply {
+                        this?.changes?.fastForEach { it.consume() }
+                        cancelled = this == null
+                    }
+                }
+
+                if (cancelled) {
+                    pressScope.cancel()
+                } else if (firstRelease != null) {
+                    pressScope.release()
+                }
+
+                if (firstRelease == null) {
+                    if (onLongClick.value != null && !cancelled) {
+                        onLongClick.value!!.invoke()
+                        awaitReleaseOrCancelled()
+                        pressScope.release()
+                    }
+                } else if (onDoubleClick.value == null) {
+                    onClick.value()
+                } else {
+                    processSecondClickIfAny(firstRelease, this@coroutineScope)
+                }
+            }
+        }
+    }
+
+    private suspend fun AwaitPointerEventScope.processSecondClickIfAny(
+        firstRelease: PointerEvent,
+        coroutineScope: CoroutineScope,
+    ) {
+        pressScope.reset()
+
+        val secondPress = awaitSecondPressUnconsumed(
+            firstRelease.changes[0]
+        )?.apply {
+            changes.fastForEach { it.consume() }
+        }
+
+        if (secondPress == null) {
+            onClick.value()
+        } else {
+            coroutineScope.handlePressInteraction(secondPress.changes[0].position)
+
+            var cancelled = false
+
+            val secondRelease = withTimeoutOrNull(longPressTimeout) {
+                awaitReleaseOrCancelled().apply {
+                    this?.changes?.fastForEach { it.consume() }
+                    cancelled = this == null
+                }
+            }
+
+            if (cancelled) {
+                pressScope.cancel()
+            } else if (secondRelease != null) {
+                pressScope.release()
+            }
+
+            if (secondRelease == null) {
+                if (onLongClick.value != null && !cancelled) {
+                    onLongClick.value!!.invoke()
+                    awaitReleaseOrCancelled()
+                    pressScope.release()
+                }
+            } else if (!cancelled) {
+                onDoubleClick.value?.invoke()
+            }
+        }
+    }
+
+    private suspend fun AwaitPointerEventScope.awaitPress(): PointerEvent {
+        return awaitPress(filterState.value)
+    }
+
+    private suspend fun AwaitPointerEventScope.awaitSecondPressUnconsumed(
+        firstUp: PointerInputChange
+    ): PointerEvent? = withTimeoutOrNull(viewConfiguration.doubleTapTimeoutMillis) {
+        val minUptime = firstUp.uptimeMillis + viewConfiguration.doubleTapMinTimeMillis
+        var event: PointerEvent
+        var change: PointerInputChange
+        // The second tap doesn't count if it happens before DoubleTapMinTime of the first tap
+        do {
+            event = awaitPress()
+            change = event.changes[0]
+        } while (change.uptimeMillis < minUptime)
+        event
+    }
+
+    private suspend fun AwaitPointerEventScope.awaitReleaseOrCancelled(): PointerEvent? {
+        var event: PointerEvent? = null
+
+        while (event == null) {
+            event = awaitPointerEvent()
+
+            val cancelled = event.changes.fastAny {
+                it.isOutOfBounds(size, Size.Zero)
+            }
+
+            if (cancelled) return null
+
+            event = event.takeIf {
+                it.isAllPressedUp(requireUnconsumed = true) &&
+                    filterState.value(it)
+            }
+
+            // Check for cancel by position consumption. We can look on the Final pass of the
+            // existing pointer event because it comes after the Main pass we checked above.
+            val consumeCheck = awaitPointerEvent(PointerEventPass.Final)
+            if (consumeCheck.changes.fastAny { it.isConsumed }) {
+                return null
+            }
+        }
+
+        return event
+    }
+
+    private class PressGestureScopeImpl(
+        density: Density
+    ) : PressGestureScope, Density by density {
+        private var isReleased = false
+        private var isCanceled = false
+        private val mutex = Mutex(locked = false)
+
+        /**
+         * Called when a gesture has been canceled.
+         */
+        fun cancel() {
+            isCanceled = true
+            mutex.unlock()
+        }
+
+        /**
+         * Called when all pointers are up.
+         */
+        fun release() {
+            isReleased = true
+            mutex.unlock()
+        }
+
+        /**
+         * Called when a new gesture has started.
+         */
+        fun reset() {
+            mutex.tryLock() // If tryAwaitRelease wasn't called, this will be unlocked.
+            isReleased = false
+            isCanceled = false
+        }
+
+        override suspend fun awaitRelease() {
+            if (!tryAwaitRelease()) {
+                throw GestureCancellationException("The press gesture was canceled.")
+            }
+        }
+
+        override suspend fun tryAwaitRelease(): Boolean {
+            if (!isReleased && !isCanceled) {
+                mutex.lock()
+            }
+            return isReleased
+        }
+    }
+}
+
+internal suspend fun AwaitPointerEventScope.awaitPress(
+    filterPressEvent: (PointerEvent) -> Boolean,
+    requireUnconsumed: Boolean = true
+): PointerEvent {
+    var event: PointerEvent? = null
+
+    while (event == null) {
+        event = awaitPointerEvent().takeIf {
+            it.isAllPressedDown(requireUnconsumed = requireUnconsumed) &&
+            filterPressEvent(it)
+        }
+    }
+
+    return event
+}
+
+private fun PointerEvent.isAllPressedDown(requireUnconsumed: Boolean = true) =
+    type == PointerEventType.Press &&
+        changes.fastAll { it.type == PointerType.Mouse && (!requireUnconsumed || !it.isConsumed) } ||
+        changes.fastAll { if (requireUnconsumed) it.changedToDown() else it.changedToDownIgnoreConsumed() }
+
+private fun PointerEvent.isAllPressedUp(requireUnconsumed: Boolean = true) =
+    type == PointerEventType.Release &&
+        changes.fastAll { it.type == PointerType.Mouse && (!requireUnconsumed || !it.isConsumed) } ||
+        changes.fastAll { if (requireUnconsumed) it.changedToUp() else it.changedToUpIgnoreConsumed() }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/CombinedClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/CombinedClick.skiko.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalComposeUiApi::class, ExperimentalComposeUiApi::class)
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+
+/**
+ * Configure component to receive clicks, double clicks and long clicks via input only (no accessibility "click" event)
+ * within the component's bounds.
+ *
+ * It allows configuration based on a pointer type via [filter]. By default, filter uses [PointerFilter.Default].
+ * [filter] should declare supported pointer types (mouse, touch, stylus, eraser) by listing them and
+ * declaring required properties for them, such as: required button (primary, secondary, etc.) and
+ * required keyboard modifiers (isCtrlPressed, isShiftPressed, ect.)
+ *
+ * @param enabled Controls the enabled state. When `false`, [onClick], [onLongClick] or
+ * [onDoubleClick] won't be invoked
+ * @param filter defines supported pointer types and required properties
+ * @param onLongClick will be called when user long presses on the element
+ * @param onDoubleClick will be called when user double clicks on the element
+ * @param onClick will be called when user clicks on the element
+ */
+@ExperimentalFoundationApi
+fun Modifier.onCombinedClick(
+    enabled: Boolean = true,
+    filter: PointerFilter.() -> Unit = PointerFilter.Default,
+    onDoubleClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+    onClick: () -> Unit
+) = composed {
+    Modifier.onCombinedClick(
+        enabled = enabled,
+        filter = filter,
+        interactionSource = remember { MutableInteractionSource() },
+        onDoubleClick = onDoubleClick,
+        onLongClick = onLongClick,
+        onClick = onClick
+    )
+}
+
+/**
+ * Configure component to receive clicks, double clicks and long clicks via input only (no accessibility "click" event)
+ * within the component's bounds.
+ *
+ * It allows configuration based on a pointer type via [filter]. By default, filter uses [PointerFilter.Default].
+ * [filter] should declare supported pointer types (mouse, touch, stylus, eraser) by listing them and
+ * declaring required properties for them, such as: required button (primary, secondary, etc.) and
+ * required keyboard modifiers (isCtrlPressed, isShiftPressed, ect.)
+ *
+ * @param interactionSource [MutableInteractionSource] that will be used to emit
+ * [PressInteraction.Press] when this clickable is pressed. Only the initial (first) press will be
+ * recorded and emitted with [MutableInteractionSource].
+ * @param enabled Controls the enabled state. When `false`, [onClick], [onLongClick] or
+ * [onDoubleClick] won't be invoked
+ * @param filter defines supported pointer types and required properties
+ * @param onLongClick will be called when user long presses on the element
+ * @param onDoubleClick will be called when user double clicks on the element
+ * @param onClick will be called when user clicks on the element
+ */
+@ExperimentalFoundationApi
+fun Modifier.onCombinedClick(
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource,
+    filter: PointerFilter.() -> Unit,
+    onDoubleClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+    onClick: () -> Unit
+) = composed(
+    inspectorInfo = {
+        name = "onCombinedClick"
+        properties["enabled"] = enabled
+        properties["filter"] = filter
+        properties["onDoubleClick"] = onDoubleClick
+        properties["onLongClick"] = onLongClick
+        properties["onClick"] = onClick
+        properties["interactionSource"] = interactionSource
+    },
+    factory = {
+        val gestureModifier = if (enabled) {
+            val pressedInteraction = remember { mutableStateOf<PressInteraction.Press?>(null) }
+            val onClickState = rememberUpdatedState(onClick)
+            val on2xClickState = rememberUpdatedState(onDoubleClick)
+            val onLongClickState = rememberUpdatedState(onLongClick)
+            val filterState = remember {
+                mutableStateOf<(PointerEvent) -> Boolean>({ false })
+            }.apply {
+                value = remember(filter) { PointerFilter().also(filter).combinedFilter() }
+            }
+
+            Modifier.pointerInput(interactionSource) {
+                val clicksHandlerScope = ClicksHandlerScope(
+                    pointerInputScope = this@pointerInput,
+                    interactionSource = interactionSource,
+                    pressedInteraction = pressedInteraction,
+                    filterState = filterState,
+                    onDoubleClick = on2xClickState,
+                    onLongClick = onLongClickState,
+                    onClick = onClickState
+                )
+
+                while (currentCoroutineContext().isActive) {
+                    clicksHandlerScope.awaitEvents()
+                }
+            }
+        } else {
+            Modifier
+        }
+
+        gestureModifier
+    }
+)

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerFilterBuilder.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerFilterBuilder.skiko.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.util.fastAll
+
+/**
+ * Provides a builder DSL for filtering [PointerEvent]s based on [PointerType].
+ *
+ * There such methods:
+ * [mouse], [touch], [stylus], [eraser], [pointer] - for possible pointer types not supported out of the box.
+ * If none of those configured, then all events will be skipped (filtered out).
+ * Those methods configure [FilterBuilder],
+ * which lets setting one required [PointerButton] and required [PointerKeyboardModifiers].
+ *
+ * The order of filters application is following:
+ * mouse, touch, stylus, eraser, pointer(s) regardless of the order (arrangement) of methods calls.
+ *
+ * Consider using [Default] which covers most common cases for click handlers (e.g.: on primary click).
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalFoundationApi
+class PointerFilter internal constructor() {
+
+    companion object {
+        @ExperimentalFoundationApi
+        val Default: PointerFilter.() -> Unit = {
+            mouse { button = PointerButton.Primary }
+            touch {
+                // no button or keyboardModifiers required
+            }
+            stylus {
+                // no button or keyboardModifiers required
+            }
+            eraser {
+                // no button or keyboardModifiers required
+            }
+        }
+
+        private val DefaultFilterByKeyboardModifiers: PointerKeyboardModifiers.() -> Boolean = { true }
+    }
+
+    inner class FilterBuilder {
+        var button: PointerButton? = null
+        var keyboardModifiers: PointerKeyboardModifiers.() -> Boolean = DefaultFilterByKeyboardModifiers
+    }
+
+    private var mouse: FilterVariant? = null
+    private var touch: FilterVariant? = null
+    private var stylus: FilterVariant? = null
+    private var eraser: FilterVariant? = null
+    private val customPointers = mutableListOf<FilterVariant>()
+
+    private fun buildFilterData(pointerType: PointerType, builder: FilterBuilder): FilterVariant {
+        return FilterVariant(
+            pointerType = pointerType,
+            button = builder.button,
+            keyboardModifiers = builder.keyboardModifiers
+        )
+    }
+
+    @ExperimentalFoundationApi
+    fun mouse(builder: FilterBuilder.() -> Unit) {
+        mouse = buildFilterData(PointerType.Mouse, FilterBuilder().also(builder))
+    }
+
+    @ExperimentalFoundationApi
+    fun touch(builder: FilterBuilder.() -> Unit) {
+        touch = buildFilterData(PointerType.Touch, FilterBuilder().also(builder))
+    }
+
+    @ExperimentalFoundationApi
+    fun stylus(builder: FilterBuilder.() -> Unit) {
+        stylus = buildFilterData(PointerType.Stylus, FilterBuilder().also(builder))
+    }
+
+    @ExperimentalFoundationApi
+    fun eraser(builder: FilterBuilder.() -> Unit) {
+        eraser = buildFilterData(PointerType.Eraser, FilterBuilder().also(builder))
+    }
+
+    @ExperimentalFoundationApi
+    fun pointer(type: PointerType, builder: FilterBuilder.() -> Unit) {
+        customPointers.add(buildFilterData(type, FilterBuilder().also(builder)))
+    }
+
+    @ExperimentalFoundationApi
+    internal fun combinedFilter(): (PointerEvent) -> Boolean {
+        return { event ->
+            mouse?.filter(event) == true ||
+                touch?.filter(event) == true ||
+                stylus?.filter(event) == true ||
+                eraser?.filter(event) == true ||
+                customPointers.any { it.filter(event) }
+        }
+    }
+}
+
+
+@OptIn(ExperimentalComposeUiApi::class)
+private data class FilterVariant(
+    val pointerType: PointerType,
+    val button: PointerButton?,
+    val keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
+) {
+    fun filter(e: PointerEvent): Boolean {
+        return e.changes.fastAll { it.type == pointerType } &&
+            keyboardModifiers(e.keyboardModifiers) &&
+            if (button != null) e.button == button else true
+
+    }
+}

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/DragGesture.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/DragGesture.skiko.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.PointerFilter
+import androidx.compose.foundation.awaitPress
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.util.fastAll
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/**
+ * Gesture detector with [filter] that waits for pointer down matching [filter] and
+ * touch slop in any direction and then calls [onDrag] for each drag event.
+ * It follows the touch slop detection of [awaitTouchSlopOrCancellation]
+ * but will consume the position change automatically once the touch slop has been crossed.
+ * [onDragStart] will be called when touch slop in passed with the last known pointer position provided.
+ * [onDragEnd] is called after pointer matching [filter] gets released,
+ * and [onDragCancel] is called if another gesture has consumed pointer input, canceling this gesture.
+ */
+@ExperimentalFoundationApi
+suspend fun PointerInputScope.detectDragGestures(
+    filter: PointerFilter.() -> Unit,
+    onDragStart: (Offset) -> Unit = {},
+    onDragCancel: () -> Unit = {},
+    onDragEnd: () -> Unit = {},
+    onDrag: (Offset) -> Unit
+) {
+    while (currentCoroutineContext().isActive) {
+        coroutineScope {
+            val combinedFilter = PointerFilter().apply(filter).combinedFilter()
+            var dragStartedContinuation: Continuation<Boolean>? = null
+
+            // Here we launch 2 coroutines:
+            // 1st to wait for drag start and for processing the drag events (dragJob);
+            // 2nd to wait for release event matching the filter - meaning the drag should complete;
+            // We do this because:
+            // 1st coroutine can't always know that drag was completed (fun drag finishes only when all pointers go up).
+            // In case of mouse, it means that fun drag will not complete if any mouse button pressed.
+            // Therefore, 2nd coroutine will cancel the 1st coroutine (dragJob) when necessary.
+
+            val dragJob = launch {
+                awaitPointerEventScope {
+                    val press = awaitPress(
+                        requireUnconsumed = false,
+                        filterPressEvent = combinedFilter
+                    )
+
+                    val overSlop = awaitDragStartOnSlop(press)
+                    val pointerId = press.changes[0].id
+
+                    if (overSlop != null) {
+                        dragStartedContinuation?.resume(true)
+                        onDragStart(press.changes[0].position)
+
+                        if (overSlop != Offset.Zero) {
+                            onDrag(overSlop)
+                        }
+
+                        try {
+                            drag(pointerId) {
+                                onDrag(it.positionChange())
+                                it.consume()
+                            }
+                        } finally {
+                            if (currentEvent.isReleased() && combinedFilter(currentEvent)) {
+                                onDragEnd()
+                            } else {
+                                onDragCancel()
+                            }
+                        }
+                    } else {
+                        dragStartedContinuation?.resume(false)
+                    }
+                }
+            }
+
+            launch {
+                val dragStarted = suspendCoroutine<Boolean> { dragStartedContinuation = it }
+                if (dragStarted) {
+                    awaitPointerEventScope {
+                        while (dragJob.isActive) {
+                            val event = awaitPointerEvent()
+                            if (event.isReleased() && combinedFilter(event)) {
+                                dragJob.cancel()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Adds a gesture detector with [filter] that waits for pointer down matching [filter] and
+ * touch slop in any direction and then calls [onDrag] for each drag event.
+ * It follows the touch slop detection of [awaitTouchSlopOrCancellation]
+ * but will consume the position change automatically once the touch slop has been crossed.
+ * [onDragStart] will be called when touch slop in passed with the last known pointer position provided.
+ * [onDragEnd] is called after pointer matching [filter] gets released,
+ * and [onDragCancel] is called if another gesture has consumed pointer input, canceling this gesture.
+ */
+@ExperimentalFoundationApi
+fun Modifier.onDragGesture(
+    enabled: Boolean = true,
+    filter: PointerFilter.() -> Unit = PointerFilter.Default,
+    onDragStart: (Offset) -> Unit = {},
+    onDragCancel: () -> Unit = {},
+    onDragEnd: () -> Unit = {},
+    onDrag: (Offset) -> Unit
+): Modifier = composed {
+    if (!enabled) return@composed Modifier
+
+    val onDragState = rememberUpdatedState(onDrag)
+    val onDragStartState = rememberUpdatedState(onDragStart)
+    val onDragEndState = rememberUpdatedState(onDragEnd)
+    val onDragCancelState = rememberUpdatedState(onDragCancel)
+    val filterState = rememberUpdatedState(filter)
+
+    Modifier.pointerInput(Unit) {
+        detectDragGestures(
+            filter = { filterState.value(this) },
+            onDragStart = { onDragStartState.value(it) },
+            onDrag = { onDragState.value(it) },
+            onDragEnd = { onDragEndState.value() },
+            onDragCancel = { onDragCancelState.value() }
+        )
+    }
+}
+
+private fun PointerEvent.isReleased() = type == PointerEventType.Release &&
+    changes.fastAll { it.type == PointerType.Mouse } || changes.fastAll { it.changedToUpIgnoreConsumed() }
+
+private suspend fun AwaitPointerEventScope.awaitDragStartOnSlop(initialDown: PointerEvent): Offset? {
+    var overSlop = Offset.Zero
+    var drag: PointerInputChange?
+    do {
+        drag = awaitPointerSlopOrCancellation(
+            initialDown.changes[0].id,
+            initialDown.changes[0].type
+        ) { change, over ->
+            change.consume()
+            overSlop = over
+        }
+    } while (drag != null && !drag.isConsumed)
+
+    return if (drag == null) {
+        null
+    } else {
+        overSlop
+    }
+}

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/WindowInfo.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/WindowInfo.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
-import kotlinx.coroutines.flow.collect
 
 /**
  * Provides information about the Window that is hosting this compose hierarchy.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ImageComposeScene.desktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -188,6 +189,7 @@ class ImageComposeScene(
      * as well as the state of the lock keys, such as Caps Lock and Num Lock.
      * @param nativeEvent The original native event.
      */
+    @OptIn(ExperimentalComposeUiApi::class)
     fun sendPointerEvent(
         eventType: PointerEventType,
         position: Offset,
@@ -196,9 +198,10 @@ class ImageComposeScene(
         type: PointerType = PointerType.Mouse,
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
-        nativeEvent: Any? = null
+        nativeEvent: Any? = null,
+        button: PointerButton? = null
     ): Unit = scene.sendPointerEvent(
-        eventType, position, scrollDelta, timeMillis, type, buttons, keyboardModifiers, nativeEvent
+        eventType, position, scrollDelta, timeMillis, type, buttons, keyboardModifiers, nativeEvent, button
     )
     /**
      * Send [KeyEvent] to the content.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -63,6 +63,7 @@ import kotlin.coroutines.CoroutineContext
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.input.pointer.AwtCursor
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerType
@@ -366,8 +367,19 @@ private fun ComposeScene.onMouseEvent(
         type = PointerType.Mouse,
         buttons = event.buttons,
         keyboardModifiers = event.keyboardModifiers,
-        nativeEvent = event
+        nativeEvent = event,
+        button = event.getPointerButton()
     )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun MouseEvent.getPointerButton(): PointerButton? {
+    if (button == MouseEvent.NOBUTTON) return null
+    return when (button) {
+        MouseEvent.BUTTON2 -> PointerButton.Tertiary
+        MouseEvent.BUTTON3 -> PointerButton.Secondary
+        else -> PointerButton(button - 1)
+    }
 }
 
 @Suppress("ControlFlowWithEmptyBody")

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -27,11 +27,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isAltPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.isLinux
 import androidx.compose.ui.isMacOs
 import androidx.compose.ui.isWindows
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.WindowInfo
+import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -47,6 +51,10 @@ import java.awt.Dimension
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Window
+import java.awt.event.InputEvent.ALT_DOWN_MASK
+import java.awt.event.InputEvent.SHIFT_DOWN_MASK
+import java.awt.event.KeyEvent.VK_ALT
+import java.awt.event.KeyEvent.VK_SHIFT
 import java.awt.event.WindowEvent
 import javax.swing.JFrame
 import kotlin.math.abs

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputEvent
@@ -415,6 +416,7 @@ class ComposeScene internal constructor(
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
+        button: PointerButton? = null
     ): Unit = postponeInvalidation {
         defaultPointerStateTracker.onPointerEvent(eventType)
 
@@ -430,7 +432,8 @@ class ComposeScene internal constructor(
             type,
             scrollDelta,
             actualButtons,
-            actualKeyboardModifiers
+            actualKeyboardModifiers,
+            button
         )
         needLayout = false
         forEachOwner { it.measureAndLayout() }
@@ -478,6 +481,7 @@ class ComposeScene internal constructor(
         owner?.processPointerInput(event)
     }
 
+    @OptIn(ExperimentalComposeUiApi::class)
     private fun processMove(event: PointerInputEvent) {
         val owner = when {
             event.buttons.areAnyPressed -> pressOwner
@@ -539,6 +543,7 @@ private class DefaultPointerStateTracker {
         private set
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 private fun pointerInputEvent(
     eventType: PointerEventType,
     position: Offset,
@@ -547,7 +552,8 @@ private fun pointerInputEvent(
     type: PointerType,
     scrollDelta: Offset,
     buttons: PointerButtons,
-    keyboardModifiers: PointerKeyboardModifiers
+    keyboardModifiers: PointerKeyboardModifiers,
+    changedButton: PointerButton?
 ): PointerInputEvent {
     return PointerInputEvent(
         eventType,
@@ -565,10 +571,12 @@ private fun pointerInputEvent(
         ),
         buttons,
         keyboardModifiers,
-        nativeEvent
+        nativeEvent,
+        changedButton
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 private fun createMoveEvent(
     nativeEvent: Any?,
     sourceEvent: PointerInputEvent,
@@ -581,7 +589,8 @@ private fun createMoveEvent(
     type = sourceEvent.pointers.first().type,
     scrollDelta = Offset(0f, 0f),
     buttons = sourceEvent.buttons,
-    keyboardModifiers = sourceEvent.keyboardModifiers
+    keyboardModifiers = sourceEvent.keyboardModifiers,
+    changedButton = null
 )
 
 internal expect fun createSkiaLayer(): SkiaLayer

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/InternalPointerEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/InternalPointerEvent.skiko.kt
@@ -16,12 +16,16 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+
+@OptIn(ExperimentalComposeUiApi::class)
 internal actual class InternalPointerEvent constructor(
     val type: PointerEventType,
     actual val changes: Map<PointerId, PointerInputChange>,
     val buttons: PointerButtons,
     val keyboardModifiers: PointerKeyboardModifiers,
-    val nativeEvent: Any?
+    val nativeEvent: Any?,
+    val button: PointerButton?
 ) {
     actual constructor(
         changes: Map<PointerId, PointerInputChange>,
@@ -31,7 +35,8 @@ internal actual class InternalPointerEvent constructor(
         changes,
         pointerInputEvent.buttons,
         pointerInputEvent.keyboardModifiers,
-        pointerInputEvent.nativeEvent
+        pointerInputEvent.nativeEvent,
+        pointerInputEvent.button
     )
 
     actual var suppressMovementConsumption: Boolean = false

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerButton.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerButton.skiko.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.pointer
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import kotlin.jvm.JvmInline
+
+@JvmInline
+@ExperimentalComposeUiApi
+value class PointerButton(val index: Int) {
+    companion object {
+        val Primary = PointerButton(0)
+        val Secondary = PointerButton(2)
+        val Tertiary = PointerButton(1)
+        val Back = PointerButton(3)
+        val Forward = PointerButton(4)
+    }
+}
+
+@ExperimentalComposeUiApi
+val PointerButton?.isPrimary: Boolean
+    get() { return this == PointerButton.Primary }
+
+@ExperimentalComposeUiApi
+val PointerButton?.isSecondary: Boolean
+    get() { return this == PointerButton.Secondary }
+
+@ExperimentalComposeUiApi
+val PointerButton?.isTertiary: Boolean
+    get() { return this == PointerButton.Tertiary }
+
+@ExperimentalComposeUiApi
+val PointerButton?.isBack: Boolean
+    get() { return this == PointerButton.Back }
+
+@ExperimentalComposeUiApi
+val PointerButton?.isForward: Boolean
+    get() { return this == PointerButton.Forward }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.skiko.kt
@@ -16,8 +16,13 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
 import org.jetbrains.skiko.SkikoPointerEventKind
-import org.jetbrains.skiko.SkikoGestureEventState
 import org.jetbrains.skiko.SkikoTouchEventKind
 
 internal actual typealias NativePointerButtons = Int
@@ -89,6 +94,7 @@ fun PointerKeyboardModifiers(
 /**
  * Describes a pointer input change event that has occurred at a particular point in time.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 actual data class PointerEvent internal constructor(
     /**
      * The changes.
@@ -115,7 +121,9 @@ actual data class PointerEvent internal constructor(
      * - there was a synthetic move event sent by compose on relayout
      * - there was a synthetic move event sent by compose when move is missing between two non-move events
      */
-    val nativeEvent: Any?
+    val nativeEvent: Any?,
+
+    val button: PointerButton?
 ) {
     internal actual constructor(
         changes: List<PointerInputChange>,
@@ -125,7 +133,8 @@ actual data class PointerEvent internal constructor(
         internalPointerEvent?.buttons ?: PointerButtons(0),
         internalPointerEvent?.keyboardModifiers ?: PointerKeyboardModifiers(0),
         internalPointerEvent?.type ?: PointerEventType.Unknown,
-        internalPointerEvent?.nativeEvent
+        internalPointerEvent?.nativeEvent,
+        internalPointerEvent?.button
     )
 
     /**
@@ -136,7 +145,8 @@ actual data class PointerEvent internal constructor(
         buttons = PointerButtons(0),
         keyboardModifiers = PointerKeyboardModifiers(0),
         _type = PointerEventType.Unknown,
-        nativeEvent = null
+        nativeEvent = null,
+        button = null
     )
 
     actual var type: PointerEventType = _type

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.skiko.kt
@@ -16,11 +16,15 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+
+@OptIn(ExperimentalComposeUiApi::class)
 internal actual data class PointerInputEvent(
     val eventType: PointerEventType,
     actual val uptime: Long,
     actual val pointers: List<PointerInputEventData>,
     val buttons: PointerButtons = PointerButtons(0),
     val keyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers(0),
-    val nativeEvent: Any? = null
+    val nativeEvent: Any? = null,
+    val button: PointerButton? = null
 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.PointerIconDefaults
 import androidx.compose.ui.input.pointer.PointerIconService
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventProcessor

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.PointerIconDefaults
 import androidx.compose.ui.input.pointer.PointerIconService
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventProcessor
@@ -358,7 +357,8 @@ internal class SkiaBasedOwner(
                 PointerEventType.Unknown,
                 timeMillis,
                 pointers.map { it.toPointerInputEventData() },
-                if (isPressed) PointerButtons(isPrimaryPressed = true) else PointerButtons()
+                if (isPressed) PointerButtons(isPrimaryPressed = true) else PointerButtons(),
+                button = null
             )
         )
     }


### PR DESCRIPTION
This PR adds new experimental APIs to handle clicks and drag gesture:

### onCombinedClick
```kotlin
fun Modifier.onCombinedClick(
    enabled: Boolean = true,
    filter: PointerFilter.() -> Unit = PointerFilter.Default,
    onDoubleClick: (() -> Unit)? = null,
    onLongClick: (() -> Unit)? = null,
    onClick: () -> Unit
): Modifier
```
It allows to configure the required buttons and pointers using `filter`. It can be added multiple times. It doesn't add click-related side effects such as indication, focusable. It also doesn't add semantics. There is an overload with `interactionSource: MutableInteractionSource` to allow indication configuration at the call site.

### detectDragGestures and onDragGesture
```kotlin
suspend fun PointerInputScope.detectDragGestures(
    filter: PointerFilter.() -> Unit, // no default value to avoid resolution issue (there is a function with the same name)
    onDragStart: (Offset) -> Unit = {},
    onDragCancel: () -> Unit = {},
    onDragEnd: () -> Unit = {},
    onDrag: (Offset) -> Unit
)

fun Modifier.onDragGesture(
    enabled: Boolean = true,
    filter: PointerFilter.() -> Unit = PointerFilter.Default,
    onDragStart: (Offset) -> Unit = {},
    onDragCancel: () -> Unit = {},
    onDragEnd: () -> Unit = {},
    onDrag: (Offset) -> Unit
): Modifier 

```
Both functions do the same thing - allow to handle drag gesture configured with `filter` (to allow only specific drags, e.g.: only with primary mouse button). The difference is the scope where they can be called). 

### Filter 
`filter` lambda allows to configure filtering based on pointer types (mouse, touch, stylus, eraser...).
Example (to allow only mouse, primary button, and shift pressed required):
```kotlin
filter = {
    mouse {
       button = PointerButton.Primary
       keyboardModifiers = { isShiftPressed }
    }
}
```

###  Example with keyboardModifiers:
```kotlin

fun main() {
    var isCtrlPressed: Boolean by mutableStateOf(false)

    singleWindowApplication(
        onPreviewKeyEvent = {
            isCtrlPressed = it.isCtrlPressed
            false
        }
    ) {
        var isDragging by remember { mutableStateOf(false) }
        val isDraggingWithCtrlPressed: Boolean by derivedStateOf {  isDragging && isCtrlPressed }

        var offset1 by remember { mutableStateOf(Offset.Zero) }
        Box(modifier = Modifier
            .offset { IntOffset(offset1.x.toInt(), offset1.y.toInt()) }
            .size(100.dp)
            .background(Color.Blue)
            .pointerInput(Unit) {
                detectDragGestures(
                    filter = { mouse { button = PointerButton.Primary } },
                    onDragStart = { isDragging = true },
                    onDragEnd = { isDragging = false },
                    onDragCancel = { isDragging = false }
                ) {
                    offset1 += it * if (isDraggingWithCtrlPressed) 2.0f else 1.0f
                }
            }.pointerHoverIcon(if (isDraggingWithCtrlPressed) PointerIconDefaults.Hand else PointerIconDefaults.Default)
        ) {
            Text("Use Left Mouse Button To Drag")
        }
    }
}
 ```