### PR TITLE
Change project name in Gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -133,7 +133,7 @@ switch (cacheSetting) {
         }
 }
 
-rootProject.name = "androidx"
+rootProject.name = "compose-multiplatform-core"
 
 dependencyResolutionManagement {
     versionCatalogs {


### PR DESCRIPTION
## Proposed Changes

  - Change project name in Gradle, so it will reflect in IDE as well

## Testing

Test: open project in IDEA, it should have "compose-multiplatform-core" name after sync

## Issues Fixed

No issues related to this PR
