### PR TITLE
Fix PointerEvent.assertHas not actually comparing to the PointerEvent.type

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestComponents.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestComponents.kt
@@ -42,7 +42,7 @@ fun Events.assertReceivedLast(type: PointerEventType, offset: Offset) =
     receivedLast().assertHas(type, offset)
 
 fun PointerEvent.assertHas(type: PointerEventType, offset: Offset) {
-    assertThat(type).isEqualTo(type)
+    assertThat(this.type).isEqualTo(type)
     assertThat(changes.first().position).isEqualTo(offset)
 }
 


### PR DESCRIPTION
## Proposed Changes

`PointerEvent.assertHas(type: PointerEventType, offset: Offset)` accidentally compares the type to itself, rather than to the `PointerEventType`. Fixed that.