### PR TITLE
When the test main clock is advanced, call ComposeScene.render with the current test time

### DIFF
--- a/compose/ui/ui-test-junit4/src/commonMain/kotlin/androidx/compose/ui/test/junit4/AbstractMainTestClock.kt
+++ b/compose/ui/ui-test-junit4/src/commonMain/kotlin/androidx/compose/ui/test/junit4/AbstractMainTestClock.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 internal abstract class AbstractMainTestClock(
     private val testScheduler: TestCoroutineScheduler,
     private val frameDelayMillis: Long,
-    private val runOnUiThread: (action: () -> Unit) -> Unit
+    private val runOnUiThread: (action: () -> Unit) -> Unit,
+    private val onTimeAdvanced: ((currentTime: Long) -> Unit)? = null,
 ) : MainTestClock {
 
     override val currentTime: Long
@@ -73,5 +74,7 @@ internal abstract class AbstractMainTestClock(
             // Therefore we also call `runCurrent` as it's done in TestCoroutineDispatcher
             testScheduler.runCurrent()
         }
+
+        onTimeAdvanced?.invoke(currentTime)
     }
 }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/BasicTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/BasicTestTest.kt
@@ -17,10 +17,8 @@
 package androidx.compose.ui.test
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.testTag
@@ -29,6 +27,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.delay
 import org.junit.Rule
 
 
@@ -77,5 +76,26 @@ class BasicTestTest {
         rule.onNodeWithTag("box").performClick()
         val clockAfter = rule.mainClock.currentTime
         assertTrue(clockAfter > clockBefore, "performClick did not advance the test clock")
+    }
+
+    @Test
+    fun advancingClockRunsRecomposition() {
+        rule.mainClock.autoAdvance = false
+
+        rule.setContent {
+            var text by remember { mutableStateOf("1") }
+            Text(text, modifier = Modifier.testTag("text"))
+
+            LaunchedEffect(Unit){
+                delay(1_000)
+                text = "2"
+            }
+        }
+
+        rule.onNodeWithTag("text").assertTextEquals("1")
+        rule.mainClock.advanceTimeBy(999, ignoreFrameDuration = true)
+        rule.onNodeWithTag("text").assertTextEquals("1")
+        rule.mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
+        rule.onNodeWithTag("text").assertTextEquals("2")
     }
 }

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/MainTestClockImpl.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/MainTestClockImpl.skikoMain.kt
@@ -22,9 +22,11 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class MainTestClockImpl(
     testScheduler: TestCoroutineScheduler,
-    frameDelayMillis: Long
+    frameDelayMillis: Long,
+    onTimeAdvanced: (Long) -> Unit
 ) : AbstractMainTestClock(
-    testScheduler,
-    frameDelayMillis,
-    ::runOnUiThread
+    testScheduler = testScheduler,
+    frameDelayMillis = frameDelayMillis,
+    runOnUiThread = ::runOnUiThread,
+    onTimeAdvanced = onTimeAdvanced
 )


### PR DESCRIPTION
## Proposed Changes

In order to sync the composition with the with the test main clock, call `ComposeScene.render` whenever the test main clock is advanced.

Unfortunately, I couldn't figure how to do this like Android does, so I hope this way will be good enough.

Android appears to use a `TestMonotonicFrameClock` (with the scheduler advanced by the `MainTestClock`) in place of our `BroadcastFrameClock` as the parent clock for `Recomposer.runRecomposeAndApplyChanges()`. This means that when the main test clock advances, `Recomposer` wakes up (from `parentFrameClock.withFrameNanos`) and runs a recomposition.

For us, however, using `Recomposer.runRecomposeAndApplyChanges()` with a `TestMonotonicFrameClock` is difficult, because it would require `ComposeScene.frameClock` (currently a `BroadcastFrameClock`) to be `TestMonotonicFrameClock` when running in a test context. Unfortunately, `ComposeScene` is rather tightly coupled with `BroadcastFrameClock`.

## Testing

Test: Added a unit test to verify that when the main test clock is advanced, a recomposition will happen correctly.
