### PR TITLE
Prevent unlimited sendAsMove calls

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -479,8 +479,13 @@ class ComposeScene internal constructor(
         processPointerInput(event)
     }
 
+    private var lastMoveEvent: PointerInputEvent? = null
+
     @Suppress("DEPRECATION")
     private fun sendAsMove(sourceEvent: PointerInputEvent, positionSourceEvent: PointerInputEvent) {
+        if (lastMoveEvent === sourceEvent) return
+        lastMoveEvent = sourceEvent
+
         val nativeEvent = createSyntheticNativeMoveEvent(
             sourceEvent.nativeEvent,
             positionSourceEvent.nativeEvent


### PR DESCRIPTION
`ComposeScene.render` method calls `pointerPositionUpdater.update()` and then `ComposeScene.sendAsMove()` is called consequently. 

When running an animation these methods are called continuously even when the pointer remains at the same point. Then it calls `hitTest` every time.

It appears to be redundant (please correct if I'm wrong) and a bit expensive in one of the Compose k/wasm samples (takes ~1 ms for each render, which could be good to save each frame). 


<img width="350" alt="Screenshot 2023-03-20 at 21 03 18" src="https://user-images.githubusercontent.com/7372778/226453162-c83176c4-a9bf-48a0-9969-95a6d9dbf161.png">
