### PR TITLE
Alert dialog to match the maximum of the width of its content

### DIFF
--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -46,10 +46,16 @@ import androidx.compose.ui.window.rememberDialogState
 import java.awt.event.KeyEvent
 import androidx.compose.ui.window.Dialog as CoreDialog
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.type
+
+/**
+ * The default padding for an [AlertDialog].
+ */
+private val AlertDialogPadding = PaddingValues(24.dp)
 
 /**
  * Alert dialog is a Dialog which interrupts the user with urgent information, details or actions.
@@ -95,6 +101,65 @@ fun AlertDialog(
 ) {
     AlertDialog(
         onDismissRequest = onDismissRequest,
+        confirmButton = confirmButton,
+        modifier = modifier,
+        dismissButton = dismissButton,
+        title = title,
+        text = text,
+        shape = shape,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        dialogPadding = AlertDialogPadding,
+        dialogProvider = dialogProvider
+    )
+}
+
+/**
+ * Alert dialog is a Dialog which interrupts the user with urgent information, details or actions.
+ *
+ * The dialog will position its buttons based on the available space. By default it will try to
+ * place them horizontally next to each other and fallback to horizontal placement if not enough
+ * space is available. There is also another version of this composable that has a slot for buttons
+ * to provide custom buttons layout.
+ *
+ * Sample of dialog:
+ * @sample androidx.compose.material.samples.AlertDialogSample
+ *
+ * @param onDismissRequest Callback that will be called when the user closes the dialog.
+ * @param confirmButton A button which is meant to confirm a proposed action, thus resolving
+ * what triggered the dialog. The dialog does not set up any events for this button so they need
+ * to be set up by the caller.
+ * @param modifier Modifier to be applied to the layout of the dialog.
+ * @param dismissButton A button which is meant to dismiss the dialog. The dialog does not set up
+ * any events for this button so they need to be set up by the caller.
+ * @param title The title of the Dialog which should specify the purpose of the Dialog. The title
+ * is not mandatory, because there may be sufficient information inside the [text]. Provided text
+ * style will be [Typography.subtitle1].
+ * @param text The text which presents the details regarding the Dialog's purpose. Provided text
+ * style will be [Typography.body2].
+ * @param shape Defines the Dialog's shape
+ * @param backgroundColor The background color of the dialog.
+ * @param contentColor The preferred content color provided by this dialog to its children.
+ * @param dialogPadding The outer padding of the dialog.
+ * @param dialogProvider Defines how to create dialog in which will be placed AlertDialog's content.
+ */
+@Composable
+@ExperimentalMaterialApi
+fun AlertDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: @Composable (() -> Unit)? = null,
+    title: @Composable (() -> Unit)? = null,
+    text: @Composable (() -> Unit)? = null,
+    shape: Shape = MaterialTheme.shapes.medium,
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    contentColor: Color = contentColorFor(backgroundColor),
+    dialogPadding: PaddingValues = AlertDialogPadding,
+    dialogProvider: AlertDialogProvider = PopupAlertDialogProvider,
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
         buttons = {
             // TODO: move the modifiers to FlowRow when it supports a modifier parameter
             Box(Modifier.fillMaxWidth().padding(all = 8.dp)) {
@@ -113,6 +178,7 @@ fun AlertDialog(
         shape = shape,
         backgroundColor = backgroundColor,
         contentColor = contentColor,
+        dialogPadding = dialogPadding,
         dialogProvider = dialogProvider
     )
 }
@@ -150,11 +216,60 @@ fun AlertDialog(
     contentColor: Color = contentColorFor(backgroundColor),
     dialogProvider: AlertDialogProvider = PopupAlertDialogProvider
 ) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        buttons = buttons,
+        modifier = modifier,
+        title = title,
+        text = text,
+        shape = shape,
+        backgroundColor = backgroundColor,
+        contentColor = contentColor,
+        dialogPadding = AlertDialogPadding,
+        dialogProvider = dialogProvider
+    )
+}
+
+/**
+ * Alert dialog is a Dialog which interrupts the user with urgent information, details or actions.
+ *
+ * This function can be used to fully customize the button area, e.g. with:
+ *
+ * @sample androidx.compose.material.samples.CustomAlertDialogSample
+ *
+ * @param onDismissRequest Callback that will be called when the user closes the dialog.
+ * @param buttons Function that emits the layout with the buttons.
+ * @param modifier Modifier to be applied to the layout of the dialog.
+ * @param title The title of the Dialog which should specify the purpose of the Dialog. The title
+ * is not mandatory, because there may be sufficient information inside the [text]. Provided text
+ * style will be [Typography.subtitle1].
+ * @param text The text which presents the details regarding the Dialog's purpose. Provided text
+ * style will be [Typography.body2].
+ * @param shape Defines the Dialog's shape.
+ * @param backgroundColor The background color of the dialog.
+ * @param contentColor The preferred content color provided by this dialog to its children.
+ * @param dialogPadding The outer padding of the dialog.
+ * @param dialogProvider Defines how to create dialog in which will be placed AlertDialog's content.
+ */
+@Composable
+@ExperimentalMaterialApi
+fun AlertDialog(
+    onDismissRequest: () -> Unit,
+    buttons: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    title: (@Composable () -> Unit)? = null,
+    text: @Composable (() -> Unit)? = null,
+    shape: Shape = MaterialTheme.shapes.medium,
+    backgroundColor: Color = MaterialTheme.colors.surface,
+    contentColor: Color = contentColorFor(backgroundColor),
+    dialogPadding: PaddingValues = AlertDialogPadding,
+    dialogProvider: AlertDialogProvider = PopupAlertDialogProvider
+) {
     with(dialogProvider) {
         AlertDialog(
             onDismissRequest = onDismissRequest,
             shape = shape,
-            modifier = modifier,
+            modifier = modifier.padding(dialogPadding),
         ) { modifier ->
             AlertDialogContent(
                 buttons = buttons,

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -158,7 +158,7 @@ fun AlertDialog(
         ) { modifier ->
             AlertDialogContent(
                 buttons = buttons,
-                modifier = modifier.width(IntrinsicSize.Min),
+                modifier = modifier.width(IntrinsicSize.Max),
                 title = title,
                 text = text,
                 shape = shape,

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.material
 
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.internal.keyEvent
 import androidx.compose.runtime.CompositionLocalProvider
@@ -73,7 +73,7 @@ class DesktopAlertDialogTest {
                 @OptIn(ExperimentalMaterialApi::class)
                 AlertDialog(
                     onDismissRequest = {},
-                    title = { Text("AlerDialog") },
+                    title = { Text("AlertDialog") },
                     text = { Text("Apply?") },
                     confirmButton = { Button(onClick = {}) { Text("Apply") } },
                     modifier = Modifier.size(dialogSize.width.dp, dialogSize.height.dp)
@@ -97,7 +97,7 @@ class DesktopAlertDialogTest {
                 @OptIn(ExperimentalMaterialApi::class)
                 AlertDialog(
                     onDismissRequest = { dismissCount++ },
-                    title = { Text("AlerDialog") },
+                    title = { Text("AlertDialog") },
                     text = { Text("Apply?") },
                     confirmButton = { Button(onClick = {}) { Text("Apply") } },
                     modifier = Modifier.size(dialogSize.width.dp, dialogSize.height.dp)
@@ -130,14 +130,13 @@ class DesktopAlertDialogTest {
         // background.
         val screenshot = renderComposeScene(400, 400){
             AlertDialog(
-                modifier = Modifier
-                    .size(width = 400.dp, height = 100.dp)
-                    .padding(horizontal = 150.dp),
+                modifier = Modifier.size(width = 400.dp, height = 100.dp),
                 onDismissRequest = {},
                 title = {},
                 text = {},
                 dismissButton = {},
                 confirmButton = {},
+                dialogPadding = PaddingValues(horizontal = 150.dp)
             )
         }
 


### PR DESCRIPTION
The problem here is the `modifier.width(IntrinsicSize.Min)` we pass to `AlertDialogContent`, asking it to size itself to the minimum width it can. This causes (at least) two problems:
1. The dialog is trying to be as narrow as possible, not using the available horizontal space.
2. Using `Modifier.widthIn` on the `AlertDialog` doesn't do anything, but it seems like a reasonable way to control the width of a dialog on the desktop.

Ideally, we shouldn't be trying to control the width at all (which would also get rid of the crash when you put lazy content in an `AlertDialog`), but the problem with that is with the `fillMaxWidth()` here:
```
        buttons = {
            // TODO: move the modifiers to FlowRow when it supports a modifier parameter
            Box(Modifier.fillMaxWidth().padding(all = 8.dp)) {
                AlertDialogFlowRow(
                    mainAxisSpacing = 8.dp,
                    crossAxisSpacing = 12.dp
                ) {
                    dismissButton?.invoke()
                    confirmButton()
                }
            }
        },
```
Without controlling the width outside of that, it will cause the dialog to always take the maximum available horizontal space.

But without the `fillMaxWidth` it's hard to position the `AlertDialogFlowRow` correctly because we can neither pass a `modifier` to `AlertDialogFlowRow` nor control its alignment inside the `Column` in `AlertDialogContent`.

**Note that all the discussion below applies to the case when the user doesn't specify a width on the `AlertDialog`.**

There are two possible solutions I see:
1. Use `IntrinsicSize.Max` instead of `IntrinsicSize.Min`
2. Try writing a custom layout to wrap `AlertDialogFlowRow` in, and don't specify any width on the `AlertDialogContent`.

Pros of 1:
The dialog would be sized to the content's maximum preferred width, but not wider. With the 2nd solution, it would always take the width of the entire window.

Pros of 2:
Using lazy content would not crash (although we said using lazy content in an `AlertDialog` is not a valid use-case). With the 1st solution, it would continue crashing.

Note that both solutions would change the existing (I would argue wrong) behavior which, if there are buttons present and the user didn't specify a width, would use the width of the buttons for the size of the dialog (because their minimum width is larger than the minimum width of the text). So before, it would look like this:

<img width="501" alt="image" src="https://user-images.githubusercontent.com/5230206/224483668-475a852b-2ec1-49da-b610-0243ce1ef2c2.png">

and after the change:

<img width="501" alt="image" src="https://user-images.githubusercontent.com/5230206/224483679-a7031783-aa56-4e07-8b9a-d03f69c20169.png">

But note that this is only if the user doesn't specify a width (or `widthIn`) himself.

## Proposed Changes

This PR goes with the simpler solution of using `IntrinsicSize.Max`. I think the benefit of sizing to the preferred content width is more important that allowing lazy content.

## Testing

Test: Manual testing with code like this:
```
@OptIn(ExperimentalMaterialApi::class)
fun main() = singleWindowApplication(
    state = WindowState(width = 500.dp, height = 400.dp),
) {
    MaterialTheme{
        AlertDialog(
            modifier = Modifier.widthIn(max = 400.dp).padding(horizontal = 30.dp),
            onDismissRequest = { },
            title = { Text("This is the title") },
            text = { Text("This is the text This is the text This is the text") },
//            dismissButton = { Button(onClick = {}){ Text("Dismiss")} },
//            confirmButton = { Button(onClick = {}){ Text("Confirm")} },
            confirmButton = {}
        )
    }
}
```

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2836
