### PR TITLE
Disable faulty tests in ScrollableFocusableInteractionTest

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableFocusableInteractionTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableFocusableInteractionTest.kt
@@ -272,6 +272,10 @@ class ScrollableFocusableInteractionTest {
 
     @Test
     fun scrollFromViewportShrink_isInterrupted_byGesture() = runParametrizedTest {
+        // This test is invalid for reverseScrolling=true. See b/285846153
+        if (reverseScrolling!!)
+            return@runParametrizedTest
+
         var viewportSize by mutableStateOf(100.toDp())
 
         setContent {
@@ -319,6 +323,10 @@ class ScrollableFocusableInteractionTest {
      */
     @Test
     fun scrollsFocusedFocusableIntoView_whenViewportExpandedThenReshrunk_afterInterruption() = runParametrizedTest {
+        // This test is invalid for reverseScrolling=true. See b/285846153
+        if (reverseScrolling!!)
+            return@runParametrizedTest
+
         var viewportSize by mutableStateOf(100.toDp())
 
         setContent {


### PR DESCRIPTION
See https://issuetracker.google.com/issues/285846153 for an explanation about what's wrong with these two tests.

I didn't investigate exactly why they were passing previously, but I'm pretty sure they shouldn't have.

## Proposed Changes

Only run these two tests with `reverseScrolling = false`.

## Testing

Test: Changed the tests themselves.
