### PR TITLE
Fix UseComposeUiTest

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/ComposeUiTest.desktop.kt
+++ b/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/ComposeUiTest.desktop.kt
@@ -25,18 +25,18 @@ typealias DesktopComposeUiTest = SkikoComposeUiTest
 /**
  * Variant of [runComposeUiTest] that allows you to specify the size of the surface.
  *
- * @param effectContext The [CoroutineContext] used to run the composition. The context for
- * `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context.
  * @param width the desired width of the surface
  * @param height the desired height of the surface
+ * @param effectContext The [CoroutineContext] used to run the composition. The context for
+ * `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context.
  */
 @ExperimentalTestApi
 fun runDesktopComposeUiTest(
-    // TODO: [1.4 Update] take effectContext into account
-    effectContext: CoroutineContext = EmptyCoroutineContext,
     width: Int = 1024,
     height: Int = 768,
+    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
+    effectContext: CoroutineContext = EmptyCoroutineContext,
     block: DesktopComposeUiTest.() -> Unit
 ) {
-    DesktopComposeUiTest(effectContext, width, height).runTest(block)
+    DesktopComposeUiTest(width, height, effectContext).runTest(block)
 }

--- a/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopComposeTestRule.desktop.kt
+++ b/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopComposeTestRule.desktop.kt
@@ -55,7 +55,7 @@ class DesktopComposeTestRule private constructor(
     @ExperimentalTestApi
     constructor(
         effectContext: CoroutineContext = EmptyCoroutineContext
-    ) : this(DesktopComposeUiTest(effectContext))
+    ) : this(DesktopComposeUiTest(effectContext = effectContext))
 
     var scene: ComposeScene
         get() = composeTest.scene

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -49,19 +49,21 @@ import org.jetbrains.skiko.currentNanoTime
 
 @ExperimentalTestApi
 actual fun runComposeUiTest(effectContext: CoroutineContext, block: ComposeUiTest.() -> Unit) {
-    // TODO: [1.4 Update] take effectContext into account
-    SkikoComposeUiTest().runTest(block)
+    SkikoComposeUiTest(effectContext = effectContext).runTest(block)
 }
 
 @ExperimentalTestApi
 fun runSkikoComposeUiTest(
     size: Size = Size(1024.0f, 768.0f),
     density: Density = Density(1f),
+    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
+    effectContext: CoroutineContext = EmptyCoroutineContext,
     block: SkikoComposeUiTest.() -> Unit
 ) {
     SkikoComposeUiTest(
         width = size.width.roundToInt(),
         height = size.height.roundToInt(),
+        effectContext = effectContext,
         density = density
     ).runTest(block)
 }
@@ -73,12 +75,18 @@ fun runSkikoComposeUiTest(
 @ExperimentalTestApi
 @OptIn(ExperimentalCoroutinesApi::class, InternalTestApi::class)
 class SkikoComposeUiTest(
-    // TODO: [1.4 Update] take effectContext into account
-    effectContext: CoroutineContext = EmptyCoroutineContext,
     width: Int = 1024,
     height: Int = 768,
+    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
+    effectContext: CoroutineContext = EmptyCoroutineContext,
     override val density: Density = Density(1f)
 ) : ComposeUiTest {
+    init {
+        require(effectContext == EmptyCoroutineContext) {
+            "The argument effectContext isn't supported yet. " +
+                "Follow https://github.com/JetBrains/compose-multiplatform/issues/2960"
+        }
+    }
 
     private val textInputService = object : PlatformTextInputService {
         var onEditCommand: ((List<EditCommand>) -> Unit)? = null


### PR DESCRIPTION
Also throw an exception if a user sets effectContext.

We will support `effectContext` in https://github.com/JetBrains/compose-multiplatform/issues/2960