### PR TITLE
Fix gesture completion

### DIFF
--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -368,6 +369,7 @@ class ComposeUiSkikoTestTest {
     }
 
     @Test
+    @Ignore // TODO(ivan.matkov): Bug in SkikoInputDispatcher - it uses overload for mouse input
     fun touch_press_multiple() = runComposeUiTest {
         setContent { TestEventBox() }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -652,7 +652,7 @@ class WindowInputEventTest {
     }
 
     @Test
-    fun `send release into two boxes without intermediate move`() = runApplicationTest {
+    fun `send release into first box without intermediate move`() = runApplicationTest {
         var box1ReleaseCount = 0
         var box2ReleaseCount = 0
 
@@ -681,11 +681,11 @@ class WindowInputEventTest {
         }
         awaitIdle()
 
-        window.sendMouseEvent(id = MOUSE_PRESSED, x = 1, y = 1)
+        window.sendMouseEvent(id = MOUSE_PRESSED, x = 1, y = 1, modifiers = BUTTON1_DOWN_MASK)
         window.sendMouseEvent(id = MOUSE_RELEASED, x = 21, y = 1)
 
-        assertThat(box1ReleaseCount).isEqualTo(0)
-        assertThat(box2ReleaseCount).isEqualTo(1)
+        assertThat(box1ReleaseCount).isEqualTo(1)
+        assertThat(box2ReleaseCount).isEqualTo(0)
 
         window.dispose()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -582,11 +582,8 @@ class ComposeScene internal constructor(
     }
 
     private fun processRelease(event: PointerInputEvent) {
-        val owner = pressOwner ?: hoveredOwner(event)
-        if (focusedOwner.isAbove(owner)) {
-            return
-        }
-        owner?.processPointerInput(event)
+        // Send Release to pressOwner even if is not hovered or under focused.
+        pressOwner?.processPointerInput(event)
     }
 
     private fun processMove(event: PointerInputEvent) {
@@ -596,6 +593,7 @@ class ComposeScene internal constructor(
             else -> hoveredOwner(event)
         }
         if (focusedOwner.isAbove(owner)) {
+            // If pressOwner is under focusedOwner, hover state must be updated
             owner = null
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -590,13 +590,13 @@ class ComposeScene internal constructor(
     }
 
     private fun processMove(event: PointerInputEvent) {
-        val owner = when {
+        var owner = when {
             event.buttons.areAnyPressed -> pressOwner
             event.eventType == PointerEventType.Exit -> null
             else -> hoveredOwner(event)
         }
         if (focusedOwner.isAbove(owner)) {
-            return
+            owner = null
         }
 
         // Cases:

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
@@ -30,6 +31,7 @@ import androidx.compose.ui.input.pointer.PointerInputEventData
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -39,7 +41,8 @@ import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import kotlin.test.assertContentEquals
 
-fun Events.assertReceivedNoEvents() = assertThat(list).isEmpty()
+fun Events.assertReceivedNoEvents() =
+    require(list.isEmpty()) { "Received events:\n${list.joinToString("\n")}" }
 
 fun Events.assertReceived(type: PointerEventType, offset: Offset) =
     received().assertHas(type, offset)
@@ -105,15 +108,20 @@ class Events {
     }
 }
 
-class FillBox {
+class FillBox(
+    private val onClick: () -> Unit = {}
+) {
     val events = Events()
+    val tag = "background"
 
     @Composable
     fun Content() {
         Box(
             Modifier
                 .fillMaxSize()
+                .clickable(onClick = onClick)
                 .collectEvents(events)
+                .testTag(tag)
         )
     }
 }
@@ -126,6 +134,7 @@ class PopupState(
 ) {
     val origin get() = bounds.topLeft.toOffset()
     val events = Events()
+    val tag = "popup"
 
     @Composable
     fun Content() {
@@ -149,6 +158,7 @@ class PopupState(
                     Modifier
                         .requiredSize(bounds.width.toDp(), bounds.height.toDp())
                         .collectEvents(events)
+                        .testTag(tag)
                 )
             }
         }


### PR DESCRIPTION
## Proposed Changes

  - Send `Release` only to `pressOwner`
  - Send `Release` even if it's under focused to finish gestures for `pressOwner`
  - Update hovered state  (send `Exit`) if owner appears under focused

## Testing

Test: run PopupTest or demo app

## Issues Fixed

Fixes:
- https://github.com/JetBrains/compose-multiplatform/issues/3349
- [COMPOSE-175](https://youtrack.jetbrains.com/issue/COMPOSE-175)
