### PR TITLE
Make one pixel beyond the scrollbar thumb react correctly to clicks

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -346,7 +346,7 @@ class ScrollbarTest {
                 assertEquals(0, scrollState.value)
             },
             assertDraggedBy = { pixelAmount ->
-                assertEquals((4*pixelAmount).toInt(), scrollState.value)
+                assertEquals((4 * pixelAmount).toInt(), scrollState.value)
             },
             assertPageDown = {
                 assertEquals(200, scrollState.value)
@@ -774,7 +774,7 @@ class ScrollbarTest {
                 rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
             },
             assertDraggedBy = { pixelAmount ->
-                rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo((-2*pixelAmount).dp)
+                rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo((-2 * pixelAmount).dp)
             },
             assertPageDown = {
                 rule.onNodeWithTag("box30").assertTopPositionInRootIsEqualTo(0.dp)
@@ -1031,7 +1031,7 @@ class ScrollbarTest {
                 onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo(0.dp)
             },
             assertDraggedBy = { pixelAmount ->
-                onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo((-2*pixelAmount).dp)
+                onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo((-2 * pixelAmount).dp)
             },
             assertPageDown = {
                 onNodeWithTag(lastBoxTag).assertTopPositionInRootIsEqualTo(80.dp)
@@ -1144,7 +1144,8 @@ class ScrollbarTest {
                 rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
             },
             assertDraggedBy = { pixelAmount ->
-                rule.onNodeWithTag("box5").assertTopPositionInRootIsEqualTo((100-pixelAmount*2).dp)
+                rule.onNodeWithTag("box5")
+                    .assertTopPositionInRootIsEqualTo((100 - pixelAmount * 2).dp)
             },
             assertPageDown = {
                 rule.onNodeWithTag("box5").assertTopPositionInRootIsEqualTo(0.dp)
@@ -1184,7 +1185,7 @@ class ScrollbarTest {
             },
             assertDraggedBy = { pixelAmount ->
                 rule.onNodeWithTag("box1_0")
-                    .assertTopPositionInRootIsEqualTo((20 - 2*pixelAmount).dp)
+                    .assertTopPositionInRootIsEqualTo((20 - 2 * pixelAmount).dp)
             },
             assertPageDown = {
                 rule.onNodeWithTag("box2_0").assertTopPositionInRootIsEqualTo(20.dp)

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -339,21 +339,19 @@ class ScrollbarTest {
             )
         }
 
-        // Thumb should be half the height of the scrollbar, as the viewport (200.dp) is half
-        // the height of the content (400.dp). So clicking on the top half of the scrollbar
-        // should do nothing.
-        for (offset in 1..50) {
-            rule.onNodeWithTag("scrollbar").performMouseInput {
-                click(position = Offset(0f, offset.toFloat()))
+        rule.testVerticalThumbEnd(
+            lastPixelPosition = Offset(0f, 49f),
+            dragAmount = 10f,
+            assertNotMoved = {
+                assertEquals(0, scrollState.value)
+            },
+            assertDraggedBy = { pixelAmount ->
+                assertEquals((4*pixelAmount).toInt(), scrollState.value)
+            },
+            assertPageDown = {
+                assertEquals(200, scrollState.value)
             }
-            assertEquals(0, scrollState.value)
-        }
-
-        // Clicking one pixel below the thumb should scroll the content by one viewport
-        rule.onNodeWithTag("scrollbar").performMouseInput {
-            click(position = Offset(0f, 51f))
-        }
-        assertEquals(200, scrollState.value)
+        )
     }
 
     // See https://github.com/JetBrains/compose-jb/issues/2640
@@ -769,19 +767,19 @@ class ScrollbarTest {
 
         rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
 
-        // Test the size of the scrollbar thumb by trying to drag by one pixel below where it
-        // should end
-        rule.onNodeWithTag("scrollbar").performMouseInput {
-            instantDrag(start = Offset(0f, 100f), end = Offset(0f, 200f))
-        }
-        rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
-
-        // Test the size of the scrollbar thumb by trying to drag by its bottommost pixel
-        // This also tests the proportionality of the scrolling
-        rule.onNodeWithTag("scrollbar").performMouseInput {
-            instantDrag(start = Offset(0f, 99f), end = Offset(0f, 104f))
-        }
-        rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo((-10).dp)
+        rule.testVerticalThumbEnd(
+            lastPixelPosition = Offset(0f, 99f),
+            dragAmount = 5f,
+            assertNotMoved = {
+                rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
+            },
+            assertDraggedBy = { pixelAmount ->
+                rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo((-2*pixelAmount).dp)
+            },
+            assertPageDown = {
+                rule.onNodeWithTag("box30").assertTopPositionInRootIsEqualTo(0.dp)
+            }
+        )
 
         // Drag the scrollbar to the bottom and test the position of the last item
         rule.onNodeWithTag("scrollbar").performMouseInput {
@@ -1026,21 +1024,23 @@ class ScrollbarTest {
     ){
         // Test the size of the scrollbar thumb by trying to drag by one pixel below where it
         // should end
-        onNodeWithTag("scrollbar").performMouseInput {
-            instantDrag(start = Offset(0f, 50f), end = Offset(0f, 200f))
-        }
-        onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo(0.dp)
-
-        // Test the size of the scrollbar thumb by trying to drag by its bottommost pixel
-        // This also tests the proportionality of the scrolling
-        onNodeWithTag("scrollbar").performMouseInput {
-            instantDrag(start = Offset(0f, 49f), end = Offset(0f, 54f))
-        }
-        onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo((-10).dp)
+        testVerticalThumbEnd(
+            lastPixelPosition = Offset(0f, 49f),
+            dragAmount = 5f,
+            assertNotMoved = {
+                onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo(0.dp)
+            },
+            assertDraggedBy = { pixelAmount ->
+                onNodeWithTag(firstBoxTag).assertTopPositionInRootIsEqualTo((-2*pixelAmount).dp)
+            },
+            assertPageDown = {
+                onNodeWithTag(lastBoxTag).assertTopPositionInRootIsEqualTo(80.dp)
+            }
+        )
 
         // Scroll to the bottom and check the last item position
         onNodeWithTag("scrollbar").performMouseInput {
-            instantDrag(start = Offset(0f, 54f), end = Offset(0f, 99f))
+            instantDrag(start = Offset(0f, 49f), end = Offset(0f, 99f))
         }
         onNodeWithTag(lastBoxTag).assertTopPositionInRootIsEqualTo(80.dp)
     }
@@ -1076,6 +1076,82 @@ class ScrollbarTest {
         rule.testLazyContentWithLineSpacing("box0", "box17")
     }
 
+    /**
+     * Validates the expected bottom pixel position of the scrollbar thumb.
+     *
+     * The testing is done by:
+     * 1. Clicking the expected bottom pixel of the thumb and verifying that nothing moves.
+     * 2. Dragging the thumb by its expected bottom pixel and verifying that the content moved.
+     * 3. Clicking one pixel below the expected bottom pixel of the thumb and verifying a page-down.
+     */
+    private fun ComposeContentTestRule.testVerticalThumbEnd(
+        nodeTag: String = "scrollbar",
+        lastPixelPosition: Offset,
+        dragAmount: Float = 10f,
+        assertNotMoved: () -> Unit,
+        assertDraggedBy: (Float) -> Unit,
+        assertPageDown: () -> Unit,
+    ) {
+        // Test that clicking the last pixel of the thumb doesn't do anything
+        onNodeWithTag(nodeTag).performMouseInput {
+            click(lastPixelPosition)
+        }
+        assertNotMoved()
+
+        // Test that the last pixel of the thumb can be dragged by,
+        val dragEnd = lastPixelPosition.plus(Offset(0f, dragAmount))
+        onNodeWithTag(nodeTag).performMouseInput {
+            instantDrag(start = lastPixelPosition, end = dragEnd)
+        }
+        assertDraggedBy(dragAmount)
+
+        // Drag back and click one pixel below the thumb
+        onNodeWithTag(nodeTag).performMouseInput {
+            instantDrag(start = dragEnd, end = lastPixelPosition)
+        }
+        assertNotMoved()
+        onNodeWithTag(nodeTag).performMouseInput {
+            click(lastPixelPosition.plus(Offset(0f, 1f)))
+        }
+        assertPageDown()
+
+        // Click above the thumb to reset the state of the scrollbar back to its initial state
+        onNodeWithTag(nodeTag).performMouseInput {
+            click(lastPixelPosition)
+        }
+        assertNotMoved()
+    }
+
+    @Test
+    fun `thumb bounds test`(){
+        // Test that the last pixel of the thumb can be dragged by,
+        // and clicking one pixel below causes a page-down
+        rule.setContent {
+            LazyListTestBox(
+                size = 100.dp,
+                scrollbarWidth = 10.dp
+            ) {
+                items(10) {
+                    Box(Modifier.size(20.dp).testTag("box$it"))
+                }
+            }
+        }
+
+        rule.testVerticalThumbEnd(
+            lastPixelPosition = Offset(0f, 49f),
+            dragAmount = 10f,
+            assertNotMoved = {
+                rule.onNodeWithTag("box0").assertTopPositionInRootIsEqualTo(0.dp)
+            },
+            assertDraggedBy = { pixelAmount ->
+                rule.onNodeWithTag("box5").assertTopPositionInRootIsEqualTo((100-pixelAmount*2).dp)
+            },
+            assertPageDown = {
+                rule.onNodeWithTag("box5").assertTopPositionInRootIsEqualTo(0.dp)
+            }
+        )
+    }
+
     @OptIn(ExperimentalFoundationApi::class)
     @Test
     fun `basic lazy list with sticky headers test`() {
@@ -1085,25 +1161,47 @@ class ScrollbarTest {
                 scrollbarWidth = 10.dp
             ) {
                 stickyHeader {
-                    Box(Modifier.size(50.dp).testTag("header1"))
+                    Box(Modifier.size(20.dp).testTag("header1"))
                 }
-                items(10) {
-                    Box(Modifier.size(20.dp).testTag("box$it"))
+                items(9) {
+                    Box(Modifier.size(20.dp).testTag("box1_$it"))
                 }
                 stickyHeader {
-                    Box(Modifier.size(50.dp).testTag("header2"))
+                    Box(Modifier.size(20.dp).testTag("header2"))
                 }
-                items(10) {
-                    Box(Modifier.size(20.dp).testTag("box${10+it}"))
+                items(9) {
+                    Box(Modifier.size(20.dp).testTag("box2_$it"))
                 }
             }
         }
+        rule.onNodeWithTag("box1_0").assertTopPositionInRootIsEqualTo(20.dp)
+
+        rule.testVerticalThumbEnd(
+            lastPixelPosition = Offset(0f, 99f),
+            dragAmount = 10f,
+            assertNotMoved = {
+                rule.onNodeWithTag("box1_0").assertTopPositionInRootIsEqualTo(20.dp)
+            },
+            assertDraggedBy = { pixelAmount ->
+                rule.onNodeWithTag("box1_0")
+                    .assertTopPositionInRootIsEqualTo((20 - 2*pixelAmount).dp)
+            },
+            assertPageDown = {
+                rule.onNodeWithTag("box2_0").assertTopPositionInRootIsEqualTo(20.dp)
+            }
+        )
 
         // Drag the scrollbar to the bottom and test the position of the last item
         rule.onNodeWithTag("scrollbar").performMouseInput {
-            instantDrag(start = Offset(0f, 0f), end = Offset(0f, 120f))
+            instantDrag(start = Offset(0f, 0f), end = Offset(0f, 100f))
         }
-        rule.onNodeWithTag("box19").assertTopPositionInRootIsEqualTo(180.dp)
+        rule.onNodeWithTag("box2_8").assertTopPositionInRootIsEqualTo(180.dp)
+
+        // Press above the scrollbar and test the new position
+        rule.onNodeWithTag("scrollbar").performMouseInput {
+            click(position = Offset(0f, 0f))
+        }
+        rule.onNodeWithTag("box1_0").assertTopPositionInRootIsEqualTo(20.dp)
     }
 
 


### PR DESCRIPTION
The detection of scrollbar track clicks used the scrollbar thumb's "raw" (floating-point) bounds. However, this misses the first pixel after the thumb, because, for example, the value `10` is in the floating point range `0..10.0`, but the actual pixel bounds of the thumb for that range would not include the 10th pixel (the size of the thumb would be `10px`, so its pixel range would be `0px..9px`).

## Proposed Changes

Size the scrollbar in integer pixels and use that size when detecting clicks on the scrollbar track (outsize the thumb).

## Testing

Test: Added a new unit test to test the last pixel (and one beyond) of the thumb, and fixed other tests which used to pass because the one-pixel-beyond the thumb was neither clickable nor draggable.
