### PR TITLE
UIKitView. Fix lifetime discrepancy within the composition.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
@@ -1,6 +1,8 @@
 package androidx.compose.ui.interop
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import kotlinx.cinterop.ObjCAction
 import platform.CoreGraphics.CGRectMake
@@ -17,12 +19,14 @@ import platform.UIKit.UITextField
  */
 @Composable
 fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier) {
+    val latestOnValueChanged by rememberUpdatedState(onValueChange)
+
     UIKitView(
         factory = {
             val textField = object : UITextField(CGRectMake(0.0, 0.0, 0.0, 0.0)) {
                 @ObjCAction
                 fun editingChanged() {
-                    onValueChange(text ?: "")
+                    latestOnValueChanged(text ?: "")
                 }
             }
             textField.addTarget(
@@ -35,13 +39,6 @@ fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier:
         modifier = modifier,
         update = { textField ->
             textField.text = value
-        },
-        onRelease = { textField ->
-            textField.removeTarget(
-                target = textField,
-                action = NSSelectorFromString(textField::editingChanged.name),
-                forControlEvents = UIControlEventEditingChanged
-            )
-        },
+        }
     )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -85,6 +85,7 @@ fun <T : UIView> UIKitView(
     // TODO: adapt UIKitView to reuse inside LazyColumn like in AndroidView:
     //  https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1)
     val componentInfo = remember { ComponentInfo<T>() }
+    val view = remember { factory() }
     val root = LocalLayerContainer.current
     val density = LocalDensity.current.density
     var rectInPixels by remember { mutableStateOf(IntRect(0, 0, 0, 0)) }
@@ -116,8 +117,8 @@ fun <T : UIView> UIKitView(
         }
     )
 
-    DisposableEffect(factory, onRelease) {
-        componentInfo.component = factory()
+    DisposableEffect(Unit) {
+        componentInfo.component = view
         componentInfo.container = UIView().apply {
             addSubview(componentInfo.component)
         }
@@ -129,6 +130,7 @@ fun <T : UIView> UIKitView(
             onRelease(componentInfo.component)
         }
     }
+
     LaunchedEffect(background) {
         if (background == Color.Unspecified) {
             componentInfo.container.backgroundColor = root.backgroundColor
@@ -136,6 +138,7 @@ fun <T : UIView> UIKitView(
             componentInfo.container.backgroundColor = parseColor(background)
         }
     }
+
     SideEffect {
         componentInfo.updater.update = update
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -85,7 +85,6 @@ fun <T : UIView> UIKitView(
     // TODO: adapt UIKitView to reuse inside LazyColumn like in AndroidView:
     //  https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1)
     val componentInfo = remember { ComponentInfo<T>() }
-    val view = remember { factory() }
     val root = LocalLayerContainer.current
     val density = LocalDensity.current.density
     var rectInPixels by remember { mutableStateOf(IntRect(0, 0, 0, 0)) }
@@ -118,7 +117,7 @@ fun <T : UIView> UIKitView(
     )
 
     DisposableEffect(Unit) {
-        componentInfo.component = view
+        componentInfo.component = factory()
         componentInfo.container = UIView().apply {
             addSubview(componentInfo.component)
         }


### PR DESCRIPTION
## Proposed Changes

- Remember the `factory` invocation result. 
- Add indirection to retrieve latest `onValueChanged` lambda.
- Remove parameters on `DisposableEffect`, since relevant `UIView` lifetime is already bound to composable function lifetime.
- Remove redundant target removal logic passed as `onRelease` lambda, [addTarget doesn't retain target](https://developer.apple.com/documentation/uikit/uicontrol/1618259-addtarget?language=objc).

## Testing

Test: launch a repro from issued mentioned below

## Issues Fixed

Fixes: Bug on https://github.com/JetBrains/compose-multiplatform/issues/3119.

## To clarify
Do we need to remember `onRelease`?
