### PR TITLE
Fix crash when we try to move focus to an empty Swing panel

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -186,9 +186,13 @@ private class FocusSwitcher<T : Component>(
                 .onFocusChanged {
                     if (it.isFocused && !isRequesting) {
                         focusManager.clearFocus(force = true)
-                        info.container.focusTraversalPolicy
-                            .getFirstComponent(info.container)
-                            .requestFocus(FocusEvent.Cause.TRAVERSAL_FORWARD)
+
+                        val component = info.container.focusTraversalPolicy.getFirstComponent(info.container)
+                        if (component != null) {
+                            component.requestFocus(FocusEvent.Cause.TRAVERSAL_FORWARD)
+                        } else {
+                            moveForward()
+                        }
                     }
                 }
                 .focusTarget()
@@ -199,9 +203,13 @@ private class FocusSwitcher<T : Component>(
                 .onFocusChanged {
                     if (it.isFocused && !isRequesting) {
                         focusManager.clearFocus(force = true)
-                        info.container.focusTraversalPolicy
-                            .getLastComponent(info.container)
-                            .requestFocus(FocusEvent.Cause.TRAVERSAL_BACKWARD)
+
+                        val component = info.container.focusTraversalPolicy.getLastComponent(info.container)
+                        if (component != null) {
+                            component.requestFocus(FocusEvent.Cause.TRAVERSAL_BACKWARD)
+                        } else {
+                            moveBackward()
+                        }
                     }
                 }
                 .focusTarget()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -348,6 +348,33 @@ class ComposeFocusTest {
     }
 
     @Test
+    fun `empty swing panel`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            MaterialTheme {
+                Column(Modifier.fillMaxSize()) {
+                    composeButton3.Content()
+                    SwingPanel(
+                        modifier = Modifier.size(100.dp),
+                        factory = {
+                            javax.swing.Box.createVerticalBox()
+                        }
+                    )
+                    composeButton4.Content()
+                }
+            }
+        }
+        window.pack()
+        window.isVisible = true
+
+        testRandomFocus(
+            composeButton3, composeButton4
+        )
+    }
+
+    @Test
     fun `popup inside window`() = runFocusTest {
         val window = ComposeWindow().disposeOnEnd()
         window.preferredSize = Dimension(500, 500)


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/2512