### PR TITLE
Make ScrollbarAdapter for LazyList take contentPadding into account.

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -472,7 +472,11 @@ private class LazyScrollbarAdapter(
     }
 
     override fun maxScrollOffset(containerSize: Int) =
-        (averageItemSize * itemCount - containerSize).coerceAtLeast(0f)
+        (averageItemSize * itemCount
+            + scrollState.layoutInfo.beforeContentPadding
+            + scrollState.layoutInfo.afterContentPadding
+            - containerSize
+        ).coerceAtLeast(0f)
 
     private val itemCount get() = scrollState.layoutInfo.totalItemsCount
 


### PR DESCRIPTION
## Proposed Changes
`LazyScrollbarAdapter. maxScrollOffset` should take into account the content padding.

## Testing

Test: with a manual reproducer and an automated test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2604

Before fix:

https://user-images.githubusercontent.com/5230206/211154564-158180b9-459e-4931-a56b-7e96c7caf9ff.mp4

After fix:

https://user-images.githubusercontent.com/5230206/211154570-c7f38276-aaf6-4e62-813e-ffad2f276931.mp4

