### PR TITLE
COMPOSE-158 1.5.0-beta03 merge. Fix Clickable.kt

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ClickableExt.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ClickableExt.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.semantics.Role
+
+internal fun Modifier.focusableClickable(
+    interactionSource: MutableInteractionSource,
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    onClick: () -> Unit
+) = composed {
+    val focusRequester = remember { FocusRequester() }
+    this
+        .focusRequester(focusRequester)
+        .focusable(enabled = enabled, interactionSource = interactionSource)
+        .then(
+            ClickableElement(
+                interactionSource,
+                focusRequester,
+                enabled,
+                onClickLabel,
+                role,
+                onClick
+            )
+        )
+}
+
+internal fun Modifier.focusableCombinedClickable(
+    interactionSource: MutableInteractionSource,
+    enabled: Boolean,
+    onClickLabel: String?,
+    role: Role? = null,
+    onClick: () -> Unit,
+    onLongClickLabel: String?,
+    onLongClick: (() -> Unit)?,
+    onDoubleClick: (() -> Unit)?
+) = composed {
+    val focusRequester = remember { FocusRequester() }
+    this
+        .focusRequester(focusRequester)
+        .focusable(enabled = enabled, interactionSource = interactionSource)
+        .then(
+            CombinedClickableElement(
+                interactionSource,
+                focusRequester,
+                enabled,
+                onClickLabel,
+                role,
+                onClick,
+                onLongClickLabel,
+                onLongClick,
+                onDoubleClick
+            )
+        )
+}

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/Clickable.desktop.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -128,7 +130,7 @@ fun Modifier.mouseClickable(
         val onClickState = rememberUpdatedState(onClick)
         val centreOffset = remember { mutableStateOf(Offset.Zero) }
         val currentKeyPressInteractions = remember { mutableMapOf<Key, PressInteraction.Press>() }
-        val (focusRequester, focusRequesterModifier) = focusRequesterAndModifier()
+        val focusRequester = remember { FocusRequester() }
         val gesture = if (enabled) {
             Modifier.pointerInput(Unit) {
                 centreOffset.value = size.center.toOffset()
@@ -148,7 +150,7 @@ fun Modifier.mouseClickable(
             Modifier
         }
         Modifier
-            .then(focusRequesterModifier)
+            .focusRequester(focusRequester)
             .genericClickableWithoutGesture(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -19,10 +19,7 @@ package androidx.compose.foundation
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
@@ -97,6 +94,7 @@ fun Modifier.onClick(
  * @param onDoubleClick will be called when user double clicks on the element
  * @param onClick will be called when user clicks on the element
  */
+// TODO(https://youtrack.jetbrains.com/issue/COMPOSE-156) rewrite to Modifier.Node
 @ExperimentalFoundationApi
 fun Modifier.onClick(
     enabled: Boolean = true,
@@ -120,7 +118,7 @@ fun Modifier.onClick(
     factory = {
 
         val gestureModifier = if (enabled) {
-            val pressedInteraction = remember { mutableStateOf<PressInteraction.Press?>(null) }
+            val interactionData = remember { AbstractClickableNode.InteractionData() }
             val onClickState = rememberUpdatedState(onClick)
             val on2xClickState = rememberUpdatedState(onDoubleClick)
             val onLongClickState = rememberUpdatedState(onLongClick)
@@ -133,19 +131,26 @@ fun Modifier.onClick(
 
             DisposableEffect(hasLongClick) {
                 onDispose {
-                    pressedInteraction.value?.let { oldValue ->
+                    interactionData.pressInteraction?.let { oldValue ->
                         val interaction = PressInteraction.Cancel(oldValue)
                         interactionSource.tryEmit(interaction)
-                        pressedInteraction.value = null
+                        interactionData.pressInteraction = null
                     }
                 }
             }
-            // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-157) Fix after merge
-//            PressedInteractionSourceDisposableEffect(
-//                interactionSource = interactionSource,
-//                pressedInteraction = pressedInteraction,
-//                currentKeyPressInteractions = currentKeyPressInteractions
-//            )
+            DisposableEffect(interactionSource) {
+                onDispose {
+                    interactionData.pressInteraction?.let { oldValue ->
+                        val interaction = PressInteraction.Cancel(oldValue)
+                        interactionSource.tryEmit(interaction)
+                        interactionData.pressInteraction = null
+                    }
+                    currentKeyPressInteractions.values.forEach {
+                        interactionSource.tryEmit(PressInteraction.Cancel(it))
+                    }
+                    currentKeyPressInteractions.clear()
+                }
+            }
 
             val matcherState = rememberUpdatedState(matcher)
 
@@ -176,13 +181,12 @@ fun Modifier.onClick(
                         onClickState.value()
                     },
                     onPress = {
-                        // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-157) Fix after merge
-//                        handlePressInteraction(
-//                            pressPoint = it,
-//                            interactionSource = interactionSource,
-//                            pressedInteraction = pressedInteraction,
-//                            delayPressInteraction = mutableStateOf({ false })
-//                        )
+                        handlePressInteraction(
+                            pressPoint = it,
+                            interactionSource = interactionSource,
+                            interactionData = interactionData,
+                            delayPressInteraction = { false }
+                        )
                     }
                 )
             }.focusRequester(focusRequester)


### PR DESCRIPTION
- Apply changes from jb-main between the base commit 6022301db806601f282c53b8cbb5a981923a1589 and the pre-merge commit 4ac3bda449d4606e5190208d074654ba041d2537: 

  - https://github.com/JetBrains/compose-multiplatform-core/pull/257

- Fix OnClick.skiko.kt

- Move large code to a ClickableExt to avoid merge conflicts

- Have to use `composed` for creating FocusRequester (as for MutableInteractionSource). Asked for solution here: https://kotlinlang.slack.com/archives/G010KHY484C/p1689181951198299