### PR TITLE
Add foundation/shape tests to skikoTests

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/Assert.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/Assert.kt
@@ -24,6 +24,10 @@ internal fun <T> AssertThat<T>.isEqualTo(a: Any?) {
     assertEquals(a, t)
 }
 
+internal fun AssertThat<Boolean>.isTrue() = t
+
+internal fun AssertThat<Boolean>.isFalse() = !t
+
 internal fun <T> assertThat(t: T): AssertThat<T> {
     return AssertThat(t)
 }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/AbsoluteCutCornerShapeTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/AbsoluteCutCornerShapeTest.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.shape
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.isFalse
+import androidx.compose.foundation.isTrue
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AbsoluteCutCornerShapeTest {
+
+    private var layoutDirection: LayoutDirection? = null
+
+    private val testParameters = arrayOf(
+        LayoutDirection.Ltr,
+        LayoutDirection.Rtl
+    )
+
+    private fun runTestWithParameters(test: () -> Unit) {
+        testParameters.forEach {
+            layoutDirection = it
+            test()
+        }
+        layoutDirection = null
+    }
+
+    private val density = Density(2f)
+    private val size = Size(100.0f, 150.0f)
+
+    @Test
+    fun cutCornersUniformCorners() = runTestWithParameters {
+        val cut = AbsoluteCutCornerShape(10.0f)
+
+        val outline = cut.toOutline() as Outline.Generic
+        assertPathsEquals(
+            outline.path,
+            Path().apply {
+                moveTo(0f, 10f)
+                lineTo(10f, 0f)
+                lineTo(90f, 0f)
+                lineTo(100f, 10f)
+                lineTo(100f, 140f)
+                lineTo(90f, 150f)
+                lineTo(10f, 150f)
+                lineTo(0f, 140f)
+                close()
+            }
+        )
+    }
+
+    @Test
+    fun cutCornersDifferentCorners() = runTestWithParameters {
+        val size1 = 12f
+        val size2 = 22f
+        val size3 = 32f
+        val size4 = 42f
+        val cut = AbsoluteCutCornerShape(
+            size1,
+            size2,
+            size3,
+            size4
+        )
+
+        val outline = cut.toOutline() as Outline.Generic
+        assertPathsEquals(
+            outline.path,
+            Path().apply {
+                moveTo(0f, size1)
+                lineTo(size1, 0f)
+                lineTo(size.width - size2, 0f)
+                lineTo(size.width, size2)
+                lineTo(size.width, size.height - size3)
+                lineTo(size.width - size3, size.height)
+                lineTo(size4, size.height)
+                lineTo(0f, size.height - size4)
+                close()
+            }
+        )
+    }
+
+    @Test
+    fun createsRectangleOutlineForZeroSizedCorners() = runTestWithParameters {
+        val rounded = AbsoluteCutCornerShape(
+            0.0f,
+            0.0f,
+            0.0f,
+            0.0f
+        )
+
+        assertThat(rounded.toOutline())
+            .isEqualTo(Outline.Rectangle(size.toRect()))
+    }
+
+    @Test
+    fun cutCornerShapesAreEquals() = runTestWithParameters {
+        assertThat(AbsoluteCutCornerShape(10.0f))
+            .isEqualTo(AbsoluteCutCornerShape(10.0f))
+    }
+
+    @Test
+    fun cutCornerUpdateAllCornerSize() = runTestWithParameters {
+        assertThat(
+            AbsoluteCutCornerShape(10.0f).copy(
+                CornerSize(
+                    5.0f
+                )
+            )
+        )
+            .isEqualTo(AbsoluteCutCornerShape(5.0f))
+    }
+
+    @Test
+    fun cutCornerUpdateTwoCornerSizes() = runTestWithParameters {
+        assertThat(
+            AbsoluteCutCornerShape(10.0f).copy(
+                topEnd = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            )
+        ).isEqualTo(
+            AbsoluteCutCornerShape(
+                topLeft = CornerSize(10.0f),
+                topRight = CornerSize(3.dp),
+                bottomLeft = CornerSize(10.0f),
+                bottomRight = CornerSize(50)
+            )
+        )
+    }
+
+    @Test
+    fun objectsWithTheSameCornersAreEquals() = runTestWithParameters {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            AbsoluteCutCornerShape(
+                topLeft = CornerSize(4.0f),
+                topRight = CornerSize(3.0f),
+                bottomLeft = CornerSize(3.dp),
+                bottomRight = CornerSize(50)
+            ).equals(
+                AbsoluteCutCornerShape(
+                    topLeft = CornerSize(4.0f),
+                    topRight = CornerSize(3.0f),
+                    bottomLeft = CornerSize(3.dp),
+                    bottomRight = CornerSize(50)
+                )
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun objectsWithDifferentCornersAreNotEquals() = runTestWithParameters {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            AbsoluteCutCornerShape(
+                topLeft = CornerSize(4.0f),
+                topRight = CornerSize(3.0f),
+                bottomLeft = CornerSize(3.dp),
+                bottomRight = CornerSize(50)
+            ).equals(
+                AbsoluteCutCornerShape(
+                    topLeft = CornerSize(4.0f),
+                    topRight = CornerSize(5.0f),
+                    bottomLeft = CornerSize(3.dp),
+                    bottomRight = CornerSize(50)
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun copyHasCorrectDefaults() = runTestWithParameters {
+        assertEquals(
+            AbsoluteCutCornerShape(
+                topLeft = 5.dp,
+                topRight = 6.dp,
+                bottomRight = 3.dp,
+                bottomLeft = 4.dp
+            ),
+            AbsoluteCutCornerShape(
+                topLeft = 1.dp,
+                topRight = 2.dp,
+                bottomRight = 3.dp,
+                bottomLeft = 4.dp
+            ).copy(topStart = CornerSize(5.dp), topEnd = CornerSize(6.dp))
+        )
+        assertEquals(
+            AbsoluteCutCornerShape(
+                topLeft = 1.dp,
+                topRight = 2.dp,
+                bottomRight = 5.dp,
+                bottomLeft = 6.dp
+            ),
+            AbsoluteCutCornerShape(
+                topLeft = 1.dp,
+                topRight = 2.dp,
+                bottomRight = 3.dp,
+                bottomLeft = 4.dp
+            ).copy(bottomEnd = CornerSize(5.dp), bottomStart = CornerSize(6.dp))
+        )
+    }
+
+    private fun Shape.toOutline() =
+        createOutline(size, layoutDirection!!, density)
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/AbsoluteRoundedCornerShapeTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/AbsoluteRoundedCornerShapeTest.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.shape
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.isFalse
+import androidx.compose.foundation.isTrue
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AbsoluteRoundedCornerShapeTest {
+
+    private var layoutDirection: LayoutDirection? = null
+
+    private val testParameters = arrayOf(
+        LayoutDirection.Ltr,
+        LayoutDirection.Rtl
+    )
+
+    private fun runTestWithParameters(test: () -> Unit) {
+        testParameters.forEach {
+            layoutDirection = it
+            test()
+        }
+        layoutDirection = null
+    }
+
+    private val density = Density(2f)
+    private val size = Size(100.0f, 150.0f)
+
+    @Test
+    fun roundedUniformCorners() = runTestWithParameters {
+        val rounded = AbsoluteRoundedCornerShape(25)
+
+        val expectedRadius = CornerRadius(25f)
+        val outline = rounded.toOutline() as Outline.Rounded
+        assertThat(outline.roundRect).isEqualTo(
+            RoundRect(size.toRect(), expectedRadius)
+        )
+    }
+
+    @Test
+    fun roundedDifferentRadius() = runTestWithParameters {
+        val radius1 = 12f
+        val radius2 = 22f
+        val radius3 = 32f
+        val radius4 = 42f
+        val rounded = AbsoluteRoundedCornerShape(
+            radius1,
+            radius2,
+            radius3,
+            radius4
+        )
+
+        val outline = rounded.toOutline() as Outline.Rounded
+        assertThat(outline.roundRect).isEqualTo(
+            RoundRect(
+                size.toRect(),
+                CornerRadius(radius1),
+                CornerRadius(radius2),
+                CornerRadius(radius3),
+                CornerRadius(radius4)
+            )
+        )
+    }
+
+    @Test
+    fun createsRectangleOutlineForZeroSizedCorners() = runTestWithParameters {
+        val rounded = AbsoluteRoundedCornerShape(
+            0.0f,
+            0.0f,
+            0.0f,
+            0.0f
+        )
+
+        assertThat(rounded.toOutline())
+            .isEqualTo(Outline.Rectangle(size.toRect()))
+    }
+
+    @Test
+    fun roundedCornerShapesAreEquals() {
+        assertThat(AbsoluteRoundedCornerShape(12.dp))
+            .isEqualTo(AbsoluteRoundedCornerShape(12.dp))
+    }
+
+    @Test
+    fun roundedCornerUpdateAllCornerSize() {
+        assertThat(
+            AbsoluteRoundedCornerShape(10.0f).copy(
+                CornerSize(
+                    5.dp
+                )
+            )
+        )
+            .isEqualTo(AbsoluteRoundedCornerShape(5.dp))
+    }
+
+    @Test
+    fun roundedCornerUpdateTwoCornerSizes() {
+        val original = AbsoluteRoundedCornerShape(10.0f)
+            .copy(
+                topStart = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            )
+
+        assertEquals(CornerSize(3.dp), original.topStart)
+        assertEquals(CornerSize(10.0f), original.topEnd)
+        assertEquals(CornerSize(50), original.bottomEnd)
+        assertEquals(CornerSize(10f), original.bottomStart)
+        assertThat(
+            AbsoluteRoundedCornerShape(10.0f).copy(
+                topStart = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            )
+        ).isEqualTo(
+            AbsoluteRoundedCornerShape(
+                topLeft = CornerSize(3.dp),
+                topRight = CornerSize(10.0f),
+                bottomRight = CornerSize(50),
+                bottomLeft = CornerSize(10.0f)
+            )
+        )
+    }
+
+    @Test
+    fun objectsWithTheSameCornersAreEquals() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            AbsoluteRoundedCornerShape(
+                topLeft = CornerSize(4.0f),
+                topRight = CornerSize(3.0f),
+                bottomRight = CornerSize(3.dp),
+                bottomLeft = CornerSize(50)
+            ).equals(
+                AbsoluteRoundedCornerShape(
+                    topLeft = CornerSize(4.0f),
+                    topRight = CornerSize(3.0f),
+                    bottomRight = CornerSize(3.dp),
+                    bottomLeft = CornerSize(50)
+                )
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun objectsWithDifferentCornersAreNotEquals() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            AbsoluteRoundedCornerShape(
+                topLeft = CornerSize(4.0f),
+                topRight = CornerSize(3.0f),
+                bottomRight = CornerSize(3.dp),
+                bottomLeft = CornerSize(50)
+            ).equals(
+                AbsoluteRoundedCornerShape(
+                    topLeft = CornerSize(4.0f),
+                    topRight = CornerSize(5.0f),
+                    bottomRight = CornerSize(3.dp),
+                    bottomLeft = CornerSize(50)
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun notEqualsToCutCornersWithTheSameSizes() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            AbsoluteRoundedCornerShape(
+                topLeft = CornerSize(4.0f),
+                topRight = CornerSize(3.0f),
+                bottomRight = CornerSize(3.dp),
+                bottomLeft = CornerSize(50)
+            ).equals(
+                AbsoluteCutCornerShape(
+                    topLeft = CornerSize(4.0f),
+                    topRight = CornerSize(3.0f),
+                    bottomRight = CornerSize(3.dp),
+                    bottomLeft = CornerSize(50)
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun copyHasCorrectDefaults() {
+        assertEquals(
+            AbsoluteRoundedCornerShape(
+                topLeft = 5.dp,
+                topRight = 6.dp,
+                bottomRight = 3.dp,
+                bottomLeft = 4.dp
+            ),
+            AbsoluteRoundedCornerShape(
+                topLeft = 1.dp,
+                topRight = 2.dp,
+                bottomRight = 3.dp,
+                bottomLeft = 4.dp
+            ).copy(topStart = CornerSize(5.dp), topEnd = CornerSize(6.dp))
+        )
+        assertEquals(
+            AbsoluteRoundedCornerShape(
+                topLeft = 1.dp,
+                topRight = 2.dp,
+                bottomRight = 5.dp,
+                bottomLeft = 6.dp
+            ),
+            AbsoluteRoundedCornerShape(
+                topLeft = 1.dp,
+                topRight = 2.dp,
+                bottomRight = 3.dp,
+                bottomLeft = 4.dp
+            ).copy(bottomEnd = CornerSize(5.dp), bottomStart = CornerSize(6.dp))
+        )
+    }
+
+    private fun Shape.toOutline() =
+        createOutline(size, layoutDirection!!, density)
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/CornerBasedShapeTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/CornerBasedShapeTest.kt
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.shape
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.isTrue
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+
+class CornerBasedShapeTest {
+
+    @Test
+    fun createOutlineCalledWithCorrectParams() {
+        val density = Density(2f, 1f)
+        val passedSize = Size(100.0f, 50.0f)
+        var assertionExecuted = false
+        val assertSizes = { size: Size,
+            topStart: Float,
+            topEnd: Float,
+            bottomEnd: Float,
+            bottomStart: Float,
+            ld: LayoutDirection ->
+            assertThat(size).isEqualTo(passedSize)
+            assertThat(topStart).isEqualTo(4.0f)
+            assertThat(topEnd).isEqualTo(3.0f)
+            assertThat(bottomEnd).isEqualTo(6.0f)
+            assertThat(bottomStart).isEqualTo(25.0f)
+            assertThat(ld).isEqualTo(LayoutDirection.Ltr)
+            assertionExecuted = true
+        }
+        val impl = Impl(
+            topStart = CornerSize(4.0f),
+            topEnd = CornerSize(3.0f),
+            bottomEnd = CornerSize(3.dp),
+            bottomStart = CornerSize(50),
+            onOutlineRequested = assertSizes
+        )
+
+        assertThat(impl.createOutline(passedSize, LayoutDirection.Ltr, density))
+            .isEqualTo(Outline.Rectangle(passedSize.toRect()))
+
+        assertThat(assertionExecuted).isTrue()
+    }
+
+    @Test
+    fun topCornersSizesAreNotLargerThenMinDimension() {
+        val density = Density(2f, 1f)
+        val sizeWithLargerWidth = Size(6.0f, 4.0f)
+        val sizeWithLargerHeight = Size(4.0f, 6.0f)
+
+        val sizesList = mutableListOf<Size>()
+        val assertSizes = { size: Size,
+            topStart: Float,
+            topEnd: Float,
+            bottomEnd: Float,
+            bottomStart: Float,
+            ld: LayoutDirection ->
+            sizesList.add(size)
+            assertThat(topStart).isEqualTo(4.0f)
+            assertThat(topEnd).isEqualTo(4.0f)
+            assertThat(bottomEnd).isEqualTo(0.0f)
+            assertThat(bottomStart).isEqualTo(0.0f)
+            assertThat(ld).isEqualTo(LayoutDirection.Ltr)
+        }
+
+        val impl = Impl(
+            topStart = CornerSize(10.0f),
+            topEnd = CornerSize(10.0f),
+            bottomEnd = CornerSize(0f),
+            bottomStart = CornerSize(0f),
+            onOutlineRequested = assertSizes
+        )
+
+        impl.createOutline(sizeWithLargerWidth, LayoutDirection.Ltr, density)
+        impl.createOutline(sizeWithLargerHeight, LayoutDirection.Ltr, density)
+
+        assertThat(sizesList).isEqualTo(mutableListOf(sizeWithLargerWidth, sizeWithLargerHeight))
+    }
+
+    @Test
+    fun topCornersUse100Percent() {
+        val density = Density(2f, 1f)
+        val sizeWithLargerWidth = Size(6.0f, 4.0f)
+        val sizeWithLargerHeight = Size(4.0f, 6.0f)
+
+        val sizesList = mutableListOf<Size>()
+        val assertSizes = { size: Size,
+            topStart: Float,
+            topEnd: Float,
+            bottomEnd: Float,
+            bottomStart: Float,
+            ld: LayoutDirection ->
+            sizesList.add(size)
+            assertThat(topStart).isEqualTo(4.0f)
+            assertThat(topEnd).isEqualTo(4.0f)
+            assertThat(bottomEnd).isEqualTo(0.0f)
+            assertThat(bottomStart).isEqualTo(0.0f)
+            assertThat(ld).isEqualTo(LayoutDirection.Ltr)
+        }
+
+        val impl = Impl(
+            topStart = CornerSize(100),
+            topEnd = CornerSize(100),
+            bottomEnd = CornerSize(0),
+            bottomStart = CornerSize(0),
+            onOutlineRequested = assertSizes
+        )
+
+        impl.createOutline(sizeWithLargerWidth, LayoutDirection.Ltr, density)
+        impl.createOutline(sizeWithLargerHeight, LayoutDirection.Ltr, density)
+
+        assertThat(sizesList).isEqualTo(mutableListOf(sizeWithLargerWidth, sizeWithLargerHeight))
+    }
+
+    @Test
+    fun copyingUsesCorrectDefaults() {
+        val impl = Impl(
+            topStart = CornerSize(4.0f),
+            topEnd = CornerSize(3.0f),
+            bottomEnd = CornerSize(3.dp),
+            bottomStart = CornerSize(50)
+        )
+        assertThat(impl)
+            .isEqualTo(
+                impl.copy(
+                    bottomEnd = CornerSize(
+                        3.dp
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun layoutDirectionIsPassed() {
+        val density = Density(2f, 1f)
+        val passedSize = Size(100.0f, 50.0f)
+        var assertionExecuted = false
+        val assertSizes = {
+            size: Size,
+            topStart: Float,
+            topEnd: Float,
+            bottomEnd: Float,
+            bottomStart: Float,
+            ld: LayoutDirection ->
+            assertThat(size).isEqualTo(passedSize)
+            assertThat(topStart).isEqualTo(4.0f)
+            assertThat(topEnd).isEqualTo(3.0f)
+            assertThat(bottomEnd).isEqualTo(6.0f)
+            assertThat(bottomStart).isEqualTo(25.0f)
+            assertThat(ld).isEqualTo(LayoutDirection.Rtl)
+            assertionExecuted = true
+        }
+        val impl = Impl(
+            topStart = CornerSize(4.0f),
+            topEnd = CornerSize(3.0f),
+            bottomEnd = CornerSize(3.dp),
+            bottomStart = CornerSize(50),
+            onOutlineRequested = assertSizes
+        )
+
+        assertThat(impl.createOutline(passedSize, LayoutDirection.Rtl, density))
+            .isEqualTo(Outline.Rectangle(passedSize.toRect()))
+
+        assertThat(assertionExecuted).isTrue()
+    }
+
+    @Test
+    fun overSizedEqualCornerSizes() {
+        val density = Density(2f, 1f)
+        val sizeWithLargerWidth = Size(6.0f, 4.0f)
+        val sizeWithLargerHeight = Size(4.0f, 6.0f)
+
+        val sizesList = mutableListOf<Size>()
+        val assertSizes = { size: Size,
+            topStart: Float,
+            topEnd: Float,
+            bottomEnd: Float,
+            bottomStart: Float,
+            ld: LayoutDirection ->
+            sizesList.add(size)
+            assertThat(topStart).isEqualTo(2.0f)
+            assertThat(topEnd).isEqualTo(2.0f)
+            assertThat(bottomEnd).isEqualTo(2.0f)
+            assertThat(bottomStart).isEqualTo(2.0f)
+            assertThat(ld).isEqualTo(LayoutDirection.Ltr)
+        }
+
+        val impl = Impl(
+            topStart = CornerSize(75),
+            topEnd = CornerSize(75),
+            bottomEnd = CornerSize(75),
+            bottomStart = CornerSize(75),
+            onOutlineRequested = assertSizes
+        )
+
+        impl.createOutline(sizeWithLargerWidth, LayoutDirection.Ltr, density)
+        impl.createOutline(sizeWithLargerHeight, LayoutDirection.Ltr, density)
+
+        assertThat(sizesList).isEqualTo(mutableListOf(sizeWithLargerWidth, sizeWithLargerHeight))
+    }
+
+    @Test
+    fun overSizedCornerSizesShouldProportionallyScale() {
+        val density = Density(2f, 1f)
+        val sizeWithLargerWidth = Size(15.0f, 10.0f)
+        val sizeWithLargerHeight = Size(10.0f, 15.0f)
+
+        val sizesList = mutableListOf<Size>()
+        val assertSizes = { size: Size,
+            topStart: Float,
+            topEnd: Float,
+            bottomEnd: Float,
+            bottomStart: Float,
+            ld: LayoutDirection ->
+            sizesList.add(size)
+            assertThat(topStart).isEqualTo(7.5f)
+            assertThat(topEnd).isEqualTo(2.5f)
+            assertThat(bottomEnd).isEqualTo(7.5f)
+            assertThat(bottomStart).isEqualTo(2.5f)
+            assertThat(ld).isEqualTo(LayoutDirection.Ltr)
+        }
+
+        val impl = Impl(
+            topStart = CornerSize(90),
+            topEnd = CornerSize(30),
+            bottomEnd = CornerSize(90),
+            bottomStart = CornerSize(30),
+            onOutlineRequested = assertSizes
+        )
+
+        impl.createOutline(sizeWithLargerWidth, LayoutDirection.Ltr, density)
+        impl.createOutline(sizeWithLargerHeight, LayoutDirection.Ltr, density)
+
+        assertThat(sizesList).isEqualTo(mutableListOf(sizeWithLargerWidth, sizeWithLargerHeight))
+    }
+}
+
+private class Impl(
+    topStart: CornerSize,
+    topEnd: CornerSize,
+    bottomEnd: CornerSize,
+    bottomStart: CornerSize,
+    private val onOutlineRequested:
+        ((Size, Float, Float, Float, Float, LayoutDirection) -> Unit)? = null
+) : CornerBasedShape(topStart, topEnd, bottomEnd, bottomStart) {
+
+    override fun createOutline(
+        size: Size,
+        topStart: Float,
+        topEnd: Float,
+        bottomEnd: Float,
+        bottomStart: Float,
+        layoutDirection: LayoutDirection
+    ): Outline {
+        onOutlineRequested?.invoke(size, topStart, topEnd, bottomEnd, bottomStart, layoutDirection)
+        return Outline.Rectangle(size.toRect())
+    }
+
+    override fun copy(
+        topStart: CornerSize,
+        topEnd: CornerSize,
+        bottomEnd: CornerSize,
+        bottomStart: CornerSize
+    ) = Impl(topStart, topEnd, bottomEnd, bottomStart, onOutlineRequested)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Impl) return false
+
+        if (topStart != other.topStart) return false
+        if (topEnd != other.topEnd) return false
+        if (bottomEnd != other.bottomEnd) return false
+        if (bottomStart != other.bottomStart) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = topStart.hashCode()
+        result = 31 * result + topEnd.hashCode()
+        result = 31 * result + bottomEnd.hashCode()
+        result = 31 * result + bottomStart.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "Impl(topStart = $topStart, topEnd = $topEnd, bottomEnd = $bottomEnd, bottomStart" +
+            " = $bottomStart)"
+    }
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/CornerSizeTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/CornerSizeTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.shape
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.InspectableValue
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+
+class CornerSizeTest {
+
+    private val density = Density(2.5f)
+    private val size = Size(150.0f, 300.0f)
+
+    @Test
+    fun pxCorners() {
+        val corner = CornerSize(24.0f)
+        assertThat(corner.toPx(size, density)).isEqualTo(24.0f)
+        assertThat(corner.inspectorValue()).isEqualTo("24.0px")
+    }
+
+    @Test
+    fun dpCorners() {
+        val corner = CornerSize(5.dp)
+        assertThat(corner.toPx(size, density)).isEqualTo(12.5f)
+        assertThat(corner.inspectorValue()).isEqualTo(5.dp)
+    }
+
+    @Test
+    fun intPercentCorners() {
+        val corner = CornerSize(15)
+        assertThat(corner.toPx(size, density)).isEqualTo(22.5f)
+        assertThat(corner.inspectorValue()).isEqualTo("15.0%")
+    }
+
+    @Test
+    fun zeroCorners() {
+        val corner = ZeroCornerSize
+        assertThat(corner.toPx(size, density)).isEqualTo(0.0f)
+        assertThat(corner.inspectorValue()).isEqualTo("ZeroCornerSize")
+    }
+
+    @Test
+    fun pxCornersAreEquals() {
+        assertThat(CornerSize(24.0f)).isEqualTo(
+            CornerSize(24.0f)
+        )
+    }
+
+    @Test
+    fun dpCornersAreEquals() {
+        assertThat(CornerSize(8.dp)).isEqualTo(
+            CornerSize(8.dp)
+        )
+    }
+
+    private fun CornerSize.inspectorValue() = (this as InspectableValue).valueOverride
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/CutCornerShapeTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/CutCornerShapeTest.kt
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.shape
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.isFalse
+import androidx.compose.foundation.isTrue
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CutCornerShapeTest {
+
+    private val density = Density(2f)
+    private val size = Size(100.0f, 150.0f)
+
+    @Test
+    fun cutCornersUniformCorners() {
+        val cut = CutCornerShape(10.0f)
+
+        val outline = cut.toOutline() as Outline.Generic
+        assertPathsEquals(
+            outline.path,
+            Path().apply {
+                moveTo(0f, 10f)
+                lineTo(10f, 0f)
+                lineTo(90f, 0f)
+                lineTo(100f, 10f)
+                lineTo(100f, 140f)
+                lineTo(90f, 150f)
+                lineTo(10f, 150f)
+                lineTo(0f, 140f)
+                close()
+            }
+        )
+    }
+
+    @Test
+    fun cutCornersDifferentCorners() {
+        val size1 = 12f
+        val size2 = 22f
+        val size3 = 32f
+        val size4 = 42f
+        val cut = CutCornerShape(
+            size1,
+            size2,
+            size3,
+            size4
+        )
+
+        val outline = cut.toOutline() as Outline.Generic
+        assertPathsEquals(
+            outline.path,
+            Path().apply {
+                moveTo(0f, size1)
+                lineTo(size1, 0f)
+                lineTo(size.width - size2, 0f)
+                lineTo(size.width, size2)
+                lineTo(size.width, size.height - size3)
+                lineTo(size.width - size3, size.height)
+                lineTo(size4, size.height)
+                lineTo(0f, size.height - size4)
+                close()
+            }
+        )
+    }
+
+    @Test
+    fun cutCornersDifferentCorners_rtl() {
+        val size1 = 12f
+        val size2 = 22f
+        val size3 = 32f
+        val size4 = 42f
+        val cut = CutCornerShape(
+            size1,
+            size2,
+            size3,
+            size4
+        )
+
+        val outline = cut.toOutline(LayoutDirection.Rtl) as Outline.Generic
+        assertPathsEquals(
+            outline.path,
+            Path().apply {
+                moveTo(0f, size2)
+                lineTo(size2, 0f)
+                lineTo(size.width - size1, 0f)
+                lineTo(size.width, size1)
+                lineTo(size.width, size.height - size4)
+                lineTo(size.width - size4, size.height)
+                lineTo(size3, size.height)
+                lineTo(0f, size.height - size3)
+                close()
+            }
+        )
+    }
+
+    @Test
+    fun createsRectangleOutlineForZeroSizedCorners() {
+        val rounded = CutCornerShape(
+            0.0f,
+            0.0f,
+            0.0f,
+            0.0f
+        )
+
+        assertThat(rounded.toOutline())
+            .isEqualTo(Outline.Rectangle(size.toRect()))
+    }
+
+    @Test
+    fun cutCornerShapesAreEquals() {
+        assertThat(CutCornerShape(10.0f))
+            .isEqualTo(CutCornerShape(10.0f))
+    }
+
+    @Test
+    fun cutCornerUpdateAllCornerSize() {
+        assertThat(
+            CutCornerShape(10.0f).copy(
+                CornerSize(
+                    5.0f
+                )
+            )
+        )
+            .isEqualTo(CutCornerShape(5.0f))
+    }
+
+    @Test
+    fun cutCornerUpdateTwoCornerSizes() {
+        assertThat(
+            CutCornerShape(10.0f).copy(
+                topEnd = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            )
+        ).isEqualTo(
+            CutCornerShape(
+                topStart = CornerSize(10.0f),
+                topEnd = CornerSize(3.dp),
+                bottomStart = CornerSize(10.0f),
+                bottomEnd = CornerSize(50)
+            )
+        )
+    }
+
+    @Test
+    fun objectsWithTheSameCornersAreEquals() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            CutCornerShape(
+                topStart = CornerSize(4.0f),
+                topEnd = CornerSize(3.0f),
+                bottomStart = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            ).equals(
+                CutCornerShape(
+                    topStart = CornerSize(4.0f),
+                    topEnd = CornerSize(3.0f),
+                    bottomStart = CornerSize(3.dp),
+                    bottomEnd = CornerSize(50)
+                )
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun objectsWithDifferentCornersAreNotEquals() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            CutCornerShape(
+                topStart = CornerSize(4.0f),
+                topEnd = CornerSize(3.0f),
+                bottomStart = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            ).equals(
+                CutCornerShape(
+                    topStart = CornerSize(4.0f),
+                    topEnd = CornerSize(5.0f),
+                    bottomStart = CornerSize(3.dp),
+                    bottomEnd = CornerSize(50)
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun copyHasCorrectDefaults() {
+        assertEquals(
+            CutCornerShape(
+                topStart = 5.dp,
+                topEnd = 6.dp,
+                bottomEnd = 3.dp,
+                bottomStart = 4.dp
+            ),
+            CutCornerShape(
+                topStart = 1.dp,
+                topEnd = 2.dp,
+                bottomEnd = 3.dp,
+                bottomStart = 4.dp
+            ).copy(topStart = CornerSize(5.dp), topEnd = CornerSize(6.dp))
+        )
+        assertEquals(
+            CutCornerShape(
+                topStart = 1.dp,
+                topEnd = 2.dp,
+                bottomEnd = 5.dp,
+                bottomStart = 6.dp
+            ),
+            CutCornerShape(
+                topStart = 1.dp,
+                topEnd = 2.dp,
+                bottomEnd = 3.dp,
+                bottomStart = 4.dp
+            ).copy(bottomEnd = CornerSize(5.dp), bottomStart = CornerSize(6.dp))
+        )
+    }
+
+    private fun Shape.toOutline(direction: LayoutDirection = LayoutDirection.Ltr) =
+        createOutline(size, direction, density)
+}
+
+fun assertPathsEquals(path1: Path, path2: Path) {
+    val diff = Path()
+    val reverseDiff = Path()
+    assertTrue(
+        diff.op(path1, path2, PathOperation.Difference) &&
+            reverseDiff.op(path2, path1, PathOperation.Difference) &&
+            diff.isEmpty &&
+            reverseDiff.isEmpty
+    )
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/RoundedCornerShapeTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/shape/RoundedCornerShapeTest.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.shape
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.isFalse
+import androidx.compose.foundation.isTrue
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RoundedCornerShapeTest {
+
+    private val density = Density(2f)
+    private val size = Size(100.0f, 150.0f)
+
+    @Test
+    fun roundedUniformCorners() {
+        val rounded = RoundedCornerShape(25)
+
+        val expectedRadius = CornerRadius(25f)
+        val outline = rounded.toOutline() as Outline.Rounded
+        assertThat(outline.roundRect).isEqualTo(
+            RoundRect(size.toRect(), expectedRadius)
+        )
+    }
+
+    @Test
+    fun roundedDifferentRadius() {
+        val radius1 = 12f
+        val radius2 = 22f
+        val radius3 = 32f
+        val radius4 = 42f
+        val rounded = RoundedCornerShape(
+            radius1,
+            radius2,
+            radius3,
+            radius4
+        )
+
+        val outline = rounded.toOutline() as Outline.Rounded
+        assertThat(outline.roundRect).isEqualTo(
+            RoundRect(
+                size.toRect(),
+                CornerRadius(radius1),
+                CornerRadius(radius2),
+                CornerRadius(radius3),
+                CornerRadius(radius4)
+            )
+        )
+    }
+
+    @Test
+    fun roundedDifferentRadius_rtl() {
+        val radius1 = 12f
+        val radius2 = 22f
+        val radius3 = 32f
+        val radius4 = 42f
+        val rounded = RoundedCornerShape(
+            radius1,
+            radius2,
+            radius3,
+            radius4
+        )
+
+        val outline = rounded.toOutline(LayoutDirection.Rtl) as Outline.Rounded
+        assertThat(outline.roundRect).isEqualTo(
+            RoundRect(
+                size.toRect(),
+                CornerRadius(radius2),
+                CornerRadius(radius1),
+                CornerRadius(radius4),
+                CornerRadius(radius3)
+            )
+        )
+    }
+
+    @Test
+    fun createsRectangleOutlineForZeroSizedCorners() {
+        val rounded = RoundedCornerShape(
+            0.0f,
+            0.0f,
+            0.0f,
+            0.0f
+        )
+
+        assertThat(rounded.toOutline())
+            .isEqualTo(Outline.Rectangle(size.toRect()))
+    }
+
+    @Test
+    fun roundedCornerShapesAreEquals() {
+        assertThat(RoundedCornerShape(12.dp))
+            .isEqualTo(RoundedCornerShape(12.dp))
+    }
+
+    @Test
+    fun roundedCornerUpdateAllCornerSize() {
+        assertThat(
+            RoundedCornerShape(10.0f).copy(
+                CornerSize(
+                    5.dp
+                )
+            )
+        )
+            .isEqualTo(RoundedCornerShape(5.dp))
+    }
+
+    @Test
+    fun roundedCornerUpdateTwoCornerSizes() {
+        val original = RoundedCornerShape(10.0f)
+            .copy(
+                topStart = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            )
+
+        assertEquals(CornerSize(3.dp), original.topStart)
+        assertEquals(CornerSize(10.0f), original.topEnd)
+        assertEquals(CornerSize(50), original.bottomEnd)
+        assertEquals(CornerSize(10.0f), original.bottomStart)
+        assertThat(
+            RoundedCornerShape(10.0f).copy(
+                topStart = CornerSize(3.dp),
+                bottomEnd = CornerSize(50)
+            )
+        ).isEqualTo(
+            RoundedCornerShape(
+                topStart = CornerSize(3.dp),
+                topEnd = CornerSize(10.0f),
+                bottomEnd = CornerSize(50),
+                bottomStart = CornerSize(10.0f)
+            )
+        )
+    }
+
+    @Test
+    fun objectsWithTheSameCornersAreEquals() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            RoundedCornerShape(
+                topStart = CornerSize(4.0f),
+                topEnd = CornerSize(3.0f),
+                bottomEnd = CornerSize(3.dp),
+                bottomStart = CornerSize(50)
+            ).equals(
+                RoundedCornerShape(
+                    topStart = CornerSize(4.0f),
+                    topEnd = CornerSize(3.0f),
+                    bottomEnd = CornerSize(3.dp),
+                    bottomStart = CornerSize(50)
+                )
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun objectsWithDifferentCornersAreNotEquals() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            RoundedCornerShape(
+                topStart = CornerSize(4.0f),
+                topEnd = CornerSize(3.0f),
+                bottomEnd = CornerSize(3.dp),
+                bottomStart = CornerSize(50)
+            ).equals(
+                RoundedCornerShape(
+                    topStart = CornerSize(4.0f),
+                    topEnd = CornerSize(5.0f),
+                    bottomEnd = CornerSize(3.dp),
+                    bottomStart = CornerSize(50)
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun notEqualsToCutCornersWithTheSameSizes() {
+        @Suppress("ReplaceCallWithBinaryOperator")
+        assertThat(
+            RoundedCornerShape(
+                topStart = CornerSize(4.0f),
+                topEnd = CornerSize(3.0f),
+                bottomEnd = CornerSize(3.dp),
+                bottomStart = CornerSize(50)
+            ).equals(
+                CutCornerShape(
+                    topStart = CornerSize(4.0f),
+                    topEnd = CornerSize(3.0f),
+                    bottomEnd = CornerSize(3.dp),
+                    bottomStart = CornerSize(50)
+                )
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun copyHasCorrectDefaults() {
+        assertEquals(
+            RoundedCornerShape(
+                topStart = 5.dp,
+                topEnd = 6.dp,
+                bottomEnd = 3.dp,
+                bottomStart = 4.dp
+            ),
+            RoundedCornerShape(
+                topStart = 1.dp,
+                topEnd = 2.dp,
+                bottomEnd = 3.dp,
+                bottomStart = 4.dp
+            ).copy(topStart = CornerSize(5.dp), topEnd = CornerSize(6.dp))
+        )
+        assertEquals(
+            RoundedCornerShape(
+                topStart = 1.dp,
+                topEnd = 2.dp,
+                bottomEnd = 5.dp,
+                bottomStart = 6.dp
+            ),
+            RoundedCornerShape(
+                topStart = 1.dp,
+                topEnd = 2.dp,
+                bottomEnd = 3.dp,
+                bottomStart = 4.dp
+            ).copy(bottomEnd = CornerSize(5.dp), bottomStart = CornerSize(6.dp))
+        )
+    }
+
+    private fun Shape.toOutline(direction: LayoutDirection = LayoutDirection.Ltr) =
+        createOutline(size, direction, density)
+}


### PR DESCRIPTION
Adopt and copy/paste foundation/shape tests from androidTests in skikoTests. 

What's your opinion? Do we need those tests (android tests already check this common functionality)? Is it worth copy/pasting them?