### PR TITLE
1.5.0-beta03 merge. Fix CoreText.kt

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldGestureModifiers.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldGestureModifiers.kt
@@ -20,7 +20,10 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.text.selection.MouseSelectionObserver
 import androidx.compose.foundation.text.selection.mouseSelectionDetector
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.focusRequester
@@ -52,6 +55,9 @@ internal fun Modifier.textFieldFocusModifier(
 internal fun Modifier.mouseDragGestureDetector(
     observer: MouseSelectionObserver,
     enabled: Boolean
-) = if (enabled) Modifier.pointerInput(observer) {
-    mouseSelectionDetector(observer)
+) = if (enabled) Modifier.composed {
+    val currentMouseSelectionObserver by rememberUpdatedState(observer)
+    pointerInput(Unit) {
+        mouseSelectionDetector(currentMouseSelectionObserver)
+    }
 } else this

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldGestureModifiers.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldGestureModifiers.kt
@@ -56,6 +56,7 @@ internal fun Modifier.mouseDragGestureDetector(
     observer: MouseSelectionObserver,
     enabled: Boolean
 ) = if (enabled) Modifier.composed {
+    // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-79) how we can rewrite this without `composed`?
     val currentMouseSelectionObserver by rememberUpdatedState(observer)
     pointerInput(Unit) {
         mouseSelectionDetector(currentMouseSelectionObserver)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.kt
@@ -29,7 +29,10 @@ import androidx.compose.foundation.text.selection.mouseSelectionDetector
 import androidx.compose.foundation.text.textPointerHoverIcon
 import androidx.compose.foundation.text.textPointerIcon
 import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
@@ -341,8 +344,11 @@ private fun SelectionRegistrar.makeSelectionModifier(
                 return true
             }
         }
-        Modifier.pointerInput(mouseSelectionObserver) {
-            mouseSelectionDetector(mouseSelectionObserver)
+        Modifier.composed {
+            val currentMouseSelectionObserver by rememberUpdatedState(mouseSelectionObserver)
+            pointerInput(Unit) {
+                mouseSelectionDetector(currentMouseSelectionObserver)
+            }
         }.pointerHoverIcon(textPointerIcon)
     }
 }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.kt
@@ -345,6 +345,7 @@ private fun SelectionRegistrar.makeSelectionModifier(
             }
         }
         Modifier.composed {
+            // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-79) how we can rewrite this without `composed`?
             val currentMouseSelectionObserver by rememberUpdatedState(mouseSelectionObserver)
             pointerInput(Unit) {
                 mouseSelectionDetector(currentMouseSelectionObserver)


### PR DESCRIPTION
- Apply changes from jb-main between the base commit 6022301db806601f282c53b8cbb5a981923a1589 and the pre-merge commit 4ac3bda449d4606e5190208d074654ba041d2537:

  - 37564c1f (this commit was a squash, and its message is a mess)

The `pointerInput(Unit)` is restarted every recomposition, because we create `mouseSelectionObserver` every time.

It can cause selection issues. We can accidentaly not have issues (they depend on how `mouseDragGestureDetector` is used inside TextField), but it can return in the future, so better to write these modifiers in a proper way.