### PR TITLE
StringBuilder.appendPartOfCharArray workaround of bug

### DIFF
--- a/compose/ui/ui-text/src/androidMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
+++ b/compose/ui/ui-text/src/androidMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+internal actual fun StringBuilder.appendPartOfCharArray(charArray: CharArray, offset: Int, len: Int) {
+    append(charArray, offset, len)
+}

--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/GapBuffer.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/GapBuffer.kt
@@ -188,8 +188,8 @@ private class GapBuffer(initBuffer: CharArray, initGapStart: Int, initGapEnd: In
      * @param builder The output string builder
      */
     fun append(builder: StringBuilder) {
-        builder.append(buffer, 0, gapStart)
-        builder.append(buffer, gapEnd, capacity - gapEnd)
+        builder.appendPartOfCharArray(buffer, 0, gapStart)
+        builder.appendPartOfCharArray(buffer, gapEnd, capacity - gapEnd)
     }
 
     /**

--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+/**
+ *
+ * Workaround to bypass bug https://youtrack.jetbrains.com/issue/KT-52336/Differs-on-JVM-and-Native-in-stringBuilder-append-charArray-0-1
+ * On JVM and Android this function work's as StringBuilder.append(char[], int offset, int len)
+ */
+internal expect fun StringBuilder.appendPartOfCharArray(charArray: CharArray, offset: Int, len: Int)

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+internal actual fun StringBuilder.appendPartOfCharArray(charArray: CharArray, offset: Int, len: Int) {
+    append(charArray, offset, len)
+}

--- a/compose/ui/ui-text/src/jsMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
+++ b/compose/ui/ui-text/src/jsMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+internal actual fun StringBuilder.appendPartOfCharArray(charArray: CharArray, offset: Int, len: Int) {
+    for (i in offset until (offset + len)) {
+        append(charArray[i])
+    }
+}

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/input/appendPartOfCharArray.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+internal actual fun StringBuilder.appendPartOfCharArray(charArray: CharArray, offset: Int, len: Int) {
+    for (i in offset until (offset + len)) {
+        append(charArray[i])
+    }
+}


### PR DESCRIPTION
We found a bug with different behavior in JVM vs other platforms (https://youtrack.jetbrains.com/issue/KT-52336/Different-behavior-on-JVM-and-Native-in-stringBuilderappendcharArray-0-1)
For now we found this workaround, to use in nativeMain and jsMain:
```Kotlin
internal actual fun StringBuilder.appendPartOfCharArray(charArray: CharArray, offset: Int, len: Int) {
    for (i in offset until (offset + len)) {
        append(charArray[i])
    }
}
```
