### PR TITLE
Fix selection with end home

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyMapping.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyMapping.kt
@@ -144,8 +144,8 @@ internal val defaultKeyMapping: KeyMapping =
                         }
                     event.isShiftPressed ->
                         when (event.key) {
-                            MappedKeys.MoveHome -> KeyCommand.SELECT_HOME
-                            MappedKeys.MoveEnd -> KeyCommand.SELECT_END
+                            MappedKeys.MoveHome -> KeyCommand.SELECT_LINE_START
+                            MappedKeys.MoveEnd -> KeyCommand.SELECT_LINE_END
                             else -> null
                         }
                     else -> null

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
@@ -27,7 +27,10 @@ import androidx.compose.ui.input.key.key
 import java.awt.event.KeyEvent as AwtKeyEvent
 
 internal actual val platformDefaultKeyMapping: KeyMapping =
-    when (DesktopPlatform.Current) {
+    createPlatformDefaultKeyMapping(DesktopPlatform.Current)
+
+internal fun createPlatformDefaultKeyMapping(platform: DesktopPlatform): KeyMapping {
+    return when (platform) {
         DesktopPlatform.MacOS -> {
             val common = commonKeyMapping(KeyEvent::isMetaPressed)
             object : KeyMapping {
@@ -110,8 +113,8 @@ internal actual val platformDefaultKeyMapping: KeyMapping =
 
                         event.isShiftPressed ->
                             when (event.key) {
-                                MappedKeys.MoveHome -> KeyCommand.SELECT_LINE_START
-                                MappedKeys.MoveEnd -> KeyCommand.SELECT_LINE_END
+                                MappedKeys.MoveHome -> KeyCommand.SELECT_HOME
+                                MappedKeys.MoveEnd -> KeyCommand.SELECT_END
                                 else -> null
                             }
                         event.isAltPressed ->
@@ -132,6 +135,7 @@ internal actual val platformDefaultKeyMapping: KeyMapping =
 
         else -> defaultKeyMapping
     }
+}
 
 internal actual object MappedKeys {
     actual val A: Key = Key(AwtKeyEvent.VK_A)

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
@@ -110,8 +110,8 @@ internal actual val platformDefaultKeyMapping: KeyMapping =
 
                         event.isShiftPressed ->
                             when (event.key) {
-                                MappedKeys.MoveHome -> KeyCommand.SELECT_HOME
-                                MappedKeys.MoveEnd -> KeyCommand.SELECT_END
+                                MappedKeys.MoveHome -> KeyCommand.SELECT_LINE_START
+                                MappedKeys.MoveEnd -> KeyCommand.SELECT_LINE_END
                                 else -> null
                             }
                         event.isAltPressed ->

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/SelectionTests.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/SelectionTests.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.google.common.truth.Truth
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class SelectionTests {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
+    @Test
+    fun `select using Shift_End and Shift_Home combinations`() = runBlocking {
+        val state = mutableStateOf(TextFieldValue("line 1\nline 2\nline 3\nline 4\nline 5"))
+
+        rule.setContent {
+            BasicTextField(
+                value = state.value,
+                onValueChange = { state.value = it },
+                modifier = Modifier.testTag("textField")
+            )
+        }
+        rule.awaitIdle()
+        rule.onNodeWithTag("textField").performMouseInput {
+            click(Offset(0f, 0f))
+        }
+        rule.awaitIdle()
+        rule.onNodeWithTag("textField").assertIsFocused()
+        Truth.assertThat(state.value.selection).isEqualTo(TextRange(0, 0))
+
+        rule.onNodeWithTag("textField").performKeyInput {
+            pressKey(Key.DirectionRight)
+        }
+        rule.awaitIdle()
+        Truth.assertThat(state.value.selection).isEqualTo(TextRange(1, 1))
+
+        rule.onNodeWithTag("textField").performKeyInput {
+            keyDown(Key.ShiftLeft)
+            pressKey(Key.MoveEnd)
+            keyUp(Key.ShiftLeft)
+        }
+        rule.awaitIdle()
+        Truth.assertThat(state.value.selection).isEqualTo(TextRange(1, 6))
+
+        rule.onNodeWithTag("textField").performKeyInput {
+            keyDown(Key.ShiftLeft)
+            pressKey(Key.MoveHome)
+            keyUp(Key.ShiftLeft)
+        }
+        rule.awaitIdle()
+        Truth.assertThat(state.value.selection).isEqualTo(TextRange(1, 0))
+    }
+}


### PR DESCRIPTION
Window and Linux will select only the line where the cursor is.
MacOS will select till the end/start of the text.