### PR TITLE
Distinguish between scrollbar (track) size and scrollable viewport size.

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
@@ -107,6 +107,9 @@ class ScrollState(initial: Int) : ScrollableState {
             }
         }
 
+    var viewportSize: Int = 0
+        internal set
+
     /**
      * [InteractionSource] that will be used to dispatch drag events when this
      * list is being dragged. If you want to know whether the fling (or smooth scroll) is in
@@ -346,6 +349,7 @@ private data class ScrollingLayoutModifier(
         // measurements inside onRemeasured are able to scroll to the new max based on the newly-
         // measured size.
         scrollerState.maxValue = side
+        scrollerState.viewportSize = if (isVertical) height else width
         return layout(width, height) {
             val scroll = scrollerState.value.coerceIn(0, side)
             val absScroll = if (isReversed) scroll - side else -scroll


### PR DESCRIPTION
## Note: This is a preliminary, non cleaned-up PR, to discuss the change(s).

## Proposed Changes
`SliderAdapter` assumes the `contentSize` argument it is given is both the size of the track and the size of the scrollable viewport, which can be seen as it passes it to `ScrollbarAdapter` functions. But this can be wrong, as the size of the scrollbar (track) can be different, such as when the scrollbar has padding.

This PR separates the two concepts. `ScrollbarAdapter` no longer needs the `containerSize` parameter and instead it becomes the source of truth for the scrollable properties: `contentSize`, `viewportSize` and `maxScrollOffset`.

For `LazyListState`, I use `LazyListState.layoutInfo.viewportSize` for the size of the viewport. Unfortunately, `ScrollState` has no corresponding viewport size property, so I had to add it.

### Possible Issues and Questions
1. The changes in the `ScrollbarAdapter` interface break compatibility, but I'm thinking that it's unlikely anyone implemented or used it directly.
2. `ScrollState.viewportSize` and the code that sets it appear to be Google's code, so we'll need to push it upstream?
3. `ScrollState.maxValue` does a weird dance with `_maxValueState` whose purpose I don't understand. I didn't replicate this dance with `viewportSize`. Should I?


## Testing

Test: with a reproducer, will add unit tests later.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2605
