### PR TITLE
Fix nonlocal return in ComposeScene.sendKeyEvent

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -149,7 +149,7 @@ class ComposeScene internal constructor(
 
     @Volatile
     private var hasPendingDraws = true
-    private inline fun <T> postponeInvalidation(block: () -> T): T {
+    private inline fun <T> postponeInvalidation(crossinline block: () -> T): T {
         check(!isClosed) { "ComposeScene is closed" }
         isInvalidationDisabled = true
         val result = try {
@@ -566,7 +566,7 @@ class ComposeScene internal constructor(
      */
     fun sendKeyEvent(event: ComposeKeyEvent): Boolean = postponeInvalidation {
         defaultPointerStateTracker.onKeyEvent(event)
-        return focusedOwner?.sendKeyEvent(event) == true
+        focusedOwner?.sendKeyEvent(event) == true
     }
 
     private var isFocused = true


### PR DESCRIPTION
`ComposeScene.sendKeyEvent` did an unintentional non-local return when calling `postponeInvalidation`.
Fixed that.
