### PR TITLE
Fix merging styles

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -243,7 +243,7 @@ internal data class ComputedStyle(
 
     fun merge(density: Density, other: SpanStyle) {
         val fontSize = fontSizeInHierarchy(density, fontSize, other.fontSize)
-        textForegroundStyle.merge(other.textForegroundStyle)
+        textForegroundStyle = textForegroundStyle.merge(other.textForegroundStyle)
         other.fontFamily?.let { fontFamily = it }
         this.fontSize = fontSize
         other.fontWeight?.let { fontWeight = it }


### PR DESCRIPTION
## Proposed Changes

Fix regression of #450

`merge` function returns a new object that wasn't properly applied

![image](https://user-images.githubusercontent.com/1836384/229448536-6452fdb1-a394-4ff3-8a8d-3d271faeaae9.png)

## Testing

Case 1: Run Codeviewer example and check if styles applies correctly
Case 2: Run `q, w, space, backspace 4x (Korean, Windows)` test to check if https://github.com/JetBrains/compose-multiplatform/issues/2916 is fixed

