### PR TITLE
fix CustomFocusTraversalTest

### DIFF
--- a/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/focus/CustomFocusTraversalTest.kt
+++ b/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/focus/CustomFocusTraversalTest.kt
@@ -54,7 +54,7 @@ class CustomFocusTraversalTest(
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "moveFocusProgrammatically = {0}, useFocusModifier = {1}")
+        @Parameterized.Parameters(name = "moveFocusProgrammatically = {0}, useFocusOrderModifier = {1}")
         fun initParameters() = listOf(
             arrayOf(true, true),
             arrayOf(true, false),
@@ -643,7 +643,9 @@ class CustomFocusTraversalTest(
         if (useFocusOrderModifier) {
             this.then(ReceiverFocusOrderModifier(block))
         } else {
-            focusProperties(FocusOrderToProperties(block))
+            focusProperties {
+                FocusOrderToProperties(block).invoke(this)
+            }
         }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
FocusOrderToProperties changes in [this commit](https://github.com/JetBrains/androidx/commit/9b0fe5c461c5263057bba30fc9f9c313274a4aec#diff-2f6de5ecd89f05a15ef9ec85f7e6543157e103fb274f43d8b393e3d2082a4cd2R240)

Fixed broken test