### PR TITLE
More multi-owner input processing fixes

### DIFF
--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -161,7 +161,7 @@ class ComposeUiSkikoTestTest {
             press()
             release()
         }
-        assertThat(events).hasSize(2)
+        assertThat(events).hasSize(3)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -173,6 +173,11 @@ class ComposeUiSkikoTestTest {
             assertThat(type).isEqualTo(Release)
             assertThat(button).isEqualTo(PointerButton.Primary)
             assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Enter)
             assertThat(changes[0].position).isEqualTo(Offset.Zero)
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
@@ -185,7 +190,7 @@ class ComposeUiSkikoTestTest {
         onNodeWithTag("test").performMouseInput {
             click(Offset(10f, 20f))
         }
-        assertThat(events).hasSize(2)
+        assertThat(events).hasSize(3)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -197,6 +202,11 @@ class ComposeUiSkikoTestTest {
             assertThat(type).isEqualTo(Release)
             assertThat(button).isEqualTo(PointerButton.Primary)
             assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Enter)
             assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
@@ -214,7 +224,7 @@ class ComposeUiSkikoTestTest {
             release(MouseButton.Tertiary)
             press(MouseButton(3))
         }
-        assertThat(events).hasSize(5)
+        assertThat(events).hasSize(6)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -244,6 +254,11 @@ class ComposeUiSkikoTestTest {
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
         events[4].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[5].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Back)
             assertThat(buttons).isEqualTo(PointerButtons(isBackPressed = true))

--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.input.pointer.PointerEventType.Companion.Move
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Scroll
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.PointerType.Companion.Mouse
 import androidx.compose.ui.input.pointer.pointerInput
@@ -383,23 +384,23 @@ class ComposeUiSkikoTestTest {
         assertThat(events).hasSize(4)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
-            assertThat(changes[0].position).isEqualTo(Offset(0f, 0f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(0).position).isEqualTo(Offset(0f, 0f))
+            assertThat(changes.find(0).type).isEqualTo(PointerType.Touch)
         }
         events[1].apply {
             assertThat(type).isEqualTo(Press)
-            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(1).position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes.find(1).type).isEqualTo(PointerType.Touch)
         }
         events[2].apply {
             assertThat(type).isEqualTo(Release)
-            assertThat(changes[0].position).isEqualTo(Offset(0f, 0f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(0).position).isEqualTo(Offset(0f, 0f))
+            assertThat(changes.find(0).type).isEqualTo(PointerType.Touch)
         }
         events[3].apply {
             assertThat(type).isEqualTo(Release)
-            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(1).position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes.find(1).type).isEqualTo(PointerType.Touch)
         }
     }
 
