### PR TITLE
TapGestureDetector.skiko.kt remove TODO comments

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/TapGesturesDetector.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/TapGesturesDetector.skiko.kt
@@ -94,8 +94,6 @@ suspend fun PointerInputScope.detectTapGestures(
 
     while (currentCoroutineContext().isActive) {
         awaitPointerEventScope {
-            // TODO: [1.4 Update] seems that launch may introduce races?
-            //  TapGestureDetectorKt.detectTapGestures also use it
             launch { pressScope.reset() }
 
             val down = awaitPress(filter = filter, requireUnconsumed = true).apply { changes[0].consume() }
@@ -146,8 +144,6 @@ suspend fun PointerInputScope.detectTapGestures(
                 if (secondPress == null) {
                     onTap?.invoke(firstRelease.changes[0].position)
                 } else {
-                    // TODO: [1.4 Update] seems that launch may introduce races?
-                    //  TapGestureDetectorKt.detectTapGestures also use it
                     launch { pressScope.reset() }
                     launch { pressScope.onPress(secondPress.changes[0].position) }
 


### PR DESCRIPTION
Using launch { pressScope.reset() } is fine.

We already have the same in commonMain code:
https://github.com/JetBrains/compose-multiplatform-core/blob/64da351ee806cdd8b9522043319bef9ddb3da75b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt#L106


Also, ComposeScene created with Dispatchers.Unconfined 
https://github.com/JetBrains/compose-multiplatform-core/blob/6ba06f4a452ac6870b0e4840013643ac2bb5fa9f/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt#L94
It means that it will launch{} coroutine immediately in the same thread before the first suspension point. (https://kotlinlang.org/docs/coroutine-context-and-dispatchers.html#unconfined-vs-confined-dispatcher)
So, `pressScope.reset()` inside launch will always be called before next launch{} calls