### PR TITLE
Export JAVA_HOME to xcodegen

### DIFF
--- a/compose/mpp/demo/.gitignore
+++ b/compose/mpp/demo/.gitignore
@@ -1,2 +1,3 @@
 *.xcodeproj
 plists
+project.generated.yml

--- a/compose/mpp/demo/project.template.yml
+++ b/compose/mpp/demo/project.template.yml
@@ -19,6 +19,7 @@ targets:
           cd "$SRCROOT"
           export JAVA_HOME=%@JAVA_HOME@%
           export OUT_DIR=`pwd`/../../../out
+          echo "JAVA_HOME: $JAVA_HOME"
           echo "OUT_DIR: $OUT_DIR"
           ../../../gradlew -i --no-daemon -p . packForXCode
         name: GradleCompile

--- a/compose/mpp/demo/project.template.yml
+++ b/compose/mpp/demo/project.template.yml
@@ -17,7 +17,7 @@ targets:
     prebuildScripts:
       - script: |
           export JAVA_HOME=%@JAVA_HOME@%
-          cd "$SRCROOT" && OUT_DIR=`pwd`/out  JAVA_TOOLS_JAR=/Users/jetbrains/jetpack_compose_ui/compose-jb/compose/scripts/../external/tools.jar  ALLOW_PUBLIC_REPOS=1  ANDROIDX_PROJECTS=compose ../../../gradlew  -i  -Pandroidx.compose.multiplatformEnabled=true  --no-daemon -Pkotlin.compiler.execution.strategy="in-process" -p . packForXCode
+          cd "$SRCROOT" && export OUT_DIR=`pwd`/../../../out && echo "OUT_DIR: $OUT_DIR" && ../../../gradlew -i -Pandroidx.compose.multiplatformEnabled=true --no-daemon -p . packForXCode
         name: GradleCompile
     info:
       path: plists/Ios/Info.plist

--- a/compose/mpp/demo/project.template.yml
+++ b/compose/mpp/demo/project.template.yml
@@ -16,8 +16,11 @@ targets:
     deploymentTarget: "12.0"
     prebuildScripts:
       - script: |
+          cd "$SRCROOT"
           export JAVA_HOME=%@JAVA_HOME@%
-          cd "$SRCROOT" && export OUT_DIR=`pwd`/../../../out && echo "OUT_DIR: $OUT_DIR" && ../../../gradlew -i -Pandroidx.compose.multiplatformEnabled=true --no-daemon -p . packForXCode
+          export OUT_DIR=`pwd`/../../../out
+          echo "OUT_DIR: $OUT_DIR"
+          ../../../gradlew -i --no-daemon -p . packForXCode
         name: GradleCompile
     info:
       path: plists/Ios/Info.plist

--- a/compose/mpp/demo/project.template.yml
+++ b/compose/mpp/demo/project.template.yml
@@ -3,7 +3,7 @@ name: %@PROJECT_NAME@%
 options:
   bundleIdPrefix: org.jetbrains
 settings:
-  DEVELOPMENT_TEAM: N462MKSJ7M
+  DEVELOPMENT_TEAM: %@COMPOSE_DEMO_APPLE_TEAM_ID@%
   CODE_SIGN_IDENTITY: "iPhone Developer"
   CODE_SIGN_STYLE: Automatic
   MARKETING_VERSION: "1.0"

--- a/compose/mpp/demo/project.template.yml
+++ b/compose/mpp/demo/project.template.yml
@@ -1,4 +1,5 @@
-name: ComposeDemo
+# this YML is to be used as a template with %@PLACEHOLDER_VALUES@% replaced with actual ones within regenerate_xcode_project.sh
+name: %@PROJECT_NAME@%
 options:
   bundleIdPrefix: org.jetbrains
 settings:
@@ -14,7 +15,9 @@ targets:
     platform: iOS
     deploymentTarget: "12.0"
     prebuildScripts:
