### PR TITLE
Stop scrolling if scroll changed for a small value

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/ContentInViewModifier.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/ContentInViewModifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,15 +33,7 @@ import androidx.compose.ui.layout.OnRemeasuredModifier
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toSize
 import kotlin.math.abs
-import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.*
 
 /**
  * Static field to turn on a bunch of verbose logging to debug animations. Since this is a constant,
@@ -210,7 +202,9 @@ internal class ContentInViewModifier(
                             )
                             val consumedScroll = scrollMultiplier * scrollBy(adjustedDelta)
                             if (DEBUG) println("[$TAG] Consumed $consumedScroll of scroll")
-                            if (consumedScroll < delta) {
+                            // consumedScroll check changed in JetBrains Fork
+                            // keep it during merge if it is not upstreamed
+                            if (abs(consumedScroll) < abs(delta)) {
                                 // If the scroll state didn't consume all the scroll on this frame,
                                 // it probably won't consume any more later either (we might have
                                 // hit the scroll bounds). This is a terminal condition for the
@@ -220,7 +214,7 @@ internal class ContentInViewModifier(
                                 // TODO(b/239671493) Should this trigger nested scrolling?
                                 animationJob.cancel(
                                     "Scroll animation cancelled because scroll was not consumed " +
-                                        "($consumedScroll < $delta)"
+                                        "(${abs(consumedScroll)} < ${abs(delta)})"
                                 )
                             }
                         },

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -828,8 +828,6 @@ class ScrollbarTest {
         }
     }
 
-    // TODO: [1.4 Update] test hangs on waitForIdle after 1.4 merge
-    @Ignore
     @Test
     @OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
     fun `basic text field with vertical scrolling test`() {


### PR DESCRIPTION
## Proposed Changes

  - Check that scroll changed only for a small value and stop scrolling

Before 7e77bb541331ce0d62cabad732e43eca41ac978a scroll used simple animation and hasn't taken result of scrollBy into account. After the androidx commit, implementation recalculates scrollDelta each frame.

In tests with TextField sometimes calculateScrollDelta returns non-zero result. But it worked this way before the mentioned commit as well.

## Testing

Test: run non-ignored `basic text field with vertical scrolling test`

## Issues Fixed

No issues related to this PR
