### PR TITLE
Download Android SDK dependencies automatically

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.unsafe.configuration-cache=false
 org.gradle.unsafe.configuration-cache-problems=warn
 org.gradle.unsafe.configuration-cache.max-problems=4000
 
-android.builder.sdkDownload=false
+#android.builder.sdkDownload=false
 android.uniquePackageNames=false
 android.enableAdditionalTestOutput=true
 android.useAndroidX=true


### PR DESCRIPTION
We still need Android SDK configured initially though, but now we don't have to update it everytime after rebase.