### PR TITLE
Fix tests

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -69,11 +69,13 @@ class ComposeDialog : JDialog {
         modalityType: ModalityType = ModalityType.MODELESS
     ) : super(null, modalityType)
 
+    constructor(graphicsConfiguration: GraphicsConfiguration? = null) :
+        super(null as Frame?, "", false, graphicsConfiguration)
+
     // don't replace super() by super(null, ModalityType.MODELESS), because
     // this constructor creates an icon in the taskbar.
     // Dialog's shouldn't be appeared in the taskbar.
-    constructor(graphicsConfiguration: GraphicsConfiguration? = null) :
-        super(null as Frame?, "", false, graphicsConfiguration)
+    constructor() : super()
 
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestComponents.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestComponents.kt
@@ -56,7 +56,7 @@ class Events {
     fun receivedLast(): PointerEvent {
         require(list.isNotEmpty()) { "The were no events" }
         val event = list.removeFirst()
-        require(list.isEmpty()) { "The event $event isn't the last" }
+        require(list.isEmpty()) { "The event $event isn't the last.\nAlso received:\n${list.joinToString("\n")}" }
         return event
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -66,7 +66,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton1, composeButton2, composeButton3, composeButton4
+            composeButton1, composeButton2, composeButton3, composeButton4
         )
     }
 
@@ -93,7 +93,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton1, composeButton2, composeButton3, composeButton4
+            composeButton1, composeButton2, composeButton3, composeButton4
         )
     }
 
@@ -123,7 +123,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, outerButton1, outerButton2, composeButton1, composeButton2, composeButton3, composeButton4
+            outerButton1, outerButton2, composeButton1, composeButton2, composeButton3, composeButton4
         )
     }
 
@@ -152,7 +152,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton1, composeButton2, composeButton3, composeButton4, outerButton3, outerButton4
+            composeButton1, composeButton2, composeButton3, composeButton4, outerButton3, outerButton4
         )
     }
 
@@ -185,7 +185,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, innerButton1, composeButton4,
+            composeButton3, innerButton1, composeButton4,
         )
     }
 
@@ -214,7 +214,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, innerButton1, composeButton4
+            composeButton3, innerButton1, composeButton4
         )
     }
 
@@ -252,8 +252,8 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, outerButton1, outerButton2, composeButton1, composeButton2,
-            innerButton1, innerButton2, innerButton3
+            outerButton1, outerButton2, composeButton1, composeButton2, innerButton1,
+            innerButton2, innerButton3
         )
     }
 
@@ -290,8 +290,8 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window,
-            innerButton1, innerButton2, innerButton3, composeButton3, composeButton4, outerButton3, outerButton4
+            innerButton1,
+            innerButton2, innerButton3, composeButton3, composeButton4, outerButton3, outerButton4
         )
     }
 
@@ -323,7 +323,7 @@ class ComposeFocusTest {
         window.pack()
         window.isVisible = true
 
-        testRandomFocus(window, innerButton1, innerButton2, innerButton3)
+        testRandomFocus(innerButton1, innerButton2, innerButton3)
     }
 
     @Test
@@ -344,7 +344,7 @@ class ComposeFocusTest {
         window.pack()
         window.isVisible = true
 
-        testRandomFocus(window, outerButton1, outerButton2, outerButton3, outerButton4)
+        testRandomFocus(outerButton1, outerButton2, outerButton3, outerButton4)
     }
 
     @Test
@@ -370,7 +370,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, composeButton4
+            composeButton3, composeButton4
         )
     }
 
@@ -407,7 +407,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, composeButton4
+            composeButton3, composeButton4
         )
     }
 
@@ -444,7 +444,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, innerButton1, composeButton4
+            composeButton3, innerButton1, composeButton4
         )
     }
 
@@ -481,7 +481,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, composeButton4
+            composeButton3, composeButton4
         )
     }
 
@@ -518,7 +518,7 @@ class ComposeFocusTest {
         window.isVisible = true
 
         testRandomFocus(
-            window, composeButton3, composeButton4
+            composeButton3, composeButton4
         )
     }
 
@@ -607,7 +607,7 @@ class ComposeFocusTest {
     private val composeButton5 = ComposeButton("composeButton5")
     private val composeButton6 = ComposeButton("composeButton6")
 
-    private suspend fun FocusTestScope.testRandomFocus(window: Window, vararg buttons: Any) {
+    private suspend fun FocusTestScope.testRandomFocus(vararg buttons: Any) {
         fun Any.validateIsFocused() {
             assertThat(
                 buttons.filter { it.isFocused() }


### PR DESCRIPTION
1.
Fix
e: D:\Development\Work\compose-jb\compose\frameworks\support\compose\ui\ui\src\desktopTest\kotlin\androidx\compose\ui\window\dialog\DialogTest.kt: (66, 34): Overload resolution ambiguity:
public constructor ComposeDialog(modalityType: Dialog.ModalityType = ...) defined in androidx.compose.ui.awt.ComposeDialog
public constructor ComposeDialog(graphicsConfiguration: GraphicsConfiguration? = ...) defined in androidx.compose.ui.awt.ComposeDialog

2.
ComposeSceneInputTest.pressed popup should own received moves outside popup
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_PublishFast_1ComposeDesktopTest/3963714?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildTestsSection=true

fails because ImageComposeScene is flaky in some cases, if not run in the UI thread

3.
ComposeSceneTest.rendering of clickable
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_PublishFast_1ComposeDesktopTest/3963714?buildTab=overview&hideProblemsFromDependencies=false&expandBuildTestsSection=true&hideTestsFromDependencies=false
remove hoverability from the test. now we animate only press/release