### PR TITLE
Expect Popup in common

### DIFF
--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/window/AndroidPopup.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/window/AndroidPopup.android.kt
@@ -86,127 +86,6 @@ import kotlinx.coroutines.isActive
 import org.jetbrains.annotations.TestOnly
 
 /**
- * Properties used to customize the behavior of a [Popup].
- *
- * @property focusable Whether the popup is focusable. When true, the popup will receive IME
- * events and key presses, such as when the back button is pressed.
- * @property dismissOnBackPress Whether the popup can be dismissed by pressing the back button.
- * If true, pressing the back button will call onDismissRequest. Note that [focusable] must be
- * set to true in order to receive key events such as the back button - if the popup is not
- * focusable then this property does nothing.
- * @property dismissOnClickOutside Whether the popup can be dismissed by clicking outside the
- * popup's bounds. If true, clicking outside the popup will call onDismissRequest.
- * @property securePolicy Policy for setting [WindowManager.LayoutParams.FLAG_SECURE] on the popup's
- * window.
- * @property excludeFromSystemGesture A flag to check whether to set the systemGestureExclusionRects.
- * The default is true.
- * @property clippingEnabled Whether to allow the popup window to extend beyond the bounds of the
- * screen. By default the window is clipped to the screen boundaries. Setting this to false will
- * allow windows to be accurately positioned.
- * The default value is true.
- * @property usePlatformDefaultWidth Whether the width of the popup's content should be limited to
- * the platform default, which is smaller than the screen width.
- */
-@Immutable
-class PopupProperties @ExperimentalComposeUiApi constructor(
-    val focusable: Boolean = false,
-    val dismissOnBackPress: Boolean = true,
-    val dismissOnClickOutside: Boolean = true,
-    val securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
-    val excludeFromSystemGesture: Boolean = true,
-    val clippingEnabled: Boolean = true,
-    val usePlatformDefaultWidth: Boolean = false
-) {
-    @OptIn(ExperimentalComposeUiApi::class)
-    constructor(
-        focusable: Boolean = false,
-        dismissOnBackPress: Boolean = true,
-        dismissOnClickOutside: Boolean = true,
-        securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
-        excludeFromSystemGesture: Boolean = true,
-        clippingEnabled: Boolean = true,
-    ) : this (
-        focusable = focusable,
-        dismissOnBackPress = dismissOnBackPress,
-        dismissOnClickOutside = dismissOnClickOutside,
-        securePolicy = securePolicy,
-        excludeFromSystemGesture = excludeFromSystemGesture,
-        clippingEnabled = clippingEnabled,
-        usePlatformDefaultWidth = false
-    )
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is PopupProperties) return false
-
-        if (focusable != other.focusable) return false
-        if (dismissOnBackPress != other.dismissOnBackPress) return false
-        if (dismissOnClickOutside != other.dismissOnClickOutside) return false
-        if (securePolicy != other.securePolicy) return false
-        if (excludeFromSystemGesture != other.excludeFromSystemGesture) return false
-        if (clippingEnabled != other.clippingEnabled) return false
-        if (usePlatformDefaultWidth != other.usePlatformDefaultWidth) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = dismissOnBackPress.hashCode()
-        result = 31 * result + focusable.hashCode()
-        result = 31 * result + dismissOnBackPress.hashCode()
-        result = 31 * result + dismissOnClickOutside.hashCode()
-        result = 31 * result + securePolicy.hashCode()
-        result = 31 * result + excludeFromSystemGesture.hashCode()
-        result = 31 * result + clippingEnabled.hashCode()
-        result = 31 * result + usePlatformDefaultWidth.hashCode()
-        return result
-    }
-}
-
-/**
- * Opens a popup with the given content.
- *
- * A popup is a floating container that appears on top of the current activity.
- * It is especially useful for non-modal UI surfaces that remain hidden until they
- * are needed, for example floating menus like Cut/Copy/Paste.
- *
- * The popup is positioned relative to its parent, using the [alignment] and [offset].
- * The popup is visible as long as it is part of the composition hierarchy.
- *
- * @sample androidx.compose.ui.samples.PopupSample
- *
- * @param alignment The alignment relative to the parent.
- * @param offset An offset from the original aligned position of the popup. Offset respects the
- * Ltr/Rtl context, thus in Ltr it will be added to the original aligned position and in Rtl it
- * will be subtracted from it.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
- * @param properties [PopupProperties] for further customization of this popup's behavior.
- * @param content The content to be displayed inside the popup.
- */
-@Composable
-fun Popup(
-    alignment: Alignment = Alignment.TopStart,
-    offset: IntOffset = IntOffset(0, 0),
-    onDismissRequest: (() -> Unit)? = null,
-    properties: PopupProperties = PopupProperties(),
-    content: @Composable () -> Unit
-) {
-    val popupPositioner = remember(alignment, offset) {
-        AlignmentOffsetPositionProvider(
-            alignment,
-            offset
-        )
-    }
-
-    Popup(
-        popupPositionProvider = popupPositioner,
-        onDismissRequest = onDismissRequest,
-        properties = properties,
-        content = content
-    )
-}
-
-/**
  * Opens a popup with the given content.
  *
  * The popup is positioned using a custom [popupPositionProvider].
@@ -219,10 +98,10 @@ fun Popup(
  * @param content The content to be displayed inside the popup.
  */
 @Composable
