### PR TITLE
Workaround getOffsetForPosition issues in SkiaParagraph.skiko.kt

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -477,7 +477,6 @@ internal class SkiaParagraph(
         val isNotEmptyLine = expectedLine.startIndex < expectedLine.endIndex // a line with only whitespaces considered to be not empty
 
         // No need to apply the workaround if the clicked position is within the line bounds (but doesn't include whitespaces)
-        //if (position.x > expectedLine.left && position.x < expectedLine.right || isEmptyLine) {
         if (position.x > expectedLine.left && position.x < expectedLine.right) {
             return glyphPosition
         }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -497,8 +497,6 @@ internal class SkiaParagraph(
         val leftX = rects?.firstOrNull()?.rect?.left ?: expectedLine.left.toFloat()
         val rightX = rects?.lastOrNull()?.rect?.right ?: expectedLine.right.toFloat()
 
-        println("LX = $leftX, RX = $rightX, click = $position")
-
         var correctedGlyphPosition = glyphPosition
 
         if (position.x <= leftX) { // when clicked to the left of a text line


### PR DESCRIPTION
Issue description:
When clicking a multiline-text at a position that is either precedes the line start (before left side) or goes after its end (after the right side), the cursor will appear at different position (not expected position, in this case its logical position is wrong).  

This happens:
 - in multiline text when a text block has an opposite direction than the primary paragraph direction
 - in text with line-breaks, when clicking to the right of a text line

In Rtl Layout

https://user-images.githubusercontent.com/7372778/187927080-44884f99-2a41-4077-96ac-601f49178857.mov



In LTR layout:

https://user-images.githubusercontent.com/7372778/187927116-5758f393-f7e8-45dc-8ba4-a6edb328f8df.mov




Fixed:


https://user-images.githubusercontent.com/7372778/187927150-f10b0d41-6972-4ea8-a585-cc3115e38225.mov


https://user-images.githubusercontent.com/7372778/187927174-ebf677cb-b313-4fed-bffd-d211106b4c0b.mov




