### PR TITLE
Replace deprecated forEachGesture{ awaitPointerEventScope{} } with awaitEachGesture{}

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.foundation
 
-import androidx.compose.foundation.gestures.forEachGesture
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -116,13 +116,11 @@ fun Modifier.contextMenuOpenDetector(
 ): Modifier {
     return if (enabled) {
         this.pointerInput(key) {
-            forEachGesture {
-                awaitPointerEventScope {
-                    val event = awaitEventFirstDown()
-                    if (event.buttons.isSecondaryPressed) {
-                        event.changes.forEach { it.consume() }
-                        onOpen(event.changes[0].position)
-                    }
+            awaitEachGesture {
+                val event = awaitEventFirstDown()
+                if (event.buttons.isSecondaryPressed) {
+                    event.changes.forEach { it.consume() }
+                    onOpen(event.changes[0].position)
                 }
             }
         }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Scrollbar.desktop.kt
@@ -18,11 +18,7 @@ package androidx.compose.foundation
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.TweenSpec
-import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.awaitHorizontalDragOrCancellation
-import androidx.compose.foundation.gestures.awaitVerticalDragOrCancellation
-import androidx.compose.foundation.gestures.drag
-import androidx.compose.foundation.gestures.forEachGesture
+import androidx.compose.foundation.gestures.*
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -839,25 +835,23 @@ private fun Modifier.scrollbarDrag(
     val currentSliderAdapter by rememberUpdatedState(sliderAdapter)
 
     pointerInput(Unit) {
-        forEachGesture {
-            awaitPointerEventScope {
-                val down = awaitFirstDown(requireUnconsumed = false)
-                val interaction = DragInteraction.Start()
-                currentInteractionSource.tryEmit(interaction)
-                currentDraggedInteraction.value = interaction
-                currentSliderAdapter.onDragStarted()
-                val isSuccess = drag(down.id) { change ->
-                    currentSliderAdapter.onDragDelta(change.positionChange())
-                    change.consume()
-                }
-                val finishInteraction = if (isSuccess) {
-                    DragInteraction.Stop(interaction)
-                } else {
-                    DragInteraction.Cancel(interaction)
-                }
-                currentInteractionSource.tryEmit(finishInteraction)
-                currentDraggedInteraction.value = null
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false)
+            val interaction = DragInteraction.Start()
+            currentInteractionSource.tryEmit(interaction)
+            currentDraggedInteraction.value = interaction
+            currentSliderAdapter.onDragStarted()
+            val isSuccess = drag(down.id) { change ->
+                currentSliderAdapter.onDragDelta(change.positionChange())
+                change.consume()
             }
+            val finishInteraction = if (isSuccess) {
+                DragInteraction.Stop(interaction)
+            } else {
+                DragInteraction.Cancel(interaction)
+            }
+            currentInteractionSource.tryEmit(finishInteraction)
+            currentDraggedInteraction.value = null
         }
     }
 }
@@ -996,27 +990,25 @@ private suspend fun PointerInputScope.detectScrollViaTrackGestures(
 ) {
     fun Offset.onScrollAxis() = if (isVertical) y else x
 
-    forEachGesture {
-        awaitPointerEventScope {
-            val down = awaitFirstDown()
-            scroller.onPress(down.position.onScrollAxis())
+    awaitEachGesture {
+        val down = awaitFirstDown()
+        scroller.onPress(down.position.onScrollAxis())
 
-            while (true) {
-                val drag =
-                    if (isVertical)
-                        awaitVerticalDragOrCancellation(down.id)
-                    else
-                        awaitHorizontalDragOrCancellation(down.id)
+        while (true) {
+            val drag =
+                if (isVertical)
+                    awaitVerticalDragOrCancellation(down.id)
+                else
+                    awaitHorizontalDragOrCancellation(down.id)
 
-                if (drag == null) {
-                    scroller.onGestureCancelled()
-                    break
-                } else if (!drag.pressed) {
-                    scroller.onRelease()
-                    break
-                } else
-                    scroller.onMovePressed(drag.position.onScrollAxis())
-            }
+            if (drag == null) {
+                scroller.onGestureCancelled()
+                break
+            } else if (!drag.pressed) {
+                scroller.onRelease()
+                break
+            } else
+                scroller.onMovePressed(drag.position.onScrollAxis())
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Replace the deprecated `forEachGesture { awaitPointerEventScope { ... } }` with `awaitEachGesture { ... }`

Note that I didn't change the usage in
- `Scrollbar.js.kt` and `Scrollbar.native.kt` because they're still using the old scrollbar implementation and I'm not sure I want to touch it.
- `material3/Slider.kt` because I understand `material3` still has an older version of Compose as a dependency.

## Testing

Test: Ran the relevant unit tests.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3045
