### PR TITLE
Include test directory into desktopTest source sets

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -192,6 +192,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                     implementation(libs.mockitoKotlin)
                 }
             }
+            desktopTest.kotlin.srcDirs("src/test/kotlin", "src/desktopTest/kotlin")
 
             nativeTest.dependsOn(jsNativeTest)
             jsTest.dependsOn(jsNativeTest)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/StringHelpersSkikoMainTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/StringHelpersSkikoMainTest.kt
@@ -22,7 +22,7 @@ import androidx.compose.foundation.text.findPrecedingBreak
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class StringHelpersTest {
+class StringHelpersSkikoMainTest {
     val complexString = "\uD83E\uDDD1\uD83C\uDFFF\u200D\uD83E\uDDB0"
 
     @Test

--- a/compose/foundation/foundation/src/test/kotlin/androidx/compose/foundation/gestures/SuspendingGestureTestUtil.kt
+++ b/compose/foundation/foundation/src/test/kotlin/androidx/compose/foundation/gestures/SuspendingGestureTestUtil.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.currentComposer
 import androidx.compose.runtime.withRunningRecomposer
-import androidx.compose.testutils.TestViewConfiguration
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -39,9 +38,11 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.materialize
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
@@ -356,4 +357,14 @@ internal class SuspendingGestureTestUtil(
         }
         override fun clear() {}
     }
+
+
+    // Copy-pasted from test-utils module (see TestViewConfiguration) to make it usable on desktop
+    class TestViewConfiguration(
+        override val longPressTimeoutMillis: Long = 500L,
+        override val doubleTapTimeoutMillis: Long = 300L,
+        override val doubleTapMinTimeMillis: Long = 40L,
+        override val touchSlop: Float = 18f,
+        override val minimumTouchTargetSize: DpSize = DpSize(48.dp, 48.dp)
+    ) : ViewConfiguration
 }

--- a/compose/foundation/foundation/src/test/kotlin/androidx/compose/foundation/text/TextSelectionLongPressDragTest.kt
+++ b/compose/foundation/foundation/src/test/kotlin/androidx/compose/foundation/text/TextSelectionLongPressDragTest.kt
@@ -40,12 +40,16 @@ import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 @OptIn(InternalFoundationTextApi::class)
+@Ignore // TODO: ignored only in JB fork (don't upstream).
+// Reason: tests fail with error "lateinit property longPressDragObserver has not been initialized"
+// It seems it requires the inputMode to be in TouchMode, which is not true on desktop by default
 class TextSelectionLongPressDragTest {
     private val selectionRegistrar = spy(SelectionRegistrarImpl())
     private val selectableId = 1L

--- a/compose/foundation/foundation/src/test/kotlin/androidx/compose/foundation/text/selection/SelectionAdjustmentTest.kt
+++ b/compose/foundation/foundation/src/test/kotlin/androidx/compose/foundation/text/selection/SelectionAdjustmentTest.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.packInts
-import androidx.test.filters.SmallTest
+//import androidx.test.filters.SmallTest
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
@@ -35,7 +35,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@SmallTest
+//@SmallTest // commented only jb fork - no such API on desktop
 @RunWith(JUnit4::class)
 class SelectionAdjustmentTest {
     @Test

--- a/compose/ui/ui-geometry/build.gradle
+++ b/compose/ui/ui-geometry/build.gradle
@@ -74,6 +74,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             commonTest.dependencies {
                 implementation(kotlin("test-junit"))
             }
+            desktopTest.kotlin.srcDirs("src/test/kotlin")
         }
     }
 }

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -182,7 +182,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:foundation:foundation"))
                 implementation(project(":compose:ui:ui-test-junit4"))
                 implementation(project(":internal-testutils-fonts"))
+                implementation(libs.mockitoCore)
+                implementation(libs.mockitoKotlin)
+                implementation(libs.kotlinReflect)
             }
+            desktopTest.kotlin.srcDirs("src/test/java", "src/desktopTest/kotlin")
+            desktopTest.resources.srcDirs("src/test/resources", "src/desktopTest/resources")
         }
     }
     dependencies {

--- a/compose/ui/ui-text/src/test/java/androidx/compose/ui/text/TextStyleLayoutAttributesTest.kt
+++ b/compose/ui/ui-text/src/test/java/androidx/compose/ui/text/TextStyleLayoutAttributesTest.kt
@@ -286,17 +286,19 @@ class TextStyleLayoutAttributesTest {
         ).isFalse()
     }
 
