### PR TITLE
Fix redundant reinitialization of pointerInput in onClick

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -139,9 +139,11 @@ fun Modifier.onClick(
                 interactionSource = interactionSource, pressedInteraction = pressedInteraction
             )
 
-            Modifier.pointerInput(interactionSource, matcher, hasLongClick, hasDoubleClick) {
+            val matcherState = rememberUpdatedState(matcher)
+
+            Modifier.pointerInput(interactionSource, hasLongClick, hasDoubleClick) {
                 detectTapGestures(
-                    matcher = matcher,
+                    matcher = matcherState.value,
                     keyboardModifiers = {
                         keyboardModifiersState.value(this)
                     },


### PR DESCRIPTION
It caused a bug: onLongClick didn't release an indication if the Composable was recomposed during the input event.