### PR TITLE
UIKit: Make rootView autoResize its subviews

### DIFF
--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-import UIKit
+import Foundation
 import SwiftUI
 import shared
 
-class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-    var window: UIWindow?
+struct ContentView: View {
+    var body: some View {
+        ComposeView()
+    }
+}
 
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        if let windowScene = scene as? UIWindowScene {
-            let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = SwiftHelper().getViewController()
-            self.window = window
-            window.makeKeyAndVisible()
-        }
+struct ComposeView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        SwiftHelper().getViewController()
     }
 
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
 }

--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/iOSApp.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/iOSApp.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,13 @@
  */
 
 import UIKit
+import SwiftUI
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate {
-
+struct iOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
 }

--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -18,12 +18,14 @@ package androidx.compose.mpp.demo
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -43,10 +45,10 @@ fun getViewControllerWithCompose() = ComposeUIViewController {
         Text(".")
         Text(".")
         Text("Hello, UIKit")
-        TextField(value = textState1.value, onValueChange = {
+        TextField(modifier = Modifier.fillMaxWidth(), value = textState1.value, onValueChange = {
             textState1.value = it
         })
-        TextField(value = textState2.value, onValueChange = {
+        TextField(modifier = Modifier.fillMaxWidth(), value = textState2.value, onValueChange = {
             textState2.value = it
         })
         Image(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.createSkiaLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.toSkiaRect
 import androidx.compose.ui.interop.LocalLayerContainer
 import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.Platform
@@ -34,17 +33,14 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import kotlin.math.roundToInt
 import androidx.compose.ui.unit.toOffset
 import kotlin.math.roundToInt
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
-import kotlinx.cinterop.copy
 import kotlinx.cinterop.useContents
 import org.jetbrains.skiko.SkikoUIView
 import org.jetbrains.skiko.TextActions
-import platform.CoreGraphics.CGFloat
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSize
@@ -56,25 +52,16 @@ import platform.Foundation.NSValue
 import platform.UIKit.CGRectValue
 import platform.UIKit.UIScreen
 import platform.UIKit.UIView
-import platform.UIKit.UIViewAutoresizing
 import platform.UIKit.UIViewAutoresizingFlexibleHeight
 import platform.UIKit.UIViewAutoresizingFlexibleWidth
 import platform.UIKit.UIViewController
 import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
-import platform.UIKit.addConstraint
 import platform.UIKit.addSubview
-import platform.UIKit.invalidateIntrinsicContentSize
-import platform.UIKit.leftAnchor
 import platform.UIKit.reloadInputViews
 import platform.UIKit.setAutoresizesSubviews
 import platform.UIKit.setAutoresizingMask
 import platform.UIKit.setClipsToBounds
-import platform.UIKit.setFrame
 import platform.UIKit.setNeedsDisplay
-import platform.UIKit.setNeedsLayout
-import platform.UIKit.setNeedsUpdateConstraints
-import platform.UIKit.viewWithTag
-import platform.UIKit.window
 import platform.darwin.NSObject
 
 fun ComposeUIViewController(content: @Composable () -> Unit): UIViewController =

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -40,9 +40,11 @@ import kotlin.math.roundToInt
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.copy
 import kotlinx.cinterop.useContents
 import org.jetbrains.skiko.SkikoUIView
 import org.jetbrains.skiko.TextActions
+import platform.CoreGraphics.CGFloat
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSize
@@ -54,12 +56,24 @@ import platform.Foundation.NSValue
 import platform.UIKit.CGRectValue
 import platform.UIKit.UIScreen
 import platform.UIKit.UIView
+import platform.UIKit.UIViewAutoresizing
+import platform.UIKit.UIViewAutoresizingFlexibleHeight
+import platform.UIKit.UIViewAutoresizingFlexibleWidth
 import platform.UIKit.UIViewController
 import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
+import platform.UIKit.addConstraint
 import platform.UIKit.addSubview
+import platform.UIKit.invalidateIntrinsicContentSize
+import platform.UIKit.leftAnchor
 import platform.UIKit.reloadInputViews
+import platform.UIKit.setAutoresizesSubviews
+import platform.UIKit.setAutoresizingMask
 import platform.UIKit.setClipsToBounds
+import platform.UIKit.setFrame
 import platform.UIKit.setNeedsDisplay
+import platform.UIKit.setNeedsLayout
+import platform.UIKit.setNeedsUpdateConstraints
+import platform.UIKit.viewWithTag
 import platform.UIKit.window
 import platform.darwin.NSObject
 
@@ -154,6 +168,10 @@ internal actual class ComposeWindow : UIViewController {
         val skikoUIView = SkikoUIView(skiaLayer).load()
         val rootView = UIView() // rootView needs to interop with UIKit
         rootView.addSubview(skikoUIView)
+        rootView.setAutoresizesSubviews(true)
+        skikoUIView.setAutoresizingMask(
+            UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
+        )
         view = rootView
         val uiKitTextInputService = UIKitTextInputService(
             showSoftwareKeyboard = {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -250,6 +250,9 @@ internal actual class ComposeWindow : UIViewController {
         val height = size.useContents { height } * scale
         layer.setSize(width.roundToInt(), height.roundToInt())
         layer.layer.needRedraw()
+        withTransitionCoordinator.animateAlongsideTransition(animation = null) {
+            layer.layer.needRedraw()
+        }
         super.viewWillTransitionToSize(size, withTransitionCoordinator)
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -249,8 +249,12 @@ internal actual class ComposeWindow : UIViewController {
         val width = size.useContents { width } * scale
         val height = size.useContents { height } * scale
         layer.setSize(width.roundToInt(), height.roundToInt())
-        layer.layer.needRedraw()
+        layer.layer.needRedraw() // TODO: remove? the following block should be enough
         withTransitionCoordinator.animateAlongsideTransition(animation = null) {
+            // Docs: https://developer.apple.com/documentation/uikit/uiviewcontrollertransitioncoordinator/1619295-animatealongsidetransition
+            // Request a frame once more on animation completion.
+            // Consider adding redrawImmediately() in SkiaLayer for ios to sync with current frame.
+            // This fixes an interop use case when Compose is embedded in SwiftUi.
             layer.layer.needRedraw()
         }
         super.viewWillTransitionToSize(size, withTransitionCoordinator)


### PR DESCRIPTION
This fixes the view size updates on screen rotation

Tested in compose/mpp/demo:
<img width="914" alt="Screenshot 2023-03-07 at 18 43 52" src="https://user-images.githubusercontent.com/7372778/223505210-7ca62cb2-10ee-43d2-83ac-af4eb3a97330.png">
