### PR TITLE
actual class WeakReference

### DIFF
--- a/compose/runtime/runtime/src/jsWasmMain/kotlin/androidx/compose/runtime/ActualJsWasm.jsWasm.kt
+++ b/compose/runtime/runtime/src/jsWasmMain/kotlin/androidx/compose/runtime/ActualJsWasm.jsWasm.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+internal actual class WeakReference<T : Any> actual constructor(reference: T) {
+    private val workaroundReference: T = reference // TODO: Properly implement weak reference
+    actual fun get(): T? = workaroundReference
+}

--- a/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/ActualNative.native.kt
+++ b/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/ActualNative.native.kt
@@ -67,6 +67,11 @@ internal actual class AtomicInt actual constructor(value: Int) {
     actual fun add(amount: Int): Int = delegate.addAndGet(amount)
 }
 
+internal actual class WeakReference<T : Any> actual constructor(reference: T) {
+    val kotlinNativeReference = kotlin.native.ref.WeakReference<T>(reference)
+    actual fun get(): T? = kotlinNativeReference.get()
+}
+
 internal actual fun identityHashCode(instance: Any?): Int =
     instance.identityHashCode()
 


### PR DESCRIPTION
Added `actual class WeakReference` for native and jsWasm sourceSets.
In jsWasm it is just a simple reference. Added TODO to implement it properly.