### PR TITLE
Fix PointerPositionUpdater not generating a synthetic Move event

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -141,6 +141,24 @@ class ComposeSceneInputTest {
     }
 
     @Test
+    fun `enter then press should generate synthetic move`() =
+        ImageComposeScene(100, 100).use { scene ->
+            val content = FillBox()
+            scene.setContent {
+                content.Content()
+            }
+
+            val position = Offset(10f, 10f)
+            scene.sendPointerEvent(PointerEventType.Enter, position)
+            scene.sendPointerEvent(PointerEventType.Press, position)
+
+            content.events.assertReceived(PointerEventType.Enter, position)
+            // synthetic event
+            content.events.assertReceived(PointerEventType.Move, position)
+            content.events.assertReceivedLast(PointerEventType.Press, position)
+        }
+
+    @Test
     fun `pressed popup should own received moves outside popup`() = ImageComposeScene(
         100,
         100


### PR DESCRIPTION
When an Enter event is sent followed by an event that requires a synthetic Move event (such as Press) `PointerPositionUpdater` will not currently generate the synthetic Move event if the positions of the pointers for the two events are the same. This is because before generating the synthetic Move it compares the pointer positions of the current event to the previous one.

## Proposed Changes
Compare the pointer positions to the last (possibly synthetic) Move event, instead of any last event.

## Testing

Test: New unit test
