### PR TITLE
Animate scroll initiated by mouse wheel input

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -353,7 +353,7 @@ private fun Modifier.animatedMouseWheelScroll(
             } else {
                 // Try to apply small delta immediately to conditionally consume
                 // an input event and to avoid useless animation.
-                tryToScrollBySmallDelta(delta, threshold = 10.dp.toPx()) {
+                tryToScrollBySmallDelta(delta, threshold = 4.dp.toPx()) {
                     channel.trySend(it).isSuccess
                 }
             }
@@ -376,7 +376,7 @@ private fun <E> untilNull(builderAction: () -> E?) = sequence<E> {
 
 private suspend fun ScrollingLogic.tryToScrollBySmallDelta(
     delta: Float,
-    threshold: Float = 10f,
+    threshold: Float = 4f,
     fallback: (Float) -> Boolean
 ): Boolean {
     var isConsumed = false

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -346,6 +346,16 @@ private fun Modifier.animatedMouseWheelScroll(
             // In case of high-resolution wheel, such as a freely rotating wheel with no notches
             // or trackpads, delta should apply directly without any delays.
             scrollLogic.value.dispatchRawDelta(scrollDelta) != Offset.Zero
+
+            /*
+             * TODO Set isScrollInProgress to true in case of touchpad.
+             *  Dispatching raw delta doesn't cause a progress indication even with wrapping in
+             *  `scrollableState.scroll` block, since it applies the change within single frame.
+             *  Touchpads emit just multiple mouse wheel events, so detecting start and end of this
+             *  "gesture" is not straight forward.
+             *  Ideally it should be resolved by catching real touches from input device instead of
+             *  introducing a timeout (after each event before resetting progress flag).
+             */
         } else with(scrollLogic.value) {
             val delta = scrollDelta.reverseIfNeeded().toFloat()
             if (isAnimationRunning) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -395,10 +395,10 @@ private suspend fun ScrollingLogic.tryToScrollBySmallDelta(
             // Gather possibility to scroll by applying a piece of required delta.
             val testDelta = if (delta > 0f) threshold else -threshold
             val consumedDelta = scrollBy(testDelta)
-            !consumedDelta.isAboutZero() && fallback(delta - testDelta)
+            consumedDelta != 0f && fallback(delta - testDelta)
         } else {
             val consumedDelta = scrollBy(delta)
-            !consumedDelta.isAboutZero()
+            consumedDelta != 0f
         }
     }
     return isConsumed

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -237,6 +237,13 @@ object ScrollableDefaults {
 }
 
 internal interface ScrollConfig {
+
+    /**
+     * Enables animated transition of scroll on mouse wheel events.
+     */
+    val isSmoothScrollingEnabled: Boolean
+        get() = true
+
     fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset
 }
 
@@ -286,10 +293,13 @@ private fun Modifier.pointerScrollable(
             }
         },
         canDrag = { down -> down.type != PointerType.Mouse }
-    )
-        // TODO Make animation configurable
-        .animatedMouseWheelScroll(scrollLogic, scrollConfig)
-        .nestedScroll(nestedScrollConnection, nestedScrollDispatcher.value)
+    ).let {
+        if (scrollConfig.isSmoothScrollingEnabled) {
+            animatedMouseWheelScroll(scrollLogic, scrollConfig)
+        } else {
+            rawMouseWheelScroll(scrollLogic, scrollConfig)
+        }
+    }.nestedScroll(nestedScrollConnection, nestedScrollDispatcher.value)
 }
 
 @Composable

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -33,10 +33,12 @@ import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
@@ -303,7 +305,7 @@ private fun Modifier.animatedMouseWheelScroll(
     scrollLogic: State<ScrollingLogic>,
     mouseWheelScrollConfig: ScrollConfig,
 ): Modifier {
-    var isAnimationRunning = false
+    var isAnimationRunning by remember { mutableStateOf(false) }
     val channel = remember { Channel<Float>(capacity = Channel.UNLIMITED) }
     LaunchedEffect(scrollLogic) {
         while (isActive) {
@@ -386,7 +388,7 @@ private suspend fun ScrollingLogic.animatedDispatchScroll(
                 target,
                 animationSpec = tween(
                     // TODO Make duration configurable
-                    durationMillis = 50,
+                    durationMillis = 100,
                     easing = LinearEasing
                 ),
                 sequentialAnimation = true

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -299,7 +299,7 @@ private fun Modifier.pointerScrollable(
             }
         },
         canDrag = { down -> down.type != PointerType.Mouse }
-    ).let {
+    ).run {
         if (scrollConfig.isSmoothScrollingEnabled) {
             animatedMouseWheelScroll(scrollLogic, scrollConfig)
         } else {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -427,7 +427,7 @@ private suspend fun ScrollingLogic.animatedDispatchScroll(
                 val delta = value - lastValue
                 if (!delta.isAboutZero()) {
                     val consumedDelta = scrollBy(delta)
-                    if (consumedDelta.isAboutZero()) {
+                    if (!(delta - consumedDelta).isAboutZero()) {
                         cancelAnimation()
                         return@animateTo
                     }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.DesktopPlatform
 import androidx.compose.foundation.fastFold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -28,6 +27,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import java.awt.event.MouseWheelEvent
+import kotlin.math.abs
 import kotlin.math.sqrt
 
 // TODO(demin): Chrome on Windows/Linux uses different scroll strategy
@@ -48,6 +48,8 @@ internal actual fun platformScrollConfig(): ScrollConfig = LocalScrollConfig.cur
 internal interface DesktopScrollConfig : ScrollConfig {
     override val isSmoothScrollingEnabled: Boolean
         get() = System.getProperty("compose.scrolling.smooth.enabled") != "false"
+
+    override fun isPreciseWheelScroll(event: PointerEvent): Boolean = event.isPreciseWheelRotation
 }
 
 // TODO(demin): is this formula actually correct? some experimental values don't fit
@@ -111,3 +113,9 @@ private val PointerEvent.shouldScrollByPage
 
 private val PointerEvent.totalScrollDelta
     get() = this.changes.fastFold(Offset.Zero) { acc, c -> acc + c.scrollDelta }
+
+private val PointerEvent.isPreciseWheelRotation
+    get() = (awtEventOrNull as? MouseWheelEvent)?.isPreciseWheelRotation ?: false
+
+private val MouseWheelEvent.isPreciseWheelRotation
+    get() = abs(preciseWheelRotation - wheelRotation.toDouble()) > 0.001

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -43,11 +43,16 @@ internal val LocalScrollConfig = compositionLocalOf {
 }
 
 @Composable
-internal actual fun platformScrollConfig() = LocalScrollConfig.current
+internal actual fun platformScrollConfig(): ScrollConfig = LocalScrollConfig.current
+
+internal interface DesktopScrollConfig : ScrollConfig {
+    override val isSmoothScrollingEnabled: Boolean
+        get() = System.getProperty("compose.scrolling.smooth.enabled") != "false"
+}
 
 // TODO(demin): is this formula actually correct? some experimental values don't fit
 //  the formula
-internal object LinuxGnomeConfig : ScrollConfig {
+internal object LinuxGnomeConfig : DesktopScrollConfig {
     // the formula was determined experimentally based on Ubuntu Nautilus behaviour
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
         return if (event.shouldScrollByPage) {
@@ -61,7 +66,7 @@ internal object LinuxGnomeConfig : ScrollConfig {
     }
 }
 
-internal object WindowsWinUIConfig : ScrollConfig {
+internal object WindowsWinUIConfig : DesktopScrollConfig {
     // the formula was determined experimentally based on Windows Start behaviour
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
         return if (event.shouldScrollByPage) {
@@ -75,7 +80,7 @@ internal object WindowsWinUIConfig : ScrollConfig {
     }
 }
 
-internal object MacOSCocoaConfig : ScrollConfig {
+internal object MacOSCocoaConfig : DesktopScrollConfig {
     // the formula was determined experimentally based on MacOS Finder behaviour
     // MacOS driver will send events with accelerating delta
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -45,16 +45,17 @@ internal val LocalScrollConfig = compositionLocalOf<ScrollConfig> {
 @Composable
 internal actual fun platformScrollConfig(): ScrollConfig = LocalScrollConfig.current
 
-internal interface DesktopScrollConfig : ScrollConfig {
-    override val isSmoothScrollingEnabled: Boolean
-        get() = System.getProperty("compose.scrolling.smooth.enabled") != "false"
+internal abstract class DesktopScrollConfig : ScrollConfig {
+    override val isSmoothScrollingEnabled by lazy {
+        System.getProperty("compose.scrolling.smooth.enabled") != "false"
+    }
 
     override fun isPreciseWheelScroll(event: PointerEvent): Boolean = event.isPreciseWheelRotation
 }
 
 // TODO(demin): is this formula actually correct? some experimental values don't fit
 //  the formula
-internal object LinuxGnomeConfig : DesktopScrollConfig {
+internal object LinuxGnomeConfig : DesktopScrollConfig() {
     // the formula was determined experimentally based on Ubuntu Nautilus behaviour
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
         return if (event.shouldScrollByPage) {
@@ -68,7 +69,7 @@ internal object LinuxGnomeConfig : DesktopScrollConfig {
     }
 }
 
-internal object WindowsWinUIConfig : DesktopScrollConfig {
+internal object WindowsWinUIConfig : DesktopScrollConfig() {
     // the formula was determined experimentally based on Windows Start behaviour
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
         return if (event.shouldScrollByPage) {
@@ -82,7 +83,7 @@ internal object WindowsWinUIConfig : DesktopScrollConfig {
     }
 }
 
-internal object MacOSCocoaConfig : DesktopScrollConfig {
+internal object MacOSCocoaConfig : DesktopScrollConfig() {
     // the formula was determined experimentally based on MacOS Finder behaviour
     // MacOS driver will send events with accelerating delta
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -46,9 +46,8 @@ internal val LocalScrollConfig = compositionLocalOf<ScrollConfig> {
 internal actual fun platformScrollConfig(): ScrollConfig = LocalScrollConfig.current
 
 internal abstract class DesktopScrollConfig : ScrollConfig {
-    override val isSmoothScrollingEnabled by lazy {
-        System.getProperty("compose.scrolling.smooth.enabled") != "false"
-    }
+    override var isSmoothScrollingEnabled = System.getProperty("compose.scrolling.smooth.enabled") != "false"
+        internal set
 
     override fun isPreciseWheelScroll(event: PointerEvent): Boolean = event.isPreciseWheelRotation
 }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -33,7 +33,7 @@ import kotlin.math.sqrt
 // TODO(demin): Chrome on Windows/Linux uses different scroll strategy
 //  (always the same scroll offset, bounds-independent).
 //  Figure out why and decide if we can use this strategy instead of the current one.
-internal val LocalScrollConfig = compositionLocalOf {
+internal val LocalScrollConfig = compositionLocalOf<ScrollConfig> {
     when (DesktopPlatform.Current) {
         DesktopPlatform.Linux -> LinuxGnomeConfig
         DesktopPlatform.Windows -> WindowsWinUIConfig

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -243,35 +243,36 @@ class DesktopScrollableTest {
             assertTrue(isSmoothScrollingEnabled)
             isSmoothScrollingEnabled = false
         }
-
-        val context = TestColumn()
-        setContent {
-            CompositionLocalProvider(
-                LocalScrollConfig provides LinuxGnomeConfig
-            ) {
-                Box(
-                    Modifier
-                        .scrollable(
-                            orientation = Orientation.Vertical,
-                            state = context.controller()
-                        )
-                        .size(10.dp, 20.dp)
-                )
+        try {
+            val context = TestColumn()
+            setContent {
+                CompositionLocalProvider(
+                    LocalScrollConfig provides LinuxGnomeConfig
+                ) {
+                    Box(
+                        Modifier
+                            .scrollable(
+                                orientation = Orientation.Vertical,
+                                state = context.controller()
+                            )
+                            .size(10.dp, 20.dp)
+                    )
+                }
             }
+
+            scene.sendPointerEvent(
+                eventType = PointerEventType.Scroll,
+                position = Offset.Zero,
+                scrollDelta = Offset(0f, -5f),
+                nativeEvent = awtWheelEvent(),
+            )
+
+            // Check without waitForIdle
+            assertThat(context.offset).isWithin(0.1f).of(5f * scrollLineLinux(20.dp))
+        } finally {
+            // Restore state
+            LinuxGnomeConfig.isSmoothScrollingEnabled = true
         }
-
-        scene.sendPointerEvent(
-            eventType = PointerEventType.Scroll,
-            position = Offset.Zero,
-            scrollDelta = Offset(0f, -5f),
-            nativeEvent = awtWheelEvent(),
-        )
-
-        // Check without waitForIdle
-        assertThat(context.offset).isWithin(0.1f).of(5f * scrollLineLinux(20.dp))
-
-        // Restore state
-        LinuxGnomeConfig.isSmoothScrollingEnabled = true
     }
 
     private class TestColumn {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -25,7 +25,10 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -36,25 +39,25 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
-@OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalTestApi
 @RunWith(JUnit4::class)
 class DesktopScrollableTest {
-    private val density = 2f
+    private val size = Size(100f, 100f)
+    private val density = Density(2f)
 
-    private fun scrollLineLinux(bounds: Dp) = sqrt(bounds.value * density)
-    private fun scrollLineWindows(bounds: Dp) = bounds.value * density / 20f
-    private fun scrollLineMacOs() = density * 10f
-    private fun scrollPage(bounds: Dp) = bounds.value * density
+    private fun scrollLineLinux(bounds: Dp) = sqrt(bounds.value * density.density)
+    private fun scrollLineWindows(bounds: Dp) = bounds.value * density.density / 20f
+    private fun scrollLineMacOs() = density.density * 10f
+    private fun scrollPage(bounds: Dp) = bounds.value * density.density
 
     @Test
-    fun `linux, scroll vertical`() = ImageComposeScene(
-        width = 100,
-        height = 100,
-        density = Density(density)
-    ).use { scene ->
+    fun `linux, scroll vertical`() = runSkikoComposeUiTest(
+        size = size,
+        density = density
+    ) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             CompositionLocalProvider(
                 LocalScrollConfig provides LinuxGnomeConfig
             ) {
@@ -76,6 +79,7 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(),
         )
 
+        waitForIdle()
         assertThat(context.offset).isWithin(0.1f).of(-3 * scrollLineLinux(20.dp))
 
         scene.sendPointerEvent(
@@ -85,18 +89,18 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(),
         )
 
+        waitForIdle()
         assertThat(context.offset).isWithin(0.1f).of(-6 * scrollLineLinux(20.dp))
     }
 
     @Test
-    fun `windows, scroll vertical`() = ImageComposeScene(
-        width = 100,
-        height = 100,
-        density = Density(density)
-    ).use { scene ->
+    fun `windows, scroll vertical`() = runSkikoComposeUiTest(
+        size = size,
+        density = density
+    ) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             CompositionLocalProvider(
                 LocalScrollConfig provides WindowsWinUIConfig
             ) {
@@ -118,6 +122,7 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(),
         )
 
+        waitForIdle()
         assertThat(context.offset).isWithin(0.1f).of(2 * scrollLineWindows(20.dp))
 
         scene.sendPointerEvent(
@@ -127,18 +132,18 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(),
         )
 
+        waitForIdle()
         assertThat(context.offset).isWithin(0.1f).of(-2 * scrollLineWindows(20.dp))
     }
 
     @Test
-    fun `windows, scroll one page vertical`() = ImageComposeScene(
-        width = 100,
-        height = 100,
-        density = Density(density)
-    ).use { scene ->
+    fun `windows, scroll one page vertical`() = runSkikoComposeUiTest(
+        size = size,
+        density = density
+    ) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             CompositionLocalProvider(
                 LocalScrollConfig provides WindowsWinUIConfig
             ) {
@@ -160,18 +165,18 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(isScrollByPages = true),
         )
 
+        waitForIdle()
         assertThat(context.offset).isWithin(0.1f).of(-scrollPage(20.dp))
     }
 
     @Test
-    fun `macOS, scroll vertical`() = ImageComposeScene(
-        width = 100,
-        height = 100,
-        density = Density(density)
-    ).use { scene ->
+    fun `macOS, scroll vertical`() = runSkikoComposeUiTest(
+        size = size,
+        density = density
+    ) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             CompositionLocalProvider(
                 LocalScrollConfig provides MacOSCocoaConfig
             ) {
@@ -193,18 +198,18 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(),
         )
 
+        waitForIdle()
         assertThat(context.offset).isWithin(0.1f).of(5.5f * scrollLineMacOs())
     }
 
     @Test
-    fun `scroll with different orientation`() = ImageComposeScene(
-        width = 100,
-        height = 100,
-        density = Density(density)
-    ).use { scene ->
+    fun `scroll with different orientation`() = runSkikoComposeUiTest(
+        size = size,
+        density = density
+    ) {
         val column = TestColumn()
 
-        scene.setContent {
+        setContent {
             CompositionLocalProvider(
                 LocalScrollConfig provides LinuxGnomeConfig
             ) {
@@ -226,6 +231,7 @@ class DesktopScrollableTest {
             nativeEvent = awtWheelEvent(),
         )
 
+        waitForIdle()
         assertThat(column.offset).isEqualTo(0f)
     }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -32,7 +30,6 @@ import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.use
 import com.google.common.truth.Truth.assertThat
 import kotlin.math.sqrt
 import org.junit.Test

--- a/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/gestures/MacosScrollableTest.kt
+++ b/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/gestures/MacosScrollableTest.kt
@@ -19,11 +19,12 @@ package androidx.compose.foundation.gestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ComposeScene
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
@@ -36,17 +37,15 @@ import platform.CoreGraphics.CGScrollEventUnit
 import platform.CoreGraphics.kCGScrollEventUnitLine
 import platform.CoreGraphics.kCGScrollEventUnitPixel
 
-@OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalTestApi
 class MacosScrollableTest {
-    private val density = 2f
-    private val scrollLine = density * 10f
+    private val density = Density(2f)
+    private val scrollLine = density.density * 10f
 
     @Test
-    fun `scroll by pixels vertically`() {
-        val scene = ComposeScene(density = Density(density))
+    fun `scroll by pixels vertically`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
-
-        scene.setContent {
+        setContent {
             Box(
                 Modifier
                     .scrollable(
@@ -57,17 +56,17 @@ class MacosScrollableTest {
             )
         }
 
-        scene.sendScrollingEvent(deltaY = 10, unit = kCGScrollEventUnitPixel)
+        sendScrollingEvent(deltaY = 10, unit = kCGScrollEventUnitPixel)
 
+        waitForIdle()
         assertEquals(10F, context.offset, 0.1F)
     }
 
     @Test
-    fun `scroll by lines vertically`() {
-        val scene = ComposeScene(density = Density(density))
+    fun `scroll by lines vertically`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             Box(
                 Modifier
                     .scrollable(
@@ -78,17 +77,17 @@ class MacosScrollableTest {
             )
         }
 
-        scene.sendScrollingEvent(deltaY = 3, unit = kCGScrollEventUnitLine)
+        sendScrollingEvent(deltaY = 3, unit = kCGScrollEventUnitLine)
 
+        waitForIdle()
         assertEquals(3F * scrollLine, context.offset, 0.1F)
     }
 
     @Test
-    fun `scroll by pixels horizontally`() {
-        val scene = ComposeScene(density = Density(density))
+    fun `scroll by pixels horizontally`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             Box(
                 Modifier
                     .scrollable(
@@ -99,17 +98,17 @@ class MacosScrollableTest {
             )
         }
 
-        scene.sendScrollingEvent(deltaX = 5, unit = kCGScrollEventUnitPixel)
+        sendScrollingEvent(deltaX = 5, unit = kCGScrollEventUnitPixel)
 
+        waitForIdle()
         assertEquals(5F, context.offset, 0.1F)
     }
 
     @Test
-    fun `scroll by lines horizontally`() {
-        val scene = ComposeScene(density = Density(density))
+    fun `scroll by lines horizontally`() = runSkikoComposeUiTest(density = density) {
         val context = TestColumn()
 
-        scene.setContent {
+        setContent {
             Box(
                 Modifier
                     .scrollable(
@@ -120,17 +119,18 @@ class MacosScrollableTest {
             )
         }
 
-        scene.sendScrollingEvent(deltaX = 2, unit = kCGScrollEventUnitLine)
+        sendScrollingEvent(deltaX = 2, unit = kCGScrollEventUnitLine)
 
+        waitForIdle()
         assertEquals(2F * scrollLine, context.offset, 0.1F)
     }
 
-    private fun ComposeScene.sendScrollingEvent(
+    private fun SkikoComposeUiTest.sendScrollingEvent(
         deltaX: Int = 0,
         deltaY: Int = 0,
         unit: CGScrollEventUnit,
     ) {
-        sendPointerEvent(
+        scene.sendPointerEvent(
             eventType = PointerEventType.Scroll,
             position = Offset.Zero,
             scrollDelta = Offset(x = deltaX.toFloat(), y = deltaY.toFloat()),
@@ -142,8 +142,7 @@ class MacosScrollableTest {
         deltaX: Int,
         deltaY: Int,
         unit: CGScrollEventUnit,
-    ): SkikoPointerEvent =
-        SkikoPointerEvent(
+    ) = SkikoPointerEvent(
             x = deltaX.toDouble(),
             y = deltaY.toDouble(),
             deltaX = deltaX.toDouble(),

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyArrangementsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/grid/LazyArrangementsTest.kt
@@ -254,6 +254,7 @@ class LazyArrangementsTest {
             scroll(itemSize.toPx() * 2f)
         }
 
+        waitForIdle()
         onNodeWithTag("1")
             .assertTopPositionInRootIsEqualTo(itemSize * 0.5f)
 
@@ -300,6 +301,7 @@ class LazyArrangementsTest {
             scroll(itemSize.toPx() * 2f, ScrollWheel.Horizontal)
         }
 
+        waitForIdle()
         onNodeWithTag("1")
             .assertLeftPositionInRootIsEqualTo(itemSize * 0.5f)
 

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyArrangementsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyArrangementsTest.kt
@@ -246,6 +246,7 @@ class LazyArrangementsTest {
             scroll(itemSize.toPx()  * 2)
         }
 
+        waitForIdle()
         onNodeWithTag("1")
             .assertTopPositionInRootIsEqualTo(itemSize * 0.5f)
 
@@ -290,6 +291,7 @@ class LazyArrangementsTest {
             scroll(itemSize.toPx()  * 2, ScrollWheel.Horizontal)
         }
 
+        waitForIdle()
         onNodeWithTag("1")
             .assertLeftPositionInRootIsEqualTo(itemSize * 0.5f)
 

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListHeadersTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListHeadersTest.kt
@@ -175,6 +175,7 @@ class LazyListHeadersTest {
             scroll(105f)
         }
 
+        waitForIdle()
         onNodeWithTag(firstHeaderTag)
             .assertIsNotDisplayed()
 
@@ -313,6 +314,7 @@ class LazyListHeadersTest {
             scroll(102f, ScrollWheel.Horizontal)
         }
 
+        waitForIdle()
         onNodeWithTag(firstHeaderTag)
             .assertIsNotDisplayed()
 

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asSkiaBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.platform.InfiniteAnimationPolicy
@@ -38,16 +37,14 @@ import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.math.roundToInt
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import kotlin.coroutines.cancellation.CancellationException
-import kotlin.math.roundToInt
-import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.IRect
-import org.jetbrains.skia.Image
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.currentNanoTime
 
@@ -139,7 +136,7 @@ class SkikoComposeUiTest(
     private fun renderNextFrame() = runOnUiThread {
         scene.render(
             surface.canvas,
-            mainClock.currentTime * 1_000_000
+            mainClock.currentTime * NanoSecondsPerMilliSecond
         )
         if (mainClock.autoAdvance) {
             mainClock.advanceTimeByFrame()
@@ -218,6 +215,8 @@ class SkikoComposeUiTest(
                 )
             }
         }
+
+        // TODO Add a wait function variant without conditions (timeout exceptions)
     }
 
     override fun registerIdlingResource(idlingResource: IdlingResource) {

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -59,11 +59,13 @@ actual fun runComposeUiTest(block: ComposeUiTest.() -> Unit) {
 @ExperimentalTestApi
 fun runSkikoComposeUiTest(
     size: Size = Size(1024.0f, 768.0f),
+    density: Density = Density(1f),
     block: SkikoComposeUiTest.() -> Unit
 ) {
     SkikoComposeUiTest(
         width = size.width.roundToInt(),
-        height = size.height.roundToInt()
+        height = size.height.roundToInt(),
+        density = density
     ).runTest(block)
 }
 
@@ -71,10 +73,9 @@ fun runSkikoComposeUiTest(
 @OptIn(ExperimentalCoroutinesApi::class, InternalTestApi::class)
 class SkikoComposeUiTest(
     width: Int = 1024,
-    height: Int = 768
+    height: Int = 768,
+    override val density: Density = Density(1f)
 ) : ComposeUiTest {
-
-    override val density = Density(1f, 1f)
 
     private val textInputService = object : PlatformTextInputService {
         var onEditCommand: ((List<EditCommand>) -> Unit)? = null


### PR DESCRIPTION
## Proposed Changes

  - Animate scroll initiated by mouse wheel input
  - Fix `isScrollInProgress`: It's true during animation now ( https://github.com/JetBrains/compose-multiplatform/issues/1423 )

## Testing

Test: Scroll some scrollable view via mouse wheel; Observe smooth animated position changes.

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/1955
