### PR TITLE
Change code about replacing Compose maven group and version

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXExtension.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXExtension.kt
@@ -39,16 +39,16 @@ open class AndroidXExtension(val project: Project) {
             File(project.getSupportRootFolder(), "libraryversions.toml")
         )
         val content = project.providers.fileContents(toml)
+        // it was removed in AOSP. When there will be a conflict on rebase, keep this
         val composeCustomVersion = project.providers.environmentVariable("COMPOSE_CUSTOM_VERSION")
-        val composeCustomGroup = project.providers.provider { "org.jetbrains.compose" }
 
         val serviceProvider = project.gradle.sharedServices.registerIfAbsent(
             "libraryVersionsService",
             LibraryVersionsService::class.java
         ) { spec ->
             spec.parameters.tomlFile = content.asText
+            // it was removed in AOSP. When there will be a conflict on rebase, keep this
             spec.parameters.composeCustomVersion = composeCustomVersion
-            spec.parameters.composeCustomGroup = composeCustomGroup
         }
         LibraryGroups = serviceProvider.get().libraryGroups
         LibraryVersions = serviceProvider.get().libraryVersions

--- a/buildSrc/private/src/main/kotlin/androidx/build/LibraryVersionsService.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/LibraryVersionsService.kt
@@ -29,8 +29,8 @@ import org.tomlj.TomlParseResult
 abstract class LibraryVersionsService : BuildService<LibraryVersionsService.Parameters> {
     interface Parameters : BuildServiceParameters {
         var tomlFile: Provider<String>
+        // it was removed in AOSP. When there will be a conflict on rebase, keep this property
         var composeCustomVersion: Provider<String>
-        var composeCustomGroup: Provider<String>
     }
 
     private val parsedTomlFile: TomlParseResult by lazy {
@@ -41,6 +41,7 @@ abstract class LibraryVersionsService : BuildService<LibraryVersionsService.Para
         val versions = parsedTomlFile.getTable("versions")
             ?: throw GradleException("Library versions toml file is missing [versions] table")
         versions.keySet().associateWith { versionName ->
+            // it was removed in AOSP. When there will be a conflict on rebase, keep this property
             val versionValue =
                 if (versionName.startsWith("COMPOSE") &&
                     parameters.composeCustomVersion.isPresent
@@ -62,11 +63,7 @@ abstract class LibraryVersionsService : BuildService<LibraryVersionsService.Para
         groups.keySet().associateWith { name ->
             val groupDefinition = groups.getTable(name)!!
             val groupName = groupDefinition.getString("group")!!
-            val finalGroupName = if (name.startsWith("COMPOSE") &&
-                parameters.composeCustomGroup.isPresent
-            ) {
-                groupName.replace("androidx.compose", parameters.composeCustomGroup.get())
-            } else groupName
+            val finalGroupName = groupName
 
             if (groupDefinition.contains(AtomicGroupVersion)) {
                 val atomicGroupVersionReference = groupDefinition.getString(AtomicGroupVersion)!!

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -160,14 +160,14 @@ CAMERA = { group = "androidx.camera", atomicGroupVersion = "versions.CAMERA" }
 CARDVIEW = { group = "androidx.cardview", atomicGroupVersion = "versions.CARDVIEW" }
 CAR_APP = { group = "androidx.car.app", atomicGroupVersion = "versions.CAR_APP" }
 COLLECTION = { group = "androidx.collection", atomicGroupVersion = "versions.COLLECTION" }
-COMPOSE_ANIMATION = { group = "androidx.compose.animation", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_COMPILER = { group = "androidx.compose.compiler", atomicGroupVersion = "versions.COMPOSE_COMPILER" }
-COMPOSE_DESKTOP = { group = "androidx.compose.desktop", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_FOUNDATION = { group = "androidx.compose.foundation", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_MATERIAL = { group = "androidx.compose.material", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_MATERIAL3 = { group = "androidx.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3" }
-COMPOSE_RUNTIME = { group = "androidx.compose.runtime", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_UI = { group = "androidx.compose.ui", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_ANIMATION = { group = "org.jetbrains.compose.animation", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_COMPILER = { group = "org.jetbrains.compose.compiler", atomicGroupVersion = "versions.COMPOSE_COMPILER" }
+COMPOSE_DESKTOP = { group = "org.jetbrains.compose.desktop", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_FOUNDATION = { group = "org.jetbrains.compose.foundation", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_MATERIAL = { group = "org.jetbrains.compose.material", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3" }
+COMPOSE_RUNTIME = { group = "org.jetbrains.compose.runtime", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_UI = { group = "org.jetbrains.compose.ui", atomicGroupVersion = "versions.COMPOSE" }
 CONCURRENT = { group = "androidx.concurrent", atomicGroupVersion = "versions.FUTURES" }
 CONSTRAINTLAYOUT = { group = "androidx.constraintlayout" }
 CONTENTPAGER = { group = "androidx.contentpager", atomicGroupVersion = "versions.CONTENTPAGER" }


### PR DESCRIPTION
This feature will be removed in https://android-review.googlesource.com/c/platform/frameworks/support/+/2313518

Because now we have our own fork, and we can configure our build as we want, there is no point to keep JetBrains-specific build logic in AOSP, if it is only a extension of AOSP build logic, or small change of it.

But in the future, if it is huge rewrite of the build logic, or there are some obstacles, we can discuss with AOSP build team what can be improved in AOSP code.