### PR TITLE
Implement NativeStringDelegate

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopStringDelegate.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopStringDelegate.desktop.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.intl.DesktopLocale
 import androidx.compose.ui.text.intl.PlatformLocale
 
 /**
- * An Desktop implementation of StringDelegate
+ * A desktop implementation of StringDelegate
  */
 internal class DesktopStringDelegate : PlatformStringDelegate {
     override fun toUpperCase(string: String, locale: PlatformLocale): String =

--- a/compose/ui/ui-text/src/jsMain/kotlin/androidx/compose/ui/text/platform/JsStringDelegate.js.kt
+++ b/compose/ui/ui-text/src/jsMain/kotlin/androidx/compose/ui/text/platform/JsStringDelegate.js.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.text.intl.JsLocale
 import androidx.compose.ui.text.intl.PlatformLocale
 
 /**
- * An Native implementation of StringDelegate
+ * A JS implementation of StringDelegate
  */
 
-internal class NativeStringDelegate() : PlatformStringDelegate {
+internal class JsStringDelegate : PlatformStringDelegate {
     override fun toUpperCase(string: String, locale: PlatformLocale): String =
         string.toUpperCase()
 
@@ -39,5 +39,5 @@ internal class NativeStringDelegate() : PlatformStringDelegate {
 }
 
 internal actual fun ActualStringDelegate(): PlatformStringDelegate =
-    //TODO("implement native StringDelegate")
-    NativeStringDelegate()
+    // TODO("implement JsStringDelegate")
+    JsStringDelegate()

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeStringDelegate.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeStringDelegate.native.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,25 +19,44 @@ package androidx.compose.ui.text.platform
 import androidx.compose.ui.text.PlatformStringDelegate
 import androidx.compose.ui.text.intl.NativeLocale
 import androidx.compose.ui.text.intl.PlatformLocale
+import platform.Foundation.*
 
 /**
- * An Native implementation of StringDelegate
+ * A native implementation of StringDelegate
  */
 
-internal class NativeStringDelegate() : PlatformStringDelegate {
+// TODO Remove once https://youtrack.jetbrains.com/issue/KT-23978 fixed
+@Suppress("CAST_NEVER_SUCCEEDS")
+internal class NativeStringDelegate : PlatformStringDelegate {
     override fun toUpperCase(string: String, locale: PlatformLocale): String =
-        string.toUpperCase()
+        toUpperCase(string as NSString, locale as NativeLocale)
+
+    private inline fun toUpperCase(string: NSString, locale: NativeLocale): String =
+        string.uppercaseStringWithLocale(locale.locale)
 
     override fun toLowerCase(string: String, locale: PlatformLocale): String =
-        string.toLowerCase()
+        toLowerCase(string as NSString, locale as NativeLocale)
+
+    private inline fun toLowerCase(string: NSString, locale: NativeLocale): String =
+        string.lowercaseStringWithLocale(locale.locale)
 
     override fun capitalize(string: String, locale: PlatformLocale): String =
-        string.capitalize()
+        string.replaceFirstChar {
+            if (it.isLowerCase())
+                capitalize(it.toString() as NSString, locale as NativeLocale)
+            else
+                it.toString()
+        }
+
+    private inline fun capitalize(string: NSString, locale: NativeLocale): String =
+        string.capitalizedStringWithLocale(locale.locale)
 
     override fun decapitalize(string: String, locale: PlatformLocale): String =
-        string.decapitalize()
+        string.replaceFirstChar { decapitalize(it.toString() as NSString, locale as NativeLocale) }
+
+    private inline fun decapitalize(string: NSString, locale: NativeLocale): String =
+        string.lowercaseStringWithLocale(locale.locale)
 }
 
 internal actual fun ActualStringDelegate(): PlatformStringDelegate =
-    //TODO("implement native StringDelegate")
     NativeStringDelegate()

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/StringTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/StringTest.kt
@@ -16,10 +16,21 @@
 
 package androidx.compose.ui.text
 
+import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.intl.LocaleList
 import kotlin.test.*
 
 class StringTest {
+
+    @Test
+    fun emptyStringTransformations() {
+        val empty = ""
+
+        assertEquals(empty.toUpperCase(Locale.current), empty)
+        assertEquals(empty.toLowerCase(Locale.current), empty)
+        assertEquals(empty.capitalize(Locale.current), empty)
+        assertEquals(empty.decapitalize(Locale.current), empty)
+    }
 
     @Test
     fun twoCharactersRepresentedAsSingleUnicodeLetter() {

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/StringTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/StringTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import androidx.compose.ui.text.intl.LocaleList
+import kotlin.test.*
+
+class StringTest {
+
+    @Test
+    fun twoCharactersRepresentedAsSingleUnicodeLetter() {
+        // https://en.wikipedia.org/wiki/D%C5%BE
+        val lowercase = "ǆ" // U+01C6
+        val titlecase = "ǅ" // U+01C5
+        val uppercase = "Ǆ" // U+01C4
+        val serbianLocale = LocaleList("sr")
+
+        assertEquals(lowercase.toUpperCase(serbianLocale), uppercase)
+        assertEquals(lowercase.toLowerCase(serbianLocale), lowercase)
+        assertEquals(lowercase.capitalize(serbianLocale), titlecase)
+        assertEquals(lowercase.decapitalize(serbianLocale), lowercase)
+
+        assertEquals(titlecase.toUpperCase(serbianLocale), uppercase)
+        assertEquals(titlecase.toLowerCase(serbianLocale), lowercase)
+        assertEquals(titlecase.capitalize(serbianLocale), titlecase)
+        assertEquals(titlecase.decapitalize(serbianLocale), lowercase)
+
+        assertEquals(uppercase.toUpperCase(serbianLocale), uppercase)
+        assertEquals(uppercase.toLowerCase(serbianLocale), lowercase)
+        assertEquals(uppercase.capitalize(serbianLocale), uppercase)
+        assertEquals(uppercase.decapitalize(serbianLocale), lowercase)
+    }
+}


### PR DESCRIPTION
## Testing

Test: added `twoCharactersRepresentedAsSingleUnicodeLetter` (fails on JS because of unimplemented `JsStringDelegate`)

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2876
