### PR TITLE
Disable `set window size by its content` on Linux, until we can fix it on our CI

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -659,7 +659,9 @@ class WindowStateTest {
     }
 
     @Test
-    fun `set window size by its content`() = runApplicationTest(useDelay = isLinux) {
+    fun `set window size by its content`() = runApplicationTest {
+        assumeTrue(!isLinux)
+
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize.Unspecified)
 


### PR DESCRIPTION
The `set window size by its content` test fails on our CI, for unknown reasons. I tested it in Linux in an emulator and it works.

## Proposed Changes

Disable the test on Linux.