### PR TITLE
Make flushing_in_another_thread test call runTest immediately

### DIFF
--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
@@ -78,29 +78,27 @@ class FlushCoroutineDispatcherTest {
     }
 
     @Test
-    fun flushing_in_another_thread() {
+    fun flushing_in_another_thread() = runTest {
         val actualNumbers = mutableListOf<Int>()
         lateinit var dispatcher: FlushCoroutineDispatcher
         val random = Random(123)
 
-        runTest {
-            withContext(Dispatchers.Default) {
-                dispatcher = FlushCoroutineDispatcher(this)
+        withContext(Dispatchers.Default) {
+            dispatcher = FlushCoroutineDispatcher(this)
 
-                val addJob = launch(dispatcher) {
-                    repeat(10000) {
-                        actualNumbers.add(it)
-                        repeat(random.nextInt(5)) {
-                            yield()
-                        }
-                    }
-                }
-
-                launch {
-                    while (addJob.isActive) {
-                        dispatcher.flush()
+            val addJob = launch(dispatcher) {
+                repeat(10000) {
+                    actualNumbers.add(it)
+                    repeat(random.nextInt(5)) {
                         yield()
                     }
+                }
+            }
+
+            launch {
+                while (addJob.isActive) {
+                    dispatcher.flush()
+                    yield()
                 }
             }
         }


### PR DESCRIPTION
This is the only correct way to run tests with coroutines for k/js and k/wasm (it's preferred for common tests)


See: https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/run-test.html

> The platform difference entails that, in order to use this function correctly in common code, one must always immediately return the produced [TestResult](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-result/index.html) from the test method, without doing anything else afterwards. See [TestResult](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-result/index.html) for details on this.

Note: `withContext` call suspends untill the block completes, so the behaviour of the test should match the prior one.