### PR TITLE
Reduce one array allocation for  createPlatformLocaleDelegate

### DIFF
--- a/compose/ui/ui-text/src/jsMain/kotlin/androidx/compose/ui/text/intl/JsPlatformLocale.js.kt
+++ b/compose/ui/ui-text/src/jsMain/kotlin/androidx/compose/ui/text/intl/JsPlatformLocale.js.kt
@@ -32,8 +32,7 @@ internal class JsLocale(val locale: dynamic) : PlatformLocale {
 internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     object : PlatformLocaleDelegate {
         override val current: LocaleList
-            // TODO: [1.4 Update] Check that it is implemented properly
-            get() = LocaleList(Locale(JsLocale(Any())))
+            get() = LocaleList(listOf(Locale(JsLocale(Any()))))
 
 
         override fun parseLanguageTag(languageTag: String): PlatformLocale {

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.native.kt
@@ -39,9 +39,8 @@ internal class NativeLocale(val locale: NSLocale) : PlatformLocale {
 
 internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     object : PlatformLocaleDelegate {
-        // TODO: [1.4 Update] Check that new solution is correct
         override val current: LocaleList
-            get() = LocaleList(Locale(NativeLocale(NSLocale.currentLocale)))
+            get() = LocaleList(listOf(Locale(NativeLocale(NSLocale.currentLocale))))
 
 
         override fun parseLanguageTag(languageTag: String): PlatformLocale {


### PR DESCRIPTION
- for native implementation (like for other implementations)
