### PR TITLE
Fix experimental usage error

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -226,6 +226,10 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             nativeTest.dependsOn(jsNativeTest)
             jsTest.dependsOn(jsNativeTest)
+
+            configureEach {
+                languageSettings.optIn("androidx.compose.foundation.ExperimentalFoundationApi")
+            }
         }
     }
     dependencies {

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -170,6 +170,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.junit)
                 implementation(libs.skikoCurrentOs)
             }
+
+            configureEach {
+                languageSettings.optIn("androidx.compose.material.ExperimentalMaterialApi")
+            }
         }
     }
     dependencies {

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -166,6 +166,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.junit)
                 implementation(libs.skikoCurrentOs)
             }
+
+            configureEach {
+                languageSettings.optIn("androidx.compose.material3.ExperimentalMaterial3Api")
+            }
         }
     }
 }

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -230,6 +230,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             }
             nativeTest.dependsOn(jsNativeTest)
             jsTest.dependsOn(jsNativeTest)
+
+            configureEach {
+                languageSettings.optIn("androidx.compose.ui.text.ExperimentalTextApi")
+            }
         }
     }
     dependencies {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -315,6 +315,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:material:material"))
                 implementation(project(":compose:ui:ui-test-junit4"))
             }
+
+            configureEach {
+                languageSettings.optIn("androidx.compose.ui.ExperimentalComposeUiApi")
+            }
         }
     }
     dependencies {


### PR DESCRIPTION
It is okay to use experimental annotations, if it is in the same module.

iOS can't be built without suppressing this warning: https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_BuildNativeForPullRequests/4232288?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandPull+Request+Details=true&expandBuildProblemsSection=true&expandBuildChangesSection=true
