### PR TITLE
UIKit samples, change deprecated annotation @UIApplicationMain -> @main

### DIFF
--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/AppDelegate.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/AppDelegate.swift
@@ -16,7 +16,7 @@
 
 import UIKit
 
-@UIApplicationMain
+@main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
 }


### PR DESCRIPTION
Annotation `@UIApplicationMain` will be deprecated.
https://github.com/apple/swift-evolution/blob/main/proposals/0383-deprecate-uiapplicationmain-and-nsapplicationmain.md