### PR TITLE
Enforce proper closing of ComposeScene in tests

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ExternalDragTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ExternalDragTest.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.density
-import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
@@ -54,7 +53,7 @@ class ExternalDragTest {
 
         val events = mutableListOf<TestDragEvent>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -87,8 +86,6 @@ class ExternalDragTest {
 
         assertThat(events.size).isEqualTo(2)
         assertThat(events.last()).isEqualTo(Drag(Offset(70f, 70f)))
-
-        exitApplication()
     }
 
 
@@ -98,7 +95,7 @@ class ExternalDragTest {
 
         val events = mutableListOf<TestDragEvent>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -134,8 +131,6 @@ class ExternalDragTest {
 
         assertThat(events.size).isEqualTo(1)
         assertThat(events[0]).isEqualTo(DragStarted(Offset(70f, 1f)))
-
-        exitApplication()
     }
 
     @Test
@@ -145,7 +140,7 @@ class ExternalDragTest {
         val eventsComponent1 = mutableListOf<TestDragEvent>()
         val eventsComponent2 = mutableListOf<TestDragEvent>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 400.dp, height = 400.dp)
@@ -202,8 +197,6 @@ class ExternalDragTest {
 
         assertThat(eventsComponent2.size).isEqualTo(2)
         assertThat(eventsComponent2.last()).isEqualTo(TestDragEvent.Drop(Offset(70f, 1f), dragData))
-
-        exitApplication()
     }
 
     @Test
@@ -212,7 +205,7 @@ class ExternalDragTest {
 
         lateinit var componentIsVisible: MutableState<Boolean>
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 400.dp, height = 400.dp)
@@ -244,7 +237,7 @@ class ExternalDragTest {
 
         val events = mutableListOf<TestDragEvent>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComplexApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComplexApplicationTest.kt
@@ -115,7 +115,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextDecoration.Companion.Underline
@@ -125,10 +124,8 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.FrameWindowScope
-import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.awaitApplication
 import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
@@ -694,7 +691,7 @@ class ComplexApplicationTest {
     fun `no memory leak when wait 3 minutes`() = runApplicationTest(
         timeoutMillis = 10 * 60 * 1000
     ) {
-        launchApplication {
+        launchTestApplication {
             AppWindow()
         }
 
@@ -712,7 +709,5 @@ class ComplexApplicationTest {
             .assertWithMessage("Memory is increased more than 15% after waiting a few minutes")
             .that(newMemory < 1.15 * oldMemory)
             .isTrue()
-
-        exitApplication()
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.monotonicFrameClock
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
@@ -37,14 +36,13 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CompletableDeferred
 import org.junit.Test
 
-@OptIn(ExperimentalComposeUiApi::class)
 class ApplicationTest {
     @Test
     fun `run application`() = runApplicationTest {
         var isInit = false
         var isDisposed = false
 
-        val appJob = launchApplication {
+        val appJob = launchTestApplication {
             DisposableEffect(Unit) {
                 isInit = true
                 onDispose {
@@ -64,7 +62,7 @@ class ApplicationTest {
         val onEffectLaunch = CompletableDeferred<Unit>()
         val shouldEnd = CompletableDeferred<Unit>()
 
-        launchApplication {
+        launchTestApplication {
             LaunchedEffect(Unit) {
                 onEffectLaunch.complete(Unit)
                 shouldEnd.await()
@@ -83,7 +81,7 @@ class ApplicationTest {
         var isOpen1 by mutableStateOf(true)
         var isOpen2 by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen1) {
                 Window(
                     onCloseRequest = {},
@@ -97,7 +95,7 @@ class ApplicationTest {
             }
         }
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen2) {
                 Window(
                     onCloseRequest = {},
@@ -132,7 +130,7 @@ class ApplicationTest {
         lateinit var appClock: MonotonicFrameClock
         lateinit var windowClock: MonotonicFrameClock
 
-        launchApplication {
+        launchTestApplication {
             LaunchedEffect(Unit) {
                 appClock = coroutineContext.monotonicFrameClock
             }
@@ -148,7 +146,5 @@ class ApplicationTest {
 
         awaitIdle()
         assertThat(windowClock).isNotEqualTo(appClock)
-
-        exitApplication()
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/MenuBarTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/MenuBarTest.kt
@@ -19,39 +19,34 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.readFirstPixel
 import androidx.compose.ui.testImage
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
 import javax.swing.JCheckBoxMenuItem
 import javax.swing.JRadioButtonMenuItem
 import javax.swing.JSeparator
+import org.junit.Test
 
-@OptIn(ExperimentalComposeUiApi::class)
 class MenuBarTest {
     @Test(timeout = 20000)
     fun `show and hide menu bar`() = runApplicationTest {
-        var isOpen by mutableStateOf(true)
         var isMenubarShowing by mutableStateOf(true)
         var window: ComposeWindow? = null
 
-        launchApplication {
-            if (isOpen) {
-                Window(onCloseRequest = {}) {
-                    window = this.window
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                window = this.window
 
-                    if (isMenubarShowing) {
-                        MenuBar {
-                            Menu("Menu0") {
-                                Item("Item0", onClick = {})
-                                Separator()
-                            }
-                            Menu("Menu1") {}
+                if (isMenubarShowing) {
+                    MenuBar {
+                        Menu("Menu0") {
+                            Item("Item0", onClick = {})
+                            Separator()
                         }
+                        Menu("Menu1") {}
                     }
                 }
             }
@@ -78,30 +73,25 @@ class MenuBarTest {
         isMenubarShowing = false
         awaitIdle()
         assertThat(window!!.jMenuBar).isNull()
-
-        isOpen = false
     }
 
     @Test(timeout = 20000)
     fun `show and hide menu`() = runApplicationTest {
-        var isOpen by mutableStateOf(true)
         var isMenuShowing by mutableStateOf(true)
         var window: ComposeWindow? = null
 
-        launchApplication {
-            if (isOpen) {
-                Window(onCloseRequest = {}) {
-                    window = this.window
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                window = this.window
 
-                    MenuBar {
-                        if (isMenuShowing) {
-                            Menu("Menu0") {
-                                Item("Item0", onClick = {})
-                                Separator()
-                            }
+                MenuBar {
+                    if (isMenuShowing) {
+                        Menu("Menu0") {
+                            Item("Item0", onClick = {})
+                            Separator()
                         }
-                        Menu("Menu1") {}
                     }
+                    Menu("Menu1") {}
                 }
             }
         }
@@ -124,31 +114,26 @@ class MenuBarTest {
             assertThat(getMenu(0).text).isEqualTo("Menu0")
             assertThat(getMenu(1).text).isEqualTo("Menu1")
         }
-
-        isOpen = false
     }
 
     @Test(timeout = 20000)
     fun `show and hide submenu`() = runApplicationTest {
-        var isOpen by mutableStateOf(true)
         var isSubmenuShowing by mutableStateOf(true)
         var window: ComposeWindow? = null
 
-        launchApplication {
-            if (isOpen) {
-                Window(onCloseRequest = {}) {
-                    window = this.window
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                window = this.window
 
-                    MenuBar {
-                        Menu("Menu0") {
-                            if (isSubmenuShowing) {
-                                Menu("Submenu0") {}
-                            }
-                            Item("Item0", onClick = {})
-                            Separator()
+                MenuBar {
+                    Menu("Menu0") {
+                        if (isSubmenuShowing) {
+                            Menu("Submenu0") {}
                         }
-                        Menu("Menu1") {}
+                        Item("Item0", onClick = {})
+                        Separator()
                     }
+                    Menu("Menu1") {}
                 }
             }
         }
@@ -173,8 +158,6 @@ class MenuBarTest {
             assertThat(getItem(1).text).isEqualTo("Item0")
             assertThat(getMenuComponent(2)).isInstanceOf(JSeparator::class.java)
         }
-
-        isOpen = false
     }
 
     @Test(timeout = 20000)
@@ -185,7 +168,7 @@ class MenuBarTest {
         var submenuLabel by mutableStateOf("Submenu")
         var itemLabel by mutableStateOf("Item")
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -212,8 +195,6 @@ class MenuBarTest {
             assertThat(getMenu(0).getItem(0).text).isEqualTo("Submenu2")
             assertThat(getMenu(0).getItem(1).text).isEqualTo("Item2")
         }
-
-        exitApplication()
     }
 
     @Test(timeout = 20000)
@@ -224,7 +205,7 @@ class MenuBarTest {
         var submenuEnabled by mutableStateOf(true)
         var itemEnabled by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -251,8 +232,6 @@ class MenuBarTest {
             assertThat(getMenu(0).getItem(0).isEnabled).isFalse()
             assertThat(getMenu(0).getItem(1).isEnabled).isFalse()
         }
-
-        exitApplication()
     }
 
     @Test(timeout = 20000)
@@ -264,7 +243,7 @@ class MenuBarTest {
 
         var icon: Painter? by mutableStateOf(redIcon)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -288,8 +267,6 @@ class MenuBarTest {
         icon = null
         awaitIdle()
         assertThat(item.icon?.readFirstPixel()).isEqualTo(null)
-
-        exitApplication()
     }
 
     // bug https://github.com/JetBrains/compose-jb/issues/1097#issuecomment-921108560
@@ -298,7 +275,7 @@ class MenuBarTest {
         var window: ComposeWindow? = null
         val redIcon = testImage(Color.Red)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -313,8 +290,6 @@ class MenuBarTest {
         awaitIdle()
         window!!.jMenuBar.getMenu(0).doClick()
         window!!.paint(window!!.graphics)
-
-        exitApplication()
     }
 
     @Test(timeout = 20000)
@@ -323,7 +298,7 @@ class MenuBarTest {
 
         var checked by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -348,8 +323,6 @@ class MenuBarTest {
         awaitIdle()
         assertThat(checked).isEqualTo(true)
         assertThat(item.state).isEqualTo(true)
-
-        exitApplication()
     }
 
     @Test(timeout = 20000)
@@ -358,7 +331,7 @@ class MenuBarTest {
 
         var checked by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -381,10 +354,7 @@ class MenuBarTest {
 
         item.doClick()
         awaitIdle()
-        assertThat(checked).isEqualTo(false)
         assertThat(item.state).isEqualTo(false)
-
-        exitApplication()
     }
 
     @Test(timeout = 20000)
@@ -393,7 +363,7 @@ class MenuBarTest {
 
         var selected by mutableStateOf(1)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -427,8 +397,6 @@ class MenuBarTest {
         assertThat(selected).isEqualTo(1)
         assertThat(item0.isSelected).isEqualTo(false)
         assertThat(item1.isSelected).isEqualTo(true)
-
-        exitApplication()
     }
 
     @Test(timeout = 20000)
@@ -437,7 +405,7 @@ class MenuBarTest {
 
         var selected by mutableStateOf(1)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}) {
                 window = this.window
 
@@ -471,7 +439,5 @@ class MenuBarTest {
         assertThat(selected).isEqualTo(0)
         assertThat(item0.isSelected).isEqualTo(true)
         assertThat(item1.isSelected).isEqualTo(false)
-
-        exitApplication()
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -25,16 +25,16 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.awaitEDT
 import java.awt.GraphicsEnvironment
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
+import androidx.compose.ui.window.launchApplication as realLaunchApplication
+
 
 internal fun runApplicationTest(
     /**
@@ -63,8 +63,11 @@ internal fun runApplicationTest(
             val exceptionHandler = TestExceptionHandler()
             withExceptionHandler(exceptionHandler) {
                 val scope = WindowTestScope(this, useDelay, hasAnimations, exceptionHandler)
-                scope.body()
-                scope.exitTestApplication()
+                try{
+                    scope.body()
+                } finally {
+                    scope.exitTestApplication()
+                }
             }
             exceptionHandler.throwIfCaught()
         }
@@ -111,19 +114,20 @@ internal class WindowTestScope(
     var isOpen by mutableStateOf(true)
     private val initialRecomposers = Recomposer.runningRecomposers.value
 
-    // TODO(demin) replace launchApplication to launchTestApplication in all tests,
-    //  because we don't close the window with simple launchApplication
     fun launchTestApplication(
         content: @Composable ApplicationScope.() -> Unit
-    ) = launchApplication {
+    ) = realLaunchApplication {
         if (isOpen) {
             content()
         }
     }
 
-    // TODO(demin) remove when we migrate from launchApplication to launchTestApplication (see TODO above)
-    fun exitApplication() {
-        isOpen = false
+    // Overload `launchApplication` to prohibit calling it from tests
+    @Suppress("unused")
+    fun launchApplication(
+        @Suppress("UNUSED_PARAMETER") content: @Composable ApplicationScope.() -> Unit
+    ): Nothing {
+        error("Do not use `launchApplication` from tests; use `launchTestApplication` instead")
     }
 
     fun exitTestApplication() {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -63,7 +63,7 @@ internal fun runApplicationTest(
             val exceptionHandler = TestExceptionHandler()
             withExceptionHandler(exceptionHandler) {
                 val scope = WindowTestScope(this, useDelay, hasAnimations, exceptionHandler)
-                try{
+                try {
                     scope.body()
                 } finally {
                     scope.exitTestApplication()
@@ -123,7 +123,10 @@ internal class WindowTestScope(
     }
 
     // Overload `launchApplication` to prohibit calling it from tests
-    @Suppress("unused")
+    @Deprecated(
+        "Do not use `launchApplication` from tests; use `launchTestApplication` instead",
+        level = DeprecationLevel.ERROR
+    )
     fun launchApplication(
         @Suppress("UNUSED_PARAMETER") content: @Composable ApplicationScope.() -> Unit
     ): Nothing {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/dialog/DialogTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/dialog/DialogTest.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberDialogState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
@@ -60,7 +59,7 @@ class DialogTest {
     fun `open and close custom dialog`() = runApplicationTest {
         var window: ComposeDialog? = null
 
-        launchApplication {
+        launchTestApplication {
             var isOpen by remember { mutableStateOf(true) }
 
             fun createWindow() = ComposeDialog().apply {
@@ -98,7 +97,7 @@ class DialogTest {
         var isOpen by mutableStateOf(true)
         var title by mutableStateOf("Title1")
 
-        launchApplication {
+        launchTestApplication {
             fun createWindow() = ComposeDialog().apply {
                 size = Dimension(300, 200)
 
@@ -136,7 +135,7 @@ class DialogTest {
     fun `open and close dialog`() = runApplicationTest {
         var window: ComposeDialog? = null
 
-        launchApplication {
+        launchTestApplication {
             Dialog(onCloseRequest = ::exitApplication) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -155,7 +154,7 @@ class DialogTest {
         var isCloseCalled by mutableStateOf(false)
         var window: ComposeDialog? = null
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Dialog(
                     onCloseRequest = {
@@ -188,7 +187,7 @@ class DialogTest {
         var isOpen by mutableStateOf(true)
         var isLoading by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 if (isLoading) {
                     Dialog(onCloseRequest = {}) {
@@ -226,7 +225,7 @@ class DialogTest {
 
         var isOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Dialog(onCloseRequest = {}) {
                     window1 = this.window
@@ -258,7 +257,7 @@ class DialogTest {
         var isOpen by mutableStateOf(true)
         var isNestedOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Dialog(
                     onCloseRequest = {},
@@ -313,7 +312,7 @@ class DialogTest {
         var testValue by mutableStateOf(0)
         val localTestValue = compositionLocalOf { testValue }
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 CompositionLocalProvider(localTestValue provides testValue) {
                     Dialog(
@@ -358,7 +357,7 @@ class DialogTest {
 
         var isOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Dialog(onCloseRequest = {}) {
                     DisposableEffect(Unit) {
@@ -392,7 +391,7 @@ class DialogTest {
             onPreviewKeyEventKeys.clear()
         }
 
-        launchApplication {
+        launchTestApplication {
             Dialog(
                 onCloseRequest = ::exitApplication,
                 onPreviewKeyEvent = {
@@ -426,8 +425,6 @@ class DialogTest {
         awaitIdle()
         assertThat(onPreviewKeyEventKeys).isEqualTo(setOf(Key.E))
         assertThat(onKeyEventKeys).isEqualTo(setOf(Key.E))
-
-        exitApplication()
     }
 
     @Test
@@ -445,7 +442,7 @@ class DialogTest {
             onNodePreviewKeyEventKeys.clear()
         }
 
-        launchApplication {
+        launchTestApplication {
             Dialog(
                 onCloseRequest = ::exitApplication,
                 onPreviewKeyEvent = {
@@ -520,8 +517,6 @@ class DialogTest {
         assertThat(onNodePreviewKeyEventKeys).isEqualTo(setOf(Key.T))
         assertThat(onNodeKeyEventKeys).isEqualTo(setOf(Key.T))
         assertThat(onWindowKeyEventKeys).isEqualTo(setOf(Key.T))
-
-        exitApplication()
     }
 
     @Test(timeout = 30000)
@@ -531,7 +526,7 @@ class DialogTest {
         var isVisibleOnFirstComposition = false
         var isVisibleOnFirstDraw = false
 
-        launchApplication {
+        launchTestApplication {
             Dialog(onCloseRequest = ::exitApplication) {
                 if (!isComposed) {
                     isVisibleOnFirstComposition = window.isVisible
@@ -550,7 +545,5 @@ class DialogTest {
         awaitIdle()
         assertThat(isVisibleOnFirstComposition).isFalse()
         assertThat(isVisibleOnFirstDraw).isFalse()
-
-        exitApplication()
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.sendMouseWheelEvent
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.density
-import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
@@ -78,7 +77,7 @@ class WindowInputEventTest {
             onPreviewKeyEventKeys.clear()
         }
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 onPreviewKeyEvent = {
@@ -112,8 +111,6 @@ class WindowInputEventTest {
         awaitIdle()
         assertThat(onPreviewKeyEventKeys).isEqualTo(setOf(Key.E))
         assertThat(onKeyEventKeys).isEqualTo(setOf(Key.E))
-
-        exitApplication()
     }
 
     @Test
@@ -131,7 +128,7 @@ class WindowInputEventTest {
             onNodePreviewKeyEventKeys.clear()
         }
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 onPreviewKeyEvent = {
@@ -206,8 +203,6 @@ class WindowInputEventTest {
         assertThat(onNodePreviewKeyEventKeys).isEqualTo(setOf(Key.T))
         assertThat(onNodeKeyEventKeys).isEqualTo(setOf(Key.T))
         assertThat(onWindowKeyEventKeys).isEqualTo(setOf(Key.T))
-
-        exitApplication()
     }
 
     @Test
@@ -216,7 +211,7 @@ class WindowInputEventTest {
 
         val events = mutableListOf<PointerEvent>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -267,8 +262,6 @@ class WindowInputEventTest {
         assertThat(events[4].type).isEqualTo(PointerEventType.Release)
         assertThat(events[4].pressed).isEqualTo(false)
         assertThat(events[4].position).isEqualTo(Offset(80 * density, 30 * density))
-
-        exitApplication()
     }
 
     @Test
@@ -279,7 +272,7 @@ class WindowInputEventTest {
         var onEnters = 0
         var onExits = 0
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -332,8 +325,6 @@ class WindowInputEventTest {
 //        assertThat(onMoves.size).isEqualTo(2)
 //        assertThat(onEnters).isEqualTo(1)
 //        assertThat(onExits).isEqualTo(1)
-
-        exitApplication()
     }
 
     @Test
@@ -342,7 +333,7 @@ class WindowInputEventTest {
 
         val deltas = mutableListOf<Offset>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -371,8 +362,6 @@ class WindowInputEventTest {
         awaitIdle()
         assertThat(deltas.size).isEqualTo(2)
         assertThat(deltas.last()).isEqualTo(Offset(0f, -1f))
-
-        exitApplication()
     }
 
     @Test
@@ -381,7 +370,7 @@ class WindowInputEventTest {
 
         val deltas = mutableListOf<Offset>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -409,8 +398,6 @@ class WindowInputEventTest {
         awaitIdle()
         assertThat(deltas.size).isEqualTo(eventCount)
         assertThat(deltas.all { it == Offset(0f, 1f) }).isTrue()
-
-        exitApplication()
     }
 
     @Test
@@ -419,7 +406,7 @@ class WindowInputEventTest {
 
         val deltas = mutableListOf<Offset>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -447,8 +434,6 @@ class WindowInputEventTest {
         awaitIdle()
         assertThat(deltas.size).isEqualTo(1)
         assertThat(deltas.first()).isEqualTo(Offset(0f, 1f))
-
-        exitApplication()
     }
 
     @Test(timeout = 5000)
@@ -458,7 +443,7 @@ class WindowInputEventTest {
         val receivedButtons = mutableListOf<PointerButtons>()
         val receivedKeyboardModifiers = mutableListOf<PointerKeyboardModifiers>()
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = 200.dp, height = 100.dp)
@@ -494,7 +479,7 @@ class WindowInputEventTest {
         assertThat(receivedButtons.size).isEqualTo(1)
         assertThat(receivedButtons.last()).isEqualTo(
             PointerButtons(
-                // on macOs ctrl + primary click is treated as secondary click
+                // on macOS ctrl + primary click is treated as secondary click
                 isPrimaryPressed = !hostOs.isMacOS,
                 isSecondaryPressed = true,
             )
@@ -521,7 +506,7 @@ class WindowInputEventTest {
         assertThat(receivedButtons.size).isEqualTo(2)
         assertThat(receivedButtons.last()).isEqualTo(
             PointerButtons(
-                // on macOs ctrl + primary click is treated as secondary click
+                // on macOS ctrl + primary click is treated as secondary click
                 isPrimaryPressed = !hostOs.isMacOS,
                 isSecondaryPressed = true,
             )
@@ -536,8 +521,6 @@ class WindowInputEventTest {
                 isNumLockOn = getLockingKeyStateSafe(KeyEvent.VK_NUM_LOCK),
             )
         )
-
-        exitApplication()
     }
 
     @Test
@@ -609,8 +592,8 @@ class WindowInputEventTest {
         }
         awaitIdle()
 
-        window.sendMouseEvent(id = MouseEvent.MOUSE_PRESSED, x = 1, y = 1)
-        window.sendMouseEvent(id = MouseEvent.MOUSE_RELEASED, x = 21, y = 1)
+        window.sendMouseEvent(id = MOUSE_PRESSED, x = 1, y = 1)
+        window.sendMouseEvent(id = MOUSE_RELEASED, x = 21, y = 1)
 
         assertThat(box1ReleaseCount).isEqualTo(0)
         assertThat(box2ReleaseCount).isEqualTo(1)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowParameterTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowParameterTest.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
@@ -31,13 +30,11 @@ import androidx.compose.ui.readFirstPixel
 import androidx.compose.ui.testImage
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import java.awt.event.WindowEvent
 
-@OptIn(ExperimentalComposeUiApi::class)
 class WindowParameterTest {
     @Test
     fun `change title`() = runApplicationTest {
@@ -45,7 +42,7 @@ class WindowParameterTest {
 
         var title by mutableStateOf("Title1")
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, title = title) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -71,7 +68,7 @@ class WindowParameterTest {
 
         var icon: Painter? by mutableStateOf(redIcon)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, icon = icon) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -97,7 +94,7 @@ class WindowParameterTest {
     fun `set undecorated`() = runApplicationTest {
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, undecorated = false) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -116,7 +113,7 @@ class WindowParameterTest {
 
         var resizable by mutableStateOf(false)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, resizable = resizable) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -139,7 +136,7 @@ class WindowParameterTest {
 
         var enabled by mutableStateOf(false)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, enabled = enabled) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -162,7 +159,7 @@ class WindowParameterTest {
 
         var focusable by mutableStateOf(false)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, focusable = focusable) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -185,7 +182,7 @@ class WindowParameterTest {
 
         var alwaysOnTop by mutableStateOf(false)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, alwaysOnTop = alwaysOnTop) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.isLinux
@@ -39,7 +38,6 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.WindowState
-import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
@@ -57,21 +55,20 @@ import org.junit.Assume.assumeTrue
 import org.junit.Test
 
 // Note that on Linux some tests are flaky. Swing event listener's on Linux has non-deterministic
-// nature. To avoid flaky'ness we use delays
+// nature. To avoid flakiness we use delays
 // (see description of `delay` parameter in TestUtils.runApplicationTest).
 // It is not a good solution, but it works.
 
 // TODO(demin): figure out how can we fix flaky tests on Linux
 // TODO(demin): fix fullscreen tests on macOs
 
-@OptIn(ExperimentalComposeUiApi::class)
 class WindowStateTest {
     @Test
     fun `manually close window`() = runApplicationTest {
         var window: ComposeWindow? = null
         var isOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Window(onCloseRequest = { isOpen = false }) {
                     window = this.window
@@ -92,7 +89,7 @@ class WindowStateTest {
         var window: ComposeWindow? = null
         var isOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Window(onCloseRequest = { isOpen = false }) {
                     window = this.window
@@ -115,7 +112,7 @@ class WindowStateTest {
         var isParentOpen by mutableStateOf(true)
         var isChildOpen by mutableStateOf(false)
 
-        launchApplication {
+        launchTestApplication {
             if (isParentOpen) {
                 Window(onCloseRequest = {}) {
                     parentWindow = this.window
@@ -156,7 +153,7 @@ class WindowStateTest {
 
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -165,8 +162,6 @@ class WindowStateTest {
         awaitIdle()
         assertThat(window?.size).isEqualTo(Dimension(200, 200))
         assertThat(window?.location).isEqualTo(Point(242, 242))
-
-        exitApplication()
     }
 
     @Test
@@ -177,7 +172,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -188,8 +183,6 @@ class WindowStateTest {
         state.position = WindowPosition(242.dp, (242).dp)
         awaitIdle()
         assertThat(window?.location).isEqualTo(Point(242, 242))
-
-        exitApplication()
     }
 
     @Test
@@ -200,7 +193,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -211,8 +204,6 @@ class WindowStateTest {
         state.size = DpSize(250.dp, 200.dp)
         awaitIdle()
         assertThat(window?.size).isEqualTo(Dimension(250, 200))
-
-        exitApplication()
     }
 
     @Test
@@ -228,7 +219,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -236,8 +227,6 @@ class WindowStateTest {
 
         awaitIdle()
         assertThat(window!!.center() maxDistance window!!.screenCenter() < 250)
-
-        exitApplication()
     }
 
     @Test
@@ -247,7 +236,7 @@ class WindowStateTest {
         var window2: ComposeWindow? = null
         var isWindow1 by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isWindow1) {
                 Window(onCloseRequest = {}, state) {
                     window1 = this.window
@@ -268,8 +257,6 @@ class WindowStateTest {
         isWindow1 = false
         awaitIdle()
         assertThat(window2?.location == Point(242, 242))
-
-        exitApplication()
     }
 
     @Test
@@ -278,7 +265,7 @@ class WindowStateTest {
     ) {
         val state = WindowState(size = DpSize(200.dp, 200.dp))
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
             }
         }
@@ -287,8 +274,6 @@ class WindowStateTest {
 
         awaitIdle()
         assertThat(state.position.isSpecified).isTrue()
-
-        exitApplication()
     }
 
     @Test
@@ -300,7 +285,7 @@ class WindowStateTest {
         val state = WindowState(size = DpSize(200.dp, 200.dp))
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -315,8 +300,6 @@ class WindowStateTest {
         state.placement = WindowPlacement.Floating
         awaitIdle()
         assertThat(window?.placement).isEqualTo(WindowPlacement.Floating)
-
-        exitApplication()
     }
 
     @Test
@@ -324,7 +307,7 @@ class WindowStateTest {
         val state = WindowState(size = DpSize(200.dp, 200.dp))
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -339,8 +322,6 @@ class WindowStateTest {
         state.placement = WindowPlacement.Floating
         awaitIdle()
         assertThat(window?.placement).isEqualTo(WindowPlacement.Floating)
-
-        exitApplication()
     }
 
     @Test
@@ -348,7 +329,7 @@ class WindowStateTest {
         val state = WindowState(size = DpSize(200.dp, 200.dp))
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -363,19 +344,17 @@ class WindowStateTest {
         state.isMinimized = false
         awaitIdle()
         assertThat(window?.isMinimized).isFalse()
-
-        exitApplication()
     }
 
     @Test
     fun `maximize and minimize `() = runApplicationTest {
-        // macOs can't be maximized and minimized at the same time
+        // macOS can't be maximized and minimized at the same time
         assumeTrue(isWindows || isLinux)
 
         val state = WindowState(size = DpSize(200.dp, 200.dp))
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -388,20 +367,18 @@ class WindowStateTest {
         awaitIdle()
         assertThat(window?.isMinimized).isTrue()
         assertThat(window?.placement).isEqualTo(WindowPlacement.Maximized)
-
-        exitApplication()
     }
 
     @Test
     fun `restore size and position after maximize`() = runApplicationTest {
-        // Swing/macOs can't re-change isMaximized in a deterministic way:
+        // Swing/macOS can't re-change isMaximized in a deterministic way:
 //        fun main() = runBlocking(MainUIDispatcher) {
 //            val window = ComposeWindow()
 //            window.size = Dimension(200, 200)
 //            window.isVisible = true
 //            window.isMaximized = true
 //            delay(100)
-//            window.isMaximized = false  // we cannot do that on macOs (window is still animating)
+//            window.isMaximized = false  // we cannot do that on macOS (window is still animating)
 //            delay(1000)
 //            println(window.isMaximized) // prints true
 //        }
@@ -414,7 +391,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -435,8 +412,6 @@ class WindowStateTest {
         assertThat(window?.placement).isEqualTo(WindowPlacement.Floating)
         assertThat(window?.size).isEqualTo(Dimension(201, 203))
         assertThat(window?.location).isEqualTo(Point(196, 257))
-
-        exitApplication()
     }
 
     @Test
@@ -450,7 +425,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -471,8 +446,6 @@ class WindowStateTest {
         assertThat(window?.placement).isEqualTo(WindowPlacement.Floating)
         assertThat(window?.size).isEqualTo(Dimension(201, 203))
         assertThat(window?.location).isEqualTo(Point(196, 257))
-
-        exitApplication()
     }
 
     @Test
@@ -484,7 +457,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -492,8 +465,6 @@ class WindowStateTest {
 
         awaitIdle()
         assertThat(window?.placement).isEqualTo(WindowPlacement.Maximized)
-
-        exitApplication()
     }
 
     @Test
@@ -517,7 +488,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -525,8 +496,6 @@ class WindowStateTest {
 
         awaitIdle()
         assertThat(window?.isMinimized).isTrue()
-
-        exitApplication()
     }
 
     @Test
@@ -542,7 +511,7 @@ class WindowStateTest {
         )
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = {}, state) {
                 window = this.window
             }
@@ -550,8 +519,6 @@ class WindowStateTest {
 
         awaitIdle()
         assertThat(window?.placement).isEqualTo(WindowPlacement.Fullscreen)
-
-        exitApplication()
     }
 
     @Test
@@ -564,11 +531,10 @@ class WindowStateTest {
             isMinimized = true,
         )
 
-        var isOpen by mutableStateOf(true)
         var index by mutableStateOf(0)
         val states = mutableListOf<WindowState>()
 
-        launchApplication {
+        launchTestApplication {
             val saveableStateHolder = rememberSaveableStateHolder()
             saveableStateHolder.SaveableStateProvider(index) {
                 val state = rememberWindowState()
@@ -582,9 +548,7 @@ class WindowStateTest {
                 }
             }
 
-            if (isOpen) {
-                Window(onCloseRequest = {}) {}
-            }
+            Window(onCloseRequest = {}) {}
         }
 
         awaitIdle()
@@ -606,8 +570,6 @@ class WindowStateTest {
         assertThat(states[2].isMinimized == newState.isMinimized)
         assertThat(states[2].size == newState.size)
         assertThat(states[2].position == newState.position)
-
-        isOpen = false
     }
 
     @Test
@@ -615,7 +577,7 @@ class WindowStateTest {
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize(300.dp, Dp.Unspecified))
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = state
@@ -634,8 +596,6 @@ class WindowStateTest {
         assertThat(window.width).isEqualTo(300)
         assertThat(window.contentSize.height).isEqualTo(200)
         assertThat(state.size).isEqualTo(DpSize(window.size.width.dp, window.size.height.dp))
-
-        exitApplication()
     }
 
     @Test
@@ -643,7 +603,7 @@ class WindowStateTest {
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize(Dp.Unspecified, 300.dp))
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = state
@@ -662,8 +622,6 @@ class WindowStateTest {
         assertThat(window.height).isEqualTo(300)
         assertThat(window.contentSize.width).isEqualTo(400)
         assertThat(state.size).isEqualTo(DpSize(window.size.width.dp, window.size.height.dp))
-
-        exitApplication()
     }
 
     @Test
@@ -671,7 +629,7 @@ class WindowStateTest {
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize(Dp.Unspecified, Dp.Unspecified))
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = state
@@ -689,8 +647,6 @@ class WindowStateTest {
         awaitIdle()
         assertThat(window.contentSize).isEqualTo(Dimension(400, 200))
         assertThat(state.size).isEqualTo(DpSize(window.size.width.dp, window.size.height.dp))
-
-        exitApplication()
     }
 
     @Test
@@ -700,7 +656,7 @@ class WindowStateTest {
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize(100.dp, 100.dp))
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = state
@@ -721,8 +677,6 @@ class WindowStateTest {
         awaitIdle()
         assertThat(window.contentSize).isEqualTo(Dimension(400, 200))
         assertThat(state.size).isEqualTo(DpSize(window.size.width.dp, window.size.height.dp))
-
-        exitApplication()
     }
 
     @Test
@@ -731,7 +685,7 @@ class WindowStateTest {
 
         var visible by mutableStateOf(false)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, visible = visible) {
                 window = this.window
             }
@@ -743,8 +697,6 @@ class WindowStateTest {
         visible = true
         awaitIdle()
         assertThat(window.isVisible).isEqualTo(true)
-
-        exitApplication()
     }
 
     @Test
@@ -753,7 +705,7 @@ class WindowStateTest {
 
         val sendChannel = Channel<Int>(Channel.UNLIMITED)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, visible = false) {
                 LaunchedEffect(Unit) {
                     sendChannel.consumeEach {
@@ -770,8 +722,6 @@ class WindowStateTest {
         sendChannel.send(2)
         awaitIdle()
         assertThat(receivedNumbers).isEqualTo(listOf(1, 2))
-
-        exitApplication()
     }
 
     @Test
@@ -781,7 +731,7 @@ class WindowStateTest {
         lateinit var window1Info: WindowInfo
         lateinit var window2Info: WindowInfo
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication) {
                 window1 = window
                 window1Info = LocalWindowInfo.current
@@ -806,8 +756,6 @@ class WindowStateTest {
         awaitIdle()
         assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
         assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
-
-        exitApplication()
     }
 
     @Test
@@ -816,7 +764,7 @@ class WindowStateTest {
 
         val sendChannel = Channel<Int>(Channel.UNLIMITED)
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication, visible = false, undecorated = true) {
                 LaunchedEffect(Unit) {
                     sendChannel.consumeEach {
@@ -833,8 +781,6 @@ class WindowStateTest {
         sendChannel.send(2)
         awaitIdle()
         assertThat(receivedNumbers).isEqualTo(listOf(1, 2))
-
-        exitApplication()
     }
 
     private val Window.contentSize

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -523,7 +523,7 @@ class WindowTest {
 
         launchTestApplication {
             Window(
-                onCloseRequest = ::exitApplication,
+                onCloseRequest = { },
                 state = rememberWindowState(width = Dp.Unspecified, height = Dp.Unspecified),
                 undecorated = true,
                 resizable = true,
@@ -536,8 +536,6 @@ class WindowTest {
         awaitIdle()
         assertEquals(32, window?.width)
         assertEquals(32, window?.height)
-
-        window?.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING))
     }
 
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LeakDetector
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
@@ -43,7 +42,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
@@ -58,15 +56,13 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
 import org.junit.Test
-import kotlinx.coroutines.cancelAndJoin
 
-@OptIn(ExperimentalComposeUiApi::class)
 class WindowTest {
     @Test
     fun `open and close custom window`() = runApplicationTest {
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             var isOpen by remember { mutableStateOf(true) }
 
             fun createWindow() = ComposeWindow().apply {
@@ -103,7 +99,7 @@ class WindowTest {
         var isOpen by mutableStateOf(true)
         var title by mutableStateOf("Title1")
 
-        launchApplication {
+        launchTestApplication {
             fun createWindow() = ComposeWindow().apply {
                 size = Dimension(300, 200)
 
@@ -141,7 +137,7 @@ class WindowTest {
     fun `open and close window`() = runApplicationTest {
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
@@ -160,7 +156,7 @@ class WindowTest {
         var isCloseCalled by mutableStateOf(false)
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Window(
                     onCloseRequest = {
@@ -193,7 +189,7 @@ class WindowTest {
         var isOpen by mutableStateOf(true)
         var isLoading by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 if (isLoading) {
                     Window(onCloseRequest = {}) {
@@ -231,7 +227,7 @@ class WindowTest {
 
         var isOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Window(onCloseRequest = {}) {
                     window1 = this.window
@@ -263,7 +259,7 @@ class WindowTest {
         var isOpen by mutableStateOf(true)
         var isNestedOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Window(
                     onCloseRequest = {},
@@ -320,7 +316,7 @@ class WindowTest {
         val local2TestValue = compositionLocalOf { 0 }
         var locals by mutableStateOf(arrayOf(local1TestValue provides 1))
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 CompositionLocalProvider(*locals) {
                     Window(
@@ -386,7 +382,7 @@ class WindowTest {
 
         var isOpen by mutableStateOf(true)
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 Window(onCloseRequest = {}) {
                     DisposableEffect(Unit) {
@@ -445,7 +441,7 @@ class WindowTest {
         var isVisibleOnFirstComposition = false
         var isVisibleOnFirstDraw = false
 
-        launchApplication {
+        launchTestApplication {
             Window(onCloseRequest = ::exitApplication) {
                 if (!isComposed) {
                     isVisibleOnFirstComposition = window.isVisible
@@ -464,8 +460,6 @@ class WindowTest {
         awaitIdle()
         assertThat(isVisibleOnFirstComposition).isFalse()
         assertThat(isVisibleOnFirstDraw).isFalse()
-
-        exitApplication()
     }
 
     @Test(timeout = 30000)
@@ -473,7 +467,7 @@ class WindowTest {
         val customDensity = Density(3.14f)
         var actualDensity: Density? = null
 
-        launchApplication {
+        launchTestApplication {
             if (isOpen) {
                 CompositionLocalProvider(LocalDensity provides customDensity) {
                     Window(onCloseRequest = ::exitApplication) {
@@ -486,8 +480,6 @@ class WindowTest {
         awaitIdle()
         assertThat(actualDensity).isNotNull()
         assertThat(actualDensity).isNotEqualTo(customDensity)
-
-        exitApplication()
     }
 
     @Test
@@ -495,7 +487,7 @@ class WindowTest {
         var isApplicationEffectEnded = false
         var isWindowEffectEnded = false
 
-        val job = launchApplication {
+        val job = launchTestApplication {
             if (isOpen) {
                 Window(onCloseRequest = ::exitApplication) {
                     LaunchedEffect(Unit) {
@@ -518,7 +510,7 @@ class WindowTest {
         }
 
         awaitIdle()
-        exitApplication()
+        exitTestApplication()
         job.cancelAndJoin()
 
         assertThat(isApplicationEffectEnded).isTrue()
@@ -529,7 +521,7 @@ class WindowTest {
     fun `undecorated resizable window with unspecified size`() = runApplicationTest {
         var window: ComposeWindow? = null
 
-        launchApplication {
+        launchTestApplication {
             Window(
                 onCloseRequest = ::exitApplication,
                 state = rememberWindowState(width = Dp.Unspecified, height = Dp.Unspecified),

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -676,7 +676,6 @@ class WindowTypeTest {
 
         awaitIdle()
         body()
-        exitApplication()
     }
 
     private suspend fun WindowTestScope.assert(


### PR DESCRIPTION
Currently, when using `runApplicationTest` with `launchApplication`, any `Windows` and `Dialogs` opened inside would leak the window, along with its `ComposeScene`, possibly causing failures in other tests, such as this: https://github.com/JetBrains/compose-multiplatform/issues/2713

## Proposed Changes

  - Replace `launchApplication` with `launchTestApplication` in all our tests.
  - Overload `launchApplication` in `WindowTestScope`, making it impossible to use `launchApplication` from `runApplicationTest`.
  - Remove redundant `exitApplication` and `isOpen = false` code from all the tests.

## Testing

Test: Count and print `ComposeScene` instances by storing them in a list in the constructor and removing in `close()`. Then run the tests with `./scripts/testDesktop`.

Before this fix, we would end up with 46 unclosed instances, and the screen would be full of windows. Afterwards, the tests finish with 0 unclosed instances and the windows disappear after each test is completed.

ComposeScene:
```
private val composeScenes = mutableSetOf<ComposeScene>()
private val sync = createSynchronizedObject()

fun addComposeScene(scene: ComposeScene){
    synchronized(sync){
        println("ComposeScenes before adding: ${composeScenes.size}")
        composeScenes.add(scene)
    }
}

fun removeComposeScene(scene: ComposeScene){
    synchronized(sync){
        composeScenes.remove(scene)
        println("ComposeScenes after removal: ${composeScenes.size}")
    }
}

class ComposeScene(...){
    init {
        addComposeScene(this)
    }

    fun close() {
        removeComposeScene(this)
        ...
    }
}
```

## Issues Fixed

Possibly fixes https://github.com/JetBrains/compose-multiplatform/issues/2713
