### PR TITLE
Fix focus interop bugs

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalComposeUiApi::class)
+
 package androidx.compose.ui.awt
 
 import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
@@ -74,6 +76,7 @@ import javax.swing.SwingUtilities
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import java.awt.Cursor
+import java.awt.event.FocusListener
 import org.jetbrains.skiko.hostOs
 
 internal class ComposeLayer {
@@ -319,6 +322,24 @@ internal class ComposeLayer {
                 if (isDisposed) return
                 catchExceptions {
                     platform.textInputService.onInputEvent(event)
+                }
+            }
+        })
+
+        _component.addFocusListener(object : FocusListener {
+            override fun focusGained(e: FocusEvent) {
+                // We don't reset focus for Compose when the window loses focus
+                // Partially because we don't support restoring focus after clearing it
+                if (e.cause != FocusEvent.Cause.ACTIVATION) {
+                    scene.requestFocus()
+                }
+            }
+
+            override fun focusLost(e: FocusEvent) {
+                // We don't reset focus for Compose when the window loses focus
+                // Partially because we don't support restoring focus after clearing it
+                if (e.cause != FocusEvent.Cause.ACTIVATION) {
+                    scene.releaseFocus()
                 }
             }
         })

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -160,21 +160,12 @@ class ComposePanel : JLayeredPane() {
                                 layer?.scene?.requestFocus()
                                 layer?.scene?.moveFocus(FocusDirection.Previous)
                             }
-                            FocusEvent.Cause.ACTIVATION -> Unit
-                            else -> {
-                                layer?.scene?.requestFocus()
-                            }
+                            else -> Unit
                         }
                     }
                 }
 
-                override fun focusLost(e: FocusEvent) {
-                    // We don't reset focus for Compose when the window loses focus
-                    // Partially because we don't support restoring focus after clearing it
-                    if (e.cause != FocusEvent.Cause.ACTIVATION) {
-                        layer?.scene?.releaseFocus()
-                    }
-                }
+                override fun focusLost(e: FocusEvent) = Unit
             })
         }
         initContent()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -31,6 +31,8 @@ import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.hostOs
 import java.awt.Color
 import java.awt.Component
+import java.awt.Container
+import java.awt.FocusTraversalPolicy
 import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
@@ -95,6 +97,14 @@ internal class ComposeWindowDelegate(
     private val clipMap = mutableMapOf<Component, ClipComponent>()
 
     init {
+        pane.focusTraversalPolicy = object : FocusTraversalPolicy() {
+            override fun getComponentAfter(aContainer: Container?, aComponent: Component?) = null
+            override fun getComponentBefore(aContainer: Container?, aComponent: Component?) = null
+            override fun getFirstComponent(aContainer: Container?) = null
+            override fun getLastComponent(aContainer: Container?) = null
+            override fun getDefaultComponent(aContainer: Container?) = null
+        }
+        pane.isFocusCycleRoot = true
         setContent {}
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.performClick
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import com.google.common.truth.BooleanSubject
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.awt.Component
@@ -163,41 +165,59 @@ class ComposeFocusTest {
         window.preferredSize = Dimension(500, 500)
 
         window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
-            add(outerButton1)
-            add(outerButton2)
-
             add(ComposePanel().apply {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton1.Content()
-                            composeButton2.Content()
+                            composeButton3.Content()
                             SwingPanel(
                                 modifier = Modifier.size(100.dp),
                                 factory = {
                                     javax.swing.Box.createVerticalBox().apply {
                                         add(innerButton1)
-                                        add(innerButton2)
-                                        add(innerButton3)
                                     }
                                 }
                             )
-                            composeButton3.Content()
                             composeButton4.Content()
                         }
                     }
                 }
             })
-            add(outerButton3)
-            add(outerButton4)
         })
         window.pack()
         window.isVisible = true
 
         testRandomFocus(
-            window, outerButton1, outerButton2, composeButton1, composeButton2,
-            innerButton1, innerButton2, innerButton3, composeButton3, composeButton4,
-            outerButton3, outerButton4
+            window, composeButton3, innerButton1, composeButton4,
+        )
+    }
+
+    @Test
+    fun `swing panel in the middle of compose window`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton3.Content()
+                    SwingPanel(
+                        modifier = Modifier.size(100.dp),
+                        factory = {
+                            javax.swing.Box.createVerticalBox().apply {
+                                add(innerButton1)
+                            }
+                        }
+                    )
+                    composeButton4.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton3, innerButton1, composeButton4
         )
     }
 
@@ -330,36 +350,206 @@ class ComposeFocusTest {
         testRandomFocus(window, outerButton1, outerButton2, outerButton3, outerButton4)
     }
 
