### PR TITLE
Adopt compositing strategy on graphicsLayer

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
@@ -52,9 +52,12 @@ fun org.jetbrains.skia.Canvas.asComposeCanvas(): Canvas = SkiaBackedCanvas(this)
 
 actual val Canvas.nativeCanvas: NativeCanvas get() = (this as SkiaBackedCanvas).skia
 
-class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
+var Canvas.alphaMultiplier: Float
+    get() = (this as SkiaBackedCanvas).alphaMultiplier
+    set(value) { (this as SkiaBackedCanvas).alphaMultiplier = value }
 
-    var alphaMultiplier: Float = 1.0f
+internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
+    internal var alphaMultiplier: Float = 1.0f
 
     private val Paint.skia get() = (this as SkiaBackedPaint).apply {
         this.alphaMultiplier = this@SkiaBackedCanvas.alphaMultiplier

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
@@ -35,7 +35,6 @@ internal class SkiaBackedPaint(
     override fun asFrameworkPaint(): NativePaint = skia
 
     private var mAlphaMultiplier = 1.0f
-    private var mColor: Color = Color.Black
 
     var alphaMultiplier: Float
         get() = mAlphaMultiplier
@@ -46,13 +45,12 @@ internal class SkiaBackedPaint(
         }
 
     private fun updateAlpha(alpha: Float = this.alpha, multiplier: Float = this.mAlphaMultiplier) {
-        skia.color = mColor.copy(alpha = alpha * multiplier).toArgb()
+        skia.color = Color(skia.color).copy(alpha = alpha * multiplier).toArgb()
     }
 
     override var alpha: Float
-        get() = mColor.alpha
+        get() = Color(skia.color).alpha
         set(value) {
-            mColor = mColor.copy(alpha = value)
             updateAlpha(alpha = value)
         }
 
@@ -63,9 +61,8 @@ internal class SkiaBackedPaint(
         }
 
     override var color: Color
-        get() = mColor
+        get() = Color(skia.color)
         set(color) {
-            mColor = color
             skia.color = color.toArgb()
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
@@ -254,11 +254,10 @@ internal class SkiaLayer(
             } else {
                 canvas.save()
             }
-            val skiaCanvas = canvas as SkiaBackedCanvas
-            if (compositingStrategy == CompositingStrategy.ModulateAlpha) {
-                skiaCanvas.alphaMultiplier = alpha
+            canvas.alphaMultiplier = if (compositingStrategy == CompositingStrategy.ModulateAlpha) {
+                alpha
             } else {
-                skiaCanvas.alphaMultiplier = 1.0f
+                1.0f
             }
 
             drawBlock(canvas)


### PR DESCRIPTION
## Proposed Changes

- Revert visibility of `SkiaBackedCanvas`
- Use native color as source of truth

Original change: https://github.com/androidx/androidx/commit/06fdca89b9f3134ef035f2f349115209140193a0
Docs: https://developer.android.com/jetpack/compose/graphics/draw/modifiers#compositing-strategy

## Testing

- Run code from https://developer.android.com/jetpack/compose/graphics/draw/modifiers#modulatealpha

<img width="240" alt="image" src="https://user-images.githubusercontent.com/1836384/229750535-1428acac-9496-4169-b236-609dfd87e385.png">

