### PR TITLE
Fix the cursor position when clicking at a position after a line-break

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -324,7 +324,7 @@ internal class SkiaParagraph(
             ?: 0
 
     override fun getLineForVerticalPosition(vertical: Float): Int {
-        return 0
+        return lineMetrics.firstOrNull { vertical < it.baseline + it.descent }?.lineNumber ?: 0
     }
 
     override fun getHorizontalPosition(offset: Int, usePrimaryDirection: Boolean): Float {
@@ -445,7 +445,20 @@ internal class SkiaParagraph(
         }
 
     override fun getOffsetForPosition(position: Offset): Int {
-        return para.getGlyphPositionAtCoordinate(position.x, position.y).position
+        val glyphPosition = para.getGlyphPositionAtCoordinate(position.x, position.y).position
+
+        // It's expected that this method should return the glyph position that lays in the line at `position.y`.
+        // When the `position` is on a line-break, glyphPosition will reference the first glyph on a next line.
+        // This will make cursor go on the next line (not a line that corresponds `position.y` coordinate).
+        // TODO: consider fixing it in skiko
+
+        val lineMetrics = lineMetricsForOffset(glyphPosition) ?: return glyphPosition
+        val expectedLine = getLineForVerticalPosition(position.y)
+        return if (expectedLine == lineMetrics.lineNumber) {
+            glyphPosition
+        } else {
+            glyphPosition - 1
+        }
     }
 
     override fun getBoundingBox(offset: Int): Rect {


### PR DESCRIPTION
Issue [#1463](https://github.com/JetBrains/compose-jb/issues/1463)

It used to make the cursor go the next line (before the first glyph).
Now the cursor will be shown after the last glyph in the clicked line.


https://user-images.githubusercontent.com/7372778/187222474-c724d54b-112d-4baa-b51d-6fa135253908.mp4

