### PR TITLE
Keep Scrollable.kt with less changes comparing to AOSP

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/ScrollableExt.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/ScrollableExt.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateTo
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.State
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+internal class RawMouseWheelScrollNode(
+    scrollingLogicState: State<ScrollingLogic>,
+    mouseWheelScrollConfig: ScrollConfig
+) : MouseWheelScrollNode(scrollingLogicState, mouseWheelScrollConfig) {
+    override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
+        val delta = with(mouseWheelScrollConfig) {
+            calculateMouseWheelScroll(pointerEvent, size)
+        }
+        return scrollingLogic.dispatchRawDelta(delta) != Offset.Zero
+    }
+}
+
+internal class AnimatedMouseWheelScrollNode(
+    scrollingLogicState: State<ScrollingLogic>,
+    mouseWheelScrollConfig: ScrollConfig
+) : MouseWheelScrollNode(scrollingLogicState, mouseWheelScrollConfig) {
+    private var isAnimationRunning = false
+    private val channel = Channel<Float>(capacity = Channel.UNLIMITED)
+
+    override fun onAttach() {
+        val density = 1f // TODO: LocalDensity.current.density (no @Composable scope)
+        coroutineScope.launch {
+            while (isActive) {
+                val event = channel.receive()
+                isAnimationRunning = true
+                scrollingLogic.animatedDispatchScroll(event, speed = 1f * density) {
+                    // Sum delta from all pending events to avoid multiple animation restarts.
+                    channel.sumOrNull()
+                }
+                isAnimationRunning = false
+            }
+        }
+    }
+
+    override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
+        val scrollDelta = with(mouseWheelScrollConfig) {
+            calculateMouseWheelScroll(pointerEvent, size)
+        }
+        return if (mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)) {
+            // In case of high-resolution wheel, such as a freely rotating wheel with no notches
+            // or trackpads, delta should apply directly without any delays.
+            scrollingLogic.dispatchRawDelta(scrollDelta) != Offset.Zero
+
+            /*
+             * TODO Set isScrollInProgress to true in case of touchpad.
+             *  Dispatching raw delta doesn't cause a progress indication even with wrapping in
+             *  `scrollableState.scroll` block, since it applies the change within single frame.
+             *  Touchpads emit just multiple mouse wheel events, so detecting start and end of this
+             *  "gesture" is not straight forward.
+             *  Ideally it should be resolved by catching real touches from input device instead of
+             *  introducing a timeout (after each event before resetting progress flag).
+             */
+        } else with(scrollingLogic) {
+            val delta = scrollDelta.reverseIfNeeded().toFloat()
+            if (isAnimationRunning) {
+                channel.trySend(delta).isSuccess
+            } else {
+                // Try to apply small delta immediately to conditionally consume
+                // an input event and to avoid useless animation.
+                tryToScrollBySmallDelta(delta, threshold = 4.dp.toPx()) {
+                    channel.trySend(it).isSuccess
+                }
+            }
+        }
+    }
+
+    private fun Channel<Float>.sumOrNull(): Float? {
+        val elements = untilNull { tryReceive().getOrNull() }.toList()
+        return if (elements.isEmpty()) null else elements.sum()
+    }
+
+    private fun <E> untilNull(builderAction: () -> E?) = sequence<E> {
+        do {
+            val element = builderAction()?.also {
+                yield(it)
+            }
+        } while (element != null)
+    }
+
+    private fun ScrollingLogic.tryToScrollBySmallDelta(
+        delta: Float,
+        threshold: Float = 4f,
+        fallback: (Float) -> Boolean
+    ): Boolean {
+        return if (abs(delta) > threshold) {
+            // Gather possibility to scroll by applying a piece of required delta.
+            val testDelta = if (delta > 0f) threshold else -threshold
+            val consumedDelta = scrollableState.dispatchRawDelta(testDelta)
+            consumedDelta != 0f && fallback(delta - testDelta)
+        } else {
+            val consumedDelta = scrollableState.dispatchRawDelta(delta)
+            consumedDelta != 0f
+        }
+    }
+
+    private suspend fun ScrollingLogic.animatedDispatchScroll(
+        eventDelta: Float,
+        speed: Float = 1f,
+        maxDurationMillis: Int = 100,
+        tryReceiveNext: () -> Float?
+    ) {
+        var target = eventDelta
+        tryReceiveNext()?.let {
+            target += it
+        }
+        if (target.isLowScrollingDelta()) {
+            return
+        }
+        scrollableState.scroll {
+            var requiredAnimation = true
+            var lastValue = 0f
+            val anim = AnimationState(0f)
+            while (requiredAnimation) {
+                requiredAnimation = false
+                val durationMillis = (abs(target - anim.value) / speed)
+                    .roundToInt()
+                    .coerceAtMost(maxDurationMillis)
+                anim.animateTo(
+                    target,
+                    animationSpec = tween(
+                        durationMillis = durationMillis,
+                        easing = LinearEasing
+                    ),
+                    sequentialAnimation = true
+                ) {
+                    val delta = value - lastValue
+                    if (!delta.isLowScrollingDelta()) {
+                        val consumedDelta = scrollBy(delta)
+                        if (!(delta - consumedDelta).isLowScrollingDelta()) {
+                            cancelAnimation()
+                            return@animateTo
+                        }
+                        lastValue += delta
+                    }
+                    tryReceiveNext()?.let {
+                        target += it
+                        requiredAnimation = !(target - lastValue).isLowScrollingDelta()
+                        cancelAnimation()
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*
+ * Returns true, if the value is too low for visible change in scroll (consumed delta, animation-based change, etc),
+ * false otherwise
+ */
+private inline fun Float.isLowScrollingDelta(): Boolean = abs(this) < 0.5f
+
+private val MouseWheelScrollNode.scrollingLogic get() = scrollingLogicState.value


### PR DESCRIPTION
- remove refactorings. Usually they are good, but not in case we need to constantly merge the upstream
- move the new functionality to the new file. Otherwise, it can conflict with near-code changes, and pollutes the merge resolver diff
