### PR TITLE
Fix merging styles

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -254,7 +254,7 @@ internal data class ComputedStyle(
 
     fun merge(density: Density, other: SpanStyle) {
         val fontSize = fontSizeInHierarchy(density, fontSize, other.fontSize)
-        textForegroundStyle = other.textForegroundStyle
+        textForegroundStyle.merge(other.textForegroundStyle)
         other.fontFamily?.let { fontFamily = it }
         this.fontSize = fontSize
         other.fontWeight?.let { fontWeight = it }


### PR DESCRIPTION
## Proposed Changes

Fixes a small regression after #426: text style is incorrect for "uncommitted" text in text field (see issue description)

## Testing

- Run `q, w, space, backspace 4x (Korean, Windows)` test
- Look at last char color

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/2916
