### PR TITLE
Implement test input methods for desktop

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -42,13 +42,13 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
-import androidx.compose.ui.test.TouchInjectionScope
+import androidx.compose.ui.test.MouseInjectionScope
 import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.junit4.DesktopComposeTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
@@ -75,8 +75,8 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 25f), end = Offset(0f, 50f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 25f), end = Offset(0f, 50f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(-50.dp)
@@ -90,8 +90,8 @@ class ScrollbarTest {
                 TestBox(size = 100.dp, childSize = 20.dp, childCount = 1, scrollbarWidth = 10.dp)
             }
             rule.awaitIdle()
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 25f), end = Offset(0f, 50f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 25f), end = Offset(0f, 50f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
@@ -106,14 +106,14 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 25f), end = Offset(0f, 500f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 25f), end = Offset(0f, 500f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(-100.dp)
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 99f), end = Offset(0f, -500f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 99f), end = Offset(0f, -500f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
@@ -128,8 +128,8 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(10f, 25f), end = Offset(0f, 50f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(10f, 25f), end = Offset(0f, 50f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
@@ -144,11 +144,12 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                down(Offset(10f, 25f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                moveTo(Offset(10f, 25f))
+                press()
                 moveBy(Offset(0f, 50f))
                 moveBy(Offset(0f, -50f))
-                up()
+                release()
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
@@ -161,13 +162,13 @@ class ScrollbarTest {
 //        ...
 //        rule.performMouseMove(0, 25)
 //        rule.mainClock.advanceTimeByFrame()
-//        down(Offset(0f, 25f))
+//        press(Offset(0f, 25f))
 //        rule.mainClock.advanceTimeByFrame()
 //        moveTo(Offset(0f, 30f))
 //        rule.mainClock.advanceTimeByFrame()
 //        moveTo(Offset(0f, 50f))
 //        rule.mainClock.advanceTimeByFrame()
-//        up()
+//        release()
 //        ...
 //    }
 
@@ -227,8 +228,8 @@ class ScrollbarTest {
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(-100.dp)
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 99f), end = Offset(0f, -500f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 99f), end = Offset(0f, -500f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
@@ -243,8 +244,9 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                down(Offset(0f, 26f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                moveTo(Offset(0f, 26f))
+                press()
             }
 
             tryUntilSucceeded {
@@ -262,8 +264,9 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                down(Offset(0f, 99f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                moveTo(Offset(0f, 99f))
+                press()
             }
 
             tryUntilSucceeded {
@@ -294,8 +297,8 @@ class ScrollbarTest {
             isContentVisible.value = true
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 25f), end = Offset(0f, 500f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 25f), end = Offset(0f, 500f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(-100.dp)
@@ -321,8 +324,8 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 0f), end = Offset(0f, 11f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 0f), end = Offset(0f, 11f))
             }
             rule.awaitIdle()
             assertEquals(2, state.firstVisibleItemIndex)
@@ -350,8 +353,8 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 99f), end = Offset(0f, 88f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 99f), end = Offset(0f, 88f))
             }
             rule.awaitIdle()
             assertEquals(2, state.firstVisibleItemIndex)
@@ -378,8 +381,8 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 0f), end = Offset(0f, 26f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 0f), end = Offset(0f, 26f))
             }
             rule.awaitIdle()
             assertEquals(5, state.firstVisibleItemIndex)
@@ -406,15 +409,15 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 0f), end = Offset(0f, 10000f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 0f), end = Offset(0f, 10000f))
             }
             rule.awaitIdle()
             assertEquals(15, state.firstVisibleItemIndex)
             assertEquals(0, state.firstVisibleItemScrollOffset)
 
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 99f), end = Offset(0f, -10000f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 99f), end = Offset(0f, -10000f))
             }
             rule.awaitIdle()
             assertEquals(0, state.firstVisibleItemIndex)
@@ -431,8 +434,8 @@ class ScrollbarTest {
                 )
             }
             rule.awaitIdle()
-            rule.onNodeWithTag("scrollbar").performTouchInput {
-                instantSwipe(start = Offset(0f, 25f), end = Offset(0f, 50f))
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 25f), end = Offset(0f, 50f))
             }
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
@@ -553,10 +556,11 @@ class ScrollbarTest {
         }
     }
 
-    private fun TouchInjectionScope.instantSwipe(start: Offset, end: Offset) {
-        down(start)
+    private fun MouseInjectionScope.instantDrag(start: Offset, end: Offset) {
+        moveTo(start)
+        press()
         moveTo(end)
-        up()
+        release()
     }
 
     @Composable

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -140,6 +140,14 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.truth)
                 implementation(libs.skiko)
             }