-    @Suppress("DEPRECATION")
-    @OptIn(ExperimentalTextApi::class)
-    @Test
-    fun returns_false_for_platformStyle_change() {
-        val style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false))
-        assertThat(
-            style.hasSameLayoutAffectingAttributes(
-                TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = true))
-            )
-        ).isFalse()
-    }
+// TODO: `includeFontPadding` is not available on desktop. Comment out when `includeFontPadding` is removed in upstream.
+// keep this comment in JB fork.
+//    @Suppress("DEPRECATION")
+//    @OptIn(ExperimentalTextApi::class)
+//    @Test
+//    fun returns_false_for_platformStyle_change() {
+//        val style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false))
+//        assertThat(
+//            style.hasSameLayoutAffectingAttributes(
+//                TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = true))
+//            )
+//        ).isFalse()
+//    }
 
     @Test
     fun returns_false_for_color_and_textAlign_change() {

--- a/compose/ui/ui-text/src/test/java/androidx/compose/ui/text/TextStyleTest.kt
+++ b/compose/ui/ui-text/src/test/java/androidx/compose/ui/text/TextStyleTest.kt
@@ -1309,17 +1309,19 @@ class TextStyleTest {
         assertThat(style.platformStyle).isNull()
     }
 
-    @OptIn(ExperimentalTextApi::class)
-    @Test
-    fun `copy without platformStyle uses existing platformStyle`() {
-        @Suppress("DEPRECATION")
-        val style = TextStyle(
-            platformStyle = PlatformTextStyle(includeFontPadding = false)
-        )
-        val newStyle = style.copy()
-
-        assertThat(newStyle.platformStyle).isEqualTo(style.platformStyle)
-    }
+// TODO: `includeFontPadding` is not available on desktop. Comment out when `includeFontPadding` is removed in upstream.
+// keep this comment in JB fork.
+//    @OptIn(ExperimentalTextApi::class)
+//    @Test
+//    fun `copy without platformStyle uses existing platformStyle`() {
+//        @Suppress("DEPRECATION")
+//        val style = TextStyle(
+//            platformStyle = PlatformTextStyle(includeFontPadding = false)
+//        )
+//        val newStyle = style.copy()
+//
+//        assertThat(newStyle.platformStyle).isEqualTo(style.platformStyle)
+//    }
 
     @OptIn(ExperimentalTextApi::class)
     @Test
@@ -1513,46 +1515,47 @@ class TextStyleTest {
         )
     }
 
