### PR TITLE
Apply the user's modifier after the padding modifier for `AlertDialog`.

### DIFF
--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -269,7 +269,7 @@ fun AlertDialog(
         AlertDialog(
             onDismissRequest = onDismissRequest,
             shape = shape,
-            modifier = modifier.padding(dialogPadding),
+            modifier = Modifier.padding(dialogPadding).then(modifier),
         ) { modifier ->
             AlertDialogContent(
                 buttons = buttons,

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopAlertDialogTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.material
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.internal.keyEvent
@@ -39,16 +40,9 @@ import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.renderComposeScene
-import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performKeyPress
-import androidx.compose.ui.test.runDesktopComposeUiTest
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.*
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -153,7 +147,7 @@ class DesktopAlertDialogTest {
 
     @OptIn(ExperimentalTestApi::class, ExperimentalMaterialApi::class)
     @Test
-    fun `alert dialog uses available width`() = runDesktopComposeUiTest(
+    fun `uses available width`() = runDesktopComposeUiTest(
         width = 800,
         height = 800
     ){
@@ -186,6 +180,33 @@ class DesktopAlertDialogTest {
         }
 
         onNodeWithTag("text_content").assertWidthIsEqualTo(200.dp)
+    }
+
+    @Test
+    fun `applies modifier inside padding`() {
+        val dialogSize = DpSize(200.dp, 200.dp)
+
+        rule.setContent {
+            @OptIn(ExperimentalMaterialApi::class)
+            AlertDialog(
+                onDismissRequest = { },
+                title = { Text("Title") },
+                text = { Text("Text") },
+                buttons = {
+                    Box(Modifier.testTag("buttons"))
+                },
+                modifier = Modifier.size(dialogSize),
+                dialogPadding = PaddingValues(50.dp)
+            )
+        }
+
+
+        // We don't have direct access to the node holding the dialog contents, so we're forced to
+        // assume that the parent of the buttons is that node
+        with(rule.onNodeWithTag("buttons").onParent()){
+            assertWidthIsEqualTo(dialogSize.width)
+            assertHeightIsEqualTo(dialogSize.height)
+        }
     }
 
     private fun calculateCenterPosition(rootSize: IntSize, childSize: IntSize): Offset {


### PR DESCRIPTION
## Proposed Changes

Apply the modifier provided by the user after the modifier that applies the `AlertDialog` padding. For example, if the user specified a `border`, it should be inside the padding.

## Testing

Test: Added a new unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2959
