### PR TITLE
Focus Swing interop. Move focus from Compose component to Swing component

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -16,17 +16,26 @@
 
 package androidx.compose.ui.awt
 
+import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.AwtCursor
 import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
-import androidx.compose.ui.platform.DesktopPlatform
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.AccessibilityControllerImpl
 import androidx.compose.ui.platform.Platform
 import androidx.compose.ui.platform.PlatformComponent
+import androidx.compose.ui.platform.PlatformInput
 import androidx.compose.ui.platform.WindowInfoImpl
+import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.window.WindowExceptionHandler
@@ -60,15 +69,8 @@ import javax.accessibility.AccessibleContext
 import javax.swing.SwingUtilities
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
-import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
-import androidx.compose.ui.ComposeScene
-import androidx.compose.ui.input.pointer.AwtCursor
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.platform.PlatformInput
-import androidx.compose.ui.semantics.SemanticsOwner
 import java.awt.Cursor
+import org.jetbrains.skiko.hostOs
 
 internal class ComposeLayer {
     private var isDisposed = false
@@ -107,6 +109,39 @@ internal class ComposeLayer {
         override val windowInfo = WindowInfoImpl()
 
         override val textInputService = PlatformInput(_component)
+
+        override val focusManager = object : FocusManager {
+            override fun clearFocus(force: Boolean) {
+                val root = component.rootPane
+                root?.focusTraversalPolicy?.getDefaultComponent(root)?.requestFocusInWindow()
+            }
+
+            override fun moveFocus(focusDirection: FocusDirection): Boolean = when (focusDirection) {
+                FocusDirection.Next -> {
+                    val toFocus = _component.focusCycleRootAncestor?.let { root ->
+                        val policy = root.focusTraversalPolicy
+                        policy.getComponentAfter(root, _component)
+                            ?: policy.getDefaultComponent(root)
+                    }
+                    val hasFocus = toFocus?.hasFocus() == true
+                    !hasFocus && toFocus?.requestFocusInWindow(FocusEvent.Cause.TRAVERSAL_FORWARD) == true
+                }
+                FocusDirection.Previous -> {
+                    val toFocus = _component.focusCycleRootAncestor?.let { root ->
+                        val policy = root.focusTraversalPolicy
+                        policy.getComponentBefore(root, _component)
+                            ?: policy.getDefaultComponent(root)
+                    }
+                    val hasFocus = toFocus?.hasFocus() == true
+                    !hasFocus && toFocus?.requestFocusInWindow(FocusEvent.Cause.TRAVERSAL_BACKWARD) == true
+                }
+                else -> false
+            }
+        }
+
+        override fun requestFocusForOwner(): Boolean {
+            return component.hasFocus() || component.requestFocusInWindow()
+        }
     }
 
     internal val scene = ComposeScene(
@@ -437,7 +472,7 @@ private fun getLockingKeyStateSafe(
 
 private val MouseEvent.isMacOsCtrlClick
     get() = (
-            DesktopPlatform.Current == DesktopPlatform.MacOS &&
+            hostOs.isMacOS &&
                     ((modifiersEx and InputEvent.BUTTON1_DOWN_MASK) != 0) &&
                     ((modifiersEx and InputEvent.CTRL_DOWN_MASK) != 0)
             )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -33,6 +33,8 @@ import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputEvent
@@ -250,6 +252,11 @@ class ComposeScene internal constructor(
         invalidateIfNeeded()
         if (owner.isFocusable) {
             focusedOwner = owner
+        }
+        if (isFocused) {
+            owner.focusManager.takeFocus()
+        } else {
+            owner.focusManager.releaseFocus()
         }
     }
 
@@ -522,6 +529,40 @@ class ComposeScene internal constructor(
     fun sendKeyEvent(event: ComposeKeyEvent): Boolean = postponeInvalidation {
         return focusedOwner?.sendKeyEvent(event) == true
     }
+
+    private var isFocused = true
+
+    /**
+     * Call this function to clear focus from the currently focused component, and set the focus to
+     * the root focus modifier.
+     */
+    @ExperimentalComposeUiApi
+    fun releaseFocus() {
+        list.forEach {
+            it.focusManager.releaseFocus()
+        }
+        isFocused = false
+    }
+
+    @ExperimentalComposeUiApi
+    fun requestFocus() {
+        list.forEach {
+            it.focusManager.takeFocus()
+        }
+        isFocused = true
+    }
+
+    /**
+     * Moves focus in the specified [direction][FocusDirection].
+     *
+     * If you are not satisfied with the default focus order, consider setting a custom order using
+     * [Modifier.focusProperties()][focusProperties].
+     *
+     * @return true if focus was moved successfully. false if the focused item is unchanged.
+     */
+    @ExperimentalComposeUiApi
+    fun moveFocus(focusDirection: FocusDirection): Boolean =
+        list.lastOrNull()?.focusManager?.moveFocus(focusDirection) ?: false
 }
 
 private class DefaultPointerStateTracker {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
@@ -16,6 +16,8 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -28,6 +30,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 // TODO(demin): make it public when we stabilize it after implementing it for uikit and js
 internal interface Platform {
     val windowInfo: WindowInfo
+    val focusManager: FocusManager
+    fun requestFocusForOwner(): Boolean
     val textInputService: PlatformTextInputService
     fun accessibilityController(owner: SemanticsOwner): AccessibilityController
     fun setPointerIcon(pointerIcon: PointerIcon)
@@ -41,6 +45,13 @@ internal interface Platform {
                 // (hidden textfield cursor, gray titlebar, etc)
                 isWindowFocused = true
             }
+
+            override val focusManager = object : FocusManager {
+                override fun clearFocus(force: Boolean) = Unit
+                override fun moveFocus(focusDirection: FocusDirection) = false
+            }
+
+            override fun requestFocusForOwner() = false
 
             override val textInputService = object : PlatformTextInputService {
                 override fun startInput(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -120,12 +120,12 @@ internal class SkiaBasedOwner(
         properties = {}
     )
 
-    private val _focusManager: FocusManagerImpl = FocusManagerImpl().apply {
+    override val focusManager = FocusManagerImpl(
+        parent = platform.focusManager
+    ).apply {
         // TODO(demin): support RTL [onRtlPropertiesChanged]
         layoutDirection = LayoutDirection.Ltr
     }
-    override val focusManager: FocusManager
-        get() = _focusManager
 
     // TODO: Set the input mode. For now we don't support touch mode, (always in Key mode).
     private val _inputModeManager = InputModeManagerImpl(
@@ -157,7 +157,7 @@ internal class SkiaBasedOwner(
     override val root = LayoutNode().also {
         it.measurePolicy = RootMeasurePolicy
         it.modifier = semanticsModifier
-            .then(_focusManager.modifier)
+            .then(focusManager.modifier)
             .then(keyInputModifier)
             .then(
                 KeyInputModifier(
@@ -180,7 +180,6 @@ internal class SkiaBasedOwner(
     init {
         snapshotObserver.startObserving()
         root.attach(this)
-        _focusManager.takeFocus()
     }
 
     fun dispose() {
@@ -220,7 +219,7 @@ internal class SkiaBasedOwner(
 
     override var showLayoutBounds = false
 
-    override fun requestFocus() = true
+    override fun requestFocus() = platform.requestFocusForOwner()
 
     override fun onAttach(node: LayoutNode) = Unit
 


### PR DESCRIPTION
If it is ComposeWindow, then we just wrap focus around, when we press Tab on the last focused component inside that window

If it is ComposePanel, we switch focus to the next Swing component after the panel

If we clear focus via Compose API, we make root Swing component focused (there always should be something focused)