-    @OptIn(ExperimentalTextApi::class)
-    @Test
-    fun `toParagraphStyle return attributes with correct values`() {
-        val textAlign = TextAlign.Justify
-        val textDirection = TextDirection.Rtl
-        val lineHeight = 100.sp
-        val textIndent = TextIndent(firstLine = 20.sp, restLine = 40.sp)
-        val lineHeightStyle = LineHeightStyle(
-            alignment = Alignment.Center,
-            trim = Trim.None
-        )
-        val hyphens = Hyphens.Auto
-        val lineBreak = LineBreak(
-            strategy = LineBreak.Strategy.Balanced,
-            strictness = LineBreak.Strictness.Strict,
-            wordBreak = LineBreak.WordBreak.Phrase
-        )
-
-        val style = TextStyle(
-            textAlign = textAlign,
-            textDirection = textDirection,
-            lineHeight = lineHeight,
-            textIndent = textIndent,
-            lineHeightStyle = lineHeightStyle,
-            lineBreak = lineBreak,
-            hyphens = hyphens
-        )
-
-        assertThat(style.toParagraphStyle()).isEqualTo(
-            ParagraphStyle(
-                textAlign = textAlign,
-                textDirection = textDirection,
-                lineHeight = lineHeight,
-                textIndent = textIndent,
-                lineHeightStyle = lineHeightStyle,
-                hyphens = hyphens,
-                lineBreak = lineBreak
-            )
-        )
-    }
+// Commented in JB fork only: LineBreak has different actual constructor on desktop (skikoMain)
+//    @OptIn(ExperimentalTextApi::class)
+//    @Test
+//    fun `toParagraphStyle return attributes with correct values`() {
+//        val textAlign = TextAlign.Justify
+//        val textDirection = TextDirection.Rtl
+//        val lineHeight = 100.sp
+//        val textIndent = TextIndent(firstLine = 20.sp, restLine = 40.sp)
+//        val lineHeightStyle = LineHeightStyle(
+//            alignment = Alignment.Center,
+//            trim = Trim.None
+//        )
+//        val hyphens = Hyphens.Auto
+//        val lineBreak = LineBreak(
+//            strategy = LineBreak.Strategy.Balanced,
+//            strictness = LineBreak.Strictness.Strict,
+//            wordBreak = LineBreak.WordBreak.Phrase
+//        )
+//
+//        val style = TextStyle(
+//            textAlign = textAlign,
+//            textDirection = textDirection,
+//            lineHeight = lineHeight,
+//            textIndent = textIndent,
+//            lineHeightStyle = lineHeightStyle,
+//            lineBreak = lineBreak,
+//            hyphens = hyphens
+//        )
+//
+//        assertThat(style.toParagraphStyle()).isEqualTo(
+//            ParagraphStyle(
+//                textAlign = textAlign,
+//                textDirection = textDirection,
+//                lineHeight = lineHeight,
+//                textIndent = textIndent,
+//                lineHeightStyle = lineHeightStyle,
+//                hyphens = hyphens,
+//                lineBreak = lineBreak
+//            )
+//        )
+//    }
 
     @Test(expected = IllegalStateException::class)
     fun `negative lineHeight throws IllegalStateException`() {

--- a/compose/ui/ui-text/src/test/java/androidx/compose/ui/text/font/AndroidFontResolverInterceptorTest.kt
+++ b/compose/ui/ui-text/src/test/java/androidx/compose/ui/text/font/AndroidFontResolverInterceptorTest.kt
@@ -19,80 +19,82 @@ package androidx.compose.ui.text.font
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-class AndroidFontResolverInterceptorTest {
-    private lateinit var subject: AndroidFontResolveInterceptor
+// It's commented only in JB fork to run more tests on desktop. The tests below use android specific APIs.
 
-    private fun createSubject(adjustment: Int) {
-        subject = AndroidFontResolveInterceptor(adjustment)
-    }
-
-    @Test
-    fun fontWeightDoesNotChange_whenBoldTextAccessibilityIsNotEnabled() {
-        val testedWeight = 400
-        val adjustment = 0
-        val expected = 400
-        createSubject(adjustment)
-        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
-            .isEqualTo(expected)
-    }
-
-    @Test
-    fun fontWeightIncreases_whenBoldTextAccessibilityIsEnabled() {
-        val testedWeight = 400
-        val adjustment = 300
-        val expected = 700
-        createSubject(adjustment)
-        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
-            .isEqualTo(expected)
-    }
-
-    @Test
-    fun fontWeightNeverExceeds1000_whenBoldTextAccessibilityIsEnabled() {
-        val testedWeight = 500
-        val adjustment = 600
-        createSubject(adjustment)
-        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
-            .isEqualTo(android.graphics.fonts.FontStyle.FONT_WEIGHT_MAX)
-    }
-
-    @Test
-    fun fontWeightWontBeZero_whenBoldTextAccessibilityIsEnabled() {
-        val testedWeight = 500
-        val adjustment = -600
-        createSubject(adjustment)
-        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
-            .isEqualTo(android.graphics.fonts.FontStyle.FONT_WEIGHT_MIN)
-    }
-
-    @Test
-    fun fontWeightWontBeNegative_whenBoldTextAccessibilityIsEnabled() {
-        val testedWeight = 500
-        val adjustment = -500
-        createSubject(adjustment)
-        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
-            .isEqualTo(android.graphics.fonts.FontStyle.FONT_WEIGHT_MIN)
-    }
-
-    @Test
-    fun fontWeightWontOverflow_whenBoldTextAccessibilityIsEnabled() {
-        val testedWeight = 500
-        val adjustment = Int.MAX_VALUE
-        createSubject(adjustment)
-        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
-            .isEqualTo(testedWeight)
-    }
-
-    @Test
-    fun otherFontArgumentsWontChange_whenBoldTextAccessibilityIsEnabled() {
-        val adjustment = 300
-        createSubject(adjustment)
-        assertThat(subject.interceptFontFamily(FontFamily.SansSerif))
-            .isEqualTo(FontFamily.SansSerif)
-
-        assertThat(subject.interceptFontStyle(FontStyle.Normal))
-            .isEqualTo(FontStyle.Normal)
-
-        assertThat(subject.interceptFontSynthesis(FontSynthesis.Weight))
-            .isEqualTo(FontSynthesis.Weight)
-    }
-}
+//class AndroidFontResolverInterceptorTest {
+//    private lateinit var subject: AndroidFontResolveInterceptor
+//
+//    private fun createSubject(adjustment: Int) {
+//        subject = AndroidFontResolveInterceptor(adjustment)
+//    }
+//
+//    @Test
+//    fun fontWeightDoesNotChange_whenBoldTextAccessibilityIsNotEnabled() {
+//        val testedWeight = 400
+//        val adjustment = 0
+//        val expected = 400
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
+//            .isEqualTo(expected)
+//    }
+//
+//    @Test
+//    fun fontWeightIncreases_whenBoldTextAccessibilityIsEnabled() {
+//        val testedWeight = 400
+//        val adjustment = 300
+//        val expected = 700
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
+//            .isEqualTo(expected)
+//    }
+//
+//    @Test
+//    fun fontWeightNeverExceeds1000_whenBoldTextAccessibilityIsEnabled() {
+//        val testedWeight = 500
+//        val adjustment = 600
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
+//            .isEqualTo(android.graphics.fonts.FontStyle.FONT_WEIGHT_MAX)
+//    }
+//
+//    @Test
+//    fun fontWeightWontBeZero_whenBoldTextAccessibilityIsEnabled() {
+//        val testedWeight = 500
+//        val adjustment = -600
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
+//            .isEqualTo(android.graphics.fonts.FontStyle.FONT_WEIGHT_MIN)
+//    }
+//
+//    @Test
+//    fun fontWeightWontBeNegative_whenBoldTextAccessibilityIsEnabled() {
+//        val testedWeight = 500
+//        val adjustment = -500
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
+//            .isEqualTo(android.graphics.fonts.FontStyle.FONT_WEIGHT_MIN)
+//    }
+//
+//    @Test
+//    fun fontWeightWontOverflow_whenBoldTextAccessibilityIsEnabled() {
+//        val testedWeight = 500
+//        val adjustment = Int.MAX_VALUE
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontWeight(FontWeight(testedWeight)).weight)
+//            .isEqualTo(testedWeight)
+//    }
+//
+//    @Test
+//    fun otherFontArgumentsWontChange_whenBoldTextAccessibilityIsEnabled() {
+//        val adjustment = 300
+//        createSubject(adjustment)
+//        assertThat(subject.interceptFontFamily(FontFamily.SansSerif))
+//            .isEqualTo(FontFamily.SansSerif)
+//
+//        assertThat(subject.interceptFontStyle(FontStyle.Normal))
+//            .isEqualTo(FontStyle.Normal)
+//
+//        assertThat(subject.interceptFontSynthesis(FontSynthesis.Weight))
+//            .isEqualTo(FontSynthesis.Weight)
+//    }
+//}

