### PR TITLE
Fix multi-owner input processing

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toOffset
-import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupLayout
 import androidx.compose.ui.window.PopupPositionProvider
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertContentEquals
@@ -121,6 +121,7 @@ class FillBox {
 class PopupState(
     val bounds: IntRect,
     private val focusable: Boolean = false,
+    private val dismissOnClickOutside: Boolean = focusable,
     private val onDismissRequest: () -> Unit = {}
 ) {
     val origin get() = bounds.topLeft.toOffset()
@@ -128,7 +129,8 @@ class PopupState(
 
     @Composable
     fun Content() {
-        Popup(
+        // TODO: Replace to public function once available
+        PopupLayout(
             popupPositionProvider = object : PopupPositionProvider {
                 override fun calculatePosition(
                     anchorBounds: IntRect,
@@ -138,7 +140,7 @@ class PopupState(
                 ) = bounds.topLeft
             },
             focusable = focusable,
-            onDismissRequest = onDismissRequest
+            onClickOutside = if (dismissOnClickOutside) onDismissRequest else null
         ) {
             with(LocalDensity.current) {
                 Box(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -72,14 +72,17 @@ internal class SkiaBasedOwner(
     initDensity: Density = Density(1f, 1f),
     initLayoutDirection: LayoutDirection = platform.layoutDirection,
     bounds: IntRect = IntRect.Zero,
-    val isFocusable: Boolean = true,
-    val onDismissRequest: (() -> Unit)? = null,
+    val focusable: Boolean = true,
+    val onClickOutside: (() -> Unit)? = null,
     private val onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     private val onKeyEvent: (KeyEvent) -> Boolean = { false },
 ) : Owner, RootForTest, SkiaRootForTest, PositionCalculator {
     override val windowInfo: WindowInfo get() = platform.windowInfo
 
-    fun isHovered(point: Offset): Boolean {
+    fun isHovered(event: PointerInputEvent) =
+        isHovered(event.pointers.first().position)
+
+    private fun isHovered(point: Offset): Boolean {
         val intOffset = IntOffset(point.x.toInt(), point.y.toInt())
         return bounds.contains(intOffset)
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -101,13 +101,11 @@ fun Popup(
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     focusable: Boolean = false,
     content: @Composable () -> Unit
-) {
-    PopupLayout(
-        popupPositionProvider,
-        focusable,
-        onDismissRequest,
-        onPreviewKeyEvent,
-        onKeyEvent,
-        content
-    )
-}
+) = PopupLayout(
+    popupPositionProvider = popupPositionProvider,
+    focusable = focusable,
+    onClickOutside = if (focusable) onDismissRequest else null,
+    onPreviewKeyEvent = onPreviewKeyEvent,
+    onKeyEvent = onKeyEvent,
+    content = content
+)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
@@ -35,7 +35,8 @@ import androidx.compose.ui.unit.round
 internal fun PopupLayout(
     popupPositionProvider: PopupPositionProvider,
     focusable: Boolean,
-    onDismissRequest: (() -> Unit)?,
+    onClickOutside: (() -> Unit)?,
+    modifier: Modifier = Modifier,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     content: @Composable () -> Unit
@@ -69,8 +70,8 @@ internal fun PopupLayout(
             pointerPositionUpdater = scene.pointerPositionUpdater,
             initDensity = density,
             initLayoutDirection = layoutDirection,
-            isFocusable = focusable,
-            onDismissRequest = onDismissRequest,
+            focusable = focusable,
+            onClickOutside = onClickOutside,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent
         )
@@ -79,6 +80,7 @@ internal fun PopupLayout(
         val composition = owner.setContent(parent = parentComposition) {
             Layout(
                 content = content,
+                modifier = modifier,
                 measurePolicy = { measurables, constraints ->
                     val width = constraints.maxWidth
                     val height = constraints.maxHeight


### PR DESCRIPTION
## Proposed Changes

Extract scene fixes from #611 into separate PR

- Separate focusable and dismissOnClickOutside logic
- Fix click outside logic for multiple owners (now it matches with android)
- Block all pointer events if it's under focusedOwner

## Testing

Test: run tests from `DesktopPopupTest` or play with multiple `Popups`
