### PR TITLE
Disable Compiler version check

### DIFF
--- a/buildSrc/public/src/main/kotlin/androidx/build/Version.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/Version.kt
@@ -75,7 +75,7 @@ data class Version(
         private const val serialVersionUID = 345435634563L
 
         private val VERSION_FILE_REGEX = Pattern.compile("^(res-)?(.*).txt$")
-        private val VERSION_REGEX = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)(-.+)?$")
+        private val VERSION_REGEX = Pattern.compile("^(\\d+)\\.(\\d+)\\.(\\d+)((?:\\.\\d+)?(?:-.+)?)?$")
 
         private fun checkedMatcher(versionString: String): Matcher {
             val matcher = VERSION_REGEX.matcher(versionString)


### PR DESCRIPTION
Changes from commit 6f363f5392df5c0cac509f7dc83884f45cbed5be

Needed for our CI when we publish to Maven:
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_UploadToMavenCentralManual/3992373?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&expandBuildChangesSection=true