### PR TITLE
Fix idea sync with dependency in mavenLocal

### DIFF
--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -72,9 +72,9 @@ def addMavenRepositories(RepositoryHandler handler) {
         }
     }
     if (System.getenv("ALLOW_PUBLIC_REPOS") != null || System.getProperty("ALLOW_PUBLIC_REPOS") != null) {
+        handler.mavenLocal()
         handler.mavenCentral()
         handler.google()
-        handler.mavenLocal()
         handler.gradlePluginPortal()
         handler.maven {
                url("https://maven.pkg.jetbrains.space/public/p/compose/dev")

--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -74,6 +74,7 @@ def addMavenRepositories(RepositoryHandler handler) {
     if (System.getenv("ALLOW_PUBLIC_REPOS") != null || System.getProperty("ALLOW_PUBLIC_REPOS") != null) {
         handler.mavenCentral()
         handler.google()
+        handler.mavenLocal()
         handler.gradlePluginPortal()
         handler.maven {
                url("https://maven.pkg.jetbrains.space/public/p/compose/dev")
@@ -81,7 +82,6 @@ def addMavenRepositories(RepositoryHandler handler) {
         handler.maven {
                url("https://maven.pkg.jetbrains.space/public/p/kotlinx-coroutines/maven")
         }
-        handler.mavenLocal()
     }
     // Ordering appears to be important: b/229733266
     def androidPluginRepoOverride = System.getenv("GRADLE_PLUGIN_REPO")


### PR DESCRIPTION
gradlePluginPortal contains problem with resolving maven-metadata.
If we publish skiko to mavenLocal, project sync failed in IDEA.

Fixed: move mavenLocal before gradlePluginPortal.