### PR TITLE
Actually remember provider in  rememberComponentRectPositionProvider

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -175,28 +175,32 @@ fun rememberComponentRectPositionProvider(
     anchor: Alignment = Alignment.BottomCenter,
     alignment: Alignment = Alignment.BottomCenter,
     offset: DpOffset = DpOffset.Zero
-): PopupPositionProvider = with(LocalDensity.current) {
-    val offsetPx = IntOffset(offset.x.roundToPx(), offset.y.roundToPx())
-    return object : PopupPositionProvider {
-        override fun calculatePosition(
-            anchorBounds: IntRect,
-            windowSize: IntSize,
-            layoutDirection: LayoutDirection,
-            popupContentSize: IntSize
-        ): IntOffset {
-            val anchorPoint = anchor.align(IntSize.Zero, anchorBounds.size, layoutDirection)
-            val tooltipArea = IntRect(
-                IntOffset(
-                    anchorBounds.left + anchorPoint.x - popupContentSize.width,
-                    anchorBounds.top + anchorPoint.y - popupContentSize.height,
-                ),
-                IntSize(
-                    popupContentSize.width * 2,
-                    popupContentSize.height * 2
+): PopupPositionProvider {
+    val offsetPx = with(LocalDensity.current) {
+        IntOffset(offset.x.roundToPx(), offset.y.roundToPx())
+    }
+    return remember(anchor, alignment, offsetPx) {
+        object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize
+            ): IntOffset {
+                val anchorPoint = anchor.align(IntSize.Zero, anchorBounds.size, layoutDirection)
+                val tooltipArea = IntRect(
+                    IntOffset(
+                        anchorBounds.left + anchorPoint.x - popupContentSize.width,
+                        anchorBounds.top + anchorPoint.y - popupContentSize.height,
+                    ),
+                    IntSize(
+                        popupContentSize.width * 2,
+                        popupContentSize.height * 2
+                    )
                 )
-            )
-            val position = alignment.align(popupContentSize, tooltipArea.size, layoutDirection)
-            return tooltipArea.topLeft + position + offsetPx
+                val position = alignment.align(popupContentSize, tooltipArea.size, layoutDirection)
+                return tooltipArea.topLeft + position + offsetPx
+            }
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -54,9 +54,13 @@ fun rememberCursorPositionProvider(
     offset: DpOffset = DpOffset.Zero,
     alignment: Alignment = Alignment.BottomEnd,
     windowMargin: Dp = 4.dp
-): PopupPositionProvider = with(LocalDensity.current) {
-    val offsetPx = Offset(offset.x.toPx(), offset.y.toPx())
-    val windowMarginPx = windowMargin.roundToPx()
+): PopupPositionProvider {
+    val offsetPx = with(LocalDensity.current) {
+        Offset(offset.x.toPx(), offset.y.toPx())
+    }
+    val windowMarginPx = with(LocalDensity.current) {
+        windowMargin.roundToPx()
+    }
     val cursorPosition = rememberCursorPosition()
 
     if (cursorPosition == null) {


### PR DESCRIPTION
## Proposed Changes
`rememberComponentRectPositionProvider` should remember returning value because its name starts with `remember`

## Testing

Test: existing unit tests

## Issues Fixed

No issues related to that
