### PR TITLE
Make EmptyLazyGridLayoutInfo internal instead of private to workaround KT-54028

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridState.kt
@@ -414,7 +414,8 @@ class LazyGridState constructor(
 }
 
 @OptIn(ExperimentalFoundationApi::class)
-private object EmptyLazyGridLayoutInfo : LazyGridLayoutInfo {
+// TODO: it was private, but made internal because of https://youtrack.jetbrains.com/issue/KT-54028
+internal object EmptyLazyGridLayoutInfo : LazyGridLayoutInfo {
     override val visibleItemsInfo = emptyList<LazyGridItemInfo>()
     override val viewportStartOffset = 0
     override val viewportEndOffset = 0


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-54028
https://github.com/JetBrains/compose-jb/issues/2255