### PR TITLE
Focus Swing interop. Move focus from Compose to SwingPanel

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -21,17 +21,27 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusTarget
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.round
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Container
+import java.awt.event.FocusEvent
+import java.awt.event.FocusListener
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.swing.JPanel
+import javax.swing.LayoutFocusTraversalPolicy
 import javax.swing.SwingUtilities
 
 val NoOpUpdate: Component.() -> Unit = {}
@@ -64,47 +74,158 @@ public fun <T : Component> SwingPanel(
 ) {
     val componentInfo = remember { ComponentInfo<T>() }
 
-    val container = LocalLayerContainer.current
+    val root = LocalLayerContainer.current
     val density = LocalDensity.current.density
+    val focusManager = LocalFocusManager.current
+    val focusSwitcher = remember { FocusSwitcher(componentInfo, focusManager) }
 
-    Layout(
-        content = {},
+    Box(
         modifier = modifier.onGloballyPositioned { childCoordinates ->
             val coordinates = childCoordinates.parentCoordinates!!
             val location = coordinates.localToWindow(Offset.Zero).round()
             val size = coordinates.size
-            componentInfo.layout.setBounds(
+            componentInfo.container.setBounds(
                 (location.x / density).toInt(),
                 (location.y / density).toInt(),
                 (size.width / density).toInt(),
                 (size.height / density).toInt()
             )
-            componentInfo.layout.validate()
-            componentInfo.layout.repaint()
-        },
-        measurePolicy = { _, _ ->
-            layout(0, 0) {}
+            componentInfo.container.validate()
+            componentInfo.container.repaint()
         }
-    )
+    ) {
+        focusSwitcher.Content()
+    }
 
     DisposableEffect(factory) {
-        componentInfo.factory = factory()
-        componentInfo.layout = JPanel().apply {
-            setLayout(BorderLayout(0, 0))
-            add(componentInfo.factory)
+        val focusListener = object : FocusListener {
+            override fun focusGained(e: FocusEvent) {
+                if (componentInfo.container.isParentOf(e.oppositeComponent)) {
+                    when (e.cause) {
+                        FocusEvent.Cause.TRAVERSAL_FORWARD -> focusSwitcher.moveForward()
+                        FocusEvent.Cause.TRAVERSAL_BACKWARD -> focusSwitcher.moveBackward()
+                        else -> Unit
+                    }
+                }
+            }
+
+            override fun focusLost(e: FocusEvent) = Unit
         }
-        componentInfo.updater = Updater(componentInfo.factory, update)
-        container.add(componentInfo.layout)
+        root.addFocusListener(focusListener)
+        componentInfo.component = factory()
+        componentInfo.container = JPanel().apply {
+            layout = BorderLayout(0, 0)
+            focusTraversalPolicy = object : LayoutFocusTraversalPolicy() {
+                override fun getComponentAfter(aContainer: Container?, aComponent: Component?): Component? {
+                    return if (aComponent == getLastComponent(aContainer)) {
+                        root
+                    } else {
+                        super.getComponentAfter(aContainer, aComponent)
+                    }
+                }
+
+                override fun getComponentBefore(aContainer: Container?, aComponent: Component?): Component? {
+                    return if (aComponent == getFirstComponent(aContainer)) {
+                        root
+                    } else {
+                        super.getComponentBefore(aContainer, aComponent)
+                    }
+                }
+            }
+            isFocusCycleRoot = true
+            add(componentInfo.component)
+        }
+        componentInfo.updater = Updater(componentInfo.component, update)
+        root.add(componentInfo.container)
         onDispose {
-            container.remove(componentInfo.layout)
+            root.remove(componentInfo.container)
             componentInfo.updater.dispose()
+            root.removeFocusListener(focusListener)
         }
     }
 
     SideEffect {
-        componentInfo.layout.setBackground(parseColor(background))
+        componentInfo.container.background = parseColor(background)
         componentInfo.updater.update = update
     }
+}
+
+private class FocusSwitcher<T : Component>(
+    private val info: ComponentInfo<T>,
+    private val focusManager: FocusManager
+) {
+    private val backwardRequester = FocusRequester()
+    private val forwardRequester = FocusRequester()
+    private var isRequesting = false
+
+    fun moveBackward() {
+        try {
+            isRequesting = true
+            backwardRequester.requestFocus()
+        } finally {
+            isRequesting = false
+        }
+        focusManager.moveFocus(FocusDirection.Previous)
+    }
+
+    fun moveForward() {
+        try {
+            isRequesting = true
+            forwardRequester.requestFocus()
+        } finally {
+            isRequesting = false
+        }
+        focusManager.moveFocus(FocusDirection.Next)
+    }
+
+    @Composable
+    fun Content() {
+        Box(
+            Modifier
+                .focusRequester(backwardRequester)
+                .onFocusChanged {
+                    if (it.isFocused && !isRequesting) {
+                        focusManager.clearFocus(force = true)
+                        info.container.focusTraversalPolicy
+                            .getFirstComponent(info.container)
+                            .requestFocus(FocusEvent.Cause.TRAVERSAL_FORWARD)
+                    }
+                }
+                .focusTarget()
+        )
+        Box(
+            Modifier
+                .focusRequester(forwardRequester)
+                .onFocusChanged {
+                    if (it.isFocused && !isRequesting) {
+                        focusManager.clearFocus(force = true)
+                        info.container.focusTraversalPolicy
+                            .getLastComponent(info.container)
+                            .requestFocus(FocusEvent.Cause.TRAVERSAL_BACKWARD)
+                    }
+                }
+                .focusTarget()
+        )
+    }
+}
+
+@Composable
+private fun Box(modifier: Modifier, content: @Composable () -> Unit = {}) {
+    Layout(
+        content = content,
+        modifier = modifier,
+        measurePolicy = { measurables, constraints ->
+            val placeables = measurables.map { it.measure(constraints) }
+            layout(
+                placeables.maxOfOrNull { it.width } ?: 0,
+                placeables.maxOfOrNull { it.height } ?: 0
+            ) {
+                placeables.forEach {
+                    it.place(0, 0)
+                }
+            }
+        }
+    )
 }
 
 private fun parseColor(color: Color): java.awt.Color {
@@ -117,8 +238,8 @@ private fun parseColor(color: Color): java.awt.Color {
 }
 
 private class ComponentInfo<T : Component> {
-    lateinit var layout: Container
-    lateinit var factory: T
+    lateinit var container: Container
+    lateinit var component: T
     lateinit var updater: Updater<T>
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
+import androidx.compose.ui.LayoutWithWorkaround
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
@@ -211,7 +212,7 @@ private class FocusSwitcher<T : Component>(
 
 @Composable
 private fun Box(modifier: Modifier, content: @Composable () -> Unit = {}) {
-    Layout(
+    LayoutWithWorkaround(
         content = content,
         modifier = modifier,
         measurePolicy = { measurables, constraints ->

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowExceptionHandlerFactory.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowExceptionHandlerFactory.desktop.kt
@@ -16,7 +16,9 @@ object DefaultWindowExceptionHandlerFactory : WindowExceptionHandlerFactory {
         // invokeLater here to dispatch a blocking operation (showMessageDialog)
         SwingUtilities.invokeLater {
             JOptionPane.showMessageDialog(
-                window,
+                // if there was an error during window init, we can't use it as a parent,
+                // otherwise we will have two exceptions in the log
+                window.takeIf { it.isDisplayable },
                 throwable.message ?: "Unknown error", "Error",
                 JOptionPane.ERROR_MESSAGE
             )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -1,0 +1,494 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.awt
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awaitEDT
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.performClick
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.KeyboardFocusManager
+import java.awt.Window
+import java.awt.event.KeyEvent
+import javax.swing.JButton
+import javax.swing.JFrame
+import kotlin.random.Random
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.skiko.MainUIDispatcher
+import org.junit.Assume
+import org.junit.Test
+
+class ComposeFocusTest {
+    @Test
+    fun `compose window`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton1.Content()
+                    composeButton2.Content()
+                    composeButton3.Content()
+                    composeButton4.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton1, composeButton2, composeButton3, composeButton4
+        )
+    }
+
+    @Test
+    fun `compose panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(
+            ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton1.Content()
+                            composeButton2.Content()
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                }
+            }
+        )
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton1, composeButton2, composeButton3, composeButton4
+        )
+    }
+
+    @Test
+    fun `compose panel in the end`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(outerButton1)
+            add(outerButton2)
+
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton1.Content()
+                            composeButton2.Content()
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                }
+            })
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, outerButton1, outerButton2, composeButton1, composeButton2, composeButton3, composeButton4
+        )
+    }
+
+    @Test
+    fun `compose panel in the beginning`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton1.Content()
+                            composeButton2.Content()
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                }
+            })
+            add(outerButton3)
+            add(outerButton4)
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton1, composeButton2, composeButton3, composeButton4, outerButton3, outerButton4
+        )
+    }
+
+    @Test
+    fun `swing panel in the middle of compose panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(outerButton1)
+            add(outerButton2)
+
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton1.Content()
+                            composeButton2.Content()
+                            SwingPanel(
+                                modifier = Modifier.size(100.dp),
+                                factory = {
+                                    javax.swing.Box.createVerticalBox().apply {
+                                        add(innerButton1)
+                                        add(innerButton2)
+                                        add(innerButton3)
+                                    }
+                                }
+                            )
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                }
+            })
+            add(outerButton3)
+            add(outerButton4)
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, outerButton1, outerButton2, composeButton1, composeButton2,
+            innerButton1, innerButton2, innerButton3, composeButton3, composeButton4,
+            outerButton3, outerButton4
+        )
+    }
+
+    @Test
+    fun `swing panel in the end of compose panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(outerButton1)
+            add(outerButton2)
+
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton1.Content()
+                            composeButton2.Content()
+                            SwingPanel(
+                                modifier = Modifier.size(100.dp),
+                                factory = {
+                                    javax.swing.Box.createVerticalBox().apply {
+                                        add(innerButton1)
+                                        add(innerButton2)
+                                        add(innerButton3)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            })
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, outerButton1, outerButton2, composeButton1, composeButton2,
+            innerButton1, innerButton2, innerButton3
+        )
+    }
+
+    @Test
+    fun `swing panel in the beginning of compose panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            SwingPanel(
+                                modifier = Modifier.size(100.dp),
+                                factory = {
+                                    javax.swing.Box.createVerticalBox().apply {
+                                        add(innerButton1)
+                                        add(innerButton2)
+                                        add(innerButton3)
+                                    }
+                                }
+                            )
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                }
+            })
+            add(outerButton3)
+            add(outerButton4)
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window,
+            innerButton1, innerButton2, innerButton3, composeButton3, composeButton4, outerButton3, outerButton4
+        )
+    }
+
+    @Test
+    fun `swing panel without compose and outer buttons`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            SwingPanel(
+                                modifier = Modifier.size(100.dp),
+                                factory = {
+                                    javax.swing.Box.createVerticalBox().apply {
+                                        add(innerButton1)
+                                        add(innerButton2)
+                                        add(innerButton3)
+                                    }
+                                }
+                            )
+                        }
+                    }
+                }
+            })
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(window, innerButton1, innerButton2, innerButton3)
+    }
+
+    @Test
+    fun `empty compose panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(outerButton1)
+            add(outerButton2)
+            add(ComposePanel().apply {
+                setContent {
+                }
+            })
+            add(outerButton3)
+            add(outerButton4)
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(window, outerButton1, outerButton2, outerButton3, outerButton4)
+    }
+
+    private val outerButton1 = JButton("outerButton1")
+    private val outerButton2 = JButton("outerButton2")
+    private val outerButton3 = JButton("outerButton3")
+    private val outerButton4 = JButton("outerButton4")
+    private val innerButton1 = JButton("innerButton1")
+    private val innerButton2 = JButton("innerButton2")
+    private val innerButton3 = JButton("innerButton3")
+    private val composeButton1 = ComposeButton("composeButton1")
+    private val composeButton2 = ComposeButton("composeButton2")
+    private val composeButton3 = ComposeButton("composeButton3")
+    private val composeButton4 = ComposeButton("composeButton4")
+
+    private suspend fun FocusTestScope.testRandomFocus(window: Window, vararg buttons: Any) {
+        fun Any.validateIsFocused() {
+            assertFocused().isTrue()
+            if (this != outerButton1) outerButton1.assertFocused().isFalse()
+            if (this != outerButton2) outerButton2.assertFocused().isFalse()
+            if (this != outerButton3) outerButton3.assertFocused().isFalse()
+            if (this != outerButton4) outerButton4.assertFocused().isFalse()
+            if (this != innerButton1) innerButton1.assertFocused().isFalse()
+            if (this != innerButton2) innerButton2.assertFocused().isFalse()
+            if (this != innerButton3) innerButton3.assertFocused().isFalse()
+            if (this != composeButton1) composeButton1.assertFocused().isFalse()
+            if (this != composeButton2) composeButton2.assertFocused().isFalse()
+            if (this != composeButton3) composeButton3.assertFocused().isFalse()
+            if (this != composeButton4) composeButton4.assertFocused().isFalse()
+        }
+
+        suspend fun cycleForward() {
+            var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            repeat(2 * buttons.size) {
+                pressNextFocusKey()
+                focusedIndex = (focusedIndex + 1).mod(buttons.size)
+                buttons[focusedIndex].validateIsFocused()
+            }
+        }
+
+        suspend fun cycleBackward() {
+            var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+
+            repeat(2 * buttons.size) {
+                pressPreviousFocusKey()
+                focusedIndex = (focusedIndex - 1).mod(buttons.size)
+                buttons[focusedIndex].validateIsFocused()
+            }
+        }
+
+        suspend fun cycleRandom() {
+            var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+
+            repeat(4 * buttons.size) {
+                @Suppress("LiftReturnOrAssignment")
+                if (Random.nextBoolean()) {
+                    pressNextFocusKey()
+                    focusedIndex = (focusedIndex + 1).mod(buttons.size)
+                } else {
+                    pressPreviousFocusKey()
+                    focusedIndex = (focusedIndex - 1).mod(buttons.size)
+                }
+                buttons[focusedIndex].validateIsFocused()
+            }
+        }
+
+        suspend fun randomRequest() {
+            val button = buttons.toList().random()
+            button.requestFocus()
+            awaitEDT()
+            button.validateIsFocused()
+        }
+
+        suspend fun randomPress() {
+            val button = buttons.filterIsInstance<Component>().randomOrNull()
+            button?.performClick()
+            awaitEDT()
+            button?.validateIsFocused()
+        }
+
+        awaitEDT()
+        buttons.first().requestFocus()
+        awaitEDT()
+        buttons.first().validateIsFocused()
+
+        repeat(30) {
+            when (Random.nextInt(5)) {
+                0 -> cycleForward()
+                1 -> cycleBackward()
+                2 -> cycleRandom()
+                3 -> randomRequest()
+                4 -> randomPress()
+            }
+        }
+    }
+}
+
+fun runFocusTest(action: suspend FocusTestScope.() -> Unit) {
+    Assume.assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+    runBlocking(MainUIDispatcher) {
+        val scope = FocusTestScope()
+        try {
+            scope.action()
+        } finally {
+            scope.onEnd()
+        }
+    }
+}
+
+class FocusTestScope {
+    private val windows = mutableListOf<Window>()
+
+    fun <T : Window> T.disposeOnEnd() : T {
+        windows.add(this)
+        return this
+    }
+
+    fun onEnd() {
+        windows.forEach { it.dispose() }
+        windows.clear()
+    }
+
+    suspend fun pressNextFocusKey() {
+        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+        focusOwner.dispatchEvent(KeyEvent(focusOwner, KeyEvent.KEY_PRESSED, 0, 0, KeyEvent.VK_TAB, '\t'))
+        awaitEDT()
+    }
+
+    suspend fun pressPreviousFocusKey() {
+        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+        focusOwner.dispatchEvent(KeyEvent(focusOwner, KeyEvent.KEY_PRESSED, 0, KeyEvent.SHIFT_DOWN_MASK, KeyEvent.VK_TAB, '\t'))
+        awaitEDT()
+    }
+}
+
+private fun Any.requestFocus(): Unit {
+    when (this) {
+        is ComposeButton -> requestFocus()
+        is Component -> requestFocusInWindow()
+        else -> error("Unknown component")
+    }
+}
+
+private fun Any.isFocused() = when (this) {
+    is ComposeButton -> isFocused
+    is Component -> hasFocus()
+    else -> error("Unknown component")
+}
+
+private fun Any.assertFocused() = when (this) {
+    is ComposeButton -> assertWithMessage("$name.isFocused").that(isFocused)
+    is JButton -> assertWithMessage("$text.isFocused").that(hasFocus())
+    else -> error("Unknown component")
+}
+
+private class ComposeButton(val name: String) {
+    var isFocused = false
+        private set
+    private val focusRequester = FocusRequester()
+
+    @Composable
+    fun Content() {
+        Button({}, modifier = Modifier.onFocusChanged { isFocused = it.isFocused }.focusRequester(focusRequester)) {}
+    }
+
+    fun requestFocus() = focusRequester.requestFocus()
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -42,6 +42,7 @@ import javax.swing.JFrame
 import kotlin.random.Random
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.MainUIDispatcher
+import org.jetbrains.skiko.hostOs
 import org.junit.Assume
 import org.junit.Test
 import org.junit.experimental.categories.Categories
@@ -425,6 +426,8 @@ class ComposeFocusTest {
 
 fun runFocusTest(action: suspend FocusTestScope.() -> Unit) {
     Assume.assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+    // on macOs if we run all tests, the window starts unfocused, so tests fail
+    Assume.assumeFalse(hostOs.isMacOS)
     runBlocking(MainUIDispatcher) {
         val scope = FocusTestScope()
         try {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume
 import org.junit.Test
+import org.junit.experimental.categories.Categories
 
 class ComposeFocusTest {
     @Test
@@ -460,7 +461,7 @@ class FocusTestScope {
     }
 }
 
-private fun Any.requestFocus(): Unit {
+private fun Any.requestFocus() {
     when (this) {
         is ComposeButton -> requestFocus()
         is Component -> requestFocusInWindow()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.awaitEDT
 import java.awt.GraphicsEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -126,16 +127,8 @@ internal class WindowTestScope(
         if (useDelay) {
             delay(500)
         }
-        // TODO(demin): It seems this not-so-good synchronization
-        //  doesn't cause flakiness in our window tests.
-        //  But more robust solution will be to use something like
-        //  TestCoroutineDispatcher/FlushCoroutineDispatcher (but we can't use it in a pure form,
-        //  because there are Swing/system events that we don't control).
-        // Most of the work usually is done after the first yield(), almost all of the work -
-        // after fourth yield()
-        repeat(100) {
-            yield()
-        }
+
+        awaitEDT()
 
         Snapshot.sendApplyNotifications()
         for (recomposerInfo in Recomposer.runningRecomposers.value - initialRecomposers) {


### PR DESCRIPTION
Compose doesn't support detecting from where we receive the focus (from the previous or from the next component). But we need to know it, so we can focus the first or the last component in SwingPanel. We create two empty Compose components to do that (if we focused on the first component - it means the focus came from the previous one).

Also added tests for all focus interop cases. On macOs the tests are disabled