### PR TITLE
Toggle on space key

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/selection/Toggleable.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/selection/Toggleable.android.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.selection
+
+import android.view.KeyEvent.KEYCODE_SPACE
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType.Companion.KeyUp
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.type
+
+/**
+ * Whether the specified [KeyEvent] represents a user intent to perform a toggle.
+ * (eg. When you press Space on a focused checkbox, it should perform a toggle).
+ */
+internal actual val KeyEvent.isToggle: Boolean
+    get() = type == KeyUp && when (key.nativeKeyCode) {
+        KEYCODE_SPACE,  // TODO recheck when we upstream
+        else -> false
+}

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/selection/Toggleable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/selection/Toggleable.kt
@@ -34,6 +34,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.modifier.ModifierLocalConsumer
 import androidx.compose.ui.modifier.ModifierLocalReadScope
@@ -288,6 +290,14 @@ private fun Modifier.toggleableImpl(
             }
         )
     }
+    fun Modifier.detectToggleFromKey() = this.onKeyEvent {
+        if (enabled && it.isToggle) {
+            onClick()
+            true
+        } else {
+            false
+        }
+    }
     this
         .then(
             remember {
@@ -302,8 +312,15 @@ private fun Modifier.toggleableImpl(
             }
         )
         .then(semantics).then(focusRequesterModifier)
+        .detectToggleFromKey()
         .indication(interactionSource, indication)
         .hoverable(enabled = enabled, interactionSource = interactionSource)
         .focusable(enabled = enabled, interactionSource = interactionSource)
         .then(gestures)
 }
+
+/**
+ * Whether the specified [KeyEvent] represents a user intent to perform a toggle.
+ * (eg. When you press Space on a focused checkbox, it should perform a toggle).
+ */
+internal expect val KeyEvent.isToggle: Boolean

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/selection/Toggleable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/selection/Toggleable.desktop.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.selection
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.type
+import java.awt.event.KeyEvent.VK_SPACE
+
+/**
+ * Whether the specified [KeyEvent] represents a user intent to perform a toggle.
+ * (eg. When you press Space on a focused checkbox, it should perform a toggle).
+ */
+internal actual val KeyEvent.isToggle: Boolean
+    get() = type == KeyEventType.KeyUp && when (key.nativeKeyCode) {
+        VK_SPACE -> true
+        else -> false
+    }

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ToggleableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ToggleableTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.internal.keyEvent
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyPress
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+class ToggleableTest {
+
+    @Test
+    fun `toggleable by Space button`() = runComposeUiTest {
+        var state: Boolean by mutableStateOf(false)
+        setContent {
+            Box(modifier = Modifier.size(100.dp, 100.dp).toggleable(
+                value = state,
+                onValueChange = {
+                    state = it
+                }
+            ).testTag("toggle"))
+        }
+
+        runOnIdle {
+            assertEquals(false, state)
+        }
+
+        onRoot().apply {
+            performKeyPress(keyEvent(Key.Tab, KeyEventType.KeyDown))
+            performKeyPress(keyEvent(Key.Tab, KeyEventType.KeyUp))
+        }
+
+        onNodeWithTag("toggle").apply {
+            performKeyPress(keyEvent(Key.Spacebar, KeyEventType.KeyDown))
+            performKeyPress(keyEvent(Key.Spacebar, KeyEventType.KeyUp))
+        }
+
+        runOnIdle {
+            assertEquals(true, state)
+        }
+
+        onNodeWithTag("toggle").apply {
+            performKeyPress(keyEvent(Key.Spacebar, KeyEventType.KeyDown))
+            performKeyPress(keyEvent(Key.Spacebar, KeyEventType.KeyUp))
+        }
+
+        runOnIdle {
+            assertEquals(false, state)
+        }
+    }
+}

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/internal/KeyEventUtils.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/internal/KeyEventUtils.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material.internal
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.nativeKeyCode
+import androidx.compose.ui.input.key.nativeKeyLocation
+import java.awt.Component
+import java.awt.event.KeyEvent
+
+private object DummyComponent : Component()
+/**
+ * The [KeyEvent] is usually created by the system. This function creates an instance of
+ * [KeyEvent] that can be used in tests.
+ */
+internal fun keyEvent(
+    key: Key,
+    keyEventType: KeyEventType,
+    modifiers: Int = 0
+): androidx.compose.ui.input.key.KeyEvent {
+    val action = when (keyEventType) {
+        KeyEventType.KeyDown -> java.awt.event.KeyEvent.KEY_PRESSED
+        KeyEventType.KeyUp -> java.awt.event.KeyEvent.KEY_RELEASED
+        else -> error("Unknown key event type")
+    }
+    return androidx.compose.ui.input.key.KeyEvent(
+        KeyEvent(
+            DummyComponent,
+            action,
+            0L,
+            modifiers,
+            key.nativeKeyCode,
+            KeyEvent.getKeyText(key.nativeKeyCode)[0],
+            key.nativeKeyLocation
+        )
+    )
+}

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/selection/Toggleable.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/selection/Toggleable.jsNative.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.selection
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import org.jetbrains.skiko.SkikoKey
+
+private val SPACE_KEY_CODE = SkikoKey.KEY_SPACE.platformKeyCode.toLong()
+/**
+ * Whether the specified [KeyEvent] represents a user intent to perform a toggle.
+ * (eg. When you press Space on a focused checkbox, it should perform a toggle).
+ */
+internal actual val KeyEvent.isToggle: Boolean
+    get() = type == KeyEventType.KeyUp && when (key.keyCode) {
+        SPACE_KEY_CODE -> true
+        else -> false
+    }


### PR DESCRIPTION
This PR is a replacement for https://github.com/JetBrains/androidx/pull/126 (the #126 was not possible to rebase on top of jb-main, because that PR was based on a different branch - release/1.0)

This PR adds some changes to the original one:
- adds KeyEvent.isToggle actual in jsNativeMain source set
- adds a test for Modifier.toggleable to toggle by Space