### PR TITLE
Reproduce StageredGrid compile error

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -32,6 +32,7 @@ class App(
         Screen("Example1") { Example1() },
         Screen("ImageViewer") { ImageViewer() },
         Screen("RoundedCornerCrashOnJS") { RoundedCornerCrashOnJS() },
+        Screen("ExampleStaggeredGrid") { ExampleStaggeredGrid() },
     )
 
     private class Screen(val title: String, val content: @Composable () -> Unit)

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/ExampleStaggeredGrid.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/ExampleStaggeredGrid.kt
@@ -31,6 +31,7 @@ import kotlin.random.Random
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ExampleStaggeredGrid() {
+    //TODO This code is not compiles on iOS
     LazyVerticalStaggeredGrid(
         StaggeredGridCells.Fixed(3),
         contentPadding = PaddingValues(8.dp),

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/ExampleStaggeredGrid.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/ExampleStaggeredGrid.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlin.random.Random
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ExampleStaggeredGrid() {
+    LazyVerticalStaggeredGrid(
+        StaggeredGridCells.Fixed(3),
+        contentPadding = PaddingValues(8.dp),
+        verticalItemSpacing = 8.dp,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(100) {
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .height(remember { (100..150).random().dp })
+                    .background(Color(Random.nextInt()))
+            )
+        }
+    }
+}


### PR DESCRIPTION
Compile time error:

```
Module "org.jetbrains.compose.foundation:foundation" has a reference to symbol [ File '/Users/dim/Desktop/github/JetBrains/compose-multiplatform-core/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasureResult.kt' <- androidx.compose.foundation.lazy.staggeredgrid/LazyStaggeredGridPositionedItem|null[0] ]. Neither the module itself nor its dependencies contain such declaration.

```

Apply workaround here: https://github.com/JetBrains/compose-multiplatform-core/pull/518