### PR TITLE
Fix rtl selection when multilines

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -216,14 +216,12 @@ internal class SkiaParagraph(
             }
 
     override fun getPathForRange(start: Int, end: Int): Path {
-        println("getPathForRange $start - $end")
         val boxes = para.getRectsForRange(
             start,
             end,
             RectHeightMode.MAX,
             RectWidthMode.TIGHT
         )
-        println("Boxes ${boxes.size} : ${boxes.joinToString { it.rect.toString() }}")
         val path = Path()
         for (b in boxes) {
             path.asSkiaPath().addRect(b.rect)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -216,12 +216,14 @@ internal class SkiaParagraph(
             }
 
     override fun getPathForRange(start: Int, end: Int): Path {
+        println("getPathForRange $start - $end")
         val boxes = para.getRectsForRange(
             start,
             end,
             RectHeightMode.MAX,
-            RectWidthMode.MAX
+            RectWidthMode.TIGHT
         )
+        println("Boxes ${boxes.size} : ${boxes.joinToString { it.rect.toString() }}")
         val path = Path()
         for (b in boxes) {
             path.asSkiaPath().addRect(b.rect)


### PR DESCRIPTION
Bad selection behaviour:

When there are more than 1 line and we try to select a part of the line, it will draw the selection rect that goes to the line end. The actual selection range is correct (if we copy/paste the text), only the drawn rectangle is wrong. It's wrong when we try to select with Shift + Arrow and when we try to select with mouse drag.
If there is only 1 line, there is no such issue. 

https://user-images.githubusercontent.com/7372778/187452698-7cf82a8a-f8ad-4426-b331-e192ac3751c1.mp4


Fixed:
The issue originates in skia. And the fix is rather a workaround: we change the mode MAX to TIGHT (see the difference on the screenshots below). 
https://user-images.githubusercontent.com/7372778/187451916-4380412e-1877-4553-95e6-d948fd76db51.mp4

Here is the difference between `RectWidthMode.TIGHT` and `RectWidthMode.MAX`

<img width="422" alt="Screenshot 2022-08-30 at 15 27 47" src="https://user-images.githubusercontent.com/7372778/187452099-3c711bf7-6617-4a2b-85d3-dd5c20285cf5.png">
<img width="424" alt="Screenshot 2022-08-30 at 15 29 20" src="https://user-images.githubusercontent.com/7372778/187452105-d624d04f-4c41-4e3f-87f2-a242dd36fdaa.png">

With `RectWidthMode.TIGHT` selection of RTL text doesn't have the issue.

What's your opinion? Can we have TIGHT instead of MAX mode? 
