### PR TITLE
Add missing `getAndIncrement` in AtomicLong implementation for web

### DIFF
--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/JsActuals.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/JsActuals.kt
@@ -26,6 +26,10 @@ actual class AtomicLong actual constructor(value: Long) {
         atomic = value
     }
 
-    actual fun getAndIncrement(): Long = TODO("Implement native atomic getAndIncrement")
+    actual fun getAndIncrement(): Long {
+        val original = atomic
+        atomic++
+        return original
+    }
 }
 


### PR DESCRIPTION
This implementation (actual for web target - jsWasmMain sourceset) **is not supposed** to be used in multi-threaded environment. 