### PR TITLE
Compute LazyScrollbarAdapter.scrollOffset via layoutInfo.visibleItemsInfo instead of firstVisibleItemIndex

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -99,8 +99,13 @@ internal class LazyScrollbarAdapter(
 ) : ScrollbarAdapter {
 
     override val scrollOffset: Double
-        get() = scrollState.firstVisibleItemIndex * averageItemSize +
-            scrollState.firstVisibleItemScrollOffset
+        get() {
+            val firstVisibleItem = scrollState.layoutInfo.visibleItemsInfo.firstOrNull()
+            return if (firstVisibleItem == null)
+                0.0
+            else
+                firstVisibleItem.index * averageItemSize - firstVisibleItem.offset
+        }
 
     override val viewportSize: Double
         get() = with(scrollState.layoutInfo){


### PR DESCRIPTION
## Proposed Changes

We currently compute `LazyScrollbarAdapter.scrollOffset` via `LazyListState.firstVisibleItemIndex` and `LazyListState.firstVisibleItemScrollOffset`:

```
    override val scrollOffset: Double
        get() = scrollState.firstVisibleItemIndex * averageItemSize +
            scrollState.firstVisibleItemScrollOffset
```

However `averageItemSize` is computed for all the items in `LazyListState.layoutInfo.visibleItemsInfo`. These two sets of values are, however, inconsistent if the lazy list has content padding. Furthermore  `LazyListState.firstVisibleItemIndex` and `firstVisibleItemScrollOffset` return values that don't actually represent what we need here; see:
- https://issuetracker.google.com/issues/233342409
- https://issuetracker.google.com/issues/198326352

This causes the scrollbar to be unable to reach the end of the track (https://github.com/JetBrains/compose-jb/issues/2640) when using content padding in the lazy list.

This PR changes the computation of `LazyScrollbarAdapter.scrollOffset` to use `LazyListState.layoutInfo.visibleItemsInfo` so that it's consistent with `averageItemSize`.

## Testing

Test: manually and with a new unit test.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2640
