### PR TITLE
Implement Char.isNeutralDirection on js and native

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
@@ -18,6 +18,9 @@ package androidx.compose.ui.text
 internal actual fun strongDirectionType(codePoint: Int): StrongDirectionType =
     codePoint.getDirectionality().toStrongDirectionType()
 
+internal actual fun Char.isNeutralDirection(): Boolean =
+    directionality.isNeutralDirection()
+
 /**
  * Get the Unicode directionality of a character.
  */
@@ -35,4 +38,12 @@ private fun CharDirectionality.toStrongDirectionType() = when (this) {
     CharDirectionality.RIGHT_TO_LEFT_ARABIC -> StrongDirectionType.Rtl
 
     else -> StrongDirectionType.None
+}
+
+private fun CharDirectionality.isNeutralDirection(): Boolean = when (this) {
+    CharDirectionality.OTHER_NEUTRALS,
+    CharDirectionality.WHITESPACE,
+    CharDirectionality.BOUNDARY_NEUTRAL -> true
+
+    else -> false
 }

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.desktop.kt
@@ -1,8 +1,0 @@
-package androidx.compose.ui.text.platform
-
-internal actual fun Char.isNeutralDirectionality(): Boolean {
-    return this.directionality == CharDirectionality.OTHER_NEUTRALS
-        || this.directionality == CharDirectionality.WHITESPACE
-        || this.directionality == CharDirectionality.BOUNDARY_NEUTRAL
-
-}

--- a/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/CharHelpers.native.kt
+++ b/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/CharHelpers.native.kt
@@ -21,6 +21,9 @@ import org.jetbrains.skia.icu.CharDirection
 internal actual fun strongDirectionType(codePoint: Int): StrongDirectionType =
     CharDirection.of(codePoint).toStrongDirectionType()
 
+internal actual fun Char.isNeutralDirection(): Boolean =
+    CharDirection.of(code).isNeutralDirection()
+
 /**
  * Get strong (R, L or AL) direction type.
  * See https://www.unicode.org/reports/tr9/
@@ -32,4 +35,12 @@ private fun Int.toStrongDirectionType() = when (this) {
     CharDirection.RIGHT_TO_LEFT_ARABIC -> StrongDirectionType.Rtl
 
     else -> StrongDirectionType.None
+}
+
+private fun Int.isNeutralDirection(): Boolean = when (this) {
+    CharDirection.OTHER_NEUTRAL,
+    CharDirection.WHITE_SPACE_NEUTRAL,
+    CharDirection.BOUNDARY_NEUTRAL -> true
+
+    else -> false
 }

--- a/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.jsNativeMain.kt
+++ b/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraphSkiko.jsNativeMain.kt
@@ -1,6 +1,0 @@
-package androidx.compose.ui.text.platform
-
-internal actual fun Char.isNeutralDirectionality(): Boolean {
-    println("TODO: implement Char.isNeutralDirectionality in jsNativeMain")
-    return false
-}

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/CharHelpers.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/CharHelpers.skiko.kt
@@ -45,6 +45,9 @@ internal value class StrongDirectionType private constructor(val value: Int) {
 
 internal expect fun strongDirectionType(codePoint: Int): StrongDirectionType
 
+// TODO: Use unicode code point instead of Char
+internal expect fun Char.isNeutralDirection(): Boolean
+
 /**
  * Determine direction based on the first strong directional character.
  * Only considers the characters outside isolate pairs.

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.text.platform.SkiaParagraphIntrinsics
 import androidx.compose.ui.text.platform.cursorHorizontalPosition
-import androidx.compose.ui.text.platform.isNeutralDirectionality
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Constraints
@@ -395,7 +394,9 @@ internal class SkiaParagraph(
             correctedGlyphPosition = paragraph.getGlyphPositionAtCoordinate(leftX + 1f, position.y).position
         } else if (position.x >= rightX) { // when clicked to the right of a text line
             correctedGlyphPosition = paragraph.getGlyphPositionAtCoordinate(rightX - 1f, position.y).position
-            val isNeutralChar = text.getOrNull(correctedGlyphPosition)?.isNeutralDirectionality() ?: false
+
+            // TODO: Use unicode code points
+            val isNeutralChar = text.getOrNull(correctedGlyphPosition)?.isNeutralDirection() ?: false
             // For RTL blocks, the position is still not correct, so we have to subtract 1 from the returned result
             if (!isNeutralChar && getBoxBackwardByOffset(correctedGlyphPosition)?.direction == Direction.RTL) {
                 correctedGlyphPosition -= 1

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -657,5 +657,3 @@ internal fun TextBox.cursorHorizontalPosition(opposite: Boolean = false): Float 
         SkDirection.RTL -> if (opposite) rect.right else rect.left
     }
 }
-
-internal expect fun Char.isNeutralDirectionality(): Boolean


### PR DESCRIPTION
## Proposed Changes

  - Move `Char.isNeutralDirectionality()` to `CharHelpers.skiko.kt`, where there are similar functions alreeady
  - Implemented it on JS and native
  - ~Added TODO for proper unicode support in paragraph~ moved to another branch

## Testing

Test: Verify `Char.isNeutralDirection` returns the same value on JVM and native

## Issues Fixed

Untracked yet ("TODO" inside `println`)