+
+            desktopTest.dependencies {
+                implementation(project(":compose:foundation:foundation"))
+                implementation(libs.truth)
+                implementation(libs.junit)
+                implementation(libs.skikoCurrentOs)
+                implementation(libs.kotlinCoroutinesSwing)
+            }
         }
     }
 

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
@@ -1,0 +1,433 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Enter
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Exit
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Move
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Scroll
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.PointerType.Companion.Mouse
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+class ComposeUiTestTest {
+    private val events = mutableListOf<PointerEvent>()
+
+    @Composable
+    private fun TestEventBox() {
+        Box(
+            Modifier
+                .size(100f.dp, 100f.dp)
+                .testTag("test")
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            events += awaitPointerEvent()
+                        }
+                    }
+                }
+        )
+    }
+
+    @Test
+    fun `mouse, move`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput {
+            moveTo(Offset(30f, 40f))
+            moveTo(Offset(30f, 50f))
+        }
+        assertThat(events).hasSize(3)
+        events[0].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Move)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Move)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 50f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+
+    @Test
+    fun `mouse, drag`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput {
+            moveTo(Offset(30f, 40f))
+            press()
+            moveTo(Offset(10f, 20f))
+        }
+        assertThat(events).hasSize(4)
+        events[0].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Move)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[3].apply {
+            assertThat(type).isEqualTo(Move)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+
+    @Test
+    fun `mouse, press primary`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput { 
+            press()
+        }
+        assertThat(events).hasSize(1)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+
+    @Test
+    fun `mouse, press and release primary`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput {
+            press()
+            release()
+        }
+        assertThat(events).hasSize(2)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+
+    @Test
+    fun `mouse, click`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput {
+            click(Offset(10f, 20f))
+        }
+        assertThat(events).hasSize(2)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+    
+    @Test
+    fun `mouse, press multiple`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput {
+            updatePointerTo(Offset(10f, 20f))
+            press(MouseButton.Primary)
+            press(MouseButton.Tertiary)
+            release(MouseButton.Primary)
+            release(MouseButton.Tertiary)
+            press(MouseButton(3))
+        }
+        assertThat(events).hasSize(5)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Tertiary)
+            assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = true, isTertiaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(button).isEqualTo(PointerButton.Primary)
+            assertThat(buttons).isEqualTo(PointerButtons(isTertiaryPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[3].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(button).isEqualTo(PointerButton.Tertiary)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[4].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(button).isEqualTo(PointerButton.Back)
+            assertThat(buttons).isEqualTo(PointerButtons(isBackPressed = true))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+    
+    @Test
+    fun `mouse, scroll`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performMouseInput {
+            updatePointerTo(Offset(30f, 40f))
+            scroll(20f)
+            scroll(-20f, ScrollWheel.Horizontal)
+        }
+        assertThat(events).hasSize(2)
+        events[0].apply {
+            assertThat(type).isEqualTo(Scroll)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].scrollDelta).isEqualTo(Offset(0f, 20f))
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Scroll)
+            assertThat(button).isEqualTo(null)
+            assertThat(buttons).isEqualTo(PointerButtons())
+            assertThat(changes[0].scrollDelta).isEqualTo(Offset(-20f, 0f))
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+    }
+
+    @Test
+    fun `touch, drag`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performTouchInput {
+            down(Offset(30f, 40f))
+            moveTo(Offset(10f, 20f))
+            moveTo(Offset(30f, 50f))
+        }
+        assertThat(events).hasSize(3)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 40f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Move)
+            assertThat(changes[0].position).isEqualTo(Offset(30f, 50f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+    }
+
+    @Test
+    fun `touch, press`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performTouchInput {
+            down(Offset.Zero)
+        }
+        assertThat(events).hasSize(1)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+    }
+
+    @Test
+    fun `touch, press and release`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performTouchInput {
+            down(Offset.Zero)
+            up()
+        }
+        assertThat(events).hasSize(2)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+    }
+
+    @Test
+    fun `touch, click`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performTouchInput {
+            click(Offset(10f, 20f))
+        }
+        assertThat(events).hasSize(3)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+    }
+
+    @Test
+    fun `touch, press multiple`() = runComposeUiTest {
+        setContent { TestEventBox() }
+
+        onNodeWithTag("test").performTouchInput {
+            down(0, Offset(0f, 0f))
+            down(1, Offset(10f, 20f))
+            up(0)
+            up(1)
+        }
+
+        val events = events.filter { it.type != Move && it.type != Enter && it.type != Exit }
+
+        assertThat(events).hasSize(4)
+        events[0].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(changes[0].position).isEqualTo(Offset(0f, 0f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[1].apply {
+            assertThat(type).isEqualTo(Press)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(changes[0].position).isEqualTo(Offset(0f, 0f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+        events[3].apply {
+            assertThat(type).isEqualTo(Release)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+        }
+    }
+
+    @Test
+    fun `text input`() = runComposeUiTest {
+        var text by mutableStateOf(TextFieldValue(""))
+        val focusRequester = FocusRequester()
+
+        setContent {
+            BasicTextField(text, { text = it }, modifier = Modifier.testTag("test").focusRequester(focusRequester))
+        }
+
+        onNodeWithTag("test").performClick()
+
+        onNodeWithTag("test").performTextInput("Text")
+        assertThat(text.text).isEqualTo("Text")
+
+        onNodeWithTag("test").performTextInput("Text")
+        assertThat(text.text).isEqualTo("TextText")
+
+        onNodeWithTag("test").performTextInputSelection(TextRange(1, 2))
+        assertThat(text.selection).isEqualTo(TextRange(1, 2))
+
+        onNodeWithTag("test").performTextClearance()
+        assertThat(text.text).isEqualTo("")
+    }
+}

--- a/compose/ui/ui-test/src/commonMain/kotlin/androidx/compose/ui/test/InputDispatcher.kt
+++ b/compose/ui/ui-test/src/commonMain/kotlin/androidx/compose/ui/test/InputDispatcher.kt
@@ -66,7 +66,9 @@ internal expect fun createInputDispatcher(
  */
 internal abstract class InputDispatcher(
     private val testContext: TestContext,
-    private val root: RootForTest
+    private val root: RootForTest,
+    private val exitHoverOnPress: Boolean = true,
+    private val moveOnScroll: Boolean = true
 ) {
     companion object {
         /**
@@ -416,7 +418,7 @@ internal abstract class InputDispatcher(
         mouse.setButtonBit(buttonId)
 
         // Exit hovering if necessary
-        if (mouse.isEntered) {
+        if (mouse.isEntered && exitHoverOnPress) {
             mouse.exitHover()
         }
         // down/move + press
@@ -484,7 +486,7 @@ internal abstract class InputDispatcher(
         mouse.enqueueRelease(buttonId)
 
         // When no buttons remaining, enter hover state immediately
-        if (mouse.hasNoButtonsPressed && isWithinRootBounds(currentMousePosition)) {
+        if (exitHoverOnPress && mouse.hasNoButtonsPressed && isWithinRootBounds(currentMousePosition)) {
             mouse.enterHover()
             mouse.enqueueMove()
         }
@@ -551,8 +553,10 @@ internal abstract class InputDispatcher(
     fun enqueueMouseScroll(delta: Float, scrollWheel: ScrollWheel) {
         val mouse = mouseInputState
 
-        // A scroll is always preceded by a move(/hover) event
-        enqueueMouseMove(currentMousePosition)
+        if (moveOnScroll) {
+            // On Android a scroll is always preceded by a move(/hover) event
+            enqueueMouseMove(currentMousePosition)
+        }
         if (isWithinRootBounds(currentMousePosition)) {
             mouse.enqueueScroll(delta, scrollWheel)
         }

--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/Actions.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/Actions.desktop.kt
@@ -16,9 +16,9 @@
 
 package androidx.compose.ui.test
 
+@OptIn(ExperimentalTestApi::class)
 internal actual fun SemanticsNodeInteraction.performClickImpl(): SemanticsNodeInteraction {
-    // TODO: Replace with performMouseInput when desktop has a mouse implementation
-    return performTouchInput {
+    return performMouseInput {
         click()
     }
 }

--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/DesktopOutput.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/DesktopOutput.desktop.kt
@@ -17,5 +17,5 @@
 package androidx.compose.ui.test
 
 internal actual fun printToLog(tag: String, message: String) {
-    TODO()
+    println("$tag: $message")
 }

--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/Mouse.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/Mouse.desktop.kt
@@ -20,6 +20,7 @@ package androidx.compose.ui.test
 
 // TODO: use constants instead of literals
 
+// TODO replace it by common PointerButton, when we upstream it
 @ExperimentalTestApi
 @JvmInline
 actual value class MouseButton(val buttonId: Int) {
@@ -28,16 +29,16 @@ actual value class MouseButton(val buttonId: Int) {
         /**
          * The left mouse button
          */
-        actual val Primary = MouseButton(1)
+        actual val Primary = MouseButton(0)
 
         /**
          * The right mouse button
          */
-        actual val Secondary = MouseButton(2)
+        actual val Secondary = MouseButton(1)
 
         /**
          * The middle mouse button
          */
-        actual val Tertiary = MouseButton(4)
+        actual val Tertiary = MouseButton(2)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -168,6 +168,7 @@ private fun PopupLayout(
     val parentComposition = rememberCompositionContext()
     val (owner, composition) = remember {
         val owner = SkiaBasedOwner(
+            scene = scene,
             platform = scene.platform,
             pointerPositionUpdater = scene.pointerPositionUpdater,
             density = density,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerButton.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerButton.skiko.kt
@@ -19,8 +19,9 @@ package androidx.compose.ui.input.pointer
 import androidx.compose.ui.ExperimentalComposeUiApi
 import kotlin.jvm.JvmInline
 
+// TODO replace MouseButton by this class after we upstream it
+
 @JvmInline
-@ExperimentalComposeUiApi
 /**
  * Represents the index of a pointer button.
  * See [PointerEvent.button], where [PointerButton] is used.
@@ -35,22 +36,17 @@ value class PointerButton(val index: Int) {
     }
 }
 
-@ExperimentalComposeUiApi
 val PointerButton?.isPrimary: Boolean
     get() { return this == PointerButton.Primary }
 
-@ExperimentalComposeUiApi
 val PointerButton?.isSecondary: Boolean
     get() { return this == PointerButton.Secondary }
 
-@ExperimentalComposeUiApi
 val PointerButton?.isTertiary: Boolean
     get() { return this == PointerButton.Tertiary }
 
-@ExperimentalComposeUiApi
 val PointerButton?.isBack: Boolean
     get() { return this == PointerButton.Back }
 
-@ExperimentalComposeUiApi
 val PointerButton?.isForward: Boolean
     get() { return this == PointerButton.Forward }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.skiko.kt
@@ -44,6 +44,7 @@ fun SkikoTouchEventKind.toCompose() = when(this) {
     else -> PointerEventType.Unknown
 }
 
+// TODO(https://github.com/JetBrains/compose-jb/issues/2184) support more buttons
 /**
  * Creates [PointerButtons] with the specified state of the pressed buttons.
  */
@@ -260,3 +261,30 @@ actual val PointerKeyboardModifiers.isScrollLockOn: Boolean
 
 actual val PointerKeyboardModifiers.isNumLockOn: Boolean
     get() = (packedValue and KeyboardModifierMasks.NumLockOn) != 0
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun PointerButtons.copyFor(
+    button: PointerButton,
+    pressed: Boolean
+): PointerButtons = when (button) {
+    PointerButton.Primary -> copy(isPrimaryPressed = pressed)
+    PointerButton.Secondary -> copy(isSecondaryPressed = pressed)
+    PointerButton.Tertiary -> copy(isTertiaryPressed = pressed)
+    PointerButton.Forward -> copy(isForwardPressed = pressed)
+    PointerButton.Back -> copy(isBackPressed = pressed)
+    else -> copy()
+}
+
+internal fun PointerButtons.copy(
+    isPrimaryPressed: Boolean = this.isPrimaryPressed,
+    isSecondaryPressed: Boolean = this.isSecondaryPressed,
+    isTertiaryPressed: Boolean = this.isTertiaryPressed,
+    isBackPressed: Boolean = this.isBackPressed,
+    isForwardPressed: Boolean = this.isForwardPressed
+): PointerButtons = PointerButtons(
+    isPrimaryPressed,
+    isSecondaryPressed,
+    isTertiaryPressed,
+    isBackPressed,
+    isForwardPressed,
+)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/TestPointerInputEventData.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/TestPointerInputEventData.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.geometry.Offset
 /**
  * This exposes PointerInputEventData for testing purposes.
  */
+@Deprecated("Will be removed in Compose 1.3")
 @InternalComposeUiApi
 class TestPointerInputEventData(
     val id: PointerId,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.input.pointer.TestPointerInputEventData
 import androidx.compose.ui.node.RootForTest
@@ -27,10 +28,17 @@ import androidx.compose.ui.node.RootForTest
 @InternalComposeUiApi
 interface SkiaRootForTest : RootForTest {
     /**
+     * The [ComposeScene] which contains this root
+     */
+    val scene: ComposeScene get() = throw UnsupportedOperationException("SkiaRootForTest.scene is not implemented")
+
+    /**
      * Process pointer event
      *
      * [timeMillis] time when the pointer event occurred
      * [pointers] state of all pointers
      */
+    @Suppress("DEPRECATION")
+    @Deprecated("Don't send events directly to root. Send events to [scene]. Will be removed in Compose 1.3")
     fun processPointerInput(timeMillis: Long, pointers: List<TestPointerInputEventData>)
 }


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/1216
Fixes https://github.com/JetBrains/compose-jb/issues/1846
Fixes https://github.com/JetBrains/compose-jb/issues/2059
Fixes https://github.com/JetBrains/compose-jb/issues/1127

Partially fixes https://github.com/JetBrains/compose-jb/issues/1177

API changes:
- make PointerButton non-experimental
- add a new non-experimental constructor for ComposeScene
- TestPointerInputEventData is deprecated

It is needed, because we can only use non-experimental API from ui-test module.

During upstream, if new public API will be changed, we have to maintain its backward compatibility.
