### PR TITLE
Don't overwrite most of the locals in ProvideCommonCompositionLocals

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/CompositionLocals.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/CompositionLocals.kt
@@ -188,31 +188,40 @@ internal val LocalPointerIconService = staticCompositionLocalOf<PointerIconServi
 @Composable
 internal fun ProvideCommonCompositionLocals(
     owner: Owner,
+    isMainOwner: Boolean,
     uriHandler: UriHandler,
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(
-        LocalAccessibilityManager provides owner.accessibilityManager,
-        LocalAutofill provides owner.autofill,
-        LocalAutofillTree provides owner.autofillTree,
-        LocalClipboardManager provides owner.clipboardManager,
-        LocalDensity provides owner.density,
         LocalFocusManager provides owner.focusOwner,
-        @Suppress("DEPRECATION") LocalFontLoader
-            providesDefault @Suppress("DEPRECATION") owner.fontLoader,
-        LocalFontFamilyResolver providesDefault owner.fontFamilyResolver,
-        LocalHapticFeedback provides owner.hapticFeedBack,
-        LocalInputModeManager provides owner.inputModeManager,
-        LocalLayoutDirection provides owner.layoutDirection,
-        LocalTextInputService provides owner.textInputService,
-        LocalPlatformTextInputPluginRegistry provides owner.platformTextInputPluginRegistry,
-        LocalTextToolbar provides owner.textToolbar,
-        LocalUriHandler provides uriHandler,
-        LocalViewConfiguration provides owner.viewConfiguration,
         LocalWindowInfo provides owner.windowInfo,
         LocalPointerIconService provides owner.pointerIconService,
-        content = content
-    )
+    ){
+        // It's possible that more locals need to be provided for a non-main owner
+        if (isMainOwner){
+            CompositionLocalProvider(
+                LocalAccessibilityManager provides owner.accessibilityManager,
+                LocalAutofill provides owner.autofill,
+                LocalAutofillTree provides owner.autofillTree,
+                LocalClipboardManager provides owner.clipboardManager,
+                LocalDensity provides owner.density,
+                @Suppress("DEPRECATION") LocalFontLoader
+                    providesDefault @Suppress("DEPRECATION") owner.fontLoader,
+                LocalFontFamilyResolver providesDefault owner.fontFamilyResolver,
+                LocalHapticFeedback provides owner.hapticFeedBack,
+                LocalInputModeManager provides owner.inputModeManager,
+                LocalLayoutDirection provides owner.layoutDirection,
+                LocalTextInputService provides owner.textInputService,
+                LocalPlatformTextInputPluginRegistry provides owner.platformTextInputPluginRegistry,
+                LocalTextToolbar provides owner.textToolbar,
+                LocalUriHandler provides uriHandler,
+                LocalViewConfiguration provides owner.viewConfiguration,
+                content = content
+            )
+        }
+        else
+            content()
+    }
 }
 
 private fun noLocalProvidedFor(name: String): Nothing {

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/CompositionLocals.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/CompositionLocals.kt
@@ -193,11 +193,14 @@ internal fun ProvideCommonCompositionLocals(
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(
+        // Locals that depend on the owner itself should be overridden always (regardless of whether
+        // this owner is the main one) are ones that .
         LocalFocusManager provides owner.focusOwner,
         LocalWindowInfo provides owner.windowInfo,
         LocalPointerIconService provides owner.pointerIconService,
     ){
-        // It's possible that more locals need to be provided for a non-main owner
+        // If any of the locals below start depending on the owner, they should be moved to the
+        // block above.
         if (isMainOwner){
             CompositionLocalProvider(
                 LocalAccessibilityManager provides owner.accessibilityManager,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -41,9 +41,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.use
 import com.google.common.truth.Truth.assertThat
@@ -72,6 +74,20 @@ class DesktopPopupTest {
         }
 
         assertThat(actualLocalValue).isEqualTo(3)
+    }
+
+    @Test
+    fun `LocalLayoutDirection is seen in popup`() {
+        lateinit var layoutDirectionInPopup: LayoutDirection
+        rule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                Popup{
+                    layoutDirectionInPopup = LocalLayoutDirection.current
+                }
+            }
+        }
+
+        assertThat(layoutDirectionInPopup).isEqualTo(LayoutDirection.Rtl)
     }
 
     @Test

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -376,8 +376,9 @@ class ComposeScene internal constructor(
         )
         attach(mainOwner)
         composition = mainOwner.setContent(
-            parentComposition ?: recomposer,
-            { compositionLocalContext }
+            parent = parentComposition ?: recomposer,
+            isMainOwner = true,
+            getCompositionLocalContext = { compositionLocalContext }
         ) {
             CompositionLocalProvider(
                 LocalComposeScene provides this,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Wrapper.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Wrapper.skiko.kt
@@ -28,8 +28,7 @@ import androidx.compose.ui.node.LayoutNode
 /**
  * Composes the given composable into [SkiaBasedOwner]
  *
- * @param parent The parent composition reference to coordinate scheduling of composition updates
- *        If null then default root composition will be used.
+ * @param parent The parent composition reference to coordinate scheduling of composition updates.
  * @param getCompositionLocalContext getter for retrieving the top-level composition local context.
  * Can be backed by `mutableStateOf` to dynamically change top-level locals.
  * @param content A `@Composable` function declaring the UI contents
@@ -37,6 +36,7 @@ import androidx.compose.ui.node.LayoutNode
 @OptIn(ExperimentalComposeUiApi::class)
 internal fun SkiaBasedOwner.setContent(
     parent: CompositionContext,
+    isMainOwner: Boolean,
     getCompositionLocalContext: () -> CompositionLocalContext? = { null },
     content: @Composable () -> Unit
 ): Composition {
@@ -46,6 +46,7 @@ internal fun SkiaBasedOwner.setContent(
         getCompositionLocalContext().provide {
             ProvideCommonCompositionLocals(
                 owner = owner,
+                isMainOwner = isMainOwner,
                 uriHandler = remember { PlatformUriHandler() },
                 content = content
             )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
@@ -79,7 +79,7 @@ internal fun PopupLayout(
         )
         scene.attach(owner)
 
-        val composition = owner.setContent(parent = parentComposition) {
+        val composition = owner.setContent(parent = parentComposition, isMainOwner = false) {
             Layout(
                 content = content,
                 measurePolicy = { measurables, constraints ->


### PR DESCRIPTION
Currently, we overwrite (by re-providing) a bunch of locals in `ProvideCommonCompositionLocals` even within a child owner. This, for example, resets a user-provided `LocalLayoutDirection` in popups.

## Proposed Changes

In a non-main owner only overwrite the locals whose value are tied to the owner itself.

## Testing

Test: Added a unit test that makes sure `LocalLayoutDirection` is propagated into `Popup`.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3142
