### PR TITLE
Don't rely on AWT in rememberCursorPositionProvider

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
+internal class TooltipAreaTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    // https://github.com/JetBrains/compose-jb/issues/2821
+    @Test
+    fun `simple tooltip is shown`(): Unit = runBlocking(Dispatchers.Main) {
+        rule.setContent {
+            TooltipArea(
+                tooltip = {
+                    Box {
+                        BasicText(
+                            text = "Tooltip",
+                            modifier = Modifier.testTag("tooltipText")
+                        )
+                    }
+                }
+            ) {
+                BasicText("Text", modifier = Modifier.size(50.dp).testTag("elementWithTooltip"))
+            }
+        }
+
+
+        rule.onNodeWithTag("elementWithTooltip").performMouseInput {
+            moveTo(Offset(30f, 40f))
+        }
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("tooltipText").assertExists()
+    }
+}

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -55,7 +55,6 @@ internal class TooltipAreaTest {
             }
         }
 
-
         rule.onNodeWithTag("elementWithTooltip").performMouseInput {
             moveTo(Offset(30f, 40f))
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -78,7 +78,6 @@ internal class DesktopCursorPositionTest {
                 }
             }
         }
-        rule.waitForIdle()
 
         rule.onNodeWithTag("testBox").performMouseInput {
             moveTo(Offset(30f, 40f))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+internal class DesktopCursorPositionTest {
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val windowSize = IntSize(200, 200)
+    private val anchorPosition = IntOffset(0, 0)
+    private val anchorSize = IntSize(100, 100)
+    private val popupSize = IntSize(20, 20)
+
+    // https://github.com/JetBrains/compose-jb/issues/2821
+    @Test
+    fun `pointer position with single component`(): Unit = runBlocking(Dispatchers.Main) {
+        var pointerPosition: IntOffset? = null
+
+        rule.setContent {
+            var savePointerPosition by remember { mutableStateOf(false) }
+            Box(
+                modifier = Modifier
+                    .size(200.dp, 200.dp)
+                    .testTag("testBox")
+                    .onPointerEvent(PointerEventType.Enter, onEvent = {
+                        savePointerPosition = true
+                    })
+            ) {
+                if (savePointerPosition) {
+                    pointerPosition = rememberCursorPositionProvider().calculatePosition(
+                        IntRect(anchorPosition, anchorSize),
+                        windowSize,
+                        LayoutDirection.Ltr,
+                        popupSize
+                    )
+                }
+            }
+        }
+        rule.waitForIdle()
+
+        rule.onNodeWithTag("testBox").performMouseInput {
+            moveTo(Offset(30f, 40f))
+        }
+        rule.waitForIdle()
+        assertThat(pointerPosition).isEqualTo(IntOffset(30, 40))
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Introduces internal `LocalPointerPositions` that provides a way to get the current position of pointers. It is used in `rememberCursorPositionProvider`
- `rememberCursorPositionProvider` doesn't rely on AWT anymore
- Add tests for this functionality

## Testing

Test: newly introduced `TooltipAreaTest` and `DesktopCursorPositionTest`

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2821
