### PR TITLE
fix SAM crash in Layout measurePolicy with value class

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/LayoutWithWorkaround.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/LayoutWithWorkaround.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+
+/*
+ * TODO: This is a version of Layout not using SAM-converted [MeasurePolicy] interface.
+ * Remove me, when SAM conversion for [MeasurePolicy] works again in Kotlin 1.7.0
+ * Check with Desktop jvm test DesktopAlertDialogTest.alignedToCenter_inPureWindow
+ */
+@Composable
+internal inline fun LayoutWithWorkaround(
+    content: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    crossinline measurePolicy: MeasureScope.(List<Measurable>, Constraints) -> MeasureResult
+) = Layout(content, modifier) { x, y -> measurePolicy(x, y) }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.LayoutWithWorkaround
 import androidx.compose.ui.LocalComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.LocalLayerContainer
@@ -151,7 +152,7 @@ private fun PopupLayout(
     var parentBounds by remember { mutableStateOf(IntRect.Zero) }
 
     // getting parent bounds
-    Layout(
+    LayoutWithWorkaround(
         content = {},
         modifier = Modifier.onGloballyPositioned { childCoordinates ->
             val coordinates = childCoordinates.parentCoordinates!!
@@ -178,7 +179,7 @@ private fun PopupLayout(
         )
         scene.attach(owner)
         val composition = owner.setContent(parent = parentComposition) {
-            Layout(
+            LayoutWithWorkaround(
                 content = content,
                 measurePolicy = { measurables, constraints ->
                     val width = constraints.maxWidth

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/UndecoratedWindowResizer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/UndecoratedWindowResizer.desktop.kt
@@ -21,13 +21,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.LayoutWithWorkaround
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Dp
@@ -53,7 +53,7 @@ internal class UndecoratedWindowResizer(
     @Composable
     fun Content() {
         if (enabled) {
-            Layout(
+            LayoutWithWorkaround(
                 {
                     Side(Cursor.W_RESIZE_CURSOR, Side.Left)
                     Side(Cursor.E_RESIZE_CURSOR, Side.Right)
@@ -123,7 +123,7 @@ internal class UndecoratedWindowResizer(
     }
 
     @Composable
-    private fun Side(cursorId: Int, sides: Int) = Layout(
+    private fun Side(cursorId: Int, sides: Int) = LayoutWithWorkaround(
         {},
         Modifier.cursor(cursorId).resizeOnDrag(sides),
         measurePolicy = { _, constraints ->


### PR DESCRIPTION
Fix crash with Layout, and measurePolicy with usage value class (or inline class)

This bug was appear only on compose:ui:ui module

Fix issue https://github.com/JetBrains/compose-jb/issues/2101
And fix same crash in PopupDialog