### PR TITLE
Change default Font on MacOs to San Francisco

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
@@ -49,6 +49,7 @@ internal actual val GenericFontFamiliesMapping by lazy {
         Platform.MacOS ->
             mapOf(
                 FontFamily.SansSerif.name to listOf(
+                    "San Francisco",
                     "Helvetica Neue",
                     "Helvetica"
                 ),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ leakcanary = "2.8.1"
 metalava = "1.0.0-alpha06"
 mockito = "2.25.0"
 protobuf = "3.19.4"
-skiko = "0.7.30"
+skiko = "0.7.32"
 sqldelight = "1.3.0"
 wire = "3.6.0"
 


### PR DESCRIPTION
It is a default font for UI in macOS. [Introduced](https://www.wired.com/2015/06/apple-abandoned-worlds-beloved-typeface/) a lot of versions ago.

<img width="150" alt="image" src="https://user-images.githubusercontent.com/5963351/190036879-aee50136-df5f-4c93-8f29-dbf36961e9f4.png"> <img width="154" alt="image" src="https://user-images.githubusercontent.com/5963351/190036767-d3814435-1c6c-4799-b3ea-630b0e82662c.png">


![image](https://designforhackers.com/wp-content/uploads/2015/10/sf-friendlier-than-helvetica.gif)

(on this screenshot ' symbol is different, not sure why. Maybe in the new version of the font it is different)

Old:
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/5963351/190037700-d007f175-733e-4041-bcaa-e6d4a1fa322d.png">
New:
<img width="1023" alt="image" src="https://user-images.githubusercontent.com/5963351/190037361-d4f1a5c2-d5ca-43d3-b4cb-c2baca232e5b.png">



It is not allowed to use San Francisco [directly](https://furbo.org/2015/07/09/i-left-my-system-fonts-in-san-francisco/). We should use "system" alias, that can point to a new font in the future.

