### PR TITLE
Replace inheritance from lambdas (fixes Kotlin/JS)

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/FocusedBounds.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/FocusedBounds.kt
@@ -68,14 +68,18 @@ private class FocusedBoundsObserverElement(
     }
 }
 
+fun interface InvokeOnLayoutCoordinates {
+    fun invoke(focusedBounds: LayoutCoordinates?)
+}
+
 private class FocusedBoundsObserverNode(
     var onPositioned: (LayoutCoordinates?) -> Unit
-) : Modifier.Node(), ModifierLocalModifierNode, (LayoutCoordinates?) -> Unit {
+) : Modifier.Node(), ModifierLocalModifierNode, InvokeOnLayoutCoordinates {
     private val parent: ((LayoutCoordinates?) -> Unit)?
         get() = if (isAttached) ModifierLocalFocusedBoundsObserver.current else null
 
     override val providedValues: ModifierLocalMap =
-        modifierLocalMapOf(entry = ModifierLocalFocusedBoundsObserver to this)
+        modifierLocalMapOf(entry = ModifierLocalFocusedBoundsObserver to { invoke(it) })
 
     /** Called when a child gains/loses focus or is focused and changes position. */
     override fun invoke(focusedBounds: LayoutCoordinates?) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridDsl.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridDsl.kt
@@ -207,14 +207,14 @@ private fun rememberRowHeightSums(
 }
 
 /** measurement cache to avoid recalculating row/column sizes on each scroll. */
-private class GridSlotCache(
-    private val calculation: Density.(Constraints) -> LazyGridSlots
+private fun GridSlotCache(
+    calculation: Density.(Constraints) -> LazyGridSlots
 ) : (Density, Constraints) -> LazyGridSlots {
-    private var cachedConstraints = Constraints()
-    private var cachedDensity: Float = 0f
-    private var cachedSizes: LazyGridSlots? = null
+    var cachedConstraints = Constraints()
+    var cachedDensity: Float = 0f
+    var cachedSizes: LazyGridSlots? = null
 
-    override fun invoke(density: Density, constraints: Constraints): LazyGridSlots {
+    fun invoke(density: Density, constraints: Constraints): LazyGridSlots {
         with(density) {
             if (
                 cachedSizes != null &&
@@ -231,6 +231,8 @@ private class GridSlotCache(
             }
         }
     }
+
+    return ::invoke
 }
 
 /**

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridDsl.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridDsl.kt
@@ -210,14 +210,14 @@ private fun rememberRowSlots(
 }
 
 /** measurement cache to avoid recalculating row/column sizes on each scroll. */
-private class LazyStaggeredGridSlotCache(
-    private val calculation: Density.(Constraints) -> LazyStaggeredGridSlots
+private fun LazyStaggeredGridSlotCache(
+    calculation: Density.(Constraints) -> LazyStaggeredGridSlots
 ) : (Density, Constraints) -> LazyStaggeredGridSlots {
-    private var cachedConstraints = Constraints()
-    private var cachedDensity: Float = 0f
-    private var cachedSizes: LazyStaggeredGridSlots? = null
+    var cachedConstraints = Constraints()
+    var cachedDensity: Float = 0f
+    var cachedSizes: LazyStaggeredGridSlots? = null
 
-    override fun invoke(density: Density, constraints: Constraints): LazyStaggeredGridSlots {
+    fun invoke(density: Density, constraints: Constraints): LazyStaggeredGridSlots {
         with(density) {
             if (
                 cachedSizes != null &&
@@ -234,6 +234,8 @@ private class LazyStaggeredGridSlotCache(
             }
         }
     }
+
+    return ::invoke
 }
 
 /** Dsl marker for [LazyStaggeredGridScope] below **/

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusProperties.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusProperties.kt
@@ -182,7 +182,7 @@ fun Modifier.focusProperties(
 ): Modifier = this then FocusPropertiesElement(scope)
 
 private data class FocusPropertiesElement(
-    val scope: FocusProperties.() -> Unit
+    val scope: InvokeOnFocusProperties
 ) : ModifierNodeElement<FocusPropertiesNode>() {
     override fun create() = FocusPropertiesNode(scope)
 
@@ -197,10 +197,10 @@ private data class FocusPropertiesElement(
 }
 
 private class FocusPropertiesNode(
-    var focusPropertiesScope: FocusProperties.() -> Unit,
+    var focusPropertiesScope: InvokeOnFocusProperties,
 ) : FocusPropertiesModifierNode, Modifier.Node() {
 
     override fun applyFocusProperties(focusProperties: FocusProperties) {
-        focusProperties.apply(focusPropertiesScope)
+        focusPropertiesScope.invoke(focusProperties)
     }
 }


### PR DESCRIPTION
Fixes COMPOSE-161 1.5.0-beta03 merge. Fix FocusedBounds.kt

- Apply changes from jb-main between the base commit 6022301db806601f282c53b8cbb5a981923a1589 and the pre-merge commit 4ac3bda449d4606e5190208d074654ba041d2537:

  - d3a653ce
  
- Find new `override fun invoke` and replace lambda inheritance there