### PR TITLE
Replace using global mouse position with known position for context menus, dropdown menus and tooltips

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -36,8 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
@@ -54,8 +54,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.round
 import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.rememberCursorPositionProvider
+import androidx.compose.ui.window.popupPositionProviderAtPosition
 import java.awt.Component
 import java.awt.MouseInfo
 import javax.swing.JMenuItem
@@ -101,14 +102,17 @@ class DefaultContextMenuRepresentation(
     @OptIn(ExperimentalComposeUiApi::class)
     @Composable
     override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
-        val isOpen = state.status is ContextMenuState.Status.Open
-        if (isOpen) {
+        val status = state.status
+        if (status is ContextMenuState.Status.Open) {
             var focusManager: FocusManager? by mutableStateOf(null)
             var inputModeManager: InputModeManager? by mutableStateOf(null)
+
             Popup(
                 focusable = true,
                 onDismissRequest = { state.status = ContextMenuState.Status.Closed },
-                popupPositionProvider = rememberCursorPositionProvider(),
+                popupPositionProvider = popupPositionProviderAtPosition(
+                    positionPx = status.rect.center.round()
+                ),
                 onKeyEvent = {
                     if (it.type == KeyEventType.KeyDown) {
                         when (it.key.nativeKeyCode) {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -54,9 +54,8 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.round
 import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.popupPositionProviderAtPosition
+import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
 import java.awt.Component
 import java.awt.MouseInfo
 import javax.swing.JMenuItem
@@ -65,7 +64,7 @@ import javax.swing.SwingUtilities
 import javax.swing.event.PopupMenuEvent
 import javax.swing.event.PopupMenuListener
 
-// Design of basic represenation is from Material specs:
+// Design of basic representation is from Material specs:
 // https://material.io/design/interaction/states.html#hover
 // https://material.io/components/menus#specs
 
@@ -110,8 +109,8 @@ class DefaultContextMenuRepresentation(
             Popup(
                 focusable = true,
                 onDismissRequest = { state.status = ContextMenuState.Status.Closed },
-                popupPositionProvider = popupPositionProviderAtPosition(
-                    positionPx = status.rect.center.round()
+                popupPositionProvider = rememberPopupPositionProviderAtPosition(
+                    positionPx = status.rect.center
                 ),
                 onKeyEvent = {
                     if (it.type == KeyEventType.KeyDown) {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -108,6 +108,7 @@ private val LocalContextMenuData = staticCompositionLocalOf<ContextMenuData?> {
  * @param onOpen Invoked when a context menu opening event is detected, with the local offset it
  * should be opened at.
  */
+@ExperimentalFoundationApi
 fun Modifier.contextMenuOpenDetector(
     key: Any? = Unit,
     enabled: Boolean = true,
@@ -130,6 +131,7 @@ fun Modifier.contextMenuOpenDetector(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 private fun Modifier.contextMenuOpenDetector(
     state: ContextMenuState,
     enabled: Boolean = true

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -54,7 +55,7 @@ fun ContextMenuArea(
 ) {
     val data = ContextMenuData(items, LocalContextMenuData.current)
 
-    Box(Modifier.contextMenuDetector(state, enabled), propagateMinConstraints = true) {
+    Box(Modifier.contextMenuOpenDetector(state, enabled), propagateMinConstraints = true) {
         content()
     }
     LocalContextMenuRepresentation.current.Representation(state) { data.allItems }
@@ -97,28 +98,46 @@ private val LocalContextMenuData = staticCompositionLocalOf<ContextMenuData?> {
     null
 }
 
-private fun Modifier.contextMenuDetector(
-    state: ContextMenuState,
-    enabled: Boolean = true
+
+/**
+ * Detects events that open a context menu (mouse right-clicks).
+ *
+ * @param onOpen Invoked when a context menu opening event is detected, with the local offset it
+ * should be opened at.
+ */
+fun Modifier.contextMenuOpenDetector(
+    key: Any? = Unit,
+    enabled: Boolean = true,
+    isOpen: Boolean,
+    onOpen: (Offset) -> Unit
 ): Modifier {
-    return if (
-        enabled && state.status == ContextMenuState.Status.Closed
-    ) {
-        this.pointerInput(state) {
+    return if (enabled && !isOpen) {
+        this.pointerInput(key) {
             forEachGesture {
                 awaitPointerEventScope {
                     val event = awaitEventFirstDown()
                     if (event.buttons.isSecondaryPressed) {
                         event.changes.forEach { it.consume() }
-                        state.status =
-                            ContextMenuState.Status.Open(Rect(event.changes[0].position, 0f))
+                        onOpen(event.changes[0].position)
                     }
                 }
             }
         }
-    } else {
-        Modifier
     }
+    else {
+        this
+    }
+}
+
+private fun Modifier.contextMenuOpenDetector(
+    state: ContextMenuState,
+    enabled: Boolean = true
+): Modifier = this.contextMenuOpenDetector(
+    key = state,
+    enabled = enabled,
+    isOpen = state.status is ContextMenuState.Status.Open
+) { pointerPosition ->
+    state.status = ContextMenuState.Status.Open(Rect(pointerPosition, 0f))
 }
 
 private suspend fun AwaitPointerEventScope.awaitEventFirstDown(): PointerEvent {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -105,17 +105,15 @@ private val LocalContextMenuData = staticCompositionLocalOf<ContextMenuData?> {
  * @param key The pointer input handling coroutine will be cancelled and **re-started** when
  * [contextMenuOpenDetector] is recomposed with a different [key].
  * @param enabled Whether to enable the detection.
- * @param isOpen Whether the context menu intended to be opened is currently open.
  * @param onOpen Invoked when a context menu opening event is detected, with the local offset it
  * should be opened at.
  */
 fun Modifier.contextMenuOpenDetector(
     key: Any? = Unit,
     enabled: Boolean = true,
-    isOpen: Boolean,
     onOpen: (Offset) -> Unit
 ): Modifier {
-    return if (enabled && !isOpen) {
+    return if (enabled) {
         this.pointerInput(key) {
             forEachGesture {
                 awaitPointerEventScope {
@@ -137,8 +135,7 @@ private fun Modifier.contextMenuOpenDetector(
     enabled: Boolean = true
 ): Modifier = this.contextMenuOpenDetector(
     key = state,
-    enabled = enabled,
-    isOpen = state.status is ContextMenuState.Status.Open
+    enabled = enabled && (state.status is ContextMenuState.Status.Closed),
 ) { pointerPosition ->
     state.status = ContextMenuState.Status.Open(Rect(pointerPosition, 0f))
 }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -102,6 +102,10 @@ private val LocalContextMenuData = staticCompositionLocalOf<ContextMenuData?> {
 /**
  * Detects events that open a context menu (mouse right-clicks).
  *
+ * @param key The pointer input handling coroutine will be cancelled and **re-started** when
+ * [contextMenuOpenDetector] is recomposed with a different [key].
+ * @param enabled Whether to enable the detection.
+ * @param isOpen Whether the context menu intended to be opened is currently open.
  * @param onOpen Invoked when a context menu opening event is detected, with the local offset it
  * should be opened at.
  */
@@ -123,8 +127,7 @@ fun Modifier.contextMenuOpenDetector(
                 }
             }
         }
-    }
-    else {
+    } else {
         this
     }
 }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
@@ -40,11 +40,9 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.round
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
-import androidx.compose.ui.window.popupPositionProviderAtPosition
+import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
 import androidx.compose.ui.window.rememberCursorPositionProvider
 import androidx.compose.ui.window.rememberComponentRectPositionProvider
 import kotlinx.coroutines.delay
@@ -155,7 +153,7 @@ fun TooltipArea(
         if (isVisible) {
             @OptIn(ExperimentalFoundationApi::class)
             Popup(
-                popupPositionProvider = tooltipPlacement.positionProvider(cursorPosition.round()),
+                popupPositionProvider = tooltipPlacement.positionProvider(cursorPosition),
                 onDismissRequest = { isVisible = false }
             ) {
                 Box(
@@ -225,7 +223,7 @@ interface TooltipPlacement {
      */
     @Suppress("DEPRECATION")
     @Composable
-    fun positionProvider(cursorPosition: IntOffset): PopupPositionProvider {
+    fun positionProvider(cursorPosition: Offset): PopupPositionProvider {
         return positionProvider()
     }
 
@@ -247,18 +245,19 @@ interface TooltipPlacement {
         @Suppress("OVERRIDE_DEPRECATION")
         @Composable
         override fun positionProvider(): PopupPositionProvider = rememberCursorPositionProvider(
-            offset,
-            alignment,
-            windowMargin
-        )
-
-        @Composable
-        override fun positionProvider(cursorPosition: IntOffset) = popupPositionProviderAtPosition(
-            positionPx = cursorPosition,
             offset = offset,
             alignment = alignment,
             windowMargin = windowMargin
         )
+
+        @Composable
+        override fun positionProvider(cursorPosition: Offset) =
+            rememberPopupPositionProviderAtPosition(
+                positionPx = cursorPosition,
+                offset = offset,
+                alignment = alignment,
+                windowMargin = windowMargin
+            )
     }
 
     /**

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
@@ -134,10 +134,13 @@ fun TooltipArea(
     Box(
         modifier = modifier
             .onGloballyPositioned { parentBounds = it.boundsInWindow() }
-            .onPointerEvent(PointerEventType.Enter) { startShowing() }
-            .onPointerEvent(PointerEventType.Move) {
-                hideIfNotHovered(parentBounds.topLeft + it.position)
+            .onPointerEvent(PointerEventType.Enter) {
                 cursorPosition = it.position
+                startShowing()
+            }
+            .onPointerEvent(PointerEventType.Move) {
+                cursorPosition = it.position
+                hideIfNotHovered(parentBounds.topLeft + it.position)
             }
             .onPointerEvent(PointerEventType.Exit) {
                 hideIfNotHovered(parentBounds.topLeft + it.position)

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.changedToDown
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -250,6 +251,7 @@ interface TooltipPlacement {
             windowMargin = windowMargin
         )
 
+        @OptIn(ExperimentalComposeUiApi::class)
         @Composable
         override fun positionProvider(cursorPosition: Offset) =
             rememberPopupPositionProviderAtPosition(

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -139,6 +139,7 @@ fun DropdownMenu(
  * tapping outside the menu's bounds
  *
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun DropdownMenu(
     state: DropdownMenuState,

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -357,12 +357,12 @@ class DropdownMenuState(initialStatus: Status = Status.Closed) {
  */
 fun Modifier.contextMenuOpenDetector(
     state: DropdownMenuState,
-    enabled: Boolean = true
+    enabled: Boolean = true,
 ): Modifier {
     return if (enabled) {
         this.contextMenuOpenDetector(
             key = state,
-            isOpen = state.status is DropdownMenuState.Status.Open
+            enabled = enabled && (state.status is DropdownMenuState.Status.Closed)
         ) { pointerPosition ->
             state.status = DropdownMenuState.Status.Open(pointerPosition.round())
         }

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -16,23 +16,30 @@
 
 package androidx.compose.material
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.internal.keyEvent
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyPress
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert
 import org.junit.Rule
@@ -46,9 +53,9 @@ class DesktopMenuTest {
     @get:Rule
     val rule = createComposeRule()
 
-    val windowSize = IntSize(100, 100)
-    val anchorPosition = IntOffset(10, 10)
-    val anchorSize = IntSize(80, 20)
+    private val windowSize = IntSize(100, 100)
+    private val anchorPosition = IntOffset(10, 10)
+    private val anchorSize = IntSize(80, 20)
 
     @Test
     fun menu_positioning_vertical_underAnchor() {
@@ -175,5 +182,50 @@ class DesktopMenuTest {
         performKeyDownAndUp(Key.DirectionDown)
         performKeyDownAndUp(Key.Enter)
         assertClicksCount(2, 2, 2)
+    }
+
+    @OptIn(ExperimentalMaterialApi::class, ExperimentalTestApi::class)
+    @Test
+    fun `right click opens DropdownMenuState`() {
+        val state = DropdownMenuState(DropdownMenuState.Status.Closed)
+        rule.setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("box")
+                    .size(100.dp, 100.dp)
+                    .contextMenuOpenDetector(
+                        state = state
+                    )
+            )
+        }
+
+        rule.onNodeWithTag("box").performMouseInput {
+            rightClick(Offset(10f, 10f))
+        }
+
+        assertThat(state.status == DropdownMenuState.Status.Open(Offset(10f, 10f)))
+    }
+
+    @OptIn(ExperimentalMaterialApi::class, ExperimentalTestApi::class)
+    @Test
+    fun `right doesn't open DropdownMenuState when disabled`() {
+        val state = DropdownMenuState(DropdownMenuState.Status.Closed)
+        rule.setContent {
+            Box(
+                modifier = Modifier
+                    .testTag("box")
+                    .size(100.dp, 100.dp)
+                    .contextMenuOpenDetector(
+                        state = state,
+                        enabled = false
+                    )
+            )
+        }
+
+        rule.onNodeWithTag("box").performMouseInput {
+            rightClick(Offset(10f, 10f))
+        }
+
+        assertThat(state.status == DropdownMenuState.Status.Closed)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.LocalLayerContainer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
@@ -56,6 +57,7 @@ private fun rememberCursorPosition(): Offset {
  * @param alignment The alignment of the popup relative to the current cursor position.
  * @param windowMargin Defines the area within the window that limits the placement of the popup.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun rememberCursorPositionProvider(
     offset: DpOffset = DpOffset.Zero,
@@ -67,9 +69,9 @@ fun rememberCursorPositionProvider(
     val cursorPosition = rememberCursorPosition()
 
     return remember(cursorPosition, offsetPx, alignment, windowMarginPx){
-        PopupPositionProviderAtOffset(
-            anchorPx = cursorPosition,
-            isAnchorRelative = false,
+        PopupPositionProviderAtPosition(
+            positionPx = cursorPosition,
+            isRelativeToAnchor = false,
             offsetPx = offsetPx,
             alignment = alignment,
             windowMarginPx = windowMarginPx
@@ -85,6 +87,7 @@ fun rememberCursorPositionProvider(
  * @param alignment The alignment of the popup relative to desired position.
  * @param windowMargin Defines the area within the window that limits the placement of the popup.
  */
+@ExperimentalComposeUiApi
 @Composable
 fun rememberPopupPositionProviderAtPosition(
     positionPx: Offset,
@@ -96,9 +99,9 @@ fun rememberPopupPositionProviderAtPosition(
     val windowMarginPx = windowMargin.roundToPx()
 
     remember(positionPx, offsetPx, alignment, windowMarginPx) {
-        PopupPositionProviderAtOffset(
-            anchorPx = positionPx,
-            isAnchorRelative = true,
+        PopupPositionProviderAtPosition(
+            positionPx = positionPx,
+            isRelativeToAnchor = true,
             offsetPx = offsetPx,
             alignment = alignment,
             windowMarginPx = windowMarginPx
@@ -109,17 +112,18 @@ fun rememberPopupPositionProviderAtPosition(
 /**
  * A [PopupPositionProvider] that positions the popup at the given offsets and alignment.
  *
- * @param anchorPx The offset of the popup's anchor, in pixels.
- * @param isAnchorRelative Whether [anchorPx] is relative to the anchor bounds passed to
+ * @param positionPx The offset of the popup's location, in pixels.
+ * @param isRelativeToAnchor Whether [positionPx] is relative to the anchor bounds passed to
  * [calculatePosition]. If `false`, it is relative to the window.
  * @param offsetPx Extra offset to be added to the position of the popup, in pixels.
  * @param alignment The alignment of the popup relative to desired position.
  * @param windowMarginPx Defines the area within the window that limits the placement of the popup,
  * in pixels.
  */
-private class PopupPositionProviderAtOffset(
-    val anchorPx: Offset,
-    val isAnchorRelative: Boolean,
+@ExperimentalComposeUiApi
+class PopupPositionProviderAtPosition(
+    val positionPx: Offset,
+    val isRelativeToAnchor: Boolean,
     val offsetPx: Offset,
     val alignment: Alignment = Alignment.BottomEnd,
     val windowMarginPx: Int,
@@ -131,8 +135,8 @@ private class PopupPositionProviderAtOffset(
         popupContentSize: IntSize
     ): IntOffset {
         val anchor = IntRect(
-            offset = anchorPx.round() +
-                (if (isAnchorRelative) anchorBounds.topLeft else IntOffset.Zero),
+            offset = positionPx.round() +
+                (if (isRelativeToAnchor) anchorBounds.topLeft else IntOffset.Zero),
             size = IntSize.Zero)
         val tooltipArea = IntRect(
             IntOffset(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -146,12 +146,9 @@ private class PopupPositionProviderAtOffset(
         if (y + popupContentSize.height > windowSize.height - windowMarginPx) {
             y -= popupContentSize.height + anchor.height
         }
-        if (x < windowMarginPx) {
-            x = windowMarginPx
-        }
-        if (y < windowMarginPx) {
-            y = windowMarginPx
-        }
+        x = x.coerceAtLeast(windowMarginPx)
+        y = y.coerceAtLeast(windowMarginPx)
+
         return IntOffset(x, y)
     }
 }


### PR DESCRIPTION
We are currently using `rememberCursorPositionProvider`, and through it, the global mouse position state in three places:
1. `DefaultContextMenuRepresentation`
2. Positioning of `CursorDropdownMenu`.
3. Positioning of tooltips: `TooltipPlacement.CursorPoint`

We would like to instead use the position of the mouse event that triggered the displaying of each of these.

## Proposed Changes

1. For `DefaultContextMenuRepresentation`, simply use the `rect` in the `ContextMenuState.Status.Open` it already has available. The modifier that changes the status to `Open` already places the mouse cursor position there.
2. For `CursorDropdownMenu`:
  - Implement `DropdownMenuState`, a new state class, similar to `ContextMenuState`. Instead of a `Rect`, it will hold an `IntOffset`.
  - Implement a new `DropdownMenu` overload that will take a `DropdownMenuState` and be controlled by it.
  - Implement a `Modifier.contextMenuOpenDetector(DropdownMenuState)` that detects right-clicks and sets the `state.status` to `Open(cursorPosition)`.
  - The user is expected to combine the new `DropdownMenu` and `contextMenuOpenDetector` together with state hoisting to display the dropdown menu (example code below).
3. For `TooltipArea`:
  - Add a new overload `TooltipPlacement.positionProvider(cursorPosition: IntOffset)` and have `TooltipArea` provide the cursor position to it when it wants to show the tooltip.
  - `TooltipPlacement.CursorPoint` will use the new cursor position argument to position the tooltip popup.

Added utilities:
- (private) `PopupPositionProviderAtOffset` that takes all the necessary arguments to position the popup.
- Use the new `PopupPositionProviderAtOffset` from both `rememberCursorPositionProvider` and from a new `popupPositionProviderAtPosition` method.
- `Modifier.contextMenuOpenDetector(onOpen)` and `Modifier.contextMenuOpenDetector(DropdownMenuState)`


Example use of `DropdownMenu`:
```
fun main() = singleWindowApplication {
    val menuState = remember{ DropdownMenuState() }
    Column{
        Spacer(Modifier.height(100.dp))
        Box(
            modifier = Modifier
                .fillMaxSize()
                .background(Color.Red)
                .contextMenuOpenDetector(menuState)
        ) {
            DropdownMenu(
                state = menuState,
            ){
                DropdownMenuItem(onClick = {}){
                    Text("Item 1")
                }
                DropdownMenuItem(onClick = {}){
                    Text("Item 2")
                }
            }
        }
    }
}
```

## Testing

Test: Manual testing

