### PR TITLE
SwingPanel performance

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/LocalLayerContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/LocalLayerContainer.desktop.kt
@@ -16,9 +16,9 @@
 
 package androidx.compose.ui.awt
 
-import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.staticCompositionLocalOf
 import java.awt.Container
 
-internal val LocalLayerContainer = compositionLocalOf<Container> {
+internal val LocalLayerContainer = staticCompositionLocalOf<Container> {
     error("CompositionLocal LayerContainer not provided")
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -17,7 +17,6 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
@@ -145,10 +144,8 @@ public fun <T : Component> SwingPanel(
         }
     }
 
-    LaunchedEffect(background) {
-        componentInfo.container.background = parseColor(background)
-    }
     SideEffect {
+        componentInfo.container.background = parseColor(background)
         componentInfo.updater.update = update
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -17,6 +17,7 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
@@ -144,8 +145,10 @@ public fun <T : Component> SwingPanel(
         }
     }
 
-    SideEffect {
+    LaunchedEffect(background) {
         componentInfo.container.background = parseColor(background)
+    }
+    SideEffect {
         componentInfo.updater.update = update
     }
 }


### PR DESCRIPTION
 - staticCompositionLocalOf has better performance
 

> If the value provided to the CompositionLocal is highly unlikely to change or will never change, use staticCompositionLocalOf to get performance benefits. (https://developer.android.com/jetpack/compose/compositionlocal#creating-apis)

 - LaunchedEffect(background) helps skip code to execute on every update.