### PR TITLE
Fix dismiss request and click on button

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.android.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerInputChange
+
+internal actual suspend fun AwaitPointerEventScope.waitForPressDown(): PointerInputChange = awaitFirstDown()

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.desktop.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputChange
+
+internal actual suspend fun AwaitPointerEventScope.waitForPressDown(): PointerInputChange =
+    awaitEvent(PointerEventPass.Main) { pointerEvent: PointerEvent ->
+        pointerEvent.type == PointerEventType.Press && pointerEvent.isPrimaryChangedDown(requireUnconsumed = true)
+    }.changes[0]

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.jsNative.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerInputChange
+
+internal actual suspend fun AwaitPointerEventScope.waitForPressDown(): PointerInputChange = awaitFirstDown()


### PR DESCRIPTION
## Found problems in inconsistent behaviour of Popup. First, we need to fix implementation of Popup's.


Fix Issue https://github.com/JetBrains/compose-jb/issues/2586

Split commonCode to handle tapAndPress into few functions. One function now expect/actual.
For Desktop, we handle press begins only on PointerEventType.Press.
On Android logic will be the same as before.

For now, some tests are failed. I will fix them in this branch after review of current changes.

Before:

https://user-images.githubusercontent.com/99798741/210183438-11cdb196-1015-458a-ad06-7f1167376252.mp4

After:

https://user-images.githubusercontent.com/99798741/210442749-77012deb-ac1a-4851-a52a-48b9a8e2a367.mp4





