### PR TITLE
Remove Android dependencies from non-Android targets

### DIFF
--- a/compose/ui/ui-tooling-data/build.gradle
+++ b/compose/ui/ui-tooling-data/build.gradle
@@ -73,10 +73,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             commonMain.dependencies {
 
                 implementation(libs.kotlinStdlib)
-
-                api "androidx.annotation:annotation:1.1.0"
-
-                api("androidx.compose.runtime:runtime:1.2.1")
+                api(project(":compose:runtime:runtime"))
                 api(project(":compose:ui:ui"))
             }
             jvmMain.dependencies {


### PR DESCRIPTION
1. We shouldn't depend on `android.annotations`, it is Android-only. The fix is similar to

2. The dependency on the exact Compose Runtime version was added here: https://android-review.googlesource.com/c/platform/frameworks/support/+/2128217

tooling-data is added as a runtime dependency, and in runtime we use the latest compose-runtime, so there is no issue if we define the latest  version for other targets

See https://kotlinlang.slack.com/archives/C01D6HTPATV/p1680269153925549

3. Also reviewed the other artifacts, everything is correct there