### PR TITLE
Deprecate Modifier.mouseClickable. It should be replaced by Modifier.onClick

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
@@ -64,11 +64,16 @@ internal actual val KeyEvent.isClick: Boolean
     }
 
 @Immutable @ExperimentalFoundationApi
+@Deprecated(
+    message = "Modifier.mouseClickable is deprecated and this MouseClickScope too. " +
+        "See Modifier.mouseClickable for replacement"
+)
 class MouseClickScope constructor(
     val buttons: PointerButtons,
     val keyboardModifiers: PointerKeyboardModifiers
 )
 
+@Suppress("DEPRECATION")
 @ExperimentalFoundationApi
 internal val EmptyClickContext = MouseClickScope(
     PointerButtons(0), PointerKeyboardModifiers(0)
@@ -80,11 +85,28 @@ internal val EmptyClickContext = MouseClickScope(
  *
  */
 @ExperimentalFoundationApi
+@Deprecated(
+    message = "Consider using Modifier.onClick to distinguish clicks with different buttons and keyboardModifiers",
+    replaceWith = ReplaceWith(
+        expression =
+        "Modifier.onClick(" +
+            "enabled = enabled,\n" +
+            "matcher = PointerMatcher.mouse(PointerButton.Primary), // add onClick for every required PointerButton\n" +
+            "keyboardModifiers = { true }, // e.g { isCtrlPressed }; Remove it to ignore keyboardModifiers\n" +
+            "onClick = { onClick() }\n" +
+            ")",
+        imports = arrayOf(
+            "androidx.compose.foundation.onClick",
+            "androidx.compose.foundation.PointerMatcher",
+            "androidx.compose.ui.input.pointer.PointerButton"
+        )
+    )
+)
 fun Modifier.mouseClickable(
     enabled: Boolean = true,
     onClickLabel: String? = null,
     role: Role? = null,
-    onClick: MouseClickScope.() -> Unit
+    @Suppress("DEPRECATION") onClick: MouseClickScope.() -> Unit
 ) = composed(
     factory = {
         val onClickState = rememberUpdatedState(onClick)

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/MouseClickableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/MouseClickableTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers


### PR DESCRIPTION
Questions:

Currently, the replaceWith expression ignores `onClickLabel` and `role` arguments. 
We can try to add `role` - `semantics(true) { if (role != null) this.role = role }`. But it ends up with weird and verbose construction when `role` value is default (null).
I think that we can't set `onClickLabel` on behalf of a user, because `onClickLabel` makes sense only for Primary click, and `onClick` can be added multiple times with different click handlers.

Also, mouseClickable adds `detectClickFromKey`, `indication`, `hoverable`, `focusableInNonTouchMode`, which are not added within `onClick` and not added by replaceWith expression. I think the most convenient option is to describe these nuances in the tutorial.

