### PR TITLE
Enable Kotlin check

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposePlugin.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposePlugin.kt
@@ -208,7 +208,7 @@ class ComposeComponentRegistrar : ComponentRegistrar {
             KotlinCompilerVersion.getVersion()?.let { version ->
                 val suppressKotlinVersionCheck = configuration.get(
                     ComposeConfiguration.SUPPRESS_KOTLIN_VERSION_COMPATIBILITY_CHECK,
-                    true
+                    false
                 )
                 if (!suppressKotlinVersionCheck && version != KOTLIN_VERSION_EXPECTATION) {
                     val msgCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY)


### PR DESCRIPTION
This reverts commit 88591eaa3c0cb51447cb20627083d404c6d86c82.

We don't need it anymore, and we shouldn't ship it into the release

See https://kotlinlang.slack.com/archives/C01D6HTPATV/p1657736565791649