### PR TITLE
navigate drop down menu items using up and down arrows

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
@@ -56,6 +56,8 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -76,14 +78,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.pointer.isAltPressed
 import androidx.compose.ui.input.pointer.isCtrlPressed
@@ -95,13 +100,16 @@ import androidx.compose.ui.input.pointer.isTertiaryPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIconDefaults
 import androidx.compose.ui.input.pointer.isBackPressed
 import androidx.compose.ui.input.pointer.isForwardPressed
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.Placeholder
@@ -482,6 +490,33 @@ private fun FrameWindowScope.ScrollableContent(scrollState: ScrollState) {
             value = amount.value / 100f,
             onValueChange = { amount.value = (it * 100) }
         )
+        val dropDownMenuExpanded = remember { mutableStateOf(false) }
+        Button(onClick = { dropDownMenuExpanded.value = true }) {
+            Text("Expand Menu")
+        }
+        DropdownMenu(
+            expanded = dropDownMenuExpanded.value,
+            onDismissRequest = {
+                dropDownMenuExpanded.value = false
+                println("OnDismissRequest")
+            }
+        ) {
+            DropdownMenuItem(modifier = Modifier, onClick = {
+                println("Item 1 clicked")
+            }) {
+                Text("Item 1")
+            }
+            DropdownMenuItem(modifier = Modifier, onClick = {
+                println("Item 2 clicked")
+            }) {
+                Text("Item 2")
+            }
+            DropdownMenuItem(modifier = Modifier, onClick = {
+                println("Item 3 clicked")
+            }) {
+                Text("Item 3")
+            }
+        }
         TextField(
             value = amount.value.toString(),
             onValueChange = { amount.value = it.toFloatOrNull() ?: 42f },
@@ -518,9 +553,9 @@ private fun FrameWindowScope.ScrollableContent(scrollState: ScrollState) {
                         else -> false
                     }
                 }.focusRequester(focusItem1)
-                .focusProperties {
-                    next = focusItem2
-                }
+                    .focusProperties {
+                        next = focusItem2
+                    }
             )
         }
 
@@ -558,12 +593,16 @@ private fun FrameWindowScope.ScrollableContent(scrollState: ScrollState) {
             )
         }
 
-        Box(modifier = Modifier.size(150.dp).background(Color.Gray).pointerHoverIcon(
-            if (isCtrlPressed.value) PointerIconDefaults.Hand else PointerIconDefaults.Default
-        )) {
-            Box(modifier = Modifier.offset(20.dp, 20.dp).size(100.dp).background(Color.Blue).pointerHoverIcon(
-                if (isCtrlPressed.value) PointerIconDefaults.Crosshair else PointerIconDefaults.Text,
-            )) {
+        Box(
+            modifier = Modifier.size(150.dp).background(Color.Gray).pointerHoverIcon(
+                if (isCtrlPressed.value) PointerIconDefaults.Hand else PointerIconDefaults.Default
+            )
+        ) {
+            Box(
+                modifier = Modifier.offset(20.dp, 20.dp).size(100.dp).background(Color.Blue).pointerHoverIcon(
+                    if (isCtrlPressed.value) PointerIconDefaults.Crosshair else PointerIconDefaults.Text,
+                )
+            ) {
                 Text("pointerHoverIcon test with Ctrl")
             }
         }

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -23,14 +23,21 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.awtEventOrNull
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -75,6 +82,7 @@ import java.awt.event.KeyEvent
  * tapping outside the menu's bounds
  * @param offset [DpOffset] to be added to the position of the menu
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Suppress("ModifierParameter")
 @Composable
 fun DropdownMenu(
@@ -115,12 +123,31 @@ fun DropdownMenu(
                 }
             },
         ) {
+            val focusManager = LocalFocusManager.current
+
             DropdownMenuContent(
                 expandedStates = expandedStates,
                 transformOriginState = transformOriginState,
-                modifier = modifier,
+                modifier = modifier.onKeyEvent {
+                    if (it.type != KeyEventType.KeyDown) return@onKeyEvent false
+                    when (it.key) {
+                        Key.DirectionDown -> {
+                            focusManager.moveFocus(FocusDirection.Next)
+                            true
+                        }
+                        Key.DirectionUp -> {
+                            focusManager.moveFocus(FocusDirection.Previous)
+                            true
+                        }
+                        else -> false
+                    }
+                },
                 content = content
             )
+
+            LaunchedEffect(Unit) {
+                focusManager.moveFocus(FocusDirection.Next)
+            }
         }
     }
 }
@@ -273,3 +300,4 @@ internal data class DesktopDropdownMenuPositionProvider(
         return IntOffset(x, y)
     }
 }
+

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -23,21 +23,25 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -110,44 +114,25 @@ fun DropdownMenu(
             transformOriginState.value = calculateTransformOrigin(parentBounds, menuBounds)
         }
 
+        var focusManager: FocusManager? by mutableStateOf(null)
+        var inputModeManager: InputModeManager? by mutableStateOf(null)
         Popup(
             focusable = focusable,
             onDismissRequest = onDismissRequest,
             popupPositionProvider = popupPositionProvider,
             onKeyEvent = {
-                if (it.type == KeyEventType.KeyDown && it.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
-                    onDismissRequest()
-                    true
-                } else {
-                    false
-                }
+                handlePopupOnKeyEvent(it, onDismissRequest, focusManager!!, inputModeManager!!)
             },
         ) {
-            val focusManager = LocalFocusManager.current
+            focusManager = LocalFocusManager.current
+            inputModeManager = LocalInputModeManager.current
 
             DropdownMenuContent(
                 expandedStates = expandedStates,
                 transformOriginState = transformOriginState,
-                modifier = modifier.onKeyEvent {
-                    if (it.type != KeyEventType.KeyDown) return@onKeyEvent false
-                    when (it.key) {
-                        Key.DirectionDown -> {
-                            focusManager.moveFocus(FocusDirection.Next)
-                            true
-                        }
-                        Key.DirectionUp -> {
-                            focusManager.moveFocus(FocusDirection.Previous)
-                            true
-                        }
-                        else -> false
-                    }
-                },
+                modifier = modifier,
                 content = content
             )
-
-            LaunchedEffect(Unit) {
-                focusManager.moveFocus(FocusDirection.Next)
-            }
         }
     }
 }
