### PR TITLE
Disable on Linux the tests that set window width/height from content.

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -611,6 +611,8 @@ class WindowStateTest {
 
     @Test
     fun `set window height by its content`() = runApplicationTest(useDelay = isLinux) {
+        assumeTrue(!isLinux)  // Flaky on our CI
+
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize(300.dp, Dp.Unspecified))
 
@@ -636,7 +638,9 @@ class WindowStateTest {
     }
 
     @Test
-    fun `set window width by its content`() = runApplicationTest(useDelay = isLinux) {
+    fun `set window width by its content`() = runApplicationTest() {
+        assumeTrue(!isLinux)  // Flaky on our CI
+
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize(Dp.Unspecified, 300.dp))
 
@@ -663,7 +667,7 @@ class WindowStateTest {
 
     @Test
     fun `set window size by its content`() = runApplicationTest {
-        assumeTrue(!isLinux)
+        assumeTrue(!isLinux) // Flaky on our CI
 
         lateinit var window: ComposeWindow
         val state = WindowState(size = DpSize.Unspecified)


### PR DESCRIPTION
## Proposed Changes

Disable the `set window width by its content` and `set window height by its content` tests on Linux. They appear to only fail in our CI.
Note that `set window size by its content` is already disabled in the code.

## Testing

Test: The tests were disabled.
