### PR TITLE
Fix value class inline bug on jvm

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -186,7 +186,7 @@ private fun PopupLayout(
                     val width = constraints.maxWidth
                     val height = constraints.maxHeight
 
-                    layout(constraints.maxWidth, constraints.maxHeight) {
+                    layout(width, height) {
                         measurables.forEach {
                             val placeable = it.measure(constraints)
                             val position = popupPositionProvider.calculatePosition(


### PR DESCRIPTION
Fix strange bug in jvm desktop test.
if **width** val used once, bug appears. If use twice - compiler work's fine.
```
class DesktopAlertDialogTest {
    @Test
    fun alignedToCenter_inPureWindow() {
    ...
```