-      - script: cd "$SRCROOT" && OUT_DIR=`pwd`/out  JAVA_TOOLS_JAR=/Users/jetbrains/jetpack_compose_ui/compose-jb/compose/scripts/../external/tools.jar  ALLOW_PUBLIC_REPOS=1  ANDROIDX_PROJECTS=compose ../../../gradlew  -i  -Pandroidx.compose.multiplatformEnabled=true  --no-daemon -Pkotlin.compiler.execution.strategy="in-process" -p . packForXCode
+      - script: |
+          export JAVA_HOME=%@JAVA_HOME@%
+          cd "$SRCROOT" && OUT_DIR=`pwd`/out  JAVA_TOOLS_JAR=/Users/jetbrains/jetpack_compose_ui/compose-jb/compose/scripts/../external/tools.jar  ALLOW_PUBLIC_REPOS=1  ANDROIDX_PROJECTS=compose ../../../gradlew  -i  -Pandroidx.compose.multiplatformEnabled=true  --no-daemon -Pkotlin.compiler.execution.strategy="in-process" -p . packForXCode
         name: GradleCompile
     info:
       path: plists/Ios/Info.plist

--- a/compose/mpp/demo/regenerate_xcode_project.sh
+++ b/compose/mpp/demo/regenerate_xcode_project.sh
@@ -7,6 +7,11 @@ if command -v xcodegen >/dev/null 2>&1; then
   # xcodegen exists
   PROJECT_NAME=ComposeDemo
 
+  if [[ -z "$COMPOSE_DEMO_APPLE_TEAM_ID" ]]; then
+    echo "COMPOSE_DEMO_APPLE_TEAM_ID is not set"
+    COMPOSE_DEMO_APPLE_TEAM_ID="N462MKSJ7M"
+  fi
+
   if [[ -z "$JAVA_HOME" ]]; then
     echo "JAVA_HOME is not set"
     exit 1
@@ -23,7 +28,7 @@ if command -v xcodegen >/dev/null 2>&1; then
   OUTPUT_FILE="project.generated.yml"
 
   # replace template placeholders with actual values
-  sed -e "s|%@JAVA_HOME@%|$JAVA_HOME|g" -e "s|%@PROJECT_NAME@%|$PROJECT_NAME|g" $INPUT_FILE > $OUTPUT_FILE
+  sed -e "s|%@JAVA_HOME@%|$JAVA_HOME|g" -e "s|%@PROJECT_NAME@%|$PROJECT_NAME|g" -e "s|%@COMPOSE_DEMO_APPLE_TEAM_ID@%|$COMPOSE_DEMO_APPLE_TEAM_ID|g" $INPUT_FILE > $OUTPUT_FILE
 
   xcodegen --spec $OUTPUT_FILE
   open $PROJECT_FILE_PATH

--- a/compose/mpp/demo/regenerate_xcode_project.sh
+++ b/compose/mpp/demo/regenerate_xcode_project.sh
@@ -5,16 +5,28 @@ cd "$(dirname "$0")" || exit
 
 if command -v xcodegen >/dev/null 2>&1; then
   # xcodegen exists
+  PROJECT_NAME=ComposeDemo
 
-  projPath="ComposeDemo.xcodeproj"
-
-  if [ -d "$projPath" ]; then
-    echo "Removing existing project"
-    rm -rf "$projPath"
+  if [[ -z "$JAVA_HOME" ]]; then
+    echo "JAVA_HOME is not set"
+    exit 1
   fi
 
-  xcodegen
-  open $projPath
+  PROJECT_FILE_PATH="$PROJECT_NAME.xcodeproj"
+
+  if [ -d "$PROJECT_FILE_PATH" ]; then
+    echo "Removing existing project"
+    rm -rf "$PROJECT_FILE_PATH"
+  fi
+
+  INPUT_FILE="project.template.yml"
+  OUTPUT_FILE="project.generated.yml"
+
+  # replace template placeholders with actual values
+  sed -e "s|%@JAVA_HOME@%|$JAVA_HOME|g" -e "s|%@PROJECT_NAME@%|$PROJECT_NAME|g" $INPUT_FILE > $OUTPUT_FILE
+
+  xcodegen --spec $OUTPUT_FILE
+  open $PROJECT_FILE_PATH
 else
   # xcodegen does not exist
   echo "Error: xcodegen not found. Please install it using 'brew install xcodegen'."


### PR DESCRIPTION
## Proposed Changes

Xcode suddenly stopped using environmental variables from ~/.zshrc on macOS. Inject it explicitly. Add QOL to set Apple Team ID during xcodegen execution.

## Testing

Test: build project from Xcode project generated by `regenerate_xcode_project.sh`

## Issues Fixed

Fixes: JAVA_HOME not resolved correctly when building ComposeDemo generated by `regenerate_xcode_project.sh`.
