### PR TITLE
UIKit keyboard appearance

### DIFF
--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
@@ -21,6 +21,7 @@ import shared
 struct ContentView: View {
     var body: some View {
         ComposeView()
+                .ignoresSafeArea(.keyboard)
     }
 }
 

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -140,7 +140,6 @@ internal class ComposeLayer(
     }
 
     fun getActiveFocusRect(): DpRect? {
-        // TODO: [1.4 Update] Check that new solution is valid
         val focusRect = scene.mainOwner?.focusOwner?.getFocusRect() ?: return null
         return focusRect.toDpRect(density)
     }


### PR DESCRIPTION
Function getActiveFocusRect() works well.
The problem was with Compose in SwiftUI with changing size of ComposeWindow.
It is a known problem and in other samples we have already made same changes with `.ignoresSafeArea(.keyboard)`

In the future, we should support resizing of ComposeWindow inside SwiftUI.