### PR TITLE
Support configurable Density in js and darwin targets

### DIFF
--- a/compose/ui/ui-unit/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
+++ b/compose/ui/ui-unit/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.unit
+
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.isSpecified
+
+/**
+ * Convert a [Offset] to a [DpOffset].
+ */
+@Stable
+fun Offset.toDpOffset(density: Density): DpOffset = with(density) {
+    if (isSpecified) {
+        DpOffset(x.toDp(), y.toDp())
+    } else {
+        DpOffset.Unspecified
+    }
+}
+
+/**
+ * Convert a [DpOffset] to a [Offset].
+ */
+@Stable
+fun DpOffset.toOffset(density: Density): Offset = with(density) {
+    if (isSpecified) {
+        Offset(x.toPx(), y.toPx())
+    } else {
+        Offset.Unspecified
+    }
+}
+
+/**
+ * Convert a [Rect] to a [DpRect].
+ */
+@Stable
+fun Rect.toDpRect(density: Density): DpRect = with(density) {
+    DpRect(
+        origin = topLeft.toDpOffset(density),
+        size = size.toDpSize()
+    )
+}

--- a/compose/ui/ui-unit/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
+++ b/compose/ui/ui-unit/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.geometry.isSpecified
  * Convert a [Offset] to a [DpOffset].
  */
 @Stable
