### PR TITLE
Fix scrollbar track-press scroll

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/v2/Scrollbar.desktop.kt
@@ -377,7 +377,7 @@ internal class TextFieldScrollbarAdapter(
 }
 
 internal class SliderAdapter(
-    private val adapter: ScrollbarAdapter,
+    val adapter: ScrollbarAdapter,
     private val trackSize: Int,
     private val minHeight: Float,
     private val reverseLayout: Boolean,


### PR DESCRIPTION
Currently, the implementation of page-scrolling the scrollbar by pressing the track (outside the thumb) is problematic:
1. The gesture detector sets remembered values (e.g. pressed location) in the composition, and then a `LaunchedEffect` actually performs the scrolling. This means that testing this behavior using a simulated "click" doesn't work, because the values in the composition are set and then re-set immediately, before a recomposition can occur and the launched effect can start.
2. It's buggy:
   - https://github.com/JetBrains/compose-jb/issues/2730
   - https://github.com/JetBrains/compose-jb/issues/2731 

## Proposed Changes

Reimplement this functionality directly in the gesture detector, and also such that the bugs are fixed.

## Testing

Test: Added new unit tests and improved existing ones.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-jb/issues/2730 https://github.com/JetBrains/compose-jb/issues/2731 
