### PR TITLE
Reimplement the finding of the UndecoratedWindowResizer via layoutId

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/UndecoratedWindowResizer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/UndecoratedWindowResizer.desktop.kt
@@ -51,7 +51,7 @@ internal class UndecoratedWindowResizer(
     private var initialWindowSize = Dimension()
 
     @Composable
-    fun Content() {
+    fun Content(modifier: Modifier) {
         if (enabled) {
             Layout(
                 {
@@ -64,7 +64,7 @@ internal class UndecoratedWindowResizer(
                     Side(Cursor.SW_RESIZE_CURSOR, Side.Left or Side.Bottom)
                     Side(Cursor.SE_RESIZE_CURSOR, Side.Right or Side.Bottom)
                 },
-                Modifier,
+                modifier = modifier,
                 measurePolicy = { measurables, constraints ->
                     val b = borderThickness.roundToPx()
                     fun Measurable.measureSide(width: Int, height: Int) = measure(


### PR DESCRIPTION
## Proposed Changes

Previously, I implemented finding the measurable for the `UndecoratedWindowResizer` by grouping all the content placeables into a separate layout. This would make `measurables[0]` the content and `measurables[1]` the resizer.

Here I use `Modifier.layoutId` to mark it and `Measurable.layoutId` to find it. This makes the extra `WindowUserContentLayout` unnecessary.

## Testing

Test: Ran the unit tests in `WindowTest` and also ran a manual test.
