### PR TITLE
Disable the `rotationZ` test except on Linux 

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicsLayerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicsLayerTest.kt
@@ -167,6 +167,11 @@ class GraphicsLayerTest {
     }
     @Test
     fun rotationZ() {
+
+        // TODO Remove once approximate comparison will be available. The problem: there is a difference
+        //  in antialiasing between platforms. The golden screenshot currently matches CI behaviour.
+        assumeTrue(isLinux)
+
         val snapshot = renderComposeScene(width = 40, height = 40) {
             testRotationBoxes(
                 rotationZ = 45f,


### PR DESCRIPTION
because it fails on Mac OS X due to antialiasing differences.

Note that the `rotationX` and `rotationY` tests are already disabled for the same reason.
