### PR TITLE
Implement brush usage in SkiaParagraph

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/example1/Main.jvm.kt
@@ -24,8 +24,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.VerticalScrollbar
-import androidx.compose.foundation.mouseClickable
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -43,6 +43,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.mouseClickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.CircleShape
@@ -78,40 +79,46 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Color.Companion.Black
+import androidx.compose.ui.graphics.Color.Companion.Blue
+import androidx.compose.ui.graphics.Color.Companion.Green
+import androidx.compose.ui.graphics.Color.Companion.Red
+import androidx.compose.ui.graphics.Color.Companion.Yellow
+import androidx.compose.ui.graphics.ImageShader
+import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIconDefaults
 import androidx.compose.ui.input.pointer.isAltPressed
+import androidx.compose.ui.input.pointer.isBackPressed
 import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isForwardPressed
 import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.input.pointer.isTertiaryPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.PointerIconDefaults
-import androidx.compose.ui.input.pointer.isBackPressed
-import androidx.compose.ui.input.pointer.isForwardPressed
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.loadImageBitmap
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.useResource
+import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
@@ -119,6 +126,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
@@ -128,15 +136,15 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.singleWindowApplication
+import kotlin.random.Random
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlin.random.Random
 
 private const val title = "Desktop Compose Elements"
 
