### PR TITLE
Fix cursor visual position at BiDi transition

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -80,6 +80,7 @@ import org.jetbrains.skia.paragraph.DecorationLineStyle as SkDecorationLineStyle
 import org.jetbrains.skia.paragraph.DecorationStyle as SkDecorationStyle
 import org.jetbrains.skia.paragraph.Shadow as SkShadow
 import org.jetbrains.skia.FontFeature
+import org.jetbrains.skia.paragraph.Direction
 
 private val DefaultFontSize = 16.sp
 
@@ -331,12 +332,14 @@ internal class SkiaParagraph(
         val prevBox = getBoxBackwardByOffset(offset)
         val nextBox = getBoxForwardByOffset(offset)
         val isRtl = paragraphIntrinsics.textDirection == ResolvedTextDirection.Rtl
+        val isLtr = !isRtl
         return when {
             prevBox == null && nextBox == null -> if (isRtl) width else 0f
             prevBox == null -> nextBox!!.cursorHorizontalPosition(true)
             nextBox == null -> prevBox.cursorHorizontalPosition()
             nextBox.direction == prevBox.direction -> nextBox.cursorHorizontalPosition(true)
-            text[offset - 1] == '\n' -> nextBox.cursorHorizontalPosition(opposite = prevBox.direction != nextBox.direction)
+            isLtr && prevBox.direction == Direction.LTR -> nextBox.cursorHorizontalPosition(opposite = true)
+            isRtl && prevBox.direction == Direction.RTL -> nextBox.cursorHorizontalPosition(opposite = true)
             // BiDi transition offset, we need to resolve ambiguity with usePrimaryDirection
             // for details see comment for MultiParagraph.getHorizontalPosition
             usePrimaryDirection -> prevBox.cursorHorizontalPosition()

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -336,7 +336,7 @@ internal class SkiaParagraph(
             prevBox == null -> nextBox!!.cursorHorizontalPosition(true)
             nextBox == null -> prevBox.cursorHorizontalPosition()
             nextBox.direction == prevBox.direction -> nextBox.cursorHorizontalPosition(true)
-            text[offset - 1] == '\n' -> nextBox.cursorHorizontalPosition(prevBox.direction != nextBox.direction)
+            text[offset - 1] == '\n' -> nextBox.cursorHorizontalPosition(opposite = prevBox.direction != nextBox.direction)
             // BiDi transition offset, we need to resolve ambiguity with usePrimaryDirection
             // for details see comment for MultiParagraph.getHorizontalPosition
             usePrimaryDirection -> prevBox.cursorHorizontalPosition()

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -336,6 +336,7 @@ internal class SkiaParagraph(
             prevBox == null -> nextBox!!.cursorHorizontalPosition(true)
             nextBox == null -> prevBox.cursorHorizontalPosition()
             nextBox.direction == prevBox.direction -> nextBox.cursorHorizontalPosition(true)
+            text[offset - 1] == '\n' -> nextBox.cursorHorizontalPosition(prevBox.direction != nextBox.direction)
             // BiDi transition offset, we need to resolve ambiguity with usePrimaryDirection
             // for details see comment for MultiParagraph.getHorizontalPosition
             usePrimaryDirection -> prevBox.cursorHorizontalPosition()


### PR DESCRIPTION
Issue description:
When cursor is at BiDi transition position, its visual position doesn't correspond the real (logical) position, leading to a confusion when we try to type more characters (new characters appear at different position than the cursor).


https://user-images.githubusercontent.com/7372778/187870660-0153d316-a0e0-423d-bf57-8ceb4d0f9807.mov

With this Fix:
https://user-images.githubusercontent.com/7372778/187870680-fd23ec2a-e60a-4b65-b1d3-5dc31dc0f996.mov


