### PR TITLE
CodeStyle. Use single name import

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -87,6 +87,8 @@
           <package name="" alias="false" withSubpackages="true" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">


### PR DESCRIPTION
We should use the same style as in AOSP to be consistent and to avoid conflicts in commonMain.

It seems the import style created for Android Studio doesn't work in IDEA, we should specify it explicitly.

Instead of
```
import androidx.compose.foundation.*
```
we will have
```
import androidx.compose.foundation.ExperimentalFoundationApi
import androidx.compose.foundation.MutatePriority
import androidx.compose.foundation.OverscrollEffect
import androidx.compose.foundation.focusGroup
import androidx.compose.foundation.gestures.Orientation.Horizontal
import androidx.compose.foundation.interaction.MutableInteractionSource
import androidx.compose.foundation.rememberOverscrollEffect
```

~~(in IDEA, in Android Studio we already have this style)~~

It seems in AS we have `androidx.compose.foundation.*` too. But AS that runs via `./gradlew studio` in AOSP reads it differently