### PR TITLE
Implement paragraph's drawStyle and blendMode paramenters

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -446,7 +446,6 @@ internal class SkiaParagraph(
         drawStyle: DrawStyle?,
         blendMode: BlendMode
     ) {
-        // TODO: [1.4 Update] take blendMode into account
         paragraph = with(layouter) {
             setTextStyle(
                 color = color,
@@ -454,6 +453,7 @@ internal class SkiaParagraph(
                 textDecoration = textDecoration
             )
             setDrawStyle(drawStyle)
+            setBlendMode(blendMode)
             layoutParagraph(
                 width = width
             )
@@ -471,7 +471,6 @@ internal class SkiaParagraph(
         drawStyle: DrawStyle?,
         blendMode: BlendMode
     ) {
-        // TODO: [1.4 Update] take blendMode into account
         paragraph = with(layouter) {
             setTextStyle(
                 brush = brush,
@@ -481,6 +480,7 @@ internal class SkiaParagraph(
                 textDecoration = textDecoration
             )
             setDrawStyle(drawStyle)
+            setBlendMode(blendMode)
             layoutParagraph(
                 width = width
             )

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -17,12 +17,9 @@
 package androidx.compose.ui.text.platform
 
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
-import androidx.compose.ui.graphics.asComposePaint
+import androidx.compose.ui.geometry.isUnspecified
+import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.DrawStyle
-import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.Placeholder
@@ -68,7 +65,6 @@ internal class ParagraphLayouter(
         fontFamilyResolver = fontFamilyResolver,
         text = text,
         textStyle = style,
-        brushSize = null,
         spanStyles = spanStyles,
         placeholders = placeholders,
         density = density,
@@ -122,7 +118,7 @@ internal class ParagraphLayouter(
     ) {
         val actualSize = builder.brushSize
         if (builder.textStyle.brush != brush ||
-            actualSize == null ||
+            actualSize.isUnspecified ||
             !actualSize.width.sameValueAs(brushSize.width) ||
             !actualSize.height.sameValueAs(brushSize.height) ||
             !builder.textStyle.alpha.sameValueAs(alpha) ||
@@ -141,7 +137,17 @@ internal class ParagraphLayouter(
     }
 
     fun setDrawStyle(drawStyle: DrawStyle?) {
-        // TODO Implement applying DrawStyle
+        if (builder.drawStyle != drawStyle) {
+            builder.drawStyle = drawStyle
+            paragraphCache = null
+        }
+    }
+
+    fun setBlendMode(blendMode: BlendMode) {
+        if (builder.blendMode != blendMode) {
+            builder.blendMode = blendMode
+            paragraphCache = null
+        }
     }
 
     fun layoutParagraph(width: Float): Paragraph {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -181,8 +181,8 @@ internal data class ComputedStyle(
     private fun toTextPaint(): Paint? = Paint().let {
         with(it.asComposePaint()) {
             color = textForegroundStyle.color
-            setBrush(textForegroundStyle.brush, brushSize, textForegroundStyle.alpha)
-            setDrawStyle(drawStyle)
+            applyBrush(textForegroundStyle.brush, brushSize, textForegroundStyle.alpha)
+            applyDrawStyle(drawStyle)
             blendMode = this@ComputedStyle.blendMode
             return@let it.takeIf { shader != null || style != PaintingStyle.Fill || !it.isSrcOver }
         }
@@ -309,7 +309,9 @@ internal class ParagraphBuilder(
      * of active styles is being compiled into single SkParagraph's style for every chunk of text
      */
     fun build(): SkParagraph {
-        initialStyle = textStyle.toSpanStyle().withReplacements()
+        initialStyle = textStyle.toSpanStyle().copyWithDefaultFontSize(
+            drawStyle = drawStyle
+        )
         defaultStyle = ComputedStyle(density, initialStyle, brushSize, blendMode)
         ops = makeOps(
             spanStyles,
@@ -575,7 +577,7 @@ private fun TextUnit.orDefaultFontSize() = when {
 }
 
 @OptIn(ExperimentalTextApi::class)
-private fun SpanStyle.withReplacements(): SpanStyle {
+private fun SpanStyle.copyWithDefaultFontSize(drawStyle: DrawStyle? = null): SpanStyle {
     val fontSize = this.fontSize.orDefaultFontSize()
     val letterSpacing = when {
         this.letterSpacing.isEm -> fontSize * this.letterSpacing.value
@@ -584,7 +586,7 @@ private fun SpanStyle.withReplacements(): SpanStyle {
     return this.copy(
         fontSize = fontSize,
         letterSpacing = letterSpacing,
-        drawStyle = this.drawStyle
+        drawStyle = drawStyle
     )
 }
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -184,7 +184,7 @@ internal data class ComputedStyle(
             setBrush(textForegroundStyle.brush, brushSize, textForegroundStyle.alpha)
             setDrawStyle(drawStyle)
             blendMode = this@ComputedStyle.blendMode
-            return@let it.takeIf { shader != null || style != PaintingStyle.Fill }
+            return@let it.takeIf { shader != null || style != PaintingStyle.Fill || !it.isSrcOver }
         }
     }
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
@@ -35,7 +35,7 @@ internal fun Paint.setBrush(brush: Brush?, size: Size, alpha: Float = Float.NaN)
         brush.applyTo(
             size,
             this,
-            if (alpha.isNaN()) this.alpha else alpha.coerceIn(0f, 1f)
+            if (alpha.isNaN()) 1f else alpha.coerceIn(0f, 1f)
         )
     } else if (brush == null) {
         shader = null

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 
 // Copied from AndroidTextPaint.
 
-internal fun Paint.setBrush(brush: Brush?, size: Size, alpha: Float = Float.NaN) {
+internal fun Paint.applyBrush(brush: Brush?, size: Size, alpha: Float = Float.NaN) {
     // if size is unspecified and brush is not null, nothing should be done.
     // it basically means brush is given but size is not yet calculated at this time.
     if ((brush is SolidColor && brush.value.isSpecified) ||
@@ -42,7 +42,7 @@ internal fun Paint.setBrush(brush: Brush?, size: Size, alpha: Float = Float.NaN)
     }
 }
 
-internal fun Paint.setDrawStyle(drawStyle: DrawStyle?) {
+internal fun Paint.applyDrawStyle(drawStyle: DrawStyle?) {
     when (drawStyle) {
         Fill, null -> {
             // Stroke properties such as strokeWidth, strokeMiter are not re-set because

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.platform
+
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.drawscope.DrawStyle
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+
+// Copied from AndroidTextPaint.
+
+internal fun Paint.setBrush(brush: Brush?, size: Size, alpha: Float = Float.NaN) {
+    // if size is unspecified and brush is not null, nothing should be done.
+    // it basically means brush is given but size is not yet calculated at this time.
+    if ((brush is SolidColor && brush.value.isSpecified) ||
+        (brush is ShaderBrush && size.isSpecified)) {
+        // alpha is always applied even if Float.NaN is passed to applyTo function.
+        // if it's actually Float.NaN, we simply send the current value
+        brush.applyTo(
+            size,
+            this,
+            if (alpha.isNaN()) this.alpha else alpha.coerceIn(0f, 1f)
+        )
+    } else if (brush == null) {
+        shader = null
+    }
+}
+
+internal fun Paint.setDrawStyle(drawStyle: DrawStyle?) {
+    when (drawStyle) {
+        Fill, null -> {
+            // Stroke properties such as strokeWidth, strokeMiter are not re-set because
+            // Fill style should make those properties no-op. Next time the style is set
+            // as Stroke, stroke properties get re-set as well.
+            style = PaintingStyle.Fill
+        }
+        is Stroke -> {
+            style = PaintingStyle.Stroke
+            strokeWidth = drawStyle.width
+            strokeMiterLimit = drawStyle.miter
+            strokeJoin = drawStyle.join
+            strokeCap = drawStyle.cap
+            pathEffect = drawStyle.pathEffect
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Implement paragraph's `drawStyle` and `blendMode` paramenters.

<img width="479" alt="image" src="https://user-images.githubusercontent.com/1836384/229071170-92de8492-06a0-49f6-8d5c-e844685a7294.png">

## Testing

```kt
val textMeasure = rememberTextMeasurer()
Canvas(modifier = Modifier
    .size(400.dp, 100.dp), onDraw = {
    drawRect(color = Green,
        topLeft = Offset(0f, 50.dp.toPx()))
    drawText(
        textMeasurer = textMeasure,
        text = "Text on Canvas",
        style = TextStyle(
            fontSize = 50.sp,
            color = Red
        ),
        topLeft = Offset(20.dp.toPx(), 20.dp.toPx()),
        blendMode = BlendMode.SrcOut
    )
})
Text(
    text = "Hello",
    style = TextStyle(
        fontSize = 200.sp,
        color = Blue,
        drawStyle = Stroke(10f)
    )
)
```

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/2883
