### PR TITLE
CfW: Update showCharacterPalette function in KeyEventHelpers

### DIFF
--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/KeyEventHelpers.js.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/KeyEventHelpers.js.kt
@@ -24,4 +24,5 @@ internal actual fun showCharacterPalette() {
     // There is no browser API to make such a system call neither directly nor indirectly:
     // NSApplication* app = [NSApplication sharedApplication];
     // [app orderFrontCharacterPalette:nil];
+    // Also, see https://github.com/whatwg/html/issues/8358 for any updates or progress
 }

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/KeyEventHelpers.js.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/KeyEventHelpers.js.kt
@@ -20,4 +20,8 @@ import androidx.compose.ui.input.key.KeyEvent
 
 internal actual fun KeyEvent.cancelsTextSelection(): Boolean = false
 
-internal actual fun showCharacterPalette():Unit = TODO("implement native showCharacterPalette")
+internal actual fun showCharacterPalette() {
+    // There is no browser API to make such a system call neither directly nor indirectly:
+    // NSApplication* app = [NSApplication sharedApplication];
+    // [app orderFrontCharacterPalette:nil];
+}


### PR DESCRIPTION
Removed the TODO comment and added a comment on the showCharacterPalette function in KeyEventHelpers.js.kt stating its non-implementation details. It is updated now to explain that there is no browser API for such a system call in the JavaScript/Wasm ecosystem, hence remaining unimplemented.
