### PR TITLE
Fix getting latest language on `Darwin`

### DIFF
--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.native.kt
@@ -35,10 +35,9 @@ internal class NativeLocale(val locale: NSLocale) : PlatformLocale {
 internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     object : PlatformLocaleDelegate {
         override val current: LocaleList
-            get() {
-                val locale = NSLocale(NSLocale.preferredLanguages.first() as String)
-                return LocaleList(listOf(Locale(NativeLocale(locale))))
-            }
+            get() = LocaleList(NSLocale.preferredLanguages.map {
+                Locale(NativeLocale(NSLocale(it as String)))
+            })
 
 
         override fun parseLanguageTag(languageTag: String): PlatformLocale {

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.native.kt
@@ -35,7 +35,10 @@ internal class NativeLocale(val locale: NSLocale) : PlatformLocale {
 internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     object : PlatformLocaleDelegate {
         override val current: LocaleList
-            get() = LocaleList(listOf(Locale(NativeLocale(NSLocale.currentLocale))))
+            get() {
+                val locale = NSLocale(NSLocale.preferredLanguages.first() as String)
+                return LocaleList(listOf(Locale(NativeLocale(locale))))
+            }
 
 
         override fun parseLanguageTag(languageTag: String): PlatformLocale {


### PR DESCRIPTION
When I was using the `Locale` Api, I found that getting the latest languages on `Darwin` was inconsistent with other Platform Api, and now use `NSLocale.preferredLanguages` to get the latest languages instead.