@@ -323,6 +331,14 @@ private fun FrameWindowScope.ScrollableContent(scrollState: ScrollState) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
+        Row {
+            Box(modifier = Modifier.size(200.dp, 200.dp).border(1.dp, Black)) {
+                BrushTextGradient(lorem)
+            }
+            Box(modifier = Modifier.size(200.dp, 200.dp).border(1.dp, Black)) {
+                BrushTextImage(lorem)
+            }
+        }
 
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -651,5 +667,38 @@ private fun RightColumn(modifier: Modifier) = Box {
     VerticalScrollbar(
         rememberScrollbarAdapter(state),
         Modifier.align(Alignment.CenterEnd)
+    )
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+fun BrushTextGradient(text: String) {
+    Text(
+        text = text,
+        style = TextStyle(
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            brush = Brush.linearGradient(
+                colors = listOf(Red, Yellow, Green, Blue)
+            )
+        )
+    )
+}
+
+@OptIn(ExperimentalTextApi::class)
+@Composable
+fun BrushTextImage(text: String) {
+    val image = remember {
+        useResource("androidx/compose/desktop/example/tray.png", ::loadImageBitmap)
+    }
+    Text(
+        text = text,
+        style = TextStyle(
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Bold,
+            brush = ShaderBrush(
+                ImageShader(image, TileMode.Repeated, TileMode.Repeated)
+            )
+        )
     )
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -53,16 +53,19 @@ internal class SkiaParagraph(
 
     private val paragraphIntrinsics = intrinsics as SkiaParagraphIntrinsics
 
-    private val layouter = paragraphIntrinsics.layouter()
+    private val layouter = paragraphIntrinsics.layouter().apply {
+        setParagraphStyle(
+            maxLines = maxLines,
+            ellipsis = ellipsisChar
+        )
+    }
 
     /**
      * Paragraph isn't always immutable, it could be changed via [paint] method without
      * rerunning layout
      */
     private var paragraph = layouter.layoutParagraph(
-        width = width,
-        maxLines = maxLines,
-        ellipsis = ellipsisChar
+        width = width
     )
 
     init {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.text
 import org.jetbrains.skia.Rect as SkRect
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
@@ -430,19 +431,19 @@ internal class SkiaParagraph(
         shadow: Shadow?,
         textDecoration: TextDecoration?
     ) {
-        paragraph = layouter.layoutParagraph(
-            width = width,
-            maxLines = maxLines,
-            ellipsis = ellipsisChar,
-            color = color,
-            shadow = shadow,
-            textDecoration = textDecoration
-        )
-
+        paragraph = with(layouter) {
+            setTextStyle(
+                color = color,
+                shadow = shadow,
+                textDecoration = textDecoration
+            )
+            layoutParagraph(
+                width = width
+            )
+        }
         paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
     }
 
-    // TODO: Use DrawStyle.
     @ExperimentalTextApi
     override fun paint(
         canvas: Canvas,
@@ -451,18 +452,20 @@ internal class SkiaParagraph(
         textDecoration: TextDecoration?,
         drawStyle: DrawStyle?
     ) {
-        paragraph = layouter.layoutParagraph(
-            width = width,
-            maxLines = maxLines,
-            ellipsis = ellipsisChar,
-            color = color,
-            shadow = shadow,
-            textDecoration = textDecoration
-        )
+        paragraph = with(layouter) {
+            setTextStyle(
+                color = color,
+                shadow = shadow,
+                textDecoration = textDecoration
+            )
+            setDrawStyle(drawStyle)
+            layoutParagraph(
+                width = width
+            )
+        }
         paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
     }
 
-    // TODO: Use DrawStyle.
     @ExperimentalTextApi
     override fun paint(
         canvas: Canvas,
@@ -472,16 +475,19 @@ internal class SkiaParagraph(
         textDecoration: TextDecoration?,
         drawStyle: DrawStyle?
     ) {
-        paragraph = layouter.layoutParagraph(
-            width = width,
-            height = height,
-            maxLines = maxLines,
-            ellipsis = ellipsisChar,
-            brush = brush,
-            alpha = alpha,
-            shadow = shadow,
-            textDecoration = textDecoration
-        )
+        paragraph = with(layouter) {
+            setTextStyle(
+                brush = brush,
+                brushSize = Size(width, height),
+                alpha = alpha,
+                shadow = shadow,
+                textDecoration = textDecoration
+            )
+            setDrawStyle(drawStyle)
+            layoutParagraph(
+                width = width
+            )
+        }
         paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
     }
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -474,6 +474,7 @@ internal class SkiaParagraph(
     ) {
         paragraph = layouter.layoutParagraph(
             width = width,
+            height = height,
             maxLines = maxLines,
             ellipsis = ellipsisChar,
             brush = brush,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -17,9 +17,9 @@
 package androidx.compose.ui.text
 
 import org.jetbrains.skia.Rect as SkRect
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
@@ -58,14 +58,14 @@ internal class SkiaParagraph(
      * Paragraph isn't always immutable, it could be changed via [paint] method without
      * rerunning layout
      */
-    private var para = layouter.layoutParagraph(
+    private var paragraph = layouter.layoutParagraph(
         width = width,
         maxLines = maxLines,
         ellipsis = ellipsisChar
     )
 
     init {
-        para.layout(width)
+        paragraph.layout(width)
     }
 
     private val text: String
@@ -75,7 +75,7 @@ internal class SkiaParagraph(
         get() = constraints.maxWidth.toFloat()
 
     override val height: Float
-        get() = para.height
+        get() = paragraph.height
 
     override val minIntrinsicWidth: Float
         get() = paragraphIntrinsics.minIntrinsicWidth
@@ -90,24 +90,24 @@ internal class SkiaParagraph(
         get() = lineMetrics.lastOrNull()?.run { baseline.toFloat() } ?: 0f
 
     override val didExceedMaxLines: Boolean
-        get() = para.didExceedMaxLines()
+        get() = paragraph.didExceedMaxLines()
 
     override val lineCount: Int
         // workaround for https://bugs.chromium.org/p/skia/issues/detail?id=11321
         get() = if (text == "") {
             1
         } else {
-            para.lineNumber.toInt()
+            paragraph.lineNumber.toInt()
         }
 
     override val placeholderRects: List<Rect?>
         get() =
-            para.rectsForPlaceholders.map {
+            paragraph.rectsForPlaceholders.map {
                 it.rect.toComposeRect()
             }
 
     override fun getPathForRange(start: Int, end: Int): Path {
-        val boxes = para.getRectsForRange(
+        val boxes = paragraph.getRectsForRange(
             start,
             end,
             RectHeightMode.MAX,
@@ -247,7 +247,7 @@ internal class SkiaParagraph(
             val metrics = layouter.defaultFont.metrics
             val ascent = -metrics.ascent.toDouble()
             val descent = metrics.descent.toDouble()
-            val baseline = para.alphabeticBaseline.toDouble()
+            val baseline = paragraph.alphabeticBaseline.toDouble()
             val height = with(layouter.paragraphStyle.strutStyle) {
                 if (isEnabled && !isHeightForced && isHeightOverridden && fontSize > 0.0f) {
                     (height * fontSize).toDouble()
@@ -264,13 +264,13 @@ internal class SkiaParagraph(
             )
         } else {
             @Suppress("UNCHECKED_CAST", "USELESS_CAST")
-            para.lineMetrics as Array<LineMetrics>
+            paragraph.lineMetrics as Array<LineMetrics>
         }
 
     private fun getBoxForwardByOffset(offset: Int): TextBox? {
         var to = offset + 1
         while (to <= text.length) {
-            val box = para.getRectsForRange(
+            val box = paragraph.getRectsForRange(
                 offset, to,
                 RectHeightMode.STRUT, RectWidthMode.TIGHT
             ).firstOrNull()
@@ -286,7 +286,7 @@ internal class SkiaParagraph(
         var from = offset - 1
         val isRtl = paragraphIntrinsics.textDirection == ResolvedTextDirection.Rtl
         while (from >= 0) {
-            val box = para.getRectsForRange(
+            val box = paragraph.getRectsForRange(
                 from, end,
                 RectHeightMode.STRUT, RectWidthMode.TIGHT
             ).firstOrNull()
@@ -314,7 +314,7 @@ internal class SkiaParagraph(
                             val rect = SkRect(width, box.rect.bottom, width, bottom)
                             TextBox(rect, box.direction)
                         } else {
-                            val nextBox =  para.getRectsForRange(
+                            val nextBox =  paragraph.getRectsForRange(
                                 offset, offset + 1,
                                 RectHeightMode.STRUT, RectWidthMode.TIGHT
                             ).first()
@@ -343,7 +343,7 @@ internal class SkiaParagraph(
         }
 
     override fun getOffsetForPosition(position: Offset): Int {
-        val glyphPosition = para.getGlyphPositionAtCoordinate(position.x, position.y).position
+        val glyphPosition = paragraph.getGlyphPositionAtCoordinate(position.x, position.y).position
 
         // Below we apply a workaround for skiko/skia issue:
         //
@@ -373,7 +373,7 @@ internal class SkiaParagraph(
 
         val rects = if (isNotEmptyLine) {
             // expectedLine width doesn't include whitespaces. Therefore we look at the Rectangle representing the line
-            para.getRectsForRange(
+            paragraph.getRectsForRange(
                 start = expectedLine.startIndex,
                 end = if (expectedLine.isHardBreak) expectedLine.endIndex else expectedLine.endIndex - 1,
                 rectHeightMode = RectHeightMode.STRUT,
@@ -393,9 +393,9 @@ internal class SkiaParagraph(
         var correctedGlyphPosition = glyphPosition
 
         if (position.x <= leftX) { // when clicked to the left of a text line
-            correctedGlyphPosition = para.getGlyphPositionAtCoordinate(leftX + 1f, position.y).position
+            correctedGlyphPosition = paragraph.getGlyphPositionAtCoordinate(leftX + 1f, position.y).position
         } else if (position.x >= rightX) { // when clicked to the right of a text line
-            correctedGlyphPosition = para.getGlyphPositionAtCoordinate(rightX - 1f, position.y).position
+            correctedGlyphPosition = paragraph.getGlyphPositionAtCoordinate(rightX - 1f, position.y).position
             val isNeutralChar = text.getOrNull(correctedGlyphPosition)?.isNeutralDirectionality() ?: false
             // For RTL blocks, the position is still not correct, so we have to subtract 1 from the returned result
             if (!isNeutralChar && getBoxBackwardByOffset(correctedGlyphPosition)?.direction == Direction.RTL) {
@@ -413,25 +413,24 @@ internal class SkiaParagraph(
 
     override fun getWordBoundary(offset: Int): TextRange {
         return when {
-            (text.getOrNull(offset)?.isLetterOrDigit() ?: false) -> para.getWordBoundary(offset).let {
+            (text.getOrNull(offset)?.isLetterOrDigit() ?: false) -> paragraph.getWordBoundary(offset).let {
                 TextRange(it.start, it.end)
             }
             (text.getOrNull(offset - 1)?.isLetterOrDigit() ?: false) ->
-                para.getWordBoundary(offset - 1).let {
+                paragraph.getWordBoundary(offset - 1).let {
                     TextRange(it.start, it.end)
                 }
             else -> TextRange(offset, offset)
         }
     }
 
-    // TODO(b/229518449): Implement an alternative to paint function that takes a brush.
     override fun paint(
         canvas: Canvas,
         color: Color,
         shadow: Shadow?,
         textDecoration: TextDecoration?
     ) {
-        para = layouter.layoutParagraph(
+        paragraph = layouter.layoutParagraph(
             width = width,
             maxLines = maxLines,
             ellipsis = ellipsisChar,
@@ -440,9 +439,10 @@ internal class SkiaParagraph(
             textDecoration = textDecoration
         )
 
-        para.paint(canvas.nativeCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
     }
 
+    // TODO: Use DrawStyle.
     @ExperimentalTextApi
     override fun paint(
         canvas: Canvas,
@@ -451,7 +451,7 @@ internal class SkiaParagraph(
         textDecoration: TextDecoration?,
         drawStyle: DrawStyle?
     ) {
-        para = layouter.layoutParagraph(
+        paragraph = layouter.layoutParagraph(
             width = width,
             maxLines = maxLines,
             ellipsis = ellipsisChar,
@@ -459,11 +459,10 @@ internal class SkiaParagraph(
             shadow = shadow,
             textDecoration = textDecoration
         )
-
-        para.paint(canvas.nativeCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
     }
 
-    // TODO(b/229518449): Implement this paint function that draws text with a Brush.
+    // TODO: Use DrawStyle.
     @ExperimentalTextApi
     override fun paint(
         canvas: Canvas,
@@ -473,8 +472,15 @@ internal class SkiaParagraph(
         textDecoration: TextDecoration?,
         drawStyle: DrawStyle?
     ) {
-        throw UnsupportedOperationException(
-            "Using brush for painting the paragraph is a separate functionality that " +
-                "is not supported on this platform")
+        paragraph = layouter.layoutParagraph(
+            width = width,
+            maxLines = maxLines,
+            ellipsis = ellipsisChar,
+            brush = brush,
+            alpha = alpha,
+            shadow = shadow,
+            textDecoration = textDecoration
+        )
+        paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
     }
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -55,7 +55,7 @@ import org.jetbrains.skia.paragraph.Paragraph
  * reusedParagraph.layout(300f): 10.004400ms
  * builder.build().layout(300f): 23.421500ms
  */
-class ParagraphLayouter(
+internal class ParagraphLayouter(
     val text: String,
     textDirection: ResolvedTextDirection,
     style: TextStyle,
@@ -142,7 +142,7 @@ class ParagraphLayouter(
     }
 
     fun setDrawStyle(drawStyle: DrawStyle?) {
-        // TODO use it!
+        // TODO Implement applying DrawStyle
     }
 
     fun layoutParagraph(width: Float): Paragraph {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Density
+import kotlin.math.abs
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.paragraph.Paragraph
 
@@ -106,8 +107,12 @@ class ParagraphLayouter(
         shadow: Shadow?,
         textDecoration: TextDecoration?
     ) {
+        val actualSize = builder.brushSize
         if (builder.textStyle.brush != brush ||
-            builder.textStyle.alpha != alpha ||
+            actualSize == null ||
+            !actualSize.width.sameValueAs(brushSize.width) ||
+            !actualSize.height.sameValueAs(brushSize.height) ||
+            !builder.textStyle.alpha.sameValueAs(alpha) ||
             builder.textStyle.shadow != shadow ||
             builder.textStyle.textDecoration != textDecoration
         ) {
@@ -129,7 +134,7 @@ class ParagraphLayouter(
     fun layoutParagraph(width: Float): Paragraph {
         val paragraph = paragraphCache
         return if (paragraph != null) {
-            if (this.width != width) {
+            if (!this.width.sameValueAs(width)) {
                 this.width = width
                 paragraph.layout(width)
             }
@@ -141,4 +146,8 @@ class ParagraphLayouter(
             }
         }
     }
+}
+
+private fun Float.sameValueAs(other: Float) : Boolean {
+    return abs(this - other) < 0.00001f
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.asComposePaint
+import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -78,23 +79,16 @@ class ParagraphLayouter(
     val defaultFont get() = builder.defaultFont
     val paragraphStyle get() = builder.paragraphStyle
 
-    fun layoutParagraph(
-        width: Float,
-        maxLines: Int = builder.maxLines,
-        ellipsis: String = builder.ellipsis,
-        color: Color = builder.textStyle.color,
-        shadow: Shadow? = builder.textStyle.shadow,
-        textDecoration: TextDecoration? = builder.textStyle.textDecoration,
-    ): Paragraph {
+    fun setTextStyle(
+        color: Color,
+        shadow: Shadow?,
+        textDecoration: TextDecoration?
+    ) {
         val actualColor = color.takeOrElse { builder.textStyle.color }
-        if (builder.maxLines != maxLines ||
-            builder.ellipsis != ellipsis ||
-            builder.textStyle.color != actualColor ||
+        if (builder.textStyle.color != actualColor ||
             builder.textStyle.shadow != shadow ||
             builder.textStyle.textDecoration != textDecoration
         ) {
-            builder.maxLines = maxLines
-            builder.ellipsis = ellipsis
             builder.textStyle = builder.textStyle.copy(
                 color = actualColor,
                 shadow = shadow,
@@ -102,42 +96,37 @@ class ParagraphLayouter(
             )
             paragraphCache = null
         }
-        return buildParagraph(builder, width)
     }
 
     @ExperimentalTextApi
-    fun layoutParagraph(
-        width: Float,
-        height: Float,
-        maxLines: Int = builder.maxLines,
-        ellipsis: String = builder.ellipsis,
-        brush: Brush? = builder.textStyle.brush,
-        alpha: Float = builder.textStyle.alpha,
-        shadow: Shadow? = builder.textStyle.shadow,
-        textDecoration: TextDecoration? = builder.textStyle.textDecoration,
-    ): Paragraph {
-        if (builder.maxLines != maxLines ||
-            builder.ellipsis != ellipsis ||
-            builder.textStyle.brush != brush ||
+    fun setTextStyle(
+        brush: Brush?,
+        brushSize: Size,
+        alpha: Float,
+        shadow: Shadow?,
+        textDecoration: TextDecoration?
+    ) {
+        if (builder.textStyle.brush != brush ||
             builder.textStyle.alpha != alpha ||
             builder.textStyle.shadow != shadow ||
             builder.textStyle.textDecoration != textDecoration
         ) {
-            builder.maxLines = maxLines
-            builder.ellipsis = ellipsis
             builder.textStyle = builder.textStyle.copy(
                 brush = brush,
                 alpha = alpha,
                 shadow = shadow,
                 textDecoration = textDecoration
             )
-            builder.brushSize = Size(width, height)
+            builder.brushSize = brushSize
             paragraphCache = null
         }
-        return buildParagraph(builder, width)
     }
 
-    private fun buildParagraph(builder: ParagraphBuilder, width: Float): Paragraph {
+    fun setDrawStyle(drawStyle: DrawStyle?) {
+        // TODO use it!
+    }
+
+    fun layoutParagraph(width: Float): Paragraph {
         val paragraph = paragraphCache
         return if (paragraph != null) {
             if (this.width != width) {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -16,10 +16,12 @@
 
 package androidx.compose.ui.text.platform
 
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -36,7 +38,7 @@ import org.jetbrains.skia.paragraph.Paragraph
  * An alternative to passing and reusing existed paragraph is to build it again, but it is 2.5x
  * slower.
  *
- * LayoutedParagraph should has only one owner to avoid concurrent usage.
+ * LayoutedParagraph should have only one owner to avoid concurrent usage.
  *
  * Tests:
  *
@@ -66,16 +68,14 @@ class ParagraphLayouter(
         density = density,
         textDirection = textDirection
     )
-    private var para = builder.build()
+    private var paragraphCache: Paragraph? = null
+    private var width: Float = Float.NaN
 
-    private var width: Float = -1f
-
-    val defaultHeight get() = builder.defaultHeight
     val defaultFont get() = builder.defaultFont
     val paragraphStyle get() = builder.paragraphStyle
 
     fun layoutParagraph(
-        width: Float = this.width,
+        width: Float,
         maxLines: Int = builder.maxLines,
         ellipsis: String = builder.ellipsis,
         color: Color = builder.textStyle.color,
@@ -83,14 +83,12 @@ class ParagraphLayouter(
         textDecoration: TextDecoration? = builder.textStyle.textDecoration,
     ): Paragraph {
         val actualColor = color.takeOrElse { builder.textStyle.color }
-        if (
-            builder.maxLines != maxLines ||
+        if (builder.maxLines != maxLines ||
             builder.ellipsis != ellipsis ||
             builder.textStyle.color != actualColor ||
             builder.textStyle.shadow != shadow ||
             builder.textStyle.textDecoration != textDecoration
         ) {
-            this.width = width
             builder.maxLines = maxLines
             builder.ellipsis = ellipsis
             builder.textStyle = builder.textStyle.copy(
@@ -98,12 +96,57 @@ class ParagraphLayouter(
                 shadow = shadow,
                 textDecoration = textDecoration
             )
-            para = builder.build()
-            para.layout(width)
-        } else if (this.width != width) {
-            this.width = width
-            para.layout(width)
+            paragraphCache = null
         }
-        return para
+        return buildParagraph(builder, width)
+    }
+
+    @ExperimentalTextApi
+    fun layoutParagraph(
+        width: Float,
+        maxLines: Int = builder.maxLines,
+        ellipsis: String = builder.ellipsis,
+        brush: Brush? = builder.textStyle.brush,
+        alpha: Float = builder.textStyle.alpha,
+        shadow: Shadow? = builder.textStyle.shadow,
+        textDecoration: TextDecoration? = builder.textStyle.textDecoration,
+    ): Paragraph {
+        if (builder.maxLines != maxLines ||
+            builder.ellipsis != ellipsis ||
+            builder.textStyle.brush != brush ||
+            builder.textStyle.alpha != alpha ||
+            builder.textStyle.shadow != shadow ||
+            builder.textStyle.textDecoration != textDecoration
+        ) {
+            builder.maxLines = maxLines
+            builder.ellipsis = ellipsis
+            builder.textStyle = builder.textStyle.copy(
+                brush = brush,
+                alpha = alpha,
+                shadow = shadow,
+                textDecoration = textDecoration
+            )
+            paragraphCache = null
+        }
+        return buildParagraph(builder, width)
+    }
+
+    private fun buildParagraph(builder: ParagraphBuilder, width: Float): Paragraph {
+        if (this.width != width) {
+            this.width = width
+        }
+        val paragraph = paragraphCache
+        return if (paragraph != null) {
+            if (this.width != width) {
+                this.width = width
+                paragraph.layout(width)
+            }
+            paragraph
+        } else {
+            builder.build().apply {
+                paragraphCache = this
+                layout(width)
+            }
+        }
     }
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -93,7 +93,6 @@ internal class ParagraphLayouter(
         }
     }
 
-
     fun setTextStyle(
         color: Color,
         shadow: Shadow?,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -16,9 +16,11 @@
 
 package androidx.compose.ui.text.platform
 
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.asComposePaint
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -29,6 +31,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Density
+import org.jetbrains.skia.Paint
 import org.jetbrains.skia.paragraph.Paragraph
 
 /**
@@ -63,6 +66,7 @@ class ParagraphLayouter(
         fontFamilyResolver = fontFamilyResolver,
         text = text,
         textStyle = style,
+        brushSize = null,
         spanStyles = spanStyles,
         placeholders = placeholders,
         density = density,
@@ -104,6 +108,7 @@ class ParagraphLayouter(
     @ExperimentalTextApi
     fun layoutParagraph(
         width: Float,
+        height: Float,
         maxLines: Int = builder.maxLines,
         ellipsis: String = builder.ellipsis,
         brush: Brush? = builder.textStyle.brush,
@@ -126,15 +131,13 @@ class ParagraphLayouter(
                 shadow = shadow,
                 textDecoration = textDecoration
             )
+            builder.brushSize = Size(width, height)
             paragraphCache = null
         }
         return buildParagraph(builder, width)
     }
 
     private fun buildParagraph(builder: ParagraphBuilder, width: Float): Paragraph {
-        if (this.width != width) {
-            this.width = width
-        }
         val paragraph = paragraphCache
         return if (paragraph != null) {
             if (this.width != width) {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -80,6 +80,20 @@ class ParagraphLayouter(
     val defaultFont get() = builder.defaultFont
     val paragraphStyle get() = builder.paragraphStyle
 
+    fun setParagraphStyle(
+        maxLines: Int,
+        ellipsis: String
+    ) {
+        if (builder.maxLines != maxLines ||
+            builder.ellipsis != ellipsis
+        ) {
+            builder.maxLines = maxLines
+            builder.ellipsis = ellipsis
+            paragraphCache = null
+        }
+    }
+
+
     fun setTextStyle(
         color: Color,
         shadow: Shadow?,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphIntrinsics.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphIntrinsics.skiko.kt
@@ -62,7 +62,13 @@ internal class SkiaParagraphIntrinsics(
     }
 
     private fun newLayouter() = ParagraphLayouter(
-        text, textDirection, style, spanStyles, placeholders, density, fontFamilyResolver
+        text = text,
+        textDirection = textDirection,
+        style = style,
+        spanStyles = spanStyles,
+        placeholders = placeholders,
+        density = density,
+        fontFamilyResolver = fontFamilyResolver
     )
 
     override var minIntrinsicWidth = 0f


### PR DESCRIPTION
## Proposed Changes

Compose 1.2.0 adds `Brush` API to `TextStyle` to provide a way to draw text with complex coloring. Here is implementation of this API for Compose Multiplatform (skiko)

## Testing

Test: Use experimental API for passing `brush` to text style

```kt
Text(
    text = text,
    style = TextStyle(
        fontWeight = FontWeight.Bold,
        brush = Brush.linearGradient(
            colors = listOf(Red, Blue)
        )
    )
)
```
<img width="402" alt="image" src="https://user-images.githubusercontent.com/1836384/223987292-c053cdbc-5b5e-4e46-80a6-e68d90fd7924.png">

## Issues Fixed

Fixes https://github.com/JetBrains/compose-jb/issues/2814
