### PR TITLE
Fix testPerformTextInput to not assume the caret is at the end.

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TextActionsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TextActionsTest.kt
@@ -74,13 +74,13 @@ class TextActionsTest {
     @Test
     fun testPerformTextInput() {
         rule.setContent {
-            TestTextField("hello")
+            TestTextField("compose")
         }
 
         with(rule.onNodeWithTag("tag")){
-            assertTextEquals("hello")
-            performTextInput(" compose")
-            assertTextEquals("hello compose")
+            assertTextEquals("compose")
+            performTextInput("hello ")
+            assertTextEquals("hello compose")  // The caret is at 0 initially
         }
     }
 
@@ -92,9 +92,9 @@ class TextActionsTest {
 
         with(rule.onNodeWithTag("tag")){
             assertTextEquals("hello")
-            performTextInputSelection(TextRange(0))
-            performTextInput("compose ")
-            assertTextEquals("compose hello")
+            performTextInputSelection(TextRange(5))
+            performTextInput(" compose")
+            assertTextEquals("hello compose")
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Due to a change in how `getNodeAndFocus` is implemented (commit b587858cdc1638e77a3746974c9a8b9bd1074005), the caret is now at 0 by default (instead of the end of the textfield), causing the `testPerformTextInput` test to fail. 

I've fixed the test to correctly assume the caret is at 0 by default.


## Testing

Test: Fixed the test