--- a/compose/ui/ui-unit/build.gradle
+++ b/compose/ui/ui-unit/build.gradle
@@ -104,6 +104,15 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.testExtJunit)
                 implementation(libs.espressoCore)
             }
+
+            desktopTest {
+                dependencies {
+                    implementation(libs.junit)
+                    implementation(libs.truth)
+                    implementation(libs.kotlinTest)
+                }
+            }
+            desktopTest.kotlin.srcDirs("src/test/kotlin")
         }
     }
     dependencies {

--- a/compose/ui/ui-util/build.gradle
+++ b/compose/ui/ui-util/build.gradle
@@ -84,6 +84,15 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             androidTest.dependencies {
                 implementation(libs.truth)
             }
+
+            desktopTest {
+                dependencies {
+                    implementation(libs.junit)
+                    implementation(libs.truth)
+                    implementation(libs.kotlinTest)
+                }
+            }
+            desktopTest.kotlin.srcDirs("src/test/kotlin")
         }
     }
 }


### PR DESCRIPTION
This will add a bunch of tests to desktopTest. Some of the tests are comment or ignored because of either android specific apis or other incompatibilities (see comments)

Potentially many of these tests could be common for all targets, but it requires many changes: get rid of juint, Truth.asserts, etc. 
Ideally such a work should be upstreamd asap, or we can decide to copy-paste these tests amd keep them separately in our fork. But running them at least for desktop is a minimal thing that we can do.