### PR TITLE
Fix initial focus for ComposePanel

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -132,13 +132,13 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             return component
         }
         val clipComponent = ClipComponent(component)
-        clipMap.put(component, clipComponent)
+        clipMap[component] = clipComponent
         layer!!.component.clipComponents.add(clipComponent)
         return super.add(component, Integer.valueOf(0))
     }
 
     override fun remove(component: Component) {
-        layer!!.component.clipComponents.remove(clipMap.get(component)!!)
+        layer!!.component.clipComponents.remove(clipMap[component]!!)
         clipMap.remove(component)
         super.remove(component)
     }
@@ -161,13 +161,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
                     // The focus can be switched from the child component inside SwingPanel.
                     // In that case, SwingPanel will take care of it.
                     if (!isParentOf(e.oppositeComponent)) {
+                        layer?.scene?.requestFocus()
                         when (e.cause) {
                             FocusEvent.Cause.TRAVERSAL_FORWARD -> {
-                                layer?.scene?.requestFocus()
                                 layer?.scene?.moveFocus(FocusDirection.Next)
                             }
                             FocusEvent.Cause.TRAVERSAL_BACKWARD -> {
-                                layer?.scene?.requestFocus()
                                 layer?.scene?.moveFocus(FocusDirection.Previous)
                             }
                             else -> Unit

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -30,9 +30,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.performClick
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
-import com.google.common.truth.BooleanSubject
 import com.google.common.truth.Truth.assertThat
-import com.google.common.truth.Truth.assertWithMessage
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
@@ -47,7 +45,6 @@ import org.jetbrains.skiko.MainUIDispatcher
 import org.jetbrains.skiko.hostOs
 import org.junit.Assume
 import org.junit.Test
-import org.junit.experimental.categories.Categories
 
 class ComposeFocusTest {
     @Test
@@ -523,6 +520,77 @@ class ComposeFocusTest {
         testRandomFocus(
             window, composeButton3, composeButton4
         )
+    }
+
+    @Test
+    fun `initial focus in ComposeWindow`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            composeButton1.Content()
+        }
+        window.pack()
+        window.isVisible = true
+
+        assertThat(composeButton1.isFocused).isFalse()
+
+        awaitEDT()
+        pressNextFocusKey()
+        awaitEDT()
+        assertThat(composeButton1.isFocused).isTrue()
+    }
+
+    @Test
+    fun `initial focus in ComposePanel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(ComposePanel().apply {
+                setContent {
+                    composeButton1.Content()
+                }
+            })
+        })
+        window.pack()
+        window.isVisible = true
+
+        assertThat(composeButton1.isFocused).isFalse()
+
+        awaitEDT()
+        pressNextFocusKey()
+        awaitEDT()
+        assertThat(composeButton1.isFocused).isTrue()
+    }
+
+    @Test
+    fun `change focus in empty ComposeWindow`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+        window.setContent { }
+        window.pack()
+        window.isVisible = true
+
+        awaitEDT()
+        pressNextFocusKey()
+    }
+
+    @Test
+    fun `change focus in empty ComposePanel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(ComposePanel().apply {
+                setContent { }
+            })
+        })
+        window.pack()
+        window.isVisible = true
+
+        awaitEDT()
+        pressNextFocusKey()
     }
 
     private val outerButton1 = TestJButton("outerButton1")


### PR DESCRIPTION
The exception when we run example with ComposePanel inside JFrame and press Tab:
```
KeyEvent can't be processed because this key input node is not active.
java.lang.IllegalStateException: KeyEvent can't be processed because this key input node is not active.
	at androidx.compose.ui.input.key.KeyInputModifier.processKeyInput-ZmokQxo(KeyInputModifier.kt:101)
	at androidx.compose.ui.platform.SkiaBasedOwner.sendKeyEvent-ZmokQxo(SkiaBasedOwner.skiko.kt:232)
	at androidx.compose.ui.ComposeScene.sendKeyEvent-ZmokQxo(ComposeScene.skiko.kt:572)
	at androidx.compose.ui.awt.ComposeLayer$onKeyEvent$1.invoke(ComposeLayer.desktop.kt:398)
	at androidx.compose.ui.awt.ComposeLayer$onKeyEvent$1.invoke(ComposeLayer.desktop.kt:394)
	at androidx.compose.ui.awt.ComposeLayer.catchExceptions(ComposeLayer.desktop.kt:107)
	at androidx.compose.ui.awt.ComposeLayer.onKeyEvent(ComposeLayer.desktop.kt:394)
	at androidx.compose.ui.awt.ComposeLayer.access$onKeyEvent(ComposeLayer.desktop.kt:85)
	at androidx.compose.ui.awt.ComposeLayer$7.keyPressed(ComposeLayer.desktop.kt:373)
	at java.desktop/java.awt.Component.processKeyEvent(Component.java:6572)
	at java.desktop/java.awt.Component.processEvent(Component.java:6391)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4990)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4822)
	at java.desktop/java.awt.KeyboardFocusManager.redispatchEvent(KeyboardFocusManager.java:1950)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchKeyEvent(DefaultKeyboardFocusManager.java:870)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.preDispatchKeyEvent(DefaultKeyboardFocusManager.java:1139)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.typeAheadAssertions(DefaultKeyboardFocusManager.java:1009)
	at java.desktop/java.awt.DefaultKeyboardFocusManager.dispatchEvent(DefaultKeyboardFocusManager.java:835)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4871)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4822)
	at androidx.compose.ui.awt.FocusTestScope.pressNextFocusKey(ComposeFocusTest.kt:725)
	at androidx.compose.ui.awt.ComposeFocusTest$change focus in empty ComposePanel$1.invokeSuspend(ComposeFocusTest.kt:597)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:316)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:770)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:740)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```