### PR TITLE
add internal expect/actual for KeyEvent extension properties to check if event is intended for navigation

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -87,17 +88,17 @@ class DefaultContextMenuRepresentation(
                 popupPositionProvider = rememberCursorPositionProvider(),
                 onKeyEvent = {
                     if (it.type == KeyEventType.KeyDown) {
-                        when (it.key) {
-                            Key.Escape -> {
+                        when (it.key.nativeKeyCode) {
+                            java.awt.event.KeyEvent.VK_ESCAPE -> {
                                 state.status = ContextMenuState.Status.Closed
                                 true
                             }
-                            Key.DirectionDown -> {
+                            java.awt.event.KeyEvent.VK_DOWN  -> {
                                 inputModeManager!!.requestInputMode(InputMode.Keyboard)
                                 focusManager!!.moveFocus(FocusDirection.Next)
                                 true
                             }
-                            Key.DirectionUp -> {
+                            java.awt.event.KeyEvent.VK_UP -> {
                                 inputModeManager!!.requestInputMode(InputMode.Keyboard)
                                 focusManager!!.moveFocus(FocusDirection.Previous)
                                 true

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -118,6 +118,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.kotlinStdlib)
             }
 
+            jsNativeMain.dependsOn(commonMain)
+            jsMain.dependsOn(jsNativeMain)
+            nativeMain.dependsOn(jsNativeMain)
+
             // TODO(b/214407011): These dependencies leak into instrumented tests as well. If you
             //  need to add Robolectric (which must be kept out of androidAndroidTest), use a top
             //  level dependencies block instead:

--- a/compose/material/material/src/androidMain/kotlin/androidx/compose/material/NavigationKeyEvents.android.kt
+++ b/compose/material/material/src/androidMain/kotlin/androidx/compose/material/NavigationKeyEvents.android.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material
+
+import android.view.KeyEvent.KEYCODE_MOVE_END
+import android.view.KeyEvent.KEYCODE_MOVE_HOME
+import android.view.KeyEvent.KEYCODE_PAGE_UP
+import android.view.KeyEvent.KEYCODE_PAGE_DOWN
+import android.view.KeyEvent.KEYCODE_DPAD_UP
+import android.view.KeyEvent.KEYCODE_DPAD_DOWN
+import android.view.KeyEvent.KEYCODE_DPAD_LEFT
+import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+
+internal actual val KeyEvent.isDirectionUp: Boolean
+    get() = key.nativeKeyCode == KEYCODE_DPAD_UP
+
+internal actual val KeyEvent.isDirectionDown: Boolean
+    get() = key.nativeKeyCode == KEYCODE_DPAD_DOWN
+
+internal actual val KeyEvent.isDirectionRight: Boolean
+    get() = key.nativeKeyCode == KEYCODE_DPAD_RIGHT
+
+internal actual val KeyEvent.isDirectionLeft: Boolean
+    get() = key.nativeKeyCode == KEYCODE_DPAD_LEFT
+
+internal actual val KeyEvent.isHome: Boolean
+    get() = key.nativeKeyCode == KEYCODE_MOVE_HOME
+
+internal actual val KeyEvent.isMoveEnd: Boolean
+    get() = key.nativeKeyCode == KEYCODE_MOVE_END
+
+internal actual val KeyEvent.isPgUp: Boolean
+    get() = key.nativeKeyCode == KEYCODE_PAGE_UP
+
+internal actual val KeyEvent.isPgDn: Boolean
+    get() = key.nativeKeyCode == KEYCODE_PAGE_DOWN

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/NavigationKeyEvents.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/NavigationKeyEvents.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material
+
+import androidx.compose.ui.input.key.KeyEvent
+
+internal expect val KeyEvent.isDirectionUp: Boolean
+internal expect val KeyEvent.isDirectionDown: Boolean
+internal expect val KeyEvent.isDirectionRight: Boolean
+internal expect val KeyEvent.isDirectionLeft: Boolean
+internal expect val KeyEvent.isHome: Boolean
+internal expect val KeyEvent.isMoveEnd: Boolean
+internal expect val KeyEvent.isPgUp: Boolean
+internal expect val KeyEvent.isPgDn: Boolean

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
@@ -278,39 +278,39 @@ private fun Modifier.slideOnKeyEvents(
         // the delta has to be discrete. In this case, 1% of the valueRange seems to make sense.
         val actualSteps = if (steps > 0) steps + 1 else 100
         val delta = rangeLength / actualSteps
-        when (it.key) {
-            Key.DirectionUp -> {
+        when {
+            it.isDirectionUp -> {
                 onValueChangeState.value((value + delta).coerceIn(valueRange))
                 true
             }
-            Key.DirectionDown -> {
+            it.isDirectionDown -> {
                 onValueChangeState.value((value - delta).coerceIn(valueRange))
                 true
             }
-            Key.DirectionRight -> {
+            it.isDirectionRight -> {
                 val sign = if (isRtl) -1 else 1
                 onValueChangeState.value((value + sign * delta).coerceIn(valueRange))
                 true
             }
-            Key.DirectionLeft -> {
+            it.isDirectionLeft -> {
                 val sign = if (isRtl) -1 else 1
                 onValueChangeState.value((value - sign * delta).coerceIn(valueRange))
                 true
             }
-            Key.Home -> {
+            it.isHome -> {
                 onValueChangeState.value(valueRange.start)
                 true
             }
-            Key.MoveEnd -> {
+            it.isMoveEnd -> {
                 onValueChangeState.value(valueRange.endInclusive)
                 true
             }
-            Key.PageUp -> {
+            it.isPgUp -> {
                 val page = (actualSteps / 10).coerceIn(1, 10)
                 onValueChangeState.value((value - page * delta).coerceIn(valueRange))
                 true
             }
-            Key.PageDown -> {
+            it.isPgDn -> {
                 val page = (actualSteps / 10).coerceIn(1, 10)
                 onValueChangeState.value((value + page * delta).coerceIn(valueRange))
                 true

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -183,13 +183,13 @@ private fun handlePopupOnKeyEvent(
         onDismissRequest()
         true
     } else if (keyEvent.type == KeyEventType.KeyDown) {
-        when (keyEvent.key) {
-            Key.DirectionDown -> {
+        when {
+            keyEvent.isDirectionDown -> {
                 inputModeManager.requestInputMode(InputMode.Keyboard)
                 focusManager.moveFocus(FocusDirection.Next)
                 true
             }
-            Key.DirectionUp -> {
+            keyEvent.isDirectionUp -> {
                 inputModeManager.requestInputMode(InputMode.Keyboard)
                 focusManager.moveFocus(FocusDirection.Previous)
                 true

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/NavigationKeyEvents.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/NavigationKeyEvents.desktop.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.nativeKeyCode
+
+internal actual val KeyEvent.isDirectionUp: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_UP
+
+internal actual val KeyEvent.isDirectionDown: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_DOWN
+
+internal actual val KeyEvent.isDirectionRight: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_RIGHT
+
+internal actual val KeyEvent.isDirectionLeft: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_LEFT
+
+internal actual val KeyEvent.isHome: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_HOME
+
+internal actual val KeyEvent.isMoveEnd: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_END
+
+internal actual val KeyEvent.isPgUp: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_PAGE_UP
+
+internal actual val KeyEvent.isPgDn: Boolean
+    get() = key.nativeKeyCode == java.awt.event.KeyEvent.VK_PAGE_DOWN

--- a/compose/material/material/src/jsNativeMain/kotlin/androidx/compose/material/NavigationKeyEvents.jsNative.kt
+++ b/compose/material/material/src/jsNativeMain/kotlin/androidx/compose/material/NavigationKeyEvents.jsNative.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material
+
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.key
+import org.jetbrains.skiko.SkikoKey
+
+private val DIRECTION_UP_KEY_CODE = SkikoKey.KEY_UP.platformKeyCode.toLong()
+private val DIRECTION_DOWN_KEY_CODE = SkikoKey.KEY_DOWN.platformKeyCode.toLong()
+private val DIRECTION_LEFT_KEY_CODE = SkikoKey.KEY_LEFT.platformKeyCode.toLong()
+private val DIRECTION_RIGHT_KEY_CODE = SkikoKey.KEY_RIGHT.platformKeyCode.toLong()
+private val HOME_KEY_CODE = SkikoKey.KEY_HOME.platformKeyCode.toLong()
+private val END_KEY_CODE = SkikoKey.KEY_END.platformKeyCode.toLong()
+private val PG_UP_KEY_CODE = SkikoKey.KEY_PGUP.platformKeyCode.toLong()
+private val PG_DN_KEY_CODE = SkikoKey.KEY_PGDOWN.platformKeyCode.toLong()
+
+internal actual val KeyEvent.isDirectionUp: Boolean
+    get() = key.keyCode == DIRECTION_UP_KEY_CODE
+
+internal actual val KeyEvent.isDirectionDown: Boolean
+    get() = key.keyCode == DIRECTION_DOWN_KEY_CODE
+
+internal actual val KeyEvent.isDirectionRight: Boolean
+    get() = key.keyCode == DIRECTION_RIGHT_KEY_CODE
+
+internal actual val KeyEvent.isDirectionLeft: Boolean
+    get() = key.keyCode == DIRECTION_LEFT_KEY_CODE
+
+internal actual val KeyEvent.isHome: Boolean
+    get() = key.keyCode == HOME_KEY_CODE
+
+internal actual val KeyEvent.isMoveEnd: Boolean
+    get() = key.keyCode == END_KEY_CODE
+
+internal actual val KeyEvent.isPgUp: Boolean
+    get() = key.keyCode == PG_UP_KEY_CODE
+
+internal actual val KeyEvent.isPgDn: Boolean
+    get() = key.keyCode == PG_DN_KEY_CODE


### PR DESCRIPTION
Add Such properties:
isDirectionDown, isDirectionUp, isDirectionLeft, isDirectionRight, isMoveEnd, isHome, isPdUp, is PgDn

Also fix usages of experimental API
