### PR TITLE
Add an internal enum UserPlatform for web target

### DIFF
--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/UserPlatform.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/UserPlatform.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import kotlinx.browser.window
+
+internal enum class UserPlatform {
+    Android,
+    IOS,
+    Linux,
+    MacOS,
+    Windows,
+    Unknown;
+
+    companion object {
+        /**
+         * In a browser, user platform can be obtained from different places:
+         * - we attempt to use not-deprecated but experimental option first (not available in all browsers)
+         * - then we attempt to use a deprecated option
+         * - if both above return an empty string, we attempt to get `Platform` from `userAgent`
+         *
+         * Note: a client can spoof these values, so it's okay only for non-critical use cases.
+         */
+        val Current: UserPlatform by lazy {
+            val platformInfo = getNavigatorInfo().takeIf {
+                it.isNotEmpty()
+            } ?: window.navigator.userAgent
+
+            when {
+                platformInfo.contains("Android", true) -> Android
+                platformInfo.contains("iPhone", true) -> IOS
+                platformInfo.contains("iOS", true) -> IOS
+                platformInfo.contains("iPad", true) -> IOS
+                platformInfo.contains("Linux", true) -> Linux
+                platformInfo.contains("Mac", true) -> MacOS
+                platformInfo.contains("Win", true) -> Windows
+                else -> Unknown
+            }
+        }
+    }
+}
+
+/**
+ * A string identifying the platform on which the user's browser is running; for example:
+ * "MacIntel", "Win32", "Linux x86_64", "Linux x86_64".
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform - deprecated
+ *
+ * A string containing the platform brand. For example, "Windows".
+ * See https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/platform - new API,
+ * but not supported in all browsers
+ */
+internal fun getNavigatorInfo(): String =
+    js("navigator.userAgentData ? navigator.userAgentData.platform : navigator.platform") as String
+


### PR DESCRIPTION
For optimal user experience desktop target distinguishes between user OS (for example Ctrl on non-MacOs vs CMD on MacOs). We need it for web too.

This PR adds an enum `UserPlatform` and `UserPlatform.Current` property to easily access the OS name.

For now, this code is internal in foundation module. In `foundation` module, `UserPlatform.Current` will be used to properly initialise `internal actual val platformDefaultKeyMapping: KeyMapping` 


But beside `foundation`, I see that similar code would be needed at least in `ui:ui` and `ui:ui-text` modules. For now, `internal enum class DesktopPlatform` is duplicated in those modules. With current approach `UserPlatform` will need to be duplicated too in `jsWasmMain` source sets of `ui` and `ui-text`. 

We can avoid duplication:
- by making the enum public (ui depends on foundation)
- by moving it to skiko, like we did with some other things we wanted to reuse. It will be public too. 
@igordmn What do you think?

