### PR TITLE
nr/fix-linux-windows-gradle-sync

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -502,7 +502,14 @@ if (isMultiplatformEnabled()) {
     includeProject(":compose:desktop:desktop:desktop-samples", "compose/desktop/desktop/samples", [BuildType.COMPOSE])
     includeProject(":compose:mpp", [BuildType.COMPOSE])
     includeProject(":compose:mpp:demo", [BuildType.COMPOSE])
-    includeProject(":compose:mpp:demo-uikit", [BuildType.COMPOSE])
+
+    // workaround for issue that on linux and windows CommonizeCInterop task fails
+    // Common code with the same check above is not extracted to simplify merge
+    // It seems that this workaround can be removed after Kotlin 1.8.20
+    def os = System.getProperty("os.name").toLowerCase(Locale.US)
+    if (os.contains("mac os x") || os.contains("darwin") || os.contains("osx")) {
+        includeProject(":compose:mpp:demo-uikit", [BuildType.COMPOSE])
+    }
 }
 includeProject(":compose:foundation", [BuildType.COMPOSE])
 includeProject(":compose:foundation:foundation", [BuildType.COMPOSE])

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 import groovy.transform.Field
 import androidx.build.gradle.gcpbuildcache.GcpBuildCache
 import androidx.build.gradle.gcpbuildcache.GcpBuildCacheServiceFactory
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 pluginManagement {
     repositories {
@@ -504,10 +505,8 @@ if (isMultiplatformEnabled()) {
     includeProject(":compose:mpp:demo", [BuildType.COMPOSE])
 
     // workaround for issue that on linux and windows CommonizeCInterop task fails
-    // Common code with the same check above is not extracted to simplify merge
     // It seems that this workaround can be removed after Kotlin 1.8.20
-    def os = System.getProperty("os.name").toLowerCase(Locale.US)
-    if (os.contains("mac os x") || os.contains("darwin") || os.contains("osx")) {
+    if (DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX()) {
         includeProject(":compose:mpp:demo-uikit", [BuildType.COMPOSE])
     }
 }


### PR DESCRIPTION
## Proposed Changes

  - Exclude demo-uikit project in Linux and Windows because of the gradle sync failure

There was a failure:
```
Could not determine the dependencies of task ':compose:mpp:demo-uikit:commonizeCInterop'.
> Could not resolve all dependencies for configuration ':compose:mpp:demo-uikit:kotlinKlibCommonizerClasspath'.
   > Consumable configurations with identical capabilities within a project (other than the default configuration) must have unique attributes, but configuration ':compose:mpp:demo-uikit:debugFrameworkUikitX64' and [configuration ':compose:mpp:demo-uikit:debugFrameworkIosFat'] contain identical attribute sets. Consider adding an additional attribute to one of the configurations to disambiguate them.  Run the 'outgoingVariants' task for more details. See https://docs.gradle.org/8.0/userguide/upgrading_version_7.html#unique_attribute_sets for more details.
```

## Testing

Test: Start gradle sync in IDE on Mac, Linux and Windows (for now there are more issues, that are fixed in separate [PR](https://github.com/JetBrains/compose-multiplatform-core/pull/466)). It should be successful

## Issues Fixed

No issues related to this PR
