### PR TITLE
Fix the scrollbar not reaching its start/end during a drag.

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -404,24 +404,27 @@ internal class SliderAdapter(
 
     val bounds get() = position..position + thumbSize
 
-    // Stores the unrestricted position during a dragging gesture
-    private var positionDuringDrag = 0.0
+    // How much of the current drag was ignored because we've reached the end of the scrollbar area
+    private var unscrolledDragDistance = 0.0
 
     /** Called when the thumb dragging starts */
     fun onDragStarted() {
-        positionDuringDrag = position
+        unscrolledDragDistance = 0.0
     }
 
     /** Called on every movement while dragging the thumb */
     fun onDragDelta(offset: Offset) {
         val dragDelta = if (isVertical) offset.y else offset.x
         val maxScrollPosition = adapter.maxScrollOffset * scrollScale
-        val sliderDelta =
-            (positionDuringDrag + dragDelta).coerceIn(0.0, maxScrollPosition) -
-                positionDuringDrag.coerceIn(0.0, maxScrollPosition)
+        val currentPosition = position
+        val targetPosition =
+            (currentPosition + dragDelta + unscrolledDragDistance).coerceIn(0.0, maxScrollPosition)
+        val sliderDelta = targetPosition - currentPosition
+
         // Have to add to position for smooth content scroll if the items are of different size
         position += sliderDelta
-        positionDuringDrag += dragDelta
+
+        unscrolledDragDistance += dragDelta - sliderDelta
     }
 
 }


### PR DESCRIPTION
## Proposed Changes

The problem was that we weren't taking into account the actual change in the slider `position` for each drag delta, and would assume it always changed as much as was asked from it.

This PR changes the way we implement https://github.com/JetBrains/compose-jb/issues/643. Instead of keeping the raw dragged distance and coercing it into `(0.0, maxScrollPosition)`, we remember how much of the `dragDelta` was "ignored" when we've reached the start or end of the scrollbar area. This allows us to move the slide relative to its current `position` on each drag delta.

## Testing

Test: Manually and with a new unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2679
