### PR TITLE
Unregister window/dialog listeners when disposing.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -29,12 +29,16 @@ import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.layoutDirection
+import java.awt.Component
 import java.awt.Dialog
 import java.awt.Dimension
 import java.awt.Frame
 import java.awt.Point
 import java.awt.Toolkit
 import java.awt.Window
+import java.awt.event.ComponentListener
+import java.awt.event.WindowListener
+import java.awt.event.WindowStateListener
 import kotlin.math.roundToInt
 
 /**
@@ -165,3 +169,39 @@ internal fun Window.makeDisplayable() {
         location = oldLocation
     }
 }
+
+internal class ListenerOnWindowRef<T>(
+    private val register: Window.(T) -> Unit,
+    private val unregister: Window.(T) -> Unit
+) {
+    private var value: T? = null
+
+    fun registerWithAndSet(window: Window, listener: T) {
+        window.register(listener)
+        value = listener
+    }
+
+    fun unregisterFromAndClear(window: Window) {
+        value?.let {
+            window.unregister(it)
+            value = null
+        }
+    }
+}
+
+internal fun windowStateListenerRef() = ListenerOnWindowRef<WindowStateListener>(
+    register = Window::addWindowStateListener,
+    unregister = Window::removeWindowStateListener
+)
+
+internal fun windowListenerRef() = ListenerOnWindowRef<WindowListener>(
+    register = Window::addWindowListener,
+    unregister = Window::removeWindowListener
+)
+
+internal fun componentListenerRef() = ListenerOnWindowRef<ComponentListener>(
+    register = Component::addComponentListener,
+    unregister = Component::removeComponentListener
+)
+
+

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -29,11 +29,13 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.ComponentUpdater
+import androidx.compose.ui.util.componentListenerRef
 import androidx.compose.ui.util.makeDisplayable
 import androidx.compose.ui.util.setIcon
 import androidx.compose.ui.util.setPositionSafely
 import androidx.compose.ui.util.setSizeSafely
 import androidx.compose.ui.util.setUndecoratedSafely
+import androidx.compose.ui.util.windowListenerRef
 import java.awt.Dialog.ModalityType
 import java.awt.Window
 import java.awt.event.ComponentAdapter
@@ -137,6 +139,19 @@ fun Dialog(
         }
     }
 
+    val listeners = remember {
+        object {
+            var windowListenerRef = windowListenerRef()
+            var componentListenerRef = componentListenerRef()
+
+            fun removeFromAndClear(window: ComposeDialog) {
+                windowListenerRef.unregisterFromAndClear(window)
+                componentListenerRef.unregisterFromAndClear(window)
+            }
+        }
+    }
+
+
     Dialog(
         visible = visible,
         onPreviewKeyEvent = onPreviewKeyEvent,
@@ -151,27 +166,35 @@ fun Dialog(
             dialog.apply {
                 // close state is controlled by DialogState.isOpen
                 defaultCloseOperation = JDialog.DO_NOTHING_ON_CLOSE
-                addWindowListener(object : WindowAdapter() {
-                    override fun windowClosing(e: WindowEvent?) {
-                        currentOnCloseRequest()
+                listeners.windowListenerRef.registerWithAndSet(
+                    this,
+                    object : WindowAdapter() {
+                        override fun windowClosing(e: WindowEvent?) {
+                            currentOnCloseRequest()
+                        }
                     }
-                })
-                addComponentListener(object : ComponentAdapter() {
-                    override fun componentResized(e: ComponentEvent) {
-                        currentState.size = DpSize(width.dp, height.dp)
-                        appliedState.size = currentState.size
-                    }
+                )
+                listeners.componentListenerRef.registerWithAndSet(
+                    this,
+                    object : ComponentAdapter() {
+                        override fun componentResized(e: ComponentEvent) {
+                            currentState.size = DpSize(width.dp, height.dp)
+                            appliedState.size = currentState.size
+                        }
 
-                    override fun componentMoved(e: ComponentEvent) {
-                        currentState.position = WindowPosition(x.dp, y.dp)
-                        appliedState.position = currentState.position
+                        override fun componentMoved(e: ComponentEvent) {
+                            currentState.position = WindowPosition(x.dp, y.dp)
+                            appliedState.position = currentState.position
+                        }
                     }
-                })
+                )
                 WindowLocationTracker.onWindowCreated(this)
             }
         },
         dispose = {
             WindowLocationTracker.onWindowDisposed(it)
+            // We need to remove them because AWT can still call them after dispose()
+            listeners.removeFromAndClear(it)
             it.dispose()
         },
         update = { dialog ->

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -133,8 +133,9 @@ internal class WindowTestScope(
         error("Do not use `launchApplication` from tests; use `launchTestApplication` instead")
     }
 
-    fun exitTestApplication() {
+    suspend fun exitTestApplication() {
         isOpen = false
+        awaitIdle()  // Wait for the windows to actually complete disposing
     }
 
     suspend fun awaitIdle() {


### PR DESCRIPTION
We have tests failing due to: 
```
java.lang.IllegalArgumentException: ComposeLayer is disposed
  at androidx.compose.ui.awt.ComposeWindowDelegate.getLayer(ComposeWindowDelegate.desktop.kt:61)
  at androidx.compose.ui.awt.ComposeWindowDelegate.access$getLayer(ComposeWindowDelegate.desktop.kt:49)
  at androidx.compose.ui.awt.ComposeWindowDelegate$_pane$1.addNotify(ComposeWindowDelegate.desktop.kt:87)
```

This happens because we don't remove the window/dialog listeners we've registered with the window, but AWT may still call them after disposal. Confusingly, the exception is thrown after the test that fails to remove the listener has completed, so the test running after it gets "blamed". If you run just the "failing" test, it of course succeeds.

## Proposed Changes

- When `runApplicationTest` calls `exitTestApplication`, wait for it to complete disposing the windows/dialogs created.
- Unregister the listeners we've registered with the window/dialog before disposing.

## Testing

Test: Ran the existing window/dialog tests, and they no longer fail.

## Issues Fixed

Fixes: https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_DesktopTestsForPullRequests/4103630