### PR TITLE
Size `UndecoratedWindowResizer` to the size of the window

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
@@ -50,6 +51,7 @@ import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import kotlin.test.assertEquals
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -522,4 +524,28 @@ class WindowTest {
         assertThat(isApplicationEffectEnded).isTrue()
         assertThat(isWindowEffectEnded).isTrue()
     }
+
+    @Test
+    fun `undecorated resizable window with unspecified size`() = runApplicationTest {
+        var window: ComposeWindow? = null
+
+        launchApplication {
+            Window(
+                onCloseRequest = ::exitApplication,
+                state = rememberWindowState(width = Dp.Unspecified, height = Dp.Unspecified),
+                undecorated = true,
+                resizable = true,
+            ) {
+                window = this.window
+                Box(Modifier.size(32.dp))
+            }
+        }
+
+        awaitIdle()
+        assertEquals(32, window?.width)
+        assertEquals(32, window?.height)
+
+        window?.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING))
+    }
+
 }


### PR DESCRIPTION
## Proposed Changes

Measure `UndecoratedWindowResizer` with the size of the window, thus not allowing to affect the size of the window.

## Testing

Test: Will write a unit test if this approach is approved.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2676
