### PR TITLE
Shape the surface behind an AlertDialog according to the dialog's shape.

### DIFF
--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -178,6 +178,7 @@ interface AlertDialogProvider {
      * @param onDismissRequest Callback that will be called when the user closes the dialog
      * @param content Content of the dialog
      */
+    @Deprecated("Will be removed in 1.5; use the overload that takes the dialog shape")
     @Composable
     fun AlertDialog(
         onDismissRequest: () -> Unit,
@@ -191,6 +192,7 @@ interface AlertDialogProvider {
      * @param shape The Dialog's shape
      * @param content Content of the dialog
      */
+    @Suppress("DEPRECATION")
     @Composable
     fun AlertDialog(
         onDismissRequest: () -> Unit,
@@ -209,6 +211,8 @@ interface AlertDialogProvider {
  */
 @ExperimentalMaterialApi
 object PopupAlertDialogProvider : AlertDialogProvider {
+
+    @Deprecated("Will be removed in 1.5; use the overload that takes the dialog shape")
     @Composable
     override fun AlertDialog(
         onDismissRequest: () -> Unit,
@@ -285,6 +289,7 @@ object PopupAlertDialogProvider : AlertDialogProvider {
  */
 @ExperimentalMaterialApi
 object UndecoratedWindowAlertDialogProvider : AlertDialogProvider {
+    @Deprecated("Will be removed in 1.5; use the overload that takes the dialog shape")
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     override fun AlertDialog(


### PR DESCRIPTION
## Proposed Changes

- Pass the shape defining the `AlertDialog` to the `AlertDialogProvider`.
- Change `PopupAlertDialogProvider` to pass the shape to the `Surface` that displays the elevation shadow, in order to draw the shadow with the correct shape.
- Change `PopupAlertDialogProvider` to use a transparent background for the `Surface` that displays the elevation shadow. Otherwise the edges of its background can still show through the dialog content's shape.
 `AlertDialogContent` uses its own `Surface` at the root, so unless the user passes a translucent `backgroundColor` to `AlertDialog`, this change should not be visible.
- Likewise change `UndecoratedWindowAlertDialogProvider` to use `CoreDialog(transparent=true)`.

Note that this adds a new function to the (public) `AlertDialogProvider` interface, but the new function has a default implementation that delegates to the old function. I think this provides backwards compatibility.

Reproducer:
```
@OptIn(ExperimentalMaterialApi::class)
fun main() = singleWindowApplication(
    state = WindowState(width = 300.dp, height = 300.dp)
) {
    Box{
        MaterialTheme {
            AlertDialog(
                onDismissRequest = { },
                buttons = {},
                text = { Text("AlertDialog") },
                shape = RoundedCornerShape(20.dp),
                backgroundColor = Color.Yellow,
            )
        }
    }
}

```
Before:

<img width="301" alt="image" src="https://user-images.githubusercontent.com/5230206/223225016-0222da62-1f58-4db1-aba3-a36b831eb7bc.png">

After:

<img width="301" alt="image" src="https://user-images.githubusercontent.com/5230206/223225094-e9504d47-bb3d-44fc-8780-6f7b440ed7a4.png">


## Testing

Test: Manual testing using the code above.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/1269
