### PR TITLE
Remove the test for concurrent use of multiple ImageComposeScenes.

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ImageComposeSceneTest.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.icons.Icons
@@ -38,9 +37,6 @@ import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.runBlocking
@@ -96,28 +92,6 @@ class ImageComposeSceneTest {
             screenshotRule.write(scene.render(50.seconds), "frame3")
             screenshotRule.write(scene.render(100.seconds), "frame4")
         }
-    }
-
-    @OptIn(ExperimentalTime::class)
-    @Test(timeout = 5000)
-    fun `run multiple ImageComposeScenes concurrently`() {
-        val service = Executors.newFixedThreadPool(50)
-
-        for(i in 1..1000) {
-            service.submit {
-                val scene = ImageComposeScene(50, 50) {
-                    Box(Modifier.fillMaxSize().background(Color.White)) {
-                        CircularProgressIndicator()
-                    }
-                }
-                scene.render() // start animation
-                scene.render(50.milliseconds).close()
-                scene.close()
-            }
-        }
-
-        service.shutdown()
-        service.awaitTermination(10000, TimeUnit.MILLISECONDS)
     }
 
     @Test


### PR DESCRIPTION
Looks like ImageComposeScene is still broken under concurrent usage (of multiple instances). The test was succeeding because `ExecutorService.submit(Runnable)` eats any exceptions thrown by the runnable. The code would throw exceptions, which were ignored, but left unclosed `ImageComposeScenes` (and thus `Recomposer`s), which leaked memory.

## Proposed Changes

 Remove the test until the behavior is fixed.
  -
  -

## Testing

Test: Remove the test.

