### PR TITLE
iOS default fonts mapping

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -24,6 +24,7 @@ val MainScreen = Screen.List(
     Screen.Example("ImageViewer") { ImageViewer() },
     Screen.Example("RoundedCornerCrashOnJS") { RoundedCornerCrashOnJS() },
     Screen.Example("TextDirection") { TextDirection() },
+    Screen.Example("FontFamilies") { FontFamilies() },
     LazyLayouts,
 )
 

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontFamilies.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontFamilies.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+
+@Composable
+fun FontFamilies() {
+    val state = rememberScrollState()
+    MaterialTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp)
+                .verticalScroll(state),
+            verticalArrangement = Arrangement
+                .spacedBy(10.dp)
+        ) {
+            for (fontFamily in listOf(
+                FontFamily.SansSerif,
+                FontFamily.Serif,
+                FontFamily.Monospace,
+                FontFamily.Cursive
+            )) {
+                FontFamilyShowcase(fontFamily)
+            }
+        }
+    }
+}
+
+@Composable
+fun FontFamilyShowcase(fontFamily: FontFamily) {
+    Column {
+        Text(
+            text = "$fontFamily"
+        )
+        Text(
+            text = "The quick brown fox jumps over the lazy dog.",
+            fontSize = 48.sp,
+            fontFamily = fontFamily
+        )
+        Text(
+            text = "1234567890",
+            fontSize = 48.sp,
+            fontFamily = fontFamily
+        )
+    }
+}

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
@@ -30,44 +30,6 @@ actual sealed class PlatformFont : Font {
         get() = "${this::class.qualifiedName}|$identity"
 }
 
-internal actual val GenericFontFamiliesMapping by lazy {
-    when (Platform.Current) {
-        Platform.Windows ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Arial"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Consolas"),
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-        Platform.MacOS ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf(
-                    "System Font",
-                    "Helvetica Neue",
-                    "Helvetica"
-                ),
-                FontFamily.Serif.name to listOf("Times"),
-                FontFamily.Monospace.name to listOf("Courier"),
-                FontFamily.Cursive.name to listOf("Apple Chancery")
-            )
-        Platform.Linux ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans"),
-                FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
-                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono"),
-                // better alternative?
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-        Platform.Unknown ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Arial"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Consolas"),
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-    }
-}
-
 /**
  * Defines a Font using resource name.
  *
@@ -214,21 +176,12 @@ private fun typefaceResource(resourceName: String): SkTypeface {
     return SkTypeface.makeFromData(Data.makeFromBytes(bytes))
 }
 
-private enum class Platform {
-    Linux,
-    Windows,
-    MacOS,
-    Unknown;
-
-    companion object {
-        val Current by lazy {
-            val name = System.getProperty("os.name")
-            when {
-                name.startsWith("Linux") -> Linux
-                name.startsWith("Win") -> Windows
-                name == "Mac OS X" -> MacOS
-                else -> Unknown
-            }
-        }
+internal actual fun currentPlatform(): Platform {
+    val name = System.getProperty("os.name")
+    return when {
+        name.startsWith("Linux") -> Platform.Linux
+        name.startsWith("Win") -> Platform.Windows
+        name == "Mac OS X" -> Platform.MacOS
+        else -> Platform.Unknown
     }
 }

--- a/compose/ui/ui-text/src/jsWasmMain/kotlin/androidx/compose/ui/text/platform/JsFont.js.kt
+++ b/compose/ui/ui-text/src/jsWasmMain/kotlin/androidx/compose/ui/text/platform/JsFont.js.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,43 +21,6 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontListFontFamily
 import org.jetbrains.skia.Data
 
-internal actual val GenericFontFamiliesMapping by lazy {
-    when (Platform.Current) {
-        Platform.Windows ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Arial"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Consolas"),
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-        Platform.MacOS ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf(
-                    "Helvetica Neue",
-                    "Helvetica"
-                ),
-                FontFamily.Serif.name to listOf("Times"),
-                FontFamily.Monospace.name to listOf("Courier"),
-                FontFamily.Cursive.name to listOf("Apple Chancery")
-            )
-        Platform.Linux ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans"),
-                FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
-                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono"),
-                // better alternative?
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-        Platform.Unknown ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Arial"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Consolas"),
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-    }
-}
-
 internal actual fun loadTypeface(font: Font): SkTypeface {
     if (font !is PlatformFont) {
         throw IllegalArgumentException("Unsupported font type: $font")
@@ -67,25 +30,5 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
     }
 }
 
-private enum class Platform {
-    Linux,
-    Windows,
-    MacOS,
-    Unknown;
-
-    companion object {
-        val Current by lazy {
-            println("TODO: selecting MacOS unconditionally")
-            MacOS
-            /*
-            val name = System.getProperty("os.name")
-            when {
-                name.startsWith("Linux") -> Linux
-                name.startsWith("Win") -> Windows
-                name == "Mac OS X" -> MacOS
-                else -> Unknown
-            }
-             */
-        }
-    }
-}
+// TODO: Select current platform
+internal actual fun currentPlatform(): Platform = Platform.Unknown

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeFont.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeFont.native.kt
@@ -15,50 +15,10 @@
  */
 package androidx.compose.ui.text.platform
 
