### PR TITLE
Fix ComposeDialog(skiaLayerAnalytics = ...)

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -38,13 +38,18 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * ComposeDialog inherits javax.swing.JDialog.
  */
 class ComposeDialog : JDialog {
-    private var skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
+    private val skiaLayerAnalytics: SkiaLayerAnalytics
+    private val delegate: ComposeWindowDelegate
 
     constructor(
         owner: Window?,
         modalityType: ModalityType = ModalityType.MODELESS,
         graphicsConfiguration: GraphicsConfiguration? = null
-    ) : super(owner, "", modalityType, graphicsConfiguration)
+    ) : super(owner, "", modalityType, graphicsConfiguration) {
+        skiaLayerAnalytics = SkiaLayerAnalytics.Empty
+        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        contentPane.add(delegate.pane)
+    }
 
     /**
      * ComposeDialog is a dialog for building UI using Compose for Desktop.
@@ -62,6 +67,8 @@ class ComposeDialog : JDialog {
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
     ) : super(owner, "", modalityType, graphicsConfiguration) {
         this.skiaLayerAnalytics = skiaLayerAnalytics
+        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        contentPane.add(delegate.pane)
     }
 
     /**
@@ -77,24 +84,32 @@ class ComposeDialog : JDialog {
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
     ) : super() {
         this.skiaLayerAnalytics = skiaLayerAnalytics
+        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        contentPane.add(delegate.pane)
     }
 
-    @Deprecated("Use the constructor with setting owner explicitly. Will be remove in 1.3")
+    @Deprecated("Use the constructor with setting owner explicitly. Will be removed in 1.3")
     constructor(
         modalityType: ModalityType = ModalityType.MODELESS
-    ) : super(null, modalityType)
+    ) : super(null, modalityType) {
+        skiaLayerAnalytics = SkiaLayerAnalytics.Empty
+        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        contentPane.add(delegate.pane)
+    }
 
     constructor(graphicsConfiguration: GraphicsConfiguration? = null) :
-        super(null as Frame?, "", false, graphicsConfiguration)
+        super(null as Frame?, "", false, graphicsConfiguration) {
+        skiaLayerAnalytics = SkiaLayerAnalytics.Empty
+        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        contentPane.add(delegate.pane)
+    }
 
     // don't replace super() by super(null, ModalityType.MODELESS), because
     // this constructor creates an icon in the taskbar.
     // Dialog's shouldn't be appeared in the taskbar.
-    constructor() : super()
-
-    private val delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
-
-    init {
+    constructor() : super() {
+        skiaLayerAnalytics = SkiaLayerAnalytics.Empty
+        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
         contentPane.add(delegate.pane)
     }
 
@@ -122,14 +137,22 @@ class ComposeDialog : JDialog {
      * further up the call stack.
      */
     @ExperimentalComposeUiApi
-    var exceptionHandler: WindowExceptionHandler? by delegate::exceptionHandler
+    var exceptionHandler: WindowExceptionHandler?
+        get() = delegate.exceptionHandler
+        set(value) {
+            delegate.exceptionHandler = value
+        }
 
     /**
      * Top-level composition locals, which will be provided for the Composable content, which is set by [setContent].
      *
      * `null` if no composition locals should be provided.
      */
-    var compositionLocalContext: CompositionLocalContext? by delegate::compositionLocalContext
+    var compositionLocalContext: CompositionLocalContext?
+        get() = delegate.compositionLocalContext
+        set(value) {
+            delegate.compositionLocalContext = value
+        }
 
     /**
      * Composes the given composable into the ComposeDialog.
@@ -181,7 +204,11 @@ class ComposeDialog : JDialog {
      * Transparency should be set only if window is not showing and `isUndecorated` is set to
      * `true`, otherwise AWT will throw an exception.
      */
