### PR TITLE
Add test reproducing reported user story. Implement fix. Document edg…

### DIFF
--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
@@ -341,13 +341,19 @@ private fun Modifier.slideOnKeyEvents(
             }
 
             KeyEventType.KeyUp -> {
-                if (it.isDirectionDown || it.isDirectionUp || it.isDirectionRight
-                    || it.isDirectionLeft || it.isHome || it.isMoveEnd || it.isPgUp || it.isPgDn
-                ) {
-                    onValueChangeFinishedState.value?.invoke()
-                    true
-                } else {
-                    false
+                when {
+                    it.isDirectionDown,
+                    it.isDirectionUp,
+                    it.isDirectionRight,
+                    it.isDirectionLeft,
+                    it.isHome,
+                    it.isMoveEnd,
+                    it.isPgUp,
+                    it.isPgDn -> {
+                        onValueChangeFinishedState.value?.invoke()
+                        true
+                    }
+                    else -> false
                 }
             }
             else -> false

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
@@ -165,6 +165,7 @@ fun Slider(
 ) {
     require(steps >= 0) { "steps should be >= 0" }
     val onValueChangeState = rememberUpdatedState(onValueChange)
+    val onValueChangeFinishedState = rememberUpdatedState(onValueChangeFinished)
     val tickFractions = remember(steps) {
         stepsToTickFractions(steps)
     }
@@ -185,7 +186,7 @@ fun Slider(
             )
             .focusRequester(focusRequester)
             .focusable(enabled, interactionSource)
-            .slideOnKeyEvents(enabled, steps, valueRange, value, isRtl, onValueChangeState)
+            .slideOnKeyEvents(enabled, steps, valueRange, value, isRtl, onValueChangeState, onValueChangeFinishedState)
     ) {
         val widthPx = constraints.maxWidth.toFloat()
         val maxPx: Float
@@ -266,6 +267,7 @@ fun Slider(
     }
 }
 
+// TODO: Edge case - losing focus on slider while key is pressed will end up with onValueChangeFinished not being invoked
 @OptIn(ExperimentalComposeUiApi::class)
 private fun Modifier.slideOnKeyEvents(
     enabled: Boolean,
@@ -273,56 +275,84 @@ private fun Modifier.slideOnKeyEvents(
     valueRange: ClosedFloatingPointRange<Float>,
     value: Float,
     isRtl: Boolean,
-    onValueChangeState: State<(Float) -> Unit>
+    onValueChangeState: State<(Float) -> Unit>,
+    onValueChangeFinishedState: State<(() -> Unit)?>
 ): Modifier {
     require(steps >= 0) { "steps should be >= 0" }
 
     return this.onKeyEvent {
-        if (it.type != KeyEventType.KeyDown || !enabled) return@onKeyEvent false
-        val rangeLength = abs(valueRange.endInclusive - valueRange.start)
-        // When steps == 0, it means that a user is not limited by a step length (delta) when using touch or mouse.
-        // But it is not possible to adjust the value continuously when using keyboard buttons -
-        // the delta has to be discrete. In this case, 1% of the valueRange seems to make sense.
-        val actualSteps = if (steps > 0) steps + 1 else 100
-        val delta = rangeLength / actualSteps
-        when {
-            it.isDirectionUp -> {
-                onValueChangeState.value((value + delta).coerceIn(valueRange))
-                true
+        if (!enabled) return@onKeyEvent false
+
+        when (it.type) {
+            KeyEventType.KeyDown -> {
+                val rangeLength = abs(valueRange.endInclusive - valueRange.start)
+                // When steps == 0, it means that a user is not limited by a step length (delta) when using touch or mouse.
+                // But it is not possible to adjust the value continuously when using keyboard buttons -
+                // the delta has to be discrete. In this case, 1% of the valueRange seems to make sense.
+                val actualSteps = if (steps > 0) steps + 1 else 100
+                val delta = rangeLength / actualSteps
+                when {
+                    it.isDirectionUp -> {
+                        onValueChangeState.value((value + delta).coerceIn(valueRange))
+                        true
+                    }
+
+                    it.isDirectionDown -> {
+                        onValueChangeState.value((value - delta).coerceIn(valueRange))
+                        true
+                    }
+
+                    it.isDirectionRight -> {
+                        val sign = if (isRtl) -1 else 1
+                        onValueChangeState.value((value + sign * delta).coerceIn(valueRange))
+                        true
+                    }
+
+                    it.isDirectionLeft -> {
+                        val sign = if (isRtl) -1 else 1
+                        onValueChangeState.value((value - sign * delta).coerceIn(valueRange))
+                        true
+                    }
+
+                    it.isHome -> {
+                        onValueChangeState.value(valueRange.start)
+                        true
+                    }
+
+                    it.isMoveEnd -> {
+                        onValueChangeState.value(valueRange.endInclusive)
+                        true
+                    }
+
+                    it.isPgUp -> {
+                        val page = (actualSteps / 10).coerceIn(1, 10)
+                        onValueChangeState.value((value - page * delta).coerceIn(valueRange))
+                        true
+                    }
+
+                    it.isPgDn -> {
+                        val page = (actualSteps / 10).coerceIn(1, 10)
+                        onValueChangeState.value((value + page * delta).coerceIn(valueRange))
+                        true
+                    }
+
+                    else -> false
+                }
             }
-            it.isDirectionDown -> {
-                onValueChangeState.value((value - delta).coerceIn(valueRange))
-                true
+
+            KeyEventType.KeyUp -> {
+                if (it.isDirectionDown || it.isDirectionUp || it.isDirectionRight
+                    || it.isDirectionLeft || it.isHome || it.isMoveEnd || it.isPgUp || it.isPgDn
+                ) {
+                    onValueChangeFinishedState.value?.invoke()
+                    true
+                } else {
+                    false
+                }
             }
-            it.isDirectionRight -> {
-                val sign = if (isRtl) -1 else 1
-                onValueChangeState.value((value + sign * delta).coerceIn(valueRange))
-                true
+            else -> {
+                false
             }
-            it.isDirectionLeft -> {
-                val sign = if (isRtl) -1 else 1
-                onValueChangeState.value((value - sign * delta).coerceIn(valueRange))
-                true
-            }
-            it.isHome -> {
-                onValueChangeState.value(valueRange.start)
-                true
-            }
-            it.isMoveEnd -> {
-                onValueChangeState.value(valueRange.endInclusive)
-                true
-            }
-            it.isPgUp -> {
-                val page = (actualSteps / 10).coerceIn(1, 10)
-                onValueChangeState.value((value - page * delta).coerceIn(valueRange))
-                true
-            }
-            it.isPgDn -> {
-                val page = (actualSteps / 10).coerceIn(1, 10)
-                onValueChangeState.value((value + page * delta).coerceIn(valueRange))
-                true
-            }
-            else -> false
         }
     }
 }

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
@@ -350,9 +350,7 @@ private fun Modifier.slideOnKeyEvents(
                     false
                 }
             }
-            else -> {
-                false
-            }
+            else -> false
         }
     }
 }

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Slider.kt
@@ -341,19 +341,13 @@ private fun Modifier.slideOnKeyEvents(
             }
 
             KeyEventType.KeyUp -> {
-                when {
-                    it.isDirectionDown,
-                    it.isDirectionUp,
-                    it.isDirectionRight,
-                    it.isDirectionLeft,
-                    it.isHome,
-                    it.isMoveEnd,
-                    it.isPgUp,
-                    it.isPgDn -> {
-                        onValueChangeFinishedState.value?.invoke()
-                        true
-                    }
-                    else -> false
+                if (it.isDirectionDown || it.isDirectionUp || it.isDirectionRight
+                    || it.isDirectionLeft || it.isHome || it.isMoveEnd || it.isPgUp || it.isPgDn
+                ) {
+                    onValueChangeFinishedState.value?.invoke()
+                    true
+                } else {
+                    false
                 }
             }
             else -> false


### PR DESCRIPTION
## Proposed Changes

Pass **onValueChangeFinished** further down the implementation in a way similar to **onValueChangeState**. Invoke it when key is released.

## Testing

Test: test containing the reported using scenario is added to kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt

## Issues Fixed

Fixes: [https://github.com/JetBrains/compose-multiplatform/issues/2798](https://github.com/JetBrains/compose-multiplatform/issues/2798)
