### PR TITLE
In placeAutoMirrored for RTL, calculate the placement position using the placeable width respecting the constraints

### DIFF
--- a/compose/foundation/foundation-layout/integration-tests/layout-demos/src/main/java/androidx/compose/foundation/layout/demos/RtlDemo.kt
+++ b/compose/foundation/foundation-layout/integration-tests/layout-demos/src/main/java/androidx/compose/foundation/layout/demos/RtlDemo.kt
@@ -24,10 +24,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -42,6 +47,14 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun RtlDemo() {
     Column(verticalArrangement = Arrangement.SpaceEvenly) {
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+            Text("RTL")
+            TestPlacementInLimitedSpace()
+        }
+        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+            Text("LTR")
+            TestPlacementInLimitedSpace()
+        }
         Text("TEXT", Modifier.align(Alignment.CenterHorizontally))
         TestText()
         Text("ROW", Modifier.align(Alignment.CenterHorizontally))
@@ -70,6 +83,20 @@ fun RtlDemo() {
         LayoutWithConstraints(text = "LD: locale")
         Text("STACK EXAMPLE", Modifier.align(Alignment.CenterHorizontally))
         StackExample()
+    }
+}
+
+@Composable
+private fun TestPlacementInLimitedSpace() {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Box(modifier = Modifier.padding(12.dp).size(56.dp).background(Color.Yellow)) {
+            IconButton( // adds minimumTouchTargetSize
+                modifier = Modifier.padding(horizontal = 12.dp),
+                onClick = { }
+            ) {
+                Icon(Icons.Filled.Info, null)
+            }
+        }
     }
 }
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/Placeable.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/Placeable.kt
@@ -299,7 +299,7 @@ abstract class Placeable : Measured {
                 placeApparentToRealOffset(position, zIndex, layerBlock)
             } else {
                 placeApparentToRealOffset(
-                    IntOffset(parentWidth - measuredSize.width - position.x, position.y),
+                    IntOffset((parentWidth - width - position.x), position.y),
                     zIndex,
                     layerBlock
                 )


### PR DESCRIPTION
It used to calculate the position using `measuredSize.width` which doesn't respect the constraints, and therefore the position could end up outside of the parent's bounds.

Test: run ui and foundation-layout tests, added an additional demo to RtlDemo
Change-Id: I946079669ef6ad783708d9f958dd4231188451c5

Cherry-picked from CL:
https://android-review.googlesource.com/c/platform/frameworks/support/+/2172328