### PR TITLE
Add oel.androidx.material.version

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -182,6 +182,7 @@ fun Project.experimentalOELPublication() : Boolean = findProperty("oel.publicati
 fun Project.oelAndroidxVersion() : String? = findProperty("oel.androidx.version") as String?
 fun Project.oelAndroidxFoundationVersion() : String? = findProperty("oel.androidx.foundation.version") as String?
 fun Project.oelAndroidxMaterial3Version() : String? = findProperty("oel.androidx.material3.version") as String?
+fun Project.oelAndroidxMaterialVersion() : String? = findProperty("oel.androidx.material.version") as String?
 
 fun enableOELPublishing(project: Project) {
     if (!project.experimentalOELPublication()) return
@@ -253,12 +254,15 @@ private fun Project.publishAndroidxReference(target: KotlinTarget) {
                         "Please specify oel.androidx.material3.version property"
                     }
                     val foundationVersion = target.project.oelAndroidxFoundationVersion() ?: composeVersion
+                    val materialVersion = target.project.oelAndroidxMaterialVersion() ?: composeVersion
 
                     val groupId = target.project.group.toString()
                     val version = if (groupId.contains("org.jetbrains.compose.material3")) {
                         material3Version
                     } else if (groupId.contains("org.jetbrains.compose.foundation")) {
                         foundationVersion
+                    } else if (groupId.contains("org.jetbrains.compose.material")){
+                        materialVersion
                     } else {
                         composeVersion
                     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -80,6 +80,8 @@ oel.publication=true
 # Look for `COMPOSE` in libraryversions.toml
 oel.androidx.version=1.3.3
 # Look for `COMPOSE_MATERIAL3` in libraryversions.toml
-oel.androidx.material3.version=1.0.2
+oel.androidx.material3.version=1.0.1
 # No jetpack compose.foundation 1.3.3 published (see https://developer.android.com/jetpack/androidx/releases/compose-foundation)
 oel.androidx.foundation.version=1.3.1
+# No jetpack compose.material 1.3.3 published (see https://developer.android.com/jetpack/androidx/releases/compose-material)
+oel.androidx.material.version=1.3.1


### PR DESCRIPTION
The common  `oel.androidx.version` (current is 1.3.3) can't be used for the current `androidx.compose.material.*` version in Jetpack Compose (1.3.1), see https://developer.android.com/jetpack/androidx/releases/compose-material