### PR TITLE
Fix a runtime test for k/js

### DIFF
--- a/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/RecomposerTests.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/RecomposerTests.kt
@@ -23,10 +23,7 @@ import androidx.compose.runtime.mock.compositionTest
 import androidx.compose.runtime.mock.expectNoChanges
 import androidx.compose.runtime.snapshots.Snapshot
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
+import kotlin.test.*
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -416,7 +413,7 @@ class RecomposerTests {
 
         // The Recomposer should have received notification for the node's state.
         @Suppress("RemoveExplicitTypeArguments")
-        assertEquals<List<Set<Any>>>(listOf(setOf(countFromEffect)), applications)
+        assertContentEquals(listOf(setOf(countFromEffect)), applications)
     }
 }
 

--- a/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/RecomposerTests.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/RecomposerTests.kt
@@ -412,7 +412,6 @@ class RecomposerTests {
         assertEquals(2, recompositions)
 
         // The Recomposer should have received notification for the node's state.
-        @Suppress("RemoveExplicitTypeArguments")
         assertContentEquals(listOf(setOf(countFromEffect)), applications)
     }
 }


### PR DESCRIPTION
Test - stateChangesDuringApplyChangesAreNotifiedBeforeFrameFinished

Use `assertContentEquals` instead of `assertEquals<List<Set<Any>>>`

`assertEquals` failed in k/js:

```
Expected <[[MutableState(value=1)@-557630351]]>, actual <[[MutableState(value=1)@-557630351]]>.
```
Visually, it looks the same, so let's use `assertContentEquals`