### PR TITLE
add all targets for compose-runtime supported by kotlin-coroutines

### DIFF
--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -70,6 +70,9 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     }
 
     kotlin {
+        // Not all modules can have these targets, so declare them here instead of androidXComposeMultiplatform.
+        // We can support the kotlin-native targets supported by kotlin coroutines:
+        // https://github.com/Kotlin/kotlinx.coroutines/blob/master/gradle/compile-native-multiplatform.gradle
         watchosArm64()
         watchosArm32()
         watchosX86()
@@ -78,6 +81,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         tvosArm64()
         tvosX64()
         tvosSimulatorArm64()
+        mingwX64()
+        linuxX64()
 
         targets.js {
             nodejs {
@@ -144,6 +149,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsNativeMain.dependsOn(commonMain)
             jsMain.dependsOn(jsNativeMain)
             nativeMain.dependsOn(jsNativeMain)
+
+            linuxX64Main.dependsOn(nativeMain)
+            linuxX64Test.dependsOn(nativeTest)
+            mingwX64Main.dependsOn(nativeMain)
+            mingwX64Test.dependsOn(nativeTest)
 
             def darwinMain = sourceSets.getByName("darwinMain")
             def darwinTest = sourceSets.getByName("darwinTest")

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -71,6 +71,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
     kotlin {
         watchosArm64()
+        watchosArm32()
         watchosX86()
         watchosX64()
         watchosSimulatorArm64()
@@ -154,6 +155,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             watchosArm64Main.dependsOn(watchOsMain)
             watchosArm64Test.dependsOn(watchOsTest)
+            watchosArm32Main.dependsOn(watchOsMain)
+            watchosArm32Test.dependsOn(watchOsTest)
             watchosX86Main.dependsOn(watchOsMain)
             watchosX86Test.dependsOn(watchOsTest)
             watchosX64Main.dependsOn(watchOsMain)

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -70,6 +70,14 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     }
 
     kotlin {
+        watchosArm64()
+        watchosX86()
+        watchosX64()
+        watchosSimulatorArm64()
+        tvosArm64()
+        tvosX64()
+        tvosSimulatorArm64()
+
         targets.js {
             nodejs {
                 testTask {
@@ -135,6 +143,35 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsNativeMain.dependsOn(commonMain)
             jsMain.dependsOn(jsNativeMain)
             nativeMain.dependsOn(jsNativeMain)
+
+            def darwinMain = sourceSets.getByName("darwinMain")
+            def darwinTest = sourceSets.getByName("darwinTest")
+
+            def watchOsMain = sourceSets.create("watchOsMain")
+            def watchOsTest = sourceSets.create("watchOsTest")
+            watchOsMain.dependsOn(darwinMain)
+            watchOsTest.dependsOn(darwinTest)
+
+            watchosArm64Main.dependsOn(watchOsMain)
+            watchosArm64Test.dependsOn(watchOsTest)
+            watchosX86Main.dependsOn(watchOsMain)
+            watchosX86Test.dependsOn(watchOsTest)
+            watchosX64Main.dependsOn(watchOsMain)
+            watchosX64Test.dependsOn(watchOsTest)
+            watchosSimulatorArm64Main.dependsOn(watchOsMain)
+            watchosSimulatorArm64Test.dependsOn(watchOsTest)
+
+            def tvOsMain = sourceSets.create("tvOsMain")
+            def tvOsTest = sourceSets.create("tvOsTest")
+            tvOsMain.dependsOn(darwinMain)
+            tvOsTest.dependsOn(darwinTest)
+
+            tvosArm64Main.dependsOn(tvOsMain)
+            tvosArm64Test.dependsOn(tvOsTest)
+            tvosX64Main.dependsOn(tvOsMain)
+            tvosX64Test.dependsOn(tvOsTest)
+            tvosSimulatorArm64Main.dependsOn(tvOsMain)
+            tvosSimulatorArm64Test.dependsOn(tvOsTest)
 
             jvmTest.dependencies {
                 implementation(libs.kotlinTestJunit)


### PR DESCRIPTION
It was requested here https://github.com/JetBrains/compose-jb/issues/2288 