### PR TITLE
Add delete command to backspace key when modified with shift

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyMapping.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyMapping.kt
@@ -94,6 +94,7 @@ internal fun commonKeyMapping(
                         MappedKeys.PageDown -> KeyCommand.SELECT_PAGE_DOWN
                         MappedKeys.MoveHome -> KeyCommand.SELECT_LINE_START
                         MappedKeys.MoveEnd -> KeyCommand.SELECT_LINE_END
+                        MappedKeys.Backspace -> KeyCommand.DELETE_PREV_CHAR
                         MappedKeys.Insert -> KeyCommand.PASTE
                         else -> null
                     }


### PR DESCRIPTION
## Proposed Changes

Map `Backspace` with `Shift` modifier to `DELETE_PREV_CHAR` `KeyCommand` instead of null.

## Testing

Test: repeat user scenario, symbol should get deleted.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3226
