### PR TITLE
Add sample, how to hide Keyboard on click outside

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.mpp.demo.textfield
 
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.TextField
@@ -26,6 +28,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 
 val TextFields = Screen.Selection(
@@ -38,6 +42,9 @@ val TextFields = Screen.Selection(
     },
     Screen.Example("Android Keyboard Types") {
         KeyboardTypeDemo()
+    },
+    Screen.Example("Hide keyboard on click outside") {
+        HideKeyboardOnClickOutside()
     },
 )
 
@@ -56,5 +63,21 @@ private fun AlmostFullscreen() {
         textState.value, { textState.value = it },
         Modifier.fillMaxSize().padding(vertical = 40.dp)
     )
+}
+
+@Composable
+private fun HideKeyboardOnClickOutside() {
+    val focusManager = LocalFocusManager.current
+    Box(
+        Modifier.fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures {
+                    focusManager.clearFocus(force = true)
+                }
+            },
+    ) {
+        val textState = remember { mutableStateOf("Click outside to hide the keyboard") }
+        TextField(textState.value, { textState.value = it })
+    }
 }
 


### PR DESCRIPTION
## Proposed Changes
 - Added a sample of how to hide the keyboard on click outside the TextField. It is helpful for iOS.

## Testing

Just run iOS Demo app


