### PR TITLE
Add more DesktopParagraph tests

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.desktop.kt
@@ -1,0 +1,8 @@
+package androidx.compose.ui.text.platform
+
+internal actual fun Char.isNeutralDirectionality(): Boolean {
+    return this.directionality == CharDirectionality.OTHER_NEUTRALS
+        || this.directionality == CharDirectionality.WHITESPACE
+        || this.directionality == CharDirectionality.BOUNDARY_NEUTRAL
+
+}

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -411,7 +411,7 @@ class DesktopParagraphTest {
             )
 
             Truth.assertThat(paragraph.getBoundingBox(0))
-                .isEqualTo(Rect(0f, 0f, fontSizeInPx, 60f))
+                .isEqualTo(Rect(0f, 0f, fontSizeInPx, 50f))
 
             Truth.assertThat(paragraph.getBoundingBox(1))
                 .isEqualTo(Rect(fontSizeInPx, 0f, fontSizeInPx * 2.5f, 50f))
@@ -490,7 +490,7 @@ class DesktopParagraphTest {
                 width = width
             )
 
-            for (i in 0..ltrText.lastIndex) {
+            for (i in ltrText.indices) {
                 Truth.assertThat(paragraph.getHorizontalPosition(i, true))
                     .isEqualTo(fontSizeInPx * i)
             }

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -317,6 +317,88 @@ class DesktopParagraphTest {
     }
 
     @Test
+    fun `test cursor position on line-break`() {
+        with(defaultDensity) {
+            val text = "abc abc  abc abc abc abc  abc"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val width = 8 * fontSizeInPx
+            val paragraph = simpleParagraph(
+                width = width,
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            Truth.assertThat(paragraph.lineCount).isEqualTo(4)
+            val y = fontSizeInPx / 2f
+
+            // first line has 2 spaces in the end
+            Truth.assertThat(
+                paragraph.getOffsetForPosition(Offset(x = width, y = y))
+            ).isEqualTo(8)
+
+            // seconds line has 1 space in the end
+            Truth.assertThat(
+                paragraph.getOffsetForPosition(Offset(x = width, y = y + fontSizeInPx))
+            ).isEqualTo(16)
+
+            // 3rd line has 2 spaces in the end
+            Truth.assertThat(
+                paragraph.getOffsetForPosition(Offset(x = width, y = y + 2 * fontSizeInPx))
+            ).isEqualTo(25)
+
+            // 4th line has no spaces
+            Truth.assertThat(
+                paragraph.getOffsetForPosition(Offset(x = width, y = y + 3 * fontSizeInPx))
+            ).isEqualTo(29)
+        }
+    }
+
+    @Test
+    fun `test cursor position in a line with many space in the end`() {
+        with(defaultDensity) {
+            // 1st: 4 spaces, 2nd: 0 spaces, 3rd: 1 space, 4th: empty line
+            val text = "abc    \ndef\ngh \n"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val width = 20 * fontSizeInPx
+            val paragraph = simpleParagraph(
+                width = width,
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            val y = fontSizeInPx / 2f
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width, y = y))).isEqualTo(7)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width, y = y + fontSizeInPx))).isEqualTo(11)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width, y = y + 2 * fontSizeInPx))).isEqualTo(15)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width, y = y + 3 * fontSizeInPx))).isEqualTo(16)
+        }
+    }
+
+    @Test
+    fun `test cursor position in a line with many space in the start`() {
+        with(defaultDensity) {
+            // 1st: 4 spaces, 2nd: 0 spaces, 3rd: 1 space, 4th: empty line
+            val text = "    abc\ndef\n gh\n"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val width = 20 * fontSizeInPx
+            val paragraph = simpleParagraph(
+                width = width,
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            val y = fontSizeInPx / 2f
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 0f, y = y))).isEqualTo(0)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 0f, y = y + fontSizeInPx))).isEqualTo(8)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 0f, y = y + 2 * fontSizeInPx))).isEqualTo(12)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 0f, y = y + 3 * fontSizeInPx))).isEqualTo(16)
+        }
+    }
+
+    @Test
     fun getBoundingBox_multicodepoints() {
         assumeTrue(isLinux)
         with(defaultDensity) {

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -91,8 +91,10 @@ class DesktopParagraphTest {
             )
 
             repeat(4) {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(fontSizeInPx * it)
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(paragraph.getCursorRect(it).right)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((fontSizeInPx * it).roundToInt())
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo(paragraph.getCursorRect(it).right.roundToInt())
             }
         }
 
@@ -109,10 +111,12 @@ class DesktopParagraphTest {
             )
 
             val leftX = paragraph.getLineLeft(0)
-            Truth.assertThat(leftX).isEqualTo(widthInPx - 3 * fontSizeInPx)
+            Truth.assertThat(leftX.roundToInt()).isEqualTo((widthInPx - 3 * fontSizeInPx).roundToInt())
             repeat(4) {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + fontSizeInPx * it)
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(paragraph.getCursorRect(it).right)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((leftX + fontSizeInPx * it).roundToInt())
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo(paragraph.getCursorRect(it).right.roundToInt())
             }
         }
     }
