### PR TITLE
Make clickable, mouseClickable, toggleable request focus onClick when the InputMode is Keyboard

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Clickable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Clickable.kt
@@ -34,13 +34,11 @@ import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.modifier.ModifierLocalConsumer
 import androidx.compose.ui.modifier.ModifierLocalReadScope
-import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.disabled
@@ -100,14 +98,10 @@ fun Modifier.clickable(
 }
 
 @Composable
-internal fun focusRequesterForKeyboardMode(): Pair<FocusRequester?, Modifier> {
-    val inputModeManager = LocalInputModeManager.current
-    return if (inputModeManager.inputMode == InputMode.Keyboard) {
-        val focusRequester = remember { FocusRequester() }
-        focusRequester to Modifier.focusRequester(focusRequester)
-    } else {
-        null to Modifier
-    }
+internal fun focusRequesterAndModifier(): Pair<FocusRequester, Modifier> {
+    val focusRequester = remember { FocusRequester() }
+    return focusRequester to Modifier.focusRequester(focusRequester)
+
 }
 
 /**
@@ -153,7 +147,7 @@ fun Modifier.clickable(
         val delayPressInteraction = rememberUpdatedState {
             isClickableInScrollableContainer.value || isRootInScrollableContainer()
         }
-        val (focusRequester, focusRequesterModifier) = focusRequesterForKeyboardMode()
+        val (focusRequester, focusRequesterModifier) = focusRequesterAndModifier()
         val gesture = Modifier.pointerInput(interactionSource, enabled) {
             detectTapAndPress(
                 onPress = { offset ->
@@ -168,7 +162,7 @@ fun Modifier.clickable(
                 },
                 onTap = {
                     if (enabled) {
-                        focusRequester?.requestFocus()
+                        focusRequester.requestFocus()
                         onClickState.value.invoke()
                     }
                 }
@@ -337,13 +331,13 @@ fun Modifier.combinedClickable(
         val delayPressInteraction = rememberUpdatedState {
             isClickableInScrollableContainer.value || isRootInScrollableContainer()
         }
-        val (focusRequester, focusRequesterModifier) = focusRequesterForKeyboardMode()
+        val (focusRequester, focusRequesterModifier) = focusRequesterAndModifier()
         val gesture =
             Modifier.pointerInput(interactionSource, hasLongClick, hasDoubleClick, enabled) {
                 detectTapGestures(
                     onDoubleTap = if (hasDoubleClick && enabled) {
                         {
-                            focusRequester?.requestFocus()
+                            focusRequester.requestFocus()
                             onDoubleClickState.value?.invoke()
                         }
                     } else {
@@ -351,7 +345,7 @@ fun Modifier.combinedClickable(
                     },
                     onLongPress = if (hasLongClick && enabled) {
                         {
-                            focusRequester?.requestFocus()
+                            focusRequester.requestFocus()
                             onLongClickState.value?.invoke()
                         }
                     } else {
@@ -369,7 +363,7 @@ fun Modifier.combinedClickable(
                     },
                     onTap = {
                         if (enabled) {
-                            focusRequester?.requestFocus()
+                            focusRequester.requestFocus()
                             onClickState.value.invoke()
                         }
                     }
@@ -537,6 +531,6 @@ internal fun Modifier.genericClickableWithoutGesture(
         .detectClickFromKey()
         .indication(interactionSource, indication)
         .hoverable(enabled = enabled, interactionSource = interactionSource)
-        .focusableInNonTouchMode(enabled = enabled, interactionSource = interactionSource)
+        .focusable(enabled = enabled, interactionSource = interactionSource)
         .then(gestureModifiers)
 }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Focusable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Focusable.kt
@@ -202,6 +202,8 @@ fun Modifier.focusGroup(): Modifier {
 
 // TODO: b/202856230 - consider either making this / a similar API public, or add a parameter to
 //  focusable to configure this behavior.
+// Consider using Modifier.focusable instead when the goal is only to prevent drawing the Focus indication in Touch mode
+// Modifier.indication prevents drawing the Focus indication in Touch mode under the hood.
 /**
  * [focusable] but only when not in touch mode - when [LocalInputModeManager] is
  * not [InputMode.Touch]

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/selection/Toggleable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/selection/Toggleable.kt
@@ -19,8 +19,8 @@ package androidx.compose.foundation.selection
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.PressedInteractionSourceDisposableEffect
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.focusRequesterForKeyboardMode
-import androidx.compose.foundation.focusableInNonTouchMode
+import androidx.compose.foundation.focusRequesterAndModifier
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.ModifierLocalScrollableContainer
 import androidx.compose.foundation.gestures.detectTapAndPress
 import androidx.compose.foundation.handlePressInteraction
@@ -267,7 +267,7 @@ private fun Modifier.toggleableImpl(
     val delayPressInteraction = rememberUpdatedState {
         isToggleableInScrollableContainer.value || isRootInScrollableContainer()
     }
-    val (focusRequester, focusRequesterModifier) = focusRequesterForKeyboardMode()
+    val (focusRequester, focusRequesterModifier) = focusRequesterAndModifier()
     val gestures = Modifier.pointerInput(interactionSource, enabled) {
         detectTapAndPress(
             onPress = { offset ->
@@ -282,7 +282,7 @@ private fun Modifier.toggleableImpl(
             },
             onTap = {
                 if (enabled) {
-                    focusRequester?.requestFocus()
+                    focusRequester.requestFocus()
                     onClickState.value.invoke()
                 }
             }
@@ -304,6 +304,6 @@ private fun Modifier.toggleableImpl(
         .then(semantics).then(focusRequesterModifier)
         .indication(interactionSource, indication)
         .hoverable(enabled = enabled, interactionSource = interactionSource)
-        .focusableInNonTouchMode(enabled = enabled, interactionSource = interactionSource)
+        .focusable(enabled = enabled, interactionSource = interactionSource)
         .then(gestures)
 }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/selection/Toggleable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/selection/Toggleable.kt
@@ -19,6 +19,7 @@ package androidx.compose.foundation.selection
 import androidx.compose.foundation.Indication
 import androidx.compose.foundation.PressedInteractionSourceDisposableEffect
 import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.focusRequesterForKeyboardMode
 import androidx.compose.foundation.focusableInNonTouchMode
 import androidx.compose.foundation.gestures.ModifierLocalScrollableContainer
 import androidx.compose.foundation.gestures.detectTapAndPress
@@ -266,6 +267,7 @@ private fun Modifier.toggleableImpl(
     val delayPressInteraction = rememberUpdatedState {
         isToggleableInScrollableContainer.value || isRootInScrollableContainer()
     }
+    val (focusRequester, focusRequesterModifier) = focusRequesterForKeyboardMode()
     val gestures = Modifier.pointerInput(interactionSource, enabled) {
         detectTapAndPress(
             onPress = { offset ->
@@ -278,7 +280,12 @@ private fun Modifier.toggleableImpl(
                     )
                 }
             },
-            onTap = { if (enabled) onClickState.value.invoke() }
+            onTap = {
+                if (enabled) {
+                    focusRequester?.requestFocus()
+                    onClickState.value.invoke()
+                }
+            }
         )
     }
     this
@@ -294,7 +301,7 @@ private fun Modifier.toggleableImpl(
                 }
             }
         )
-        .then(semantics)
+        .then(semantics).then(focusRequesterModifier)
         .indication(interactionSource, indication)
         .hoverable(enabled = enabled, interactionSource = interactionSource)
         .focusableInNonTouchMode(enabled = enabled, interactionSource = interactionSource)

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
@@ -110,12 +110,12 @@ fun Modifier.mouseClickable(
 ) = composed(
     factory = {
         val onClickState = rememberUpdatedState(onClick)
-        val (focusRequester, focusRequesterModifier) = focusRequesterForKeyboardMode()
+        val (focusRequester, focusRequesterModifier) = focusRequesterAndModifier()
         val gesture = if (enabled) {
             Modifier.pointerInput(Unit) {
                 detectTapWithContext(
                     onTap = { down, _ ->
-                        focusRequester?.requestFocus()
+                        focusRequester.requestFocus()
                         onClickState.value.invoke(
                             MouseClickScope(
                                 down.buttons,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
@@ -110,10 +110,12 @@ fun Modifier.mouseClickable(
 ) = composed(
     factory = {
         val onClickState = rememberUpdatedState(onClick)
+        val (focusRequester, focusRequesterModifier) = focusRequesterForKeyboardMode()
         val gesture = if (enabled) {
             Modifier.pointerInput(Unit) {
                 detectTapWithContext(
                     onTap = { down, _ ->
+                        focusRequester?.requestFocus()
                         onClickState.value.invoke(
                             MouseClickScope(
                                 down.buttons,
@@ -127,6 +129,7 @@ fun Modifier.mouseClickable(
             Modifier
         }
         Modifier
+            .then(focusRequesterModifier)
             .genericClickableWithoutGesture(
                 gestureModifiers = gesture,
                 enabled = enabled,

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/RequestFocusTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/RequestFocusTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusState
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.use
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+class RequestFocusTest {
+
+    @Test
+    fun `mouseClickable should request focus on click`() =
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = Density(1f)
+        ).use { scene ->
+            var focusState: FocusState? = null
+            var clicked = false
+            scene.setContent {
+                Box(modifier = Modifier
+                    .size(25.dp)
+                    .onFocusChanged { focusState = it }
+                    .mouseClickable { clicked = true }
+                )
+            }
+
+            assertThat(clicked).isEqualTo(false)
+            assertThat(focusState?.isFocused).isEqualTo(false)
+
+            val downButtons = PointerButtons(isPrimaryPressed = true)
+            val upButtons = PointerButtons(isPrimaryPressed = false)
+            scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = downButtons)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), buttons = upButtons)
+
+            assertThat(clicked).isEqualTo(true)
+            assertThat(focusState?.hasFocus).isEqualTo(true)
+        }
+
+    @Test
+    fun `clickable should request focus on click`() =
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = Density(1f)
+        ).use { scene ->
+            var focusState: FocusState? = null
+            var clicked = false
+            scene.setContent {
+                Box(modifier = Modifier
+                    .size(25.dp)
+                    .onFocusChanged { focusState = it }
+                    .clickable { clicked = true }
+                )
+            }
+
+            assertThat(clicked).isEqualTo(false)
+            assertThat(focusState?.isFocused).isEqualTo(false)
+
+            val downButtons = PointerButtons(isPrimaryPressed = true)
+            val upButtons = PointerButtons(isPrimaryPressed = false)
+            scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = downButtons)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), buttons = upButtons)
+
+            assertThat(clicked).isEqualTo(true)
+            assertThat(focusState?.hasFocus).isEqualTo(true)
+        }
+
+
+    @Test
+    fun `toggleable should request focus on click`() =
+        ImageComposeScene(
+            width = 100,
+            height = 100,
+            density = Density(1f)
+        ).use { scene ->
+            var focusState: FocusState? = null
+            var clicked = false
+            scene.setContent {
+                Box(modifier = Modifier
+                    .size(25.dp)
+                    .onFocusChanged { focusState = it }
+                    .toggleable(false) { clicked = true }
+                )
+            }
+
+            assertThat(clicked).isEqualTo(false)
+            assertThat(focusState?.isFocused).isEqualTo(false)
+
+            val downButtons = PointerButtons(isPrimaryPressed = true)
+            val upButtons = PointerButtons(isPrimaryPressed = false)
+            scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = downButtons)
+            scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), buttons = upButtons)
+
+            assertThat(clicked).isEqualTo(true)
+            assertThat(focusState?.hasFocus).isEqualTo(true)
+        }
+}

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
@@ -70,6 +70,8 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.lerp
 import androidx.compose.ui.graphics.Color
@@ -168,11 +170,13 @@ fun Slider(
     }
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 
+    val focusRequester = remember { FocusRequester() }
     BoxWithConstraints(
         modifier
             .minimumTouchTargetSize()
             .requiredSizeIn(minWidth = ThumbRadius * 2, minHeight = ThumbRadius * 2)
             .sliderSemantics(value, enabled, onValueChange, valueRange, steps)
+            .focusRequester(focusRequester)
             .focusable(enabled, interactionSource)
             .slideOnKeyEvents(enabled, steps, valueRange, value, isRtl, onValueChangeState)
     ) {
@@ -209,6 +213,7 @@ fun Slider(
         val gestureEndAction = rememberUpdatedState<(Float) -> Unit> { velocity: Float ->
             val current = rawOffset.value
             val target = snapValueToTick(current, tickFractions, minPx, maxPx)
+            focusRequester.requestFocus()
             if (current != target) {
                 scope.launch {
                     animateToTarget(draggableState, current, target, velocity)

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SliderTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SliderTest.kt
@@ -29,6 +29,10 @@ import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performKeyPress
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.material.internal.keyEvent
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
 import kotlin.math.roundToInt
 import org.junit.Assert
 import org.junit.Rule
@@ -261,6 +265,29 @@ class SliderTest {
         rule.onRoot().performKeyPress(keyEvent(Key.Home, KeyEventType.KeyUp))
         rule.runOnIdle {
             Assert.assertEquals(0f, state.value)
+        }
+    }
+
+    @Test
+    fun `Slider should request focus on Tap`() {
+        var hasFocus = false
+        rule.setContent {
+            Slider(
+                value = 0.1f,
+                onValueChange = {},
+                modifier = Modifier.onFocusChanged {
+                    hasFocus = it.isFocused
+                }.testTag("slider")
+            )
+        }
+
+        rule.onNodeWithTag("slider").performTouchInput {
+            down(Offset(10f, 5f))
+            up()
+        }
+
+        rule.runOnIdle {
+            Assert.assertEquals(true, hasFocus)
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -37,9 +37,11 @@ import androidx.compose.ui.focus.FocusManagerImpl
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.InputModeManagerImpl
 import androidx.compose.ui.input.InputMode.Companion.Keyboard
+import androidx.compose.ui.input.InputMode.Companion.Touch
 import androidx.compose.ui.input.key.Key.Companion.Back
 import androidx.compose.ui.input.key.Key.Companion.DirectionCenter
 import androidx.compose.ui.input.key.Key.Companion.Tab
@@ -132,11 +134,19 @@ internal class SkiaBasedOwner(
     private val _inputModeManager = InputModeManagerImpl(
         initialInputMode = Keyboard,
         onRequestInputModeChange = {
-            // TODO: Change the input mode programmatically. For now we just return true if the
-            //  requested input mode is Keyboard mode.
-            it == Keyboard
+            if (it == Touch || it == Keyboard) {
+                setInputMode(it)
+                true
+            } else {
+                false
+            }
         }
     )
+
+    private fun setInputMode(inputMode: InputMode) {
+        _inputModeManager.inputMode = inputMode
+    }
+
     override val inputModeManager: InputModeManager
         get() = _inputModeManager
 
@@ -147,6 +157,7 @@ internal class SkiaBasedOwner(
             val focusDirection = getFocusDirection(it)
             if (focusDirection == null || it.type != KeyDown) return@KeyInputModifier false
 
+            inputModeManager.requestInputMode(Keyboard)
             // Consume the key event if we moved focus.
             focusManager.moveFocus(focusDirection)
         },
@@ -359,6 +370,9 @@ internal class SkiaBasedOwner(
         event: PointerInputEvent,
         isInBounds: Boolean = true
     ): ProcessResult {
+        if (event.button != null) {
+            inputModeManager.requestInputMode(Touch)
+        }
         return pointerInputEventProcessor.process(
             event,
             this,


### PR DESCRIPTION
Changes in this PR:
- replace `focusableInNonTouchMode` usages by simple `focusable` (this change assumes that the purpose of the former was to simply prevent Focus indication in Touch mode. We want to focus on `focusable` items without any indications in Touch mode. This ensures that when users start navigating with Tab, the focus will move from relevant component to its relevant neighbours)
- add `focusRequester` in `clickable` and `toggleable` and request focus when Tap event occurs 
- make `Modifier.indication` skip FocusInteraction.Focus when `LocalInputModeManager` is in Touch mode
- make SkiaBasedOwner distinguish Touch and Keyboard input modes