### PR TITLE
After each ComposeScene.render phase, send apply notifications and perform the corresponding changes.

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -57,6 +58,8 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.keyEvent
@@ -150,6 +153,22 @@ class ComposeSceneTest {
         awaitNextRender()
         screenshotRule.snap(surface, "frame3_clipToBounds")
         assertFalse(hasRenders())
+    }
+
+    // https://github.com/JetBrains/compose-multiplatform/issues/3137
+    @Test
+    fun `rendering of Text state change`() = renderingTest(width = 400, height = 200) {
+        var text by mutableStateOf("before")
+        setContent {
+            Text(text)
+        }
+        awaitNextRender()
+        val before = surface.makeImageSnapshot().toComposeImageBitmap().toPixelMap().buffer
+
+        text = "after"
+        awaitNextRender()
+        val after = surface.makeImageSnapshot().toComposeImageBitmap().toPixelMap().buffer
+        assertThat(after).isNotEqualTo(before)
     }
 
     @Test(timeout = 5000)


### PR DESCRIPTION
Because we hold off on sending the apply notifications during `ComposeScene.render`, any snapshot state changes that are made in one phase (recomposition, layout, draw) are not visible in the next phase until the next time `ComposeScene.render` is called.

Some widgets, however, use snapshot state changes to signal from one phase to the next that some work needs to be done. For example `TextState.layoutInvalidation` and `TextState.drawScopeInvalidation`. Due to this, a change in the `text` parameter of `Text` would not be realized until 3 render iterations have occurred.

## Proposed Changes

Call 
```
Snapshot.sendApplyNotifications()
snapshotChanges.perform()
```
between each phase of `ComposeScene.render`.

## Testing

Test: Added a new unit test to verify that the drawn text in `Text` changes after one render iteration.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3137
