### PR TITLE
Cherry-pick deadlock fix of Composition.dispose()

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
@@ -20,6 +20,7 @@ package androidx.compose.runtime
 import androidx.compose.runtime.collection.IdentityArrayMap
 import androidx.compose.runtime.collection.IdentityArraySet
 import androidx.compose.runtime.collection.IdentityScopeMap
+import androidx.compose.runtime.collection.fastForEach
 import androidx.compose.runtime.snapshots.fastAll
 import androidx.compose.runtime.snapshots.fastAny
 import androidx.compose.runtime.snapshots.fastForEach
@@ -693,7 +694,7 @@ internal class CompositionImpl(
             }
         }
 
-        for (value in values) {
+        values.fastForEach { value ->
             if (value is RecomposeScopeImpl) {
                 value.invalidateForResult(null)
             } else {

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
@@ -199,7 +199,7 @@ class Recomposer(
     private var runnerJob: Job? = null
     private var closeCause: Throwable? = null
     private val knownCompositions = mutableListOf<ControlledComposition>()
-    private var snapshotInvalidations = mutableSetOf<Any>()
+    private var snapshotInvalidations = IdentityArraySet<Any>()
     private val compositionInvalidations = mutableListOf<ControlledComposition>()
     private val compositionsAwaitingApply = mutableListOf<ControlledComposition>()
     private val compositionValuesAwaitingInsert = mutableListOf<MovableContentStateReference>()
@@ -280,7 +280,7 @@ class Recomposer(
     private fun deriveStateLocked(): CancellableContinuation<Unit>? {
         if (_state.value <= State.ShuttingDown) {
             knownCompositions.clear()
-            snapshotInvalidations = mutableSetOf()
+            snapshotInvalidations = IdentityArraySet()
             compositionInvalidations.clear()
             compositionsAwaitingApply.clear()
             compositionValuesAwaitingInsert.clear()
@@ -296,7 +296,7 @@ class Recomposer(
                 State.Inactive
             }
             runnerJob == null -> {
-                snapshotInvalidations = mutableSetOf()
+                snapshotInvalidations = IdentityArraySet()
                 compositionInvalidations.clear()
                 if (broadcastFrameClock.hasAwaiters) State.InactivePendingWork else State.Inactive
             }
@@ -420,7 +420,7 @@ class Recomposer(
                     if (_state.value <= State.ShuttingDown) return@run
                 }
             }
-            snapshotInvalidations = mutableSetOf()
+            snapshotInvalidations = IdentityArraySet()
             if (deriveStateLocked() != null) {
                 error("called outside of runRecomposeAndApplyChanges")
             }
@@ -435,7 +435,7 @@ class Recomposer(
             knownCompositions.fastForEach { composition ->
                 composition.recordModificationsOf(changes)
             }
-            snapshotInvalidations = mutableSetOf()
+            snapshotInvalidations = IdentityArraySet()
         }
         compositionInvalidations.fastForEach(onEachInvalidComposition)
         compositionInvalidations.clear()
@@ -657,7 +657,7 @@ class Recomposer(
 
                 compositionsAwaitingApply.clear()
                 compositionInvalidations.clear()
-                snapshotInvalidations = mutableSetOf()
+                snapshotInvalidations = IdentityArraySet()
 
                 compositionValuesAwaitingInsert.clear()
                 compositionValuesRemoved.clear()

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.collection.IdentityArrayIntMap
 import androidx.compose.runtime.collection.IdentityArrayMap
 import androidx.compose.runtime.collection.IdentityArraySet
 import androidx.compose.runtime.collection.IdentityScopeMap
+import androidx.compose.runtime.collection.fastForEach
 import androidx.compose.runtime.collection.mutableVectorOf
 import androidx.compose.runtime.composeRuntimeError
 import androidx.compose.runtime.observeDerivedStateRecalculations
@@ -515,7 +516,7 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
          */
         fun recordInvalidation(changes: Set<Any>): Boolean {
             var hasValues = false
-            for (value in changes) {
+            changes.fastForEach { value ->
                 if (value in dependencyToDerivedStates) {
                     // Find derived state that is invalidated by this change
                     dependencyToDerivedStates.forEachScopeOf(value) { derivedState ->

--- a/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/collection/IdentityArraySetTest.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/collection/IdentityArraySetTest.kt
@@ -182,6 +182,54 @@ class IdentityArraySetTest {
         assertTrue(setOfT.containsAll(listOf(stuff[0], stuff[1], stuff[2])))
     }
 
+    @Test
+    fun addAll_Collection() {
+        set.addAll(list)
+
+        assertEquals(list.size, set.size)
+        for (value in list) {
+            assertTrue(value in set)
+        }
+    }
+
+    @Test
+    fun addAll_IdentityArraySet() {
+        val anotherSet = IdentityArraySet<Stuff>()
+        anotherSet.addAll(list)
+
+        set.addAll(anotherSet)
+
+        for (value in list) {
+            assertTrue(value in set)
+        }
+
+        set.addAll(anotherSet)
+
+        assertEquals(anotherSet.size, set.size)
+        for (value in list) {
+            assertTrue(value in set)
+        }
+
+        val stuff = Array(100) { Stuff(it) }
+        for (i in 0 until 100 step 2) {
+            anotherSet.add(stuff[i])
+        }
+        set.addAll(anotherSet)
+
+        for (i in stuff.indices) {
+            val value = stuff[i]
+            if (i % 2 == 0) {
+                assertTrue(value in set, "Expected to have element $i in $set")
+            } else {
+                assertFalse(value in set, "Didn't expect to have element $i in $set")
+            }
+        }
+
+        for (value in list) {
+            assertTrue(value in set)
+        }
+    }
+
     private fun testRemoveValueAtIndex(index: Int) {
         val value = set[index]
         val initialSize = set.size

--- a/compose/runtime/runtime/src/jvmTest/kotlin/androidx/compose/runtime/CompositionTestsJvm.kt
+++ b/compose/runtime/runtime/src/jvmTest/kotlin/androidx/compose/runtime/CompositionTestsJvm.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import androidx.compose.runtime.mock.EmptyApplier
+import androidx.compose.runtime.snapshots.Snapshot
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import org.junit.Test
+
+
+class CompositionTestsJvm {
+
+    // This test can't be in commonTest because there's no runBlocking in JS
+    @Test(timeout = 10000)
+    fun testCompositionAndRecomposerDeadlock() {
+        runBlocking {
+            withGlobalSnapshotManager {
+                repeat(100) {
+                    val job = Job(parent = coroutineContext[Job])
+                    val coroutineContext = Dispatchers.Unconfined + job
+                    val recomposer = Recomposer(coroutineContext)
+
+                    launch(
+                        coroutineContext + BroadcastFrameClock(),
+                        start = CoroutineStart.UNDISPATCHED
+                    ) {
+                        recomposer.runRecomposeAndApplyChanges()
+                    }
+
+                    val composition = Composition(EmptyApplier(), recomposer)
+                    composition.setContent {
+
+                        val innerComposition = Composition(
+                            EmptyApplier(),
+                            rememberCompositionContext(),
+                        )
+
+                        DisposableEffect(composition) {
+                            onDispose {
+                                innerComposition.dispose()
+                            }
+                        }
+                    }
+
+                    var value by mutableStateOf(1)
+                    launch(Dispatchers.Default + job) {
+                        while (true) {
+                            value += 1
+                            delay(1)
+                        }
+                    }
+
+                    composition.dispose()
+                    recomposer.close()
+                    job.cancel()
+                }
+            }
+        }
+    }
+
+    private inline fun CoroutineScope.withGlobalSnapshotManager(block: CoroutineScope.() -> Unit) {
+        val channel = Channel<Unit>(Channel.CONFLATED)
+        val job = launch {
+            channel.consumeEach {
+                Snapshot.sendApplyNotifications()
+            }
+        }
+        val unregisterToken = Snapshot.registerGlobalWriteObserver {
+            channel.trySend(Unit)
+        }
+        try {
+            block()
+        } finally {
+            unregisterToken.dispose()
+            job.cancel()
+        }
+    }
+
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
@@ -94,7 +94,6 @@ class ImageComposeSceneTest {
         }
     }
 
-    @Ignore("See https://github.com/JetBrains/compose-jb/issues/1866")
     @Test
     fun `run multiple ImageComposeScene`() {
         for (i in 1..300) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -231,9 +231,7 @@ class DesktopPopupTest {
         rule.waitForIdle()
     }
 
-    // TODO(https://github.com/JetBrains/compose-jb/issues/1866) enable when deadlock is fixed
     @Test
-    @Ignore("Enable when deadlock https://github.com/JetBrains/compose-jb/issues/1866 is fixed")
     fun `call dismiss if clicked outside of focusable popup`() = ImageComposeScene(
         100,
         100
@@ -258,9 +256,7 @@ class DesktopPopupTest {
         assertThat(onDismissRequestCallCount).isEqualTo(1)
     }
 
-    // TODO(https://github.com/JetBrains/compose-jb/issues/1866) enable when deadlock is fixed
     @Test
-    @Ignore("Enable when deadlock https://github.com/JetBrains/compose-jb/issues/1866 is fixed")
     fun `pass event if clicked outside of non-focusable popup`() = ImageComposeScene(
         100,
         100
@@ -285,9 +281,7 @@ class DesktopPopupTest {
         assertThat(onDismissRequestCallCount).isEqualTo(0)
     }
 
-    // TODO(https://github.com/JetBrains/compose-jb/issues/1866) enable when deadlock is fixed
     @Test
-    @Ignore("Enable when deadlock https://github.com/JetBrains/compose-jb/issues/1866 is fixed")
     fun `can scroll outside of non-focusable popup`() = ImageComposeScene(100, 100).use { scene ->
         val background = FillBox()
         val popup = PopupState(IntRect(20, 20, 60, 60), focusable = false)
@@ -301,9 +295,7 @@ class DesktopPopupTest {
         background.events.assertReceivedLast(PointerEventType.Scroll, Offset(10f, 10f))
     }
 
-    // TODO(https://github.com/JetBrains/compose-jb/issues/1866) enable when deadlock is fixed
     @Test
-    @Ignore("Enable when deadlock https://github.com/JetBrains/compose-jb/issues/1866 is fixed")
     fun `can't scroll outside of focusable popup`() = ImageComposeScene(100, 100).use { scene ->
         val background = FillBox()
         val popup = PopupState(IntRect(20, 20, 60, 60), focusable = true)

--- a/external/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
+++ b/external/paparazzi/paparazzi/src/main/java/app/cash/paparazzi/Paparazzi.kt
@@ -572,10 +572,19 @@ class Paparazzi @JvmOverloads constructor(
       val snapshotInvalidations = recomposer.javaClass
         .getDeclaredField("snapshotInvalidations")
         .apply { isAccessible = true }
-        .get(recomposer) as MutableCollection<*>
+        .get(recomposer)
       compositionInvalidations.clear()
-      snapshotInvalidations.clear()
       applyObservers.clear()
+
+      if (snapshotInvalidations is MutableCollection<*>) {
+        snapshotInvalidations.clear()
+      } else {
+        // backed by IdentityArraySet
+        snapshotInvalidations.javaClass
+          .getDeclaredMethod("clear")
+          .apply { isAccessible = true }
+          .invoke(snapshotInvalidations)
+      }
     }
 
     val dispatcher =


### PR DESCRIPTION
## Proposed Changes

 - Cherry pick the [fix](https://android-review.googlesource.com/c/platform/frameworks/support/+/2439279) of the [deadlock in Composition.dispose](https://issuetracker.google.com/issues/267647309) (and another commit the fix was dependent on).
 - Re-enable tests that were disabled due to this deadlock.


## Testing

Test: Ran the re-enabled tests.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/1866
