### PR TITLE
Move all jb-main settings into repository

### DIFF
--- a/.run/desktop/run1.run.xml
+++ b/.run/desktop/run1.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run1" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/compose/desktop/desktop" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="run1" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/desktop/run1rtl.run.xml
+++ b/.run/desktop/run1rtl.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run1rtl" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/compose/desktop/desktop" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="run1rtl" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/desktop/run3.run.xml
+++ b/.run/desktop/run3.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run3" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/compose/desktop/desktop" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="desktop-samples:run3" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/desktop/run4.run.xml
+++ b/.run/desktop/run4.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="run4" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/compose/desktop/desktop" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="desktop-samples:run4" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/desktop/runmouseclicks.run.xml
+++ b/.run/desktop/runmouseclicks.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="runmouseclicks" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/compose/desktop/desktop" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="runmouseclicks" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/desktop/test.run.xml
+++ b/.run/desktop/test.run.xml
@@ -1,0 +1,30 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="test" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":compose:ui:ui:cleanDesktopTest" />
+          <option value=":compose:ui:ui:desktopTest" />
+          <option value=":compose:foundation:foundation:cleanDesktopTest" />
+          <option value=":compose:foundation:foundation:desktopTest" />
+          <option value=":compose:material:material:cleanDesktopTest" />
+          <option value=":compose:material:material:desktopTest" />
+          <option value=":compose:ui:ui-graphics:cleanDesktopTest" />
+          <option value=":compose:ui:ui-graphics:desktopTest" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -66,3 +66,13 @@ kotlin.native.ignoreDisabledTargets=true
 kotlin.native.binary.memoryModel=experimental
 # Disable kotlin/native klib binary cache
 kotlin.native.cacheKind=none
+
+# properties for jb-main branch
+androidx.compose.multiplatformEnabled=true
+androidx.versionExtraCheckEnabled=false
+androidx.alternativeProjectUrl=https://github.com/JetBrains/compose-jb
+jetbrains.compose.jsCompilerTestsEnabled=true
+androidx.validateProjectStructure=false
+oel.publication=true
+oel.androidx.version=1.2.1
+oel.androidx.material3.version=1.0.0-alpha14

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=../../../../tools/external/gradle/gradle-7.5-20220518001855+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -118,13 +118,13 @@ else
     plat="linux"
 fi
 
-# Tests for lint checks default to using sdk defined by this variable. This removes a lot of
-# setup from each lint module.
-export ANDROID_HOME="$APP_HOME/../../prebuilts/fullsdk-$plat"
-# override JAVA_HOME, because CI machines have it and it points to very old JDK
-export JAVA_HOME="$APP_HOME/../../prebuilts/jdk/jdk11/$plat-$platform_suffix"
-export JAVA_TOOLS_JAR="$APP_HOME/../../prebuilts/jdk/jdk8/$plat-x86/lib/tools.jar"
+# Compose/jb-main specific configuration
+export ANDROID_HOME="$APP_HOME/jbdeps/android-sdk/$plat"
+export JAVA_TOOLS_JAR="$APP_HOME/jbdeps/jdk8/tools.jar"
 export STUDIO_GRADLE_JDK=$JAVA_HOME
+export ALLOW_PUBLIC_REPOS=1
+export ANDROIDX_PROJECTS=COMPOSE
+export COMPOSE_CUSTOM_GROUP=org.jetbrains.compose
 
 # Warn developers if they try to build top level project without the full checkout
 [ ! -d "$JAVA_HOME" ] && echo "You likely checked out the standalone AndroidX git project.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -82,7 +82,7 @@ set CMD_LINE_ARGS=%*
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 @rem Compose/jb-main specific configuration
-set ANDROID_HOME="%APP_HOME%/jbdeps/android-sdk/windows"
+@rem TODO support download for Windows set ANDROID_HOME="%APP_HOME%/jbdeps/android-sdk/windows"
 set JAVA_TOOLS_JAR="%APP_HOME%/jbdeps/jdk8/tools.jar"
 set STUDIO_GRADLE_JDK=%JAVA_HOME%
 set ALLOW_PUBLIC_REPOS=1

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,108 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      https://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Compose/jb-main specific configuration
+set ANDROID_HOME="%APP_HOME%/jbdeps/android-sdk/windows"
+set JAVA_TOOLS_JAR="%APP_HOME%/jbdeps/jdk8/tools.jar"
+set STUDIO_GRADLE_JDK=%JAVA_HOME%
+set ALLOW_PUBLIC_REPOS=1
+set ANDROIDX_PROJECTS=COMPOSE
+set COMPOSE_CUSTOM_GROUP=org.jetbrains.compose
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/jbdeps/.gitignore
+++ b/jbdeps/.gitignore
@@ -1,0 +1,3 @@
+android-sdk/linux/
+android-sdk/darwin/
+android-sdk/windows/

