### PR TITLE
Remove neediness of Android NDK, fix Windows build

### DIFF
--- a/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
@@ -122,6 +122,12 @@ abstract class SdkResourceGenerator : DefaultTask() {
 
         @JvmStatic
         fun generateForHostTest(project: Project) {
+            // We have this error on Windows:
+            // Could not create task ':compose:compiler:compiler:integration-tests:generateSdkResource'.
+            // > this and base files have different roots: ~\.m2\repository and ...\compose-jb\compose\frameworks\support\compose\compiler\compiler\integration-tests.
+            val os = System.getProperty("os.name").lowercase()
+            if (os.startsWith("win")) return
+
             val provider = registerSdkResourceGeneratorTask(project)
             val extension = project.extensions.getByType<JavaPluginExtension>()
             val testSources = extension.sourceSets.getByName("test")

--- a/compose/ui/ui-inspection/build.gradle
+++ b/compose/ui/ui-inspection/build.gradle
@@ -79,12 +79,14 @@ android {
         main.resources.srcDirs += "src/main/proto"
     }
 
-    externalNativeBuild {
-        cmake {
-            path "src/main/cpp/CMakeLists.txt"
-            version libs.versions.cmake.get()
-        }
-    }
+// We don't need NDK for developing Compose Multiplatform.
+// It is only needed for Layout inspector for Android target.
+//    externalNativeBuild {
+//        cmake {
+//            path "src/main/cpp/CMakeLists.txt"
+//            version libs.versions.cmake.get()
+//        }
+//    }
 
     lintOptions {
         // Restriction not important for inspectors, which only runs at dev-time

--- a/inspection/inspection/build.gradle
+++ b/inspection/inspection/build.gradle
@@ -50,11 +50,13 @@ android {
         minSdkVersion 26
     }
 
-    externalNativeBuild {
-        cmake {
-            path "src/main/native/CMakeLists.txt"
-            version "3.22.1"
-        }
-    }
+// We don't need NDK for developing Compose Multiplatform.
+// It is only needed for Layout inspector for Android target.
+//    externalNativeBuild {
+//        cmake {
+//            path "src/main/native/CMakeLists.txt"
+//            version "3.22.1"
+//        }
+//    }
     namespace "androidx.inspection"
 }

--- a/jbdeps/android-sdk/downloadAndroidSdk
+++ b/jbdeps/android-sdk/downloadAndroidSdk
@@ -17,41 +17,23 @@ clone() {
 downloadLinuxSDK() {
     clone linux/platforms/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-32 master
     clone linux/sources/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-32 master
-    clone linux/ndk https://android.googlesource.com/toolchain/prebuilts/ndk/r23 master
-    ln -s "$PWD/linux/ndk" linux/ndk-bundle # prepare to update androidx submodule
     clone linux/build-tools/30.0.3 https://android.googlesource.com/platform/prebuilts/fullsdk-linux/build-tools/30.0.3 master
     clone linux/platform-tools https://android.googlesource.com/platform/prebuilts/fullsdk-linux/platform-tools master
     clone linux/tools https://android.googlesource.com/platform/prebuilts/fullsdk-linux/tools master
-    clone linux/cmake https://android.googlesource.com/platform/prebuilts/cmake/linux-x86 master
-    clone linux/ninja https://android.googlesource.com/platform/prebuilts/ninja/linux-x86 master
 }
 
 downloadMacOsSDK() {
     clone darwin/platforms/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/platforms/android-32 master
     clone darwin/sources/android-32 https://android.googlesource.com/platform/prebuilts/fullsdk/sources/android-32 master
-    clone darwin/ndk https://android.googlesource.com/toolchain/prebuilts/ndk-darwin/r23 master
-    ln -s "$PWD/darwin/ndk" darwin/ndk-bundle # prepare to update androidx submodule
     clone darwin/build-tools/30.0.3 https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/build-tools/30.0.3 master
     clone darwin/platform-tools https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/platform-tools master
     clone darwin/tools https://android.googlesource.com/platform/prebuilts/fullsdk-darwin/tools master
-    clone darwin/cmake https://android.googlesource.com/platform/prebuilts/cmake/darwin-x86 master
-    clone darwin/ninja https://android.googlesource.com/platform/prebuilts/ninja/darwin-x86 master
-}
-
-setupNativeBuildTools() {
-    mkdir -p $1/native-build-tools/bin/
-    pushd $1/native-build-tools/bin/
-    ln -s ../../ninja/ninja .
-    ln -s ../../cmake/bin/cmake .
-    popd
 }
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     downloadLinuxSDK
-    setupNativeBuildTools linux
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     downloadMacOsSDK
-    setupNativeBuildTools darwin
 elif [[ "$OSTYPE" == "cygwin" ]]; then
     echo "Please download Android SDK manually (https://developer.android.com/studio)"
 elif [[ "$OSTYPE" == "msys" ]]; then

--- a/tracing/tracing-perfetto-binary/build.gradle
+++ b/tracing/tracing-perfetto-binary/build.gradle
@@ -64,12 +64,14 @@ android {
             main.jniLibs.srcDirs += new File(unzippedPrebuiltsAarDir, "jni")
         }
     } else { // build .so files from scratch
-        externalNativeBuild {
-            cmake {
-                path "src/main/cpp/CMakeLists.txt"
-                version libs.versions.cmake.get()
-            }
-        }
+// We don't need NDK for developing Compose Multiplatform.
+// It is only needed for Benchmarking Android target.
+//        externalNativeBuild {
+//            cmake {
+//                path "src/main/cpp/CMakeLists.txt"
+//                version libs.versions.cmake.get()
+//            }
+//        }
     }
     namespace "androidx.tracing.perfetto.binary"
 }


### PR DESCRIPTION
Android NDK is only needed for Android, and only for Layout inspector and benchmarking. Usually, when we develop Compose Multiplatform, we rare check something on Android, and almost never in Layout inspector or in benchmarks.

Keeping Android NDK fresh on every rebase is a difficult task, because it has a non-default tree structure.

I checked, the Android target keeps working.