### PR TITLE
Compose should take into consideration iOS text size user preference.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -104,7 +104,8 @@ internal actual class ComposeWindow : UIViewController {
 
     private val fontScale: Float
         get() {
-            val contentSizeCategory = traitCollection.preferredContentSizeCategory ?: UIContentSizeCategoryUnspecified
+            val contentSizeCategory =
+                traitCollection.preferredContentSizeCategory ?: UIContentSizeCategoryUnspecified
 
             return uiContentSizeCategoryToFontScaleMap[contentSizeCategory] ?: 1.0f
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -54,22 +54,26 @@ import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
 import platform.Foundation.NSValue
-import platform.UIKit.CGRectValue
-import platform.UIKit.UIColor
-import platform.UIKit.UIScreen
-import platform.UIKit.UIView
-import platform.UIKit.UIViewAutoresizingFlexibleHeight
-import platform.UIKit.UIViewAutoresizingFlexibleWidth
-import platform.UIKit.UIViewController
-import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
-import platform.UIKit.addSubview
-import platform.UIKit.backgroundColor
-import platform.UIKit.reloadInputViews
-import platform.UIKit.setAutoresizesSubviews
-import platform.UIKit.setAutoresizingMask
-import platform.UIKit.setClipsToBounds
-import platform.UIKit.setNeedsDisplay
+import platform.UIKit.*
 import platform.darwin.NSObject
+
+private val uiContentSizeCategoryToFontScaleMap = mapOf(
+    UIContentSizeCategoryExtraSmall to 0.9f,
+    UIContentSizeCategorySmall to 0.95f,
+    UIContentSizeCategoryMedium to 1.0f,
+    UIContentSizeCategoryLarge to 1.05f,
+    UIContentSizeCategoryExtraLarge to 1.1f,
+    UIContentSizeCategoryExtraExtraLarge to 1.15f,
+    UIContentSizeCategoryExtraExtraExtraLarge to 1.2f,
+
+    UIContentSizeCategoryAccessibilityMedium to 1.3f,
+    UIContentSizeCategoryAccessibilityLarge to 1.4f,
+    UIContentSizeCategoryAccessibilityExtraLarge to 1.5f,
+    UIContentSizeCategoryAccessibilityExtraExtraLarge to 1.6f,
+    UIContentSizeCategoryAccessibilityExtraExtraExtraLarge to 1.7f,
+
+    // UIContentSizeCategoryUnspecified
+)
 
 fun ComposeUIViewController(content: @Composable () -> Unit): UIViewController =
     ComposeWindow().apply {
@@ -98,8 +102,15 @@ internal actual class ComposeWindow : UIViewController {
     @OverrideInit
     constructor(coder: NSCoder) : super(coder)
 
+    private val fontScale: Float
+        get() {
+            val contentSizeCategory = traitCollection.preferredContentSizeCategory ?: UIContentSizeCategoryUnspecified
+
+            return uiContentSizeCategoryToFontScaleMap[contentSizeCategory] ?: 1.0f
+        }
+
     private val density: Density
-        get() = Density(layer.layer.contentScale)
+        get() = Density(layer.layer.contentScale, fontScale)
 
     private lateinit var layer: ComposeLayer
     private lateinit var content: @Composable () -> Unit
@@ -275,6 +286,21 @@ internal actual class ComposeWindow : UIViewController {
             layer.layer.needRedraw()
         }
         super.viewWillTransitionToSize(size, withTransitionCoordinator)
+    }
+
+    override fun traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        val newSizeCategory = traitCollection.preferredContentSizeCategory
+
+        if (newSizeCategory != null && previousTraitCollection?.preferredContentSizeCategory != newSizeCategory) {
+            // will force a view to do layout on a next main runloop tick
+            // which will cause viewWillLayoutSubviews
+            // which will assign new density to layer (which takes new fontScale into consideration)
+            // and will force recomposition, because it will change
+
+            view.setNeedsLayout()
+        }
     }
 
     override fun viewWillLayoutSubviews() {


### PR DESCRIPTION
## Proposed Changes

As per [doc](https://jetbrains.team/p/ui/documents/folders?d=2w3lSY2dZZ1c), iOS doesn't use linear font scaling, like Android does. Reimplementing the same behavior would break Material components, which are designed with linear scaling in mind. A good workaround would be to construct a new **Density** with **fontScale** taking iOS font size setting into consideration and pass it to Compose every time a **traitCollection** with updated user font size preference arrives to **ComposeWindow**.

## Testing

Test: Change text size settings from within iOS Settings. (Settings/Accessibility/Display & Text Size/Larger Text on Simulator). Launch using iOS App configuration, navigate to the settings, select different font size, navigate back to app and see changes applied.

## Issues Fixed

Fixes: [https://github.com/JetBrains/compose-multiplatform/issues/2567
](https://github.com/JetBrains/compose-multiplatform/issues/2567)
