### PR TITLE
Fix PointerIconTest.whenNotHoveredShouldNeverCommit

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -36,6 +36,8 @@ import java.awt.image.MultiResolutionImage
 import java.text.AttributedString
 import javax.swing.Icon
 import javax.swing.ImageIcon
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 
 fun testImage(color: Color): Painter = run {
@@ -206,3 +208,9 @@ suspend fun awaitEDT() {
 fun Dimension.toDpSize() = DpSize(width.dp, height.dp)
 
 fun Point.toWindowPosition() = WindowPosition(x.dp, y.dp)
+
+actual fun runTestInUiThread(body: suspend () -> Unit) {
+    runBlocking(Dispatchers.Main) {
+        body()
+    }
+}

--- a/compose/ui/ui/src/jsTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/jsTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+actual fun runTestInUiThread(body: suspend () -> Unit) {
+    runTest(StandardTestDispatcher()) {
+        body()
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+expect fun runTestInUiThread(body: suspend () -> Unit)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -29,9 +29,11 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.platform.LocalPointerIconService
 import androidx.compose.ui.platform.Platform
+import androidx.compose.ui.runTestInUiThread
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.use
+import kotlin.coroutines.coroutineContext
 import kotlin.test.Test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
@@ -232,9 +234,9 @@ class PointerIconTest {
         }
     }
 
+    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/3352) fix race between the main thread and return to `runTest(UnconfinedTestDispatcher())`
     @Test
-    @OptIn(ExperimentalCoroutinesApi::class)
-    fun whenNotHoveredShouldNeverCommit() = runTest(UnconfinedTestDispatcher()) {
+    fun whenNotHoveredShouldNeverCommit() = runTestInUiThread {
         val component = IconPlatform()
         val surface = Surface.makeRasterN32Premul(100, 100)
         var scene: ComposeScene? = null

--- a/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+
+actual fun runTestInUiThread(body: suspend () -> Unit) {
+    runBlocking(Dispatchers.Main) {
+        body()
+    }
+}


### PR DESCRIPTION
It has a race with GlobalSnapshotManager, which is in UI thread