### PR TITLE
fix sam crash on jvm desktop

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/Layout.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/Layout.kt
@@ -134,6 +134,16 @@ inline fun Layout(
     )
 }
 
+/*
+ * TODO: This is a version of Layout not using SAM-converted [MeasurePolicy] interface.
+ * Remove me, when SAM conversion for [MeasurePolicy] works again.
+ */
+@Composable inline fun Layout(
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    crossinline measurePolicy: MeasureScope.(List<Measurable>, Constraints) -> MeasureResult
+) = Layout(content, modifier, MeasurePolicy { x, y -> measurePolicy(x, y) })
+
 @Suppress("ComposableLambdaParameterPosition")
 @Composable
 @UiComposable


### PR DESCRIPTION
Revert to workaround **inline fun Layout** without SAM-converted [MeasurePolicy] interface
It needs to fix test `DesktopAlertDialogTest.alignedToCenter_inPureWindow` with exception `java.lang.NoSuchMethodError: 'int androidx.compose.ui.unit.Constraints.getMaxWidth()`