### PR TITLE
Focus Swing interop. Move focus from Swing  component to Compose compoonent inside ComposePanel

### DIFF
--- a/compose/desktop/desktop/samples/build.gradle
+++ b/compose/desktop/desktop/samples/build.gradle
@@ -112,6 +112,15 @@ task runLayout(type: JavaExec) {
                     compilation.runtimeDependencyFiles
 }
 
+task runFocusTest(type: JavaExec) {
+    dependsOn(":compose:desktop:desktop:jar")
+    main = "androidx.compose.desktop.examples.focustest.Main_jvmKt"
+    def compilation = kotlin.jvm().compilations["main"]
+    classpath =
+        compilation.output.allOutputs +
+        compilation.runtimeDependencyFiles
+}
+
 task run {
     dependsOn("run1")
 }

--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/focustest/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/focustest/Main.jvm.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.desktop.examples.focustest
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.TextField
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.unit.dp
+import java.awt.Dimension
+import javax.swing.JButton
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+
+fun main() = SwingUtilities.invokeLater {
+    val window = JFrame()
+    window.preferredSize = Dimension(300, 800)
+    window.defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+    window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+        add(JButton())
+        add(JButton())
+
+        add(ComposePanel().apply {
+            setContent {
+                MaterialTheme {
+                    Column(Modifier.fillMaxSize()) {
+                        Button({}) {}
+                        Button({}) {}
+                        TextField("", {}, singleLine = true)
+                        SwingPanel(
+                            modifier = Modifier.size(100.dp),
+                            factory = {
+                                javax.swing.Box.createVerticalBox().apply {
+                                    add(JButton())
+                                    add(JButton())
+                                    add(JButton())
+                                }
+                            }
+                        )
+                        Button({}) {}
+
+                        SwingPanel(
+                            modifier = Modifier.size(100.dp),
+                            factory = {
+                                javax.swing.Box.createVerticalBox().apply {
+                                    add(JButton())
+                                    ComposePanel().apply {
+                                        setContent {
+                                            MaterialTheme {
+                                                Column(Modifier.fillMaxSize()) {
+                                                    Button({}) {}
+                                                    SwingPanel(
+                                                        modifier = Modifier.size(100.dp),
+                                                        factory = {
+                                                            javax.swing.Box.createVerticalBox().apply {
+                                                                add(JButton())
+                                                                add(JButton())
+                                                            }
+                                                        }
+                                                    )
+                                                    Button({}) {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                    add(JButton())
+                                }
+                            }
+                        )
+
+                        Button({}) {}
+                    }
+                }
+            }
+        })
+        add(JButton())
+        add(JButton())
+    })
+
+    window.pack()
+    window.isVisible = true
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.awt
+
+import java.awt.Component
+
+internal fun Component.isParentOf(component: Component?): Boolean {
+    var parent = component?.parent
+    while (parent != null) {
+        if (parent == this) {
+            return true
+        }
+        parent = parent.parent
+    }
+    return false
+}


### PR DESCRIPTION
- all focus methods of ComposePanel ad delegated to SkiaLayer
- we override focusTraversalPolicy of `ComposePanel`, so we can move focus to the next/previous component after `ComposePanel`
- we call scene.releaseFocus() in `init`, because now Swing itself will request focus for `ComposePanel`. And when it do it, we will restore the focus
- when `ComposePanel` receives the focus, it focuses on the first/last Compose component inside it