-fun Popup(
+actual fun Popup(
     popupPositionProvider: PopupPositionProvider,
-    onDismissRequest: (() -> Unit)? = null,
-    properties: PopupProperties = PopupProperties(),
+    onDismissRequest: (() -> Unit)?,
+    properties: PopupProperties,
     content: @Composable () -> Unit
 ) {
     val view = LocalView.current

--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/window/SecureFlagPolicy.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/window/SecureFlagPolicy.android.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import android.view.WindowManager
+
+/**
+ * Policy on setting [WindowManager.LayoutParams.FLAG_SECURE] on a window.
+ */
+actual enum class SecureFlagPolicy {
+    /**
+     * Inherit [WindowManager.LayoutParams.FLAG_SECURE] from the parent window and pass it on the
+     * window that is using this policy.
+     */
+    Inherit,
+
+    /**
+     * Forces [WindowManager.LayoutParams.FLAG_SECURE] to be set on the window that is using this
+     * policy.
+     */
+    SecureOn,
+    /**
+     * No [WindowManager.LayoutParams.FLAG_SECURE] will be set on the window that is using this
+     * policy.
+     */
+    SecureOff
+}
+
+internal fun SecureFlagPolicy.shouldApplySecureFlag(isSecureFlagSetOnParent: Boolean): Boolean {
+    return when (this) {
+        SecureFlagPolicy.SecureOff -> false
+        SecureFlagPolicy.SecureOn -> true
+        SecureFlagPolicy.Inherit -> isSecureFlagSetOnParent
+    }
+}

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
@@ -16,14 +16,93 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.height
-import androidx.compose.ui.unit.width
+
+/**
+ * Properties used to customize the behavior of a [Popup].
+ *
+ * @property focusable Whether the popup is focusable. When true, the popup will receive IME
+ * events and key presses, such as when the back button is pressed.
+ * @property dismissOnBackPress Whether the popup can be dismissed by pressing the back button.
+ * If true, pressing the back button will call onDismissRequest. Note that [focusable] must be
+ * set to true in order to receive key events such as the back button - if the popup is not
+ * focusable then this property does nothing.
+ * @property dismissOnClickOutside Whether the popup can be dismissed by clicking outside the
+ * popup's bounds. If true, clicking outside the popup will call onDismissRequest.
+ * @property securePolicy Policy for setting [android.view.WindowManager.LayoutParams.FLAG_SECURE] on the popup's
+ * window.
+ * @property excludeFromSystemGesture A flag to check whether to set the systemGestureExclusionRects.
+ * The default is true.
+ * @property clippingEnabled Whether to allow the popup window to extend beyond the bounds of the
+ * screen. By default the window is clipped to the screen boundaries. Setting this to false will
+ * allow windows to be accurately positioned.
+ * The default value is true.
+ * @property usePlatformDefaultWidth Whether the width of the popup's content should be limited to
+ * the platform default, which is smaller than the screen width.
+ */
+@Immutable
+class PopupProperties @ExperimentalComposeUiApi constructor(
+    val focusable: Boolean = false,
+    val dismissOnBackPress: Boolean = true,
+    val dismissOnClickOutside: Boolean = true,
+    val securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
+    val excludeFromSystemGesture: Boolean = true,
+    val clippingEnabled: Boolean = true,
+    val usePlatformDefaultWidth: Boolean = false
+) {
+    @OptIn(ExperimentalComposeUiApi::class)
+    constructor(
+        focusable: Boolean = false,
+        dismissOnBackPress: Boolean = true,
+        dismissOnClickOutside: Boolean = true,
+        securePolicy: SecureFlagPolicy = SecureFlagPolicy.Inherit,
+        excludeFromSystemGesture: Boolean = true,
+        clippingEnabled: Boolean = true,
+    ) : this (
+        focusable = focusable,
+        dismissOnBackPress = dismissOnBackPress,
+        dismissOnClickOutside = dismissOnClickOutside,
+        securePolicy = securePolicy,
+        excludeFromSystemGesture = excludeFromSystemGesture,
+        clippingEnabled = clippingEnabled,
+        usePlatformDefaultWidth = false
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PopupProperties) return false
+
+        if (focusable != other.focusable) return false
+        if (dismissOnBackPress != other.dismissOnBackPress) return false
+        if (dismissOnClickOutside != other.dismissOnClickOutside) return false
+        if (securePolicy != other.securePolicy) return false
+        if (excludeFromSystemGesture != other.excludeFromSystemGesture) return false
+        if (clippingEnabled != other.clippingEnabled) return false
+        if (usePlatformDefaultWidth != other.usePlatformDefaultWidth) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = dismissOnBackPress.hashCode()
+        result = 31 * result + focusable.hashCode()
+        result = 31 * result + dismissOnBackPress.hashCode()
+        result = 31 * result + dismissOnClickOutside.hashCode()
+        result = 31 * result + securePolicy.hashCode()
+        result = 31 * result + excludeFromSystemGesture.hashCode()
+        result = 31 * result + clippingEnabled.hashCode()
+        result = 31 * result + usePlatformDefaultWidth.hashCode()
+        return result
+    }
+}
 
 /**
  * Calculates the position of a [Popup] on screen.
@@ -99,3 +178,66 @@ internal class AlignmentOffsetPositionProvider(
         return popupPosition
     }
 }
+
+/**
+ * Opens a popup with the given content.
+ *
+ * A popup is a floating container that appears on top of the current activity.
+ * It is especially useful for non-modal UI surfaces that remain hidden until they
+ * are needed, for example floating menus like Cut/Copy/Paste.
+ *
+ * The popup is positioned relative to its parent, using the [alignment] and [offset].
+ * The popup is visible as long as it is part of the composition hierarchy.
+ *
+ * @sample androidx.compose.ui.samples.PopupSample
+ *
+ * @param alignment The alignment relative to the parent.
+ * @param offset An offset from the original aligned position of the popup. Offset respects the
+ * Ltr/Rtl context, thus in Ltr it will be added to the original aligned position and in Rtl it
+ * will be subtracted from it.
+ * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param properties [PopupProperties] for further customization of this popup's behavior.
+ * @param content The content to be displayed inside the popup.
+ */
+@Composable
+fun Popup(
+    alignment: Alignment = Alignment.TopStart,
+    offset: IntOffset = IntOffset(0, 0),
+    onDismissRequest: (() -> Unit)? = null,
+    properties: PopupProperties = PopupProperties(),
+    content: @Composable () -> Unit
+) {
+    val popupPositioner = remember(alignment, offset) {
+        AlignmentOffsetPositionProvider(
+            alignment,
+            offset
+        )
+    }
+
+    Popup(
+        popupPositionProvider = popupPositioner,
+        onDismissRequest = onDismissRequest,
+        properties = properties,
+        content = content
+    )
+}
+
+/**
+ * Opens a popup with the given content.
+ *
+ * The popup is positioned using a custom [popupPositionProvider].
+ *
+ * @sample androidx.compose.ui.samples.PopupSample
+ *
+ * @param popupPositionProvider Provides the screen position of the popup.
+ * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param properties [PopupProperties] for further customization of this popup's behavior.
+ * @param content The content to be displayed inside the popup.
+ */
+@Composable
+expect fun Popup(
+    popupPositionProvider: PopupPositionProvider,
+    onDismissRequest: (() -> Unit)? = null,
+    properties: PopupProperties = PopupProperties(),
+    content: @Composable () -> Unit
+)

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/SecureFlagPolicy.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/SecureFlagPolicy.kt
@@ -16,25 +16,24 @@
 
 package androidx.compose.ui.window
 
-import android.view.WindowManager
-
 /**
- * Policy on setting [WindowManager.LayoutParams.FLAG_SECURE] on a window.
+ * Policy on setting [android.view.WindowManager.LayoutParams.FLAG_SECURE] on a window.
  */
 enum class SecureFlagPolicy {
     /**
-     * Inherit [WindowManager.LayoutParams.FLAG_SECURE] from the parent window and pass it on the
+     * Inherit [android.view.WindowManager.LayoutParams.FLAG_SECURE] from the parent window and pass it on the
      * window that is using this policy.
      */
     Inherit,
 
     /**
-     * Forces [WindowManager.LayoutParams.FLAG_SECURE] to be set on the window that is using this
+     * Forces [android.view.WindowManager.LayoutParams.FLAG_SECURE] to be set on the window that is using this
      * policy.
      */
     SecureOn,
+
     /**
-     * No [WindowManager.LayoutParams.FLAG_SECURE] will be set on the window that is using this
+     * No [android.view.WindowManager.LayoutParams.FLAG_SECURE] will be set on the window that is using this
      * policy.
      */
     SecureOff

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -19,7 +19,8 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.key.*
 import androidx.compose.ui.unit.IntOffset
 
 /**
@@ -124,6 +125,7 @@ fun Popup(
  * @param properties [PopupProperties] for further customization of this popup's behavior.
  * @param content The content to be displayed inside the popup.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 actual fun Popup(
     popupPositionProvider: PopupPositionProvider,
@@ -131,10 +133,22 @@ actual fun Popup(
     properties: PopupProperties,
     content: @Composable () -> Unit
 ) {
+    // TODO: handle properties.dismissOnClickOutside
+    // TODO: handle properties.clippingEnabled
     PopupLayout(
         popupPositionProvider,
         properties.focusable,
         onDismissRequest,
+        onKeyEvent = {
+            if (properties.dismissOnBackPress &&
+                it.type == KeyEventType.KeyDown && it.key == Key.Escape &&
+                onDismissRequest != null) {
+                onDismissRequest()
+                true
+            } else {
+                false
+            }
+        },
         content = content
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -111,3 +111,30 @@ fun Popup(
         content
     )
 }
+
+/**
+ * Opens a popup with the given content.
+ *
+ * The popup is positioned using a custom [popupPositionProvider].
+ *
+ * @sample androidx.compose.ui.samples.PopupSample
+ *
+ * @param popupPositionProvider Provides the screen position of the popup.
+ * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param properties [PopupProperties] for further customization of this popup's behavior.
+ * @param content The content to be displayed inside the popup.
+ */
+@Composable
+actual fun Popup(
+    popupPositionProvider: PopupPositionProvider,
+    onDismissRequest: (() -> Unit)?,
+    properties: PopupProperties,
+    content: @Composable () -> Unit
+) {
+    PopupLayout(
+        popupPositionProvider,
+        properties.focusable,
+        onDismissRequest,
+        content = content
+    )
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/SecureFlagPolicy.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/SecureFlagPolicy.skiko.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 
 package androidx.compose.ui.window
 
-expect enum class SecureFlagPolicy {
+actual enum class SecureFlagPolicy {
     Inherit
 }


### PR DESCRIPTION
## Proposed Changes

  - Move Android's `PopupProperties` to common to avoid changing Android's public API
  - Expect only default value of `SecureFlagPolicy` in common
  - Partially support `PopupProperties` in skiko implementation

## Testing

Test: try to use `Popup` from common sourceset
