### PR TITLE
Add JsName annotation for JavaScript interop

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusTargetModifierNode.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusTargetModifierNode.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.focus
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.node.DelegatableNode
+import kotlin.js.JsName
 
 /**
  * This modifier node can be used to create a modifier that makes a component focusable.
@@ -36,4 +37,6 @@ sealed interface FocusTargetModifierNode : DelegatableNode {
  * This modifier node can be used to create a modifier that makes a component focusable.
  * Use a different instance of [FocusTargetModifierNode] for each focusable component.
  */
+
+@JsName("funFocusTargetModifierNode")
 fun FocusTargetModifierNode(): FocusTargetModifierNode = FocusTargetNode()

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -40,6 +40,7 @@ import kotlin.coroutines.RestrictsSuspension
 import kotlin.coroutines.createCoroutine
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.js.JsName
 import kotlin.math.max
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
@@ -158,6 +159,7 @@ interface PointerInputScope : Density {
      */
     @Suppress("GetterSetterNames")
     @get:Suppress("GetterSetterNames")
+    @JsName("varinterceptOutOfBoundsChildEvents")
     var interceptOutOfBoundsChildEvents: Boolean
         get() = false
         set(_) {}


### PR DESCRIPTION
It fixes such an error:
```JavaScript name (...) generated for this declaration clashes with another declaration```

__

k/js target won't compile yet. But if this PR's branch is combined with https://github.com/JetBrains/compose-multiplatform-core/pull/669 and https://github.com/JetBrains/compose-multiplatform-core/pull/668, then `./gradlew :compose:mpp:demo:jsBrowserRun` gets compiled and runs 