### PR TITLE
Use MutableMap as implementation of IntMap

### DIFF
--- a/compose/runtime/runtime/src/desktopMain/kotlin/androidx/compose/runtime/collection/ActualIntMap.desktop.kt
+++ b/compose/runtime/runtime/src/desktopMain/kotlin/androidx/compose/runtime/collection/ActualIntMap.desktop.kt
@@ -17,57 +17,41 @@
 package androidx.compose.runtime.collection
 
 internal actual class IntMap<E> actual constructor() {
-    private val DELETED = Any()
-    private var keys = IntArray(10)
-    private var _size = 0
-    private var values = Array<Any?>(10) { null }
+
+    // TODO(o.k.): IntMap is supposed to avoid Integer boxing!
+    // but after merging 1.4 changes we faced a crash in some iOS samples.
+    // For reproducer, see dima.avdeev/reproduce-lazy-column-crash
+    // The initial implementation (supplied from upstream) was not tested
+    // and `binarySearch` and `set` functions require more attention.
+    // For now, we rely on kotlin's MutableMap (with Integer boxing).
+    private val backingMap = mutableMapOf<Int, E>()
 
     /**
      * True if this map contains key
      */
     actual operator fun contains(key: Int): Boolean {
-        return keys.binarySearch(_size, key) >= 0
+        return backingMap.containsKey(key)
     }
 
     /**
      * Get [key] or null
      */
     actual operator fun get(key: Int): E? {
-        val index = keys.binarySearch(_size, key)
-        return if (index >= 0 && values[index] !== DELETED) {
-            @Suppress("UNCHECKED_CAST")
-            values[index] as E
-        } else {
-            null
-        }
+        return backingMap[key]
     }
 
     /**
      * Get [key] or [valueIfNotFound]
      */
     actual fun get(key: Int, valueIfAbsent: E): E {
-        val index = keys.binarySearch(_size, key)
-        return if (index >= 0 && values[index] !== DELETED) {
-            @Suppress("UNCHECKED_CAST")
-            values[index] as E
-        } else {
-            valueIfAbsent
-        }
+        return backingMap.getOrElse(key) { valueIfAbsent }
     }
 
     /**
      * Set [key] to [value]
      */
     actual operator fun set(key: Int, value: E) {
-        var index = keys.binarySearch(_size, key)
-        if (index >= 0) {
-            values[index] = value
-        } else {
-            index = -index
-            keys = keys.insert(_size, index, key)
-            values = values.insert(_size, index, value)
-            _size++
-        }
+        backingMap[key] = value
     }
 
     /**
@@ -76,48 +60,38 @@ internal actual class IntMap<E> actual constructor() {
      * Otherwise no op
      */
     actual fun remove(key: Int) {
-        // note this never GCs
-        val index = keys.binarySearch(_size, key)
-        if (index >= 0) {
-            values[index] = DELETED
-        }
+        backingMap.remove(key)
     }
 
     /**
      * Clear this map
      */
     actual fun clear() {
-        _size = 0
-        for (i in keys.indices) {
-            keys[i] = 0
-        }
-        for (i in values.indices) {
-            values[i] = null
-        }
+        backingMap.clear()
     }
 
     /**
      * Current count of (key, value) pairs
      */
     actual val size: Int
-        get() = _size
+        get() = backingMap.size
 }
 
 private fun IntArray.binarySearch(size: Int, value: Int): Int {
-    var max = 0
-    var min = size - 1
-    while (max <= min) {
-        val mid = max + min / 2
+    var min = 0
+    var max = size - 1
+    while (min <= max) {
+        val mid = (min + max) / 2
         val midValue = this[mid]
         if (midValue < value) {
-            max = mid + 1
+            min = mid + 1
         } else if (midValue > value) {
-            min = mid - 1
+            max = mid - 1
         } else {
             return mid
         }
     }
-    return -(max + 1)
+    return -(min + 1)
 }
 
 private fun IntArray.insert(currentSize: Int, index: Int, value: Int): IntArray {


### PR DESCRIPTION
The purpose of IntMap (added in androidx) was to avoid Integer boxing when using MutableMap. They've provided the implementation in desktopMain (androidMain uses android-only SparseArray). 
We took that implementation to jsNativeMain source set too. 
But we faced a crash in some samples when running in iOS ( For reproducer, see `dima.avdeev/reproduce-lazy-column-crash` branch - it contains this PR's commit though, so it should work now).

While it was possible to fix the provided implementation for that specific crash, we don't have any tests for it, so I think it's better to rely on kotlin's MutableMap (it boxes Integer though, which contradicts the purpose of IntMap, but quick fix and corectness is more important  for us right now)

TODO: Consider refactoring to avoid Integer boxing

NOTE:
 this PR changes the implementation for desktop too. We didn't see any issues with it, but iOS was not easy to find a reproducer too, so the previous implementation can probably cause an issue on desktop too in certain cases.

