### PR TITLE
Fix FlushCoroutineDispatcher.scheduleResumeAfterDelay to cancel delayed task

### DIFF
--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
@@ -16,16 +16,13 @@
 
 package androidx.compose.ui.platform
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.yield
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlinx.coroutines.withContext
+import kotlin.test.assertTrue
+import kotlinx.coroutines.*
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class FlushCoroutineDispatcherTest {
@@ -105,5 +102,20 @@ class FlushCoroutineDispatcherTest {
 
         assertEquals((0 until 10000).toList(), actualNumbers)
         assertFalse(dispatcher.hasTasks())
+    }
+
+    @Test
+    fun delayed_tasks_are_cancelled() = runTest {
+        val coroutineScope = CoroutineScope(Dispatchers.Unconfined)
+        val dispatcher = FlushCoroutineDispatcher(coroutineScope)
+        val job = launch(dispatcher){
+            delay(Long.MAX_VALUE/2)
+        }
+        assertTrue(dispatcher.hasTasks())
+        job.cancel()
+        assertTrue(
+            !dispatcher.hasTasks(),
+            "FlushCoroutineDispatcher has a delayed task that has been cancelled"
+        )
     }
 }


### PR DESCRIPTION
...when the continuation is cancelled.

## Proposed Changes

Our current implementation of `FlushCoroutineDispatcher.scheduleResumeAfterDelay` never cancels the delayed task it scheduled when the continuation it was asked to schedule is cancelled. This causes a memory leak, and some tests to get stuck (because compose never becomes idle when FlushCoroutineDispatcher has delayed tasks.

Note that the delayed task is run inside a `finally` block because according to the documentation of `Delay.scheduleResumeAfterDelay` the continuation must be run even if it is cancelled:
```
* Continuation **must be scheduled** to resume even if it is already cancelled, because a cancellation is just
* an exception that the coroutine that used `delay` might wanted to catch and process. It might
* need to close some resources in its `finally` blocks, for example.
```

## Testing

Test: Added a unit test.
