### PR TITLE
Implement TextFieldScrollState and TextFieldScrollbarAdapter

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -190,7 +190,8 @@ internal fun CoreTextField(
     enabled: Boolean = true,
     readOnly: Boolean = false,
     decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
-        @Composable { innerTextField -> innerTextField() }
+        @Composable { innerTextField -> innerTextField() },
+    textScrollerPosition: TextFieldScrollerPosition? = null,
 ) {
     val focusRequester = FocusRequester()
 
@@ -205,10 +206,20 @@ internal fun CoreTextField(
     // Scroll state
     val singleLine = maxLines == 1 && !softWrap && imeOptions.singleLine
     val orientation = if (singleLine) Orientation.Horizontal else Orientation.Vertical
-    val scrollerPosition = rememberSaveable(
+    val scrollerPosition = textScrollerPosition ?: rememberSaveable(
         orientation,
         saver = TextFieldScrollerPosition.Saver
     ) { TextFieldScrollerPosition(orientation) }
+    if (scrollerPosition.orientation != orientation){
+        throw IllegalArgumentException(
+            "Mismatching scroller orientation; " + (
+                if (orientation == Orientation.Vertical)
+                    "only single-line, non-wrap text fields can scroll horizontally"
+                else
+                    "single-line, non-wrap text fields can only scroll horizontally"
+                )
+        )
+    }
 
     // State
     val transformedText = remember(value, visualTransformation) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
@@ -247,6 +247,12 @@ internal class TextFieldScrollerPosition(
         private set
 
     /**
+     * Size of the visible part, on the scrollable axis, in pixels.
+     */
+    var viewportSize by mutableStateOf(0)
+        private set
+
+    /**
      * Keeps the cursor position before a new symbol has been typed or the text field has been
      * dragged. We check it to understand if the [offset] needs to be updated.
      */
@@ -279,6 +285,7 @@ internal class TextFieldScrollerPosition(
             previousCursorRect = cursorRect
         }
         offset = offset.coerceIn(0f, difference)
+        viewportSize = containerSize
     }
 
     /*@VisibleForTesting*/

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -29,10 +29,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextFieldScrollState
 import androidx.compose.foundation.v2.LazyGridScrollbarAdapter
 import androidx.compose.foundation.v2.LazyListScrollbarAdapter
 import androidx.compose.foundation.v2.ScrollableScrollbarAdapter
 import androidx.compose.foundation.v2.SliderAdapter
+import androidx.compose.foundation.v2.TextFieldScrollbarAdapter
 import androidx.compose.foundation.v2.maxScrollOffset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocal
@@ -635,6 +637,18 @@ fun rememberScrollbarAdapter(
 }
 
 /**
+ * Create and [remember] [androidx.compose.foundation.v2.ScrollbarAdapter] for text field with
+ * the given instance of [TextFieldScrollState].
+ */
+@JvmName("rememberScrollbarAdapter2")
+@Composable
+fun rememberScrollbarAdapter(
+    scrollState: TextFieldScrollState,
+): androidx.compose.foundation.v2.ScrollbarAdapter = remember(scrollState) {
+    ScrollbarAdapter(scrollState)
+}
+
+/**
  * ScrollbarAdapter for Modifier.verticalScroll and Modifier.horizontalScroll
  *
  * [scrollState] is instance of [ScrollState] which is used by scrollable component
@@ -709,6 +723,36 @@ fun ScrollbarAdapter(
 fun ScrollbarAdapter(
     scrollState: LazyGridState
 ): androidx.compose.foundation.v2.ScrollbarAdapter = LazyGridScrollbarAdapter(scrollState)
+
+/**
+ * ScrollbarAdapter for text fields.
+ *
+ * [scrollState] is instance of [TextFieldScrollState] which is used by scrollable component
+ *
+ * Scrollbar size and position will be dynamically changed on the current visible content.
+ *
+ * Example:
+ *     Box(Modifier.fillMaxSize()) {
+ *         val scrollState = rememberTextFieldVerticalScrollState()
+ *
+ *         BasicTextField(
+ *             value = ...,
+ *             onValueChange = ...,
+ *             scrollState = state
+ *         ) {
+ *             ...
+ *         }
+ *
+ *         VerticalScrollbar(
+ *             adapter = rememberScrollbarAdapter(scrollState)
+ *             modifier = Modifier.align(Alignment.CenterEnd).fillMaxHeight(),
+ *         )
+ *     }
+ */
+@JvmName("ScrollbarAdapter2")
+fun ScrollbarAdapter(
+    scrollState: TextFieldScrollState
+): androidx.compose.foundation.v2.ScrollbarAdapter = TextFieldScrollbarAdapter(scrollState)
 
 /**
  * Defines how to scroll the scrollable component

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -640,6 +640,7 @@ fun rememberScrollbarAdapter(
  * Create and [remember] [androidx.compose.foundation.v2.ScrollbarAdapter] for text field with
  * the given instance of [TextFieldScrollState].
  */
+@ExperimentalFoundationApi
 @JvmName("rememberScrollbarAdapter2")
 @Composable
 fun rememberScrollbarAdapter(
@@ -749,6 +750,7 @@ fun ScrollbarAdapter(
  *         )
  *     }
  */
+@ExperimentalFoundationApi
 @JvmName("ScrollbarAdapter2")
 fun ScrollbarAdapter(
     scrollState: TextFieldScrollState

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -571,8 +571,6 @@ fun OldScrollbarAdapter(
  *
  * [scrollState] is instance of [LazyListState] which is used by scrollable component
  *
- * Scrollbar size and position will be dynamically changed on the current visible content.
- *
  * Example:
  *     Box(Modifier.fillMaxSize()) {
  *         val state = rememberLazyListState()
@@ -678,8 +676,6 @@ fun ScrollbarAdapter(
  *
  * [scrollState] is instance of [LazyListState] which is used by scrollable component
  *
- * Scrollbar size and position will be dynamically changed on the current visible content.
- *
  * Example:
  *     Box(Modifier.fillMaxSize()) {
  *         val state = rememberLazyListState()
@@ -704,8 +700,6 @@ fun ScrollbarAdapter(
  *
  * [scrollState] is instance of [LazyGridState] which is used by scrollable component
  *
- * Scrollbar size and position will be dynamically changed on the current visible content.
- *
  * Example:
  *     Box(Modifier.fillMaxSize()) {
  *         val state = rememberLazyGridState()
@@ -729,8 +723,6 @@ fun ScrollbarAdapter(
  * ScrollbarAdapter for text fields.
  *
  * [scrollState] is instance of [TextFieldScrollState] which is used by scrollable component
- *
- * Scrollbar size and position will be dynamically changed on the current visible content.
  *
  * Example:
  *     Box(Modifier.fillMaxSize()) {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/BasicTextField.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/BasicTextField.desktop.kt
@@ -118,6 +118,7 @@ import androidx.compose.ui.text.input.VisualTransformation
  * decorations, the text field implementation will pass in a framework-controlled composable
  * parameter "innerTextField" to the decorationBox lambda you provide. You must call
  * innerTextField exactly once.
+ * @param scrollState The state holder for the text field's scrolling-related properties.
  */
 @ExperimentalFoundationApi
 @Suppress("DuplicatedCode")
@@ -265,6 +266,7 @@ fun BasicTextField(
  * decorations, the text field implementation will pass in a framework-controlled composable
  * parameter "innerTextField" to the decorationBox lambda you provide. You must call
  * innerTextField exactly once.
+ * @param scrollState The state holder for the text field's scrolling-related properties.
  */
 @ExperimentalFoundationApi
 @Suppress("DuplicatedCode")

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/BasicTextField.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/BasicTextField.desktop.kt
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+
+/**
+ * Basic composable that enables users to edit text via hardware or software keyboard, but
+ * provides no decorations like hint or placeholder.
+ *
+ * Whenever the user edits the text, [onValueChange] is called with the most up to date state
+ * represented by [String] with which developer is expected to update their state.
+ *
+ * Unlike [TextFieldValue] overload, this composable does not let the developer to control
+ * selection, cursor and text composition information. Please check [TextFieldValue] and
+ * corresponding [BasicTextField] overload for more information.
+ *
+ * It is crucial that the value provided in the [onValueChange] is fed back into [BasicTextField] in
+ * order to have the final state of the text being displayed.
+ *
+ * Example usage:
+ * @sample androidx.compose.foundation.samples.BasicTextFieldWithStringSample
+ *
+ * Please keep in mind that [onValueChange] is useful to be informed about the latest state of the
+ * text input by users, however it is generally not recommended to modify the value that you get
+ * via [onValueChange] callback. Any change to this value may result in a context reset and end
+ * up with input session restart. Such a scenario would cause glitches in the UI or text input
+ * experience for users.
+ *
+ * This composable provides basic text editing functionality, however does not include any
+ * decorations such as borders, hints/placeholder. A design system based implementation such as
+ * Material Design Filled text field is typically what is needed to cover most of the needs. This
+ * composable is designed to be used when a custom implementation for different design system is
+ * needed.
+ *
+ * For example, if you need to include a placeholder in your TextField, you can write a composable
+ * using the decoration box like this:
+ * @sample androidx.compose.foundation.samples.PlaceholderBasicTextFieldSample
+ *
+ * If you want to add decorations to your text field, such as icon or similar, and increase the
+ * hit target area, use the decoration box:
+ * @sample androidx.compose.foundation.samples.TextFieldWithIconSample
+ *
+ * In order to create formatted text field, for example for entering a phone number or a social
+ * security number, use a [visualTransformation] parameter. Below is the example of the text field
+ * for entering a credit card number:
+ * @sample androidx.compose.foundation.samples.CreditCardSample
+ *
+ * @param value the input [String] text to be shown in the text field
+ * @param onValueChange the callback that is triggered when the input service updates the text. An
+ * updated text comes as a parameter of the callback
+ * @param modifier optional [Modifier] for this text field.
+ * @param enabled controls the enabled state of the [BasicTextField]. When `false`, the text
+ * field will be neither editable nor focusable, the input of the text field will not be selectable
+ * @param readOnly controls the editable state of the [BasicTextField]. When `true`, the text
+ * field can not be modified, however, a user can focus it and copy text from it. Read-only text
+ * fields are usually used to display pre-filled forms that user can not edit
+ * @param textStyle Style configuration that applies at character level such as color, font etc.
+ * @param keyboardOptions software keyboard options that contains configuration such as
+ * [KeyboardType] and [ImeAction].
+ * @param keyboardActions when the input service emits an IME action, the corresponding callback
+ * is called. Note that this IME action may be different from what you specified in
+ * [KeyboardOptions.imeAction].
+ * @param singleLine when set to true, this text field becomes a single horizontally scrolling
+ * text field instead of wrapping onto multiple lines. The keyboard will be informed to not show
+ * the return key as the [ImeAction]. Note that [maxLines] parameter will be ignored as the
+ * maxLines attribute will be automatically set to 1.
+ * @param maxLines the maximum height in terms of maximum number of visible lines. Should be
+ * equal or greater than 1. Note that this parameter will be ignored and instead maxLines will be
+ * set to 1 if [singleLine] is set to true.
+ * @param visualTransformation The visual transformation filter for changing the visual
+ * representation of the input. By default no visual transformation is applied.
+ * @param onTextLayout Callback that is executed when a new text layout is calculated. A
+ * [TextLayoutResult] object that callback provides contains paragraph information, size of the
+ * text, baselines and other details. The callback can be used to add additional decoration or
+ * functionality to the text. For example, to draw a cursor or selection around the text.
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this TextField. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this TextField in different [Interaction]s.
+ * @param cursorBrush [Brush] to paint cursor with. If [SolidColor] with [Color.Unspecified]
+ * provided, there will be no cursor drawn
+ * @param decorationBox Composable lambda that allows to add decorations around text field, such
+ * as icon, placeholder, helper messages or similar, and automatically increase the hit target area
+ * of the text field. To allow you to control the placement of the inner text field relative to your
+ * decorations, the text field implementation will pass in a framework-controlled composable
+ * parameter "innerTextField" to the decorationBox lambda you provide. You must call
+ * innerTextField exactly once.
+ */
+@Composable
+fun BasicTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
+        @Composable { innerTextField -> innerTextField() },
+    scrollState: TextFieldScrollState
+) {
+    // Holds the latest internal TextFieldValue state. We need to keep it to have the correct value
+    // of the composition.
+    var textFieldValueState by remember { mutableStateOf(TextFieldValue(text = value)) }
+    // Holds the latest TextFieldValue that BasicTextField was recomposed with. We couldn't simply
+    // pass `TextFieldValue(text = value)` to the CoreTextField because we need to preserve the
+    // composition.
+    val textFieldValue = textFieldValueState.copy(text = value)
+
+    SideEffect {
+        if (textFieldValue.selection != textFieldValueState.selection ||
+            textFieldValue.composition != textFieldValueState.composition) {
+            textFieldValueState = textFieldValue
+        }
+    }
+    // Last String value that either text field was recomposed with or updated in the onValueChange
+    // callback. We keep track of it to prevent calling onValueChange(String) for same String when
+    // CoreTextField's onValueChange is called multiple times without recomposition in between.
+    var lastTextValue by remember(value) { mutableStateOf(value) }
+
+    CoreTextField(
+        value = textFieldValue,
+        onValueChange = { newTextFieldValueState ->
+            textFieldValueState = newTextFieldValueState
+
+            val stringChangedSinceLastInvocation = lastTextValue != newTextFieldValueState.text
+            lastTextValue = newTextFieldValueState.text
+
+            if (stringChangedSinceLastInvocation) {
+                onValueChange(newTextFieldValueState.text)
+            }
+        },
+        modifier = modifier,
+        textStyle = textStyle,
+        visualTransformation = visualTransformation,
+        onTextLayout = onTextLayout,
+        interactionSource = interactionSource,
+        cursorBrush = cursorBrush,
+        imeOptions = keyboardOptions.toImeOptions(singleLine = singleLine),
+        keyboardActions = keyboardActions,
+        softWrap = !singleLine,
+        maxLines = if (singleLine) 1 else maxLines,
+        decorationBox = decorationBox,
+        enabled = enabled,
+        readOnly = readOnly,
+        textScrollerPosition = scrollState.scrollerPosition
+    )
+}
+
+/**
+ * Basic composable that enables users to edit text via hardware or software keyboard, but
+ * provides no decorations like hint or placeholder.
+ *
+ * Whenever the user edits the text, [onValueChange] is called with the most up to date state
+ * represented by [TextFieldValue]. [TextFieldValue] contains the text entered by user, as well
+ * as selection, cursor and text composition information. Please check [TextFieldValue] for the
+ * description of its contents.
+ *
+ * It is crucial that the value provided in the [onValueChange] is fed back into [BasicTextField] in
+ * order to have the final state of the text being displayed.
+ *
+ * Example usage:
+ * @sample androidx.compose.foundation.samples.BasicTextFieldSample
+ *
+ * Please keep in mind that [onValueChange] is useful to be informed about the latest state of the
+ * text input by users, however it is generally not recommended to modify the values in the
+ * [TextFieldValue] that you get via [onValueChange] callback. Any change to the values in
+ * [TextFieldValue] may result in a context reset and end up with input session restart. Such
+ * a scenario would cause glitches in the UI or text input experience for users.
+ *
+ * This composable provides basic text editing functionality, however does not include any
+ * decorations such as borders, hints/placeholder. A design system based implementation such as
+ * Material Design Filled text field is typically what is needed to cover most of the needs. This
+ * composable is designed to be used when a custom implementation for different design system is
+ * needed.
+ *
+ * For example, if you need to include a placeholder in your TextField, you can write a composable
+ * using the decoration box like this:
+ * @sample androidx.compose.foundation.samples.PlaceholderBasicTextFieldSample
+ *
+ *
+ * If you want to add decorations to your text field, such as icon or similar, and increase the
+ * hit target area, use the decoration box:
+ * @sample androidx.compose.foundation.samples.TextFieldWithIconSample
+ *
+ * @param value The [androidx.compose.ui.text.input.TextFieldValue] to be shown in the
+ * [BasicTextField].
+ * @param onValueChange Called when the input service updates the values in [TextFieldValue].
+ * @param modifier optional [Modifier] for this text field.
+ * @param enabled controls the enabled state of the [BasicTextField]. When `false`, the text
+ * field will be neither editable nor focusable, the input of the text field will not be selectable
+ * @param readOnly controls the editable state of the [BasicTextField]. When `true`, the text
+ * field can not be modified, however, a user can focus it and copy text from it. Read-only text
+ * fields are usually used to display pre-filled forms that user can not edit
+ * @param textStyle Style configuration that applies at character level such as color, font etc.
+ * @param keyboardOptions software keyboard options that contains configuration such as
+ * [KeyboardType] and [ImeAction].
+ * @param keyboardActions when the input service emits an IME action, the corresponding callback
+ * is called. Note that this IME action may be different from what you specified in
+ * [KeyboardOptions.imeAction].
+ * @param singleLine when set to true, this text field becomes a single horizontally scrolling
+ * text field instead of wrapping onto multiple lines. The keyboard will be informed to not show
+ * the return key as the [ImeAction]. Note that [maxLines] parameter will be ignored as the
+ * maxLines attribute will be automatically set to 1.
+ * @param maxLines the maximum height in terms of maximum number of visible lines. Should be
+ * equal or greater than 1. Note that this parameter will be ignored and instead maxLines will be
+ * set to 1 if [singleLine] is set to true.
+ * @param visualTransformation The visual transformation filter for changing the visual
+ * representation of the input. By default no visual transformation is applied.
+ * @param onTextLayout Callback that is executed when a new text layout is calculated. A
+ * [TextLayoutResult] object that callback provides contains paragraph information, size of the
+ * text, baselines and other details. The callback can be used to add additional decoration or
+ * functionality to the text. For example, to draw a cursor or selection around the text.
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this TextField. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this TextField in different [Interaction]s.
+ * @param cursorBrush [Brush] to paint cursor with. If [SolidColor] with [Color.Unspecified]
+ * provided, there will be no cursor drawn
+ * @param decorationBox Composable lambda that allows to add decorations around text field, such
+ * as icon, placeholder, helper messages or similar, and automatically increase the hit target area
+ * of the text field. To allow you to control the placement of the inner text field relative to your
+ * decorations, the text field implementation will pass in a framework-controlled composable
+ * parameter "innerTextField" to the decorationBox lambda you provide. You must call
+ * innerTextField exactly once.
+ */
+@Composable
+fun BasicTextField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
+    textStyle: TextStyle = TextStyle.Default,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    singleLine: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    cursorBrush: Brush = SolidColor(Color.Black),
+    decorationBox: @Composable (innerTextField: @Composable () -> Unit) -> Unit =
+        @Composable { innerTextField -> innerTextField() },
+    scrollState: TextFieldScrollState
+) {
+    CoreTextField(
+        value = value,
+        onValueChange = {
+            if (value != it) {
+                onValueChange(it)
+            }
+        },
+        modifier = modifier,
+        textStyle = textStyle,
+        visualTransformation = visualTransformation,
+        onTextLayout = onTextLayout,
+        interactionSource = interactionSource,
+        cursorBrush = cursorBrush,
+        imeOptions = keyboardOptions.toImeOptions(singleLine = singleLine),
+        keyboardActions = keyboardActions,
+        softWrap = !singleLine,
+        maxLines = if (singleLine) 1 else maxLines,
+        decorationBox = decorationBox,
+        enabled = enabled,
+        readOnly = readOnly,
+        textScrollerPosition = scrollState.scrollerPosition
+    )
+}
+
+

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/BasicTextField.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/BasicTextField.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.Composable
@@ -118,6 +119,8 @@ import androidx.compose.ui.text.input.VisualTransformation
  * parameter "innerTextField" to the decorationBox lambda you provide. You must call
  * innerTextField exactly once.
  */
+@ExperimentalFoundationApi
+@Suppress("DuplicatedCode")
 @Composable
 fun BasicTextField(
     value: String,
@@ -263,6 +266,8 @@ fun BasicTextField(
  * parameter "innerTextField" to the decorationBox lambda you provide. You must call
  * innerTextField exactly once.
  */
+@ExperimentalFoundationApi
+@Suppress("DuplicatedCode")
 @Composable
 fun BasicTextField(
     value: TextFieldValue,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.desktop.kt.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.desktop.kt.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.MutatePriority
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.ScrollScope
@@ -34,6 +35,7 @@ import androidx.compose.runtime.remember
  * must be [Orientation.Horizontal]. For all others, it must be [Orientation.Vertical].
  * @param initial the initial value for [TextFieldScrollState.offset]
  */
+@ExperimentalFoundationApi
 @Composable
 fun rememberTextFieldScrollState(
     orientation: Orientation,
@@ -55,6 +57,7 @@ fun rememberTextFieldScrollState(
  *
  * @param initial the initial value for [TextFieldScrollState.offset]
  */
+@ExperimentalFoundationApi
 @Composable
 fun rememberTextFieldVerticalScrollState(initial: Int = 0): TextFieldScrollState {
     return rememberTextFieldScrollState(Orientation.Vertical, initial)
@@ -71,6 +74,7 @@ fun rememberTextFieldVerticalScrollState(initial: Int = 0): TextFieldScrollState
  *
  * @param initial the initial value for [TextFieldScrollState.offset]
  */
+@ExperimentalFoundationApi
 @Composable
 fun rememberTextFieldHorizontalScrollState(initial: Int = 0): TextFieldScrollState {
     return rememberTextFieldScrollState(Orientation.Horizontal, initial)
@@ -85,6 +89,7 @@ fun rememberTextFieldHorizontalScrollState(initial: Int = 0): TextFieldScrollSta
  * must be [Orientation.Horizontal]. For all others, it must be [Orientation.Vertical].
  * @param initial the initial value for [TextFieldScrollState.offset]
  */
+@ExperimentalFoundationApi
 class TextFieldScrollState(
     orientation: Orientation,
     initial: Int = 0,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.desktop.kt.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.desktop.kt.kt
@@ -47,8 +47,8 @@ fun rememberTextFieldScrollState(
 }
 
 /**
- * Creates a [TextFieldScrollState] that is remembered across compositions, for vertically
- * scrolling a text field.
+ * Creates a [TextFieldScrollState] that is remembered across compositions, for a vertically
+ * scrolling text field.
  *
  * This cannot be used with text fields that are single-line and non-wrapping.
  *
@@ -64,8 +64,8 @@ fun rememberTextFieldVerticalScrollState(initial: Int = 0): TextFieldScrollState
 }
 
 /**
- * Creates a [TextFieldScrollState] that is remembered across compositions, for horizontally
- * scrolling a text field.
+ * Creates a [TextFieldScrollState] that is remembered across compositions, for a horizontally
+ * scrolling text field.
  *
  * This can only be used with text fields that are single-line and non-wrapping.
  *

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.desktop.kt.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.desktop.kt.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.MutatePriority
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollScope
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+
+/**
+ * Creates a [TextFieldScrollState] that is remembered across compositions.
+ *
+ * Changes to the provided initial value will **not** result in the state being recreated or
+ * changed in any way if it has already been created.
+ *
+ * @param orientation the direction of scrolling. For single-line, non-wrapping text fields this
+ * must be [Orientation.Horizontal]. For all others, it must be [Orientation.Vertical].
+ * @param initial the initial value for [TextFieldScrollState.offset]
+ */
+@Composable
+fun rememberTextFieldScrollState(
+    orientation: Orientation,
+    initial: Int = 0,
+): TextFieldScrollState {
+    return remember(orientation) {
+        TextFieldScrollState(orientation, initial)
+    }
+}
+
+/**
+ * Creates a [TextFieldScrollState] that is remembered across compositions, for vertically
+ * scrolling a text field.
+ *
+ * This cannot be used with text fields that are single-line and non-wrapping.
+ *
+ * Changes to the provided initial value will **not** result in the state being recreated or
+ * changed in any way if it has already been created.
+ *
+ * @param initial the initial value for [TextFieldScrollState.offset]
+ */
+@Composable
+fun rememberTextFieldVerticalScrollState(initial: Int = 0): TextFieldScrollState {
+    return rememberTextFieldScrollState(Orientation.Vertical, initial)
+}
+
+/**
+ * Creates a [TextFieldScrollState] that is remembered across compositions, for horizontally
+ * scrolling a text field.
+ *
+ * This can only be used with text fields that are single-line and non-wrapping.
+ *
+ * Changes to the provided initial value will **not** result in the state being recreated or
+ * changed in any way if it has already been created.
+ *
+ * @param initial the initial value for [TextFieldScrollState.offset]
+ */
+@Composable
+fun rememberTextFieldHorizontalScrollState(initial: Int = 0): TextFieldScrollState {
+    return rememberTextFieldScrollState(Orientation.Horizontal, initial)
+}
+
+/**
+ * A state object that can be hoisted to control and observe scrolling of a [BasicTextField].
+ *
+ * In most cases, this will be created via [rememberTextFieldScrollState].
+ *
+ * @param orientation the direction of scrolling. For single-line, non-wrapping text fields this
+ * must be [Orientation.Horizontal]. For all others, it must be [Orientation.Vertical].
+ * @param initial the initial value for [TextFieldScrollState.offset]
+ */
+class TextFieldScrollState(
+    orientation: Orientation,
+    initial: Int = 0,
+): ScrollableState{
+
+    /**
+     * The underlying [TextFieldScrollerPosition] that is the scroll state of text fields.
+     */
+    internal val scrollerPosition = TextFieldScrollerPosition(orientation, initial.toFloat())
+
+    /**
+     * The scroll offset, in pixels.
+     */
+    var offset: Float by scrollerPosition::offset
+
+    /**
+     * The maximum scroll offset, in pixels.
+     */
+    val maxOffset: Float by scrollerPosition::maximum
+
+    /**
+     * The size of the visible part of the text field, in the direction of scrolling, in pixels.
+     */
+    val viewportSize: Int by scrollerPosition::viewportSize
+
+    private val scrollableState = ScrollableState {
+        val raw = offset + it
+        val prevOffset = offset
+        offset = raw.coerceIn(0f, maxOffset)
+
+        // Avoid floating-point rounding error
+        if (offset != prevOffset) offset - prevOffset else it
+    }
+
+    override suspend fun scroll(
+        scrollPriority: MutatePriority,
+        block: suspend ScrollScope.() -> Unit
+    ): Unit = scrollableState.scroll(scrollPriority, block)
+
+    override fun dispatchRawDelta(delta: Float): Float =
+        scrollableState.dispatchRawDelta(delta)
+
+    override val isScrollInProgress: Boolean
+        get() = scrollableState.isScrollInProgress
+
+}

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.grid.LazyGridItemInfo
 import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.text.TextFieldScrollState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.geometry.Offset
@@ -334,6 +335,25 @@ internal class LazyGridScrollbarAdapter(
 
 }
 
+
+internal class TextFieldScrollbarAdapter(
+    private val scrollState: TextFieldScrollState
+): ScrollbarAdapter{
+
+    override val scrollOffset: Double
+        get() = scrollState.offset.toDouble()
+
+    override val contentSize: Double
+        get() = scrollState.maxOffset + viewportSize
+
+    override val viewportSize: Double
+        get() = scrollState.viewportSize.toDouble()
+
+    override suspend fun scrollTo(scrollOffset: Double) {
+        scrollState.offset = scrollOffset.toFloat().coerceIn(0f, scrollState.maxOffset)
+    }
+
+}
 
 internal class SliderAdapter(
     private val adapter: ScrollbarAdapter,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.v2
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollBy
@@ -336,6 +337,7 @@ internal class LazyGridScrollbarAdapter(
 }
 
 
+@ExperimentalFoundationApi
 internal class TextFieldScrollbarAdapter(
     private val scrollState: TextFieldScrollState
 ): ScrollbarAdapter{

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -336,8 +336,7 @@ internal class LazyGridScrollbarAdapter(
 
 }
 
-
-@ExperimentalFoundationApi
+@OptIn(ExperimentalFoundationApi::class)
 internal class TextFieldScrollbarAdapter(
     private val scrollState: TextFieldScrollState
 ): ScrollbarAdapter{


### PR DESCRIPTION
## Proposed Changes

In order to support scrollbars for text fields, we need to expose their scroll state and implement a ScrollbarAdapter for it.

  - Implement `TextFieldScrollState` which wraps the actual (internal) text field scroll state object: `TextFieldScrollerPosition`, in order to allow hoisting.
  - Add `BasicTextField` overloads that accept the new TextFieldScrollState. Unfortunately this means copy-pasting them from the upstream source. We will need to remember to update them whenever the upstream changes.
  - Add a `TextFieldScrollerPosition` parameter to `CoreTextField` so that our new BasicTextFields can unwrap and pass the wrapper scroller position to it.
  - Add a `viewportSize` property to TextFieldScrollerPosition.

## Testing

Test: Unit and manual tests

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/1575
