### PR TITLE
Fix scrollbar not working in the presence of sticky headers in LazyList.

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.MouseInjectionScope
-import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -757,7 +756,7 @@ class ScrollbarTest {
     }
 
     @Test
-    fun `basic lazy grid scrollbar test`() {
+    fun `basic lazy grid test`() {
         rule.setContent {
             LazyGridTestBox(
                 // 3x20 grid, each item is 30x20 dp
@@ -1077,6 +1076,37 @@ class ScrollbarTest {
 
         rule.testLazyContentWithLineSpacing("box0", "box17")
     }
+
+    @OptIn(ExperimentalFoundationApi::class)
+    @Test
+    fun `basic lazy list with sticky headers test`() {
+        rule.setContent {
+            LazyListTestBox(
+                size = 200.dp,
+                scrollbarWidth = 10.dp
+            ) {
+                stickyHeader {
+                    Box(Modifier.size(50.dp).testTag("header1"))
+                }
+                items(10) {
+                    Box(Modifier.size(20.dp).testTag("box$it"))
+                }
+                stickyHeader {
+                    Box(Modifier.size(50.dp).testTag("header2"))
+                }
+                items(10) {
+                    Box(Modifier.size(20.dp).testTag("box${10+it}"))
+                }
+            }
+        }
+
+        // Drag the scrollbar to the bottom and test the position of the last item
+        rule.onNodeWithTag("scrollbar").performMouseInput {
+            instantDrag(start = Offset(0f, 0f), end = Offset(0f, 120f))
+        }
+        rule.onNodeWithTag("box19").assertTopPositionInRootIsEqualTo(180.dp)
+    }
+
 
     @OptIn(InternalTestApi::class, ExperimentalComposeUiApi::class)
     private fun ComposeTestRule.performMouseScroll(x: Int, y: Int, delta: Float) {


### PR DESCRIPTION
## Proposed Changes

Part of the big scrollbar fix-set we moved away from using `LazyListState.firstVisibleItemIndex` and `LazyListState.firstVisibleItemScrollOffset` to `LazyListState.layoutInfo.visibleItemsInfo` because the former don't provide sensible values in the presence of top content padding.

Unfortunately, when the list contains sticky headers (and one is actually stickied) `visibleItemsInfo[0]` refers to the stickied header, even when the scroll position is very far from its "natural" position. This breaks our implementation.

This PR partially works around the problem by detecting and ignoring the stickied header. It's not a robust solution (e.g. it doesn't work when the stickied header covers the entire list; possibly in other cases as well). In the future, we should work with Google to add an `LazyListState` API that will allow us to estimate the scroll position.

## Testing

Test: Added a unit test.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2940
