### PR TITLE
Fix Korean text input

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeLayer.desktop.kt
@@ -331,17 +331,14 @@ internal class ComposeLayer(
         _component.addInputMethodListener(object : InputMethodListener {
             override fun caretPositionChanged(event: InputMethodEvent?) {
                 if (isDisposed) return
-                if (event != null) {
-                    catchExceptions {
-                        platform.textInputService.onInputEvent(event)
-                    }
-                }
+                // Which OSes and which input method could produce such events? We need to have some
+                // specific cases in mind before implementing this
             }
 
             override fun inputMethodTextChanged(event: InputMethodEvent) {
                 if (isDisposed) return
                 catchExceptions {
-                    platform.textInputService.onInputEvent(event)
+                    platform.textInputService.inputMethodTextChanged(event)
                 }
             }
         })

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/DesktopInputComponentTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/DesktopInputComponentTest.kt
@@ -56,7 +56,7 @@ class DesktopInputComponentTest {
 
         val familyEmoji = "\uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC66\u200D\uD83D\uDC66"
 
-        input.onInputEvent(
+        input.inputMethodTextChanged(
             InputMethodEvent(
                 DummyComponent,
                 InputMethodEvent.INPUT_METHOD_TEXT_CHANGED,
@@ -104,7 +104,7 @@ class DesktopInputComponentTest {
         component.enabledInput!!.getSelectedText(null)
         input.charKeyPressed = false
 
-        input.onInputEvent(
+        input.inputMethodTextChanged(
             InputMethodEvent(
                 DummyComponent,
                 InputMethodEvent.INPUT_METHOD_TEXT_CHANGED,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -1,0 +1,688 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window.window
+
+import androidx.compose.material.TextField
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.sendInputEvent
+import androidx.compose.ui.sendKeyEvent
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowTestScope
+import androidx.compose.ui.window.runApplicationTest
+import com.google.common.truth.Truth.assertThat
+import java.awt.event.KeyEvent.KEY_LOCATION_UNKNOWN
+import java.awt.event.KeyEvent.KEY_PRESSED
+import java.awt.event.KeyEvent.KEY_RELEASED
+import java.awt.event.KeyEvent.KEY_TYPED
+import org.junit.Test
+
+/**
+ * Tests for emulate input to the native window on various systems.
+ *
+ * Events were captured on each system via logging.
+ */
+class WindowTypeTest {
+    private var window: ComposeWindow? = null
+    private var text by mutableStateOf(TextFieldValue(""))
+
+    @Test
+    fun `q, w, space, backspace 4x (English)`() = runTypeTest {
+        // q
+        window?.sendKeyEvent(81, 'q', KEY_PRESSED)
+        window?.sendKeyEvent(0, 'q', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = null)
+
+        // w
+        window?.sendKeyEvent(87, 'w', KEY_PRESSED)
+        window?.sendKeyEvent(0, 'w', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "qw", selection = TextRange(2), composition = null)
+
+        // space
+        window?.sendKeyEvent(32, ' ', KEY_PRESSED)
+        window?.sendKeyEvent(0, ' ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "qw ", selection = TextRange(3), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "qw", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, space, backspace 4x (Russian)`() = runTypeTest {
+        // q
+        window?.sendKeyEvent(81, 'й', KEY_PRESSED)
+        window?.sendKeyEvent(0, 'й', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(81, 'й', KEY_RELEASED)
+        assert(text, "й", selection = TextRange(1), composition = null)
+
+        // w
+        window?.sendKeyEvent(87, 'ц', KEY_PRESSED)
+        window?.sendKeyEvent(0, 'ц', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(87, 'ц', KEY_RELEASED)
+        assert(text, "йц", selection = TextRange(2), composition = null)
+
+        // space
+        window?.sendKeyEvent(32, ' ', KEY_PRESSED)
+        window?.sendKeyEvent(0, ' ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "йц ", selection = TextRange(3), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "йц", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "й", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `f, g, space, backspace 4x (Arabic)`() = runTypeTest {
+        // q
+        window?.sendKeyEvent(70, 'ب', KEY_PRESSED)
+        window?.sendKeyEvent(0, 'ب', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(70, 'ب', KEY_RELEASED)
+        assert(text, "ب", selection = TextRange(1), composition = null)
+
+        // w
+        window?.sendKeyEvent(71, 'ل', KEY_PRESSED)
+        window?.sendKeyEvent(0, 'ل', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(71, 'ل', KEY_RELEASED)
+        assert(text, "بل", selection = TextRange(2), composition = null)
+
+        // space
+        window?.sendKeyEvent(32, ' ', KEY_PRESSED)
+        window?.sendKeyEvent(0, ' ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "بل ", selection = TextRange(3), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "بل", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ب", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, space, backspace 4x (Korean, Windows)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("ㅂ", 1)
+        window?.sendInputEvent("ㅈ", 0)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = TextRange(1, 2))
+
+        // space
+        window?.sendInputEvent(null, 0)
+        window?.sendKeyEvent(0, 'ㅈ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_PRESSED)
+        window?.sendKeyEvent(0, ' ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "ㅂㅈ ", selection = TextRange(3), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, backspace 3x (Korean, Windows)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("ㅂ", 1)
+        window?.sendInputEvent("ㅈ", 0)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = TextRange(1, 2))
+
+        // backspace
+        window?.sendInputEvent(null, 0)
+        window?.sendInputEvent(null, 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `f, g, space, backspace 3x (Korean, Windows)`() = runTypeTest {
+        // f
+        window?.sendInputEvent("ㄹ", 0)
+        window?.sendKeyEvent(81, 'f', KEY_RELEASED)
+        assert(text, "ㄹ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // g
+        window?.sendInputEvent("ㅀ", 0)
+        window?.sendKeyEvent(87, 'g', KEY_RELEASED)
+        assert(text, "ㅀ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // space
+        window?.sendInputEvent(null, 0)
+        window?.sendKeyEvent(0, 'ㅀ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_PRESSED)
+        window?.sendKeyEvent(0, ' ', KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "ㅀ ", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅀ", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `f, g, backspace 2x (Korean, Windows)`() = runTypeTest {
+        // f
+        window?.sendInputEvent("ㄹ", 0)
+        window?.sendKeyEvent(81, 'f', KEY_RELEASED)
+        assert(text, "ㄹ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // g
+        window?.sendInputEvent("ㅀ", 0)
+        window?.sendKeyEvent(87, 'g', KEY_RELEASED)
+        assert(text, "ㅀ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // backspace
+        window?.sendInputEvent("ㄹ", 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㄹ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // backspace
+        window?.sendInputEvent(null, 0)
+        window?.sendInputEvent(null, 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, space, backspace 4x (Korean, macOS)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendKeyEvent(81, 'ㅂ', KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendInputEvent("ㅂ", 1)
+        window?.sendInputEvent("ㅈ", 0)
+        window?.sendKeyEvent(87, 'ㅈ', KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = TextRange(1, 2))
+
+        // space
+        window?.sendInputEvent("ㅈ ", 0)
+        window?.sendInputEvent("ㅈ ", 2)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "ㅂㅈ ", selection = TextRange(3), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, backspace 3x (Korean, macOS)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendKeyEvent(81, 'ㅂ', KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendInputEvent("ㅂ", 1)
+        window?.sendInputEvent("ㅈ", 0)
+        window?.sendKeyEvent(87, 'ㅈ', KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = TextRange(1, 2))
+
+        // backspace
+        window?.sendInputEvent("ㅈ", 0)
+        window?.sendInputEvent("ㅈ", 1)
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    // f, g on macOs prints 2 separate symbols (comparing to Windows), so we test t + y
+    @Test
+    fun `t, y, space, backspace 3x (Korean, MacOS)`() = runTypeTest {
+        // t
+        window?.sendInputEvent("ㅅ", 0)
+        window?.sendKeyEvent(84, 'ㅅ', KEY_RELEASED)
+        assert(text, "ㅅ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // y
+        window?.sendInputEvent("쇼", 0)
+        window?.sendKeyEvent(89, 'ㅛ', KEY_RELEASED)
+        assert(text, "쇼", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // space
+        window?.sendInputEvent("쇼 ", 0)
+        window?.sendInputEvent("쇼 ", 2)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "쇼 ", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "쇼", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `t, y, backspace 2x (Korean, MacOS)`() = runTypeTest {
+        // t
+        window?.sendInputEvent("ㅅ", 0)
+        window?.sendKeyEvent(84, 'ㅅ', KEY_RELEASED)
+        assert(text, "ㅅ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // y
+        window?.sendInputEvent("쇼", 0)
+        window?.sendKeyEvent(89, 'ㅛ', KEY_RELEASED)
+        assert(text, "쇼", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // backspace
+        window?.sendInputEvent("ㅅ", 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅅ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // backspace
+        window?.sendInputEvent("ㅅ", 0)
+        window?.sendInputEvent("ㅅ", 1)
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, space, backspace 4x (Korean, Linux)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("ㅂ", 0)
+        window?.sendKeyEvent(0, 'ㅂ', KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent(null, 0)
+        window?.sendInputEvent("ㅂ", 1)
+        window?.sendInputEvent("ㅈ", 0)
+        window?.sendKeyEvent(0, 'ㅈ', KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = TextRange(1, 2))
+
+        // space
+        window?.sendInputEvent(null, 0)
+        window?.sendInputEvent("ㅈ", 1)
+        window?.sendKeyEvent(32, ' ', KEY_PRESSED)
+        window?.sendKeyEvent(0, ' ', KEY_TYPED)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "ㅂㅈ ", selection = TextRange(3), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂㅈ", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "ㅂ", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, space, backspace 3x (Chinese, Windows)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("q", 0)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("q'w", 0)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "q'w", selection = TextRange(3), composition = TextRange(0, 3))
+
+        // space
+        window?.sendInputEvent("請問", 2)
+        window?.sendInputEvent(null, 0)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "請問", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "請", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, backspace 3x (Chinese, Windows)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("q", 0)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("q'w", 0)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "q'w", selection = TextRange(3), composition = TextRange(0, 3))
+
+        // backspace
+        window?.sendInputEvent("q", 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // backspace
+        window?.sendInputEvent(null, 0)
+        window?.sendInputEvent(null, 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, space, backspace 3x (Chinese, macOS)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("q", 0)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("q w", 0)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "q w", selection = TextRange(3), composition = TextRange(0, 3))
+
+        // space
+        window?.sendInputEvent("请问", 2)
+        window?.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assert(text, "请问", selection = TextRange(2), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "请", selection = TextRange(1), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    @Test
+    fun `q, w, backspace 3x (Chinese, macOS)`() = runTypeTest {
+        // q
+        window?.sendInputEvent("q", 0)
+        window?.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window?.sendInputEvent("q w", 0)
+        window?.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assert(text, "q w", selection = TextRange(3), composition = TextRange(0, 3))
+
+        // backspace
+        window?.sendInputEvent("q", 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // backspace
+        window?.sendInputEvent("", 0)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+
+        // backspace
+        window?.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window?.sendKeyEvent(0, Char(8), KEY_TYPED, KEY_LOCATION_UNKNOWN)
+        window?.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assert(text, "", selection = TextRange(0), composition = null)
+    }
+
+    private fun runTypeTest(body: suspend WindowTestScope.() -> Unit) = runApplicationTest(hasAnimations = true) {
+        launchTestApplication {
+            Window(onCloseRequest = ::exitApplication) {
+                this@WindowTypeTest.window = this.window
+                val focusRequester = FocusRequester()
+                TextField(text, { text = it }, modifier = Modifier.focusRequester(focusRequester))
+
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+            }
+        }
+
+        awaitIdle()
+        body()
+        exitApplication()
+    }
+
+    private suspend fun WindowTestScope.assert(
+        actual: TextFieldValue, text: String, selection: TextRange, composition: TextRange?
+    ) {
+        awaitIdle()
+        assertThat(actual.text).isEqualTo(text)
+        assertThat(actual.selection).isEqualTo(selection)
+        assertThat(actual.composition).isEqualTo(composition)
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -43,6 +43,8 @@ import org.junit.Test
  * Tests for emulate input to the native window on various systems.
  *
  * Events were captured on each system via logging.
+ * All tests can run on all OS'es.
+ * The OS names in test names just represent an unique order of input events on these OS'es.
  */
 class WindowTypeTest {
     private var window: ComposeWindow? = null


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-jb/issues/2600

1. We shouldn't skip input events with empty text, they will clear the current uncommitted text. In case of Korean, Swing will send a clear event of the previous char when we press Space, and send a separate "KEY_TYPED" event for the last character:
- press q -> q uncommitted
- press w -> commit q, w uncommitted
- press Space -> discard committed text (event with empty text), send KEY_TYPED event with w and KEY_TYPED event with Space

2. Add tests for test input. I traced Swing events on each OS to mimic integration tests (It is difficult to write real input tests)
