### PR TITLE
Reproduce RoundedCornerCrashOnJS

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
@@ -16,20 +16,23 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun RoundedCornerCrashOnJS() {
-    Surface(
-        modifier = Modifier.size(100.dp),
-        shape = RoundedCornerShape(0.dp, 9.dp, 9.dp, 9.dp),
-        elevation = 1.dp,
+    Box(
+        modifier = Modifier
+            .size(100.dp)
+            .graphicsLayer {
+                shadowElevation = 5.dp.toPx()
+                shape = RoundedCornerShape(0.dp, 9.dp, 9.dp, 9.dp)
+            }
     ) {
-
     }
 }

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun RoundedCornerCrashOnJS() {
     // Crash happens in ShadowUtils.drawShadow(
+    // Related issue https://github.com/JetBrains/compose-multiplatform/issues/3013
     Box(
         modifier = Modifier
             .size(100.dp)

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun RoundedCornerCrashOnJS() {
+    // Crash happens in ShadowUtils.drawShadow(
     Box(
         modifier = Modifier
             .size(100.dp)

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/RoundedCornerCrashOnJS.kt
@@ -18,17 +18,17 @@ package androidx.compose.mpp.demo
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
+import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun RoundedCornerCrashOnJS() {
-    Button(
+    Surface(
         modifier = Modifier.size(100.dp),
         shape = RoundedCornerShape(0.dp, 9.dp, 9.dp, 9.dp),
-        onClick = { }
+        elevation = 1.dp,
     ) {
 
     }


### PR DESCRIPTION
Reproduce crash on JS with shadow and RoundedCornerShape and shadowElevation
Related issue: https://github.com/JetBrains/compose-multiplatform/issues/3013

Crash happens inside skiko ShadowUtil.drawShadow()
https://github.com/JetBrains/compose-multiplatform-core/blob/edc2b2fe7bea9c8c8f58ca2be96bb56080552fab/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt#L302