### PR TITLE
Add delay on Mac OS X in window state tests that minimize the window

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -340,7 +340,7 @@ class WindowStateTest {
     }
 
     @Test
-    fun minimize() = runApplicationTest {
+    fun minimize() = runApplicationTest(useDelay = isMacOs, delayMillis = 1000) {
         val state = WindowState(size = DpSize(200.dp, 200.dp))
         lateinit var window: ComposeWindow
 
@@ -515,7 +515,10 @@ class WindowStateTest {
     }
 
     @Test
-    fun `minimize window before show`() = runApplicationTest {
+    fun `minimize window before show`() = runApplicationTest(
+        useDelay = isMacOs,
+        delayMillis = 1000
+    ) {
         val state = WindowState(
             size = DpSize(200.dp, 200.dp),
             position = WindowPosition(Alignment.Center),


### PR DESCRIPTION
Without this, the minimize animation doesn't complete and Mac OS X leaves the window in the tray.

## Proposed Changes

Add `useDelay = isMacOS` for two window state tests.

## Testing

Test: Ran `WindowStateTests` before and after. Before, the two windows would remain the minimized section of the dock. Afterwards, they don't.
