### PR TITLE
Show new window/dialog on the same display

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.window.WindowExceptionHandler
 import org.jetbrains.skiko.GraphicsApi
 import java.awt.Component
 import java.awt.Dialog
+import java.awt.Frame
+import java.awt.GraphicsConfiguration
 import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
@@ -40,8 +42,9 @@ class ComposeDialog : JDialog {
 
     constructor(
         owner: Window?,
-        modalityType: ModalityType = ModalityType.MODELESS
-    ) : super(owner, modalityType)
+        modalityType: ModalityType = ModalityType.MODELESS,
+        graphicsConfiguration: GraphicsConfiguration? = null
+    ) : super(owner, "", modalityType, graphicsConfiguration)
 
     /**
      * ComposeDialog is a dialog for building UI using Compose for Desktop.
@@ -55,8 +58,9 @@ class ComposeDialog : JDialog {
     constructor(
         owner: Window?,
         modalityType: ModalityType = ModalityType.MODELESS,
+        graphicsConfiguration: GraphicsConfiguration? = null,
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
-    ) : super(owner, modalityType) {
+    ) : super(owner, "", modalityType, graphicsConfiguration) {
         this.skiaLayerAnalytics = skiaLayerAnalytics
     }
 
@@ -65,7 +69,11 @@ class ComposeDialog : JDialog {
         modalityType: ModalityType = ModalityType.MODELESS
     ) : super(null, modalityType)
 
-    constructor() : super()
+    // don't replace super() by super(null, ModalityType.MODELESS), because
+    // this constructor creates an icon in the taskbar.
+    // Dialog's shouldn't be appeared in the taskbar.
+    constructor(graphicsConfiguration: GraphicsConfiguration? = null) :
+        super(null as Frame?, "", false, graphicsConfiguration)
 
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -53,7 +53,7 @@ internal fun ComposeWindow.setSizeSafely(size: DpSize) {
  */
 internal fun ComposeWindow.setPositionSafely(
     position: WindowPosition,
-    platformDefaultPosition: Point?
+    platformDefaultPosition: () -> Point?
 ) {
     if (placement == WindowPlacement.Floating) {
         (this as Window).setPositionSafely(position, platformDefaultPosition)
@@ -97,9 +97,9 @@ internal fun Window.setSizeSafely(size: DpSize) {
 
 internal fun Window.setPositionSafely(
     position: WindowPosition,
-    platformDefaultPosition: Point?
+    platformDefaultPosition: () -> Point?
 ) = when (position) {
-    WindowPosition.PlatformDefault -> location = platformDefaultPosition
+    WindowPosition.PlatformDefault -> location = platformDefaultPosition()
     is WindowPosition.Aligned -> align(position.alignment)
     is WindowPosition.Absolute -> setLocation(
         position.x.value.roundToInt(),

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.window.layoutDirection
 import java.awt.Dialog
 import java.awt.Dimension
 import java.awt.Frame
+import java.awt.Point
 import java.awt.Toolkit
 import java.awt.Window
 import kotlin.math.roundToInt
@@ -51,10 +52,11 @@ internal fun ComposeWindow.setSizeSafely(size: DpSize) {
  * Otherwise we will reset maximized / fullscreen state.
  */
 internal fun ComposeWindow.setPositionSafely(
-    position: WindowPosition
+    position: WindowPosition,
+    platformDefaultPosition: Point?
 ) {
     if (placement == WindowPlacement.Floating) {
-        (this as Window).setPositionSafely(position)
+        (this as Window).setPositionSafely(position, platformDefaultPosition)
     }
 }
 
@@ -94,9 +96,10 @@ internal fun Window.setSizeSafely(size: DpSize) {
 }
 
 internal fun Window.setPositionSafely(
-    position: WindowPosition
+    position: WindowPosition,
+    platformDefaultPosition: Point?
 ) = when (position) {
-    WindowPosition.PlatformDefault -> setLocationByPlatformSafely(true)
+    WindowPosition.PlatformDefault -> location = platformDefaultPosition
     is WindowPosition.Aligned -> align(position.alignment)
     is WindowPosition.Absolute -> setLocation(
         position.x.value.roundToInt(),
@@ -108,24 +111,16 @@ internal fun Window.align(alignment: Alignment) {
     val screenInsets = Toolkit.getDefaultToolkit().getScreenInsets(graphicsConfiguration)
     val screenBounds = graphicsConfiguration.bounds
     val size = IntSize(size.width, size.height)
-    val screenSize = IntSize(screenBounds.width, screenBounds.height)
+    val screenSize = IntSize(
+        screenBounds.width - screenInsets.left - screenInsets.right,
+        screenBounds.height - screenInsets.top - screenInsets.bottom
+    )
     val location = alignment.align(size, screenSize, LayoutDirection.Ltr)
 
     setLocation(
-        screenInsets.left + location.x,
-        screenInsets.top + location.y
+        screenBounds.x + screenInsets.left + location.x,
+        screenBounds.y + screenInsets.top + location.y
     )
-}
-
-/**
- * We cannot call [Frame.setLocation] if window is showing - AWT will throw an
- * exception.
- * But we can call [Frame.setLocationByPlatform] if isLocationByPlatform isn't changed.
- */
-internal fun Window.setLocationByPlatformSafely(isLocationByPlatform: Boolean) {
-    if (this.isLocationByPlatform != isLocationByPlatform) {
-        this.isLocationByPlatform = isLocationByPlatform
-    }
 }
 
 /**
@@ -159,10 +154,14 @@ internal fun Window.setIcon(painter: Painter?) {
 
 internal fun Window.makeDisplayable() {
     val oldPreferredSize = preferredSize
+    val oldLocation = location
     preferredSize = size
     try {
         pack()
     } finally {
         preferredSize = oldPreferredSize
+        // pack() messes with location in case of multiple displays with different densities,
+        // so we restore it to the value before pack()
+        location = oldLocation
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -142,10 +142,11 @@ fun Dialog(
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         create = {
+            val graphicsConfiguration = WindowLocationTracker.lastActiveGraphicsConfiguration
             val dialog = if (owner != null) {
-                ComposeDialog(owner, ModalityType.DOCUMENT_MODAL)
+                ComposeDialog(owner, ModalityType.DOCUMENT_MODAL, graphicsConfiguration = graphicsConfiguration)
             } else {
-                ComposeDialog()
+                ComposeDialog(graphicsConfiguration = graphicsConfiguration)
             }
             dialog.apply {
                 // close state is controlled by DialogState.isOpen
@@ -166,9 +167,13 @@ fun Dialog(
                         appliedState.position = currentState.position
                     }
                 })
+                WindowLocationTracker.onWindowCreated(this)
             }
         },
-        dispose = ComposeDialog::dispose,
+        dispose = {
+            WindowLocationTracker.onWindowDisposed(it)
+            it.dispose()
+        },
         update = { dialog ->
             updater.update {
                 set(currentTitle, dialog::setTitle)
@@ -184,7 +189,7 @@ fun Dialog(
                 appliedState.size = state.size
             }
             if (state.position != appliedState.position) {
-                dialog.setPositionSafely(state.position)
+                dialog.setPositionSafely(state.position, WindowLocationTracker.getCascadeLocationFor(dialog))
                 appliedState.position = state.position
             }
         },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -189,7 +189,10 @@ fun Dialog(
                 appliedState.size = state.size
             }
             if (state.position != appliedState.position) {
-                dialog.setPositionSafely(state.position, WindowLocationTracker.getCascadeLocationFor(dialog))
+                dialog.setPositionSafely(
+                    state.position,
+                    platformDefaultPosition = { WindowLocationTracker.getCascadeLocationFor(dialog) }
+                )
                 appliedState.position = state.position
             }
         },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Geometry.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Geometry.desktop.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import java.awt.Dimension
+import java.awt.Point
+import java.awt.Rectangle
+
+internal val Dimension.rightBottom get() = Point(width, height)
+internal operator fun Point.plus(other: Point) = Point(x + other.x, y + other.y)
+internal operator fun Point.minus(other: Point) = Point(x - other.x, y - other.y)
+
+internal val Rectangle.leftTop get() = Point(x, y)
+internal val Rectangle.rightBottom get() = Point(x + width, y + height)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -158,7 +158,8 @@ fun Window(
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         create = {
-            ComposeWindow().apply {
+            val graphicsConfiguration = WindowLocationTracker.lastActiveGraphicsConfiguration
+            ComposeWindow(graphicsConfiguration = graphicsConfiguration).apply {
                 // close state is controlled by WindowState.isOpen
                 defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
                 addWindowListener(object : WindowAdapter() {
@@ -188,9 +189,13 @@ fun Window(
                         appliedState.position = currentState.position
                     }
                 })
+                WindowLocationTracker.onWindowCreated(this)
             }
         },
-        dispose = ComposeWindow::dispose,
+        dispose = {
+            WindowLocationTracker.onWindowDisposed(it)
+            it.dispose()
+        },
         update = { window ->
             updater.update {
                 set(currentTitle, window::setTitle)
@@ -207,7 +212,7 @@ fun Window(
                 appliedState.size = state.size
             }
             if (state.position != appliedState.position) {
-                window.setPositionSafely(state.position)
+                window.setPositionSafely(state.position, WindowLocationTracker.getCascadeLocationFor(window))
                 appliedState.position = state.position
             }
             if (state.placement != appliedState.placement) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -212,7 +212,10 @@ fun Window(
                 appliedState.size = state.size
             }
             if (state.position != appliedState.position) {
-                window.setPositionSafely(state.position, WindowLocationTracker.getCascadeLocationFor(window))
+                window.setPositionSafely(
+                    state.position,
+                    platformDefaultPosition = { WindowLocationTracker.getCascadeLocationFor(window) }
+                )
                 appliedState.position = state.position
             }
             if (state.placement != appliedState.placement) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowLocationTracker.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowLocationTracker.desktop.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import java.awt.GraphicsConfiguration
+import java.awt.GraphicsEnvironment
+import java.awt.Point
+import java.awt.Toolkit
+import java.awt.Window
+import java.awt.event.WindowEvent
+import java.awt.event.WindowFocusListener
+
+/**
+ * Track position of all opened windows and provide an appropriate location for new created windows.
+ *
+ * Needed to place windows in cascade, and on the same screen.
+ *
+ * Singleton because we have only the single platform.
+ * We basically override the standard behaviour of the window manager.
+ */
+internal object WindowLocationTracker {
+    private val cascadeOffset = Point(48, 48)
+
+    private var lastFocusedWindows = mutableSetOf<Window>()
+
+    private val focusListener = object : WindowFocusListener {
+        override fun windowGainedFocus(e: WindowEvent) {
+            // put window on the top of the set
+            lastFocusedWindows.remove(e.window)
+            lastFocusedWindows.add(e.window)
+        }
+
+        override fun windowLostFocus(e: WindowEvent) = Unit
+    }
+
+    fun onWindowCreated(window: Window) {
+        window.addWindowFocusListener(focusListener)
+    }
+
+    fun onWindowDisposed(window: Window) {
+        window.removeWindowFocusListener(focusListener)
+        lastFocusedWindows.remove(window)
+    }
+
+    val lastActiveGraphicsConfiguration: GraphicsConfiguration? get() =
+        lastFocusedWindows.lastOrNull()?.graphicsConfiguration
+
+    fun getCascadeLocationFor(window: Window): Point {
+        val lastWindow = lastFocusedWindows.lastOrNull()
+        val graphicsConfiguration = lastWindow?.graphicsConfiguration ?:
+            GraphicsEnvironment.getLocalGraphicsEnvironment().defaultScreenDevice?.defaultConfiguration
+
+        return if (graphicsConfiguration != null) {
+            val screenBounds = graphicsConfiguration.bounds
+            val screenInsets = Toolkit.getDefaultToolkit().getScreenInsets(graphicsConfiguration)
+            val screenLeftTop = screenBounds.leftTop + Point(screenInsets.left, screenInsets.top)
+            val screenRightBottom = screenBounds.rightBottom - Point(screenInsets.right, screenInsets.bottom)
+
+            val lastLocation = lastWindow?.location ?: screenLeftTop
+            var location = lastLocation + cascadeOffset
+            val rightBottom = location + window.size.rightBottom
+            if (rightBottom.x > screenRightBottom.x || rightBottom.y > screenRightBottom.y) {
+                location = screenLeftTop + cascadeOffset
+            }
+            location
+        } else {
+            cascadeOffset
+        }
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowPosition.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowPosition.desktop.kt
@@ -58,7 +58,8 @@ sealed class WindowPosition {
 
     /**
      * Initial position of the window that depends on the platform.
-     * Usually every new window will be positioned in a cascade mode.
+     * Usually every new window will be positioned in a cascade mode,
+     * on the same display where the previous focused window was.
      *
      * This value should be used only before window will be visible.
      * After window will be visible, it cannot change its position to the PlatformDefault
@@ -73,7 +74,7 @@ sealed class WindowPosition {
     }
 
     /**
-     * Window will be aligned when it will be shown on the screen. [alignment] defines how the
+     * Window will be aligned when it will be shown on the current screen. [alignment] defines how the
      * window will be aligned (in the center, or in some of the corners). Window
      * will be aligned in the area that is not occupied by the screen insets (taskbar, OS menubar)
      */


### PR DESCRIPTION
Tested manually on Windows/macOs/Linux with two displays. Tested the case when we disconnect one display.

The new behaviour of opening windows is different from platform default. Windows/macOS, for example, shows every new window slighly shifted in compare to the previous opened window. We on the other hand shift in compare to the previous focused window, not the opened.

RelNote:
Changed behaviour of the initial position of the new window. Now it shows on the display, where was the latest focused window

Fixes https://github.com/JetBrains/compose-jb/issues/1845