### PR TITLE
Fix ComposeFocusTest

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -122,7 +122,12 @@ internal class SkiaBasedOwner(
         properties = {}
     )
 
-    override val focusOwner: FocusOwner = FocusOwnerImpl {
+    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2944)
+    //  Check if ComposePanel/SwingPanel focus interop work correctly with new features of
+    //  the focus system (it works with the old features like moveFocus/clearFocus)
+    override val focusOwner: FocusOwner = FocusOwnerImpl(
+        parent = parentFocusManager
+    ) {
         registerOnEndApplyChangesListener(it)
     }.apply {
         layoutDirection = platform.layoutDirection


### PR DESCRIPTION
Move changes from https://github.com/JetBrains/compose-multiplatform-core/pull/227/files, which were lost after the merge.

DesktopMenuTest's focus test is still failing though