### PR TITLE
Fix SkikoComposeUiTest.isIdle

### DIFF
--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -158,6 +158,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:material:material"))
                 implementation(libs.skikoCommon)
                 implementation(libs.kotlinTest)
+                implementation(libs.atomicFu)
             }
 
             desktopTest.dependsOn(skikoTest)

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.platform.InfiniteAnimationPolicy
 import androidx.compose.ui.platform.SkiaRootForTest
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.test.junit4.MainTestClockImpl
-import androidx.compose.ui.test.junit4.TextInputServiceForTests
 import androidx.compose.ui.test.junit4.UncaughtExceptionHandler
 import androidx.compose.ui.test.junit4.isOnUiThread
 import androidx.compose.ui.text.ExperimentalTextApi
@@ -201,7 +200,9 @@ class SkikoComposeUiTest(
 
     private fun shouldPumpTime(): Boolean {
         return mainClock.autoAdvance &&
-            (Snapshot.current.hasPendingChanges() || scene.hasInvalidations())
+            (Snapshot.current.hasPendingChanges()
+                || Snapshot.isApplyObserverNotificationPending
+                || scene.hasInvalidations())
     }
 
     @OptIn(InternalComposeUiApi::class)

--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -430,7 +430,7 @@ class ComposeUiSkikoTestTest {
 
     // See https://github.com/JetBrains/compose-multiplatform/issues/3117
     @Test
-    fun recompositionCompletesBeforeSetContentReturns() = repeat(300) {
+    fun recompositionCompletesBeforeSetContentReturns() = repeat(1000) {
         runSkikoComposeUiTest {
             var globalValue by atomic(0)
             setContent {

--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -19,14 +19,9 @@ package androidx.compose.ui.test
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
@@ -40,12 +35,15 @@ import androidx.compose.ui.input.pointer.PointerEventType.Companion.Scroll
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.PointerType.Companion.Mouse
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.atomicfu.atomic
+
 
 @OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
 class ComposeUiSkikoTestTest {
@@ -429,6 +427,33 @@ class ComposeUiSkikoTestTest {
         onNodeWithTag("test").performTextClearance()
         assertThat(text.text).isEqualTo("")
     }
+
+    // See https://github.com/JetBrains/compose-multiplatform/issues/3117
+    @Test
+    fun recompositionCompletesBeforeSetContentReturns() = repeat(300) {
+        runSkikoComposeUiTest {
+            var globalValue by atomic(0)
+            setContent {
+                var localValue by remember{ mutableStateOf(0) }
+
+                remember(localValue) {
+                    globalValue = localValue
+                }
+
+                Layout(
+                    {},
+                    Modifier,
+                    measurePolicy = { _, constraints ->
+                        localValue = 100
+                        layout(constraints.maxWidth, constraints.maxHeight) {}
+                    }
+                )
+            }
+
+            assertThat(globalValue).isEqualTo(100)
+        }
+    }
+
 }
 
 private class AssertThat<T>(val t: T)


### PR DESCRIPTION
Currently, when `Snapshot.isApplyObserverNotificationPending` is being called concurrently with the test thread (which GlobalSnapshotManager typically does), `SkikoComposeUiTest.isIdle` can return true because the snapshot changes have already been cleared (`Snapshot.current.hasPendingChanges()` already returns false), but `ComposeScene` hasn't received the notification(s) yet (`scene.hasInvalidations()` still returns false).

This breaks unit tests which set up a scene and expect it to be idle/stable when `setContent` or `waitForidle` returns.

## Proposed Changes

Fix `SkikoComposeUiTest.isIdle` to return false when `Snapshot.sendApplyNotifications` is running (via the new `Snapshot.isApplyObserverNotificationPending` property).

## Testing

Test: new unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3117