@@ -130,7 +134,8 @@ class DesktopParagraphTest {
             )
 
             repeat(4) {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo((3 - it) * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo(((3 - it) * fontSizeInPx).roundToInt())
             }
         }
 
@@ -147,9 +152,10 @@ class DesktopParagraphTest {
             )
 
             val leftX = paragraph.getLineLeft(0)
-            Truth.assertThat(leftX).isEqualTo(widthInPx - 3 * fontSizeInPx)
+            Truth.assertThat(leftX.roundToInt()).isEqualTo((widthInPx - 3 * fontSizeInPx).roundToInt())
             repeat(4) {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + (3 - it) * fontSizeInPx )
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((leftX + (3 - it) * fontSizeInPx).roundToInt())
             }
         }
     }
@@ -168,10 +174,12 @@ class DesktopParagraphTest {
 
             val rightX = paragraph.getLineRight(0)
             (0..3).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(it * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((it * fontSizeInPx).roundToInt())
             }
             (4..7).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX - (it - 4) * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((rightX - (it - 4) * fontSizeInPx).roundToInt())
             }
         }
         with(defaultDensity) {
@@ -185,10 +193,12 @@ class DesktopParagraphTest {
 
             val leftX = paragraph.getLineLeft(0)
             (0..3).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + (3 - it) * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((leftX + (3 - it) * fontSizeInPx).roundToInt())
             }
             (7 downTo 4).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(it * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((it * fontSizeInPx).roundToInt())
             }
         }
 
