### PR TITLE
Fix perspective transform usage

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -26,6 +26,7 @@ val MainScreen = Screen.Selection(
     Screen.Example("TextDirection") { TextDirection() },
     Screen.Example("FontFamilies") { FontFamilies() },
     Screen.Example("LottieAnimation") { LottieAnimation() },
+    Screen.Example("GraphicsLayerSettings") { GraphicsLayerSettings() },
     LazyLayouts,
 )
 

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/GraphicsLayerSettings.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/GraphicsLayerSettings.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Slider
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterHorizontally
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.DefaultCameraDistance
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlin.math.round
+import kotlin.math.roundToInt
+
+@Composable
+fun GraphicsLayerSettings() {
+    var scaleX by remember { mutableStateOf(1f) }
+    var scaleY by remember { mutableStateOf(1f) }
+    var translationX by remember { mutableStateOf(0f) }
+    var translationY by remember { mutableStateOf(0f) }
+    var rotationX by remember { mutableStateOf(0f) }
+    var rotationY by remember { mutableStateOf(0f) }
+    var rotationZ by remember { mutableStateOf(0f) }
+    var cameraDistance by remember { mutableStateOf(DefaultCameraDistance) }
+    var originX by remember { mutableStateOf(0.5f) }
+    var originY by remember { mutableStateOf(0.5f) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(20.dp)
+    ) {
+        Box(
+            Modifier
+                .graphicsLayer(
+                    scaleX = scaleX,
+                    scaleY = scaleY,
+                    translationX = translationX,
+                    translationY = translationY,
+                    rotationX = rotationX,
+                    rotationY = rotationY,
+                    rotationZ = rotationZ,
+                    cameraDistance = cameraDistance,
+                    transformOrigin = TransformOrigin(originX, originY),
+                )
+                .align(CenterHorizontally)
+                .size(200.dp)
+                .background(MaterialTheme.colors.secondary)
+                .pointerHoverIcon(PointerIcon.Hand)
+        ) {
+            Box(
+                modifier = Modifier
+                    .offset(10.dp, 10.dp)
+                    .size(80.dp)
+                    .background(MaterialTheme.colors.primary)
+                    .pointerHoverIcon(PointerIcon.Crosshair)
+            )
+        }
+
+        Spacer(Modifier.height(20.dp))
+        SliderSetting("ScaleX", scaleX, 0.5f..2f) { scaleX = it }
+        SliderSetting("ScaleY", scaleY, 0.5f..2f) { scaleY = it }
+        SliderSetting("TranslationX", translationX, -250f..250f) { translationX = it }
+        SliderSetting("TranslationY", translationY, -250f..250f) { translationY = it }
+        SliderSetting("RotateX", rotationX, -180f..180f) { rotationX = it }
+        SliderSetting("RotateY", rotationY, -180f..180f) { rotationY = it }
+        SliderSetting("RotateZ", rotationZ, -180f..180f) { rotationZ = it }
+        SliderSetting("OriginX", originX, 0f..1f) { originX = it }
+        SliderSetting("OriginY", originY, 0f..1f) { originY = it }
+        SliderSetting("CameraDistance", cameraDistance, 3f..30f) { cameraDistance = it }
+    }
+}
+
+@Composable
+private fun SliderSetting(text: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    onValueChange: (Float) -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.height(30.dp)
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.width(120.dp)
+        )
+        Text(
+            text = "${round(value * 10f) / 10f}",
+            fontFamily = FontFamily.Monospace,
+            maxLines = 1,
+            overflow = TextOverflow.Clip,
+            modifier = Modifier.width(50.dp)
+        )
+        var steps = ((range.endInclusive - range.start) / 0.1f).roundToInt()
+        if (steps > 100) steps /= 10
+        if (steps > 100) steps /= 10
+        Slider(
+            value = value,
+            onValueChange,
+            valueRange = range,
+            steps = steps - 1
+        )
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.unit.*
+import kotlin.math.abs
 import kotlin.math.max
 import org.jetbrains.skia.*
 
@@ -179,11 +180,15 @@ internal class SkiaLayer(
             rotateX(rotationX)
             scale(scaleX, scaleY)
         }
