### PR TITLE
actual Modifier.textPointerHoverIcon for jsNative

### DIFF
--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/BasicText.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/BasicText.jsNative.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.text.selection.SelectionRegistrar
+import androidx.compose.ui.Modifier
+
+internal actual fun Modifier.textPointerHoverIcon(
+    selectionRegistrar: SelectionRegistrar?
+): Modifier = this

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/BasicText.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/BasicText.jsNative.kt
@@ -21,4 +21,4 @@ import androidx.compose.ui.Modifier
 
 internal actual fun Modifier.textPointerHoverIcon(
     selectionRegistrar: SelectionRegistrar?
-): Modifier = this
+): Modifier = this //TODO: Implement on some platforms. Maybe on JS?


### PR DESCRIPTION
Added empty actual `Modifier.textPointerHoverIcon()` for jsNative sourceSet in foundation module.