### PR TITLE
Introduce ComposePanel that can be disposed manually

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -78,11 +78,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private var content: (@Composable () -> Unit)? = null
 
     /**
-     * Represents whether [ComposePanel] is attached to Swing hierarchy.
-     */
-    private var isAttached = false
-
-    /**
      * Determines whether the Compose state in [ComposePanel] should be disposed
      * when panel is detached from Swing hierarchy (when [removeNotify] is called).
      *
@@ -109,7 +104,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      */
     @ExperimentalComposeUiApi
     fun dispose() {
-        if (!isAttached && bridge != null) {
+        if (bridge != null) {
             bridge!!.dispose()
             super.remove(bridge!!.component)
             bridge = null
@@ -188,7 +183,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             initContent()
             super.add(bridge!!.component, Integer.valueOf(1))
         }
-        isAttached = true
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
@@ -233,7 +227,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
 
     @OptIn(ExperimentalComposeUiApi::class)
     override fun removeNotify() {
-        isAttached = false
         if (isDisposeOnRemove) {
             dispose()
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -77,6 +77,45 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private val clipMap = mutableMapOf<Component, ClipComponent>()
     private var content: (@Composable () -> Unit)? = null
 
+    /**
+     * Represents whether [ComposePanel] is attached to Swing hierarchy.
+     */
+    private var isAttached = false
+
+    /**
+     * Determines whether the Compose state in [ComposePanel] should be disposed
+     * when panel is detached from Swing hierarchy (when [removeNotify] is called).
+     *
+     * If it is set to false, it is developer's responsibility to call [dispose] function
+     * when Compose state and all related to [ComposePanel] resources are no longer needed.
+     * It can be useful for cases when [ComposePanel] can be attached/detached to Swing hierarchy multiple times,
+     * so with [isDisposeOnRemove] = `false` state will be preserved.
+     *
+     * On the other hand, [isDisposeOnRemove] = `true` can be useful for stateless components,
+     * that can be recreated for each attaching to Swing hierarchy.
+     *
+     * @see dispose
+     */
+    @ExperimentalComposeUiApi
+    var isDisposeOnRemove: Boolean = true
+
+    /**
+     * Disposes Compose state and rendering resources.
+     *
+     * Should be called only when [ComposePanel] is detached from Swing hierarchy.
+     * Otherwise, nothing will happen.
+     *
+     * @see isDisposeOnRemove
+     */
+    @ExperimentalComposeUiApi
+    fun dispose() {
+        if (!isAttached && bridge != null) {
+            bridge!!.dispose()
+            super.remove(bridge!!.component)
+            bridge = null
+        }
+    }
+
     override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
         bridge?.component?.setSize(width, height)
         super.setBounds(x, y, width, height)
@@ -144,9 +183,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
 
         // After [super.addNotify] is called we can safely initialize the bridge and composable
         // content.
-        bridge = createComposeBridge()
-        initContent()
-        super.add(bridge!!.component, Integer.valueOf(1))
+        if (bridge == null) {
+            bridge = createComposeBridge()
+            initContent()
+            super.add(bridge!!.component, Integer.valueOf(1))
+        }
+        isAttached = true
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
@@ -189,13 +231,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         }
     }
 
+    @OptIn(ExperimentalComposeUiApi::class)
     override fun removeNotify() {
-        if (bridge != null) {
-            bridge!!.dispose()
-            super.remove(bridge!!.component)
-            bridge = null
+        isAttached = false
+        if (isDisposeOnRemove) {
+            dispose()
         }
-
         super.removeNotify()
     }
 


### PR DESCRIPTION
## Proposed Changes

Current implementation of ComposePanel disposes Compose content on each detach from Swing hierarchy. But for some cases (like toolwindows in IntelliJ) it doesn't work well, since state getting lost. This state can be controlled only externally. For example, in IntelliJ `Disposable` is used for that.

This PR adds the `ComposePanel.isDisposeOnRemove` property. By default, it is true. If it is false, the Compose state will be preserved when the ComposePanel is removed from the UI hierarchy. In this case, the Compose state must be controlled by developers - they must call `ComposePanel.dispose()` manually.

## Testing

Test: run introduced test

## Issues Fixed

No issues related to this PR
