### PR TITLE
Fix build on Windows

### DIFF
--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -22,7 +22,13 @@ include ":public"
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
-            from(files("../gradle/libs.versions.toml"))
+            // For JetBrains Fork only. Keep during merge.
+            // Androidx doesn't support windows development, but we should.
+            // `gradle` folder is symlinked for other modules like (:compose:runtime),
+            // and it works fine for Mac and Linux but not for Windows
+            if (System.getProperty("os.name").startsWith("Windows")) {
+                from(files("../gradle/libs.versions.toml"))
+            }
             def agpOverride = System.getenv("GRADLE_PLUGIN_VERSION")
             if (agpOverride != null) {
                 logger.warn("Using custom version ${agpOverride} of AGP due to GRADLE_PLUGIN_VERSION being set.")

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -22,6 +22,7 @@ include ":public"
 dependencyResolutionManagement {
     versionCatalogs {
         libs {
+            from(files("../gradle/libs.versions.toml"))
             def agpOverride = System.getenv("GRADLE_PLUGIN_VERSION")
             if (agpOverride != null) {
                 logger.warn("Using custom version ${agpOverride} of AGP due to GRADLE_PLUGIN_VERSION being set.")

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+
 include ":jetpad-integration"
 include ":plugins"
 include ":private"
@@ -26,7 +28,7 @@ dependencyResolutionManagement {
             // Androidx doesn't support windows development, but we should.
             // `gradle` folder is symlinked for other modules like (:compose:runtime),
             // and it works fine for Mac and Linux but not for Windows
-            if (System.getProperty("os.name").startsWith("Windows")) {
+            if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows()) {
                 from(files("../gradle/libs.versions.toml"))
             }
             def agpOverride = System.getenv("GRADLE_PLUGIN_VERSION")

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -21,7 +21,7 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
-    id("AndroidXPaparazziPlugin")
+    //id("AndroidXPaparazziPlugin") // isn't supported on Windows
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -22,7 +22,7 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
-    id("AndroidXPaparazziPlugin")
+    //id("AndroidXPaparazziPlugin") // isn't supported on Windows
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)


### PR DESCRIPTION
1. `from(files("../gradle/libs.versions.toml"))` was before, but removed in https://android-review.googlesource.com/c/platform/frameworks/support/+/2261481

"This is no longer needed because we symlink directly to frameworks/support/gradle/libs.versions.toml"

There were issues with symlinks on Windows in the past, better not to rely on them in our build configuration.

2. AndroidXPaparazziPlugin is for screenshot testing.