### PR TITLE
PlatformOptimizedCancellationException

### DIFF
--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/InternalMutatorMutex.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/InternalMutatorMutex.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.animation.core
 
-import androidx.compose.runtime.PlatformOptimizedCancellationException
+import androidx.compose.animation.core.internal.PlatformOptimizedCancellationException
 import androidx.compose.runtime.Stable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -60,7 +60,8 @@ internal enum class MutatePriority {
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class MutationInterruptedException : PlatformOptimizedCancellationException("Mutation interrupted")
+private class MutationInterruptedException :
+    PlatformOptimizedCancellationException("Mutation interrupted")
 
 /**
  * Mutual exclusion for UI state mutation over time.

--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/InternalMutatorMutex.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/InternalMutatorMutex.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.animation.core
 
+import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.Stable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -59,13 +60,7 @@ internal enum class MutatePriority {
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class MutationInterruptedException : CancellationException("Mutation interrupted") {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-}
+private class MutationInterruptedException : PlatformOptimizedCancellationException("Mutation interrupted")
 
 /**
  * Mutual exclusion for UI state mutation over time.

--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/internal/PlatformOptimizedCancellationException.common.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/internal/PlatformOptimizedCancellationException.common.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.animation.core.internal
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Represents a platform-optimized cancellation exception.
+ * This allows us to configure exceptions separately on JVM and other platforms.
+ */
+internal expect abstract class PlatformOptimizedCancellationException(
+    message: String? = null
+) : CancellationException

--- a/compose/animation/animation-core/src/jsNativeMain/kotlin/androidx/compose/animation/core/internal/PlatformOptimizedCancellationException.common.jsNative.kt
+++ b/compose/animation/animation-core/src/jsNativeMain/kotlin/androidx/compose/animation/core/internal/PlatformOptimizedCancellationException.common.jsNative.kt
@@ -1,7 +1,5 @@
-// ktlint-disable filename
-
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +14,10 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation
+package androidx.compose.animation.core.internal
 
 import kotlinx.coroutines.CancellationException
 
-internal actual typealias AtomicReference<V> = java.util.concurrent.atomic.AtomicReference<V>
-
-internal actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong
-
 internal actual abstract class PlatformOptimizedCancellationException actual constructor(
     message: String?
-) : CancellationException(message) {
-
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-
-}
+) : CancellationException(message)

--- a/compose/animation/animation-core/src/jvmMain/kotlin/androidx/compose/animation/core/internal/PlatformOptimizedCancellationException.jvm.kt
+++ b/compose/animation/animation-core/src/jvmMain/kotlin/androidx/compose/animation/core/internal/PlatformOptimizedCancellationException.jvm.kt
@@ -1,7 +1,5 @@
-// ktlint-disable filename
-
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +14,9 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation
+package androidx.compose.animation.core.internal
 
 import kotlinx.coroutines.CancellationException
