### PR TITLE
Add workaround if layout result is invalid

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -179,25 +179,17 @@ internal class SkiaParagraph(
     }
 
     override fun getLineHeight(lineIndex: Int) =
-        if (lineIndex !in lineMetrics.indices) {
-            0f
-        } else lineMetrics[lineIndex].height.toFloat()
+        lineMetrics.getOrNull(lineIndex)?.height?.toFloat() ?: 0f
 
     override fun getLineWidth(lineIndex: Int) =
-        if (lineIndex !in lineMetrics.indices) {
-            0f
-        } else lineMetrics[lineIndex].width.toFloat()
+        lineMetrics.getOrNull(lineIndex)?.width?.toFloat() ?: 0f
 
     override fun getLineStart(lineIndex: Int) =
-        if (lineIndex !in lineMetrics.indices) {
-            0
-        } else lineMetrics[lineIndex].startIndex
+        lineMetrics.getOrNull(lineIndex)?.startIndex ?: 0
 
-    override fun getLineEnd(lineIndex: Int, visibleEnd: Boolean) =
-        if (lineIndex !in lineMetrics.indices) {
-            0
-        } else if (visibleEnd) {
-            val metrics = lineMetrics[lineIndex]
+    override fun getLineEnd(lineIndex: Int, visibleEnd: Boolean): Int {
+        val metrics = lineMetrics.getOrNull(lineIndex) ?: return 0
+        return if (visibleEnd) {
             // workarounds for https://bugs.chromium.org/p/skia/issues/detail?id=11321 :(
             // we are waiting for fixes
             if (lineIndex > 0 && metrics.startIndex < lineMetrics[lineIndex - 1].endIndex) {
@@ -211,8 +203,9 @@ internal class SkiaParagraph(
                 metrics.endExcludingWhitespaces
             }
         } else {
-            lineMetrics[lineIndex].endIndex
+            metrics.endIndex
         }
+    }
 
     override fun isLineEllipsized(lineIndex: Int) = false
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -88,10 +88,11 @@ internal class SkiaParagraph(
 
     override val lineCount: Int
         // workaround for https://bugs.chromium.org/p/skia/issues/detail?id=11321
-        get() = if (text == "") {
+        // workaround for invalid paragraph layout result
+        get() = if (text == "" || paragraph.lineNumber < 1) {
             1
         } else {
-            paragraph.lineNumber.toInt()
+            paragraph.lineNumber
         }
 
     override val placeholderRects: List<Rect?>
@@ -177,29 +178,40 @@ internal class SkiaParagraph(
         return metrics.last()
     }
 
-    override fun getLineHeight(lineIndex: Int) = lineMetrics[lineIndex].height.toFloat()
+    override fun getLineHeight(lineIndex: Int) =
+        if (lineIndex !in lineMetrics.indices) {
+            0f
+        } else lineMetrics[lineIndex].height.toFloat()
 
-    override fun getLineWidth(lineIndex: Int) = lineMetrics[lineIndex].width.toFloat()
+    override fun getLineWidth(lineIndex: Int) =
+        if (lineIndex !in lineMetrics.indices) {
+            0f
+        } else lineMetrics[lineIndex].width.toFloat()
 
-    override fun getLineStart(lineIndex: Int) = lineMetrics[lineIndex].startIndex.toInt()
+    override fun getLineStart(lineIndex: Int) =
+        if (lineIndex !in lineMetrics.indices) {
+            0
+        } else lineMetrics[lineIndex].startIndex
 
     override fun getLineEnd(lineIndex: Int, visibleEnd: Boolean) =
-        if (visibleEnd) {
+        if (lineIndex !in lineMetrics.indices) {
+            0
+        } else if (visibleEnd) {
             val metrics = lineMetrics[lineIndex]
             // workarounds for https://bugs.chromium.org/p/skia/issues/detail?id=11321 :(
             // we are waiting for fixes
             if (lineIndex > 0 && metrics.startIndex < lineMetrics[lineIndex - 1].endIndex) {
-                metrics.endIndex.toInt()
+                metrics.endIndex
             } else if (
                 metrics.startIndex < text.length &&
-                text[metrics.startIndex.toInt()] == '\n'
+                text[metrics.startIndex] == '\n'
             ) {
-                metrics.startIndex.toInt()
+                metrics.startIndex
             } else {
-                metrics.endExcludingWhitespaces.toInt()
+                metrics.endExcludingWhitespaces
             }
         } else {
-            lineMetrics[lineIndex].endIndex.toInt()
+            lineMetrics[lineIndex].endIndex
         }
 
     override fun isLineEllipsized(lineIndex: Int) = false


### PR DESCRIPTION
## Proposed Changes

Add extra checks to avoid crash in case of layout result. The root problem will be fixed later.

## Testing

```kt
fun main() = singleWindowApplication {
    SelectionContainer {
        Text(
            text = buildAnnotatedString {
                append("🦊")
                addStyle(SpanStyle(Color.Red), 1, 2)
            }
        )
    }
}
```