### PR TITLE
Fix lazy list tests copied from androidx

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -199,6 +199,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(commonTest)
                 dependencies {
                     implementation(project(":compose:ui:ui-test-junit4"))
+                    implementation(project(":internal-testutils-kmp"))
                     implementation(libs.skikoCommon)
                 }
             }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/Assert.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/Assert.kt
@@ -23,6 +23,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
+// TODO: may be replace it with :internal-testutils-kmp?
+//  So tests copied from androidx will work properly
+
 internal class AssertThat<T>(val t: T?, val message: String? = null)
 
 internal class AssertMessage(private val message: String) {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
@@ -16,12 +16,6 @@
 
 package androidx.compose.foundation.copyPasteAndroidTests.lazy.list
 
-import androidx.compose.foundation.*
-import androidx.compose.foundation.assertThat
-import androidx.compose.foundation.containsAtLeast
-import androidx.compose.foundation.containsExactly
-import androidx.compose.foundation.isEqualTo
-import androidx.compose.foundation.isLessThan
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -59,6 +53,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.LayoutDirection.Ltr
 import androidx.compose.ui.unit.LayoutDirection.Rtl
+import androidx.kruth.assertThat
 import kotlin.test.Test
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
@@ -232,7 +232,7 @@ class LazyListBeyondBoundsTest {
             beyondBoundsLayout!!.layout(beyondBoundsLayoutDirection) {
                 // Assert that the beyond bounds items are present.
                 if (expectedExtraItemsBeforeVisibleBounds()) {
-                    assertThat(placedItems.sorted()).containsExactly(4, 5, 6, 7)
+                    assertThat(placedItems).containsExactly(4, 5, 6, 7)
                     assertThat(visibleItems).containsExactly(5, 6, 7)
                 } else {
                     assertThat(placedItems).containsExactly(5, 6, 7, 8)
@@ -291,7 +291,7 @@ class LazyListBeyondBoundsTest {
                 } else {
                     // Assert that the beyond bounds items are present.
                     if (expectedExtraItemsBeforeVisibleBounds()) {
-                        assertThat(placedItems.sorted()).containsExactly(3, 4, 5, 6, 7)
+                        assertThat(placedItems).containsExactly(3, 4, 5, 6, 7)
                         assertThat(visibleItems).containsExactly(5, 6, 7)
                     } else {
                         assertThat(placedItems).containsExactly(5, 6, 7, 8, 9)
@@ -349,7 +349,7 @@ class LazyListBeyondBoundsTest {
                 } else {
                     // Assert that the beyond bounds items are present.
                     if (expectedExtraItemsBeforeVisibleBounds()) {
-                        assertThat(placedItems.sorted()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7)
+                        assertThat(placedItems).containsExactly(0, 1, 2, 3, 4, 5, 6, 7)
                         assertThat(visibleItems).containsExactly(5, 6, 7)
                     } else {
                         assertThat(placedItems).containsExactly(5, 6, 7, 8, 9, 10)
@@ -413,7 +413,7 @@ class LazyListBeyondBoundsTest {
                     }
                     Before, After -> {
                         if (expectedExtraItemsBeforeVisibleBounds()) {
-                            assertThat(placedItems.sorted()).containsExactly(4, 5, 6, 7)
+                            assertThat(placedItems).containsExactly(4, 5, 6, 7)
                             assertThat(visibleItems).containsExactly(5, 6, 7)
                         } else {
                             assertThat(placedItems).containsExactly(5, 6, 7, 8)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
@@ -237,7 +237,7 @@ class LazyListBeyondBoundsTest {
             beyondBoundsLayout!!.layout(beyondBoundsLayoutDirection) {
                 // Assert that the beyond bounds items are present.
                 if (expectedExtraItemsBeforeVisibleBounds()) {
-                    assertThat(placedItems).containsExactly(4, 5, 6, 7)
+                    assertThat(placedItems.sorted()).containsExactly(4, 5, 6, 7)
                     assertThat(visibleItems).containsExactly(5, 6, 7)
                 } else {
                     assertThat(placedItems).containsExactly(5, 6, 7, 8)
@@ -296,7 +296,7 @@ class LazyListBeyondBoundsTest {
                 } else {
                     // Assert that the beyond bounds items are present.
                     if (expectedExtraItemsBeforeVisibleBounds()) {
-                        assertThat(placedItems).containsExactly(3, 4, 5, 6, 7)
+                        assertThat(placedItems.sorted()).containsExactly(3, 4, 5, 6, 7)
                         assertThat(visibleItems).containsExactly(5, 6, 7)
                     } else {
                         assertThat(placedItems).containsExactly(5, 6, 7, 8, 9)
@@ -354,7 +354,7 @@ class LazyListBeyondBoundsTest {
                 } else {
                     // Assert that the beyond bounds items are present.
                     if (expectedExtraItemsBeforeVisibleBounds()) {
-                        assertThat(placedItems).containsExactly(0, 1, 2, 3, 4, 5, 6, 7)
+                        assertThat(placedItems.sorted()).containsExactly(0, 1, 2, 3, 4, 5, 6, 7)
                         assertThat(visibleItems).containsExactly(5, 6, 7)
                     } else {
                         assertThat(placedItems).containsExactly(5, 6, 7, 8, 9, 10)
@@ -418,7 +418,7 @@ class LazyListBeyondBoundsTest {
                     }
                     Before, After -> {
                         if (expectedExtraItemsBeforeVisibleBounds()) {
-                            assertThat(placedItems).containsExactly(4, 5, 6, 7)
+                            assertThat(placedItems.sorted()).containsExactly(4, 5, 6, 7)
                             assertThat(visibleItems).containsExactly(5, 6, 7)
                         } else {
                             assertThat(placedItems).containsExactly(5, 6, 7, 8)


### PR DESCRIPTION
## Proposed Changes

I don't know exactly why, but items for horizontal lazy list not visible items are placed after visible ones, that causes tests to fail. 
Practically there should be no difference in order, but weird that android tests seems to work in another way

## Testing

Test: run LazyListBeyondBoundsTest
