### PR TITLE
[UIKit] Fix keyboard behavior

### DIFF
--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -139,8 +139,13 @@ internal class ComposeLayer(
         scene.constraints = Constraints(maxWidth = width, maxHeight = height)
     }
 
-    fun getActiveFocusRect(): DpRect? =
-        scene.mainOwner?.focusManager?.getActiveFocusModifier()?.focusRect()?.toDpRect(density)
+    fun getActiveFocusRect(): DpRect? {
+        val activeFocusModifier = scene.mainOwner?.focusManager?.getActiveFocusModifier()
+        if (activeFocusModifier?.parent == null) {
+            return null // Ignore root FocusModifier
+        }
+        return activeFocusModifier.focusRect().toDpRect(density)
+    }
 
     fun setContent(
         onPreviewKeyEvent: (ComposeKeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -102,12 +102,18 @@ internal actual class ComposeWindow : UIViewController {
                 if (hiddenPartOfFocusedElement > 0) {
                     // If focused element hidden by keyboard, then change UIView bounds.
                     // Focused element will be visible
+                    val focusedTop = focused.top.value
+                    val composeOffsetY = if (hiddenPartOfFocusedElement < focusedTop) {
+                        hiddenPartOfFocusedElement
+                    } else {
+                        maxOf(focusedTop, 0f).toDouble()
+                    }
                     view.setClipsToBounds(true)
                     val (width, height) = getViewFrameSize()
                     view.layer.setBounds(
                         CGRectMake(
                             x = 0.0,
-                            y = hiddenPartOfFocusedElement,
+                            y = composeOffsetY,
                             width = width.toDouble(),
                             height = height.toDouble()
                         )


### PR DESCRIPTION
Fix keyboard behaviour with SwiftUI interop. The problem was in the default root FocusModifier. Now, we will handle it, And if only root FocusModifier is active - we will ignore it.

## Previously
When nothing is focused, and the keyboard appears — the Compose view moves up. That is wrong behavior.


https://user-images.githubusercontent.com/99798741/218848401-da607a48-1665-4fcb-8637-f71096251092.mp4



## After
Now, if nothing is focused, and a keyboard appears — then Compose view will stay on current position.


https://user-images.githubusercontent.com/99798741/218848418-eaf619c0-066d-463b-a5f0-bbedad6b550a.mp4

 