### PR TITLE
[UIKit, TextField] Fix index out of bounds

### DIFF
--- a/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/input/GapBuffer.jsNativeMain.kt
+++ b/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/input/GapBuffer.jsNativeMain.kt
@@ -22,7 +22,7 @@ internal actual fun String.toCharArray(
     startIndex: Int,
     endIndex: Int
 ) {
-    (startIndex..endIndex).forEach {
+    (startIndex until endIndex).forEach {
         destination[destinationOffset + it] = get(it)
     }
 }


### PR DESCRIPTION
Little mistake in UIKit
actual fun String.toCharArray(..)

**The last index should be excluded**