### PR TITLE
Add unit test for scrollbar with empty lazy column

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -143,7 +143,12 @@ internal abstract class LazyLineContentAdapter: ScrollbarAdapter{
      */
     protected abstract fun averageVisibleLineSize(): Double
 
-    private val averageLineSize by derivedStateOf { averageVisibleLineSize() }
+    private val averageLineSize by derivedStateOf {
+        if (totalLineCount() == 0)
+            0.0
+        else
+            averageVisibleLineSize()
+    }
 
     override val scrollOffset: Double
         get() {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -764,6 +764,29 @@ class ScrollbarTest {
         }
     }
 
+    @Test
+    fun `test empty lazy list`(){
+        runBlocking(Dispatchers.Main) {
+            rule.setContent {
+                LazyListTestBox(
+                    size = 100.dp, childSize = 20.dp, childCount = 0, scrollbarWidth = 10.dp
+                )
+            }
+            rule.awaitIdle()
+
+            // Just play around and make sure it doesn't crash
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                instantDrag(start = Offset(0f, 25f), end = Offset(0f, 50f))
+            }
+            rule.awaitIdle()
+            rule.onNodeWithTag("scrollbar").performMouseInput {
+                moveTo(Offset(0f, 0f))
+                press()
+            }
+            rule.awaitIdle()
+        }
+    }
+
     private suspend fun tryUntilSucceeded(block: suspend () -> Unit) {
         while (true) {
             try {


### PR DESCRIPTION
## Proposed Changes

The crash itself has been fixed in the last commit of https://github.com/JetBrains/androidx/pull/375 simply because the algorithm for calculating the average item size now returns `0.0` instead of `NaN` for an empty list.

This PR:
- Adds an explicit test to even avoid calling the average item size calculation when the total item count is 0
- Adds a unit test for an empty lazy column.

## Testing

Test: new unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2179