-    private val outerButton1 = JButton("outerButton1")
-    private val outerButton2 = JButton("outerButton2")
-    private val outerButton3 = JButton("outerButton3")
-    private val outerButton4 = JButton("outerButton4")
-    private val innerButton1 = JButton("innerButton1")
-    private val innerButton2 = JButton("innerButton2")
-    private val innerButton3 = JButton("innerButton3")
+    @Test
+    fun `popup inside window`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton1.Content()
+                    composeButton2.Content()
+                    Popup(focusable = true) {
+                        composeButton3.Content()
+                        composeButton4.Content()
+                    }
+                    composeButton5.Content()
+                    composeButton6.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton3, composeButton4
+        )
+    }
+
+    @Test
+    fun `popup inside panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(outerButton1)
+            add(outerButton2)
+
+            add(ComposePanel().apply {
+                setContent {
+                    MaterialTheme {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton1.Content()
+                            composeButton2.Content()
+                            Popup(focusable = true) {
+                                composeButton3.Content()
+                                composeButton4.Content()
+                            }
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                }
+            })
+
+            add(outerButton3)
+            add(outerButton4)
+        })
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton3, composeButton4
+        )
+    }
+
+    @Test
+    fun `popup with swingPanel`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton1.Content()
+                    composeButton2.Content()
+                    Popup(focusable = true) {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton3.Content()
+                            SwingPanel(
+                                modifier = Modifier.size(100.dp),
+                                factory = {
+                                    javax.swing.Box.createVerticalBox().apply {
+                                        add(innerButton1)
+                                    }
+                                }
+                            )
+                            composeButton4.Content()
+                        }
+                    }
+                    composeButton5.Content()
+                    composeButton6.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton3, innerButton1, composeButton4
+        )
+    }
+
+    @Test
+    fun `popup with swingPanel before it`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton1.Content()
+                    composeButton2.Content()
+                    SwingPanel(
+                        modifier = Modifier.size(100.dp),
+                        factory = {
+                            javax.swing.Box.createVerticalBox().apply {
+                                add(innerButton1)
+                            }
+                        }
+                    )
+                    Popup(focusable = true) {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                    composeButton5.Content()
+                    composeButton6.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton3, composeButton4
+        )
+    }
+
+    @Test
+    fun `popup with swingPanel after it`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton1.Content()
+                    composeButton2.Content()
+                    Popup(focusable = true) {
+                        Column(Modifier.fillMaxSize()) {
+                            composeButton3.Content()
+                            composeButton4.Content()
+                        }
+                    }
+                    SwingPanel(
+                        modifier = Modifier.size(100.dp),
+                        factory = {
+                            javax.swing.Box.createVerticalBox().apply {
+                                add(innerButton1)
+                            }
+                        }
+                    )
+                    composeButton5.Content()
+                    composeButton6.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            window, composeButton3, composeButton4
+        )
+    }
+
+    private val outerButton1 = TestJButton("outerButton1")
+    private val outerButton2 = TestJButton("outerButton2")
+    private val outerButton3 = TestJButton("outerButton3")
+    private val outerButton4 = TestJButton("outerButton4")
+    private val innerButton1 = TestJButton("innerButton1")
+    private val innerButton2 = TestJButton("innerButton2")
+    private val innerButton3 = TestJButton("innerButton3")
     private val composeButton1 = ComposeButton("composeButton1")
     private val composeButton2 = ComposeButton("composeButton2")
     private val composeButton3 = ComposeButton("composeButton3")
     private val composeButton4 = ComposeButton("composeButton4")
+    private val composeButton5 = ComposeButton("composeButton5")
+    private val composeButton6 = ComposeButton("composeButton6")
 
     private suspend fun FocusTestScope.testRandomFocus(window: Window, vararg buttons: Any) {
         fun Any.validateIsFocused() {
-            assertFocused().isTrue()
-            if (this != outerButton1) outerButton1.assertFocused().isFalse()
-            if (this != outerButton2) outerButton2.assertFocused().isFalse()
-            if (this != outerButton3) outerButton3.assertFocused().isFalse()
-            if (this != outerButton4) outerButton4.assertFocused().isFalse()
-            if (this != innerButton1) innerButton1.assertFocused().isFalse()
-            if (this != innerButton2) innerButton2.assertFocused().isFalse()
-            if (this != innerButton3) innerButton3.assertFocused().isFalse()
-            if (this != composeButton1) composeButton1.assertFocused().isFalse()
-            if (this != composeButton2) composeButton2.assertFocused().isFalse()
-            if (this != composeButton3) composeButton3.assertFocused().isFalse()
-            if (this != composeButton4) composeButton4.assertFocused().isFalse()
+            assertThat(
+                buttons.filter { it.isFocused() }
+            ).containsExactly(this)
         }
 
         suspend fun cycleForward() {
             var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            println("cycleForward from ${buttons[focusedIndex]}")
+
             repeat(2 * buttons.size) {
                 pressNextFocusKey()
                 focusedIndex = (focusedIndex + 1).mod(buttons.size)
@@ -369,6 +559,7 @@ class ComposeFocusTest {
 
         suspend fun cycleBackward() {
             var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            println("cycleBackward from ${buttons[focusedIndex]}")
 
             repeat(2 * buttons.size) {
                 pressPreviousFocusKey()
@@ -379,6 +570,7 @@ class ComposeFocusTest {
 
         suspend fun cycleRandom() {
             var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            println("cycleRandom from ${buttons[focusedIndex]}")
 
             repeat(4 * buttons.size) {
                 @Suppress("LiftReturnOrAssignment")
@@ -394,6 +586,8 @@ class ComposeFocusTest {
         }
 
         suspend fun randomRequest() {
+            println("randomRequest")
+
             val button = buttons.toList().random()
             button.requestFocus()
             awaitEDT()
@@ -401,6 +595,8 @@ class ComposeFocusTest {
         }
 
         suspend fun randomPress() {
+            println("randomPress")
+
             val button = buttons.filterIsInstance<Component>().randomOrNull()
             button?.performClick()
             awaitEDT()
@@ -408,6 +604,7 @@ class ComposeFocusTest {
         }
 
         awaitEDT()
+        println("firstButton")
         buttons.first().requestFocus()
         awaitEDT()
         buttons.first().validateIsFocused()
@@ -478,12 +675,6 @@ private fun Any.isFocused() = when (this) {
     else -> error("Unknown component")
 }
 
-private fun Any.assertFocused() = when (this) {
-    is ComposeButton -> assertWithMessage("$name.isFocused").that(isFocused)
-    is JButton -> assertWithMessage("$text.isFocused").that(hasFocus())
-    else -> error("Unknown component")
-}
-
 private class ComposeButton(val name: String) {
     var isFocused = false
         private set
@@ -495,4 +686,9 @@ private class ComposeButton(val name: String) {
     }
 
     fun requestFocus() = focusRequester.requestFocus()
+
+    override fun toString() = name
+}
+private class TestJButton(name: String) : JButton(name) {
+    override fun toString(): String = text
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -357,6 +357,7 @@ class ComposeScene internal constructor(
         val mainOwner = SkiaBasedOwner(
             this,
             platform,
+            platform.focusManager,
             pointerPositionUpdater,
             density,
             IntSize(constraints.maxWidth, constraints.maxHeight).toIntRect(),
@@ -584,9 +585,7 @@ class ComposeScene internal constructor(
 
     @ExperimentalComposeUiApi
     fun requestFocus() {
-        list.forEach {
-            it.focusManager.takeFocus()
-        }
+        list.findLast { it.isFocusable }?.focusManager?.takeFocus()
         isFocused = true
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
@@ -50,10 +50,7 @@ internal interface Platform {
                 isWindowFocused = true
             }
 
-            override val focusManager = object : FocusManager {
-                override fun clearFocus(force: Boolean) = Unit
-                override fun moveFocus(focusDirection: FocusDirection) = false
-            }
+            override val focusManager = EmptyFocusManager
 
             override fun requestFocusForOwner() = false
 
@@ -80,4 +77,9 @@ internal interface Platform {
             override fun setPointerIcon(pointerIcon: PointerIcon) = Unit
         }
     }
+}
+
+internal object EmptyFocusManager : FocusManager {
+    override fun clearFocus(force: Boolean) = Unit
+    override fun moveFocus(focusDirection: FocusDirection) = false
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -94,6 +94,7 @@ private typealias Command = () -> Unit
 internal class SkiaBasedOwner(
     override val scene: ComposeScene,
     private val platform: Platform,
+    parentFocusManager: FocusManager = EmptyFocusManager,
     private val pointerPositionUpdater: PointerPositionUpdater,
     density: Density = Density(1f, 1f),
     bounds: IntRect = IntRect.Zero,
@@ -125,7 +126,7 @@ internal class SkiaBasedOwner(
     )
 
     override val focusManager = FocusManagerImpl(
-        parent = platform.focusManager
+        parent = parentFocusManager
     ).apply {
         layoutDirection = platform.layoutDirection
     }


### PR DESCRIPTION
Wrong focus was when we have:
- a popup and a SwingPanel. Fix is in SkiaBaseOwner - we pass different parent focus manager for popups.
- SwingPanel inside ComposeWindow. Fix is in ComposeLayer and ComposeWindowDelegate.

[The feature PR](https://github.com/JetBrains/androidx/pull/229)