@@ -187,6 +172,35 @@ fun DropdownMenuItem(
     )
 }
 
+@ExperimentalComposeUiApi
+private fun handlePopupOnKeyEvent(
+    keyEvent: androidx.compose.ui.input.key.KeyEvent,
+    onDismissRequest: () -> Unit,
+    focusManager: FocusManager,
+    inputModeManager: InputModeManager
+): Boolean {
+    return if (keyEvent.type == KeyEventType.KeyDown && keyEvent.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
+        onDismissRequest()
+        true
+    } else if (keyEvent.type == KeyEventType.KeyDown) {
+        when (keyEvent.key) {
+            Key.DirectionDown -> {
+                inputModeManager.requestInputMode(InputMode.Keyboard)
+                focusManager.moveFocus(FocusDirection.Next)
+                true
+            }
+            Key.DirectionUp -> {
+                inputModeManager.requestInputMode(InputMode.Keyboard)
+                focusManager.moveFocus(FocusDirection.Previous)
+                true
+            }
+            else -> false
+        }
+    } else {
+        false
+    }
+}
+
 /**
  *
  * A [CursorDropdownMenu] behaves similarly to [Popup] and will use the current position of the mouse
@@ -200,6 +214,7 @@ fun DropdownMenuItem(
  * @param onDismissRequest Called when the user requests to dismiss the menu, such as by
  * tapping outside the menu's bounds
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Suppress("ModifierParameter")
 @Composable
 fun CursorDropdownMenu(
@@ -215,19 +230,20 @@ fun CursorDropdownMenu(
     if (expandedStates.currentState || expandedStates.targetState) {
         val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
 
+        var focusManager: FocusManager? by mutableStateOf(null)
+        var inputModeManager: InputModeManager? by mutableStateOf(null)
+
         Popup(
             focusable = focusable,
             onDismissRequest = onDismissRequest,
             popupPositionProvider = rememberCursorPositionProvider(),
             onKeyEvent = {
-                if (it.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
-                    onDismissRequest()
-                    true
-                } else {
-                    false
-                }
+                handlePopupOnKeyEvent(it, onDismissRequest, focusManager!!, inputModeManager!!)
             },
         ) {
+            focusManager = LocalFocusManager.current
+            inputModeManager = LocalInputModeManager.current
+
             DropdownMenuContent(
                 expandedStates = expandedStates,
                 transformOriginState = transformOriginState,

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -112,4 +112,68 @@ class DesktopMenuTest {
             Assert.assertEquals(1, dismissCount)
         }
     }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Test
+    fun `navigate DropDownMenu using arrows`() {
+        var item1Clicked = 0
+        var item2Clicked = 0
+        var item3Clicked = 0
+
+        rule.setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f, 1f)) {
+                DropdownMenu(true, onDismissRequest = {},
+                    modifier = Modifier.testTag("dropDownMenu")) {
+                    DropdownMenuItem({
+                        item1Clicked++
+                    }) { Text("item1") }
+                    DropdownMenuItem({
+                        item2Clicked++
+                    }) { Text("item2") }
+                    DropdownMenuItem({
+                        item3Clicked++
+                    }) { Text("item3") }
+                }
+            }
+        }
+
+        fun performKeyDownAndUp(key: Key) {
+            rule.onNodeWithTag("dropDownMenu").apply {
+                performKeyPress(keyEvent(key, KeyEventType.KeyDown))
+                performKeyPress(keyEvent(key, KeyEventType.KeyUp))
+            }
+        }
+
+        fun assertClicksCount(i1: Int, i2: Int, i3: Int) {
+            rule.runOnIdle {
+                assertThat(item1Clicked).isEqualTo(i1)
+                assertThat(item2Clicked).isEqualTo(i2)
+                assertThat(item3Clicked).isEqualTo(i3)
+            }
+        }
+
+        performKeyDownAndUp(Key.DirectionDown)
+        performKeyDownAndUp(Key.Enter)
+        assertClicksCount(1, 0, 0)
+
+        performKeyDownAndUp(Key.DirectionUp)
+        performKeyDownAndUp(Key.Enter)
+        assertClicksCount(1, 0, 1)
+
+        performKeyDownAndUp(Key.DirectionUp)
+        performKeyDownAndUp(Key.Enter)
+        assertClicksCount(1, 1, 1)
+
+        performKeyDownAndUp(Key.DirectionDown)
+        performKeyDownAndUp(Key.Enter)
+        assertClicksCount(1, 1, 2)
+
+        performKeyDownAndUp(Key.DirectionDown)
+        performKeyDownAndUp(Key.Enter)
+        assertClicksCount(2, 1, 2)
+
+        performKeyDownAndUp(Key.DirectionDown)
+        performKeyDownAndUp(Key.Enter)
+        assertClicksCount(2, 2, 2)
+    }
 }


### PR DESCRIPTION
When DropDownMenu/CursorDropdownMenu or ContextMenu (on TextField) pops up, the menu items can be navigated using Up and Down arrows. 