### PR TITLE
Fix sending touches in `SkikoInputDispatcher`

### DIFF
--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.input.pointer.PointerEventType.Companion.Move
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Scroll
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.PointerType.Companion.Mouse
 import androidx.compose.ui.input.pointer.pointerInput
@@ -385,23 +386,23 @@ class ComposeUiSkikoTestTest {
         assertThat(events).hasSize(4)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
-            assertThat(changes[0].position).isEqualTo(Offset(0f, 0f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(0).position).isEqualTo(Offset(0f, 0f))
+            assertThat(changes.find(0).type).isEqualTo(PointerType.Touch)
         }
         events[1].apply {
             assertThat(type).isEqualTo(Press)
-            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(1).position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes.find(1).type).isEqualTo(PointerType.Touch)
         }
         events[2].apply {
             assertThat(type).isEqualTo(Release)
-            assertThat(changes[0].position).isEqualTo(Offset(0f, 0f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(0).position).isEqualTo(Offset(0f, 0f))
+            assertThat(changes.find(0).type).isEqualTo(PointerType.Touch)
         }
         events[3].apply {
             assertThat(type).isEqualTo(Release)
-            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
-            assertThat(changes[0].type).isEqualTo(PointerType.Touch)
+            assertThat(changes.find(1).position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes.find(1).type).isEqualTo(PointerType.Touch)
         }
     }
 
@@ -441,3 +442,6 @@ private fun <T : Collection<*>> AssertThat<T>.hasSize(size: Int) {
 private fun <T> assertThat(t: T): AssertThat<T> {
     return AssertThat(t)
 }
+
+private fun List<PointerInputChange>.find(id: Int) =
+    this.first { it.id.value.toInt() == id }

--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -370,7 +370,6 @@ class ComposeUiSkikoTestTest {
     }
 
     @Test
-    @Ignore // TODO(ivan.matkov): Bug in SkikoInputDispatcher - it uses overload for mouse input
     fun touch_press_multiple() = runComposeUiTest {
         setContent { TestEventBox() }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -557,8 +557,7 @@ class ComposeScene internal constructor(
             PointerEventType.Scroll -> processScroll(event)
         }
 
-        val isAnyPointerDown = event.pointers.fastAny { it.down }
-        if (!isAnyPointerDown) {
+        if (!event.isAnyPointerDown) {
             pressOwner = null
         }
     }
@@ -589,7 +588,7 @@ class ComposeScene internal constructor(
 
     private fun processMove(event: PointerInputEvent) {
         var owner = when {
-            event.buttons.areAnyPressed -> pressOwner
+            event.isAnyPointerDown -> pressOwner
             event.eventType == PointerEventType.Exit -> null
             else -> hoveredOwner(event)
         }
@@ -790,3 +789,5 @@ private fun pointerInputEvent(
 internal expect fun createSkiaLayer(): SkiaLayer
 
 internal expect fun NativeKeyEvent.toPointerKeyboardModifiers(): PointerKeyboardModifiers
+
+private val PointerInputEvent.isAnyPointerDown get() = pointers.fastAny { it.down }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEvent.skiko.kt
@@ -16,9 +16,6 @@
 
 package androidx.compose.ui.input.pointer
 
-import androidx.compose.ui.ExperimentalComposeUiApi
-
-@OptIn(ExperimentalComposeUiApi::class)
 internal actual data class PointerInputEvent(
     val eventType: PointerEventType,
     actual val uptime: Long,


### PR DESCRIPTION
## Proposed Changes

Currently `SkikoInputDispatcher` uses incorrect overload to send touch events from tests. It leads missing `changes` data in events and possible incorrect behaviour like tracking currently "pressed" pointers.

- Fixes handling touch gestures in `Popup`

## Testing

Test: run `ComposeUiSkikoTestTest`

## Issues Fixed

Fixes `touch_press_multiple` test after locking `Release` event to `pressOwner`. See #685
