### PR TITLE
Configure VCS mappings and pull requests navigation

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -7,6 +7,10 @@
           <option name="issueRegexp" value="b\/(\d*)" />
           <option name="linkRegexp" value="https://issuetracker.google.com/$1" />
         </IssueNavigationLink>
+        <IssueNavigationLink>
+          <option name="issueRegexp" value="#(\d+)" />
+          <option name="linkRegexp" value="https://github.com/JetBrains/compose-multiplatform-core/pull/$1" />
+        </IssueNavigationLink>
       </list>
     </option>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -11,11 +11,6 @@
     </option>
   </component>
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../../external/icing" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../../external/icu" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../../external/protobuf" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../../external/webview_support_interfaces" vcs="Git" />
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/../../golden" vcs="Git" />
   </component>
 </project>


### PR DESCRIPTION
## Proposed Changes

- Remove redundant directory mappings to get rid of errors on project opening
- Provide pull requests to IssueNavigationLink, so IntelliJ Git support will detect it and show #222 as link in Git Log/History etc.

## Testing

Test: manual

## Issues Fixed

No issues related to these changes