### PR TITLE
Set InputMode.Touch for iOS as default

### DIFF
--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -16,12 +16,21 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Checkbox
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.ComposeUIViewController
 
 // TODO This module is just a proxy to run the demo from mpp:demo. Figure out how to get rid of it.
 //  If it is removed, there is no available configuration in IDE
 fun getViewControllerWithCompose() = ComposeUIViewController {
-    val app = remember() { App() }
-    app.Content()
+    Column {
+        var checked1 by remember { mutableStateOf(false) }
+        Checkbox(checked1, { checked1 = it })
+        var checked2 by remember { mutableStateOf(false) }
+        Checkbox(checked2, { checked2 = it })
+    }
 }

--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -16,21 +16,12 @@
 
 package androidx.compose.mpp.demo
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Checkbox
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.window.ComposeUIViewController
 
 // TODO This module is just a proxy to run the demo from mpp:demo. Figure out how to get rid of it.
 //  If it is removed, there is no available configuration in IDE
 fun getViewControllerWithCompose() = ComposeUIViewController {
-    Column {
-        var checked1 by remember { mutableStateOf(false) }
-        Checkbox(checked1, { checked1 = it })
-        var checked2 by remember { mutableStateOf(false) }
-        Checkbox(checked2, { checked2 = it })
-    }
+    val app = remember() { App() }
+    app.Content()
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
@@ -19,6 +19,9 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.input.InputModeManagerImpl
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -33,6 +36,7 @@ import androidx.compose.ui.unit.LayoutDirection
 internal interface Platform {
     val windowInfo: WindowInfo
     val focusManager: FocusManager
+    val inputModeManager: InputModeManager
     val layoutDirection: LayoutDirection
         get() = LayoutDirection.Ltr
 
@@ -53,6 +57,7 @@ internal interface Platform {
                 isWindowFocused = true
             }
 
+            override val inputModeManager = DefaultInputModeManager()
             override val focusManager = EmptyFocusManager
 
             override fun requestFocusForOwner() = false
@@ -97,6 +102,26 @@ internal interface Platform {
             }
         }
     }
+}
+
+internal fun DefaultInputModeManager(
+    initialInputMode: InputMode = InputMode.Keyboard
+) : InputModeManager {
+    lateinit var inputModeManager: InputModeManagerImpl
+
+    inputModeManager = InputModeManagerImpl(
+        initialInputMode = initialInputMode,
+        onRequestInputModeChange = {
+            if (it == InputMode.Touch || it == InputMode.Keyboard) {
+                inputModeManager.inputMode = it
+                true
+            } else {
+                false
+            }
+        }
+    )
+
+    return inputModeManager
 }
 
 internal object EmptyFocusManager : FocusManager {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -110,25 +110,8 @@ internal class SkiaBasedOwner(
         layoutDirection = platform.layoutDirection
     }
 
-    // TODO: Set the input mode. For now we don't support touch mode, (always in Key mode).
-    private val _inputModeManager = InputModeManagerImpl(
-        initialInputMode = Keyboard,
-        onRequestInputModeChange = {
-            if (it == Touch || it == Keyboard) {
-                setInputMode(it)
-                true
-            } else {
-                false
-            }
-        }
-    )
-
-    private fun setInputMode(inputMode: InputMode) {
-        _inputModeManager.inputMode = inputMode
-    }
-
     override val inputModeManager: InputModeManager
-        get() = _inputModeManager
+        get() = platform.inputModeManager
 
     override val modifierLocalManager: ModifierLocalManager = ModifierLocalManager(this)
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -21,13 +21,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.createSkiaLayer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.interop.LocalLayerContainer
 import androidx.compose.ui.native.ComposeLayer
+import androidx.compose.ui.platform.*
+import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.Platform
-import androidx.compose.ui.platform.TextToolbar
-import androidx.compose.ui.platform.TextToolbarStatus
 import androidx.compose.ui.platform.UIKitTextInputService
-import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
@@ -237,6 +237,8 @@ internal actual class ComposeWindow : UIViewController {
                     else
                         TextToolbarStatus.Hidden
             }
+
+            override val inputModeManager = DefaultInputModeManager(InputMode.Touch)
         }
         layer = ComposeLayer(
             layer = skiaLayer,


### PR DESCRIPTION
Fixes this bug:

https://user-images.githubusercontent.com/5963351/230464184-62d2cfab-ed56-45c0-98de-eca842a972b9.mov

The widget receives the focus on click and if it is Keyboard, shows an indication. On desktop we see it only when we switch the focus with Tab