### PR TITLE
Add JvmName annotation related to Scrollbar commonization

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:JvmName("Scrollbar_desktopKt")
+
 package androidx.compose.foundation
 
 import androidx.compose.animation.animateColorAsState

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldScrollState.skiko.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:JvmName("TextFieldScrollState_desktop_ktKt")
+
 package androidx.compose.foundation.text
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -23,6 +25,7 @@ import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import kotlin.jvm.JvmName
 
 
 /**


### PR DESCRIPTION
This PR adds:
```
@file:JvmName("Scrollbar_desktopKt") // in Scrollbar.skiko.kt, it used to be named 'Scrollbar.desktop.kt'
@file:JvmName("TextFieldScrollState_desktop_ktKt") // in TextFieldScrollState.skiko.kt, it used to be name `TextFieldScrollState.desktop.kt.kt`
```


