### PR TITLE
Fix incorrect Skiko render target on iOS Metal.

### DIFF
--- a/compose/mpp/demo/regenerate_xcode_project.sh
+++ b/compose/mpp/demo/regenerate_xcode_project.sh
@@ -14,6 +14,7 @@ if command -v xcodegen >/dev/null 2>&1; then
   fi
 
   xcodegen
+  open $projPath
 else
   # xcodegen does not exist
   echo "Error: xcodegen not found. Please install it using 'brew install xcodegen'."

--- a/compose/mpp/demo/regenerate_xcode_project.sh
+++ b/compose/mpp/demo/regenerate_xcode_project.sh
@@ -1,0 +1,21 @@
+# Script to regenerate xcode project
+
+# make script folder current or exit
+cd "$(dirname "$0")" || exit
+
+if command -v xcodegen >/dev/null 2>&1; then
+  # xcodegen exists
+
+  projPath="ComposeDemo.xcodeproj"
+
+  if [ -d "$projPath" ]; then
+    echo "Removing existing project"
+    rm -rf "$projPath"
+  fi
+
+  xcodegen
+else
+  # xcodegen does not exist
+  echo "Error: xcodegen not found. Please install it using 'brew install xcodegen'."
+  exit 1
+fi

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -26,34 +26,19 @@ import androidx.compose.ui.interop.LocalLayerContainer
 import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.*
-import androidx.compose.ui.platform.DefaultInputModeManager
-import androidx.compose.ui.platform.Platform
-import androidx.compose.ui.platform.UIKitTextInputService
 import androidx.compose.ui.text.input.PlatformTextInputService
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.unit.*
 import kotlin.math.roundToInt
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.launch
 import org.jetbrains.skiko.SkikoUIView
 import org.jetbrains.skiko.TextActions
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSize
-import platform.Foundation.NSCoder
-import platform.Foundation.NSNotification
-import platform.Foundation.NSNotificationCenter
-import platform.Foundation.NSSelectorFromString
-import platform.Foundation.NSValue
+import platform.Foundation.*
 import platform.UIKit.*
 import platform.darwin.NSObject
 
@@ -180,11 +165,17 @@ internal actual class ComposeWindow : UIViewController {
         ).load()
         val rootView = UIView() // rootView needs to interop with UIKit
         rootView.backgroundColor = UIColor.whiteColor
+
+        skikoUIView.translatesAutoresizingMaskIntoConstraints = false
         rootView.addSubview(skikoUIView)
-        rootView.setAutoresizesSubviews(true)
-        skikoUIView.setAutoresizingMask(
-            UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
-        )
+
+        NSLayoutConstraint.activateConstraints(listOf(
+            skikoUIView.leadingAnchor.constraintEqualToAnchor(rootView.leadingAnchor),
+            skikoUIView.trailingAnchor.constraintEqualToAnchor(rootView.trailingAnchor),
+            skikoUIView.topAnchor.constraintEqualToAnchor(rootView.topAnchor),
+            skikoUIView.bottomAnchor.constraintEqualToAnchor(rootView.bottomAnchor)
+        ))
+
         view = rootView
         val uiKitTextInputService = UIKitTextInputService(
             showSoftwareKeyboard = {


### PR DESCRIPTION
## Proposed Changes

Since this bug was caused by incorrect SkikoUIView size, we can just use NSLayoutConstraints instead of autoresize mask to constrain SkikoUIView size to ComposeWindow.view.

## Testing

Test: launch from within Xcode. Click on M(Metal) debugger.
<img width="436" alt="Screenshot 2023-05-09 at 11 45 05" src="https://user-images.githubusercontent.com/4167681/237059107-b7221d91-899f-4750-85c0-d90865644ee7.png">

Select Scope to be Metal GPU and count to 2, click capture. Scroll or trigger redraw in any other way. Investigate command buffers and check that render targets are of expected size.

## Issues Fixed

Fixes: incorrect Skiko render target on iOS Metal.

Before: 
![image](https://user-images.githubusercontent.com/4167681/237060734-ba894c5c-d5f7-412d-959b-06fa65c38ef4.png)

After: 
<img width="320" alt="Screenshot 2023-05-09 at 11 53 14" src="https://user-images.githubusercontent.com/4167681/237061240-765772ad-a5af-4144-83dc-a62570d9568c.png">

