### PR TITLE
Add a separate `oel.androidx.foundation.version`

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -180,6 +180,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
 
 fun Project.experimentalOELPublication() : Boolean = findProperty("oel.publication") == "true"
 fun Project.oelAndroidxVersion() : String? = findProperty("oel.androidx.version") as String?
+fun Project.oelAndroidxFoundationVersion() : String? = findProperty("oel.androidx.foundation.version") as String?
 fun Project.oelAndroidxMaterial3Version() : String? = findProperty("oel.androidx.material3.version") as String?
 
 fun enableOELPublishing(project: Project) {
@@ -251,8 +252,16 @@ private fun Project.publishAndroidxReference(target: KotlinTarget) {
                     val material3Version = requireNotNull(target.project.oelAndroidxMaterial3Version()) {
                         "Please specify oel.androidx.material3.version property"
                     }
+                    val foundationVersion = target.project.oelAndroidxFoundationVersion() ?: composeVersion
 
-                    val version = if (target.project.group.toString().contains("org.jetbrains.compose.material3")) material3Version else composeVersion
+                    val groupId = target.project.group.toString()
+                    val version = if (groupId.contains("org.jetbrains.compose.material3")) {
+                        material3Version
+                    } else if (groupId.contains("org.jetbrains.compose.foundation")) {
+                        foundationVersion
+                    } else {
+                        composeVersion
+                    }
                     val newDependency = target.project.group.toString().replace("org.jetbrains.compose", "androidx.compose") + ":" + name + ":" + version
                     conf.dependencies.add(target.project.dependencies.create(newDependency))
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -81,3 +81,5 @@ oel.publication=true
 oel.androidx.version=1.3.3
 # Look for `COMPOSE_MATERIAL3` in libraryversions.toml
 oel.androidx.material3.version=1.0.2
+# No jetpack compose.foundation 1.3.3 published (see https://developer.android.com/jetpack/androidx/releases/compose-foundation)
+oel.androidx.foundation.version=1.3.1


### PR DESCRIPTION
Reason: androidx.compose.foundation latest version (1.3.1) doesn't match compose.runtime and compose.ui version (1.3.3)


Latest stable jetpack compose.ui version  is 1.3.3 - https://developer.android.com/jetpack/androidx/releases/compose-ui#1.3.3
Latest stable jetpack compose.foundation version is 1.3.1 - https://developer.android.com/jetpack/androidx/releases/compose-foundation#1.3.1

So I think we have to add one more property for foundation lib version