### PR TITLE
Make InvokeOnLayoutCoordinates private

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/FocusedBounds.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/FocusedBounds.kt
@@ -68,7 +68,7 @@ private class FocusedBoundsObserverElement(
     }
 }
 
-fun interface InvokeOnLayoutCoordinates {
+private fun interface InvokeOnLayoutCoordinates {
     fun invoke(focusedBounds: LayoutCoordinates?)
 }
 


### PR DESCRIPTION
## API change

`InvokeOnLayoutCoordinates` is no longer public. It was made public by mistake.

## Testing

- Run desktop sample (haven't tested it on Web)
- CI builds
- this function isn't used by other projects in [GitHub](https://github.com/search?q=InvokeOnLayoutCoordinates+&type=code)