### PR TITLE
Fix a large icon in macOs menu

### DIFF
--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageConverters.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageConverters.desktop.kt
@@ -176,15 +176,21 @@ private class PainterImage(
         // optimizations to avoid unnecessary rasterizations
         when (painter) {
             is BufferedImagePainter -> painter.image
-            is BitmapPainter -> asBitmap(width, height).toAwtImage()
-            else -> asBitmap(
-                (width * density.density).roundToInt(),
-                (height * density.density).roundToInt()
-            ).toAwtImage()
+            else -> asBitmap(width, height).toAwtImage()
         }
     }
 
-    override fun getResolutionVariants() = listOf(defaultImage)
+    private val scaledImage by lazy {
+        asBitmap(
+            (width * density.density).roundToInt(),
+            (height * density.density).roundToInt()
+        ).toAwtImage()
+    }
+
+    override fun getResolutionVariants() = when (painter) {
+        is BufferedImagePainter, is BitmapPainter -> listOf(defaultImage) // raster images
+        else -> listOf(defaultImage, scaledImage) // vector images
+    }
 }
 
 // TODO(demin): should we optimize toAwtImage/toBitmap? Currently we convert colors according to the


### PR DESCRIPTION
macOs seems uses the first image's size to determine the size of the item's icon, but uses the more suitable image for hidpi (i.e. scaledImage)

Fixes https://github.com/JetBrains/compose-jb/issues/2150