@@ -439,3 +440,6 @@ private fun <T : Collection<*>> AssertThat<T>.hasSize(size: Int) {
 private fun <T> assertThat(t: T): AssertThat<T> {
     return AssertThat(t)
 }
+
+private fun List<PointerInputChange>.find(id: Int) =
+    this.first { it.id.value.toInt() == id }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/InputDispatcher.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/InputDispatcher.skikoMain.kt
@@ -40,7 +40,7 @@ private class TestInputEvent(
     val action: () -> Unit
 )
 
-@OptIn(InternalComposeUiApi::class)
+@OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
 internal class SkikoInputDispatcher(
     private val testContext: TestContext,
     private val root: SkiaRootForTest
@@ -57,28 +57,23 @@ internal class SkikoInputDispatcher(
     private var modifiers = 0
 
     override fun PartialGesture.enqueueDown(pointerId: Int) {
-        val position = lastPositions[pointerId]!!
         val timeMillis = currentTime
+        val pointers = lastPointers.values.toList()
         enqueue(timeMillis) {
             scene.sendPointerEvent(
                 PointerEventType.Press,
-                position = position,
-                type = PointerType.Touch,
+                pointers = pointers,
                 timeMillis = timeMillis
             )
         }
     }
     override fun PartialGesture.enqueueMove() {
-        val position = Offset(
-            lastPositions.values.map { it.x }.average().toFloat(),
-            lastPositions.values.map { it.y }.average().toFloat(),
-        )
         val timeMillis = currentTime
+        val pointers = lastPointers.values.toList()
         enqueue(timeMillis) {
             scene.sendPointerEvent(
                 PointerEventType.Move,
-                position = position,
-                type = PointerType.Touch,
+                pointers = pointers,
                 timeMillis = timeMillis
             )
         }
@@ -93,13 +88,12 @@ internal class SkikoInputDispatcher(
     }
 
     override fun PartialGesture.enqueueUp(pointerId: Int) {
-        val position = lastPositions[pointerId]!!
         val timeMillis = currentTime
+        val pointers = lastPointers.values.toList()
         enqueue(timeMillis) {
             scene.sendPointerEvent(
                 PointerEventType.Release,
-                position = position,
-                type = PointerType.Touch,
+                pointers = pointers,
                 timeMillis = timeMillis
             )
         }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/InputDispatcher.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/InputDispatcher.skikoMain.kt
@@ -15,6 +15,7 @@
  */
 package androidx.compose.ui.test
 
+import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
@@ -23,6 +24,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.platform.SkiaRootForTest
@@ -58,7 +60,14 @@ internal class SkikoInputDispatcher(
 
     override fun PartialGesture.enqueueDown(pointerId: Int) {
         val timeMillis = currentTime
-        val pointers = lastPointers.values.toList()
+        val pointers = lastPositions.map {
+            ComposeScene.Pointer(
+                id = PointerId(it.key.toLong()),
+                position = it.value,
+                pressed = true,
+                type = PointerType.Touch
+            )
+        }
         enqueue(timeMillis) {
             scene.sendPointerEvent(
                 PointerEventType.Press,
@@ -69,7 +78,14 @@ internal class SkikoInputDispatcher(
     }
     override fun PartialGesture.enqueueMove() {
         val timeMillis = currentTime
-        val pointers = lastPointers.values.toList()
+        val pointers = lastPositions.map {
+            ComposeScene.Pointer(
+                id = PointerId(it.key.toLong()),
+                position = it.value,
+                pressed = true,
+                type = PointerType.Touch
+            )
+        }
         enqueue(timeMillis) {
             scene.sendPointerEvent(
                 PointerEventType.Move,
@@ -89,7 +105,14 @@ internal class SkikoInputDispatcher(
 
     override fun PartialGesture.enqueueUp(pointerId: Int) {
         val timeMillis = currentTime
-        val pointers = lastPointers.values.toList()
+        val pointers = lastPositions.map {
+            ComposeScene.Pointer(
+                id = PointerId(it.key.toLong()),
+                position = it.value,
+                pressed = pointerId != it.key,
+                type = PointerType.Touch
+            )
+        }
         enqueue(timeMillis) {
             scene.sendPointerEvent(
                 PointerEventType.Release,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -228,17 +228,19 @@ class ComposeSceneInputTest {
 
         scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 20f))
         background.events.assertReceivedNoEvents()
-        cutPopup.events.assertReceivedLast(
+        cutPopup.events.assertReceived(
             PointerEventType.Release, Offset(20f, 20f) - cutPopup.origin)
-        overlappedPopup.events.assertReceivedNoEvents()
-        independentPopup.events.assertReceivedNoEvents()
-
-        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
-        background.events.assertReceivedNoEvents()
         cutPopup.events.assertReceivedLast(
             PointerEventType.Exit, Offset(20f, 20f) - cutPopup.origin)
         overlappedPopup.events.assertReceivedLast(
             PointerEventType.Enter, Offset(20f, 20f) - overlappedPopup.origin)
+        independentPopup.events.assertReceivedNoEvents()
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
+        background.events.assertReceivedNoEvents()
+        cutPopup.events.assertReceivedNoEvents()
+        overlappedPopup.events.assertReceivedLast(
+            PointerEventType.Move, Offset(20f, 20f) - overlappedPopup.origin)
         independentPopup.events.assertReceivedNoEvents()
 
         scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f))
@@ -257,7 +259,8 @@ class ComposeSceneInputTest {
 
         scene.sendPointerEvent(PointerEventType.Release, Offset(-10f, -10f))
         background.events.assertReceivedNoEvents()
-        cutPopup.events.assertReceivedNoEvents()
+        cutPopup.events.assertReceivedLast(
+            PointerEventType.Enter, Offset(-10f, -10f) - cutPopup.origin)
         overlappedPopup.events.assertReceivedLast(
             PointerEventType.Release, Offset(-10f, -10f) - overlappedPopup.origin
         )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -652,7 +652,7 @@ class WindowInputEventTest {
     }
 
     @Test
-    fun `send release into two boxes without intermediate move`() = runApplicationTest {
+    fun `send release into first box without intermediate move`() = runApplicationTest {
         var box1ReleaseCount = 0
         var box2ReleaseCount = 0
 
@@ -681,11 +681,11 @@ class WindowInputEventTest {
         }
         awaitIdle()
 
-        window.sendMouseEvent(id = MOUSE_PRESSED, x = 1, y = 1)
+        window.sendMouseEvent(id = MOUSE_PRESSED, x = 1, y = 1, modifiers = BUTTON1_DOWN_MASK)
         window.sendMouseEvent(id = MOUSE_RELEASED, x = 21, y = 1)
 
-        assertThat(box1ReleaseCount).isEqualTo(0)
-        assertThat(box2ReleaseCount).isEqualTo(1)
+        assertThat(box1ReleaseCount).isEqualTo(1)
+        assertThat(box2ReleaseCount).isEqualTo(0)
 
         window.dispose()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -166,10 +166,10 @@ class ComposeScene internal constructor(
         }
     }
 
-    private inline fun <T> reversedOwners(action: (List<SkiaBasedOwner>) -> T): T {
+    private inline fun forEachOwnerReversed(action: (SkiaBasedOwner) -> Unit) {
         listCopy.addAll(owners)
         try {
-            return action(listCopy.asReversed())
+            listCopy.asReversed().forEach(action)
         } finally {
             listCopy.clear()
         }
@@ -563,11 +563,12 @@ class ComposeScene internal constructor(
     }
 
     private fun processPress(event: PointerInputEvent) {
-        val owner = reversedOwners {
-            for (owner in it) {
+        forEachOwnerReversed { owner ->
             if (owner.isHovered(event)) {
                 // Stop once the position of in bounds of the owner
-                    return@reversedOwners owner
+                owner.processPointerInput(event)
+                pressOwner = owner
+                return@processPress
             }
             owner.onClickOutside?.invoke()
             if (owner == focusedOwner) {
@@ -575,10 +576,6 @@ class ComposeScene internal constructor(
                 return@processPress
             }
         }
-            return@reversedOwners null
-        }
-        owner?.processPointerInput(event)
-        pressOwner = owner
     }
 
     private fun processRelease(event: PointerInputEvent) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -286,8 +286,8 @@ class ComposeScene internal constructor(
         if (owner == focusedOwner) {
             focusedOwner = owners.lastOrNull { it.focusable }
         }
-        if (owner == lastMoveOwner) {
-            lastMoveOwner = null
+        if (owner == lastHoverOwner) {
+            lastHoverOwner = null
         }
         if (owner == pressOwner) {
             pressOwner = null
@@ -417,7 +417,7 @@ class ComposeScene internal constructor(
 
     private var focusedOwner: SkiaBasedOwner? = null
     private var pressOwner: SkiaBasedOwner? = null
-    private var lastMoveOwner: SkiaBasedOwner? = null
+    private var lastHoverOwner: SkiaBasedOwner? = null
     private fun hoveredOwner(event: PointerInputEvent): SkiaBasedOwner? =
         owners.lastOrNull { it.isHovered(event) }
 
@@ -565,16 +565,16 @@ class ComposeScene internal constructor(
     private fun processPress(event: PointerInputEvent) {
         val owner = reversedOwners {
             for (owner in it) {
-                if (owner.isHovered(event)) {
-                    // Stop once the position of in bounds of the owner
+            if (owner.isHovered(event)) {
+                // Stop once the position of in bounds of the owner
                     return@reversedOwners owner
-                }
-                owner.onClickOutside?.invoke()
-                if (owner == focusedOwner) {
-                    // Stop if it's in focus, do not pass the event to hovered owner
-                    return@processPress
-                }
             }
+            owner.onClickOutside?.invoke()
+            if (owner == focusedOwner) {
+                // Stop if it's in focus, do not pass the event to hovered owner
+                return@processPress
+            }
+        }
             return@reversedOwners null
         }
         owner?.processPointerInput(event)
@@ -582,11 +582,15 @@ class ComposeScene internal constructor(
     }
 
     private fun processRelease(event: PointerInputEvent) {
-        val owner = pressOwner ?: hoveredOwner(event)
-        if (focusedOwner.isAbove(owner)) {
-            return
+        pressOwner
+            .takeIf { !focusedOwner.isAbove(it) }
+            ?.processPointerInput(event)
+        if (!event.buttons.areAnyPressed) {
+            // Changing hover during Move event can be blocked by sticking to pressOwner
+            hoveredOwner(event)
+                .takeIf { !focusedOwner.isAbove(it) }
+                ?.let { processHover(event, it) }
         }
-        owner?.processPointerInput(event)
     }
 
     private fun processMove(event: PointerInputEvent) {
@@ -598,28 +602,37 @@ class ComposeScene internal constructor(
         if (focusedOwner.isAbove(owner)) {
             owner = null
         }
+        if (processHover(event, owner)) {
+            return
+        }
+        owner?.processPointerInput(
+            event.copy(eventType = PointerEventType.Move)
+        )
+    }
 
+    private fun processHover(event: PointerInputEvent, owner: SkiaBasedOwner?): Boolean {
+        if (!event.pointers.fastAny { it.type == PointerType.Mouse }) {
+            // Track hover only for mouse
+            return false
+        }
         // Cases:
         // - move from outside to the window (owner != null, lastMoveOwner == null): Enter
         // - move from the window to outside (owner == null, lastMoveOwner != null): Exit
         // - move from one point of the window to another (owner == lastMoveOwner): Move
         // - move from one popup to another (owner != lastMoveOwner): [Popup 1] Exit, [Popup 2] Enter
-
-        if (owner != lastMoveOwner && event.pointers.fastAny { it.type == PointerType.Mouse }) {
-            lastMoveOwner?.processPointerInput(
-                event.copy(eventType = PointerEventType.Exit),
-                isInBounds = false
-            )
-            owner?.processPointerInput(
-                event.copy(eventType = PointerEventType.Enter)
-            )
-        } else {
-            owner?.processPointerInput(
-                event.copy(eventType = PointerEventType.Move)
-            )
+        if (owner == lastHoverOwner) {
+            // Owner wasn't changed
+            return false
         }
-
-        lastMoveOwner = owner
+        lastHoverOwner?.processPointerInput(
+            event.copy(eventType = PointerEventType.Exit),
+            isInBounds = false
+        )
+        owner?.processPointerInput(
+            event.copy(eventType = PointerEventType.Enter)
+        )
+        lastHoverOwner = owner
+        return true
     }
 
     private fun processScroll(event: PointerInputEvent) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -597,6 +597,7 @@ class ComposeScene internal constructor(
             else -> hoveredOwner(event)
         }
         if (focusedOwner.isAbove(owner)) {
+            // If pressOwner is under focusedOwner, hover state must be updated
             owner = null
         }
         if (processHover(event, owner)) {
@@ -607,6 +608,10 @@ class ComposeScene internal constructor(
         )
     }
 
+    /**
+     * Updates hover state and generates [PointerEventType.Enter] and [PointerEventType.Exit]
+     * events. Returns true if [event] is consumed.
+     */
     private fun processHover(event: PointerInputEvent, owner: SkiaBasedOwner?): Boolean {
         if (!event.pointers.fastAny { it.type == PointerType.Mouse }) {
             // Track hover only for mouse
@@ -629,6 +634,8 @@ class ComposeScene internal constructor(
             event.copy(eventType = PointerEventType.Enter)
         )
         lastHoverOwner = owner
+
+        // Changing hovering state replaces Move event, so treat it as consumed
         return true
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -556,8 +556,7 @@ class ComposeScene internal constructor(
             PointerEventType.Scroll -> processScroll(event)
         }
 
-        val isAnyPointerDown = event.pointers.fastAny { it.down }
-        if (!isAnyPointerDown) {
+        if (!event.isAnyPointerDown) {
             pressOwner = null
         }
     }
@@ -582,7 +581,7 @@ class ComposeScene internal constructor(
         pressOwner
             .takeIf { !focusedOwner.isAbove(it) }
             ?.processPointerInput(event)
-        if (!event.buttons.areAnyPressed) {
+        if (!event.isAnyPointerDown) {
             // Changing hover during Move event can be blocked by sticking to pressOwner
             hoveredOwner(event)
                 .takeIf { !focusedOwner.isAbove(it) }
@@ -592,7 +591,7 @@ class ComposeScene internal constructor(
 
     private fun processMove(event: PointerInputEvent) {
         var owner = when {
-            event.buttons.areAnyPressed -> pressOwner
+            event.isAnyPointerDown -> pressOwner
             event.eventType == PointerEventType.Exit -> null
             else -> hoveredOwner(event)
         }
@@ -808,3 +807,5 @@ private fun pointerInputEvent(
 internal expect fun createSkiaLayer(): SkiaLayer
 
 internal expect fun NativeKeyEvent.toPointerKeyboardModifiers(): PointerKeyboardModifiers
+
+private val PointerInputEvent.isAnyPointerDown get() = pointers.fastAny { it.down }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -590,13 +590,13 @@ class ComposeScene internal constructor(
     }
 
     private fun processMove(event: PointerInputEvent) {
-        val owner = when {
+        var owner = when {
             event.buttons.areAnyPressed -> pressOwner
             event.eventType == PointerEventType.Exit -> null
             else -> hoveredOwner(event)
         }
         if (focusedOwner.isAbove(owner)) {
-            return
+            owner = null
         }
 
         // Cases:

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.skiko.kt
@@ -16,9 +16,6 @@
 
 package androidx.compose.ui.input.pointer
 
-import androidx.compose.ui.ExperimentalComposeUiApi
-
-@OptIn(ExperimentalComposeUiApi::class)
 internal actual data class PointerInputEvent(
     val eventType: PointerEventType,
     actual val uptime: Long,

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.input.pointer.PointerInputEventData
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -39,7 +40,8 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import kotlin.test.assertContentEquals
 
-fun Events.assertReceivedNoEvents() = assertThat(list).isEmpty()
+fun Events.assertReceivedNoEvents() =
+    require(list.isEmpty()) { "Received events:\n${list.joinToString("\n")}" }
 
 fun Events.assertReceived(type: PointerEventType, offset: Offset) =
     received().assertHas(type, offset)
@@ -107,6 +109,7 @@ class Events {
 
 class FillBox {
     val events = Events()
+    val tag = "background"
 
     @Composable
     fun Content() {
@@ -114,6 +117,7 @@ class FillBox {
             Modifier
                 .fillMaxSize()
                 .collectEvents(events)
+                .testTag(tag)
         )
     }
 }
@@ -126,6 +130,7 @@ class PopupState(
 ) {
     val origin get() = bounds.topLeft.toOffset()
     val events = Events()
+    val tag = "popup"
 
     @Composable
     fun Content() {
@@ -149,6 +154,7 @@ class PopupState(
                     Modifier
                         .requiredSize(bounds.width.toDp(), bounds.height.toDp())
                         .collectEvents(events)
+                        .testTag(tag)
                 )
             }
         }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -16,14 +16,24 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.*
 import androidx.compose.ui.*
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
@@ -352,7 +362,7 @@ class PopupTest {
     }
 
     @Test
-    fun caNotScrollOutsideOfFocusablePopup() = runSkikoComposeUiTest(
+    fun cannotScrollOutsideOfFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
     ) {
         val background = FillBox()
@@ -365,5 +375,47 @@ class PopupTest {
 
         scene.sendPointerEvent(PointerEventType.Scroll, Offset(10f, 10f))
         background.events.assertReceivedNoEvents()
+    }
+
+    @Test
+    fun closeFocusablePopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val openPopup = mutableStateOf(false)
+        val popup = PopupState(
+            IntRect(20, 20, 60, 60),
+            focusable = true,
+            onDismissRequest = {
+                openPopup.value = false
+            }
+        )
+
+        setContent {
+            background.Content()
+            if (openPopup.value) {
+                popup.Content()
+            }
+        }
+
+        // Moving without popup generates Enter because it's in bounds
+        scene.sendPointerEvent(PointerEventType.Move, Offset(15f, 15f))
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(15f, 15f))
+
+        // Open popup
+        openPopup.value = true
+        onNodeWithTag(popup.tag).assertIsDisplayed()
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(15f, 15f))
+
+        // Click (Press-Move-Release cycle) outside closes popup and sends only Enter event to background
+        val buttons = PointerButtons(
+            isPrimaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
+        onNodeWithTag(popup.tag).assertDoesNotExist() // Wait that it's really closed before next events
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(11f, 11f), buttons = buttons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(11f, 11f), button = PointerButton.Primary)
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
     }
 }


### PR DESCRIPTION
## Proposed Changes

  - Simplify `onClickOutside` handling (`forEachOwnerReversed` with single type return)
  - Fix handling hover state (enter/exit events) during `Move`
  - Update hover state during `Release`
  - Fix touch test input dispatcher

## Testing

Test: run `PopupTest` or demo app

## Issues Fixed

Fixes:
- https://github.com/JetBrains/compose-multiplatform/issues/3349
- [COMPOSE-175](https://youtrack.jetbrains.com/issue/COMPOSE-175)
