### PR TITLE
Fix infinite emitting of Move events when we use pointerHoverIcon

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -98,10 +98,11 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                         val isOutsideRelease = event.type == PointerEventType.Release &&
                             event.changes[0].isOutOfBounds(size, Size.Zero)
 
-                        hovered.value = false
                         if (event.type != PointerEventType.Exit && !isOutsideRelease) {
                             hovered.value = true
                             pointerIconService.current = rememberIcon.value
+                        } else {
+                            hovered.value = false
                         }
                     }
                 }


### PR DESCRIPTION
Fixes this:
```
import androidx.compose.material.Text
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.Modifier
import androidx.compose.ui.input.pointer.PointerEventType
import androidx.compose.ui.input.pointer.PointerIconDefaults
import androidx.compose.ui.input.pointer.onPointerEvent
import androidx.compose.ui.input.pointer.pointerHoverIcon
import androidx.compose.ui.window.singleWindowApplication

@OptIn(ExperimentalComposeUiApi::class)
fun main() = singleWindowApplication {
    Text("sdfsdf", Modifier
        .onPointerEvent(PointerEventType.Move) {
            println("Move")
        }
        .pointerHoverIcon(PointerIconDefaults.Hand, overrideDescendants = true))
}
```
When we hover the text, Move events are emitted continuously.

Probably will fix this: https://github.com/JetBrains/compose-jb/issues/2201, not sure. Wasn't able to reproduce.

Wasn't able to write a proper test for this behaviour for reasonable amount of time, unfortunately. Also, it seems this bug can happen anywhere, if we won't be careful.
Any change to state leads to recomposition, even if we rollback this state later in the same function