-
-internal actual typealias AtomicReference<V> = java.util.concurrent.atomic.AtomicReference<V>
-
-internal actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong
 
 internal actual abstract class PlatformOptimizedCancellationException actual constructor(
     message: String?

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Expect.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Expect.kt
@@ -18,6 +18,8 @@
 
 package androidx.compose.foundation
 
+import kotlinx.coroutines.CancellationException
+
 expect class AtomicReference<V>(value: V) {
     fun get(): V
     fun set(value: V)
@@ -30,3 +32,11 @@ expect class AtomicLong(value: Long) {
     fun set(value: Long)
     fun getAndIncrement(): Long
 }
+
+/**
+ * Represents a platform-optimized cancellation exception.
+ * This allows us to configure exceptions separately on JVM and other platforms.
+ */
+internal expect abstract class PlatformOptimizedCancellationException(
+    message: String? = null
+) : CancellationException

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/MutatorMutex.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/MutatorMutex.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.foundation
 
-import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.Stable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -59,7 +58,8 @@ enum class MutatePriority {
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class MutationInterruptedException : PlatformOptimizedCancellationException("Mutation interrupted")
+private class MutationInterruptedException :
+    PlatformOptimizedCancellationException("Mutation interrupted")
 
 /**
  * Mutual exclusion for UI state mutation over time.

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/MutatorMutex.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/MutatorMutex.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation
 
+import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.Stable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -58,13 +59,7 @@ enum class MutatePriority {
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class MutationInterruptedException : CancellationException("Mutation interrupted") {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-}
+private class MutationInterruptedException : PlatformOptimizedCancellationException("Mutation interrupted")
 
 /**
  * Mutual exclusion for UI state mutation over time.

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/ActualJsNative.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/ActualJsNative.jsNative.kt
@@ -1,7 +1,5 @@
-// ktlint-disable filename
-
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +16,8 @@
 
 package androidx.compose.foundation
 
-import kotlinx.coroutines.CancellationException
-
-internal actual typealias AtomicReference<V> = java.util.concurrent.atomic.AtomicReference<V>
-
-internal actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.cancellation.CancellationException
 
 internal actual abstract class PlatformOptimizedCancellationException actual constructor(
     message: String?
-) : CancellationException(message) {
-
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-
-}
+) : CancellationException(message)

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Effects.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Effects.kt
@@ -18,7 +18,6 @@ package androidx.compose.runtime
 
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -386,15 +385,9 @@ fun LaunchedEffect(
     remember(key1, key2, key3) { LaunchedEffectImpl(applyContext, block) }
 }
 
-private class LeftCompositionCancellationException : CancellationException(
+private class LeftCompositionCancellationException : PlatformOptimizedCancellationException(
     "The coroutine scope left the composition"
-) {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-}
+)
 
 /**
  * When [LaunchedEffect] enters the composition it will launch [block] into the composition's

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Expect.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Expect.kt
@@ -106,11 +106,12 @@ internal expect class SnapshotContextElementImpl(
     snapshot: Snapshot
 ) : SnapshotContextElement
 
+internal expect fun logError(message: String, e: Throwable)
+
 /**
  * Represents a platform-optimized cancellation exception.
  * This allows us to configure exceptions separately on JVM and other platforms.
  */
-expect abstract class PlatformOptimizedCancellationException(message: String? = null) :
-    CancellationException
-
-internal expect fun logError(message: String, e: Throwable)
+internal expect abstract class PlatformOptimizedCancellationException(
+    message: String? = null
+) : CancellationException

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Expect.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Expect.kt
@@ -18,6 +18,7 @@ package androidx.compose.runtime
 
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.snapshots.SnapshotContextElement
+import kotlinx.coroutines.CancellationException
 
 internal expect fun getCurrentThreadId(): Long
 
@@ -104,5 +105,12 @@ internal expect fun <T> invokeComposableForResult(
 internal expect class SnapshotContextElementImpl(
     snapshot: Snapshot
 ) : SnapshotContextElement
+
+/**
+ * Represents a platform-optimized cancellation exception.
+ * This allows us to configure exceptions separately on JVM and other platforms.
+ */
+expect abstract class PlatformOptimizedCancellationException(message: String? = null) :
+    CancellationException
 
 internal expect fun logError(message: String, e: Throwable)

--- a/compose/runtime/runtime/src/jsNativeMain/kotlin/androidx/compose/runtime/ActualJsNative.jsNative.kt
+++ b/compose/runtime/runtime/src/jsNativeMain/kotlin/androidx/compose/runtime/ActualJsNative.jsNative.kt
@@ -17,6 +17,7 @@
 package androidx.compose.runtime
 
 import androidx.compose.runtime.snapshots.SnapshotMutableState
+import kotlin.coroutines.cancellation.CancellationException
 
 internal actual fun <T> createSnapshotMutableState(
     value: T,
@@ -38,3 +39,6 @@ internal actual fun createSnapshotMutableFloatState(
 internal actual fun createSnapshotMutableDoubleState(
     value: Double
 ): MutableDoubleState = SnapshotMutableDoubleStateImpl(value)
+
+actual abstract class PlatformOptimizedCancellationException actual constructor(message: String?) :
+    CancellationException(message)

--- a/compose/runtime/runtime/src/jsNativeMain/kotlin/androidx/compose/runtime/ActualJsNative.jsNative.kt
+++ b/compose/runtime/runtime/src/jsNativeMain/kotlin/androidx/compose/runtime/ActualJsNative.jsNative.kt
@@ -40,5 +40,6 @@ internal actual fun createSnapshotMutableDoubleState(
     value: Double
 ): MutableDoubleState = SnapshotMutableDoubleStateImpl(value)
 
-actual abstract class PlatformOptimizedCancellationException actual constructor(message: String?) :
-    CancellationException(message)
+internal actual abstract class PlatformOptimizedCancellationException actual constructor(
+    message: String?
+) : CancellationException(message)

--- a/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
+++ b/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
@@ -79,8 +79,9 @@ internal actual class SnapshotContextElementImpl actual constructor(
     }
 }
 
-actual abstract class PlatformOptimizedCancellationException actual constructor(message: String?) :
-    CancellationException(message) {
+internal actual abstract class PlatformOptimizedCancellationException actual constructor(
+    message: String?
+) : CancellationException(message) {
 
     override fun fillInStackTrace(): Throwable {
         // Avoid null.clone() on Android <= 6.0 when accessing stackTrace

--- a/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
+++ b/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.internal.emptyThreadMap
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.snapshots.SnapshotContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ThreadContextElement
 
 internal actual typealias AtomicReference<V> = java.util.concurrent.atomic.AtomicReference<V>
@@ -76,4 +77,15 @@ internal actual class SnapshotContextElementImpl actual constructor(
     override fun restoreThreadContext(context: CoroutineContext, oldState: Snapshot?) {
         snapshot.unsafeLeave(oldState)
     }
+}
+
+actual abstract class PlatformOptimizedCancellationException actual constructor(message: String?) :
+    CancellationException(message) {
+
+    override fun fillInStackTrace(): Throwable {
+        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
+        stackTrace = emptyArray()
+        return this
+    }
+
 }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Expect.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Expect.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui
 
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
+import kotlinx.coroutines.CancellationException
 
 internal expect fun areObjectsOfSameType(a: Any, b: Any): Boolean
 
@@ -37,3 +38,11 @@ internal expect fun areObjectsOfSameType(a: Any, b: Any): Boolean
 internal expect fun InspectorInfo.tryPopulateReflectively(
     element: ModifierNodeElement<*>
 )
+
+/**
+ * Represents a platform-optimized cancellation exception.
+ * This allows us to configure exceptions separately on JVM and other platforms.
+ */
+internal expect abstract class PlatformOptimizedCancellationException(
+    message: String? = null
+) : CancellationException

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Modifier.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Modifier.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui
 
-import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.internal.JvmDefaultWithCompatibility
 import androidx.compose.ui.node.DelegatableNode

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Modifier.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Modifier.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui
 
+import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.internal.JvmDefaultWithCompatibility
 import androidx.compose.ui.node.DelegatableNode
@@ -25,7 +26,6 @@ import androidx.compose.ui.node.NodeKind
 import androidx.compose.ui.node.ObserverNodeOwnerScope
 import androidx.compose.ui.node.invalidateDraw
 import androidx.compose.ui.node.requireOwner
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -35,15 +35,9 @@ import kotlinx.coroutines.cancel
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class ModifierNodeDetachedCancellationException : CancellationException(
+private class ModifierNodeDetachedCancellationException : PlatformOptimizedCancellationException(
     "The Modifier.Node was detached"
-) {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-}
+)
 
 /**
  * An ordered, immutable collection of [modifier elements][Modifier.Element] that decorate or add

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerEventTimeoutCancellationException.common.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerEventTimeoutCancellationException.common.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.pointer
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * An exception thrown from [AwaitPointerEventScope.withTimeout] when the execution time
+ * of the coroutine is too long.
+ */
+expect class PointerEventTimeoutCancellationException(time: Long) : CancellationException

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -751,4 +751,4 @@ private class PointerInputResetException : PlatformOptimizedCancellationExceptio
  * we shouldn't need to worry about other code calling addSuppressed on this exception
  * so a singleton instance is used
  */
-private object CancelTimeoutCancellationException : PlatformOptimizedCancellationException("")
+private object CancelTimeoutCancellationException : PlatformOptimizedCancellationException()

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.collection.mutableVectorOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.fastMapNotNull
@@ -42,7 +43,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.math.max
 import kotlinx.coroutines.CancellableContinuation
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -744,12 +744,8 @@ internal class SuspendingPointerInputModifierNodeImpl(
  */
 class PointerEventTimeoutCancellationException(
     time: Long
-) : CancellationException("Timed out waiting for $time ms") {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
+) : PlatformOptimizedCancellationException("Timed out waiting for $time ms") {
+
 }
 
 /**
@@ -757,23 +753,11 @@ class PointerEventTimeoutCancellationException(
  * javaClass.simpleName lookups to build the exception message and stack trace collection.
  * Remove if these are changed in kotlinx.coroutines.
  */
-private class PointerInputResetException : CancellationException("Pointer input was reset") {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-}
+private class PointerInputResetException : PlatformOptimizedCancellationException("Pointer input was reset")
 
 /**
  * Also used in place of standard Job cancellation pathway; since we control this code path
  * we shouldn't need to worry about other code calling addSuppressed on this exception
  * so a singleton instance is used
  */
-private object CancelTimeoutCancellationException : CancellationException() {
-    override fun fillInStackTrace(): Throwable {
-        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
-        stackTrace = emptyArray()
-        return this
-    }
-}
+private object CancelTimeoutCancellationException : PlatformOptimizedCancellationException("")

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -16,9 +16,9 @@
 
 package androidx.compose.ui.input.pointer
 
-import androidx.compose.runtime.PlatformOptimizedCancellationException
 import androidx.compose.runtime.collection.mutableVectorOf
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.PlatformOptimizedCancellationException
 import androidx.compose.ui.fastMapNotNull
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.internal.JvmDefaultWithCompatibility
@@ -738,15 +738,6 @@ internal class SuspendingPointerInputModifierNodeImpl(
     }
 }
 
-/**
- * An exception thrown from [AwaitPointerEventScope.withTimeout] when the execution time
- * of the coroutine is too long.
- */
-class PointerEventTimeoutCancellationException(
-    time: Long
-) : PlatformOptimizedCancellationException("Timed out waiting for $time ms") {
-
-}
 
 /**
  * Used in place of the standard Job cancellation pathway to avoid reflective

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/Actuals.jsNativeMain.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/Actuals.jsNativeMain.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
+import kotlin.coroutines.cancellation.CancellationException
 import org.jetbrains.skiko.SkikoInputModifiers
 
 internal actual fun NativeKeyEvent.toPointerKeyboardModifiers(): PointerKeyboardModifiers {
@@ -39,3 +40,7 @@ internal actual fun InspectorInfo.tryPopulateReflectively(
     element: ModifierNodeElement<*>
 ) {
 }
+
+internal actual abstract class PlatformOptimizedCancellationException actual constructor(
+    message: String?
+) : CancellationException(message)

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/input/pointer/PointerEventTimeoutCancellationException.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/input/pointer/PointerEventTimeoutCancellationException.jsNative.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.pointer
+
+import kotlinx.coroutines.CancellationException
+
+actual class PointerEventTimeoutCancellationException actual constructor(
+    time: Long
+) : CancellationException("Timed out waiting for $time ms")

--- a/compose/ui/ui/src/jvmMain/kotlin/androidx/compose/ui/Actual.kt
+++ b/compose/ui/ui/src/jvmMain/kotlin/androidx/compose/ui/Actual.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.util.fastForEach
+import kotlinx.coroutines.CancellationException
 
 internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a::class.java === b::class.java
@@ -46,4 +47,16 @@ internal actual fun InspectorInfo.tryPopulateReflectively(
                 }
             }
         }
+}
+
+internal actual abstract class PlatformOptimizedCancellationException actual constructor(
+    message: String?
+) : CancellationException(message) {
+
+    override fun fillInStackTrace(): Throwable {
+        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
+        stackTrace = emptyArray()
+        return this
+    }
+
 }

--- a/compose/ui/ui/src/jvmMain/kotlin/androidx/compose/ui/input/pointer/PointerEventTimeoutCancellationException.jvm.kt
+++ b/compose/ui/ui/src/jvmMain/kotlin/androidx/compose/ui/input/pointer/PointerEventTimeoutCancellationException.jvm.kt
@@ -1,7 +1,5 @@
-// ktlint-disable filename
-
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +14,13 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation
+package androidx.compose.ui.input.pointer
 
 import kotlinx.coroutines.CancellationException
 
-internal actual typealias AtomicReference<V> = java.util.concurrent.atomic.AtomicReference<V>
-
-internal actual typealias AtomicLong = java.util.concurrent.atomic.AtomicLong
-
-internal actual abstract class PlatformOptimizedCancellationException actual constructor(
-    message: String?
-) : CancellationException(message) {
+actual class PointerEventTimeoutCancellationException actual constructor(
+    time: Long
+) : CancellationException("Timed out waiting for $time ms") {
 
     override fun fillInStackTrace(): Throwable {
         // Avoid null.clone() on Android <= 6.0 when accessing stackTrace


### PR DESCRIPTION
This code is not compiles on commonMain:
```
override fun fillInStackTrace(): Throwable {
        // Avoid null.clone() on Android <= 6.0 when accessing stackTrace
        stackTrace = emptyArray()
        return this
    }
```

fix compilation by adding abstract Added PlatformOptimizedCancellationException.
It has expect / actual for `jvmMain` and `jsNativeMain` sourceSets

But, that do you think about access modifiers?
For now, I made it `public` just for a discussion about this approach with abstract class.
I see 2 ways:
 - made it public with `@InternalComposeApi` annotation
 - made it internal and copy to all modules where it is used.