### PR TITLE
Rename desktop's Dialog to DialogWindow

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/layout/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/layout/Main.jvm.kt
@@ -24,13 +24,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberDialogState
 import kotlinx.coroutines.delay
 
 fun main() = application {
-    Dialog(
+    DialogWindow(
         onCloseRequest = ::exitApplication,
         state = rememberDialogState(width = 400.dp, height = 600.dp),
         undecorated = true,

--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/popupexample/AppContent.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/popupexample/AppContent.jvm.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Notification
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.TrayState
@@ -276,7 +276,7 @@ fun WindowScope.Content(
                 backgroundColor = Color(70, 70, 70)
             )
         } else {
-            Dialog(
+            DialogWindow(
                 onCloseRequest = dismiss
             ) {
                 WindowContent(

--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/windowapi/Examples.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/windowapi/Examples.jvm.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.AwtWindow
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.MenuBar
 import androidx.compose.ui.window.Notification
 import androidx.compose.ui.window.Tray
@@ -262,7 +262,7 @@ fun dialog() = GlobalScope.launchApplication {
             }
 
             if (isDialogShowing) {
-                Dialog(onCloseRequest = { isDialogShowing = false }) {
+                DialogWindow(onCloseRequest = { isDialogShowing = false }) {
                     Text("Dialog")
                 }
             }
@@ -279,7 +279,7 @@ fun hideDialog() = GlobalScope.launchApplication {
             Text("Dialog")
         }
 
-        Dialog(
+        DialogWindow(
             onCloseRequest = { isDialogVisible = false },
             visible = isDialogVisible
         ) {

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -44,13 +44,13 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.rememberDialogState
 import java.awt.event.KeyEvent
-import androidx.compose.ui.window.Dialog as CoreDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.window.DialogWindow
 
 /**
  * The default padding for an [AlertDialog].
@@ -414,7 +414,7 @@ object UndecoratedWindowAlertDialogProvider : AlertDialogProvider {
         onDismissRequest: () -> Unit,
         content: @Composable () -> Unit
     ) {
-        CoreDialog(
+        DialogWindow(
             onCloseRequest = onDismissRequest,
             state = rememberDialogState(width = Dp.Unspecified, height = Dp.Unspecified),
             undecorated = true,

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/FiltersTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/FiltersTest.kt
@@ -26,7 +26,7 @@ import androidx.compose.material.TextField
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Popup
 import org.junit.Ignore
 import org.junit.Rule
@@ -45,7 +45,7 @@ class FiltersTest {
     @Ignore  // TODO: Fix Dialog to have the dialog() semantic property
     fun testIsDialog() {
         rule.setContent {
-            Dialog(
+            DialogWindow(
                 onCloseRequest = {},
             ){
                 Text(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -65,7 +65,7 @@ import kotlin.system.exitProcess
  * example, from some event listener), use `GlobalScope.launchApplication` instead.
  *
  * Application can launch background tasks using [LaunchedEffect]
- * or create [Window], [Dialog], or [Tray] in a declarative Compose way:
+ * or create [Window], [DialogWindow], or [Tray] in a declarative Compose way:
  *
  * ```
  * fun main() = application {
@@ -86,7 +86,7 @@ import kotlin.system.exitProcess
  *
  * When there is no any active compositions, this function will end.
  * Active composition is a composition that have active coroutine (for example, launched in
- * [LaunchedEffect]) or that have child composition created inside [Window], [Dialog], or [Tray].
+ * [LaunchedEffect]) or that have child composition created inside [Window], [DialogWindow], or [Tray].
  *
  * Don't use any animation in this function
  * (for example, [withFrameNanos] or [androidx.compose.animation.core.animateFloatAsState]),
@@ -94,7 +94,7 @@ import kotlin.system.exitProcess
  * frames as fast as possible.
  *
  * All animation's should be created inside Composable content of the
- * [Window] / [Dialog] / [ComposePanel].
+ * [Window] / [DialogWindow] / [ComposePanel].
  *
  * @param exitProcessOnExit should `exitProcess(0)` be called after the application is closed.
  * exitProcess speedup process exit (instant instead of 1-4sec).
@@ -156,7 +156,7 @@ fun CoroutineScope.launchApplication(
  * An entry point for the Compose application.
  *
  * Application can launch background tasks using [LaunchedEffect]
- * or create [Window], [Dialog], or [Tray] in a declarative Compose way:
+ * or create [Window], [DialogWindow], or [Tray] in a declarative Compose way:
  *
  * ```
  * fun main() = runBlocking {
@@ -179,7 +179,7 @@ fun CoroutineScope.launchApplication(
  *
  * When there is no any active compositions, this function will end.
  * Active composition is a composition that have active coroutine (for example, launched in
- * [LaunchedEffect]) or that have child composition created inside [Window], [Dialog], or [Tray].
+ * [LaunchedEffect]) or that have child composition created inside [Window], [DialogWindow], or [Tray].
  *
  * Don't use any animation in this function
  * (for example, [withFrameNanos] or [androidx.compose.animation.core.animateFloatAsState]),
@@ -187,7 +187,7 @@ fun CoroutineScope.launchApplication(
  * frames as fast as possible.
  *
  * All animation's should be created inside Composable content of the
- * [Window] / [Dialog] / [ComposePanel].
+ * [Window] / [DialogWindow] / [ComposePanel].
  */
 suspend fun awaitApplication(
     content: @Composable ApplicationScope.() -> Unit

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/AwtWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/AwtWindow.desktop.kt
@@ -46,7 +46,7 @@ import java.awt.Window
  *
  * [AwtWindow] is needed for creating window's / dialog's that still can't be created with
  * the default Compose functions [androidx.compose.ui.window.Window] or
- * [androidx.compose.ui.window.Dialog].
+ * [androidx.compose.ui.window.DialogWindow].
  *
  * @param visible Is [Window] visible to user.
  * Note that if we set `false` - native resources will not be released. They will be released

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -43,6 +43,41 @@ import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import javax.swing.JDialog
 
+@Deprecated(
+    message = "Replaced by DialogWindow",
+    replaceWith = ReplaceWith("DialogWindow(onCloseRequest, state, visible, title, icon, undecorated, transparent, resizable, enabled, focusable, onPreviewKeyEvent, onKeyEvent, content)")
+)
+@Composable
+fun Dialog(
+    onCloseRequest: () -> Unit,
+    state: DialogState = rememberDialogState(),
+    visible: Boolean = true,
+    title: String = "Untitled",
+    icon: Painter? = null,
+    undecorated: Boolean = false,
+    transparent: Boolean = false,
+    resizable: Boolean = true,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
+    onKeyEvent: ((KeyEvent) -> Boolean) = { false },
+    content: @Composable DialogWindowScope.() -> Unit
+) = DialogWindow(
+    onCloseRequest,
+    state,
+    visible,
+    title,
+    icon,
+    undecorated,
+    transparent,
+    resizable,
+    enabled,
+    focusable,
+    onPreviewKeyEvent,
+    onKeyEvent,
+    content
+)
+
 /**
  * Composes platform dialog in the current composition. When Dialog enters the composition,
  * a new platform dialog will be created and receives the focus. When Dialog leaves the
@@ -101,7 +136,7 @@ import javax.swing.JDialog
  * @param content content of the dialog
  */
 @Composable
-fun Dialog(
+fun DialogWindow(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
     visible: Boolean = true,
@@ -223,6 +258,29 @@ fun Dialog(
     )
 }
 
+@Deprecated(
+    message = "Replaced by DialogWindow",
+    replaceWith = ReplaceWith("DialogWindow(visible, onPreviewKeyEvent, onKeyEvent, create, dispose, update, content)")
+)
+@Composable
+fun Dialog(
+    visible: Boolean = true,
+    onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
+    onKeyEvent: ((KeyEvent) -> Boolean) = { false },
+    create: () -> ComposeDialog,
+    dispose: (ComposeDialog) -> Unit,
+    update: (ComposeDialog) -> Unit = {},
+    content: @Composable DialogWindowScope.() -> Unit
+) = DialogWindow(
+    visible,
+    onPreviewKeyEvent,
+    onKeyEvent,
+    create,
+    dispose,
+    update,
+    content
+)
+
 // TODO(demin): fix mouse hover after opening a dialog.
 //  When we open a modal dialog, ComposeLayer/mouseExited will
 //  never be called for the parent window. See ./gradlew run3
@@ -268,7 +326,7 @@ fun Dialog(
 @OptIn(ExperimentalComposeUiApi::class)
 @Suppress("unused")
 @Composable
-fun Dialog(
+fun DialogWindow(
     visible: Boolean = true,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -83,7 +83,7 @@ fun Dialog(
  * a new platform dialog will be created and receives the focus. When Dialog leaves the
  * composition, dialog will be disposed and closed.
  *
- * Dialog is a modal window. It means it blocks the parent [Window] / [Dialog] in which composition
+ * Dialog is a modal window. It means it blocks the parent [Window] / [DialogWindow] in which composition
  * context it was created.
  *
  * Usage:
@@ -107,11 +107,11 @@ fun Dialog(
  * the native dialog will update its corresponding properties.
  * If [DialogState.position] is not [WindowPosition.isSpecified], then after the first show on the
  * screen [DialogState.position] will be set to the absolute values.
- * @param visible Is [Dialog] visible to user.
+ * @param visible Is [DialogWindow] visible to user.
  * If `false`:
- * - internal state of [Dialog] is preserved and will be restored next time the dialog
+ * - internal state of [DialogWindow] is preserved and will be restored next time the dialog
  * will be visible;
- * - native resources will not be released. They will be released only when [Dialog]
+ * - native resources will not be released. They will be released only when [DialogWindow]
  * will leave the composition.
  * @param title Title in the titlebar of the dialog
  * @param icon Icon in the titlebar of the window (for platforms which support this).
@@ -185,8 +185,7 @@ fun DialogWindow(
         }
     }
 
-
-    Dialog(
+    DialogWindow(
         visible = visible,
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
@@ -292,7 +291,7 @@ fun Dialog(
  * Once Dialog leaves the composition, [dispose] will be called to free resources that
  * obtained by the [ComposeDialog].
  *
- * Dialog is a modal window. It means it blocks the parent [Window] / [Dialog] in which composition
+ * Dialog is a modal window. It means it blocks the parent [Window] / [DialogWindow] in which composition
  * context it was created.
  *
  * The [update] block can be run multiple times (on the UI thread as well) due to recomposition,
@@ -301,13 +300,13 @@ fun Dialog(
  * Note the block will also be ran once right after the [create] block completes.
  *
  * Dialog is needed for creating dialog's that still can't be created with
- * the default Compose function [androidx.compose.ui.window.Dialog]
+ * the default Compose function [androidx.compose.ui.window.DialogWindow]
  *
  * @param visible Is [ComposeDialog] visible to user.
  * If `false`:
  * - internal state of [ComposeDialog] is preserved and will be restored next time the dialog
  * will be visible;
- * - native resources will not be released. They will be released only when [Dialog]
+ * - native resources will not be released. They will be released only when [DialogWindow]
  * will leave the composition.
  * @param onPreviewKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. It gives ancestors of a focused component the chance to intercept a [KeyEvent].
@@ -370,12 +369,12 @@ fun DialogWindow(
 }
 
 /**
- * Receiver scope which is used by [androidx.compose.ui.window.Dialog].
+ * Receiver scope which is used by [androidx.compose.ui.window.DialogWindow].
  */
 @Stable
 interface DialogWindowScope : WindowScope {
     /**
-     * [ComposeDialog] that was created inside [androidx.compose.ui.window.Dialog].
+     * [ComposeDialog] that was created inside [androidx.compose.ui.window.DialogWindow].
      */
     override val window: ComposeDialog
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowScope.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowScope.kt
@@ -21,13 +21,13 @@ import java.awt.Window
 
 /**
  * Receiver scope which is used by [androidx.compose.ui.window.Window] and
- * [androidx.compose.ui.window.Dialog].
+ * [androidx.compose.ui.window.DialogWindow].
  */
 @Stable
 interface WindowScope {
     /**
      * [Window] that was created inside [androidx.compose.ui.window.Window]
-     * or [androidx.compose.ui.window.Dialog]
+     * or [androidx.compose.ui.window.DialogWindow]
      */
     val window: Window
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/dialog/DialogTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/dialog/DialogTest.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.rememberDialogState
@@ -79,7 +79,7 @@ class DialogTest {
             }
 
             if (isOpen) {
-                Dialog(
+                DialogWindow(
                     create = ::createWindow,
                     dispose = ComposeDialog::dispose
                 ) {
@@ -114,7 +114,7 @@ class DialogTest {
             }
 
             if (isOpen) {
-                Dialog(
+                DialogWindow(
                     create = ::createWindow,
                     dispose = ComposeDialog::dispose,
                     update = { it.title = title }
@@ -141,7 +141,7 @@ class DialogTest {
         var window: ComposeDialog? = null
 
         launchTestApplication {
-            Dialog(onCloseRequest = ::exitApplication) {
+            DialogWindow(onCloseRequest = ::exitApplication) {
                 window = this.window
                 Box(Modifier.size(32.dp).background(Color.Red))
             }
@@ -161,7 +161,7 @@ class DialogTest {
 
         launchTestApplication {
             if (isOpen) {
-                Dialog(
+                DialogWindow(
                     onCloseRequest = {
                         isCloseCalled = true
                     }
@@ -195,12 +195,12 @@ class DialogTest {
         launchTestApplication {
             if (isOpen) {
                 if (isLoading) {
-                    Dialog(onCloseRequest = {}) {
+                    DialogWindow(onCloseRequest = {}) {
                         window1 = this.window
                         Box(Modifier.size(32.dp).background(Color.Red))
                     }
                 } else {
-                    Dialog(onCloseRequest = {}) {
+                    DialogWindow(onCloseRequest = {}) {
                         window2 = this.window
                         Box(Modifier.size(32.dp).background(Color.Blue))
                     }
@@ -232,12 +232,12 @@ class DialogTest {
 
         launchTestApplication {
             if (isOpen) {
-                Dialog(onCloseRequest = {}) {
+                DialogWindow(onCloseRequest = {}) {
                     window1 = this.window
                     Box(Modifier.size(32.dp).background(Color.Red))
                 }
 
-                Dialog(onCloseRequest = {}) {
+                DialogWindow(onCloseRequest = {}) {
                     window2 = this.window
                     Box(Modifier.size(32.dp).background(Color.Blue))
                 }
@@ -264,7 +264,7 @@ class DialogTest {
 
         launchTestApplication {
             if (isOpen) {
-                Dialog(
+                DialogWindow(
                     onCloseRequest = {},
                     state = rememberDialogState(
                         size = DpSize(600.dp, 600.dp),
@@ -274,7 +274,7 @@ class DialogTest {
                     Box(Modifier.size(32.dp).background(Color.Red))
 
                     if (isNestedOpen) {
-                        Dialog(
+                        DialogWindow(
                             onCloseRequest = {},
                             state = rememberDialogState(
                                 size = DpSize(300.dp, 300.dp),
@@ -320,7 +320,7 @@ class DialogTest {
         launchTestApplication {
             if (isOpen) {
                 CompositionLocalProvider(localTestValue provides testValue) {
-                    Dialog(
+                    DialogWindow(
                         onCloseRequest = {},
                         state = rememberDialogState(
                             size = DpSize(600.dp, 600.dp),
@@ -329,7 +329,7 @@ class DialogTest {
                         actualValue1 = localTestValue.current
                         Box(Modifier.size(32.dp).background(Color.Red))
 
-                        Dialog(
+                        DialogWindow(
                             onCloseRequest = {},
                             state = rememberDialogState(
                                 size = DpSize(300.dp, 300.dp),
@@ -364,7 +364,7 @@ class DialogTest {
 
         launchTestApplication {
             if (isOpen) {
-                Dialog(onCloseRequest = {}) {
+                DialogWindow(onCloseRequest = {}) {
                     DisposableEffect(Unit) {
                         initCount++
                         onDispose {
@@ -397,7 +397,7 @@ class DialogTest {
         }
 
         launchTestApplication {
-            Dialog(
+            DialogWindow(
                 onCloseRequest = ::exitApplication,
                 onPreviewKeyEvent = {
                     onPreviewKeyEventKeys.add(it.key)
@@ -448,7 +448,7 @@ class DialogTest {
         }
 
         launchTestApplication {
-            Dialog(
+            DialogWindow(
                 onCloseRequest = ::exitApplication,
                 onPreviewKeyEvent = {
                     onWindowPreviewKeyEventKeys.add(it.key)
@@ -537,7 +537,7 @@ class DialogTest {
         var expectedCanvasSizePx: Size? = null
 
         launchTestApplication {
-            Dialog(
+            DialogWindow(
                 onCloseRequest = ::exitApplication,
                 state = dialogState
             ) {


### PR DESCRIPTION
## Proposed Changes

  - Rename existing Dialog function to avoid same naming with commonized `Dialog`
  - See https://github.com/JetBrains/compose-multiplatform-core/pull/632#discussion_r1259957338

## API change

```diff
- androidx.compose.ui.window.Dialog(onCloseRequest, state, visible, title, icon, undecorated, transparent, resizable, enabled, focusable, onPreviewKeyEvent, onKeyEvent, content)
+ androidx.compose.ui.window.DialogWindow(onCloseRequest, state, visible, title, icon, undecorated, transparent, resizable, enabled, focusable, onPreviewKeyEvent, onKeyEvent, content)
```

## Testing

Test: N/A
