### PR TITLE
Remove synchronization between GlobalSnapshotManager and `ComposeScene.postponeInvalidation`

### DIFF
--- a/compose/ui/ui/src/darwinMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.native.kt
+++ b/compose/ui/ui/src/darwinMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.native.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.platform
 
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.platform.GlobalSnapshotManager.ensureStarted
-import androidx.compose.ui.createSynchronizedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
@@ -37,7 +36,6 @@ import kotlinx.coroutines.Dispatchers
  * may establish different policies for these notifications.
  */
 internal actual object GlobalSnapshotManager {
-    internal actual val sync = createSynchronizedObject()
     private val started = AtomicInt(0)
 
     actual fun ensureStarted() {

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.js.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.platform
 
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.platform.GlobalSnapshotManager.ensureStarted
-import androidx.compose.ui.createSynchronizedObject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -37,7 +36,6 @@ import kotlinx.coroutines.launch
  * may establish different policies for these notifications.
  */
 internal actual object GlobalSnapshotManager {
-    internal actual val sync = createSynchronizedObject()
     private val started = AtomicInt(0)
 
     actual fun ensureStarted() {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -150,11 +150,10 @@ class ComposeScene internal constructor(
         check(!isClosed) { "ComposeScene is closed" }
         isInvalidationDisabled = true
         val result = try {
-            // We must see the actual state before we will do [block]
-            // TODO(https://github.com/JetBrains/compose-jb/issues/1854) get rid of synchronized.
-            synchronized(GlobalSnapshotManager.sync) {
-                Snapshot.sendApplyNotifications()
-            }
+            // Try to get see the up-to-date state before running block
+            // Note that this doesn't guarantee it, if sendApplyNotifications is called concurrently
+            // in a different thread than this code.
+            Snapshot.sendApplyNotifications()
             snapshotChanges.perform()
             block()
         } finally {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.skiko.kt
@@ -16,8 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.SynchronizedObject
-
 /**
  * Platform-specific mechanism for starting a monitor of global snapshot state writes
  * in order to schedule the periodic dispatch of snapshot apply notifications.
@@ -26,10 +24,7 @@ import androidx.compose.ui.SynchronizedObject
  *
  * Composition bootstrapping mechanisms for a particular platform/framework should call
  * [ensureStarted] during setup to initialize periodic global snapshot notifications.
- * For desktop, these notifications are always sent on [MainUIDispatcher]. Other platforms
- * may establish different policies for these notifications.
  */
 internal expect object GlobalSnapshotManager {
-    internal val sync: SynchronizedObject
     fun ensureStarted()
 }


### PR DESCRIPTION
The synchronization between `GlobalSnapshotManager` and `ComposeScene.postponeInvalidation` attempts to make sure that any modified state is applied (notifications sent) before the next frame is executed. However following discussions with Chuck Jazdzewski from Google, it appears that this is not achievable, and in fact should not be a goal. The only guarantee made by compose-runtime is that any changes in state will _eventually_ be seen in compose.

## Proposed Changes

Remove the synchronization.

## Testing

Test: Manual test run

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/1854
