### PR TITLE
Add higher than 60hz support to demo projects

### DIFF
--- a/compose/mpp/demo-uikit/build.gradle.kts
+++ b/compose/mpp/demo-uikit/build.gradle.kts
@@ -104,6 +104,8 @@ apple {
         sceneDelegateClass = "SceneDelegate"
         launchStoryboard = "LaunchScreen"
 
+        // TODO: extend applePlugin to have make it possible to add 'CADisableMinimumFrameDurationOnPhone' set to 'YES' in plist in generated project
+
         dependencies {
             // Here we can add additional dependencies to Swift sourceSet
         }

--- a/compose/mpp/demo-uikit/build.gradle.kts
+++ b/compose/mpp/demo-uikit/build.gradle.kts
@@ -104,7 +104,7 @@ apple {
         sceneDelegateClass = "SceneDelegate"
         launchStoryboard = "LaunchScreen"
 
-        // TODO: extend applePlugin to have make it possible to add 'CADisableMinimumFrameDurationOnPhone' set to 'YES' in plist in generated project
+        // TODO: add 'CADisableMinimumFrameDurationOnPhone' set to 'YES'
 
         dependencies {
             // Here we can add additional dependencies to Swift sourceSet

--- a/compose/mpp/demo/project.yml
+++ b/compose/mpp/demo/project.yml
@@ -20,6 +20,7 @@ targets:
       path: plists/Ios/Info.plist
       properties:
         UILaunchStoryboardName: "LaunchStoryboard" # needs for proper iOS app size and modern features
+        CADisableMinimumFrameDurationOnPhone: true
     sources:
       - "src/"
     settings:


### PR DESCRIPTION
## Proposed Changes

Change similar to https://github.com/JetBrains/compose-multiplatform-ios-android-template/pull/17

## Testing

Test: launch compose/mpp/demo/regenerate_xcode_project.sh and check that new entry is present in plist.

## Issues Fixed

Fixes: inability to utilize high refresh rate iPhone screens.

## Remark

I didn't find a way to integrate the same change using our gradle apple plugin, marked relevant place with TODO
