### PR TITLE
Set code editor visual guide and wrap at 100 columns

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,7 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
+    <option name="SOFT_MARGINS" value="100" />
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="STATIC_FIELD_NAME_PREFIX" value="s" />

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,6 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <state>
     <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-    <option name="PREFERRED_PROJECT_CODE_STYLE" value="AndroidStyle" />
   </state>
 </component>

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -131,7 +131,9 @@ fun defaultScrollbarStyle() = ScrollbarStyle(
  * @param interactionSource [MutableInteractionSource] that will be used to dispatch
  * [DragInteraction.Start] when this Scrollbar is being dragged.
  */
-@Deprecated("Use VerticalScrollbar(adapter: androidx.compose.foundation.v2.ScrollbarAdapter) instead")
+@Deprecated("Use VerticalScrollbar(" +
+    "adapter: androidx.compose.foundation.v2.ScrollbarAdapter)" +
+    " instead")
 @Composable
 fun VerticalScrollbar(
     @Suppress("DEPRECATION") adapter: ScrollbarAdapter,
@@ -449,7 +451,9 @@ private class OldScrollbarAdapterAsNew(
  * us to seamlessly use the new implementations, and enjoy all their benefits.
  */
 @Suppress("DEPRECATION")
-private fun ScrollbarAdapter.asNewAdapter(trackSize: Int): androidx.compose.foundation.v2.ScrollbarAdapter =
+private fun ScrollbarAdapter.asNewAdapter(
+    trackSize: Int
+): androidx.compose.foundation.v2.ScrollbarAdapter =
     if (this is NewScrollbarAdapterAsOld)
         this.newAdapter  // Just unwrap
     else
@@ -507,8 +511,8 @@ fun rememberOldScrollbarAdapter(
 }
 
 /**
- * Create and [remember] (old) [ScrollbarAdapter] for lazy scrollable container and current instance of
- * [scrollState]
+ * Create and [remember] (old) [ScrollbarAdapter] for lazy scrollable container and current instance
+ * of [scrollState]
  */
 @Deprecated(
     message ="Use rememberScrollbarAdapter instead",

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -38,13 +38,15 @@ import kotlinx.coroutines.runBlocking
  */
 interface ScrollbarAdapter {
 
-    // We use `Double` values here in order to allow scrolling both very large (think LazyList with millions of items)
-    // and very small (think something whose natural coordinates are less than 1) content.
+    // We use `Double` values here in order to allow scrolling both very large (think LazyList with
+    // millions of items) and very small (think something whose natural coordinates are less than 1)
+    // content.
 
     /**
      * Scroll offset of the content inside the scrollable component.
      *
-     * For example, a value of `100` could mean the content is scrolled by 100 pixels from the start.
+     * For example, a value of `100` could mean the content is scrolled by 100 pixels from the
+     * start.
      */
     val scrollOffset: Double
 
@@ -256,13 +258,19 @@ internal class LazyGridScrollbarAdapter(
 
     private val isVertical = scrollState.layoutInfo.orientation == Orientation.Vertical
 
-    private val unknownLine = if (isVertical) LazyGridItemInfo.UnknownRow else LazyGridItemInfo.UnknownColumn
+    private val unknownLine = with(LazyGridItemInfo) {
+        if (isVertical) UnknownRow else UnknownColumn
+    }
 
     private fun LazyGridItemInfo.line() = if (isVertical) row else column
 
-    private fun LazyGridItemInfo.mainAxisSize() = if (isVertical) size.height else size.width
+    private fun LazyGridItemInfo.mainAxisSize() = with (size) {
+        if (isVertical) height else width
+    }
 
-    private fun LazyGridItemInfo.mainAxisOffset() = if (isVertical) offset.y else offset.x
+    private fun LazyGridItemInfo.mainAxisOffset() = with(offset) {
+        if (isVertical) y else x
+    }
 
     override fun firstVisibleLine(): VisibleLine? {
         return scrollState.layoutInfo.visibleItemsInfo
@@ -304,11 +312,12 @@ internal class LazyGridScrollbarAdapter(
 
     override fun averageVisibleLineSize(): Double {
         val visibleItemsInfo = scrollState.layoutInfo.visibleItemsInfo
-        val indexOfFirstKnownLineItem = visibleItemsInfo.indexOfFirst { it.line() != unknownLine  }
+        val indexOfFirstKnownLineItem = visibleItemsInfo.indexOfFirst { it.line() != unknownLine }
         if (indexOfFirstKnownLineItem == -1)
             return 0.0
 
-        val realVisibleItemsInfo = visibleItemsInfo.subList(indexOfFirstKnownLineItem, visibleItemsInfo.size)
+        val realVisibleItemsInfo = visibleItemsInfo
+            .subList(indexOfFirstKnownLineItem, visibleItemsInfo.size)
         val lastLine = realVisibleItemsInfo.last().line()
         val lastLineSize = realVisibleItemsInfo
             .asReversed()
@@ -319,7 +328,8 @@ internal class LazyGridScrollbarAdapter(
         val first = realVisibleItemsInfo.first()
         val last = realVisibleItemsInfo.last()
         val lineCount = last.line() - first.line() + 1
-        return (last.mainAxisOffset() + lastLineSize - first.mainAxisOffset()).toDouble() / lineCount
+        val lineSizeSum = last.mainAxisOffset() + lastLineSize - first.mainAxisOffset()
+        return lineSizeSum.toDouble() / lineCount
     }
 
 }
@@ -388,7 +398,8 @@ internal class SliderAdapter(
         val sliderDelta =
             (positionDuringDrag + dragDelta).coerceIn(0.0, maxScrollPosition) -
                 positionDuringDrag.coerceIn(0.0, maxScrollPosition)
-        position += sliderDelta  // Have to add to position for smooth content scroll if the items are of different size
+        // Have to add to position for smooth content scroll if the items are of different size
+        position += sliderDelta
         positionDuringDrag += dragDelta
     }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -165,11 +165,17 @@ class ScrollbarTest {
         runBlocking(Dispatchers.Main) {
             val scale = 2f  // Content distance to corresponding scrollbar distance
             rule.setContent(scrollbarProvider) {
-                TestBox(size = 100.dp, childSize = 10.dp * scale, childCount = 10, scrollbarWidth = 10.dp)
+                TestBox(
+                    size = 100.dp,
+                    childSize = 10.dp * scale,
+                    childCount = 10,
+                    scrollbarWidth = 10.dp
+                )
             }
             rule.awaitIdle()
 
-            // While thumb is at the top, drag it up and then down the same distance. Content should not move.
+            // While thumb is at the top, drag it up and then down the same distance.
+            // Content should not move.
             rule.onNodeWithTag("scrollbar").performMouseInput {
                 moveTo(Offset(0f, 25f))
                 press()
@@ -180,7 +186,8 @@ class ScrollbarTest {
             rule.awaitIdle()
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
 
-            // While thumb is at the top, drag it up and then down a bit more. Content should move by the diff.
+            // While thumb is at the top, drag it up and then down a bit more.
+            // Content should move by the diff.
             rule.onNodeWithTag("scrollbar").performMouseInput {
                 moveTo(Offset(0f, 25f))
                 press()
@@ -200,7 +207,8 @@ class ScrollbarTest {
             }
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(-50.dp * scale)
 
-            // While thumb is at the bottom, drag it down and then up the same distance. Content should not move
+            // While thumb is at the bottom, drag it down and then up the same distance.
+            // Content should not move
             rule.onNodeWithTag("scrollbar").performMouseInput {
                 moveTo(Offset(0f, 75f))
                 press()
@@ -210,7 +218,8 @@ class ScrollbarTest {
             }
             rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(-50.dp * scale)
 
-            // While thumb is at the bottom, drag it down and then up a bit more. Content should move by the diff
+            // While thumb is at the bottom, drag it down and then up a bit more.
+            // Content should move by the diff
             rule.onNodeWithTag("scrollbar").performMouseInput {
                 moveTo(Offset(0f, 75f))
                 press()
@@ -251,7 +260,8 @@ class ScrollbarTest {
                 press()
             }
 
-            // Scroll all the way down, one pixel at a time. Make sure the content moves "up" every time.
+            // Scroll all the way down, one pixel at a time.
+            // Make sure the content moves "up" every time.
             for (i in 1..100){
                 val firstVisibleItemIndexBefore = listState.firstVisibleItemIndex
                 val firstVisibleItemScrollOffsetBefore = listState.firstVisibleItemScrollOffset
@@ -264,20 +274,21 @@ class ScrollbarTest {
 
                 if (firstVisibleItemIndexAfter < firstVisibleItemIndexBefore)
                     throw AssertionError(
-                        "First visible item index decreased on iteration $i while dragging down; " +
+                        "First visible item index decreased on iteration $i when dragging down; " +
                         "before=$firstVisibleItemIndexBefore, after=$firstVisibleItemIndexAfter"
                     )
                 else if ((firstVisibleItemIndexAfter == firstVisibleItemIndexBefore) &&
                     (firstVisibleItemScrollOffsetAfter < firstVisibleItemScrollOffsetBefore))
                     throw AssertionError(
-                        "First visible item offset decreased on iteration $i while dragging down; " +
+                        "First visible item offset decreased on iteration $i when dragging down; " +
                             "item index=$firstVisibleItemIndexAfter, " +
                             "offset before=$firstVisibleItemScrollOffsetBefore, " +
                             "offset after=$firstVisibleItemScrollOffsetAfter"
                     )
             }
 
-            // Scroll back all the way up, one pixel at a time. Make sure the content moves "down" every time
+            // Scroll back all the way up, one pixel at a time.
+            // Make sure the content moves "down" every time
             for (i in 1..100){
                 val firstVisibleItemIndexBefore = listState.firstVisibleItemIndex
                 val firstVisibleItemScrollOffsetBefore = listState.firstVisibleItemScrollOffset
@@ -332,8 +343,8 @@ class ScrollbarTest {
 
             rule.awaitIdle()
 
-            // Note that if the scrolling is incorrect, this can fail not only with a wrong value, but also by not
-            // finding the box node, as it may have not scrolled into view.
+            // Note that if the scrolling is incorrect, this can fail not only with a wrong value,
+            // but also by not finding the box node, as it may have not scrolled into view.
             // Last box should be at containerSize - bottomPadding - boxSize
             rule.onNodeWithTag("box19").assertTopPositionInRootIsEqualTo(100.dp - 25.dp - 10.dp)
         }
@@ -355,10 +366,11 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            // Thumb should be half the height of the scrollbar, as the viewport (200.dp) is half the height of the
-            // content (400.dp). So clicking on the top half of the scrollbar should do nothing.
+            // Thumb should be half the height of the scrollbar, as the viewport (200.dp) is half
+            // the height of the content (400.dp). So clicking on the top half of the scrollbar
+            // should do nothing.
             for (offset in 1..50){
-                // Use moveTo -> press -> awaitIdle -> test -> release because click doesn't appear to work
+                // Use moveTo -> press -> awaitIdle -> test -> release because click doesn't work
                 rule.onNodeWithTag("scrollbar").performMouseInput {
                     moveTo(position = Offset(0f, offset.toFloat()))
                     press()
@@ -408,7 +420,7 @@ class ScrollbarTest {
             }
             rule.awaitIdle()
 
-            // Test whether the scrollbar is at the bottom by trying to drag it up by the last pixel.
+            // Test whether the scrollbar is at the bottom by trying to drag it by the last pixel.
             // If it's not at the bottom, the drag will not succeed
             rule.onNodeWithTag("scrollbar").performMouseInput {
                 instantDrag(start = Offset(0f, 299f), end = Offset(0f, 0f))
@@ -549,7 +561,9 @@ class ScrollbarTest {
     @Theory
     @Test(timeout = 3000)
     @Suppress("JUnitMalformedDeclaration")
-    fun `dynamically change content then drag slider to the end`(scrollbarProvider: ScrollbarProvider) {
+    fun `dynamically change content then drag slider to the end`(
+        scrollbarProvider: ScrollbarProvider
+    ) {
         runBlocking(Dispatchers.Main) {
             val isContentVisible = mutableStateOf(false)
             rule.setContent(scrollbarProvider) {
@@ -1001,7 +1015,8 @@ class ScrollbarTest {
         // 2. Take a ScrollbarImpl argument
         // 3. Set the argument as the ScrollbarImplLocal, typically via
         //    ComposeContentTestRule.setContent(ScrollbarImpl, @Composable () -> Unit)
-        // Tests that should only run on the new implementation should just be marked with `@Test` as usual.
+        // Tests that should only run on the new implementation should just be marked with `@Test`
+        // as usual.
 
         @JvmField
         @DataPoint
@@ -1016,8 +1031,8 @@ class ScrollbarTest {
 }
 
 /**
- * Abstracts the implementation of the scrollbar (actually just the adapter) to allow us to test both the new and old
- * adapters.
+ * Abstracts the implementation of the scrollbar (actually just the adapter) to allow us to test
+ * both the new and old adapters.
  */
 sealed class ScrollbarImpl<A: Any> {
 
@@ -1212,15 +1227,21 @@ private object NewScrollbar: ScrollbarImpl<androidx.compose.foundation.v2.Scroll
         )
     }
 
-    override fun adapterFor(scrollState: ScrollState): androidx.compose.foundation.v2.ScrollbarAdapter {
+    override fun adapterFor(
+        scrollState: ScrollState
+    ): androidx.compose.foundation.v2.ScrollbarAdapter {
         return ScrollbarAdapter(scrollState)
     }
 
-    override fun adapterFor(scrollState: LazyListState): androidx.compose.foundation.v2.ScrollbarAdapter {
+    override fun adapterFor(
+        scrollState: LazyListState
+    ): androidx.compose.foundation.v2.ScrollbarAdapter {
         return ScrollbarAdapter(scrollState)
     }
 
-    override fun adapterFor(scrollState: LazyGridState): androidx.compose.foundation.v2.ScrollbarAdapter {
+    override fun adapterFor(
+        scrollState: LazyGridState
+    ): androidx.compose.foundation.v2.ScrollbarAdapter {
         return ScrollbarAdapter(scrollState)
     }
     


### PR DESCRIPTION
## Proposed Changes

- Set in the IDEA settings visual guide and hard wrap to 100 columns.
- Wrap some code I recently added at 100 columns.
