### PR TITLE
UIKit Clipboard, simplify permission request

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformClipboardManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformClipboardManager.skiko.kt
@@ -28,4 +28,6 @@ internal class PlatformClipboardManager : ClipboardManager {
     override fun setText(annotatedString: AnnotatedString) {
         skikoClipboardManager.setText(annotatedString.text)
     }
+
+    override fun hasText(): Boolean = skikoClipboardManager.hasText()
 }


### PR DESCRIPTION
UIKit require permission to get clipboard content.
Previously on text selection, a permission request was required.

Now, we can use the method `skikoClipboardManager.hasText()` to skip permission request on text selection.