### PR TITLE
UIKit: If focused element hidden by keyboard, then change UIView bounds

### DIFF
--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -17,46 +17,56 @@
 package androidx.compose.mpp.demo
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Text
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.TextField
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Application
 
 fun getViewControllerWithCompose() = Application("Compose/Native sample") {
-    var textState1 by remember { mutableStateOf("text field 1") }
-    var textState2 by remember { mutableStateOf("text field 2") }
-    Column {
-        Text(".")
-        Text(".")
-        Text(".")
-        Text(".")
-        Text(".")
-        Text(".")
-        Text(".")
-        Text(".")
-        Text("Hello, UIKit")
-        TextField(value = textState1, onValueChange = {
-            textState1 = it
-        })
-        TextField(value = textState2, onValueChange = {
-            textState2 = it
-        })
-        Image(
-            painter = object : Painter() {
-                override val intrinsicSize: Size = Size(16f, 16f)
-                override fun DrawScope.onDraw() {
-                    drawRect(color = Color.Blue)
+    val modifier = Modifier
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Box(Modifier.weight(1f)) {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                state = rememberLazyListState(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                repeat(100) {
+                    item {
+                        var currentTextFieldState by remember { mutableStateOf("textField $it") }
+                        TextField(value = currentTextFieldState, onValueChange = {
+                            currentTextFieldState = it
+                        })
+                    }
                 }
+            }
+        }
+
+        var bottomTextFieldState by remember { mutableStateOf("bottom TextField") }
+        TextField(
+            modifier = modifier.fillMaxWidth()
+                .background(Color.LightGray)
+                .padding(10.dp),
+            value = bottomTextFieldState,
+            onValueChange = {
+                bottomTextFieldState = it
             },
-            contentDescription = "image sample"
         )
     }
 }

--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -17,56 +17,46 @@
 package androidx.compose.mpp.demo
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Text
 import androidx.compose.material.TextField
-import androidx.compose.runtime.*
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Application
 
 fun getViewControllerWithCompose() = Application("Compose/Native sample") {
-    val modifier = Modifier
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
-        Box(Modifier.weight(1f)) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                state = rememberLazyListState(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                repeat(100) {
-                    item {
-                        var currentTextFieldState by remember { mutableStateOf("textField $it") }
-                        TextField(value = currentTextFieldState, onValueChange = {
-                            currentTextFieldState = it
-                        })
-                    }
+    var textState1 by remember { mutableStateOf("text field 1") }
+    var textState2 by remember { mutableStateOf("text field 2") }
+    Column {
+        Text(".")
+        Text(".")
+        Text(".")
+        Text(".")
+        Text(".")
+        Text(".")
+        Text(".")
+        Text(".")
+        Text("Hello, UIKit")
+        TextField(value = textState1, onValueChange = {
+            textState1 = it
+        })
+        TextField(value = textState2, onValueChange = {
+            textState2 = it
+        })
+        Image(
+            painter = object : Painter() {
+                override val intrinsicSize: Size = Size(16f, 16f)
+                override fun DrawScope.onDraw() {
+                    drawRect(color = Color.Blue)
                 }
-            }
-        }
-
-        var bottomTextFieldState by remember { mutableStateOf("bottom TextField") }
-        TextField(
-            modifier = modifier.fillMaxWidth()
-                .background(Color.LightGray)
-                .padding(10.dp),
-            value = bottomTextFieldState,
-            onValueChange = {
-                bottomTextFieldState = it
             },
+            contentDescription = "image sample"
         )
     }
 }

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/js/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/js/ComposeWindow.js.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.ui.createSkiaLayer
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.native.ComposeLayer
 import kotlinx.browser.document
 import org.w3c.dom.HTMLCanvasElement
@@ -32,6 +33,7 @@ internal actual class ComposeWindow actual constructor(){
         hideSoftwareKeyboard = {
             println("TODO hideSoftwareKeyboard in JS")
         },
+        getTopLeftOffset = { Offset.Zero },
     )
 
     val title: String

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -128,11 +128,11 @@ internal class ComposeLayer(
         isDisposed = true
     }
 
-    internal fun setSize(width: Int, height: Int) {
+    fun setSize(width: Int, height: Int) {
         scene.constraints = Constraints(maxWidth = width, maxHeight = height)
     }
 
-    internal fun getActiveFocusRect():Rect? {
+    fun getActiveFocusRect():Rect? {
         return scene.mainOwner?.focusManager?.getActiveFocusModifier()?.focusRect()
     }
 

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.focus.focusRect
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.toCompose
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.Platform
@@ -42,6 +44,7 @@ internal class ComposeLayer(
     internal val layer: SkiaLayer,
     showSoftwareKeyboard: () -> Unit,
     hideSoftwareKeyboard: () -> Unit,
+    private val getTopLeftOffset: () -> Offset,
 ) {
     private var isDisposed = false
     private val inputService = SkiaTextInputService(
@@ -81,7 +84,7 @@ internal class ComposeLayer(
                     scene.sendPointerEvent(
                         eventType = event.kind.toCompose(),
                         // TODO: account for the proper density.
-                        position = Offset(event.x.toFloat(), event.y.toFloat()), // * density,
+                        position = Offset(event.x.toFloat(), event.y.toFloat()) - getTopLeftOffset(), // * density,
                         timeMillis = currentMillis(),
                         type = PointerType.Touch,
                         nativeEvent = event
@@ -96,7 +99,7 @@ internal class ComposeLayer(
             scene.sendPointerEvent(
                 eventType = event.kind.toCompose(),
                 // TODO: account for the proper density.
-                position = Offset(event.x.toFloat(), event.y.toFloat()), // * density,
+                position = Offset(event.x.toFloat(), event.y.toFloat()) - getTopLeftOffset(), // * density,
                 timeMillis = currentMillis(),
                 type = PointerType.Mouse,
                 nativeEvent = event
@@ -127,6 +130,10 @@ internal class ComposeLayer(
 
     internal fun setSize(width: Int, height: Int) {
         scene.constraints = Constraints(maxWidth = width, maxHeight = height)
+    }
+
+    internal fun getActiveFocusRect():Rect? {
+        return scene.mainOwner?.focusManager?.getActiveFocusModifier()?.focusRect()
     }
 
     fun setContent(

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/macos/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/macos/ComposeWindow.macos.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.ui.createSkiaLayer
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.native.ComposeLayer
 
 import platform.AppKit.*
@@ -32,6 +33,7 @@ internal actual class ComposeWindow actual constructor() {
         layer = createSkiaLayer(),
         showSoftwareKeyboard = {},
         hideSoftwareKeyboard = {},
+        getTopLeftOffset = { Offset.Zero },
     )
 
     val title: String

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
@@ -85,27 +85,6 @@ internal actual class ComposeWindow : UIViewController {
         }
     }
 
-    init {
-        NSNotificationCenter.defaultCenter.addObserver(
-            observer = keyboardVisibilityListener,
-            selector = NSSelectorFromString("keyboardWillShow:"),
-            name = platform.UIKit.UIKeyboardWillShowNotification,
-            `object` = null
-        )
-        NSNotificationCenter.defaultCenter.addObserver(
-            observer = keyboardVisibilityListener,
-            selector = NSSelectorFromString("keyboardWillHide:"),
-            name = platform.UIKit.UIKeyboardWillHideNotification,
-            `object` = null
-        )
-        NSNotificationCenter.defaultCenter.addObserver(
-            observer = keyboardVisibilityListener,
-            selector = NSSelectorFromString("keyboardDidHide:"),
-            name = platform.UIKit.UIKeyboardDidHideNotification,
-            `object` = null
-        )
-    }
-
     actual fun setTitle(title: String) {
         println("TODO: set title to SkiaWindow")
     }
@@ -131,11 +110,44 @@ internal actual class ComposeWindow : UIViewController {
         super.viewDidAppear(animated)
         val (width, height) = getViewFrameSize()
         layer.setSize(width, height)
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = keyboardVisibilityListener,
+            selector = NSSelectorFromString("keyboardWillShow:"),
+            name = platform.UIKit.UIKeyboardWillShowNotification,
+            `object` = null
+        )
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = keyboardVisibilityListener,
+            selector = NSSelectorFromString("keyboardWillHide:"),
+            name = platform.UIKit.UIKeyboardWillHideNotification,
+            `object` = null
+        )
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = keyboardVisibilityListener,
+            selector = NSSelectorFromString("keyboardDidHide:"),
+            name = platform.UIKit.UIKeyboardDidHideNotification,
+            `object` = null
+        )
     }
 
     // viewDidUnload() is deprecated and not called.
     override fun viewDidDisappear(animated: Boolean) {
         this.dispose()
+        NSNotificationCenter.defaultCenter.removeObserver(
+            observer = keyboardVisibilityListener,
+            name = platform.UIKit.UIKeyboardWillShowNotification,
+            `object` = null
+        )
+        NSNotificationCenter.defaultCenter.removeObserver(
+            observer = keyboardVisibilityListener,
+            name = platform.UIKit.UIKeyboardWillHideNotification,
+            `object` = null
+        )
+        NSNotificationCenter.defaultCenter.removeObserver(
+            observer = keyboardVisibilityListener,
+            name = platform.UIKit.UIKeyboardDidHideNotification,
+            `object` = null
+        )
     }
 
     actual fun setContent(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
@@ -161,8 +161,7 @@ internal actual class ComposeWindow : UIViewController {
                 point = CGPointMake(0.0, 0.0),
                 toCoordinateSpace = UIScreen.mainScreen.coordinateSpace()
             )
-        val offset = topLeftPoint.useContents { Offset(x.toFloat(), y.toFloat()) }
-        return offset
+        return topLeftPoint.useContents { Offset(x.toFloat(), y.toFloat()) }
     }
 
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
@@ -2,13 +2,25 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.createSkiaLayer
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.native.ComposeLayer
+import androidx.compose.ui.unit.IntSize
 import kotlinx.cinterop.ExportObjCClass
+import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
 import platform.Foundation.NSCoder
 import platform.UIKit.UIScreen
 import platform.UIKit.UIViewController
 import org.jetbrains.skiko.SkikoUIView
+import platform.CoreGraphics.CGPointMake
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSNotification
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSSelectorFromString
+import platform.Foundation.NSValue
+import platform.UIKit.CGRectValue
+import platform.UIKit.setClipsToBounds
+import platform.darwin.NSObject
 
 // The only difference with macos' Window is that
 // it has return type of UIViewController rather than unit.
@@ -21,7 +33,6 @@ fun Application(
     setContent(content)
 } as UIViewController
 
-
 @ExportObjCClass
 internal actual class ComposeWindow : UIViewController {
     @OverrideInit
@@ -32,15 +43,74 @@ internal actual class ComposeWindow : UIViewController {
 
     private lateinit var layer: ComposeLayer
     private lateinit var content: @Composable () -> Unit
+    private val keyboardVisibilityListener = object : NSObject() {
+        @Suppress("unused")
+        @ObjCAction
+        fun keyboardWillShow(arg: NSNotification) {
+            val keyboardInfo = arg.userInfo!!["UIKeyboardFrameEndUserInfoKey"] as NSValue
+            val keyboardHeight = keyboardInfo.CGRectValue().useContents { size.height }
+            val screenHeight = UIScreen.mainScreen.bounds.useContents { size.height }
+            val focused = layer.getActiveFocusRect()
+            if (focused != null) {
+                val focusedBottom = focused.bottom + getTopLeftOffset().y
+                val hiddenPartOfFocusedElement = focusedBottom + keyboardHeight - screenHeight
+                if (hiddenPartOfFocusedElement > 0) {
+                    // If focused element hidden by keyboard, then change UIView bounds.
+                    // Focused element will be visible
+                    view.setClipsToBounds(true)
+                    val (width, height) = getViewFrameSize()
+                    view.layer.setBounds(
+                        CGRectMake(
+                            x = 0.0,
+                            y = hiddenPartOfFocusedElement,
+                            width = width.toDouble(),
+                            height = height.toDouble()
+                        )
+                    )
+                }
+            }
+        }
+
+        @Suppress("unused")
+        @ObjCAction
+        fun keyboardWillHide(arg: NSNotification) {
+            val (width, height) = getViewFrameSize()
+            view.layer.setBounds(CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()))
+        }
+
+        @Suppress("unused")
+        @ObjCAction
+        fun keyboardDidHide(arg: NSNotification) {
+            view.setClipsToBounds(false)
+        }
+    }
+
+    init {
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = keyboardVisibilityListener,
+            selector = NSSelectorFromString("keyboardWillShow:"),
+            name = platform.UIKit.UIKeyboardWillShowNotification,
+            `object` = null
+        )
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = keyboardVisibilityListener,
+            selector = NSSelectorFromString("keyboardWillHide:"),
+            name = platform.UIKit.UIKeyboardWillHideNotification,
+            `object` = null
+        )
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = keyboardVisibilityListener,
+            selector = NSSelectorFromString("keyboardDidHide:"),
+            name = platform.UIKit.UIKeyboardDidHideNotification,
+            `object` = null
+        )
+    }
 
     actual fun setTitle(title: String) {
         println("TODO: set title to SkiaWindow")
     }
 
     override fun loadView() {
-        val (width, height) = UIScreen.mainScreen.bounds.useContents {
-            this.size.width to this.size.height
-        }
         val skiaLayer = createSkiaLayer()
         val skikoUIView = SkikoUIView(skiaLayer).load()
         view = skikoUIView
@@ -52,9 +122,16 @@ internal actual class ComposeWindow : UIViewController {
             hideSoftwareKeyboard = {
                 skikoUIView.hideScreenKeyboard()
             },
+            getTopLeftOffset = ::getTopLeftOffset,
         )
         layer.setContent(content = content)
-        layer.setSize(width.toInt(), height.toInt())
+    }
+
+    override fun viewWillAppear(animated: Boolean) {
+        println("traitCollection().displayScale: ${traitCollection().displayScale}")
+        super.viewDidAppear(animated)
+        val (width, height) = getViewFrameSize()
+        layer.setSize(width, height)
     }
 
     // viewDidUnload() is deprecated and not called.
@@ -72,4 +149,20 @@ internal actual class ComposeWindow : UIViewController {
     actual fun dispose() {
         layer.dispose()
     }
+
+    private fun getViewFrameSize(): IntSize {
+        val (width, height) = view.frame().useContents { this.size.width to this.size.height }
+        return IntSize(width.toInt(), height.toInt())
+    }
+
+    private fun getTopLeftOffset(): Offset {
+        val topLeftPoint =
+            view.coordinateSpace().convertPoint(
+                point = CGPointMake(0.0, 0.0),
+                toCoordinateSpace = UIScreen.mainScreen.coordinateSpace()
+            )
+        val offset = topLeftPoint.useContents { Offset(x.toFloat(), y.toFloat()) }
+        return offset
+    }
+
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeWindow.uikit.kt
@@ -128,7 +128,6 @@ internal actual class ComposeWindow : UIViewController {
     }
 
     override fun viewWillAppear(animated: Boolean) {
-        println("traitCollection().displayScale: ${traitCollection().displayScale}")
         super.viewDidAppear(animated)
         val (width, height) = getViewFrameSize()
         layer.setSize(width, height)


### PR DESCRIPTION
On UIKit we have convenient method setBounds(...) and setClipsToBounds(true).
It hide's part of UIView and moves visible part to original coordinates with animation.