### PR TITLE
UIKit, handle didReceiveMemoryWarning

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalMemoryWarning.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalMemoryWarning.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interop
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+val LocalMemoryWarning = staticCompositionLocalOf<Flow<Unit>> { emptyFlow() }


### PR DESCRIPTION
These are temporary changes that need to quickly fix a problem in the sample.
Only on UIKit sourceSet