### PR TITLE
Disable decoys generation for SAM in fun interfaces

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/AbstractDecoysLowering.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/AbstractDecoysLowering.kt
@@ -22,6 +22,8 @@ import androidx.compose.compiler.plugins.kotlin.lower.AbstractComposeLowering
 import androidx.compose.compiler.plugins.kotlin.lower.includeFileNameInExceptionTrace
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureSerializer
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrConstructor
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFile
@@ -32,6 +34,7 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.DeepCopySymbolRemapper
 import org.jetbrains.kotlin.ir.util.hasAnnotation
 import org.jetbrains.kotlin.ir.util.isEnumClass
+import org.jetbrains.kotlin.ir.util.isInterface
 import org.jetbrains.kotlin.ir.util.isLocal
 import org.jetbrains.kotlin.ir.util.parentAsClass
 
@@ -59,10 +62,18 @@ abstract class AbstractDecoysLowering(
         }
     }
 
-    protected fun IrFunction.shouldBeRemapped(): Boolean =
-        !isLocalFunction() &&
+    protected fun IrFunction.shouldBeRemapped(): Boolean {
+        val parentIsFunInterface = (parent as? IrClass).let {
+            it?.isInterface == true &&
+                it.isFun &&
+                (this as? IrSimpleFunction)?.modality == Modality.ABSTRACT
+        }
+
+        return !isLocalFunction() &&
             !isEnumConstructor() &&
-            (hasComposableAnnotation() || hasComposableParameter())
+            (hasComposableAnnotation() || hasComposableParameter()) &&
+            !parentIsFunInterface
+    }
 
     private fun IrFunction.isLocalFunction(): Boolean =
         origin == IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA ||


### PR DESCRIPTION
fun interfaces can contain only 1 SAM, but decoys generation would add another one (so 2 in total), which leads to an error in further kotlin lowerings (SAM transformation).

With this commit, fun interface(s) won't be affected by decoys generation and decoys substitution.