@@ -205,10 +215,12 @@ class DesktopParagraphTest {
 
             val rightX = paragraph.getLineRight(0)
             (3 downTo 0).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX - (3 - it) * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((rightX - (3 - it) * fontSizeInPx).roundToInt())
             }
             (4..7).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX -  it * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((rightX -  it * fontSizeInPx).roundToInt())
             }
         }
         with(defaultDensity) {
@@ -224,10 +236,12 @@ class DesktopParagraphTest {
             val leftX = paragraph.getLineLeft(0)
             val rightX = paragraph.getLineRight(0)
             (0..3).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX - it * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((rightX - it * fontSizeInPx).roundToInt())
             }
             (4..7).forEach {
-                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + (it - 4) * fontSizeInPx)
+                Truth.assertThat(paragraph.getCursorRect(it).left.roundToInt())
+                    .isEqualTo((leftX + (it - 4) * fontSizeInPx).roundToInt())
             }
         }
     }

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -73,7 +73,245 @@ class DesktopParagraphTest {
                 Truth.assertThat(box.left).isEqualTo(i * fontSizeInPx)
                 Truth.assertThat(box.right).isEqualTo((i + 1) * fontSizeInPx)
                 Truth.assertThat(box.top).isZero()
-                Truth.assertThat(box.bottom).isEqualTo(fontSizeInPx + 10)
+                Truth.assertThat(box.bottom).isEqualTo(fontSizeInPx)
+            }
+        }
+    }
+
+    @Test
+    fun `test cursor position of LTR text in LTR and RTL paragraphs`() {
+        // LTR paragraph
+        with(defaultDensity) {
+            val text = "abc"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            repeat(4) {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(fontSizeInPx * it)
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(paragraph.getCursorRect(it).right)
+            }
+        }
+
+        // RTL paragraph
+        with(defaultDensity) {
+            val text = "abc"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val widthInPx = fontSizeInPx * 10
+            val paragraph = simpleParagraph(
+                text = text,
+                width = widthInPx,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Rtl)
+            )
+
+            val leftX = paragraph.getLineLeft(0)
+            Truth.assertThat(leftX).isEqualTo(widthInPx - 3 * fontSizeInPx)
+            repeat(4) {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + fontSizeInPx * it)
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(paragraph.getCursorRect(it).right)
+            }
+        }
+    }
+
+    @Test
+    fun `test cursor position of RTL text in LTR and RTL paragraphs`() {
+        // LTR paragraph
+        with(defaultDensity) {
+            val text = "אסד"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            repeat(4) {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo((3 - it) * fontSizeInPx)
+            }
+        }
+
+        // RTL paragraph
+        with(defaultDensity) {
+            val text = "אסד"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val widthInPx = fontSizeInPx * 10
+            val paragraph = simpleParagraph(
+                text = text,
+                width = widthInPx,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Rtl)
+            )
+
+            val leftX = paragraph.getLineLeft(0)
+            Truth.assertThat(leftX).isEqualTo(widthInPx - 3 * fontSizeInPx)
+            repeat(4) {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + (3 - it) * fontSizeInPx )
+            }
+        }
+    }
+
+    @Test
+    fun `test cursor position of BiDi text in LTR and RTL paragraphs`() {
+        // LTR paragraph
+        with(defaultDensity) {
+            val text = "asd אסד"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            val rightX = paragraph.getLineRight(0)
+            (0..3).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(it * fontSizeInPx)
+            }
+            (4..7).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX - (it - 4) * fontSizeInPx)
+            }
+        }
+        with(defaultDensity) {
+            val text = "אסד asd"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            val leftX = paragraph.getLineLeft(0)
+            (0..3).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + (3 - it) * fontSizeInPx)
+            }
+            (7 downTo 4).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(it * fontSizeInPx)
+            }
+        }
+
+        // RTL paragraph
+        with(defaultDensity) {
+            val text = "asd אסד"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                width = 10 * fontSizeInPx,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Rtl)
+            )
+
+            val rightX = paragraph.getLineRight(0)
+            (3 downTo 0).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX - (3 - it) * fontSizeInPx)
+            }
+            (4..7).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX -  it * fontSizeInPx)
+            }
+        }
+        with(defaultDensity) {
+            val text = "אסד asd"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                width = 10 * fontSizeInPx,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Rtl)
+            )
+
+            val leftX = paragraph.getLineLeft(0)
+            val rightX = paragraph.getLineRight(0)
+            (0..3).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(rightX - it * fontSizeInPx)
+            }
+            (4..7).forEach {
+                Truth.assertThat(paragraph.getCursorRect(it).left).isEqualTo(leftX + (it - 4) * fontSizeInPx)
+            }
+        }
+    }
+
+    @Test
+    fun `test cursor position in RTl text when clicking on an empty line`() {
+        // Tests if (leftX == rightX) in getOffsetForPosition
+        with(defaultDensity) {
+            val text = "asd\n"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                width = 10 * fontSizeInPx,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Rtl)
+            )
+
+            val leftX = paragraph.getLineLeft(0)
+            val rightX = paragraph.getLineRight(0)
+
+            val clickX = (leftX + rightX) / 2f
+            val secondLineY = (paragraph.getLineBottom(1) + paragraph.getLineTop(1)) / 2f
+
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(clickX, secondLineY))).isEqualTo(4)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(leftX - fontSizeInPx, secondLineY))).isEqualTo(4)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(rightX + fontSizeInPx, secondLineY))).isEqualTo(4)
+        }
+    }
+
+    @Test
+    fun `test getOffsetByPosition`() {
+        // LTR
+        with(defaultDensity) {
+            val text = " abc \ndef ghi"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val paragraph = simpleParagraph(
+                text = text,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Ltr)
+            )
+
+            val firstLineY = (paragraph.getLineBottom(0) + paragraph.getLineTop(0)) / 2f
+            (0..5).forEach {
+                Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = fontSizeInPx * it, y = firstLineY)))
+                    .isEqualTo(it)
+            }
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 1000f, y = firstLineY))).isEqualTo(5)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = -100f, y = firstLineY))).isEqualTo(0)
+
+            val secondLineY = (paragraph.getLineBottom(1) + paragraph.getLineTop(1)) / 2f
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 1000f, y = secondLineY))).isEqualTo(13)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = -100f, y = secondLineY))).isEqualTo(6)
+
+            (6..13).forEach {
+                Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = fontSizeInPx * (it - 6), y = secondLineY))).isEqualTo(it)
+            }
+        }
+
+        // RTL
+        with(defaultDensity) {
+            val text = " אסד \nקשע תטו"
+            val fontSize = 50.sp
+            val fontSizeInPx = fontSize.toPx()
+            val width = 10 * fontSizeInPx
+            val paragraph = simpleParagraph(
+                text = text,
+                width = width,
+                style = TextStyle(fontSize = fontSize, textDirection = TextDirection.Rtl)
+            )
+
+            val firstLineY = (paragraph.getLineBottom(0) + paragraph.getLineTop(0)) / 2f
+            (0..5).forEach {
+                Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width - fontSizeInPx * it, y = firstLineY)))
+                    .isEqualTo(it)
+            }
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width + fontSizeInPx, y = firstLineY))).isEqualTo(0)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = 0f, y = firstLineY))).isEqualTo(5)
+
+            val secondLineY = 20f + (paragraph.getLineBottom(1) + paragraph.getLineTop(1)) / 2f
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width - 1f, y = secondLineY))).isEqualTo(6)
+            Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = -100f, y = secondLineY))).isEqualTo(13)
+
+            (7..13).forEach {
+                Truth.assertThat(paragraph.getOffsetForPosition(Offset(x = width - (it - 6) * fontSizeInPx, y = secondLineY))).isEqualTo(it)
             }
         }
     }
