### PR TITLE
simplify AppCode instuctions

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -2,7 +2,6 @@
 - Java 17 (should be specified in JAVA_HOME)
 - [macOs/Linux] Android SDK downloaded via `./jbdeps/android-sdk/downloadAndroidSdk`
 - [Windows] Android SDK downloaded from Android Studio and specified in ANDROID_SDK_ROOT
-- [Optional, macOs] For AppCode IDE, specify environment variable `export ANDROID_SDK_ROOT=[YOUR_PATH]/jbdeps/android-sdk/darwin` (in ~/.zshrc)
 
 ## Developing in IDE
 1. Download Android Studio from [the official site](https://developer.android.com/studio/archive) (it is mandatory to use the version, written [here](https://github.com/JetBrains/androidx/blob/jb-main/gradle/libs.versions.toml#L11)). As an alternative you can use IDEA, which is compatible with [this AGP version](https://github.com/JetBrains/androidx/blob/jb-main/gradle/libs.versions.toml#L5), or you can disable Android plugin in IDEA plugins, to develop non-Android targets.


### PR DESCRIPTION
We don't need ANDROID_SDK_ROOT for iOS target anymore