### PR TITLE
When first packing a window that has a specified size, set the root constraints of the composition to that size

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -111,6 +111,7 @@ private fun Window.setSizeImpl(size: DpSize) {
 
     if (!isDisplayable) {
         // Pack to allow drawing the first frame
+        preferredSize = Dimension(width, height)
         pack()
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -37,16 +37,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.FrameWindowScope
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowPlacement
-import androidx.compose.ui.window.WindowState
-import androidx.compose.ui.window.rememberWindowState
+import androidx.compose.ui.unit.*
+import androidx.compose.ui.window.*
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
@@ -604,4 +598,40 @@ class WindowTest {
         assertEquals(32, window?.height)
     }
 
+    @Test
+    fun `showing a window should measure content specified size`() = runApplicationTest{
+        val constraintsList = mutableListOf<Constraints>()
+        val windowSize = DpSize(400.dp, 300.dp)
+        lateinit var window: ComposeWindow
+
+        launchTestApplication {
+            Window(
+                onCloseRequest = { },
+                state = rememberWindowState(size = windowSize),
+            ) {
+                window = this.window
+                Layout(
+                    measurePolicy = { _, constraints ->
+                        constraintsList.add(constraints)
+                        layout(0, 0){ }
+                    }
+                )
+            }
+        }
+
+        awaitIdle()
+
+        with(window.density) {
+            val expectedSize = (windowSize - window.insets.toSize()).toSize()
+            assertEquals(
+                listOf(
+                    Constraints(
+                        maxWidth = expectedSize.width.toInt(),
+                        maxHeight = expectedSize.height.toInt()
+                    )
+                ),
+                constraintsList
+            )
+        }
+    }
 }


### PR DESCRIPTION
In [Fix window flashing background with unspecified size](https://github.com/JetBrains/compose-multiplatform-core/pull/442) I forgot to set the root constraints to the specified size, if there is one. This caused `pack()` to measure the window's contents with at `Constraints(maxWidth=0, maxHeight=0)`.

## Proposed Changes
Set the root constraints by setting the window's preferred size.

## Testing

Test: Added a new unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2951
