### PR TITLE
Do not expose skiko library

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
@@ -232,7 +232,7 @@ fun sortPomDependencies(pom: String): String {
         .filterIsInstance<Element>()
         .forEach { element ->
             val deps = element.elements()
-            val sortedDeps = deps.toSortedSet(compareBy { it.stringValue }).toList()
+            val sortedDeps = deps.sortedBy { it.stringValue }.toList()
 
             // Content contains formatting nodes, so to avoid modifying those we replace
             // each element with the sorted element from its respective index. Note this

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -117,7 +117,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             skikoMain {
                 dependsOn(commonMain)
                 dependencies {
-                    api(libs.skikoCommon)
+                    implementation(libs.skikoCommon)
                 }
             }
 
@@ -135,7 +135,6 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
                 dependencies {
                     implementation(kotlin("stdlib-js"))
-                    api(libs.skikoCommon)
                 }
             }
 

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -118,7 +118,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.kotlinStdlib)
             }
 
-            jsNativeMain.dependsOn(commonMain)
+            jsNativeMain {
+                dependsOn(commonMain)
+                dependencies {
+                    implementation(libs.skikoCommon)
+                }
+            }
             nativeMain.dependsOn(jsNativeMain)
             jsWasmMain.dependsOn(jsNativeMain)
 

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -121,6 +121,9 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             skikoMain {
                 dependsOn(commonMain)
+                dependencies {
+                    implementation(libs.skikoCommon)
+                }
             }
 
             desktopMain.dependsOn(skikoMain)

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -94,7 +94,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             skikoMain {
                 dependsOn(commonMain)
                 dependencies {
-                    api(libs.skikoCommon)
+                    implementation(libs.skikoCommon)
                 }
             }
 
@@ -106,7 +106,6 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
                 dependencies {
                     implementation(kotlin("stdlib-js"))
-                    api(libs.skikoCommon)
                 }
             }
 

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -143,6 +143,9 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             skikoMain {
                 dependsOn(commonMain)
+                dependencies {
+                    implementation(libs.skikoCommon)
+                }
             }
 
             desktopMain.dependsOn(skikoMain)

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -120,7 +120,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             skikoMain {
                 dependsOn(commonMain)
                 dependencies {
-                    api(libs.skikoCommon)
+                    implementation(libs.skikoCommon)
                 }
             }
 
@@ -137,7 +137,6 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
                 dependencies {
                     implementation(kotlin("stdlib-js"))
-                    api(libs.skikoCommon)
                 }
             }
 

--- a/compose/ui/ui-tooling/build.gradle
+++ b/compose/ui/ui-tooling/build.gradle
@@ -60,6 +60,7 @@ androidXMultiplatform {
                 dependsOn(commonMain)
                 dependencies {
                     api(project(":compose:runtime:runtime"))
+                    implementation(libs.skikoCommon)
                 }
             }
         }

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -198,7 +198,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependencies {
                     api(project(":compose:ui:ui-graphics"))
                     api(project(":compose:ui:ui-text"))
-                    api(libs.skikoCommon)
+                    implementation(libs.skikoCommon)
                 }
             }
             desktopMain {
@@ -216,7 +216,6 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
                 dependencies {
                     implementation(kotlin("stdlib-js"))
-                    api(libs.skikoCommon)
                 }
             }
 


### PR DESCRIPTION
## Proposed Changes

Skiko library is currently [included](https://github.com/JetBrains/compose-multiplatform-core/blob/feaab5420821266f10982a0b36d41b22d89bc3bf/compose/ui/ui/build.gradle#LL201C30-L201C41) as `api` that makes possible using this unstable API without explicit adding the library.
It's even [used](https://github.com/JetBrains/compose-multiplatform/blob/master/examples/imageviewer/shared/src/iosMain/kotlin/example/imageviewer/filter/BitmapFilter.ios.kt#L7) in the official samples that might lead to widespread usage of it.
Since it's an implementation details, it should not be exposed by default. In the same time we need to allow users use it "as is" by adding skiko as explicit dependency to their project.

## API Change

Skiko library is not exported as the library API anymore. If you need to use `org.jetbrains.skiko.*` or `org.jetbrains.skia.*`, please include this library directly into the project.
Compose plugin contains DSL to avoid version conflicts

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3152
