### PR TITLE
Ignore failing `navigate DropDownMenu using arrows` test

### DIFF
--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.runners.JUnit4
 import org.junit.runner.RunWith
@@ -120,6 +121,7 @@ class DesktopMenuTest {
         }
     }
 
+    @Ignore // TODO: remove ignore when changes from http://r.android.com/2520700 will be merged
     @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `navigate DropDownMenu using arrows`() {


### PR DESCRIPTION
## Proposed Changes

  - ignore `navigate DropDownMenu using arrows` test until it will be fixed in androidx

## Testing

Test: run this test, it should be ignored

## Issues Fixed

No issues related to the PR
