### PR TITLE
Fix Comparator compilation in commonMain

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/OneDimensionalFocusSearch.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/OneDimensionalFocusSearch.kt
@@ -219,12 +219,9 @@ private inline fun <T> MutableVector<T>.forEachItemBefore(item: T, action: (T) -
  */
 private object FocusableChildrenComparator : Comparator<FocusTargetNode> {
     override fun compare(
-        focusTarget1: FocusTargetNode?,
-        focusTarget2: FocusTargetNode?
+        focusTarget1: FocusTargetNode,
+        focusTarget2: FocusTargetNode
     ): Int {
-        requireNotNull(focusTarget1)
-        requireNotNull(focusTarget2)
-
         // Ignore focus modifiers that won't be considered during focus search.
         if (!focusTarget1.isEligibleForFocusSearch || !focusTarget2.isEligibleForFocusSearch) {
             if (focusTarget1.isEligibleForFocusSearch) return -1


### PR DESCRIPTION
## Proposed Changes

  - Fix Comparator compilation in commonMain/OneDimensionalFocusSearch. It requires not nullable arguments.
  
  Previously, it compiles on JVM because of platform types in the JVM Comparator interface. And arguments were checked with requireNotNull. Now, requireNotNull is not needed, because the same logic already exists in kotlin runtime to throw Exception in case of nullable arguments.