### PR TITLE
Use hard dependencies for "compose.desktop.currentOs"

### DIFF
--- a/compose/desktop/desktop/build.gradle
+++ b/compose/desktop/desktop/build.gradle
@@ -102,13 +102,13 @@ def jvmOs(container, name, skikoDep) {
                 def desktopDependency = dependenciesNode.appendNode("dependency")
                 desktopDependency.appendNode("groupId", projectGroup)
                 desktopDependency.appendNode("artifactId", projectName)
-                desktopDependency.appendNode("version", composeVersion)
+                desktopDependency.appendNode("version", "[$composeVersion]")
                 desktopDependency.appendNode("scope", "compile")
 
                 def skikoDependency = dependenciesNode.appendNode("dependency")
                 skikoDependency.appendNode("groupId", skikoModule.group)
                 skikoDependency.appendNode("artifactId", skikoModule.name)
-                skikoDependency.appendNode("version", skikoVersion)
+                skikoDependency.appendNode("version", "[$skikoVersion]")
                 skikoDependency.appendNode("scope", "runtime")
             }
         }


### PR DESCRIPTION
## Proposed Changes

  - Use hard dependencies for "compose.desktop.currentOs" to avoid native binaries mismatch
  - Use `[1.0]` syntax from [POM Reference](https://maven.apache.org/pom.html#dependency-version-requirement-specification)

## Testing

Test:
1. clone https://github.com/JetBrains/compose-multiplatform-template
2. replace compose version in shared/build.gradle.kts 33-35 to
```
implementation("org.jetbrains.compose.runtime:runtime:1.5.0-dev1071")
implementation("org.jetbrains.compose.foundation:foundation:1.5.0-dev1071")
implementation("org.jetbrains.compose.material:material:1.5.0-dev1071")
```
3. run desktop app

