### PR TITLE
Make ImageComposeScene skikoMain-common to use it in skikoTests

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -86,19 +86,11 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         desktop()
         darwin()
         js()
+
+        configureDarwinFlags()
     }
 
     kotlin {
-        // linker-option need to run tests on macOS
-        macosX64 {
-            binaries.findTest(NativeBuildType.DEBUG).freeCompilerArgs +=
-                    ["-linker-option", "-framework", "-linker-option", "Metal"]
-        }
-        macosArm64 {
-            binaries.findTest(NativeBuildType.DEBUG).freeCompilerArgs +=
-                    ["-linker-option", "-framework", "-linker-option", "Metal"]
-        }
-
         /*
          * When updating dependencies, make sure to make the an an analogous update in the
          * corresponding block above

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -171,6 +171,13 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             skikoTest {
                 dependsOn(commonTest)
+                dependencies {
+                    implementation(project(":compose:ui:ui-test-junit4"))
+                    implementation(libs.skikoCommon)
+                }
+            }
+            jsNativeTest {
+                dependsOn(skikoTest)
             }
 
             desktopTest {
@@ -186,8 +193,8 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 }
             }
 
-            nativeTest.dependsOn(skikoTest)
-            jsTest.dependsOn(skikoTest)
+            nativeTest.dependsOn(jsNativeTest)
+            jsTest.dependsOn(jsNativeTest)
         }
     }
     dependencies {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/Assert.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/Assert.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import kotlin.test.assertEquals
+
+internal class AssertThat<T>(val t: T)
+
+internal fun <T> AssertThat<T>.isEqualTo(a: Any?) {
+    assertEquals(a, t)
+}
+
+internal fun <T> assertThat(t: T): AssertThat<T> {
+    return AssertThat(t)
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/OnClickTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/OnClickTest.kt
@@ -159,7 +159,7 @@ class OnClickTest {
         scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), button = button)
         scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), button = button)
 
-        waitUntil(500) { clicksCount == 1 }
+        waitUntil(viewConfiguration!!.doubleTapTimeoutMillis * 2) { clicksCount == 1 }
         assertThat(clicksCount).isEqualTo(1)
         assertThat(doubleClickCount).isEqualTo(0)
 
@@ -172,7 +172,7 @@ class OnClickTest {
         )
         scene.sendPointerEvent(PointerEventType.Release, Offset(5f, 5f), button = button)
 
-        waitUntil(500) { doubleClickCount == 1 }
+        waitUntil(viewConfiguration!!.doubleTapTimeoutMillis / 2) { doubleClickCount == 1 }
         assertThat(clicksCount).isEqualTo(1)
         assertThat(doubleClickCount).isEqualTo(1)
     }
@@ -202,8 +202,10 @@ class OnClickTest {
     ) = runSkikoComposeUiTest {
         var clicksCount = 0
         var longClickCount = 0
+        var viewConfiguration: ViewConfiguration? = null
 
         setContent {
+            viewConfiguration = LocalViewConfiguration.current
             Box(
                 modifier = Modifier
                     .onClick(
@@ -219,14 +221,14 @@ class OnClickTest {
         scene.sendPointerEvent(PointerEventType.Press, Offset(0f, 0f), button = button)
         scene.sendPointerEvent(PointerEventType.Release, Offset(0f, 0f), button = button)
 
-        waitUntil(500) { clicksCount == 1 }
+        waitUntil(viewConfiguration!!.longPressTimeoutMillis) { clicksCount == 1 }
         assertThat(clicksCount).isEqualTo(1)
         assertThat(longClickCount).isEqualTo(0)
 
         scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
         scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f), button = button)
 
-        waitUntil(1000) { longClickCount == 1 }
+        waitUntil(viewConfiguration!!.longPressTimeoutMillis * 2) { longClickCount == 1 }
         assertThat(clicksCount).isEqualTo(1)
         assertThat(longClickCount).isEqualTo(1)
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/DragGestureTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/DragGestureTest.kt
@@ -33,19 +33,22 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.use
 import kotlin.math.ceil
+import kotlin.test.Ignore
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
-import org.junit.Ignore
-import org.junit.Test
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalFoundationApi::class)
 class DragGestureTest {
 
     @Test
-    fun `draggable by mouse primary button`() {
+    fun draggable_by_mouse_primary_button() {
         val density = Density(1f)
         val viewConfiguration = DefaultViewConfiguration(density)
 
@@ -126,7 +129,7 @@ class DragGestureTest {
     }
 
     @Test
-    fun `draggable by mouse secondary button, ignores primary button`() {
+    fun draggable_by_mouse_secondary_button_ignores_primary_button() {
         val density = Density(1f)
         val viewConfiguration = DefaultViewConfiguration(density)
 
@@ -178,7 +181,7 @@ class DragGestureTest {
     }
 
     @Test
-    fun `draggable by touch`() {
+    fun draggable_by_touch() {
         val density = Density(1f)
         val viewConfiguration = DefaultViewConfiguration(density)
 
@@ -265,7 +268,7 @@ class DragGestureTest {
     }
 
     @Test
-    fun `draggable by touch, ignores mouse`() {
+    fun draggable_by_touch_ignores_mouse() {
         val density = Density(1f)
         val viewConfiguration = DefaultViewConfiguration(density)
 
@@ -320,9 +323,10 @@ class DragGestureTest {
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     @Ignore // remove Ignore if needed later when startDragOnLongPress mode supported
-    fun `draggable by mouse OnLongPress primary button`() = runBlocking {
+    fun draggable_by_mouse_OnLongPress_primary_button() = runTest(UnconfinedTestDispatcher()) {
         val density = Density(1f)
         val viewConfiguration = DefaultViewConfiguration(density)
 

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -48,6 +48,11 @@ actual fun runComposeUiTest(block: ComposeUiTest.() -> Unit) {
 }
 
 @ExperimentalTestApi
+fun runSkikoComposeUiTest(block: SkikoComposeUiTest.() -> Unit) {
+    SkikoComposeUiTest().runTest(block)
+}
+
+@ExperimentalTestApi
 @OptIn(ExperimentalCoroutinesApi::class, InternalTestApi::class)
 class SkikoComposeUiTest(
     width: Int = 1024,

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -174,6 +174,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             skikoMain {
                 dependsOn(commonMain)
                 dependencies {
+                    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
                     api(project(":compose:ui:ui-graphics"))
                     api(project(":compose:ui:ui-text"))
                     api(libs.skikoCommon)
@@ -240,6 +241,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             skikoTest.dependencies {
                 implementation(libs.kotlinTest)
+                implementation(libs.kotlinCoroutinesTest)
                 implementation(project(":compose:material:material"))
                 implementation(project(":compose:foundation:foundation"))
             }

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -174,7 +174,6 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             skikoMain {
                 dependsOn(commonMain)
                 dependencies {
-                    implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
                     api(project(":compose:ui:ui-graphics"))
                     api(project(":compose:ui:ui-text"))
                     api(libs.skikoCommon)

--- a/compose/ui/ui/src/darwinMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.native.kt
+++ b/compose/ui/ui/src/darwinMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.native.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.launch
-import org.jetbrains.skiko.SkikoDispatchers
+import kotlinx.coroutines.Dispatchers
 
 /**
  * Platform-specific mechanism for starting a monitor of global snapshot state writes
@@ -43,7 +43,7 @@ internal actual object GlobalSnapshotManager {
     actual fun ensureStarted() {
         if (started.compareAndSet(0, 1)) {
             val channel = Channel<Unit>(Channel.CONFLATED)
-            CoroutineScope(SkikoDispatchers.Main).launch {
+            CoroutineScope(Dispatchers.Default).launch {
                 channel.consumeEach {
                     Snapshot.sendApplyNotifications()
                 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -108,17 +108,13 @@ class ImageComposeScene(
     height: Int,
     density: Density = Density(1f),
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
-    effectDispatcher: CoroutineDispatcher? = null,
-    recomposeDispatcher: CoroutineDispatcher? = null,
     content: @Composable () -> Unit = {},
 ) {
     private val surface = Surface.makeRasterN32Premul(width, height)
 
     private val scene = ComposeScene(
         density = density,
-        coroutineContext = coroutineContext,
-        customEffectDispatcher = effectDispatcher,
-        customRecomposeDispatcher = recomposeDispatcher
+        coroutineContext = coroutineContext
     ).apply {
         constraints = Constraints(maxWidth = surface.width, maxHeight = surface.height)
         setContent(content = content)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -39,10 +39,10 @@ import kotlin.time.DurationUnit.NANOSECONDS
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.datetime.Clock
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.Surface
+import org.jetbrains.skiko.currentNanoTime
 
 /**
  * Render Compose [content] into an [Image]
@@ -213,7 +213,7 @@ class ImageComposeScene(
         eventType: PointerEventType,
         position: Offset,
         scrollDelta: Offset = Offset(0f, 0f),
-        timeMillis: Long = Clock.System.now().toEpochMilliseconds(),
+        timeMillis: Long = currentNanoTime() / 1_000_000L,
         type: PointerType = PointerType.Mouse,
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,13 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.DurationUnit.NANOSECONDS
 import kotlin.time.ExperimentalTime
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.datetime.Clock
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.Surface
@@ -107,13 +108,17 @@ class ImageComposeScene(
     height: Int,
     density: Density = Density(1f),
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+    effectDispatcher: CoroutineDispatcher? = null,
+    recomposeDispatcher: CoroutineDispatcher? = null,
     content: @Composable () -> Unit = {},
 ) {
     private val surface = Surface.makeRasterN32Premul(width, height)
 
     private val scene = ComposeScene(
         density = density,
-        coroutineContext = coroutineContext
+        coroutineContext = coroutineContext,
+        customEffectDispatcher = effectDispatcher,
+        customRecomposeDispatcher = recomposeDispatcher
     ).apply {
         constraints = Constraints(maxWidth = surface.width, maxHeight = surface.height)
         setContent(content = content)
@@ -208,7 +213,7 @@ class ImageComposeScene(
         eventType: PointerEventType,
         position: Offset,
         scrollDelta: Offset = Offset(0f, 0f),
-        timeMillis: Long = System.nanoTime() / 1_000_000L,
+        timeMillis: Long = Clock.System.now().toEpochMilliseconds(),
         type: PointerType = PointerType.Mouse,
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,


### PR DESCRIPTION
- new experimental public `fun runSkikoComposeUiTest(block: SkikoComposeUiTest.() -> Unit)`
- GlobalSnapshotManager on native uses Disptachers.Default instead of SkikoMainUiDispatcher
- adjusted the tests