### PR TITLE
Add needRedraw after size change

### DIFF
--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -140,6 +140,8 @@ internal class ComposeLayer(
 
     fun setSize(width: Int, height: Int) {
         scene.constraints = Constraints(maxWidth = width, maxHeight = height)
+
+        layer.needRedraw()
     }
 
     fun getActiveFocusRect(): DpRect? {

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -59,7 +59,6 @@ internal actual class ComposeWindow actual constructor() {
     init {
         layer.layer.attachTo(canvas)
         canvas.setAttribute("tabindex", "0")
-        layer.layer.needRedraw()
 
         layer.setSize(canvas.width, canvas.height)
     }


### PR DESCRIPTION
## Proposed Changes

Add `needRedraw` inside `setSize`. Previously on iOS it happened in `completionHandler` for `viewWillTransitionToSize` coordinator, which duplicated logic of `viewWillLayoutSubviews`, which will be called after transition, except there wasn't a `needRedraw` call.

## Testing

Test: rotate iOS device and expect a layer to redraw correctly.

## Issues Fixed

Fixes: bug introduced by https://github.com/JetBrains/compose-multiplatform-core/pull/583.

## To investigate
`setSize` was always called and changed scene constraints. Why didn't that change ended with invalidation and `needRedraw` called from compose?
