### PR TITLE
iOS TextField, configure focusable behavior on keyboard appearing

### DIFF
--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -145,7 +145,6 @@ internal class ComposeLayer(
     }
 
     fun getActiveFocusRect(): DpRect? {
-        // TODO: [1.4 Update] Check that new solution is valid
         val focusRect = scene.mainOwner?.focusOwner?.getFocusRect() ?: return null
         return focusRect.toDpRect(density)
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
@@ -34,7 +34,7 @@ sealed interface OnFocusBehavior {
 
     /**
      * The Compose view will be panned in "y" coordinates.
-     * Focusable element should be displayed above the keyboard.
+     * A focusable element should be displayed above the keyboard.
      */
     object FocusableAboveKeyboard : OnFocusBehavior
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
@@ -28,7 +28,7 @@ class ComposeUIViewControllerConfiguration {
 
 sealed interface OnFocusBehavior {
     /**
-     * Compose view will stay on current position.
+     * The Compose view will stay on the current position.
      */
     object DoNothing : OnFocusBehavior
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
@@ -33,7 +33,7 @@ sealed interface OnFocusBehavior {
     object DoNothing : OnFocusBehavior
 
     /**
-     * Compose view will be panned in "y" coordinates.
+     * The Compose view will be panned in "y" coordinates.
      * Focusable element should be displayed above the keyboard.
      */
     object FocusableAboveKeyboard : OnFocusBehavior

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
@@ -19,7 +19,7 @@ package androidx.compose.ui.uikit
 /**
  * Configuration of ComposeUIViewController behavior.
  */
-class Configuration {
+class ComposeUIViewControllerConfiguration {
     /**
      * Control Compose behaviour on focus changed inside Compose.
      */

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Configuration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Configuration.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.uikit
+
+class Configuration {
+    /**
+     * Control Compose behaviour on focus changed inside Compose.
+     */
+    var onFocusBehavior: OnFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+}
+
+sealed interface OnFocusBehavior {
+    /**
+     * Compose view will stay on current position.
+     */
+    object DoNothing : OnFocusBehavior
+
+    /**
+     * Compose view will be panned in "y" coordinates.
+     * Focusable element should be displayed above the keyboard.
+     */
+    object FocusableAboveKeyboard : OnFocusBehavior
+
+    // TODO Better to control OnFocusBehavior with existing WindowInsets.
+    // Definition: object: FocusableBetweenInsets(insets: WindowInsets) : OnFocusBehavior
+    // Usage: onFocusBehavior = FocusableBetweenInsets(WindowInsets.ime.union(WindowInsets.systemBars))
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Configuration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Configuration.kt
@@ -16,6 +16,9 @@
 
 package androidx.compose.ui.uikit
 
+/**
+ * Configuration of ComposeUIViewController behavior.
+ */
 class Configuration {
     /**
      * Control Compose behaviour on focus changed inside Compose.

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -153,30 +153,9 @@ internal actual class ComposeWindow : UIViewController {
             }
 
             if (configuration.onFocusBehavior == OnFocusBehavior.FocusableAboveKeyboard) {
-                val focused = layer.getActiveFocusRect()
-                if (focused != null) {
-                    val hiddenPartOfFocusedElement =
-                        keyboardHeight - layer.layer.height + focused.bottom.value
-                    if (hiddenPartOfFocusedElement > 0) {
-                        // If focused element hidden by keyboard, then change UIView bounds.
-                        // Focused element will be visible
-                        val focusedTop = focused.top.value
-                        val composeOffsetY = if (hiddenPartOfFocusedElement < focusedTop) {
-                            hiddenPartOfFocusedElement
-                        } else {
-                            maxOf(focusedTop, 0f).toDouble()
-                        }
-                        val (width, height) = getViewFrameSize()
-                        view.layer.setBounds(
-                            CGRectMake(
-                                x = 0.0,
-                                y = composeOffsetY,
-                                width = width.toDouble(),
-                                height = height.toDouble()
-                            )
-                        )
-                    }
-                }
+                updateViewBounds(
+                    focusedOffsetY(keyboardHeight)
+                )
             }
         }
 
@@ -185,9 +164,39 @@ internal actual class ComposeWindow : UIViewController {
         fun keyboardDidHide(arg: NSNotification) {
             keyboardOverlapHeightState.value = 0f
             if (configuration.onFocusBehavior == OnFocusBehavior.FocusableAboveKeyboard) {
-                val (width, height) = getViewFrameSize()
-                view.layer.setBounds(CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()))
+                updateViewBounds(0.0)
             }
+        }
+
+        private fun focusedOffsetY(keyboardHeight: Double): Double {
+            val focused = layer.getActiveFocusRect() ?: return 0.0
+
+            val hiddenPartOfFocusedElement: Double =
+                keyboardHeight - layer.layer.height + focused.bottom.value
+            return if (hiddenPartOfFocusedElement > 0) {
+                // If focused element hidden by keyboard, then change UIView bounds.
+                // Focused element will be visible
+                val focusedTop = focused.top.value
+                if (hiddenPartOfFocusedElement < focusedTop) {
+                    hiddenPartOfFocusedElement
+                } else {
+                    maxOf(focusedTop, 0f).toDouble()
+                }
+            } else {
+                0.0
+            }
+        }
+
+        private fun updateViewBounds(offsetY: Double) {
+            val (width, height) = getViewFrameSize()
+            view.layer.setBounds(
+                CGRectMake(
+                    x = 0.0,
+                    y = offsetY,
+                    width = width.toDouble(),
+                    height = height.toDouble()
+                )
+            )
         }
     }
 


### PR DESCRIPTION
Focusable, like TextField, can be shown above the keyboard. Behavior can be configured in ComposeUIViewController function.

New way to create iOS ComposeUIViewController:

```
ComposeUIViewController(
    configure = {
        onFocusBehavior = OnFocusBehavior.DoNothing
    }
) {
    // Composable content
}
```


Issues:
 - https://github.com/JetBrains/compose-multiplatform/issues/2752
 - https://github.com/JetBrains/compose-multiplatform/issues/3128
