### PR TITLE
Implement Delay in FlushCoroutineDispatcher and make SkikoComposeUiTest support infinite animations

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -25,14 +25,19 @@ import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.Volatile
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.Delay
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.InternalCoroutinesApi
 
 /**
  * Dispatcher with the ability to immediately perform (flush) all pending tasks.
  * Without a flush all tasks are dispatched in the dispatcher provided by [scope]
  */
+@OptIn(InternalCoroutinesApi::class)
 internal class FlushCoroutineDispatcher(
     scope: CoroutineScope
-) : CoroutineDispatcher() {
+) : CoroutineDispatcher(), Delay {
     // Dispatcher should always be alive, even if Job is cancelled. Otherwise coroutines which
     // use this dispatcher won't be properly cancelled.
     // TODO replace it by scope.coroutineContext[Dispatcher] when it will be no longer experimental
@@ -85,6 +90,14 @@ internal class FlushCoroutineDispatcher(
             body()
         } finally {
             isPerformingRun = false
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun scheduleResumeAfterDelay(timeMillis: Long, continuation: CancellableContinuation<Unit>) {
+        scope.launch {
+            kotlinx.coroutines.delay(timeMillis)
+            dispatch(coroutineContext, Runnable { continuation.resume(Unit, null) })
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -220,6 +220,9 @@ internal class SkiaBasedOwner(
 
     override val viewConfiguration = platform.viewConfiguration
 
+    override val hasPendingMeasureOrLayout: Boolean
+        get() = measureAndLayoutDelegate.hasPendingMeasureOrLayout
+
     init {
         snapshotObserver.startObserving()
         root.attach(this)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
@@ -33,6 +33,11 @@ interface SkiaRootForTest : RootForTest {
     val scene: ComposeScene get() = throw UnsupportedOperationException("SkiaRootForTest.scene is not implemented")
 
     /**
+     * Whether the Owner has pending layout work.
+     */
+    val hasPendingMeasureOrLayout: Boolean
+
+    /**
      * Process pointer event
      *
      * [timeMillis] time when the pointer event occurred


### PR DESCRIPTION
This PR (it's rather a draft to discuss the intention) contains 2 changes: 
- Make FlushCoroutineDispatcher implement Delay (to allow skip delays in tests)
- Make SkikoComposeUiTest support infnite animations when mainClock.autoAdvanced == false

