### PR TITLE
Wait until compose is idle before returning from DesktopTestOwner.getRoots()

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/BasicTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/BasicTestTest.kt
@@ -98,4 +98,17 @@ class BasicTestTest {
         rule.mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
         rule.onNodeWithTag("text").assertTextEquals("2")
     }
+
+    @Test
+    fun obtainingSemanticsNodeInteractionWaitsUntilIdle() {
+        var text by mutableStateOf("1")
+
+        rule.setContent {
+            Text(text, modifier = Modifier.testTag("text"))
+        }
+
+        rule.onNodeWithTag("text").assertTextEquals("1")
+        text = "2"
+        rule.onNodeWithTag("text").assertTextEquals("2")
+    }
 }

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -220,7 +220,7 @@ class SkikoComposeUiTest(
             ++i
         }
 
-        val hasPendingMeasureOrLayout = testOwner.getRoots(true).any {
+        val hasPendingMeasureOrLayout = testOwner.roots.any {
             (it as SkiaRootForTest).hasPendingMeasureOrLayout
         }
 
@@ -325,6 +325,9 @@ class SkikoComposeUiTest(
     }
 
     private inner class DesktopTestOwner : TestOwner {
+        val roots: Set<RootForTest>
+            get() = this@SkikoComposeUiTest.scene.roots
+
         @OptIn(ExperimentalTextApi::class)
         override fun performTextInput(node: SemanticsNode, action: TextInputForTests.() -> Unit) {
             runOnIdle {
@@ -337,6 +340,7 @@ class SkikoComposeUiTest(
         }
 
         override fun getRoots(atLeastOneRootExpected: Boolean): Set<RootForTest> {
+            waitForIdle()
             return this@SkikoComposeUiTest.scene.roots
         }
 


### PR DESCRIPTION
## Proposed Changes

Run `waitUntilIdle` in `DesktopTestOwner.getRoots()`, as expected by its contract (documented in `TestOwner.getRoots()`). This makes tests wait until compose is idle when obtaining any semantic node interactions (`onNode` and such), as expected.

## Testing

Test: Added a unit test.
