### PR TITLE
Add missing compose test API for k/wasm target

### DIFF
--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -81,6 +81,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         desktop()
         darwin()
         js()
+        wasm()
 
         configureDarwinFlags()
     }
@@ -148,6 +149,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             desktopMain.dependsOn(skikoMain)
             nativeMain.dependsOn(skikoMain)
             jsMain.dependsOn(skikoMain)
+            wasmMain.dependsOn(skikoMain)
 
             desktopMain.dependencies {
                 implementation(libs.truth)
@@ -163,6 +165,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             desktopTest.dependsOn(skikoTest)
             jsTest.dependsOn(skikoTest)
             nativeTest.dependsOn(skikoTest)
+            wasmTest.dependsOn(skikoTest)
 
             desktopTest.dependencies {
                 implementation(libs.truth)

--- a/compose/ui/ui-test-junit4/src/wasmMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.wasmMain.kt
+++ b/compose/ui/ui-test-junit4/src/wasmMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.wasmMain.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test.junit4
+
+/**
+ * Runs the given action on the UI thread.
+ *
+ * This method is blocking until the action is complete.
+ */
+internal actual fun <T> runOnUiThread(action: () -> T): T {
+    return action()
+}
+
+/**
+ * Returns if the call is made on the main thread.
+ */
+internal actual fun isOnUiThread(): Boolean = true

--- a/compose/ui/ui-test-junit4/src/wasmMain/kotlin/androidx/compose/ui/test/junit4/UncaughtExceptionHandler.wasmMain.kt
+++ b/compose/ui/ui-test-junit4/src/wasmMain/kotlin/androidx/compose/ui/test/junit4/UncaughtExceptionHandler.wasmMain.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test.junit4
+
+internal actual inline fun <T> synchronized(lock: Any, block: () -> T) = block()

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -86,6 +86,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         desktop()
         darwin()
         js()
+        wasm()
     }
 
     kotlin {
@@ -148,6 +149,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             desktopMain.dependsOn(skikoMain)
             jsNativeMain.dependsOn(skikoMain)
             jsMain.dependsOn(jsNativeMain)
+            wasmMain.dependsOn(jsNativeMain)
             nativeMain.dependsOn(jsNativeMain)
             uikitMain.dependsOn(nativeMain)
             macosMain.dependsOn(nativeMain)

--- a/compose/ui/ui-test/src/wasmMain/kotlin/androidx/compose/ui/test/Actions.wasmMain.kt
+++ b/compose/ui/ui-test/src/wasmMain/kotlin/androidx/compose/ui/test/Actions.wasmMain.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+@OptIn(ExperimentalTestApi::class)
+internal actual fun SemanticsNodeInteraction.performClickImpl(): SemanticsNodeInteraction {
+    return performMouseInput {
+        click()
+    }
+}

--- a/compose/ui/ui-test/src/wasmMain/kotlin/androidx/compose/ui/test/Actuals.wasmMain.kt
+++ b/compose/ui/ui-test/src/wasmMain/kotlin/androidx/compose/ui/test/Actuals.wasmMain.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+/**
+ * Returns the hash code for the given object that is unique across all currently allocated objects.
+ * The hash code for the null reference is zero.
+ *
+ * Can be negative, and near Int.MAX_VALUE, so it can overflow if used as part of calculations.
+ * For example, don't use this:
+ * ```
+ * val comparison = identityHashCode(midVal) - identityHashCode(leftVal)
+ * if (comparison < 0) ...
+ * ```
+ * Use this instead:
+ * ```
+ * if (identityHashCode(midVal) < identityHashCode(leftVal)) ...
+ * ```
+ */
+internal actual fun identityHashCode(instance: Any?): Int {
+    if (instance == null) {
+        return 0
+    }
+    return instance.hashCode()
+}

--- a/compose/ui/ui-test/src/wasmMain/kotlin/androidx/compose/ui/test/InputDispatcher.wasmMain.kt
+++ b/compose/ui/ui-test/src/wasmMain/kotlin/androidx/compose/ui/test/InputDispatcher.wasmMain.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalTestApi::class)
+
+package androidx.compose.ui.test
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+
+/**
+ * The [KeyEvent] is usually created by the system. This function creates an instance of
+ * [KeyEvent] that can be used in tests.
+ */
+internal actual fun keyEvent(
+    key: Key, keyEventType: KeyEventType, modifiers: Int
+): KeyEvent = TODO()
+
+internal actual fun Int.updatedKeyboardModifiers(key: Key, down: Boolean): Int = this // TODO: implement updatedKeyboardModifiers

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -301,6 +301,9 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsTest {
                 dependsOn(skikoTest)
             }
+            wasmTest {
+                dependsOn(skikoTest)
+            }
 
             desktopTest.dependencies {
                 implementation(libs.truth)


### PR DESCRIPTION
This enables the running wasmBrowserTest in all compose modules. Although some tests fail - requires an investigation. 