### PR TITLE
Remove JUnit usages in runtime common tests

### DIFF
--- a/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/TestUtils.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/TestUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.TestScope
+import kotlinx.test.testWithTimeout
+
+
+private const val DEFAULT_DISPATCH_TIMEOUT_MS = 60_000L
+
+@ExperimentalCoroutinesApi
+internal fun runTest(
+    context: CoroutineContext = EmptyCoroutineContext,
+    dispatchTimeoutMs: Long = DEFAULT_DISPATCH_TIMEOUT_MS,
+    timeoutMs: Long? = null,
+    testBody: suspend TestScope.() -> Unit
+): TestResult = kotlinx.coroutines.test.runTest(context, dispatchTimeoutMs) {
+    val testScope = this
+    if (timeoutMs == null) {
+        testBody()
+    } else {
+        testWithTimeout(timeoutMs) {
+            testBody(testScope)
+        }
+    }
+}

--- a/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateListTests.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateListTests.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.test.IgnoreJsTarget
+import kotlinx.test.testWithTimeout
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SnapshotStateListTests {
@@ -572,124 +573,132 @@ class SnapshotStateListTests {
         }
     }
 
-    @Test(timeout = 10_000)
+    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentGlobalModifications_addAll(): Unit = runTest(UnconfinedTestDispatcher()) {
-        repeat(100) {
-            val list = mutableStateListOf<Int>()
-            coroutineScope {
-                repeat(100) { index ->
-                    launch(Dispatchers.Default) {
-                        list.addAll(0, Array(10) { index * 100 + it }.toList())
-                    }
-                }
-            }
-
-            repeat(100) { index ->
-                repeat(10) {
-                    assertTrue(list.contains(index * 100 + it))
-                }
-            }
-        }
-    }
-
-    @Test(timeout = 5000)
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentMixingWriteApply_add(): Unit = runTest {
-        repeat(1000) {
-            val lists = Array(100) { mutableStateListOf<Int>() }.toList()
-            val channel = Channel<Unit>(Channel.CONFLATED)
-            coroutineScope {
-                // Launch mutator
-                launch(Dispatchers.Default) {
+    fun concurrentGlobalModifications_addAll() = runTest(UnconfinedTestDispatcher()) {
+        testWithTimeout(10_000) {
+            repeat(100) {
+                val list = mutableStateListOf<Int>()
+                coroutineScope {
                     repeat(100) { index ->
-                        lists.fastForEach { list ->
-                            list.add(index)
+                        launch(Dispatchers.Default) {
+                            list.addAll(0, Array(10) { index * 100 + it }.toList())
                         }
-
-                        // Simulate the write observer
-                        channel.trySend(Unit)
                     }
-                    channel.close()
                 }
 
-                // Simulate the global snapshot manager
-                launch(Dispatchers.Default) {
-                    channel.consumeEach {
-                        Snapshot.notifyObjectsInitialized()
+                repeat(100) { index ->
+                    repeat(10) {
+                        assertTrue(list.contains(index * 100 + it))
                     }
                 }
             }
         }
-        // Should only get here if the above doesn't deadlock.
     }
 
-    @Test(timeout = 5000)
+    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentMixingWriteApply_addAll_clear(): Unit = runTest {
-        repeat(100) {
-            val lists = Array(100) { mutableStateListOf<Int>() }.toList()
-            val data = Array(100) { index -> index }.toList()
-            val channel = Channel<Unit>(Channel.CONFLATED)
-            coroutineScope {
-                // Launch mutator
-                launch(Dispatchers.Default) {
-                    repeat(100) {
-                        lists.fastForEach { list ->
-                            list.addAll(data)
-                            list.clear()
-                        }
-                        // Simulate the write observer
-                        channel.trySend(Unit)
-                    }
-                    channel.close()
-                }
+    fun concurrentMixingWriteApply_add() = runTest(UnconfinedTestDispatcher()) {
+        testWithTimeout(5000) {
+            repeat(1000) {
+                val lists = Array(100) { mutableStateListOf<Int>() }.toList()
+                val channel = Channel<Unit>(Channel.CONFLATED)
+                coroutineScope {
+                    // Launch mutator
+                    launch(Dispatchers.Default) {
+                        repeat(100) { index ->
+                            lists.fastForEach { list ->
+                                list.add(index)
+                            }
 
-                // Simulate the global snapshot manager
-                launch(Dispatchers.Default) {
-                    channel.consumeEach {
-                        Snapshot.notifyObjectsInitialized()
+                            // Simulate the write observer
+                            channel.trySend(Unit)
+                        }
+                        channel.close()
+                    }
+
+                    // Simulate the global snapshot manager
+                    launch(Dispatchers.Default) {
+                        channel.consumeEach {
+                            Snapshot.notifyObjectsInitialized()
+                        }
                     }
                 }
             }
+            // Should only get here if the above doesn't deadlock.
         }
-        // Should only get here if the above doesn't deadlock.
     }
 
-    @Test(timeout = 5000)
+    @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentMixingWriteApply_addAll_removeRange(): Unit = runTest {
-        repeat(10) {
-            val lists = Array(100) { mutableStateListOf<Int>() }.toList()
-            val data = Array(100) { index -> index }.toList()
-            val channel = Channel<Unit>(Channel.CONFLATED)
-            coroutineScope {
-                // Launch mutator
-                launch(Dispatchers.Default) {
-                    repeat(100) {
-                        lists.fastForEach { list ->
-                            list.addAll(data)
-                            list.removeRange(0, data.size)
+    fun concurrentMixingWriteApply_addAll_clear() = runTest {
+        testWithTimeout(5000) {
+            repeat(100) {
+                val lists = Array(100) { mutableStateListOf<Int>() }.toList()
+                val data = Array(100) { index -> index }.toList()
+                val channel = Channel<Unit>(Channel.CONFLATED)
+                coroutineScope {
+                    // Launch mutator
+                    launch(Dispatchers.Default) {
+                        repeat(100) {
+                            lists.fastForEach { list ->
+                                list.addAll(data)
+                                list.clear()
+                            }
+                            // Simulate the write observer
+                            channel.trySend(Unit)
                         }
-                        // Simulate the write observer
-                        channel.trySend(Unit)
+                        channel.close()
                     }
-                    channel.close()
-                }
 
-                // Simulate the global snapshot manager
-                launch(Dispatchers.Default) {
-                    channel.consumeEach {
-                        Snapshot.notifyObjectsInitialized()
+                    // Simulate the global snapshot manager
+                    launch(Dispatchers.Default) {
+                        channel.consumeEach {
+                            Snapshot.notifyObjectsInitialized()
+                        }
                     }
                 }
             }
+            // Should only get here if the above doesn't deadlock.
         }
-        // Should only get here if the above doesn't deadlock.
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @IgnoreJsTarget // Not relevant in a single threaded environment
+    fun concurrentMixingWriteApply_addAll_removeRange() = runTest {
+        testWithTimeout(5000) {
+            repeat(10) {
+                val lists = Array(100) { mutableStateListOf<Int>() }.toList()
+                val data = Array(100) { index -> index }.toList()
+                val channel = Channel<Unit>(Channel.CONFLATED)
+                coroutineScope {
+                    // Launch mutator
+                    launch(Dispatchers.Default) {
+                        repeat(100) {
+                            lists.fastForEach { list ->
+                                list.addAll(data)
+                                list.removeRange(0, data.size)
+                            }
+                            // Simulate the write observer
+                            channel.trySend(Unit)
+                        }
+                        channel.close()
+                    }
+
+                    // Simulate the global snapshot manager
+                    launch(Dispatchers.Default) {
+                        channel.consumeEach {
+                            Snapshot.notifyObjectsInitialized()
+                        }
+                    }
+                }
+            }
+            // Should only get here if the above doesn't deadlock.
+        }
     }
 
     @Test

--- a/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateListTests.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateListTests.kt
@@ -29,9 +29,8 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runTest
+import androidx.compose.runtime.runTest
 import kotlinx.test.IgnoreJsTarget
-import kotlinx.test.testWithTimeout
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SnapshotStateListTests {
@@ -576,22 +575,22 @@ class SnapshotStateListTests {
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentGlobalModifications_addAll() = runTest(UnconfinedTestDispatcher()) {
-        testWithTimeout(10_000) {
-            repeat(100) {
-                val list = mutableStateListOf<Int>()
-                coroutineScope {
-                    repeat(100) { index ->
-                        launch(Dispatchers.Default) {
-                            list.addAll(0, Array(10) { index * 100 + it }.toList())
-                        }
-                    }
-                }
-
+    fun concurrentGlobalModifications_addAll() = runTest(
+        UnconfinedTestDispatcher(), timeoutMs = 10_000
+    ) {
+        repeat(100) {
+            val list = mutableStateListOf<Int>()
+            coroutineScope {
                 repeat(100) { index ->
-                    repeat(10) {
-                        assertTrue(list.contains(index * 100 + it))
+                    launch(Dispatchers.Default) {
+                        list.addAll(0, Array(10) { index * 100 + it }.toList())
                     }
+                }
+            }
+
+            repeat(100) { index ->
+                repeat(10) {
+                    assertTrue(list.contains(index * 100 + it))
                 }
             }
         }
@@ -600,105 +599,99 @@ class SnapshotStateListTests {
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentMixingWriteApply_add() = runTest(UnconfinedTestDispatcher()) {
-        testWithTimeout(5000) {
-            repeat(1000) {
-                val lists = Array(100) { mutableStateListOf<Int>() }.toList()
-                val channel = Channel<Unit>(Channel.CONFLATED)
-                coroutineScope {
-                    // Launch mutator
-                    launch(Dispatchers.Default) {
-                        repeat(100) { index ->
-                            lists.fastForEach { list ->
-                                list.add(index)
-                            }
-
-                            // Simulate the write observer
-                            channel.trySend(Unit)
+    fun concurrentMixingWriteApply_add() = runTest(UnconfinedTestDispatcher(), timeoutMs = 5000) {
+        repeat(1000) {
+            val lists = Array(100) { mutableStateListOf<Int>() }.toList()
+            val channel = Channel<Unit>(Channel.CONFLATED)
+            coroutineScope {
+                // Launch mutator
+                launch(Dispatchers.Default) {
+                    repeat(100) { index ->
+                        lists.fastForEach { list ->
+                            list.add(index)
                         }
-                        channel.close()
+
+                        // Simulate the write observer
+                        channel.trySend(Unit)
                     }
+                    channel.close()
+                }
 
-                    // Simulate the global snapshot manager
-                    launch(Dispatchers.Default) {
-                        channel.consumeEach {
-                            Snapshot.notifyObjectsInitialized()
-                        }
+                // Simulate the global snapshot manager
+                launch(Dispatchers.Default) {
+                    channel.consumeEach {
+                        Snapshot.notifyObjectsInitialized()
                     }
                 }
             }
-            // Should only get here if the above doesn't deadlock.
         }
+        // Should only get here if the above doesn't deadlock.
     }
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentMixingWriteApply_addAll_clear() = runTest {
-        testWithTimeout(5000) {
-            repeat(100) {
-                val lists = Array(100) { mutableStateListOf<Int>() }.toList()
-                val data = Array(100) { index -> index }.toList()
-                val channel = Channel<Unit>(Channel.CONFLATED)
-                coroutineScope {
-                    // Launch mutator
-                    launch(Dispatchers.Default) {
-                        repeat(100) {
-                            lists.fastForEach { list ->
-                                list.addAll(data)
-                                list.clear()
-                            }
-                            // Simulate the write observer
-                            channel.trySend(Unit)
+    fun concurrentMixingWriteApply_addAll_clear() = runTest(timeoutMs = 5000) {
+        repeat(100) {
+            val lists = Array(100) { mutableStateListOf<Int>() }.toList()
+            val data = Array(100) { index -> index }.toList()
+            val channel = Channel<Unit>(Channel.CONFLATED)
+            coroutineScope {
+                // Launch mutator
+                launch(Dispatchers.Default) {
+                    repeat(100) {
+                        lists.fastForEach { list ->
+                            list.addAll(data)
+                            list.clear()
                         }
-                        channel.close()
+                        // Simulate the write observer
+                        channel.trySend(Unit)
                     }
+                    channel.close()
+                }
 
-                    // Simulate the global snapshot manager
-                    launch(Dispatchers.Default) {
-                        channel.consumeEach {
-                            Snapshot.notifyObjectsInitialized()
-                        }
+                // Simulate the global snapshot manager
+                launch(Dispatchers.Default) {
+                    channel.consumeEach {
+                        Snapshot.notifyObjectsInitialized()
                     }
                 }
             }
-            // Should only get here if the above doesn't deadlock.
         }
+        // Should only get here if the above doesn't deadlock.
     }
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     @IgnoreJsTarget // Not relevant in a single threaded environment
-    fun concurrentMixingWriteApply_addAll_removeRange() = runTest {
-        testWithTimeout(5000) {
-            repeat(10) {
-                val lists = Array(100) { mutableStateListOf<Int>() }.toList()
-                val data = Array(100) { index -> index }.toList()
-                val channel = Channel<Unit>(Channel.CONFLATED)
-                coroutineScope {
-                    // Launch mutator
-                    launch(Dispatchers.Default) {
-                        repeat(100) {
-                            lists.fastForEach { list ->
-                                list.addAll(data)
-                                list.removeRange(0, data.size)
-                            }
-                            // Simulate the write observer
-                            channel.trySend(Unit)
+    fun concurrentMixingWriteApply_addAll_removeRange() = runTest(timeoutMs = 5000) {
+        repeat(10) {
+            val lists = Array(100) { mutableStateListOf<Int>() }.toList()
+            val data = Array(100) { index -> index }.toList()
+            val channel = Channel<Unit>(Channel.CONFLATED)
+            coroutineScope {
+                // Launch mutator
+                launch(Dispatchers.Default) {
+                    repeat(100) {
+                        lists.fastForEach { list ->
+                            list.addAll(data)
+                            list.removeRange(0, data.size)
                         }
-                        channel.close()
+                        // Simulate the write observer
+                        channel.trySend(Unit)
                     }
+                    channel.close()
+                }
 
-                    // Simulate the global snapshot manager
-                    launch(Dispatchers.Default) {
-                        channel.consumeEach {
-                            Snapshot.notifyObjectsInitialized()
-                        }
+                // Simulate the global snapshot manager
+                launch(Dispatchers.Default) {
+                    channel.consumeEach {
+                        Snapshot.notifyObjectsInitialized()
                     }
                 }
             }
-            // Should only get here if the above doesn't deadlock.
         }
+        // Should only get here if the above doesn't deadlock.
     }
 
     @Test

--- a/compose/runtime/runtime/src/commonTest/kotlin/kotlinx/test/Expects.kt
+++ b/compose/runtime/runtime/src/commonTest/kotlin/kotlinx/test/Expects.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.test
+
+import kotlinx.coroutines.CoroutineScope
+
+expect suspend fun testWithTimeout(timeoutMs: Long, block: suspend CoroutineScope.() -> Unit)

--- a/compose/runtime/runtime/src/jsTest/kotlin/kotlinx/test/Actuals.js.kt
+++ b/compose/runtime/runtime/src/jsTest/kotlin/kotlinx/test/Actuals.js.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.test
+
+import kotlin.js.Promise
+import kotlinx.coroutines.*
+
+@OptIn(DelicateCoroutinesApi::class)
+actual suspend fun testWithTimeout(timeoutMs: Long, block: suspend CoroutineScope.() -> Unit) {
+    Promise { resolve, reject ->
+        GlobalScope.launch {
+            try {
+                withTimeout(timeoutMs) {
+                    block()
+                }
+                resolve(Unit)
+            } catch (t: Throwable) {
+                reject(t)
+            }
+        }
+    }.await()
+}

--- a/compose/runtime/runtime/src/jvmTest/kotlin/kotlinx/test/Actuals.jvm.kt
+++ b/compose/runtime/runtime/src/jvmTest/kotlin/kotlinx/test/Actuals.jvm.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+actual suspend fun testWithTimeout(timeoutMs: Long, block: suspend CoroutineScope.() -> Unit) =
+    runBlocking {
+        withTimeout(timeoutMs, block)
+    }

--- a/compose/runtime/runtime/src/nativeTest/kotlin/kotlinx/test/Actuals.native.kt
+++ b/compose/runtime/runtime/src/nativeTest/kotlin/kotlinx/test/Actuals.native.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+actual suspend fun testWithTimeout(timeoutMs: Long, block: suspend CoroutineScope.() -> Unit) =
+    runBlocking {
+        // TODO: k/native tests run in debug mode and much-much slower than jvm,
+        // so we adjust for it here by multiplying by 10 :(
+        withTimeout(timeoutMs * 10, block)
+    }


### PR DESCRIPTION
Test(timeout = 10000) is only available for jvm target, so we use a custom alternative - `testWithTimeout` function

Note: this a reason why weekly CI failed to complete