### PR TITLE
Declare and implement a new v2.ScrollbarAdapter

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
@@ -110,8 +110,10 @@ class ScrollState(initial: Int) : ScrollableState {
     /**
      * Size of the viewport on the scrollable axis, or 0 if still unknown.
      */
-    var viewportSize: Int by mutableStateOf(0, structuralEqualityPolicy())
-        internal set
+    // This property is internal until it is merged upstream, because we can't expose an API that
+    // doesn't exist on Android. Once it is merged upstream, it should be made public with an
+    // internal setter
+    internal var viewportSize: Int by mutableStateOf(0, structuralEqualityPolicy())
 
     /**
      * [InteractionSource] that will be used to dispatch drag events when this

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
@@ -108,6 +108,12 @@ class ScrollState(initial: Int) : ScrollableState {
         }
 
     /**
+     * Size of the viewport on the scrollable axis, or 0 if still unknown.
+     */
+    var viewportSize: Int by mutableStateOf(0, structuralEqualityPolicy())
+        internal set
+
+    /**
      * [InteractionSource] that will be used to dispatch drag events when this
      * list is being dragged. If you want to know whether the fling (or smooth scroll) is in
      * progress, use [isScrollInProgress].
@@ -346,6 +352,7 @@ private data class ScrollingLayoutModifier(
         // measurements inside onRemeasured are able to scroll to the new max based on the newly-
         // measured size.
         scrollerState.maxValue = side
+        scrollerState.viewportSize = if (isVertical) height else width
         return layout(width, height) {
             val scroll = scrollerState.value.coerceIn(0, side)
             val absScroll = if (isReversed) scroll - side else -scroll

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
@@ -108,9 +108,9 @@ class ScrollState(initial: Int) : ScrollableState {
         }
 
     /**
-     * Size of the viewport on the scrollable axis, or -1 if still unknown.
+     * Size of the viewport on the scrollable axis, or 0 if still unknown.
      */
-    internal var viewportSize: Int by mutableStateOf(-1, structuralEqualityPolicy())
+    internal var viewportSize: Int by mutableStateOf(0, structuralEqualityPolicy())
 
     /**
      * [InteractionSource] that will be used to dispatch drag events when this

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
@@ -110,9 +110,6 @@ class ScrollState(initial: Int) : ScrollableState {
     /**
      * Size of the viewport on the scrollable axis, or -1 if still unknown.
      */
-    // This property is internal until it is merged upstream, because we can't expose an API that
-    // doesn't exist on Android. Once it is merged upstream, it should be made public with an
-    // internal setter
     internal var viewportSize: Int by mutableStateOf(-1, structuralEqualityPolicy())
 
     /**

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Scroll.kt
@@ -108,12 +108,12 @@ class ScrollState(initial: Int) : ScrollableState {
         }
 
     /**
-     * Size of the viewport on the scrollable axis, or 0 if still unknown.
+     * Size of the viewport on the scrollable axis, or -1 if still unknown.
      */
     // This property is internal until it is merged upstream, because we can't expose an API that
     // doesn't exist on Android. Once it is merged upstream, it should be made public with an
     // internal setter
-    internal var viewportSize: Int by mutableStateOf(0, structuralEqualityPolicy())
+    internal var viewportSize: Int by mutableStateOf(-1, structuralEqualityPolicy())
 
     /**
      * [InteractionSource] that will be used to dispatch drag events when this

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -301,17 +301,17 @@ private class OldAdapterAsNew(
     private val trackSize: Int
 ) : NewScrollbarAdapter {
 
-    override val scrollOffset: Float
-        get() = oldAdapter.scrollOffset
+    override val scrollOffset: Double
+        get() = oldAdapter.scrollOffset.toDouble()
 
-    override val contentSize: Float
-        get() = oldAdapter.maxScrollOffset(trackSize) + trackSize
+    override val contentSize: Double
+        get() = (oldAdapter.maxScrollOffset(trackSize) + trackSize).toDouble()
 
-    override val viewportSize: Float
-        get() = trackSize.toFloat()
+    override val viewportSize: Double
+        get() = trackSize.toDouble()
 
-    override suspend fun scrollTo(scrollOffset: Float) {
-        oldAdapter.scrollTo(trackSize, scrollOffset)
+    override suspend fun scrollTo(scrollOffset: Double) {
+        oldAdapter.scrollTo(trackSize, scrollOffset.toFloat())
     }
 
 }
@@ -338,14 +338,14 @@ private class NewAdapterAsOld(
 ): ScrollbarAdapter {
 
     override val scrollOffset: Float
-        get() = newAdapter.scrollOffset
+        get() = newAdapter.scrollOffset.toFloat()
 
     override suspend fun scrollTo(containerSize: Int, scrollOffset: Float) {
-        newAdapter.scrollTo(scrollOffset)
+        newAdapter.scrollTo(scrollOffset.toDouble())
     }
 
     override fun maxScrollOffset(containerSize: Int): Float {
-        return newAdapter.maxScrollOffset
+        return newAdapter.maxScrollOffset.toFloat()
     }
 
 }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -593,8 +593,8 @@ fun OldScrollbarAdapter(
 ): ScrollbarAdapter = ScrollbarAdapter(scrollState).asOldAdapter()
 
 /**
- * Create and [remember] [OldScrollbarAdapter] for scrollable container and current instance of
- * [scrollState]
+ * Create and [remember] [androidx.compose.foundation.v2.ScrollbarAdapter] for
+ * scrollable container with the given instance [ScrollState].
  */
 @JvmName("rememberScrollbarAdapter2")
 @Composable
@@ -605,8 +605,8 @@ fun rememberScrollbarAdapter(
 }
 
 /**
- * Create and [remember] [OldScrollbarAdapter] for lazy scrollable container and current instance of
- * [scrollState]
+ * Create and [remember] [androidx.compose.foundation.v2.ScrollbarAdapter] for
+ * lazy scrollable container with the given instance [LazyListState].
  */
 @JvmName("rememberScrollbarAdapter2")
 @Composable

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 import kotlin.math.sign
 import kotlinx.coroutines.delay
 
@@ -697,13 +698,22 @@ interface ScrollbarAdapter {
 
 }
 
+private fun computeSlidePositionAndSize(sliderAdapter: SliderAdapter): Pair<Int, Int> {
+    val adapterPosition = sliderAdapter.position
+    val position = adapterPosition.roundToInt()
+    val size = (sliderAdapter.thumbSize + adapterPosition - position).roundToInt()
+
+    return Pair(position, size)
+}
+
 private fun verticalMeasurePolicy(
     sliderAdapter: SliderAdapter,
     setContainerSize: (Int) -> Unit,
     scrollThickness: Int
 ) = MeasurePolicy { measurables, constraints ->
     setContainerSize(constraints.maxHeight)
-    val height = sliderAdapter.thumbSize.toInt()
+    val (position, height) = computeSlidePositionAndSize(sliderAdapter)
+
     val placeable = measurables.first().measure(
         Constraints.fixed(
             constraints.constrainWidth(scrollThickness),
@@ -711,7 +721,7 @@ private fun verticalMeasurePolicy(
         )
     )
     layout(placeable.width, constraints.maxHeight) {
-        placeable.place(0, sliderAdapter.position.toInt())
+        placeable.place(0, position)
     }
 }
 
@@ -721,7 +731,8 @@ private fun horizontalMeasurePolicy(
     scrollThickness: Int
 ) = MeasurePolicy { measurables, constraints ->
     setContainerSize(constraints.maxWidth)
-    val width = sliderAdapter.thumbSize.toInt()
+    val (position, width) = computeSlidePositionAndSize(sliderAdapter)
+
     val placeable = measurables.first().measure(
         Constraints.fixed(
             width,
@@ -729,7 +740,7 @@ private fun horizontalMeasurePolicy(
         )
     )
     layout(constraints.maxWidth, placeable.height) {
-        placeable.place(sliderAdapter.position.toInt(), 0)
+        placeable.place(position, 0)
     }
 }
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -174,6 +174,9 @@ fun rememberScrollbarAdapter(
 
 /**
  * Defines how to scroll the scrollable component and how to display a scrollbar for it.
+ *
+ * The values of this interface are typically in pixels, but do not have to be.
+ * It's possible to create an adapter with any scroll range of `Double` values.
  */
 interface ScrollbarAdapter {
 
@@ -182,7 +185,8 @@ interface ScrollbarAdapter {
 
     /**
      * Scroll offset of the content inside the scrollable component.
-     * Offset "100" means that the content is scrolled by 100 pixels from the start.
+     *
+     * For example, a value of `100` could mean the content is scrolled by 100 pixels from the start.
      */
     val scrollOffset: Double
 
@@ -197,10 +201,10 @@ interface ScrollbarAdapter {
     val viewportSize: Double
 
     /**
-     * Instantly jump to [scrollOffset] in pixels
+     * Instantly jump to [scrollOffset].
      *
-     * @param scrollOffset target value in pixels to jump to,
-     *  value will be coerced to the valid scroll range.
+     * @param scrollOffset target offset to jump to, value will be coerced to the valid
+     * scroll range.
      */
     suspend fun scrollTo(scrollOffset: Double)
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.v2
+
+import androidx.compose.foundation.LocalScrollbarStyle
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.Scrollbar
+import androidx.compose.foundation.ScrollbarStyle
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlinx.coroutines.runBlocking
+
+
+/**
+ * Vertical scrollbar that can be attached to some scrollable
+ * component (ScrollableColumn, LazyColumn) and share common state with it.
+ *
+ * Can be placed independently.
+ *
+ * Example:
+ *     val state = rememberScrollState(0f)
+ *
+ *     Box(Modifier.fillMaxSize()) {
+ *         Box(modifier = Modifier.verticalScroll(state)) {
+ *             ...
+ *         }
+ *
+ *         VerticalScrollbar(
+ *             Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+ *             rememberScrollbarAdapter(state)
+ *         )
+ *     }
+ *
+ * @param adapter [ScrollbarAdapter] that will be used to communicate with scrollable component
+ * @param modifier the modifier to apply to this layout
+ * @param reverseLayout reverse the direction of scrolling and layout, when `true`
+ * and [LazyListState.firstVisibleItemIndex] == 0 then scrollbar
+ * will be at the bottom of the container.
+ * It is usually used in pair with `LazyColumn(reverseLayout = true)`
+ * @param style [ScrollbarStyle] to define visual style of scrollbar
+ * @param interactionSource [MutableInteractionSource] that will be used to dispatch
+ * [DragInteraction.Start] when this Scrollbar is being dragged.
+ */
+@Composable
+fun VerticalScrollbar(
+    adapter: ScrollbarAdapter,
+    modifier: Modifier = Modifier,
+    reverseLayout: Boolean = false,
+    style: ScrollbarStyle = LocalScrollbarStyle.current,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) = Scrollbar(
+    newAdapter = adapter,
+    modifier,
+    reverseLayout,
+    style,
+    interactionSource,
+    isVertical = true
+)
+
+/**
+ * Horizontal scrollbar that can be attached to some scrollable
+ * component (Modifier.verticalScroll(), LazyRow) and share common state with it.
+ *
+ * Can be placed independently.
+ *
+ * Example:
+ *     val state = rememberScrollState(0f)
+ *
+ *     Box(Modifier.fillMaxSize()) {
+ *         Box(modifier = Modifier.verticalScroll(state)) {
+ *             ...
+ *         }
+ *
+ *         HorizontalScrollbar(
+ *             Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
+ *             rememberScrollbarAdapter(state)
+ *         )
+ *     }
+ *
+ * @param adapter [ScrollbarAdapter] that will be used to communicate with scrollable component
+ * @param modifier the modifier to apply to this layout
+ * @param reverseLayout reverse the direction of scrolling and layout, when `true`
+ * and [LazyListState.firstVisibleItemIndex] == 0 then scrollbar
+ * will be at the end of the container.
+ * It is usually used in pair with `LazyRow(reverseLayout = true)`
+ * @param style [ScrollbarStyle] to define visual style of scrollbar
+ * @param interactionSource [MutableInteractionSource] that will be used to dispatch
+ * [DragInteraction.Start] when this Scrollbar is being dragged.
+ */
+@Composable
+fun HorizontalScrollbar(
+    adapter: ScrollbarAdapter,
+    modifier: Modifier = Modifier,
+    reverseLayout: Boolean = false,
+    style: ScrollbarStyle = LocalScrollbarStyle.current,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) = Scrollbar(
+    newAdapter = adapter,
+    modifier,
+    if (LocalLayoutDirection.current == LayoutDirection.Rtl) !reverseLayout else reverseLayout,
+    style,
+    interactionSource,
+    isVertical = false
+)
+
+@Composable
+private fun Scrollbar(
+    newAdapter: ScrollbarAdapter,
+    modifier: Modifier = Modifier,
+    reverseLayout: Boolean,
+    style: ScrollbarStyle,
+    interactionSource: MutableInteractionSource,
+    isVertical: Boolean
+) = Scrollbar(
+    oldOrNewAdapter = newAdapter,
+    newScrollbarAdapterFactory = { adapter, _ -> adapter },
+    modifier = modifier,
+    reverseLayout = reverseLayout,
+    style = style,
+    interactionSource = interactionSource,
+    isVertical = isVertical
+)
+
+/**
+ * Create and [remember] [ScrollbarAdapter] for scrollable container and current instance of
+ * [scrollState]
+ */
+@Composable
+fun rememberScrollbarAdapter(
+    scrollState: ScrollState
+): ScrollbarAdapter = remember(scrollState) {
+    ScrollbarAdapter(scrollState)
+}
+
+/**
+ * Create and [remember] [ScrollbarAdapter] for lazy scrollable container and current instance of
+ * [scrollState]
+ */
+@Composable
+fun rememberScrollbarAdapter(
+    scrollState: LazyListState,
+): ScrollbarAdapter {
+    return remember(scrollState) {
+        ScrollbarAdapter(scrollState)
+    }
+}
+
+/**
+ * Defines how to scroll the scrollable component and how to display a scrollbar for it.
+ */
+interface ScrollbarAdapter {
+
+    /**
+     * Scroll offset of the content inside the scrollable component.
+     * Offset "100" means that the content is scrolled by 100 pixels from the start.
+     */
+    val scrollOffset: Float
+
+    /**
+     * The size of the scrollable content, on the scrollable axis.
+     */
+    val contentSize: Float
+
+    /**
+     * The size of the viewport, on the scrollable axis.
+     */
+    val viewportSize: Float
+
+    /**
+     * Instantly jump to [scrollOffset] in pixels
+     *
+     * @param scrollOffset target value in pixels to jump to,
+     *  value will be coerced to the valid scroll range.
+     */
+    suspend fun scrollTo(scrollOffset: Float)
+
+}
+
+/**
+ * The maximum scroll offset of the scrollable content.
+ */
+val ScrollbarAdapter.maxScrollOffset: Float
+    get() = (contentSize - viewportSize).coerceAtLeast(0f)
+
+/**
+ * ScrollbarAdapter for Modifier.verticalScroll and Modifier.horizontalScroll
+ *
+ * [scrollState] is instance of [ScrollState] which is used by scrollable component
+ *
+ * Example:
+ *     val state = rememberScrollState(0f)
+ *
+ *     Box(Modifier.fillMaxSize()) {
+ *         Box(modifier = Modifier.verticalScroll(state)) {
+ *             ...
+ *         }
+ *
+ *         VerticalScrollbar(
+ *             Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+ *             rememberScrollbarAdapter(state)
+ *         )
+ *     }
+ */
+fun ScrollbarAdapter(
+    scrollState: ScrollState
+): ScrollbarAdapter = ScrollableScrollbarAdapter(scrollState)
+
+private class ScrollableScrollbarAdapter(
+    private val scrollState: ScrollState
+) : ScrollbarAdapter {
+
+    override val scrollOffset: Float get() = scrollState.value.toFloat()
+
+    override suspend fun scrollTo(scrollOffset: Float) {
+        scrollState.scrollTo(scrollOffset.roundToInt())
+    }
+
+    override val contentSize: Float
+        // This isn't strictly correct, as the actual content can be smaller
+        // than the viewport when scrollState.maxValue is 0, but the scrollbar
+        // doesn't really care as long as contentSize <= viewportSize; it's
+        // just not showing itself
+        get() = scrollState.maxValue + viewportSize
+
+    override val viewportSize: Float
+        get() = scrollState.viewportSize.toFloat()
+
+}
+
+/**
+ * ScrollbarAdapter for lazy lists.
+ *
+ * [scrollState] is instance of [LazyListState] which is used by scrollable component
+ *
+ * Scrollbar size and position will be dynamically changed on the current visible content.
+ *
+ * Example:
+ *     Box(Modifier.fillMaxSize()) {
+ *         val state = rememberLazyListState()
+ *
+ *         LazyColumn(state = state) {
+ *             ...
+ *         }
+ *
+ *         VerticalScrollbar(
+ *             Modifier.align(Alignment.CenterEnd),
+ *             rememberScrollbarAdapter(state)
+ *         )
+ *     }
+ */
+fun ScrollbarAdapter(
+    scrollState: LazyListState
+): ScrollbarAdapter = LazyScrollbarAdapter(
+    scrollState
+)
+
+private class LazyScrollbarAdapter(
+    private val scrollState: LazyListState
+) : ScrollbarAdapter {
+
+    override val scrollOffset: Float
+        get() = scrollState.firstVisibleItemIndex * averageItemSize +
+            scrollState.firstVisibleItemScrollOffset
+
+    override val viewportSize: Float
+        get() = with(scrollState.layoutInfo){
+            if (orientation == Orientation.Vertical)
+                viewportSize.height
+            else
+                viewportSize.width
+        }.toFloat()
+
+    override val contentSize: Float
+        get() {
+            return averageItemSize * itemCount +
+                scrollState.layoutInfo.beforeContentPadding +
+                scrollState.layoutInfo.afterContentPadding
+        }
+
+    override suspend fun scrollTo(scrollOffset: Float) {
+        val distance = scrollOffset - this@LazyScrollbarAdapter.scrollOffset
+
+        // if we scroll less than viewport we need to use scrollBy function to avoid
+        // undesirable scroll jumps (when an item size is different)
+        //
+        // if we scroll more than viewport we should immediately jump to this position
+        // without recreating all items between the current and the new position
+        if (abs(distance) <= viewportSize) {
+            scrollState.scrollBy(distance)
+        } else {
+            snapTo(scrollOffset)
+        }
+    }
+
+    private suspend fun snapTo(scrollOffset: Float) {
+        // In case of very big values, we can catch an overflow, so convert values to double and
+        // coerce them
+//        val averageItemSize = 26.000002f
+//        val scrollOffsetCoerced = 2.54490608E8.toFloat()
+//        val index = (scrollOffsetCoerced / averageItemSize).toInt() // 9788100
+//        val offset = (scrollOffsetCoerced - index * averageItemSize) // -16.0
+//        println(offset)
+
+        val maximumValue = maxScrollOffset.toDouble()
+        val scrollOffsetCoerced = scrollOffset.toDouble().coerceIn(0.0, maximumValue)
+        val averageItemSize = averageItemSize.toDouble()
+
+        val index = (scrollOffsetCoerced / averageItemSize)
+            .toInt()
+            .coerceAtLeast(0)
+            .coerceAtMost(itemCount - 1)
+
+        val offset = (scrollOffsetCoerced - index * averageItemSize)
+            .toInt()
+            .coerceAtLeast(0)
+
+        scrollState.scrollToItem(index = index, scrollOffset = offset)
+    }
+
+    private val itemCount get() = scrollState.layoutInfo.totalItemsCount
+
+    private val averageItemSize by derivedStateOf {
+        scrollState
+            .layoutInfo
+            .visibleItemsInfo
+            .asSequence()
+            .map { it.size }
+            .average()
+            .toFloat()
+    }
+
+}
+
+internal class SliderAdapter(
+    private val adapter: ScrollbarAdapter,
+    private val trackSize: Int,
+    private val minHeight: Float,
+    private val reverseLayout: Boolean,
+    private val isVertical: Boolean,
+) {
+
+    private val contentSize get() = adapter.contentSize
+    private val visiblePart get() = adapter.viewportSize / contentSize
+
+    val thumbSize
+        get() = (trackSize * visiblePart)
+            .coerceAtLeast(minHeight)
+            .coerceAtMost(trackSize.toFloat())
+
+    private val scrollScale: Float
+        get() {
+            val extraScrollbarSpace = trackSize - thumbSize
+            val extraContentSpace = adapter.maxScrollOffset  // == contentSize - viewportSize
+            return if (extraContentSpace == 0f) 1f else extraScrollbarSpace / extraContentSpace
+        }
+
+    private var rawPosition: Float
+        get() = scrollScale * adapter.scrollOffset
+        set(value) {
+            runBlocking {
+                adapter.scrollTo(value / scrollScale)
+            }
+        }
+
+    var position: Float
+        get() = if (reverseLayout) trackSize - thumbSize - rawPosition else rawPosition
+        set(value) {
+            rawPosition = if (reverseLayout) {
+                trackSize - thumbSize - value
+            } else {
+                value
+            }
+        }
+
+    val bounds get() = position..position + thumbSize
+
+    // Stores the unrestricted position during a dragging gesture
+    private var positionDuringDrag = 0f
+
+    /** Called when the thumb dragging starts */
+    fun onDragStarted() {
+        positionDuringDrag = position
+    }
+
+    /** Called on every movement while dragging the thumb */
+    fun onDragDelta(offset: Offset) {
+        val dragDelta = if (isVertical) offset.y else offset.x
+        val maxScrollPosition = adapter.maxScrollOffset * scrollScale
+        val sliderDelta =
+            (positionDuringDrag + dragDelta).coerceIn(0f, maxScrollPosition) -
+                positionDuringDrag.coerceIn(0f, maxScrollPosition)
+        position += sliderDelta  // Have to add to position for smooth content scroll if the items are of different size
+        positionDuringDrag += dragDelta
+    }
+
+}

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -169,7 +169,14 @@ internal class SliderAdapter(
 ) {
 
     private val contentSize get() = adapter.contentSize
-    private val visiblePart get() = (adapter.viewportSize / contentSize).coerceAtMost(1.0)
+    private val visiblePart: Double
+        get() {
+            val contentSize = contentSize
+            return if (contentSize == 0.0)
+                1.0
+            else
+                (adapter.viewportSize / contentSize).coerceAtMost(1.0)
+        }
 
     val thumbSize
         get() = (trackSize * visiblePart).coerceAtLeast(minHeight.toDouble())

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -16,161 +16,17 @@
 
 package androidx.compose.foundation.v2
 
-import androidx.compose.foundation.LocalScrollbarStyle
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.Scrollbar
-import androidx.compose.foundation.ScrollbarStyle
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollBy
-import androidx.compose.foundation.interaction.DragInteraction
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.LayoutDirection
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.runBlocking
 
-
-/**
- * Vertical scrollbar that can be attached to some scrollable
- * component (ScrollableColumn, LazyColumn) and share common state with it.
- *
- * Can be placed independently.
- *
- * Example:
- *     val state = rememberScrollState(0f)
- *
- *     Box(Modifier.fillMaxSize()) {
- *         Box(modifier = Modifier.verticalScroll(state)) {
- *             ...
- *         }
- *
- *         VerticalScrollbar(
- *             Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
- *             rememberScrollbarAdapter(state)
- *         )
- *     }
- *
- * @param adapter [ScrollbarAdapter] that will be used to communicate with scrollable component
- * @param modifier the modifier to apply to this layout
- * @param reverseLayout reverse the direction of scrolling and layout, when `true`
- * and [LazyListState.firstVisibleItemIndex] == 0 then scrollbar
- * will be at the bottom of the container.
- * It is usually used in pair with `LazyColumn(reverseLayout = true)`
- * @param style [ScrollbarStyle] to define visual style of scrollbar
- * @param interactionSource [MutableInteractionSource] that will be used to dispatch
- * [DragInteraction.Start] when this Scrollbar is being dragged.
- */
-@Composable
-fun VerticalScrollbar(
-    adapter: ScrollbarAdapter,
-    modifier: Modifier = Modifier,
-    reverseLayout: Boolean = false,
-    style: ScrollbarStyle = LocalScrollbarStyle.current,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
-) = Scrollbar(
-    newAdapter = adapter,
-    modifier,
-    reverseLayout,
-    style,
-    interactionSource,
-    isVertical = true
-)
-
-/**
- * Horizontal scrollbar that can be attached to some scrollable
- * component (Modifier.verticalScroll(), LazyRow) and share common state with it.
- *
- * Can be placed independently.
- *
- * Example:
- *     val state = rememberScrollState(0f)
- *
- *     Box(Modifier.fillMaxSize()) {
- *         Box(modifier = Modifier.verticalScroll(state)) {
- *             ...
- *         }
- *
- *         HorizontalScrollbar(
- *             Modifier.align(Alignment.BottomCenter).fillMaxWidth(),
- *             rememberScrollbarAdapter(state)
- *         )
- *     }
- *
- * @param adapter [ScrollbarAdapter] that will be used to communicate with scrollable component
- * @param modifier the modifier to apply to this layout
- * @param reverseLayout reverse the direction of scrolling and layout, when `true`
- * and [LazyListState.firstVisibleItemIndex] == 0 then scrollbar
- * will be at the end of the container.
- * It is usually used in pair with `LazyRow(reverseLayout = true)`
- * @param style [ScrollbarStyle] to define visual style of scrollbar
- * @param interactionSource [MutableInteractionSource] that will be used to dispatch
- * [DragInteraction.Start] when this Scrollbar is being dragged.
- */
-@Composable
-fun HorizontalScrollbar(
-    adapter: ScrollbarAdapter,
-    modifier: Modifier = Modifier,
-    reverseLayout: Boolean = false,
-    style: ScrollbarStyle = LocalScrollbarStyle.current,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
-) = Scrollbar(
-    newAdapter = adapter,
-    modifier,
-    if (LocalLayoutDirection.current == LayoutDirection.Rtl) !reverseLayout else reverseLayout,
-    style,
-    interactionSource,
-    isVertical = false
-)
-
-@Composable
-private fun Scrollbar(
-    newAdapter: ScrollbarAdapter,
-    modifier: Modifier = Modifier,
-    reverseLayout: Boolean,
-    style: ScrollbarStyle,
-    interactionSource: MutableInteractionSource,
-    isVertical: Boolean
-) = Scrollbar(
-    oldOrNewAdapter = newAdapter,
-    newScrollbarAdapterFactory = { adapter, _ -> adapter },
-    modifier = modifier,
-    reverseLayout = reverseLayout,
-    style = style,
-    interactionSource = interactionSource,
-    isVertical = isVertical
-)
-
-/**
- * Create and [remember] [ScrollbarAdapter] for scrollable container and current instance of
- * [scrollState]
- */
-@Composable
-fun rememberScrollbarAdapter(
-    scrollState: ScrollState
-): ScrollbarAdapter = remember(scrollState) {
-    ScrollbarAdapter(scrollState)
-}
-
-/**
- * Create and [remember] [ScrollbarAdapter] for lazy scrollable container and current instance of
- * [scrollState]
- */
-@Composable
-fun rememberScrollbarAdapter(
-    scrollState: LazyListState,
-): ScrollbarAdapter {
-    return remember(scrollState) {
-        ScrollbarAdapter(scrollState)
-    }
-}
 
 /**
  * Defines how to scroll the scrollable component and how to display a scrollbar for it.
@@ -216,30 +72,7 @@ interface ScrollbarAdapter {
 val ScrollbarAdapter.maxScrollOffset: Double
     get() = (contentSize - viewportSize).coerceAtLeast(0.0)
 
-/**
- * ScrollbarAdapter for Modifier.verticalScroll and Modifier.horizontalScroll
- *
- * [scrollState] is instance of [ScrollState] which is used by scrollable component
- *
- * Example:
- *     val state = rememberScrollState(0f)
- *
- *     Box(Modifier.fillMaxSize()) {
- *         Box(modifier = Modifier.verticalScroll(state)) {
- *             ...
- *         }
- *
- *         VerticalScrollbar(
- *             Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
- *             rememberScrollbarAdapter(state)
- *         )
- *     }
- */
-fun ScrollbarAdapter(
-    scrollState: ScrollState
-): ScrollbarAdapter = ScrollableScrollbarAdapter(scrollState)
-
-private class ScrollableScrollbarAdapter(
+internal class ScrollableScrollbarAdapter(
     private val scrollState: ScrollState
 ) : ScrollbarAdapter {
 
@@ -261,34 +94,7 @@ private class ScrollableScrollbarAdapter(
 
 }
 
-/**
- * ScrollbarAdapter for lazy lists.
- *
- * [scrollState] is instance of [LazyListState] which is used by scrollable component
- *
- * Scrollbar size and position will be dynamically changed on the current visible content.
- *
- * Example:
- *     Box(Modifier.fillMaxSize()) {
- *         val state = rememberLazyListState()
- *
- *         LazyColumn(state = state) {
- *             ...
- *         }
- *
- *         VerticalScrollbar(
- *             Modifier.align(Alignment.CenterEnd),
- *             rememberScrollbarAdapter(state)
- *         )
- *     }
- */
-fun ScrollbarAdapter(
-    scrollState: LazyListState
-): ScrollbarAdapter = LazyScrollbarAdapter(
-    scrollState
-)
-
-private class LazyScrollbarAdapter(
+internal class LazyScrollbarAdapter(
     private val scrollState: LazyListState
 ) : ScrollbarAdapter {
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -695,7 +695,6 @@ class ScrollbarTest {
                 }
             }
 
-            @Suppress("DEPRECATION")
             VerticalScrollbar(
                 adapter = rememberScrollbarAdapter(state),
                 modifier = Modifier
@@ -720,7 +719,6 @@ class ScrollbarTest {
                 content = scrollableContent
             )
 
-            @Suppress("DEPRECATION")
             VerticalScrollbar(
                 adapter = rememberScrollbarAdapter(state),
                 modifier = Modifier
@@ -755,7 +753,6 @@ class ScrollbarTest {
                 }
             }
 
-            @Suppress("DEPRECATION")
             VerticalScrollbar(
                 adapter = rememberScrollbarAdapter(state),
                 reverseLayout = reverseLayout,
@@ -784,7 +781,6 @@ class ScrollbarTest {
                 content = content
             )
 
-            @Suppress("DEPRECATION")
             VerticalScrollbar(
                 adapter = rememberScrollbarAdapter(state),
                 reverseLayout = reverseLayout,


### PR DESCRIPTION
... in order to distinguish between scrollbar (track) size and scrollable viewport size.

## Proposed Changes
- Add a new `ScrollbarAdapter` interface in `androidx.compose.foundation.v2`
- The new interface will provide `contentSize` and `viewportSize`. `maxScrollOffset` will be implemented as an extension function.
- Add `ScrollState.viewportSize` in order to support the new `ScrollbarAdapter` implementation for a regular scrollable container.
- Implement the new `ScrollbarAdapter` for `ScrollState` and for `LazyListState`.
- ~~Copy all public functions in `androidx.compose.foundation.Scrollbar` to the new `androidx.compose.foundation.v2.Scrollbar` and mark all the old ones as deprecated.~~
- Provide full binary backwards compatibility using `@JvmName` and partial source backwards compatibility by naming the new functions the same as the old ones. The only exception is the scrollbar adapter interface itself, for which the users will need to change the import from `androidx.compose.foundation` to `androidx.compose.foundation.v2`

## Testing

Test: Manually and with new unit tests.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2605
