### PR TITLE
Remove the extra Surface used to draw the AlertDialog's shadow.

### DIFF
--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.window.rememberDialogState
 import java.awt.event.KeyEvent
 import androidx.compose.ui.window.Dialog as CoreDialog
 import androidx.compose.foundation.background
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.type
@@ -153,7 +154,8 @@ fun AlertDialog(
         AlertDialog(
             onDismissRequest = onDismissRequest,
             shape = shape,
-        ) {
+            modifier = modifier,
+        ) { modifier ->
             AlertDialogContent(
                 buttons = buttons,
                 modifier = modifier.width(IntrinsicSize.Min),
@@ -178,7 +180,7 @@ interface AlertDialogProvider {
      * @param onDismissRequest Callback that will be called when the user closes the dialog
      * @param content Content of the dialog
      */
-    @Deprecated("Will be removed in 1.5; use the overload that takes the dialog shape")
+    @Deprecated("Will be removed in 1.5; use the other overload")
     @Composable
     fun AlertDialog(
         onDismissRequest: () -> Unit,
@@ -197,10 +199,11 @@ interface AlertDialogProvider {
     fun AlertDialog(
         onDismissRequest: () -> Unit,
         shape: Shape,
-        content: @Composable () -> Unit
+        modifier: Modifier,
+        content: @Composable (Modifier) -> Unit
     ) = AlertDialog(
         onDismissRequest = onDismissRequest,
-        content = content
+        content = { content(modifier) }
     )
 }
 
@@ -212,7 +215,7 @@ interface AlertDialogProvider {
 @ExperimentalMaterialApi
 object PopupAlertDialogProvider : AlertDialogProvider {
 
-    @Deprecated("Will be removed in 1.5; use the overload that takes the dialog shape")
+    @Deprecated("Will be removed in 1.5; use the other overload")
     @Composable
     override fun AlertDialog(
         onDismissRequest: () -> Unit,
@@ -221,7 +224,8 @@ object PopupAlertDialogProvider : AlertDialogProvider {
         AlertDialog(
             onDismissRequest = onDismissRequest,
             shape = RectangleShape,
-            content = content
+            modifier = Modifier,
+            content = { content() }
         )
     }
 
@@ -229,7 +233,8 @@ object PopupAlertDialogProvider : AlertDialogProvider {
     override fun AlertDialog(
         onDismissRequest: () -> Unit,
         shape: Shape,
-        content: @Composable () -> Unit
+        modifier: Modifier,
+        content: @Composable (Modifier) -> Unit
     ) {
         // Popups on the desktop are by default embedded in the component in which
         // they are defined and aligned within its bounds. But an [AlertDialog] needs
@@ -267,17 +272,15 @@ object PopupAlertDialogProvider : AlertDialogProvider {
                     },
                 contentAlignment = Alignment.Center
             ) {
-                Surface(
-                    modifier = Modifier.pointerInput(onDismissRequest) {
-                        detectTapGestures(onPress = {
-                            // Workaround to disable clicks on Surface background
-                            // https://github.com/JetBrains/compose-jb/issues/2581
-                        })
-                    },
-                    shape = shape,
-                    color = Color.Transparent,
-                    elevation = 24.dp,
-                    content = content
+                content(
+                    modifier
+                        .shadow(elevation = 24.dp, shape = shape)
+                        .pointerInput(onDismissRequest) {
+                            detectTapGestures(onPress = {
+                                // Workaround to disable clicks on Surface background
+                                // https://github.com/JetBrains/compose-jb/issues/2581
+                            })
+                        }
                 )
             }
         }

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
@@ -16,30 +16,35 @@
 
 package androidx.compose.material
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.internal.keyEvent
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.renderComposeScene
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyPress
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
-import org.junit.runners.JUnit4
-import org.junit.runner.RunWith
+import org.junit.Assert.assertNotEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class DesktopAlertDialogTest {
@@ -49,8 +54,8 @@ class DesktopAlertDialogTest {
 
     @Test
     fun alignedToCenter_inPureWindow() {
-        var rootSize = IntSize(1024, 768) // default value
-        var dialogSize = IntSize(150, 150)
+        val rootSize = IntSize(1024, 768) // default value
+        val dialogSize = IntSize(150, 150)
         var location = Offset.Zero
         rule.setContent {
             CompositionLocalProvider(LocalDensity provides Density(1f, 1f)) {
@@ -103,6 +108,37 @@ class DesktopAlertDialogTest {
         rule.runOnIdle {
             assertEquals(1, dismissCount)
         }
+    }
+
+    // https://github.com/JetBrains/compose-multiplatform/issues/2857
+    @OptIn(ExperimentalMaterialApi::class)
+    @Test
+    fun `shadow drawn at content bounds`() {
+        // Show an AlertDialog with very large horizontal padding and check that the pixel
+        // at the edge of where the dialog would have been without padding has the same color as the
+        // background.
+        val screenshot = renderComposeScene(400, 400){
+            AlertDialog(
+                modifier = Modifier
+                    .size(width = 400.dp, height = 100.dp)
+                    .padding(horizontal = 150.dp),
+                onDismissRequest = {},
+                title = {},
+                text = {},
+                dismissButton = {},
+                confirmButton = {},
+            )
+        }
+
+        val pixels = screenshot.toComposeImageBitmap().toPixelMap()
+        val backgroundPixel = pixels[0, 0]
+        val nearEdgeWithoutPaddingPixel = pixels[0, 200]
+        val nearRealEdgePixel = pixels[149, 200]
+
+        assertEquals(nearEdgeWithoutPaddingPixel, backgroundPixel)
+
+        // Also check that the shadow is present near the actual edge of the content
+        assertNotEquals(nearRealEdgePixel, backgroundPixel)
     }
 
     private fun calculateCenterPosition(rootSize: IntSize, childSize: IntSize): Offset {


### PR DESCRIPTION
Replace it with a `Modifier.shadow` passed to `AlertDialogContent`.

## Proposed Changes
 
 - Remove the extra `Surface` created by `PopupAlertDialogProvider`.
 - Pass the AlertDialog's modifier to the `AlertDialogProvider` and allow it to control the modifier given to `AlertDialogContent`. This allows PopupAlertDialogProvider to add a `Modifier.shadow()` to the AlertDialogContent itself, rather than drawing it on an additional surface.

## Testing

Before: 

<img width="401" alt="224303077-c5244eb9-c013-43a7-9992-125dcbcc4631" src="https://user-images.githubusercontent.com/5230206/224313336-881ea01f-04a0-4d4d-b31b-071d4137c1d6.png">

After:

<img width="401" alt="image" src="https://user-images.githubusercontent.com/5230206/224313350-81ad2b49-8e24-4464-b84a-4711314c59c8.png">


Test: Added a unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2857
