### PR TITLE
Fix ComposeLayer.jsNative.kt pointer events handling for web and macos: they don't support multitouch for now

### DIFF
--- a/compose/mpp/demo/gradle.properties
+++ b/compose/mpp/demo/gradle.properties
@@ -2,3 +2,4 @@
 kotlin.native.binary.memoryModel=experimental
 # Caching plays bad with skiko libraries
 kotlin.native.cacheKind=none
+kotlin.incremental.js.ir=false

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/native/Actuals.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/native/Actuals.js.kt
@@ -20,3 +20,4 @@ import kotlinx.coroutines.CoroutineDispatcher
 
 internal actual fun getMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
 
+internal actual val supportsMultitouch: Boolean get() = false

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/native/Actuals.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/native/Actuals.macos.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.native
+
+internal actual val supportsMultitouch: Boolean get() = false

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/native/Actuals.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/native/Actuals.uikit.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.native
+
+internal actual val supportsMultitouch: Boolean get() = true


### PR DESCRIPTION
This is rather a workaround. 

The issue:
W/o this change, clicks don't work in web and macos. (can be tested in demo:mpp)
Reported in slack: https://kotlinlang.slack.com/archives/C01F2HV7868/p1680666718902669

web and macos don't support multitouch for now, so we can use the old sendPointerEvent method that doesn't take pointers.