### PR TITLE
Fix missing InterfaceOrientation rawValue, remove redundant logic

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import platform.UIKit.*
 
 /**
- * Wraps iOS enum statusBarOrientation()
+ * Wraps valid layout values for iOS UIInterfaceOrientation
  */
 @InternalComposeApi
 @Immutable
@@ -34,22 +34,16 @@ enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
     LandscapeRight(UIInterfaceOrientationLandscapeRight);
 
     companion object {
-        fun getByRawValue(orientation: UIInterfaceOrientation): InterfaceOrientation {
+        fun getByRawValue(orientation: UIInterfaceOrientation): InterfaceOrientation? {
             return values().firstOrNull {
                 it.rawValue == orientation
-            } ?: error("Can't find orientation rawValue $orientation in enum InterfaceOrientation")
+            }
         }
-
-        /**
-         * Return iOS statusBarOrientation() wrapped with Kotlin enum [InterfaceOrientation]
-         */
-        fun getStatusBarOrientation(): InterfaceOrientation =
-            getByRawValue(UIApplication.sharedApplication().statusBarOrientation())
     }
 }
 
 /**
- * Composition local for [InterfaceOrientation] of current Application
+ * Composition local for [InterfaceOrientation]
  */
 @InternalComposeApi
 val LocalInterfaceOrientationState = staticCompositionLocalOf<State<InterfaceOrientation>> {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -98,7 +98,7 @@ internal actual class ComposeWindow : UIViewController {
     )
 
     /*
-     * On newest iOS interfaceOrientation will be deduced from [UIWindowScene] of [UIWindow]
+     * On iOS >= 13.0 interfaceOrientation will be deduced from [UIWindowScene] of [UIWindow]
      * to which our [ComposeWindow] is attached.
      * It's never UIInterfaceOrientationUnknown, if accessed after owning [UIWindow] was made key and visible:
      * https://developer.apple.com/documentation/uikit/uiwindow/1621601-makekeyandvisible?language=objc
@@ -302,19 +302,6 @@ internal actual class ComposeWindow : UIViewController {
         size: CValue<CGSize>,
         withTransitionCoordinator: UIViewControllerTransitionCoordinatorProtocol
     ) {
-        layer.setDensity(density)
-        val scale = density.density
-        val width = size.useContents { width } * scale
-        val height = size.useContents { height } * scale
-        layer.setSize(width.roundToInt(), height.roundToInt())
-        layer.layer.needRedraw() // TODO: remove? the following block should be enough
-        withTransitionCoordinator.animateAlongsideTransition(animation = null) {
-            // Docs: https://developer.apple.com/documentation/uikit/uiviewcontrollertransitioncoordinator/1619295-animatealongsidetransition
-            // Request a frame once more on animation completion.
-            // Consider adding redrawImmediately() in SkiaLayer for ios to sync with current frame.
-            // This fixes an interop use case when Compose is embedded in SwiftUi.
-            layer.layer.needRedraw()
-        }
         super.viewWillTransitionToSize(size, withTransitionCoordinator)
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -98,8 +98,8 @@ internal actual class ComposeWindow : UIViewController {
     )
 
     /*
-     * On newest iOS interfaceOrientation will be deduced from [UIWindowScene] to which [UIWindow]
-     * with rootViewController being our [ComposeWindow] is attached.
+     * On newest iOS interfaceOrientation will be deduced from [UIWindowScene] of [UIWindow]
+     * to which our [ComposeWindow] is attached.
      * It's never UIInterfaceOrientationUnknown, if accessed after owning [UIWindow] was made key and visible:
      * https://developer.apple.com/documentation/uikit/uiwindow/1621601-makekeyandvisible?language=objc
      */

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -91,7 +91,7 @@ internal actual class ComposeWindow : UIViewController {
 
     /*
      * Initial value is arbitarily chosen to avoid propagating invalid value logic
-     * It's never the case to reflect that in type system
+     * It's never the case in real usage scenario to reflect that in type system
      */
     private val interfaceOrientationState = mutableStateOf(
         InterfaceOrientation.Portrait


### PR DESCRIPTION
## Proposed Changes

Remove UIDeviceOrientation change notifications listening, since [it's orthogonal to UIInterfaceOrientation](https://stackoverflow.com/questions/33243843/what-is-the-difference-between-uidevice-orientation-and-uiinterface-orientation)
Differentiate between new and deprecated API for orientation retrieval based on iOS version.
Update orientation composition local inside `viewWillLayout`.
Orientation update will call `viewWillTransitionToSize` followed by `viewSafeAreaInsetsDidChange` and `viewWillLayout`. If orientation change happens when app is in background, `viewSafeAreaInsetsDidChange`  and `willViewLayout` will still be called after it becomes active, so it's the best place for it.

## Testing

Test: run regenerate_xcodeproject.sh, launch the app.

## Issues Fixed

Fixes: startup crash on xcodegen generated project. Crashes when creating ComposeWindow on iOS in case statusBarOrientation of UIApplication is invalid (usually before UIWindow becomes key and visible). Trying to proactively obtain current interface orientation before view is ready for layout is a bad idea.