-    var isTransparent: Boolean by delegate::isTransparent
+    var isTransparent: Boolean
+        get() = delegate.isTransparent
+        set(value) {
+            delegate.isTransparent = value
+        }
 
     /**
      * Registers a task to run when the rendering API changes.

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import java.awt.AWTEvent
 import java.awt.Component
+import java.awt.Container
 import java.awt.EventQueue
 import java.awt.Image
 import java.awt.Toolkit
@@ -87,7 +88,7 @@ fun Window.sendKeyEvent(
     return event.isConsumed
 }
 
-fun JFrame.sendMouseEvent(
+fun Container.sendMouseEvent(
     id: Int,
     x: Int,
     y: Int,
@@ -110,7 +111,7 @@ fun JFrame.sendMouseEvent(
     return event.isConsumed
 }
 
-fun JFrame.sendMouseWheelEvent(
+fun Container.sendMouseWheelEvent(
     x: Int,
     y: Int,
     scrollType: Int = MouseWheelEvent.WHEEL_UNIT_SCROLL,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeDialogTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeDialogTest.kt
@@ -52,12 +52,14 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.junit.Assume
 import org.junit.Test
 
+// A copy of ComposeWindowTest adapted for ComposeDialog. Don't change it, if it isn't specific for ComposeDialog.
+// A copy because it is better to keep tests less abstract, and we can't properly abstract away from JFrame/JDialog.
 @OptIn(ExperimentalComposeUiApi::class)
-class ComposeWindowTest {
+class ComposeDialogTest {
     @Test
     fun `catch exception on setContent`() = runApplicationTest {
         val caughtExceptions = mutableListOf<Throwable>()
-        val window = ComposeWindow()
+        val window = ComposeDialog()
         try {
             window.isUndecorated = true
             window.size = Dimension(200, 200)
@@ -81,7 +83,7 @@ class ComposeWindowTest {
     @Test
     fun `catch exception on render`() = runApplicationTest {
         val caughtExceptions = mutableListOf<Throwable>()
-        val window = ComposeWindow()
+        val window = ComposeDialog()
         try {
             window.isUndecorated = true
             window.size = Dimension(200, 200)
@@ -108,7 +110,7 @@ class ComposeWindowTest {
     @Test
     fun `catch exception on event`() = runApplicationTest {
         val caughtExceptions = mutableListOf<Throwable>()
-        val window = ComposeWindow()
+        val window = ComposeDialog()
         try {
             window.isUndecorated = true
             window.size = Dimension(200, 200)
@@ -145,7 +147,7 @@ class ComposeWindowTest {
         Assume.assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
 
         runBlocking(MainUIDispatcher) {
-            val window = ComposeWindow()
+            val window = ComposeDialog()
             try {
                 window.preferredSize = Dimension(234, 345)
                 window.isUndecorated = true
@@ -163,7 +165,7 @@ class ComposeWindowTest {
         Assume.assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
 
         runBlocking(MainUIDispatcher) {
-            val window = ComposeWindow()
+            val window = ComposeDialog()
             try {
                 window.setContent {
                     Box(Modifier.requiredSize(300.dp, 400.dp))
@@ -190,7 +192,7 @@ class ComposeWindowTest {
         val layoutPassConstraints = mutableListOf<Constraints>()
 
         runBlocking(MainUIDispatcher) {
-            val window = ComposeWindow()
+            val window = ComposeDialog()
             try {
                 window.size = Dimension(300, 400)
                 window.setContent {
@@ -220,7 +222,7 @@ class ComposeWindowTest {
     // bug https://github.com/JetBrains/compose-jb/issues/1448
     @Test
     fun `dispose window in event handler`() = runApplicationTest {
-        val window = ComposeWindow()
+        val window = ComposeDialog()
         try {
             var isClickHappened = false
             window.size = Dimension(300, 400)
@@ -259,7 +261,7 @@ class ComposeWindowTest {
                 return super.renderer(skikoVersion, os, api)
             }
         }
-        val window = ComposeWindow(graphicsConfiguration = null, skiaLayerAnalytics = analytics)
+        val window = ComposeDialog(skiaLayerAnalytics = analytics)
         try {
             window.size = Dimension(100, 100)
             window.isVisible = true


### PR DESCRIPTION
It seems didn't work, because of this order of initialization:

```
private var skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
private val delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)

constructor(skiaLayerAnalytics: SkiaLayerAnalytics) : super() {
    this.skiaLayerAnalytics = skiaLayerAnalytics
}
```