--- a/jbdeps/android-sdk/downloadAndroidSdk
+++ b/jbdeps/android-sdk/downloadAndroidSdk
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+
+clone() {
+    mkdir -p $1
+    pushd $1
+    git init
+    git config advice.detachedHead false
+    git fetch --depth=1 $2 $3
+    git checkout FETCH_HEAD
+    popd
+}
+
+# Commit hashes and sdk versions from https://android.googlesource.com/platform/manifest/+/refs/heads/androidx-main/default.xml
+
+downloadLinuxSDK() {
+    clone linux/platforms/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-32 master
+    clone linux/sources/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-32 master
+    clone linux/ndk https://android.googlesource.com/toolchain/prebuilts/ndk/r23 master
+    ln -s "$PWD/linux/ndk" linux/ndk-bundle # prepare to update androidx submodule
+    clone linux/build-tools/30.0.3 https://android.googlesource.com/platform/prebuilts/fullsdk-linux/build-tools/30.0.3 master
+    clone linux/platform-tools https://android.googlesource.com/platform/prebuilts/fullsdk-linux/platform-tools master
+    clone linux/tools https://android.googlesource.com/platform/prebuilts/fullsdk-linux/tools master
+    clone linux/cmake https://android.googlesource.com/platform/prebuilts/cmake/linux-x86 master
+    clone linux/ninja https://android.googlesource.com/platform/prebuilts/ninja/linux-x86 master
+}
+
+downloadMacOsSDK() {
+    clone darwin/platforms/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-32 master
+    clone darwin/sources/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-32 master
+    clone darwin/ndk https://android.googlesource.com/toolchain/prebuilts/ndk-darwin/r23 master
+    ln -s "$PWD/darwin/ndk" darwin/ndk-bundle # prepare to update androidx submodule
+    clone darwin/build-tools/30.0.3 https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/build-tools/30.0.3 master
+    clone darwin/platform-tools https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/platform-tools master
+    clone darwin/tools https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/tools master
+    clone darwin/cmake https://android.googlesource.com/platform/prebuilts/cmake/darwin-x86 master
+    clone darwin/ninja https://android.googlesource.com/platform/prebuilts/ninja/darwin-x86 master
+}
+
+setupNativeBuildTools() {
+    mkdir -p $1/native-build-tools/bin/
+    pushd $1/native-build-tools/bin/
+    ln -s ../../ninja/ninja .
+    ln -s ../../cmake/bin/cmake .
+    popd
+}
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    downloadLinuxSDK
+    setupNativeBuildTools linux
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    downloadMacOsSDK
+    setupNativeBuildTools darwin
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+    echo "Please download Android SDK manually (https://developer.android.com/studio)"
+elif [[ "$OSTYPE" == "msys" ]]; then
+    echo "Please download Android SDK manually (https://developer.android.com/studio)"
+elif [[ "$OSTYPE" == "win32" ]]; then
+    echo "Please download Android SDK manually (https://developer.android.com/studio)"
+else
+    echo "Unknown OS"
+fi
+


### PR DESCRIPTION
It isn't hard to solve conflicts for them when we merge the upstream branch, and it significantly simplifies project setup.

Note that `gradlew` and `gradlew.bat` are modified (the additional section with env. variables).

Pros:
- we can clone only androidx
- we can setup auto tests on github actions
- no more desync issues (config is one version, and repo is another)
- no manual configuration in IDEA. works almost out of the box