### PR TITLE
Fix pointer icon test

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -408,7 +408,6 @@ internal class SkiaBasedOwner(
         requestLayout?.invoke()
     }
 
-    // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-163) check after merge
     override val pointerIconService = object : PointerIconService {
         private var desiredPointerIcon: PointerIcon? = null
 

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -157,6 +157,9 @@ class PointerIconTest {
             }
         }
 
+        // skip one frame, so Compose will properly calculate Boxes hierarchy
+        // and detect overrideDescendants
+        scene.render()
         scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
         assertThat(iconService.getIcon()).isEqualTo(PointerIcon.Hand)
 
@@ -247,7 +250,9 @@ class PointerIconTest {
         try {
             scene.constraints = Constraints(maxWidth = surface.width, maxHeight = surface.height)
             scene.setContent {
-                Box(modifier = Modifier.size(100.dp, 100.dp).pointerInput(Unit) { }) {
+                Box(
+                    modifier = Modifier.size(100.dp, 100.dp).pointerHoverIcon(PointerIcon.Default)
+                ) {
                     Box(
                         modifier = Modifier.pointerHoverIcon(iconState.value).size(30.dp, 30.dp)
                     )


### PR DESCRIPTION
## Proposed Changes

It seems that reimplemented hoverIcon works fine, but there is an known issue that it sometime we need one additional frame to calculate hover hierarchy

## Testing

Test: run PointerIconTest