@@ -94,10 +332,10 @@ class DesktopParagraphTest {
                 .isEqualTo(Rect(0f, 0f, fontSizeInPx, 60f))
 
             Truth.assertThat(paragraph.getBoundingBox(1))
-                .isEqualTo(Rect(fontSizeInPx, 0f, fontSizeInPx * 2.5f, 60f))
+                .isEqualTo(Rect(fontSizeInPx, 0f, fontSizeInPx * 2.5f, 50f))
 
             Truth.assertThat(paragraph.getBoundingBox(5))
-                .isEqualTo(Rect(fontSizeInPx, 0f, fontSizeInPx * 2.5f, 60f))
+                .isEqualTo(Rect(fontSizeInPx, 0f, fontSizeInPx * 2.5f, 50f))
         }
     }
 
@@ -170,7 +408,7 @@ class DesktopParagraphTest {
                 width = width
             )
 
-            for (i in 0..ltrText.length) {
+            for (i in 0..ltrText.lastIndex) {
                 Truth.assertThat(paragraph.getHorizontalPosition(i, true))
                     .isEqualTo(fontSizeInPx * i)
             }

--- a/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.jsNativeMain.kt
+++ b/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.jsNativeMain.kt
@@ -1,0 +1,6 @@
+package androidx.compose.ui.text.platform
+
+internal actual fun Char.isNeutralDirectionality(): Boolean {
+    println("TODO: implement Char.isNeutralDirectionality in jsNativeMain")
+    return false
+}

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -496,14 +496,19 @@ internal class SkiaParagraph(
         val leftX = rects?.firstOrNull()?.rect?.left ?: expectedLine.left.toFloat()
         val rightX = rects?.lastOrNull()?.rect?.right ?: expectedLine.right.toFloat()
 
+        if (leftX == rightX) {
+            return glyphPosition
+        }
+
         var correctedGlyphPosition = glyphPosition
 
         if (position.x <= leftX) { // when clicked to the left of a text line
             correctedGlyphPosition = para.getGlyphPositionAtCoordinate(leftX + 1f, position.y).position
         } else if (position.x >= rightX) { // when clicked to the right of a text line
             correctedGlyphPosition = para.getGlyphPositionAtCoordinate(rightX - 1f, position.y).position
+            val isNeutralChar = text.getOrNull(correctedGlyphPosition)?.isNeutralDirectionality() ?: false
             // For RTL blocks, the position is still not correct, so we have to subtract 1 from the returned result
-            if (getBoxBackwardByOffset(correctedGlyphPosition)?.direction == Direction.RTL) {
+            if (!isNeutralChar && getBoxBackwardByOffset(correctedGlyphPosition)?.direction == Direction.RTL) {
                 correctedGlyphPosition -= 1
             }
         }
@@ -1067,3 +1072,5 @@ internal fun TextBox.cursorHorizontalPosition(opposite: Boolean = false): Float 
         SkDirection.RTL -> if (opposite) rect.right else rect.left
     }
 }
+
+internal expect fun Char.isNeutralDirectionality(): Boolean


### PR DESCRIPTION
Beside tests, this PR also adds a new internal function:
`internal expect fun Char.isNeutralDirectionality(): Boolean` - it helps for a better workaround for cursor position in RTL paragraphs.

Also, it updates some existing tests. 