### PR TITLE
Fix San Francisco font as a default (macOS)

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
@@ -49,7 +49,7 @@ internal actual val GenericFontFamiliesMapping by lazy {
         Platform.MacOS ->
             mapOf(
                 FontFamily.SansSerif.name to listOf(
-                    "San Francisco",
+                    "System Font",
                     "Helvetica Neue",
                     "Helvetica"
                 ),


### PR DESCRIPTION
In https://github.com/JetBrains/androidx/pull/296 I accidentally pushed the wrong fix, which doesn't work.

Thanks Alexander Maryanovsky pointed at this [here](https://kotlinlang.slack.com/archives/C01D6HTPATV/p1670249182045759?thread_ts=1669996652.181129&cid=C01D6HTPATV)