### PR TITLE
Remove redundant space conversion for touches coordinates

### DIFF
--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -38,7 +38,6 @@ import org.jetbrains.skiko.*
 internal class ComposeLayer(
     internal val layer: SkiaLayer,
     platform: Platform,
-    private val getTopLeftOffset: () -> Offset,
     private val input: SkikoInput,
 ) {
     private var isDisposed = false
@@ -71,7 +70,7 @@ internal class ComposeLayer(
         @OptIn(ExperimentalComposeUiApi::class)
         private fun onPointerEventWithMultitouch(event: SkikoPointerEvent) {
             val scale = density.density
-            val topLeftOffset = getTopLeftOffset()
+
             scene.sendPointerEvent(
                 eventType = event.kind.toCompose(),
                 pointers = event.pointers.map {
@@ -80,7 +79,7 @@ internal class ComposeLayer(
                         position = Offset(
                             x = it.x.toFloat() * scale,
                             y = it.y.toFloat() * scale
-                        ) - topLeftOffset,
+                        ),
                         pressed = it.pressed,
                         type = it.device.toCompose(),
                         pressure = it.pressure.toFloat(),
@@ -99,7 +98,7 @@ internal class ComposeLayer(
                 position = Offset(
                     x = event.x.toFloat() * scale,
                     y = event.y.toFloat() * scale
-                ) - getTopLeftOffset(),
+                ),
                 timeMillis = currentMillis(),
                 type = PointerType.Mouse,
                 nativeEvent = event

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -66,7 +66,6 @@ internal actual class ComposeWindow(val canvasId: String)  {
     private val layer = ComposeLayer(
         layer = createSkiaLayer(),
         platform = platform,
-        getTopLeftOffset = { Offset.Zero },
         input = jsTextInputService.input
     )
 

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -35,7 +35,6 @@ internal actual class ComposeWindow actual constructor() {
     val layer = ComposeLayer(
         layer = createSkiaLayer(),
         platform = platform,
-        getTopLeftOffset = { Offset.Zero },
         input = macosTextInputService.input
     )
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -326,8 +326,6 @@ internal actual class ComposeWindow : UIViewController {
         layer = ComposeLayer(
             layer = skiaLayer,
             platform = uiKitPlatform,
-            // TODO: Review if it's needed for other users of ComposeLayer.jsNative.kt
-            getTopLeftOffset = { Offset.Zero },
             input = uiKitTextInputService.skikoInput,
         )
         layer.setContent(content = {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -326,7 +326,8 @@ internal actual class ComposeWindow : UIViewController {
         layer = ComposeLayer(
             layer = skiaLayer,
             platform = uiKitPlatform,
-            getTopLeftOffset = ::getTopLeftOffset,
+            // TODO: Review if it's needed for other users of ComposeLayer.jsNative.kt
+            getTopLeftOffset = { Offset.Zero },
             input = uiKitTextInputService.skikoInput,
         )
         layer.setContent(content = {
@@ -428,14 +429,5 @@ internal actual class ComposeWindow : UIViewController {
     private fun getViewFrameSize(): IntSize {
         val (width, height) = view.frame().useContents { this.size.width to this.size.height }
         return IntSize(width.toInt(), height.toInt())
-    }
-
-    private fun getTopLeftOffset(): Offset {
-        val topLeftPoint =
-            view.coordinateSpace().convertPoint(
-                point = CGPointMake(0.0, 0.0),
-                toCoordinateSpace = view.window?.coordinateSpace() ?: UIScreen.mainScreen.coordinateSpace()
-            )
-        return topLeftPoint.useContents { DpOffset(x.dp, y.dp).toOffset(density) }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Avoid redundant touches coordinate space conversion.

## Testing

Test: manual check on all demo screens on iOS.

## Issues Fixed

Fixes: split window bug on iPad.

## Codependent with
https://github.com/JetBrains/skiko/pull/762