-        matrix *= Matrix().apply {
-            // the camera location is passed in inches, set in pt
-            val depth = cameraDistance * 72f
-            set(row = 2, column = 3, v = -1f / depth)
-            set(row = 2, column = 2, v = 0f)
+        // Perspective transform should be applied only in case of rotations to avoid
+        // multiply application in hierarchies.
+        // See Android's frameworks/base/libs/hwui/RenderProperties.cpp for reference
+        if (!rotationX.isZero() || !rotationY.isZero()) {
+            matrix *= Matrix().apply {
+                // The camera location is passed in inches, set in pt
+                val depth = cameraDistance * 72f
+                this[2, 3] = -1f / depth
+            }
         }
         matrix *= Matrix().apply {
             translate(x = pivotX + translationX, y = pivotY + translationY)
@@ -307,3 +312,7 @@ internal class SkiaLayer(
         )
     }
 }
+
+// Copy from Android's frameworks/base/libs/hwui/utils/MathUtils.h
+private const val NON_ZERO_EPSILON = 0.001f
+private inline fun Float.isZero(): Boolean = abs(this) <= NON_ZERO_EPSILON

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaLayer.skiko.kt
@@ -41,8 +41,7 @@ internal class SkiaLayer(
     internal val matrix = Matrix()
     private val inverseMatrix: Matrix
         get() = Matrix().apply {
-            setFrom(matrix)
-            invert()
+            matrix.invertTo(this)
         }
 
     private val pictureRecorder = PictureRecorder()
@@ -193,6 +192,15 @@ internal class SkiaLayer(
         matrix *= Matrix().apply {
             translate(x = pivotX + translationX, y = pivotY + translationY)
         }
+
+        // Third column and row are irrelevant for 2D space.
+        // Zeroing required to get correct inverse transformation matrix.
+        matrix[2, 0] = 0f
+        matrix[2, 1] = 0f
+        matrix[2, 3] = 0f
+        matrix[0, 2] = 0f
+        matrix[1, 2] = 0f
+        matrix[3, 2] = 0f
     }
 
     override fun invalidate() {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/GraphicsLayerWithInputTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/GraphicsLayerWithInputTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.pointer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.*
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+
+@OptIn(ExperimentalTestApi::class)
+class GraphicsLayerWithInputTest {
+
+    @Test
+    fun testClickOnScaledBox() = runSkikoComposeUiTest {
+        var clickCounter = 0
+        var scale by mutableStateOf(1f)
+        var containerSize = IntSize.Zero
+
+        setContent {
+            Box(
+                modifier = Modifier.fillMaxSize()
+                    .testTag("container")
+                    .onGloballyPositioned {
+                        containerSize = it.size
+                    }
+            ) {
+                Box(modifier = Modifier.graphicsLayer(scaleX = scale, scaleY = scale)
+                    .align(Alignment.Center)
+                    .size(20.dp)
+                    .background(Color.Green)
+                    .clickable {
+                        clickCounter++
+                    })
+            }
+        }
+
+        assertEquals(0, clickCounter)
+        println("Size = $containerSize")
+        assertNotEquals(IntSize.Zero, containerSize)
+
+        this.onNodeWithTag("container").performMouseInput {
+            click(Offset(containerSize.width / 2f, containerSize.height / 2f))
+        }
+        waitForIdle()
+        assertEquals(1, clickCounter)
+
+
+        this.onNodeWithTag("container").performMouseInput {
+            // top left corner
+            click(Offset(containerSize.width / 2f - 9, containerSize.height / 2f - 9))
+        }
+        waitForIdle()
+        assertEquals(2, clickCounter)
+
+        this.onNodeWithTag("container").performMouseInput {
+            // bottom right corner
+            click(Offset(containerSize.width / 2f + 9, containerSize.height / 2f + 9))
+        }
+        waitForIdle()
+        assertEquals(3, clickCounter)
+
+
+        // Now we try to click beyond the box before scaling
+
+        this.onNodeWithTag("container").performMouseInput {
+            click(Offset(containerSize.width / 2f - 18, containerSize.height / 2f - 18))
+        }
+        waitForIdle()
+        assertEquals(3, clickCounter)
+
+        this.onNodeWithTag("container").performMouseInput {
+            // bottom right corner
+            click(Offset(containerSize.width / 2f + 18, containerSize.height / 2f + 18))
+        }
+        waitForIdle()
+        assertEquals(3, clickCounter)
+
+        scale = 2f
+        waitForIdle()
+
+
+        // After scaling: Now clicking beyond the old box rectangle
+
+        this.onNodeWithTag("container").performMouseInput {
+            click(Offset(containerSize.width / 2f - 18, containerSize.height / 2f - 18))
+        }
+        waitForIdle()
+        assertEquals(4, clickCounter)
+
+        this.onNodeWithTag("container").performMouseInput {
+            // bottom right corner
+            click(Offset(containerSize.width / 2f + 18, containerSize.height / 2f + 18))
+        }
+        waitForIdle()
+        assertEquals(5, clickCounter)
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/SkiaLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/SkiaLayerTest.kt
@@ -19,14 +19,9 @@ package androidx.compose.ui.platform
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.round
+import androidx.compose.ui.unit.*
 import kotlin.math.PI
 import kotlin.math.cos
-import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -35,42 +30,67 @@ import kotlin.test.assertTrue
 class SkiaLayerTest {
 
     private val layer = TestSkiaLayer()
-    private val cos45 = cos(PI / 4)
+    private val cos45 = cos(PI / 4).toFloat()
+
+    private val matrix get() = layer.matrix
+    private val inverseMatrix get() = Matrix().apply {
+        matrix.invertTo(this)
+    }
+
 
     @Test
     fun initial() {
-        val matrix = layer.matrix
-
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
     fun move() {
         layer.move(IntOffset(10, 20))
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
     fun resize() {
         layer.resize(IntSize(100, 10))
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
     fun resize_and_move() {
         layer.resize(IntSize(100, 10))
         layer.move(IntOffset(10, 20))
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -81,10 +101,15 @@ class SkiaLayerTest {
             translationY = 20f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(10, 20), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(110, 30), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(10f, 20f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(110f, 30f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -95,10 +120,15 @@ class SkiaLayerTest {
             translationY = 20f,
             transformOrigin = TransformOrigin(1f, 1f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(10, 20), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(110, 30), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(10f, 20f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(110f, 30f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -109,10 +139,15 @@ class SkiaLayerTest {
             scaleY = 4f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(200, 40), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(200f, 40f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -123,10 +158,15 @@ class SkiaLayerTest {
             scaleY = 4f,
             transformOrigin = TransformOrigin(1f, 1f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(-100, -30), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(-100f, -30f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -137,11 +177,16 @@ class SkiaLayerTest {
             transformOrigin = TransformOrigin(0f, 0f),
             cameraDistance = Float.MAX_VALUE
         )
-        val matrix = layer.matrix
 
-        val y = (10 * cos45).roundToInt()
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, y), matrix.map(Offset(100f, 10f)).round())
+        val y = 10 * cos45
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, y),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -152,11 +197,16 @@ class SkiaLayerTest {
             transformOrigin = TransformOrigin(1f, 1f),
             cameraDistance = Float.MAX_VALUE
         )
-        val matrix = layer.matrix
 
-        val y = 10 * (1 - cos45.toFloat())
-        assertEquals(Offset(0f, y), matrix.map(Offset(0f, 0f)))
-        assertEquals(Offset(100f, 10f), matrix.map(Offset(100f, 10f)))
+        val y = 10 * (1 - cos45)
+        assertMapping(
+            from = Offset(0f, y),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -167,11 +217,16 @@ class SkiaLayerTest {
             transformOrigin = TransformOrigin(0f, 0f),
             cameraDistance = Float.MAX_VALUE
         )
-        val matrix = layer.matrix
 
-        val x = (100 * cos45).roundToInt()
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(x, 10), matrix.map(Offset(100f, 10f)).round())
+        val x = 100 * cos45
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(x, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -182,11 +237,16 @@ class SkiaLayerTest {
             transformOrigin = TransformOrigin(1f, 1f),
             cameraDistance = Float.MAX_VALUE
         )
-        val matrix = layer.matrix
 
-        val x = (100 * (1 - cos45)).roundToInt()
-        assertEquals(IntOffset(x, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        val x = 100 * (1 - cos45)
+        assertMapping(
+            from = Offset(x, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -196,10 +256,15 @@ class SkiaLayerTest {
             rotationZ = 90f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(-10, 100), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(-10f, 100f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -209,10 +274,15 @@ class SkiaLayerTest {
             rotationZ = 90f,
             transformOrigin = TransformOrigin(1f, 1f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(110, -90), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100, 10), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(110f, -90f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(100f, 10f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -225,10 +295,15 @@ class SkiaLayerTest {
             scaleY = 4f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0 + 60, 0 + 7), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100 * 2 + 60, 10 * 4 + 7), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(60f, 7f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(260f, 47f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -240,10 +315,15 @@ class SkiaLayerTest {
             rotationZ = 90f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0 + 60, 0 + 7), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(-10 + 60, 100 + 7), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(60f, 7f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(50f, 107f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -256,12 +336,16 @@ class SkiaLayerTest {
             transformOrigin = TransformOrigin(0f, 0f),
             cameraDistance = Float.MAX_VALUE
         )
-        val matrix = layer.matrix
 
-        val y = (10 * cos45).roundToInt()
-        val translationY = 7
-        assertEquals(IntOffset(0 + 60, 0 + translationY), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(100 + 60, y + translationY), matrix.map(Offset(100f, 10f)).round())
+        val y = 10 * cos45
+        assertMapping(
+            from = Offset(60f, 7f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(160f, 7f + y),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -274,12 +358,16 @@ class SkiaLayerTest {
             transformOrigin = TransformOrigin(0f, 0f),
             cameraDistance = Float.MAX_VALUE
         )
-        val matrix = layer.matrix
 
-        val x = (100 * cos45).roundToInt()
-        val translationX = 60
-        assertEquals(IntOffset(0 + translationX, 0 + 7), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(x + translationX, 10 + 7), matrix.map(Offset(100f, 10f)).round())
+        val x = 100 * cos45
+        assertMapping(
+            from = Offset(60f, 7f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(x + 60f, 17f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -291,10 +379,15 @@ class SkiaLayerTest {
             rotationZ = 90f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0, 0), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(-10 * 4, 100 * 2), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(0f, 0f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(-40f, 200f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -308,10 +401,15 @@ class SkiaLayerTest {
             rotationZ = 90f,
             transformOrigin = TransformOrigin(0f, 0f)
         )
-        val matrix = layer.matrix
 
-        assertEquals(IntOffset(0 + 60, 0 + 7), matrix.map(Offset(0f, 0f)).round())
-        assertEquals(IntOffset(-10 * 4 + 60, 100 * 2 + 7), matrix.map(Offset(100f, 10f)).round())
+        assertMapping(
+            from = Offset(60f, 7f),
+            to = Offset(0f, 0f)
+        )
+        assertMapping(
+            from = Offset(20f, 207f),
+            to = Offset(100f, 10f)
+        )
     }
 
     @Test
@@ -371,6 +469,17 @@ class SkiaLayerTest {
         invalidateParentLayer = {},
         drawBlock = {}
     )
+
+    private fun assertMapping(from: Offset, to: Offset) {
+        assertEquals(from, matrix.map(to), 0.001f)
+        assertEquals(to, inverseMatrix.map(from), 0.001f)
+    }
+
+    private fun assertEquals(expected: Offset, actual: Offset, absoluteTolerance: Float) {
+        val message = "Expected <$expected>, actual <$actual>."
+        assertEquals(expected.x, actual.x, absoluteTolerance, message)
+        assertEquals(expected.y, actual.y, absoluteTolerance, message)
+    }
 
     private fun SkiaLayer.updateProperties(
         scaleX: Float = 1f,


### PR DESCRIPTION
## Proposed Changes

- `matrix[2, 2]` should not be zeroed, and perspective transform should be applied only in case of rotation.
- Third column and row are irrelevant for 2D space. Zeroing required to get correct inverse transformation matrix.
- Test that applying `inverseMatrix` do opposite than applying `matrix`
- Add graphicsLayer settings page to mpp

<img width="1136" alt="Screenshot 2023-06-07 at 13 22 51" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/970c6803-a8e5-47f7-82c5-60f140245046">

## Testing

Test: run code from https://github.com/JetBrains/compose-multiplatform/issues/3230#issuecomment-1575535074
Unit tests: run tests from `SkiaLayerTest`

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3230
