### PR TITLE
Fix focus search issue

### DIFF
--- a/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/focus/OneDimensionalFocusSearchPreviousTest.kt
+++ b/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/focus/OneDimensionalFocusSearchPreviousTest.kt
@@ -275,6 +275,72 @@ class OneDimensionalFocusSearchPreviousTest {
     }
 
     @Test
+    fun focusMovesToParent() {
+        // Arrange.
+        val (parent, child1, child2, child3) = List(4) { mutableStateOf(false) }
+        rule.setContentForTest {
+            FocusableBox(parent, 0, 0, 10, 10) {
+                FocusableBox(child1, 10, 0, 10, 10, initialFocus)
+                FocusableBox(child2, 20, 0, 10, 10)
+                FocusableBox(child3, 20, 0, 10, 10)
+            }
+        }
+
+        // Act.
+        val movedFocusSuccessfully = rule.runOnIdle { focusManager.moveFocus(Previous) }
+
+        // Assert.
+        rule.runOnIdle {
+            assertThat(movedFocusSuccessfully).isTrue()
+            assertThat(parent.value).isTrue()
+        }
+    }
+
+    @Test
+    fun focusMovesToParent_ignoresDeactivated() {
+        // Arrange.
+        val (item, parent, child1, child2) = List(4) { mutableStateOf(false) }
+        rule.setContentForTest {
+            FocusableBox(item, 0, 0, 10, 10)
+            FocusableBox(parent, 0, 0, 10, 10, deactivated = true) {
+                FocusableBox(child1, 10, 0, 10, 10, initialFocus)
+                FocusableBox(child2, 20, 0, 10, 10)
+            }
+        }
+
+        // Act.
+        val movedFocusSuccessfully = rule.runOnIdle { focusManager.moveFocus(Previous) }
+
+        // Assert.
+        rule.runOnIdle {
+            assertThat(movedFocusSuccessfully).isTrue()
+            assertThat(item.value).isTrue()
+        }
+    }
+
+    @Test
+    fun focusMovesToParent_ignoresDeactivated_andWrapsAround() {
+        // Arrange.
+        val (parent, child1, child2, child3) = List(4) { mutableStateOf(false) }
+        rule.setContentForTest {
+            FocusableBox(parent, 0, 0, 10, 10, deactivated = true) {
+                FocusableBox(child1, 10, 0, 10, 10, initialFocus)
+                FocusableBox(child2, 20, 0, 10, 10)
+                FocusableBox(child3, 0, 0, 10, 10)
+            }
+        }
+
+        // Act.
+        val movedFocusSuccessfully = rule.runOnIdle { focusManager.moveFocus(Previous) }
+
+        // Assert.
+        rule.runOnIdle {
+            assertThat(movedFocusSuccessfully).isTrue()
+            assertThat(child3.value).isTrue()
+        }
+    }
+
+    @Test
     fun focusWrapsAroundToLastItem() {
         // Arrange.
         val (item1, item2, item3) = List(3) { mutableStateOf(false) }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/OneDimensionalFocusSearch.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/OneDimensionalFocusSearch.kt
@@ -71,10 +71,9 @@ private fun FocusTargetModifierNode.backwardFocusSearch(
 
         // Unlike forwardFocusSearch, backwardFocusSearch visits the children before the parent.
         when (focusedChild.focusStateImpl) {
-            ActiveParent ->
-                focusedChild.backwardFocusSearch(onFound) ||
+            ActiveParent -> focusedChild.backwardFocusSearch(onFound) ||
                 generateAndSearchChildren(focusedChild, Previous, onFound) ||
-                (fetchFocusProperties().canFocus && onFound.invoke(focusedChild))
+                (focusedChild.fetchFocusProperties().canFocus && onFound.invoke(focusedChild))
 
             // Since this item "is focused", it means we already visited all its children.
             // So just search among its siblings.


### PR DESCRIPTION
Fix a bug in 2D focus search, where we use the parent's canFocus property instead of the child's property.

cherry-pick of http://r.android.com/2520700