-import kotlin.native.OsFamily as NativeOsFamily
 import kotlin.native.Platform as NativePlatform
 import org.jetbrains.skia.Typeface as SkTypeface
 import androidx.compose.ui.text.font.Font
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontListFontFamily
 import org.jetbrains.skia.Data
-
-internal actual val GenericFontFamiliesMapping by lazy {
-    when (Platform.Current) {
-        Platform.Windows ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Arial"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Consolas"),
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-        Platform.MacOS ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf(
-                    "Helvetica Neue",
-                    "Helvetica"
-                ),
-                FontFamily.Serif.name to listOf("Times"),
-                FontFamily.Monospace.name to listOf("Courier"),
-                FontFamily.Cursive.name to listOf("Apple Chancery")
-            )
-        Platform.Linux ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans"),
-                FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
-                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono"),
-                // better alternative?
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-        Platform.Unknown ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Arial"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Consolas"),
-                FontFamily.Cursive.name to listOf("Comic Sans MS")
-            )
-    }
-}
 
 internal actual fun loadTypeface(font: Font): SkTypeface {
     if (font !is PlatformFont) {
@@ -72,18 +32,12 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
     }
 }
 
-private enum class Platform {
-    Linux,
-    Windows,
-    MacOS,
-    Unknown;
-
-    companion object {
-        val Current: Platform = when(NativePlatform.osFamily) {
-            NativeOsFamily.MACOSX -> MacOS
-            NativeOsFamily.LINUX -> Linux
-            NativeOsFamily.WINDOWS -> Windows
-            else -> Unknown
-        }
-    }
+internal actual fun currentPlatform(): Platform = when (NativePlatform.osFamily) {
+    OsFamily.MACOSX -> Platform.MacOS
+    OsFamily.IOS -> Platform.IOS
+    OsFamily.LINUX -> Platform.Linux
+    OsFamily.WINDOWS -> Platform.Windows
+    OsFamily.TVOS -> Platform.TvOS
+    OsFamily.WATCHOS -> Platform.WatchOS
+    else -> Platform.Unknown
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -239,10 +239,10 @@ internal val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
             )
         Platform.IOS, Platform.TvOS, Platform.WatchOS ->
             mapOf(
-                FontFamily.SansSerif.name to listOf("System Font", "Helvetica Neue", "Helvetica"),
-                FontFamily.Serif.name to listOf("Times"),
-                FontFamily.Monospace.name to listOf("Courier"),
-                FontFamily.Cursive.name to listOf("Apple Chancery")
+                FontFamily.SansSerif.name to listOf("Helvetica"),
+                FontFamily.Serif.name to listOf("Times New Roman"),
+                FontFamily.Monospace.name to listOf("Menlo", "Courier"),
+                FontFamily.Cursive.name to listOf("Snell Roundhand")
             )
         Platform.Unknown ->
             mapOf(

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -230,19 +230,14 @@ internal val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Consolas"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-        Platform.MacOS ->
+        Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS ->
             mapOf(
-                FontFamily.SansSerif.name to listOf("System Font", "Helvetica Neue", "Helvetica"),
-                FontFamily.Serif.name to listOf("Times"),
-                FontFamily.Monospace.name to listOf("Courier"),
-                FontFamily.Cursive.name to listOf("Apple Chancery")
-            )
-        Platform.IOS, Platform.TvOS, Platform.WatchOS ->
-            mapOf(
-                FontFamily.SansSerif.name to listOf("Helvetica"),
-                FontFamily.Serif.name to listOf("Times New Roman"),
-                FontFamily.Monospace.name to listOf("Menlo", "Courier"),
-                FontFamily.Cursive.name to listOf("Snell Roundhand")
+                // .AppleSystem* aliases is the only legal way to get default SF and NY fonts.
+                FontFamily.SansSerif.name to listOf(".AppleSystemUIFont", "Helvetica Neue", "Helvetica"),
+                FontFamily.Serif.name to listOf(".AppleSystemUIFontSerif", "Times", "Times New Roman"),
+                FontFamily.Monospace.name to listOf(".AppleSystemUIFontMonospaced", "Menlo", "Courier"),
+                // Safari "font-family: cursive" real font names from macOS and iOS.
+                FontFamily.Cursive.name to listOf("Apple Chancery", "Snell Roundhand")
             )
         Platform.Unknown ->
             mapOf(

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -200,5 +200,56 @@ internal class FontCache {
         }
 }
 
-internal expect val GenericFontFamiliesMapping: Map<String, List<String>>
+internal enum class Platform {
+    Unknown,
+    Linux,
+    Windows,
+    MacOS,
+    IOS,
+    TvOS,
+    WatchOS,
+}
+
+internal expect fun currentPlatform(): Platform
 internal expect fun loadTypeface(font: Font): SkTypeface
+
+internal val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
+    when (currentPlatform()) {
+        Platform.Linux ->
+            mapOf(
+                FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans"),
+                FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
+                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono"),
+                // better alternative?
+                FontFamily.Cursive.name to listOf("Comic Sans MS")
+            )
+        Platform.Windows ->
+            mapOf(
+                FontFamily.SansSerif.name to listOf("Arial"),
+                FontFamily.Serif.name to listOf("Times New Roman"),
+                FontFamily.Monospace.name to listOf("Consolas"),
+                FontFamily.Cursive.name to listOf("Comic Sans MS")
+            )
+        Platform.MacOS ->
+            mapOf(
+                FontFamily.SansSerif.name to listOf("System Font", "Helvetica Neue", "Helvetica"),
+                FontFamily.Serif.name to listOf("Times"),
+                FontFamily.Monospace.name to listOf("Courier"),
+                FontFamily.Cursive.name to listOf("Apple Chancery")
+            )
+        Platform.IOS, Platform.TvOS, Platform.WatchOS ->
+            mapOf(
+                FontFamily.SansSerif.name to listOf("System Font", "Helvetica Neue", "Helvetica"),
+                FontFamily.Serif.name to listOf("Times"),
+                FontFamily.Monospace.name to listOf("Courier"),
+                FontFamily.Cursive.name to listOf("Apple Chancery")
+            )
+        Platform.Unknown ->
+            mapOf(
+                FontFamily.SansSerif.name to listOf("Arial"),
+                FontFamily.Serif.name to listOf("Times New Roman"),
+                FontFamily.Monospace.name to listOf("Consolas"),
+                FontFamily.Cursive.name to listOf("Comic Sans MS")
+            )
+    }
+}


### PR DESCRIPTION
## Proposed Changes

  - Move duplicated code to common(skiko)
  - Add iOS defaults fonts (from Safari defaults)
  - Use .AppleSystem* aliases
  - Add FontFamilies page to demo

## Testing

Test: Run mpp demo, look at new FontFamilies page

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/2874
Fixes (partially) https://github.com/JetBrains/compose-multiplatform/issues/2985 (TODO: revisit windows fonts)
