### PR TITLE
Fix text input popup position

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.kt
@@ -173,6 +173,8 @@ internal class TextFieldDelegate {
             }
             val globalLT = layoutCoordinates.localToRoot(Offset(bbox.left, bbox.top))
 
+            // TODO remove `Deprecated`, if it is removed in AOSP repository
+            @Suppress("DEPRECATION")
             textInputSession.notifyFocusedRect(
                 Rect(Offset(globalLT.x, globalLT.y), Size(bbox.width, bbox.height))
             )

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.kt
@@ -17,8 +17,11 @@
 package androidx.compose.foundation.text
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.Paragraph
 import androidx.compose.ui.text.SpanStyle
@@ -124,6 +127,55 @@ internal class TextFieldDelegate {
                 }
             }
             TextPainter.paint(canvas, textLayoutResult)
+        }
+
+        /**
+         * Notify system that focused input area.
+         *
+         * System is typically scrolled up not to be covered by keyboard.
+         *
+         * @param value The editor model
+         * @param textDelegate The text delegate
+         * @param layoutCoordinates The layout coordinates
+         * @param textInputSession The current input session.
+         * @param hasFocus True if focus is gained.
+         * @param offsetMapping The mapper from/to editing buffer to/from visible text.
+         */
+        @JvmStatic
+        internal fun notifyFocusedRect(
+            value: TextFieldValue,
+            textDelegate: TextDelegate,
+            textLayoutResult: TextLayoutResult,
+            layoutCoordinates: LayoutCoordinates,
+            textInputSession: TextInputSession,
+            hasFocus: Boolean,
+            offsetMapping: OffsetMapping
+        ) {
+            if (!hasFocus) {
+                return
+            }
+            val focusOffsetInTransformed = offsetMapping.originalToTransformed(value.selection.max)
+            val bbox = when {
+                focusOffsetInTransformed < textLayoutResult.layoutInput.text.length -> {
+                    textLayoutResult.getBoundingBox(focusOffsetInTransformed)
+                }
+                focusOffsetInTransformed != 0 -> {
+                    textLayoutResult.getBoundingBox(focusOffsetInTransformed - 1)
+                }
+                else -> { // empty text.
+                    val defaultSize = computeSizeForDefaultText(
+                        textDelegate.style,
+                        textDelegate.density,
+                        textDelegate.fontFamilyResolver
+                    )
+                    Rect(0f, 0f, 1.0f, defaultSize.height.toFloat())
+                }
+            }
+            val globalLT = layoutCoordinates.localToRoot(Offset(bbox.left, bbox.top))
+
+            textInputSession.notifyFocusedRect(
+                Rect(Offset(globalLT.x, globalLT.y), Size(bbox.width, bbox.height))
+            )
         }
 
         /**

--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/TextInputService.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/TextInputService.kt
@@ -157,8 +157,18 @@ class TextInputSession(
         }
     }
 
-    @Suppress("DeprecatedCallableAddReplaceWith", "DEPRECATION")
-    @Deprecated("This method should not be called, used BringIntoViewRequester instead.")
+    /**
+     * Notify the focused rectangle to the system.
+     *
+     * The system can ignore this information or use it to show additional functionality near this rectangle.
+     *
+     * For example, desktop systems show a popup near the focused input area (for some languages).
+     *
+     * If the session is not open, no action will be performed.
+     *
+     * @param rect the rectangle that describes the boundaries on the screen that requires focus
+     * @return false if this session expired and no action was performed
+     */
     fun notifyFocusedRect(rect: Rect): Boolean = ensureOpenSession {
         platformTextInputService.notifyFocusedRect(rect)
     }
@@ -265,7 +275,13 @@ interface PlatformTextInputService {
      */
     fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue)
 
-    @Deprecated("This method should not be called, used BringIntoViewRequester instead.")
+    /**
+     * Notify the focused rectangle to the system.
+     *
+     * The system can ignore this information or use it to show additional functionality near this rectangle.
+     *
+     * For example, desktop systems show a popup near the focused input area (for some languages).
+     */
     fun notifyFocusedRect(rect: Rect) {
     }
 }

--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/TextInputService.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/TextInputService.kt
@@ -169,6 +169,9 @@ class TextInputSession(
      * @param rect the rectangle that describes the boundaries on the screen that requires focus
      * @return false if this session expired and no action was performed
      */
+    // TODO remove `Deprecated`, if it is removed in AOSP repository
+    @Suppress("DEPRECATION")
+    @Deprecated("This method should not be called, used BringIntoViewRequester instead.")
     fun notifyFocusedRect(rect: Rect): Boolean = ensureOpenSession {
         platformTextInputService.notifyFocusedRect(rect)
     }
@@ -282,6 +285,8 @@ interface PlatformTextInputService {
      *
      * For example, desktop systems show a popup near the focused input area (for some languages).
      */
+    // TODO remove `Deprecated`, if it is removed in AOSP repository
+    @Deprecated("This method should not be called, used BringIntoViewRequester instead.")
     fun notifyFocusedRect(rect: Rect) {
     }
 }


### PR DESCRIPTION
CL: https://android-review.googlesource.com/c/platform/frameworks/support/+/2319924
the only difference with the CL is that we still keep this method Deprecated, to avoid confusion in the future, if we fix this issue another way.

If this CL will be merged, during rebase most probably will be conflicts. Just drop this commit then.

Fixes https://github.com/JetBrains/compose-jb/issues/2040
Fixes https://github.com/JetBrains/compose-jb/issues/2493

notifyFocusedRect was deprecated in https://android-review.googlesource.com/c/platform/frameworks/support/+/1959647

On Android, before deprecation this method was used to scroll to the focused text input.
This functionality was extracted to the text field itself, but we had another functionality on the other platforms.
On Desktop we show text input popup near text input (for some languages):
https://github.com/JetBrains/compose-jb/issues/2040#issuecomment-1333429514

I think that this method is the right choice to implement this functionality, but I am not completely sure. Here my thoughts about alternatives:

1. Use BringIntoViewRequester. Not sure that it is possible, because its purpose - to show the view to the user, not use the passed information to determine the text popup position
2. Get information about focused area from another source that is not related to text input. For example, we can inject FocusManager, and retrieve the focused rect from it. Probably not a good idea, because the rect of arbitrary focused node isn't the same thing as the rect of focused input area.