+@ExperimentalUnitApi
 fun Offset.toDpOffset(density: Density): DpOffset = with(density) {
     if (isSpecified) {
         DpOffset(x.toDp(), y.toDp())
@@ -37,6 +38,7 @@ fun Offset.toDpOffset(density: Density): DpOffset = with(density) {
  * Convert a [DpOffset] to a [Offset].
  */
 @Stable
+@ExperimentalUnitApi
 fun DpOffset.toOffset(density: Density): Offset = with(density) {
     if (isSpecified) {
         Offset(x.toPx(), y.toPx())
@@ -49,6 +51,7 @@ fun DpOffset.toOffset(density: Density): Offset = with(density) {
  * Convert a [Rect] to a [DpRect].
  */
 @Stable
+@ExperimentalUnitApi
 fun Rect.toDpRect(density: Density): DpRect = with(density) {
     DpRect(
         origin = topLeft.toDpOffset(density),

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -26,11 +26,16 @@ import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.w3c.dom.HTMLCanvasElement
 
 internal actual class ComposeWindow actual constructor() {
 
-    private val density: Density = Density(1f) //todo get and update density from Browser platform
+    private val density: Density = Density(
+        density = window.devicePixelRatio.toFloat(),
+        fontScale = 1f
+    )
+
     private val jsTextInputService = JSTextInputService()
     val platform = object : Platform by Platform.Empty {
         override val textInputService = jsTextInputService
@@ -63,11 +68,7 @@ internal actual class ComposeWindow actual constructor() {
         canvas.setAttribute("tabindex", "0")
         layer.layer.needRedraw()
 
-        val scale = layer.layer.contentScale
-        layer.setSize(
-            (canvas.width / scale).toInt(),
-            (canvas.height / scale).toInt()
-        )
+        layer.setSize(canvas.width, canvas.height)
     }
 
     /**
@@ -79,6 +80,7 @@ internal actual class ComposeWindow actual constructor() {
         content: @Composable () -> Unit
     ) {
         println("ComposeWindow.setContent")
+        layer.setDensity(density)
         layer.setContent(
             content = content
         )

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -38,10 +38,12 @@ import org.jetbrains.skiko.SkikoTouchEvent
 import org.jetbrains.skiko.SkikoTouchEventKind
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.ExperimentalUnitApi
 import androidx.compose.ui.unit.toDpRect
 import org.jetbrains.skiko.SkikoInput
 import org.jetbrains.skiko.currentNanoTime
 
+@OptIn(ExperimentalUnitApi::class)
 internal class ComposeLayer(
     internal val layer: SkiaLayer,
     platform: Platform,

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -37,6 +37,8 @@ import org.jetbrains.skiko.SkikoPointerEvent
 import org.jetbrains.skiko.SkikoTouchEvent
 import org.jetbrains.skiko.SkikoTouchEventKind
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.toDpRect
 import org.jetbrains.skiko.SkikoInput
 import org.jetbrains.skiko.currentNanoTime
 
@@ -135,9 +137,8 @@ internal class ComposeLayer(
         scene.constraints = Constraints(maxWidth = width, maxHeight = height)
     }
 
-    fun getActiveFocusRect(): Rect? {
-        return scene.mainOwner?.focusManager?.getActiveFocusModifier()?.focusRect()
-    }
+    fun getActiveFocusRect(): DpRect? =
+        scene.mainOwner?.focusManager?.getActiveFocusModifier()?.focusRect()?.toDpRect(density)
 
     fun setContent(
         onPreviewKeyEvent: (ComposeKeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
@@ -25,8 +25,7 @@ import androidx.compose.ui.geometry.isSpecified
  * Convert a [Offset] to a [DpOffset].
  */
 @Stable
-@ExperimentalUnitApi
-fun Offset.toDpOffset(density: Density): DpOffset = with(density) {
+internal fun Offset.toDpOffset(density: Density): DpOffset = with(density) {
     if (isSpecified) {
         DpOffset(x.toDp(), y.toDp())
     } else {
@@ -38,8 +37,7 @@ fun Offset.toDpOffset(density: Density): DpOffset = with(density) {
  * Convert a [DpOffset] to a [Offset].
  */
 @Stable
-@ExperimentalUnitApi
-fun DpOffset.toOffset(density: Density): Offset = with(density) {
+internal fun DpOffset.toOffset(density: Density): Offset = with(density) {
     if (isSpecified) {
         Offset(x.toPx(), y.toPx())
     } else {
@@ -51,8 +49,7 @@ fun DpOffset.toOffset(density: Density): Offset = with(density) {
  * Convert a [Rect] to a [DpRect].
  */
 @Stable
-@ExperimentalUnitApi
-fun Rect.toDpRect(density: Density): DpRect = with(density) {
+internal fun Rect.toDpRect(density: Density): DpRect = with(density) {
     DpRect(
         origin = topLeft.toDpOffset(density),
         size = size.toDpSize()

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.createSkiaLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.MacosTextInputService
-
 import androidx.compose.ui.platform.Platform
+import androidx.compose.ui.unit.Density
 import platform.AppKit.*
 import platform.Foundation.*
 import kotlinx.cinterop.*
@@ -65,7 +65,9 @@ internal actual class ComposeWindow actual constructor() {
         layer.layer.attachTo(nsWindow)
         nsWindow.orderFrontRegardless()
         contentRect.useContents {
-            layer.setSize(size.width.toInt(), size.height.toInt())
+            val scale = nsWindow.backingScaleFactor.toFloat()
+            layer.setDensity(Density(scale))
+            layer.setSize((size.width * scale).toInt(), (size.height * scale).toInt())
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -55,6 +55,7 @@ import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
 import platform.UIKit.reloadInputViews
 import platform.UIKit.setClipsToBounds
 import platform.UIKit.setNeedsDisplay
+import platform.UIKit.window
 import platform.darwin.NSObject
 
 // The only difference with macos' Window is that
@@ -77,7 +78,7 @@ internal actual class ComposeWindow : UIViewController {
     constructor(coder: NSCoder) : super(coder)
 
     private val density: Density
-        get() = Density(UIScreen.mainScreen.scale.toFloat())
+        get() = Density(layer.layer.contentScale)
 
     private lateinit var layer: ComposeLayer
     private lateinit var content: @Composable () -> Unit
@@ -200,7 +201,7 @@ internal actual class ComposeWindow : UIViewController {
         withTransitionCoordinator: UIViewControllerTransitionCoordinatorProtocol
     ) {
         layer.setDensity(density)
-        val scale = layer.layer.contentScale
+        val scale = density.density
         val width = size.useContents { width } * scale
         val height = size.useContents { height } * scale
         layer.setSize(width.roundToInt(), height.roundToInt())
@@ -211,7 +212,7 @@ internal actual class ComposeWindow : UIViewController {
         super.viewDidAppear(animated)
         val (width, height) = getViewFrameSize()
         layer.setDensity(density)
-        val scale = layer.layer.contentScale
+        val scale = density.density
         layer.setSize((width * scale).roundToInt(), (height * scale).roundToInt())
         NSNotificationCenter.defaultCenter.addObserver(
             observer = keyboardVisibilityListener,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
+import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
@@ -39,6 +40,7 @@ import org.jetbrains.skiko.SkikoUIView
 import org.jetbrains.skiko.TextActions
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGSize
 import platform.Foundation.NSCoder
 import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
@@ -47,6 +49,7 @@ import platform.Foundation.NSValue
 import platform.UIKit.CGRectValue
 import platform.UIKit.UIScreen
 import platform.UIKit.UIViewController
+import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
 import platform.UIKit.reloadInputViews
 import platform.UIKit.setClipsToBounds
 import platform.UIKit.setNeedsDisplay
@@ -188,6 +191,18 @@ internal actual class ComposeWindow : UIViewController {
             input = uiKitTextInputService.skikoInput,
         )
         layer.setContent(content = content)
+    }
+
+    override fun viewWillTransitionToSize(
+        size: CValue<CGSize>,
+        withTransitionCoordinator: UIViewControllerTransitionCoordinatorProtocol
+    ) {
+        layer.setDensity(density)
+        val scale = layer.layer.contentScale
+        val width = size.useContents { width } * scale
+        val height = size.useContents { height } * scale
+        layer.setSize(width.roundToInt(), height.roundToInt())
+        super.viewWillTransitionToSize(size, withTransitionCoordinator)
     }
 
     override fun viewWillAppear(animated: Boolean) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
@@ -70,7 +71,9 @@ internal actual class ComposeWindow : UIViewController {
     @OverrideInit
     constructor(coder: NSCoder) : super(coder)
 
-    private val density: Density = Density(1f) //todo get and update density from UIKit Platform
+    private val density: Density
+        get() = Density(UIScreen.mainScreen.scale.toFloat())
+
     private lateinit var layer: ComposeLayer
     private lateinit var content: @Composable () -> Unit
     private val keyboardVisibilityListener = object : NSObject() {
@@ -190,7 +193,9 @@ internal actual class ComposeWindow : UIViewController {
     override fun viewWillAppear(animated: Boolean) {
         super.viewDidAppear(animated)
         val (width, height) = getViewFrameSize()
-        layer.setSize(width, height)
+        layer.setDensity(density)
+        val scale = layer.layer.contentScale
+        layer.setSize((width * scale).roundToInt(), (height * scale).roundToInt())
         NSNotificationCenter.defaultCenter.addObserver(
             observer = keyboardVisibilityListener,
             selector = NSSelectorFromString("keyboardWillShow:"),

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -29,8 +29,10 @@ import androidx.compose.ui.platform.UIKitTextInputService
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toOffset
 import kotlin.math.roundToInt
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
@@ -88,7 +90,7 @@ internal actual class ComposeWindow : UIViewController {
             val screenHeight = UIScreen.mainScreen.bounds.useContents { size.height }
             val focused = layer.getActiveFocusRect()
             if (focused != null) {
-                val focusedBottom = focused.bottom + getTopLeftOffset().y
+                val focusedBottom = focused.bottom.value + getTopLeftOffset().y
                 val hiddenPartOfFocusedElement = focusedBottom + keyboardHeight - screenHeight
                 if (hiddenPartOfFocusedElement > 0) {
                     // If focused element hidden by keyboard, then change UIView bounds.
@@ -273,7 +275,7 @@ internal actual class ComposeWindow : UIViewController {
                 point = CGPointMake(0.0, 0.0),
                 toCoordinateSpace = UIScreen.mainScreen.coordinateSpace()
             )
-        return topLeftPoint.useContents { Offset(x.toFloat(), y.toFloat()) }
+        return topLeftPoint.useContents { DpOffset(x.dp, y.dp).toOffset(density) }
     }
 
 }


### PR DESCRIPTION
On uikit:
We set the density initially and when screen size changes (e.g. orientation change).
On mac and js:
We set the density only initally for now.

P.S. I didn't find how to change the screen density on iphone simulator. 