### PR TITLE
Adapt Compose to interop with SwiftUI

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.createSkiaLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.toSkiaRect
 import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.Platform
 import androidx.compose.ui.platform.TextToolbar
@@ -52,9 +53,9 @@ import platform.UIKit.UIScreen
 import platform.UIKit.UIViewController
 import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
 import platform.UIKit.reloadInputViews
-import platform.UIKit.setBounds
 import platform.UIKit.setClipsToBounds
 import platform.UIKit.setNeedsDisplay
+import platform.UIKit.window
 import platform.darwin.NSObject
 
 // The only difference with macos' Window is that

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -103,7 +103,7 @@ internal actual class ComposeWindow : UIViewController {
                     // Focused element will be visible
                     view.setClipsToBounds(true)
                     val (width, height) = getViewFrameSize()
-                    view.setBounds(
+                    view.layer.setBounds(
                         CGRectMake(
                             x = 0.0,
                             y = hiddenPartOfFocusedElement,


### PR DESCRIPTION
Little changes for proper interop Compose with SwiftUI.
 - correctly handles keyboard appearance
 - life cycle of UIViewController and Skia Canvas