### PR TITLE
Move SnapshotThreadLocal to common part

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Expect.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Expect.kt
@@ -19,16 +19,7 @@ package androidx.compose.runtime
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.snapshots.SnapshotContextElement
 
-/**
- * This is similar to a `java.lang.ThreadLocal` but has lower overhead because it avoids a weak reference.
- * This should only be used when the writes are delimited by a try...finally call that will clean
- * up the reference such as [androidx.compose.runtime.snapshots.Snapshot.enter] else the reference
- * could get pinned by the thread local causing a leak.
- */
-internal expect class SnapshotThreadLocal<T>() {
-    fun get(): T?
-    fun set(value: T?)
-}
+internal expect fun getCurrentThreadId(): Long
 
 /**
  * Returns the hash code for the given object that is unique across all currently allocated objects.
@@ -61,8 +52,6 @@ internal expect class AtomicInt(value: Int) {
 }
 
 internal fun AtomicInt.postIncrement(): Int = add(1) - 1
-
-internal expect fun ensureMutable(it: Any)
 
 expect annotation class CompositionContextLocal
 

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/SnapshotThreadLocal.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/SnapshotThreadLocal.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import androidx.compose.runtime.internal.ThreadMap
+import androidx.compose.runtime.internal.emptyThreadMap
+
+/**
+ * This is similar to a `java.lang.ThreadLocal` but has lower overhead because it avoids a weak reference.
+ * This should only be used when the writes are delimited by a try...finally call that will clean
+ * up the reference such as [androidx.compose.runtime.snapshots.Snapshot.enter] else the reference
+ * could get pinned by the thread local causing a leak.
+ */
+internal class SnapshotThreadLocal<T> {
+    private val map = AtomicReference<ThreadMap>(emptyThreadMap)
+    private val writeMutex = SynchronizedObject()
+
+    @Suppress("UNCHECKED_CAST")
+    fun get(): T? = map.get().get(getCurrentThreadId()) as T?
+
+    fun set(value: T?) {
+        val key = getCurrentThreadId()
+        synchronized(writeMutex) {
+            val current = map.get()
+            if (current.trySet(key, value)) return
+            map.set(current.newWith(key, value))
+        }
+    }
+}

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/ThreadMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/ThreadMap.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compose/runtime/runtime/src/jsMain/kotlin/androidx/compose/runtime/ActualJs.js.kt
+++ b/compose/runtime/runtime/src/jsMain/kotlin/androidx/compose/runtime/ActualJs.js.kt
@@ -27,15 +27,7 @@ import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.toDuration
 
-internal actual class SnapshotThreadLocal<T> actual constructor() {
-    private var value: T? = null
-
-    actual fun get() = value
-
-    actual fun set(value: T?) {
-        this.value = value
-    }
-}
+internal actual fun getCurrentThreadId(): Long = 0
 
 internal actual class AtomicInt actual constructor(private var value: Int) {
     actual fun get(): Int = value
@@ -88,8 +80,6 @@ internal actual fun identityHashCode(instance: Any?): Int {
         )
     }
 }
-
-internal actual fun ensureMutable(it: Any) { /* NOTHING */ }
 
 actual annotation class CompositionContextLocal {}
 

--- a/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
+++ b/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
@@ -25,22 +25,7 @@ import kotlinx.coroutines.ThreadContextElement
 
 internal actual typealias AtomicReference<V> = java.util.concurrent.atomic.AtomicReference<V>
 
-internal actual class SnapshotThreadLocal<T> {
-    private val map = AtomicReference<ThreadMap>(emptyThreadMap)
-    private val writeMutex = Any()
-
-    @Suppress("UNCHECKED_CAST")
-    actual fun get(): T? = map.get().get(Thread.currentThread().id) as T?
-
-    actual fun set(value: T?) {
-        val key = Thread.currentThread().id
-        synchronized(writeMutex) {
-            val current = map.get()
-            if (current.trySet(key, value)) return
-            map.set(current.newWith(key, value))
-        }
-    }
-}
+internal actual fun getCurrentThreadId(): Long = Thread.currentThread().id
 
 internal actual fun identityHashCode(instance: Any?): Int = System.identityHashCode(instance)
 
@@ -69,8 +54,6 @@ internal actual class AtomicInt actual constructor(value: Int) {
     actual fun set(value: Int) = delegate.set(value)
     actual fun add(amount: Int): Int = delegate.addAndGet(amount)
 }
-
-internal actual fun ensureMutable(it: Any) { /* NOTHING */ }
 
 /**
  * Implementation of [SnapshotContextElement] that enters a single given snapshot when updating


### PR DESCRIPTION
- to have the only implementation for all platforms
- remove unused ensureMutable
- use kotlin.native.concurrent.AtomicReference for AtomicReference implementation (instead of deprecated FreezableAtomicReference)

Fixes https://github.com/JetBrains/compose-jb/issues/2547, https://github.com/JetBrains/compose-jb/issues/2652