### PR TITLE
Implement idling resources for tests.

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopSynchronization.desktop.kt
+++ b/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopSynchronization.desktop.kt
@@ -45,3 +45,10 @@ internal actual fun <T> runOnUiThread(action: () -> T): T {
 internal actual fun isOnUiThread(): Boolean {
     return SwingUtilities.isEventDispatchThread()
 }
+
+/**
+ * Blocks the calling thread for [timeMillis] milliseconds.
+ */
+internal actual fun sleep(timeMillis: Long) {
+    Thread.sleep(timeMillis)
+}

--- a/compose/ui/ui-test-junit4/src/jsMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.jsMain.kt
+++ b/compose/ui/ui-test-junit4/src/jsMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.jsMain.kt
@@ -29,3 +29,10 @@ internal actual fun <T> runOnUiThread(action: () -> T): T {
  * Returns if the call is made on the main thread.
  */
 internal actual fun isOnUiThread(): Boolean = true
+
+/**
+ * Throws an [UnsupportedOperationException].
+ */
+internal actual fun sleep(timeMillis: Long) {
+    throw UnsupportedOperationException("sleep is not supported in JS target")
+}

--- a/compose/ui/ui-test-junit4/src/nativeMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.nativeMain.kt
+++ b/compose/ui/ui-test-junit4/src/nativeMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.nativeMain.kt
@@ -16,13 +16,17 @@
 
 package androidx.compose.ui.test.junit4
 
+import androidx.compose.ui.test.NanoSecondsPerMilliSecond
 import kotlin.coroutines.suspendCoroutine
+import kotlinx.cinterop.cValue
 import kotlinx.coroutines.runBlocking
 import platform.Foundation.NSDate
 import platform.Foundation.NSDefaultRunLoopMode
 import platform.Foundation.NSRunLoop
 import platform.Foundation.performBlock
 import platform.Foundation.runMode
+import platform.posix.nanosleep
+import platform.posix.timespec
 
 /**
  * Runs the given action on the UI thread.
@@ -48,3 +52,15 @@ internal actual fun <T> runOnUiThread(action: () -> T): T {
  * Returns if the call is made on the main thread.
  */
 internal actual fun isOnUiThread(): Boolean = NSRunLoop.currentRunLoop === NSRunLoop.mainRunLoop
+
+/**
+ * Blocks the calling thread for [timeMillis] milliseconds.
+ */
+internal actual fun sleep(timeMillis: Long) {
+    val time = cValue<timespec> {
+        tv_sec = timeMillis / 1000
+        tv_nsec = timeMillis.mod(1000L) * NanoSecondsPerMilliSecond
+    }
+
+    nanosleep(time, null)
+}

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.skikoMain.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/Synchronization.skikoMain.kt
@@ -27,3 +27,10 @@ internal expect fun <T> runOnUiThread(action: () -> T): T
  * Returns if the call is made on the main thread.
  */
 internal expect fun isOnUiThread(): Boolean
+
+/**
+ * Blocks the calling thread for the given number of milliseconds.
+ *
+ * On targets that don't support this, should throw an [UnsupportedOperationException].
+ */
+internal expect fun sleep(timeMillis: Long)


### PR DESCRIPTION
## Proposed Changes

Implement support for [idling resources](https://developer.android.com/jetpack/compose/testing#idling-resources) in `SkikoComposeUiTest`.
Note that the typical way idling resources are used requires `sleep` (and doesn't make sense in a single-threaded environment), so I added it as an expect/actual, with the JS implementation raising an exception.

We can consider supporting idling resources for JS, but it would require a different API.

## Testing

Test: Added a unit test.
