### PR TITLE
Support overriding context menus for selectable texts and text fields

### DIFF
--- a/.run/desktop/run4.run.xml
+++ b/.run/desktop/run4.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="run4" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
+  <configuration default="false" name="runSwing" type="GradleRunConfiguration" factoryName="Gradle" folderName="desktop">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/compose/desktop/desktop" />
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="desktop-samples:run4" />
+          <option value="desktop-samples:runSwing" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/compose/desktop/desktop/samples/build.gradle
+++ b/compose/desktop/desktop/samples/build.gradle
@@ -82,7 +82,7 @@ task run3(type: JavaExec) {
         compilation.runtimeDependencyFiles
 }
 
-task run4(type: JavaExec) {
+task runSwing(type: JavaExec) {
     dependsOn(":compose:desktop:desktop:jar")
     main = "androidx.compose.desktop.examples.swingexample.Main_jvmKt"
     def compilation = kotlin.jvm().compilations["main"]

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -26,21 +26,24 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.JPopupTextMenu
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.nativeKeyCode
@@ -53,23 +56,43 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.rememberCursorPositionProvider
+import java.awt.Component
+import java.awt.MouseInfo
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
+import javax.swing.SwingUtilities
+import javax.swing.event.PopupMenuEvent
+import javax.swing.event.PopupMenuListener
 
 // Design of basic represenation is from Material specs:
 // https://material.io/design/interaction/states.html#hover
 // https://material.io/components/menus#specs
 
+/**
+ * Representation of a context menu that is suitable for light themes of the application.
+ */
 val LightDefaultContextMenuRepresentation = DefaultContextMenuRepresentation(
     backgroundColor = Color.White,
     textColor = Color.Black,
     itemHoverColor = Color.Black.copy(alpha = 0.04f)
 )
 
+/**
+ * Representation of a context menu that is suitable for dark themes of the application.
+ */
 val DarkDefaultContextMenuRepresentation = DefaultContextMenuRepresentation(
     backgroundColor = Color(0xFF121212), // like surface in darkColors
     textColor = Color.White,
     itemHoverColor = Color.White.copy(alpha = 0.04f)
 )
 
+/**
+ * Custom representation of a context menu that allows to specify different colors.
+ *
+ * @param backgroundColor Color of a context menu background.
+ * @param textColor Color of the text in a context menu
+ * @param itemHoverColor Color of the item background when we hover it.
+ */
 class DefaultContextMenuRepresentation(
     private val backgroundColor: Color,
     private val textColor: Color,
@@ -77,7 +100,7 @@ class DefaultContextMenuRepresentation(
 ) : ContextMenuRepresentation {
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
-    override fun Representation(state: ContextMenuState, items: List<ContextMenuItem>) {
+    override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
         val isOpen = state.status is ContextMenuState.Status.Open
         if (isOpen) {
             var focusManager: FocusManager? by mutableStateOf(null)
@@ -121,7 +144,7 @@ class DefaultContextMenuRepresentation(
                         .verticalScroll(rememberScrollState())
 
                 ) {
-                    items.distinctBy { it.label }.forEach { item ->
+                    items().distinctBy { it.label }.forEach { item ->
                         MenuItemContent(
                             itemHoverColor = itemHoverColor,
                             onClick = {
@@ -168,6 +191,61 @@ private fun MenuItemContent(
         verticalAlignment = Alignment.CenterVertically
     ) {
         content()
+    }
+}
+
+/**
+ * [ContextMenuRepresentation] that uses [JPopupMenu] to show a context menu for [ContextMenuArea].
+ *
+ * You can use it overriding [LocalContextMenuRepresentation] on the top level of your application.
+ *
+ * See also [JPopupTextMenu] that allows more specific customization for the text context menu.
+ *
+ * @param owner The root component, who owns a context menu. Usually it is [ComposeWindow] or [ComposePanel].
+ * @param createMenu Describes how to create [JPopupMenu]. Use it if you want customization of the menu.
+ * @param createItem Describes how to create a context menu item. Use it if you want customization of the menu items.
+ */
+@ExperimentalFoundationApi
+class JPopupContextMenuRepresentation(
+    private val owner: Component,
+    private val createMenu: () -> JPopupMenu = { JPopupMenu() },
+    private val createItem: (ContextMenuItem) -> Component = { item ->
+        JMenuItem(item.label).apply {
+            addActionListener { item.onClick() }
+        }
+    }
+) : ContextMenuRepresentation {
+    @Composable
+    override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
+        val isOpen = state.status is ContextMenuState.Status.Open
+        if (isOpen) {
+            val menu = remember {
+                createMenu().apply {
+                    addPopupMenuListener(object : PopupMenuListener {
+                        override fun popupMenuWillBecomeVisible(e: PopupMenuEvent?) = Unit
+
+                        override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent?) {
+                            state.status = ContextMenuState.Status.Closed
+                        }
+
+                        override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
+                    })
+                }
+            }
+
+            for (item in items().distinctBy { it.label }) {
+                menu.add(createItem(item))
+            }
+
+            DisposableEffect(Unit) {
+                val mousePosition = MouseInfo.getPointerInfo().location
+                SwingUtilities.convertPointFromScreen(mousePosition, owner)
+                menu.show(owner, mousePosition.x, mousePosition.y)
+                onDispose {
+                    menu.isVisible = false
+                }
+            }
+        }
     }
 }
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -91,7 +91,7 @@ val DarkDefaultContextMenuRepresentation = DefaultContextMenuRepresentation(
  *
  * @param backgroundColor Color of a context menu background.
  * @param textColor Color of the text in a context menu
- * @param itemHoverColor Color of the item background when we hover it.
+ * @param itemHoverColor Color of an item background when we hover it.
  */
 class DefaultContextMenuRepresentation(
     private val backgroundColor: Color,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -230,11 +230,11 @@ class JPopupContextMenuRepresentation(
 
                         override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
                     })
-                }
-            }
 
-            for (item in items().distinctBy { it.label }) {
-                menu.add(createItem(item))
+                    for (item in items().distinctBy { it.label }) {
+                        add(createItem(item))
+                    }
+                }
             }
 
             DisposableEffect(Unit) {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -202,25 +202,29 @@ private fun MenuItemContent(
  * See also [JPopupTextMenu] that allows more specific customization for the text context menu.
  *
  * @param owner The root component that owns a context menu. Usually it is [ComposeWindow] or [ComposePanel].
- * @param createMenu Describes how to create [JPopupMenu]. Use it if you want customization of the menu.
- * @param createItem Describes how to create a context menu item. Use it if you want customization of menu items.
+ * @param createMenu Describes how to create [JPopupMenu] from list of [ContextMenuItem]
  */
 @ExperimentalFoundationApi
 class JPopupContextMenuRepresentation(
     private val owner: Component,
-    private val createMenu: () -> JPopupMenu = { JPopupMenu() },
-    private val createItem: (ContextMenuItem) -> Component = { item ->
-        JMenuItem(item.label).apply {
-            addActionListener { item.onClick() }
+    private val createMenu: (List<ContextMenuItem>) -> JPopupMenu = { items ->
+        JPopupMenu().apply {
+            for (item in items) {
+                add(
+                    JMenuItem(item.label).apply {
+                        addActionListener { item.onClick() }
+                    }
+                )
+            }
         }
-    }
+    },
 ) : ContextMenuRepresentation {
     @Composable
     override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
         val isOpen = state.status is ContextMenuState.Status.Open
         if (isOpen) {
             val menu = remember {
-                createMenu().apply {
+                createMenu(items()).apply {
                     addPopupMenuListener(object : PopupMenuListener {
                         override fun popupMenuWillBecomeVisible(e: PopupMenuEvent?) = Unit
 
@@ -230,10 +234,6 @@ class JPopupContextMenuRepresentation(
 
                         override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
                     })
-
-                    for (item in items().distinctBy { it.label }) {
-                        add(createItem(item))
-                    }
                 }
             }
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -144,7 +144,7 @@ class DefaultContextMenuRepresentation(
                         .verticalScroll(rememberScrollState())
 
                 ) {
-                    items().distinctBy { it.label }.forEach { item ->
+                    items().forEach { item ->
                         MenuItemContent(
                             itemHoverColor = itemHoverColor,
                             onClick = {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -197,13 +197,13 @@ private fun MenuItemContent(
 /**
  * [ContextMenuRepresentation] that uses [JPopupMenu] to show a context menu for [ContextMenuArea].
  *
- * You can use it overriding [LocalContextMenuRepresentation] on the top level of your application.
+ * You can use it by overriding [LocalContextMenuRepresentation] on the top level of your application.
  *
  * See also [JPopupTextMenu] that allows more specific customization for the text context menu.
  *
- * @param owner The root component, who owns a context menu. Usually it is [ComposeWindow] or [ComposePanel].
+ * @param owner The root component that owns a context menu. Usually it is [ComposeWindow] or [ComposePanel].
  * @param createMenu Describes how to create [JPopupMenu]. Use it if you want customization of the menu.
- * @param createItem Describes how to create a context menu item. Use it if you want customization of the menu items.
+ * @param createItem Describes how to create a context menu item. Use it if you want customization of menu items.
  */
 @ExperimentalFoundationApi
 class JPopupContextMenuRepresentation(

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -54,12 +54,10 @@ fun ContextMenuArea(
 ) {
     val data = ContextMenuData(items, LocalContextMenuData.current)
 
-    ContextMenuDataProvider(data) {
-        Box(Modifier.contextMenuDetector(state, enabled), propagateMinConstraints = true) {
-            content()
-        }
-        LocalContextMenuRepresentation.current.Representation(state) { data.allItems }
+    Box(Modifier.contextMenuDetector(state, enabled), propagateMinConstraints = true) {
+        content()
     }
+    LocalContextMenuRepresentation.current.Representation(state) { data.allItems }
 }
 
 /**

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -58,7 +58,7 @@ fun ContextMenuArea(
         Box(Modifier.contextMenuDetector(state, enabled), propagateMinConstraints = true) {
             content()
         }
-        LocalContextMenuRepresentation.current.Representation(state, data.allItems)
+        LocalContextMenuRepresentation.current.Representation(state) { data.allItems }
     }
 }
 
@@ -139,7 +139,7 @@ private suspend fun AwaitPointerEventScope.awaitEventFirstDown(): PointerEvent {
  * @param label The text to be displayed as a context menu item.
  * @param onClick The action to be executed after click on the item.
  */
-class ContextMenuItem(
+open class ContextMenuItem(
     val label: String,
     val onClick: () -> Unit
 ) {
@@ -249,7 +249,14 @@ class ContextMenuState {
  */
 interface ContextMenuRepresentation {
     @Composable
-    fun Representation(state: ContextMenuState, items: List<ContextMenuItem>)
+    @Deprecated(
+        "Use another overload that loads items only when they are needed",
+        replaceWith = ReplaceWith("Representation(state, { items }")
+    )
+    fun Representation(state: ContextMenuState, items: List<ContextMenuItem>) = Representation(state) { items }
+
+    @Composable
+    fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>)
 }
 
 /**

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -243,6 +243,7 @@ class JPopupTextMenu(
                 createMenu(textManager, it)
             }
         ) {
+            // We pass emptyList, but it will be merged with the other custom items defined via ContextMenuDataProvider, and passed to createMenu
             ContextMenuArea({ emptyList() }, state, content = content)
         }
     }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -148,7 +148,7 @@ interface TextContextMenu {
      * Defines an area, that describes how to open and show text context menus.
      * Usually it uses [ContextMenuArea] as the implementation.
      *
-     * @param actions Available actions that can be performed with text for which we show the text context menu.
+     * @param actions Available actions that can be performed on the text for which we show the text context menu.
      * @param state [ContextMenuState] of menu controlled by this area.
      * @param content The content of the [ContextMenuArea].
      */
@@ -216,16 +216,16 @@ interface TextContextMenu {
 /**
  * [TextContextMenu] that uses [JPopupMenu] to show the text context menu.
  *
- * You can use it overriding [TextContextMenu] on the top level of your application.
+ * You can use it by overriding [TextContextMenu] on the top level of your application.
  *
- * @param owner owner component of the context menu. Usually it is the root [ComposeWindow] or [ComposePanel].
- * @param createMenu describes how to create [JPopupMenu]. Use it if you want customization of the menu
- * @param createItem describes how to create a generic context menu item. Use it if you want customization
- * of the menu items. It is usually used for items provided by [ContextMenuArea] in user code.
- * @param createCut describes hot to create the menu item for Cut action
- * @param createCopy describes hot to create the menu item for Copy action
- * @param createPaste describes hot to create the menu item for Paste action
- * @param createSelectAll describes hot to create the menu item for Select All action
+ * @param owner The root component that owns a context menu. Usually it is [ComposeWindow] or [ComposePanel].
+ * @param createMenu Describes how to create [JPopupMenu]. Use it if you want customization of the menu.
+ * @param createItem Describes how to create a generic context menu item. Use it if you want customization.
+ * of the menu items. It is called for items provided by [ContextMenuArea] in user code.
+ * @param createCut Describes hot to create the menu item for Cut action.
+ * @param createCopy Describes hot to create the menu item for Copy action.
+ * @param createPaste Describes hot to create the menu item for Paste action.
+ * @param createSelectAll Describes hot to create the menu item for Select All action.
  */
 @ExperimentalFoundationApi
 class JPopupTextMenu(

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -14,21 +14,36 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalFoundationApi::class)
+
 package androidx.compose.foundation.text
 
 import androidx.compose.foundation.ContextMenuArea
 import androidx.compose.foundation.ContextMenuItem
 import androidx.compose.foundation.ContextMenuState
 import androidx.compose.foundation.DesktopPlatform
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.JPopupContextMenuRepresentation
+import androidx.compose.foundation.LocalContextMenuRepresentation
+import androidx.compose.foundation.text.TextContextMenu.Actions
 import androidx.compose.foundation.text.selection.SelectionManager
 import androidx.compose.foundation.text.selection.TextFieldSelectionManager
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalLocalization
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import java.awt.Component
+import javax.swing.JMenuItem
+import javax.swing.JPopupMenu
 import kotlinx.coroutines.flow.collect
 
 @Composable
@@ -40,7 +55,7 @@ internal actual fun ContextMenuArea(
     if (DesktopPlatform.Current == DesktopPlatform.MacOS) {
         OpenMenuAdjuster(state) { manager.contextMenuOpenAdjustment(it) }
     }
-    ContextMenuArea(manager.contextMenuItems(), state, content = content)
+    LocalTextContextMenu.current.Area(manager.actions, state, content)
 }
 
 @Composable
@@ -52,7 +67,7 @@ internal actual fun ContextMenuArea(
     if (DesktopPlatform.Current == DesktopPlatform.MacOS) {
         OpenMenuAdjuster(state) { manager.contextMenuOpenAdjustment(it) }
     }
-    ContextMenuArea(manager.contextMenuItems(), state, content = content)
+    LocalTextContextMenu.current.Area(manager.actions, state, content)
 }
 
 @Composable
@@ -66,59 +81,204 @@ internal fun OpenMenuAdjuster(state: ContextMenuState, adjustAction: (Offset) ->
     }
 }
 
-@Composable
-internal fun TextFieldSelectionManager.contextMenuItems(): () -> List<ContextMenuItem> {
-    val platformLocalization = LocalLocalization.current
-    return {
-        val result = mutableListOf<ContextMenuItem>()
-        val isPassword = visualTransformation is PasswordVisualTransformation
-        if (!value.selection.collapsed && !isPassword) {
-            result.add(
-                ContextMenuItem(platformLocalization.copy) {
-                    copy(false)
-                    focusRequester?.requestFocus()
-                }
-            )
-        }
+private val TextFieldSelectionManager.actions get() = object : Actions {
+    val isPassword get() = visualTransformation is PasswordVisualTransformation
 
+    override val cut: (() -> Unit)? get() =
         if (!value.selection.collapsed && editable && !isPassword) {
-            result.add(
-                ContextMenuItem(platformLocalization.cut) {
-                    cut()
-                    focusRequester?.requestFocus()
-                }
-            )
-        }
-
-        if (editable && clipboardManager?.getText() != null) {
-            result.add(
-                ContextMenuItem(platformLocalization.paste) {
-                    paste()
-                    focusRequester?.requestFocus()
-                }
-            )
-        }
-
-        if (value.selection.length != value.text.length) {
-            result.add(
-                ContextMenuItem(platformLocalization.selectAll) {
-                    selectAll()
-                    focusRequester?.requestFocus()
-                }
-            )
-        }
-        result
-    }
-}
-
-@Composable
-internal fun SelectionManager.contextMenuItems(): () -> List<ContextMenuItem> {
-    val localization = LocalLocalization.current
-    return {
-        listOf(
-            ContextMenuItem(localization.copy) {
-                copy()
+            {
+                cut()
+                focusRequester?.requestFocus()
             }
-        )
+        } else {
+            null
+        }
+
+    override val copy: (() -> Unit)? get() =
+        if (!value.selection.collapsed && !isPassword) {
+            {
+                copy(false)
+                focusRequester?.requestFocus()
+            }
+        } else {
+            null
+        }
+
+    override val paste: (() -> Unit)? get() =
+        if (editable && clipboardManager?.getText() != null) {
+            {
+                paste()
+                focusRequester?.requestFocus()
+            }
+        } else {
+            null
+        }
+
+    override val selectAll: (() -> Unit)? get() =
+        if (value.selection.length != value.text.length) {
+            {
+                selectAll()
+                focusRequester?.requestFocus()
+            }
+        } else {
+            null
+        }
+}
+
+private val SelectionManager.actions get() = object : Actions {
+    override var cut: (() -> Unit)? = null
+    override var copy: (() -> Unit)? = { copy() }
+    override var paste: (() -> Unit)? = null
+    override var selectAll: (() -> Unit)? = null
+}
+
+/**
+ * Composition local that keeps [TextContextMenu].
+ */
+@ExperimentalFoundationApi
+val LocalTextContextMenu:
+    ProvidableCompositionLocal<TextContextMenu> = staticCompositionLocalOf { TextContextMenu.Default }
+
+/**
+ * Describes how to show the text context menu for selectable texts and text fields.
+ */
+@ExperimentalFoundationApi
+interface TextContextMenu {
+    /**
+     * Defines an area, that describes how to open and show text context menus.
+     * Usually it uses [ContextMenuArea] as the implementation.
+     *
+     * @param actions Available actions that can be performed with text for which we show the text context menu.
+     * @param state [ContextMenuState] of menu controlled by this area.
+     * @param content The content of the [ContextMenuArea].
+     */
+    @Composable
+    fun Area(actions: Actions, state: ContextMenuState, content: @Composable () -> Unit)
+
+    /**
+     * Available actions that can be performed with text for which we show the text context menu.
+     */
+    @ExperimentalFoundationApi
+    interface Actions {
+        /**
+         * Action for cutting the selected text to the clipboard. Null if there is no text to cut.
+         */
+        val cut: (() -> Unit)?
+
+        /**
+         * Action for copy the selected text to the clipboard. Null if there is no text to copy.
+         */
+        val copy: (() -> Unit)?
+
+        /**
+         * Action for pasting text from the clipboard. Null if there is no text in the clipboard.
+         */
+        val paste: (() -> Unit)?
+
+        /**
+         * Action for selecting the whole text. Null if the text is already selected.
+         */
+        val selectAll: (() -> Unit)?
+    }
+
+    companion object {
+        /**
+         * [TextContextMenu] that is used by default in Compose.
+         */
+        @ExperimentalFoundationApi
+        val Default = object : TextContextMenu {
+            @Composable
+            override fun Area(actions: Actions, state: ContextMenuState, content: @Composable () -> Unit) {
+                val localization = LocalLocalization.current
+                val items = {
+                    listOfNotNull(
+                        actions.cut?.let {
+                            ContextMenuItem(localization.cut, it)
+                        },
+                        actions.copy?.let {
+                            ContextMenuItem(localization.copy, it)
+                        },
+                        actions.paste?.let {
+                            ContextMenuItem(localization.paste, it)
+                        },
+                        actions.selectAll?.let {
+                            ContextMenuItem(localization.selectAll, it)
+                        },
+                    )
+                }
+
+                ContextMenuArea(items, state, content = content)
+            }
+        }
     }
 }
+
+/**
+ * [TextContextMenu] that uses [JPopupMenu] to show the text context menu.
+ *
+ * You can use it overriding [TextContextMenu] on the top level of your application.
+ *
+ * @param owner owner component of the context menu. Usually it is the root [ComposeWindow] or [ComposePanel].
+ * @param createMenu describes how to create [JPopupMenu]. Use it if you want customization of the menu
+ * @param createItem describes how to create a generic context menu item. Use it if you want customization
+ * of the menu items. It is usually used for items provided by [ContextMenuArea] in user code.
+ * @param createCut describes hot to create the menu item for Cut action
+ * @param createCopy describes hot to create the menu item for Copy action
+ * @param createPaste describes hot to create the menu item for Paste action
+ * @param createSelectAll describes hot to create the menu item for Select All action
+ */
+@ExperimentalFoundationApi
+class JPopupTextMenu(
+    private val owner: Component,
+    private val createMenu: () -> JPopupMenu = { JPopupMenu() },
+    private val createItem: (ContextMenuItem) -> Component = { item ->
+        JMenuItem(item.label).apply {
+            addActionListener { item.onClick() }
+        }
+    },
+    private val createCut: (ContextMenuItem) -> Component = createItem,
+    private val createCopy: (ContextMenuItem) -> Component = createItem,
+    private val createPaste: (ContextMenuItem) -> Component = createItem,
+    private val createSelectAll: (ContextMenuItem) -> Component = createItem
+) : TextContextMenu {
+    @Composable
+    override fun Area(actions: Actions, state: ContextMenuState, content: @Composable () -> Unit) {
+        val localization = LocalLocalization.current
+        val items = {
+            listOfNotNull(
+                actions.cut?.let {
+                    JPopupContextMenuItem(localization.cut, it, createCut)
+                },
+                actions.copy?.let {
+                    JPopupContextMenuItem(localization.copy, it, createCopy)
+                },
+                actions.paste?.let {
+                    JPopupContextMenuItem(localization.paste, it, createPaste)
+                },
+                actions.selectAll?.let {
+                    JPopupContextMenuItem(localization.selectAll, it, createSelectAll)
+                },
+            )
+        }
+
+        CompositionLocalProvider(
+            LocalContextMenuRepresentation provides JPopupContextMenuRepresentation(
+                owner,
+                createMenu
+            ) { item ->
+                when (item) {
+                    is JPopupContextMenuItem -> item.createJMenuItem(item)
+                    else -> createItem(item)
+                }
+            }
+        ) {
+            ContextMenuArea(items, state, content = content)
+        }
+    }
+}
+
+private class JPopupContextMenuItem(
+    label: String,
+    onClick: () -> Unit,
+    val createJMenuItem: (ContextMenuItem) -> Component
+) : ContextMenuItem(label, onClick)

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -142,7 +142,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             }
 
             desktopTest.dependencies {
-                implementation(project(":compose:foundation:foundation"))
+                implementation(project(":compose:material:material"))
                 implementation(libs.truth)
                 implementation(libs.junit)
                 implementation(libs.skikoCurrentOs)

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
@@ -19,7 +19,6 @@ package androidx.compose.ui.test
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -46,8 +45,6 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
-import kotlin.time.ExperimentalTime
-import kotlin.time.measureTime
 import org.junit.Test
 
 @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
@@ -68,51 +65,6 @@ class ComposeUiTestTest {
                     }
                 }
         )
-    }
-
-    @OptIn(ExperimentalTime::class)
-    @Test
-    fun test1() = runComposeUiTest {
-        var text by mutableStateOf("")
-        setContent {
-            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
-        }
-
-        println(measureTime {
-        onNode(hasTestTag("tag")).performTextInput("different text")
-        })
-//
-//        onNode(hasTestTag("tag")).assertTextContains("different text")
-    }
-    @Test
-    fun test2() = runComposeUiTest {
-        var text by mutableStateOf("")
-        setContent {
-            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
-        }
-        onNode(hasTestTag("tag")).performTextInput("different text")
-
-        onNode(hasTestTag("tag")).assertTextContains("different text")
-    }
-    @Test
-    fun test3() = runComposeUiTest {
-        var text by mutableStateOf("")
-        setContent {
-            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
-        }
-        onNode(hasTestTag("tag")).performTextInput("different text")
-
-        onNode(hasTestTag("tag")).assertTextContains("different text")
-    }
-    @Test
-    fun test4() = runComposeUiTest {
-        var text by mutableStateOf("")
-        setContent {
-            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
-        }
-        onNode(hasTestTag("tag")).performTextInput("different text")
-
-        onNode(hasTestTag("tag")).assertTextContains("different text")
     }
 
     @Test

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.test
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -45,6 +46,8 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
+import kotlin.time.ExperimentalTime
+import kotlin.time.measureTime
 import org.junit.Test
 
 @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
@@ -65,6 +68,51 @@ class ComposeUiTestTest {
                     }
                 }
         )
+    }
+
+    @OptIn(ExperimentalTime::class)
+    @Test
+    fun test1() = runComposeUiTest {
+        var text by mutableStateOf("")
+        setContent {
+            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
+        }
+
+        println(measureTime {
+        onNode(hasTestTag("tag")).performTextInput("different text")
+        })
+//
+//        onNode(hasTestTag("tag")).assertTextContains("different text")
+    }
+    @Test
+    fun test2() = runComposeUiTest {
+        var text by mutableStateOf("")
+        setContent {
+            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
+        }
+        onNode(hasTestTag("tag")).performTextInput("different text")
+
+        onNode(hasTestTag("tag")).assertTextContains("different text")
+    }
+    @Test
+    fun test3() = runComposeUiTest {
+        var text by mutableStateOf("")
+        setContent {
+            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
+        }
+        onNode(hasTestTag("tag")).performTextInput("different text")
+
+        onNode(hasTestTag("tag")).assertTextContains("different text")
+    }
+    @Test
+    fun test4() = runComposeUiTest {
+        var text by mutableStateOf("")
+        setContent {
+            TextField(text, onValueChange = { text = it }, Modifier.testTag("tag"))
+        }
+        onNode(hasTestTag("tag")).performTextInput("different text")
+
+        onNode(hasTestTag("tag")).assertTextContains("different text")
     }
 
     @Test

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -332,17 +332,19 @@ internal class ComposeLayer(
 
         _component.addFocusListener(object : FocusListener {
             override fun focusGained(e: FocusEvent) {
-                // We don't reset focus for Compose when the window loses focus
-                // Partially because we don't support restoring focus after clearing it
-                if (e.cause != FocusEvent.Cause.ACTIVATION) {
+                // We don't reset focus for Compose when the component loses focus temporary.
+                // Partially because we don't support restoring focus after clearing it.
+                // Focus can be lost temporary when another window or popup takes focus.
+                if (!e.isTemporary) {
                     scene.requestFocus()
                 }
             }
 
             override fun focusLost(e: FocusEvent) {
-                // We don't reset focus for Compose when the window loses focus
-                // Partially because we don't support restoring focus after clearing it
-                if (e.cause != FocusEvent.Cause.ACTIVATION) {
+                // We don't reset focus for Compose when the component loses focus temporary.
+                // Partially because we don't support restoring focus after clearing it.
+                // Focus can be lost temporary when another window or popup takes focus.
+                if (!e.isTemporary) {
                     scene.releaseFocus()
                 }
             }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformLocalization.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformLocalization.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 
 interface PlatformLocalization {
@@ -32,6 +33,6 @@ internal val defaultPlatformLocalization = object : PlatformLocalization {
     override val selectAll = "Select All"
 }
 
-val LocalLocalization = staticCompositionLocalOf {
+val LocalLocalization: ProvidableCompositionLocal<PlatformLocalization> = staticCompositionLocalOf {
     defaultPlatformLocalization
 }


### PR DESCRIPTION
- [Tutorial](https://github.com/JetBrains/compose-jb/blob/dffa46d4bb83be63628707171daaa30da4e47ccf/tutorials/Context_Menu/README.md#swing-interoperability)
- Fix `ContextMenuRepresentation` - items now requested only when they needed. Before that we construct items when we show the text, and immediately access the clipboard. Now we construct items and access the clipboard only when we show the context menu.
- Fix losing focus behaviour. When we show the JPopupMenu, we show a separate window, and the main window loses the focus. When the window loses the focus, we also reset all focus inside Compose, except some cases (when we minimize the window, or show another window). Use `event.isTemporary` to determine that we shouldn't reset the focus.
- Add `JPopupContextMenuRepresentation` - uses swing menu to show a generic context menu (not only for texts)
- Add `JPopupTextMenu` - uses swing menu to show the text context menu. Allows customisation of each text context menu item separately.