### PR TITLE
Add desktop target to mpp demo

### DIFF
--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -129,6 +129,14 @@ kotlin {
             }
         }
 
+        val desktopMain by getting {
+            dependsOn(skikoMain)
+            dependencies {
+                implementation(libs.skikoCurrentOs)
+                implementation(project(":compose:desktop:desktop"))
+            }
+        }
+
         val jsMain by getting {
             dependsOn(skikoMain)
             resources.setSrcDirs(resources.srcDirs)
@@ -207,4 +215,14 @@ if (System.getProperty("os.name") == "Mac OS X") {
             }
         }
     }
+}
+
+tasks.create("runDesktop", JavaExec::class.java) {
+    dependsOn(":compose:desktop:desktop:jar")
+    main = "androidx.compose.mpp.demo.Main_desktopKt"
+    systemProperty("skiko.fps.enabled", "true")
+    val compilation = kotlin.jvm("desktop").compilations["main"]
+    classpath =
+        compilation.output.allOutputs +
+            compilation.runtimeDependencyFiles
 }

--- a/compose/mpp/demo/src/desktopMain/kotlin/androidx/compose/mpp/demo/Main.desktop.kt
+++ b/compose/mpp/demo/src/desktopMain/kotlin/androidx/compose/mpp/demo/Main.desktop.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.singleWindowApplication
+
+fun main() = singleWindowApplication(
+    title = "Compose MPP demo",
+    state = WindowState(width = 1024.dp, height = 850.dp),
+) {
+    myContent()
+}


### PR DESCRIPTION
It would simplify checking/comparing some changes for all platforms at one place