### PR TITLE
Fix hover and `dismissOnClickOutside` handling 

### DIFF
--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -162,7 +162,7 @@ class ComposeUiSkikoTestTest {
             press()
             release()
         }
-        assertThat(events).hasSize(2)
+        assertThat(events).hasSize(3)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -174,6 +174,11 @@ class ComposeUiSkikoTestTest {
             assertThat(type).isEqualTo(Release)
             assertThat(button).isEqualTo(PointerButton.Primary)
             assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Enter)
             assertThat(changes[0].position).isEqualTo(Offset.Zero)
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
@@ -186,7 +191,7 @@ class ComposeUiSkikoTestTest {
         onNodeWithTag("test").performMouseInput {
             click(Offset(10f, 20f))
         }
-        assertThat(events).hasSize(2)
+        assertThat(events).hasSize(3)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -198,6 +203,11 @@ class ComposeUiSkikoTestTest {
             assertThat(type).isEqualTo(Release)
             assertThat(button).isEqualTo(PointerButton.Primary)
             assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Enter)
             assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
@@ -215,7 +225,7 @@ class ComposeUiSkikoTestTest {
             release(MouseButton.Tertiary)
             press(MouseButton(3))
         }
-        assertThat(events).hasSize(5)
+        assertThat(events).hasSize(6)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -245,6 +255,11 @@ class ComposeUiSkikoTestTest {
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
         events[4].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[5].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Back)
             assertThat(buttons).isEqualTo(PointerButtons(isBackPressed = true))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -228,17 +228,19 @@ class ComposeSceneInputTest {
 
         scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 20f))
         background.events.assertReceivedNoEvents()
-        cutPopup.events.assertReceivedLast(
+        cutPopup.events.assertReceived(
             PointerEventType.Release, Offset(20f, 20f) - cutPopup.origin)
-        overlappedPopup.events.assertReceivedNoEvents()
-        independentPopup.events.assertReceivedNoEvents()
-
-        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
-        background.events.assertReceivedNoEvents()
         cutPopup.events.assertReceivedLast(
             PointerEventType.Exit, Offset(20f, 20f) - cutPopup.origin)
         overlappedPopup.events.assertReceivedLast(
             PointerEventType.Enter, Offset(20f, 20f) - overlappedPopup.origin)
+        independentPopup.events.assertReceivedNoEvents()
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
+        background.events.assertReceivedNoEvents()
+        cutPopup.events.assertReceivedNoEvents()
+        overlappedPopup.events.assertReceivedLast(
+            PointerEventType.Move, Offset(20f, 20f) - overlappedPopup.origin)
         independentPopup.events.assertReceivedNoEvents()
 
         scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f))
@@ -257,7 +259,8 @@ class ComposeSceneInputTest {
 
         scene.sendPointerEvent(PointerEventType.Release, Offset(-10f, -10f))
         background.events.assertReceivedNoEvents()
-        cutPopup.events.assertReceivedNoEvents()
+        cutPopup.events.assertReceivedLast(
+            PointerEventType.Enter, Offset(-10f, -10f) - cutPopup.origin)
         overlappedPopup.events.assertReceivedLast(
             PointerEventType.Release, Offset(-10f, -10f) - overlappedPopup.origin
         )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -614,7 +614,7 @@ class ComposeScene internal constructor(
         val owner = hoveredOwner(event)
         if (isInteractive(owner)) {
             processHover(event, owner)
-        } else {
+        } else if (pressOwner == null) {
             // If hovered owner is not interactive, then it means that
             // - It's not focusedOwner
             // - It placed under focusedOwner or not exist at all

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -166,10 +166,10 @@ class ComposeScene internal constructor(
         }
     }
 
-    private inline fun <T> reversedOwners(action: (List<SkiaBasedOwner>) -> T): T {
+    private inline fun forEachOwnerReversed(action: (SkiaBasedOwner) -> Unit) {
         listCopy.addAll(owners)
         try {
-            return action(listCopy.asReversed())
+            listCopy.asReversed().forEach(action)
         } finally {
             listCopy.clear()
         }
@@ -563,11 +563,12 @@ class ComposeScene internal constructor(
     }
 
     private fun processPress(event: PointerInputEvent) {
-        val owner = reversedOwners {
-            for (owner in it) {
+        forEachOwnerReversed { owner ->
             if (owner.isHovered(event)) {
                 // Stop once the position of in bounds of the owner
-                    return@reversedOwners owner
+                owner.processPointerInput(event)
+                pressOwner = owner
+                return@processPress
             }
             owner.onClickOutside?.invoke()
             if (owner == focusedOwner) {
@@ -575,10 +576,6 @@ class ComposeScene internal constructor(
                 return@processPress
             }
         }
-            return@reversedOwners null
-        }
-        owner?.processPointerInput(event)
-        pressOwner = owner
     }
 
     private fun processRelease(event: PointerInputEvent) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -419,12 +419,23 @@ class ComposeScene internal constructor(
     private var focusedOwner: SkiaBasedOwner? = null
     private var pressOwner: SkiaBasedOwner? = null
     private var lastHoverOwner: SkiaBasedOwner? = null
-    private fun hoveredOwner(event: PointerInputEvent): SkiaBasedOwner? =
-        owners.lastOrNull { it.isHovered(event) }
 
-    private fun SkiaBasedOwner?.isAbove(
-        targetOwner: SkiaBasedOwner?
-    ) = this != null && targetOwner != null && owners.indexOf(this) > owners.indexOf(targetOwner)
+    /**
+     * Find hovered owner for position of first pointer.
+     */
+    private fun hoveredOwner(event: PointerInputEvent): SkiaBasedOwner? {
+        // TODO: get rid of first(). Check if it's mouse?
+        val position = event.pointers.first().position
+        return owners.lastOrNull { it.isInBounds(position) }
+    }
+
+    /**
+     * Check if [focusedOwner] blocks input for this owner.
+     */
+    private fun isInteractive(owner: SkiaBasedOwner?) =
+        focusedOwner == null || owner == null ||
+            owners.indexOf(focusedOwner) <= owners.indexOf(owner)
+
 
     // TODO(demin): return Boolean (when it is consumed)
     /**
@@ -557,6 +568,7 @@ class ComposeScene internal constructor(
             PointerEventType.Scroll -> processScroll(event)
         }
 
+        // Clean pressOwner when there is no pressed pointers/buttons
         if (!event.isAnyPointerDown) {
             pressOwner = null
         }
@@ -568,29 +580,45 @@ class ComposeScene internal constructor(
             previousPressOwner.processPointerInput(event)
             return
         }
+        val pointer = event.pointers.first().position
         forEachOwnerReversed { owner ->
-            if (owner.isHovered(event)) {
-                // Stop once the position of in bounds of the owner
+
+            // If the position of in bounds of the owner - send event to it and stop processing
+            if (owner.isInBounds(pointer)) {
                 owner.processPointerInput(event)
                 pressOwner = owner
-                return@processPress
+                return
             }
-            owner.onClickOutside?.invoke()
+
+            // Input event is out of bounds - send click outside notification
+            owner.onOutsidePointerEvent?.invoke(event)
+
+            // if the owner is in focus, do not pass the event to underlying owners
             if (owner == focusedOwner) {
-                // Stop if it's in focus, do not pass the event to hovered owner
-                return@processPress
+                return
             }
         }
     }
 
     private fun processRelease(event: PointerInputEvent) {
-        // Send Release to pressOwner even if is not hovered or under focused.
+        // Send Release to pressOwner even if is not hovered or under focused
         pressOwner?.processPointerInput(event)
-        if (!event.buttons.areAnyPressed) {
-            // Changing hover during Move event can be blocked by sticking to pressOwner
-            hoveredOwner(event)
-                .takeIf { !focusedOwner.isAbove(it) }
-                ?.let { processHover(event, it) }
+
+        // Process further only if last pointer was released
+        if (event.isAnyPointerDown) {
+            return
+        }
+
+        // Changing hover during Move event can be blocked by sticking to pressOwner
+        val owner = hoveredOwner(event)
+        if (isInteractive(owner)) {
+            processHover(event, owner)
+        } else {
+            // If hovered owner is not interactive, then it means that
+            // - It's not focusedOwner
+            // - It placed under focusedOwner or not exist at all
+            // In all these cases the even happened outside focused owner bounds
+            focusedOwner?.onOutsidePointerEvent?.invoke(event)
         }
     }
 
@@ -600,7 +628,7 @@ class ComposeScene internal constructor(
             event.eventType == PointerEventType.Exit -> null
             else -> hoveredOwner(event)
         }
-        if (focusedOwner.isAbove(owner)) {
+        if (!isInteractive(owner)) {
             // If pressOwner is under focusedOwner, hover state must be updated
             owner = null
         }
@@ -645,10 +673,9 @@ class ComposeScene internal constructor(
 
     private fun processScroll(event: PointerInputEvent) {
         val owner = hoveredOwner(event)
-        if (focusedOwner.isAbove(owner)) {
-            return
+        if (isInteractive(owner)) {
+            owner?.processPointerInput(event)
         }
-        owner?.processPointerInput(event)
     }
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -563,6 +563,11 @@ class ComposeScene internal constructor(
     }
 
     private fun processPress(event: PointerInputEvent) {
+        val previousPressOwner = pressOwner
+        if (previousPressOwner != null) {
+            previousPressOwner.processPointerInput(event)
+            return
+        }
         forEachOwnerReversed { owner ->
             if (owner.isHovered(event)) {
                 // Stop once the position of in bounds of the owner

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -75,16 +75,13 @@ internal class SkiaBasedOwner(
     initLayoutDirection: LayoutDirection = platform.layoutDirection,
     bounds: IntRect = IntRect.Zero,
     val focusable: Boolean = true,
-    val onClickOutside: (() -> Unit)? = null,
+    val onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     private val onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     private val onKeyEvent: (KeyEvent) -> Boolean = { false },
 ) : Owner, RootForTest, SkiaRootForTest, PositionCalculator {
     override val windowInfo: WindowInfo get() = platform.windowInfo
 
-    fun isHovered(event: PointerInputEvent) =
-        isHovered(event.pointers.first().position)
-
-    private fun isHovered(point: Offset): Boolean {
+    fun isInBounds(point: Offset): Boolean {
         val intOffset = IntOffset(point.x.toInt(), point.y.toInt())
         return bounds.contains(intOffset)
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -22,6 +22,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.*
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
+import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.unit.IntOffset
 
 @Immutable
@@ -131,7 +134,13 @@ fun Popup(
 ) = PopupLayout(
     popupPositionProvider = popupPositionProvider,
     focusable = focusable,
-    onClickOutside = if (focusable) onDismissRequest else null,
+    onOutsidePointerEvent = {
+        if (focusable &&
+            it.isDismissRequest() &&
+            onDismissRequest != null) {
+            onDismissRequest()
+        }
+    },
     onPreviewKeyEvent = onPreviewKeyEvent,
     onKeyEvent = onKeyEvent,
     content = content
@@ -203,7 +212,13 @@ actual fun Popup(
     PopupLayout(
         popupPositionProvider,
         properties.focusable,
-        if (properties.dismissOnClickOutside) onDismissRequest else null,
+        onOutsidePointerEvent = {
+            if (properties.dismissOnClickOutside &&
+                it.isDismissRequest() &&
+                onDismissRequest != null) {
+                onDismissRequest()
+            }
+        },
         onKeyEvent = {
             if (properties.dismissOnBackPress &&
                 it.type == KeyEventType.KeyDown && it.key == Key.Escape &&
@@ -217,3 +232,10 @@ actual fun Popup(
         content = content
     )
 }
+
+private fun PointerInputEvent.isMainAction() =
+    button == PointerButton.Primary ||
+        button == null && pointers.size == 1
+
+private fun PointerInputEvent.isDismissRequest() =
+    eventType == Press && isMainAction()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.LocalComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
@@ -35,8 +36,8 @@ import androidx.compose.ui.unit.round
 internal fun PopupLayout(
     popupPositionProvider: PopupPositionProvider,
     focusable: Boolean,
-    onClickOutside: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     content: @Composable () -> Unit
@@ -72,7 +73,7 @@ internal fun PopupLayout(
             initDensity = density,
             initLayoutDirection = layoutDirection,
             focusable = focusable,
-            onClickOutside = onClickOutside,
+            onOutsidePointerEvent = onOutsidePointerEvent,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent
         )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
@@ -157,6 +159,34 @@ class PopupState(
                 Box(
                     Modifier
                         .requiredSize(bounds.width.toDp(), bounds.height.toDp())
+                        .collectEvents(events)
+                        .testTag(tag)
+                )
+            }
+        }
+    }
+}
+
+class DialogState(
+    val size: IntSize,
+    private val dismissOnClickOutside: Boolean = true,
+    private val onDismissRequest: () -> Unit = {}
+) {
+    val events = Events()
+    val tag = "dialog"
+
+    @Composable
+    fun Content() {
+        Dialog(
+            onDismissRequest = onDismissRequest,
+            properties = DialogProperties(
+                dismissOnClickOutside = dismissOnClickOutside
+            )
+        ) {
+            with(LocalDensity.current) {
+                Box(
+                    Modifier
+                        .requiredSize(size.width.toDp(), size.height.toDp())
                         .collectEvents(events)
                         .testTag(tag)
                 )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.DialogState
+import androidx.compose.ui.FillBox
+import androidx.compose.ui.assertReceived
+import androidx.compose.ui.assertReceivedLast
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.touch
+import androidx.compose.ui.unit.IntSize
+import kotlin.test.Test
+import kotlin.test.fail
+
+@OptIn(ExperimentalTestApi::class)
+class DialogTest {
+
+    @Test
+    fun openFocusablePopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val openDialog = mutableStateOf(false)
+        val background = FillBox {
+            openDialog.value = true
+        }
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = {
+                openDialog.value = false
+            }
+        )
+
+        setContent {
+            background.Content()
+            if (openDialog.value) {
+                dialog.Content()
+            }
+        }
+
+        // Click (Press-Release cycle) opens popup and sends all events to "background"
+        val buttons = PointerButtons(
+            isPrimaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+        onNodeWithTag(dialog.tag).assertIsDisplayed()
+
+        background.events.assertReceived(PointerEventType.Press, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Enter, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(10f, 10f))
+    }
+
+    @Test
+    fun closeFocusablePopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val openDialog = mutableStateOf(false)
+        val background = FillBox {
+            openDialog.value = true
+        }
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = {
+                openDialog.value = false
+            }
+        )
+
+        setContent {
+            background.Content()
+            if (openDialog.value) {
+                dialog.Content()
+            }
+        }
+
+        // Moving without popup generates Enter because it's in bounds
+        scene.sendPointerEvent(PointerEventType.Move, Offset(15f, 15f))
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(15f, 15f))
+
+        // Open dialog
+        openDialog.value = true
+        onNodeWithTag(dialog.tag).assertIsDisplayed()
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(15f, 15f))
+
+        // Click (Press-Move-Release cycle) outside closes popup and sends only Enter event to background
+        val buttons = PointerButtons(
+            isPrimaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
+        onNodeWithTag(dialog.tag).assertIsDisplayed() // Close should happen only on Release event
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(11f, 11f), buttons = buttons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(11f, 11f), button = PointerButton.Primary)
+        onNodeWithTag(dialog.tag).assertDoesNotExist()
+
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
+    }
+
+    @Test
+    fun nonPrimaryButtonClickDoesNotDismissPopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = { fail() }
+        )
+
+        setContent {
+            background.Content()
+            dialog.Content()
+        }
+
+        val buttons = PointerButtons(
+            isSecondaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Secondary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Secondary)
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -120,6 +120,51 @@ class DialogTest {
     }
 
     @Test
+    fun secondClickDoesNotDismissPopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = {
+                fail()
+            }
+        )
+
+        setContent {
+            background.Content()
+            dialog.Content()
+        }
+
+        scene.sendPointerEvent(
+            PointerEventType.Press,
+            pointers = listOf(
+                touch(50f, 50f, pressed = true, id = 1),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Press,
+            pointers = listOf(
+                touch(50f, 50f, pressed = true, id = 1),
+                touch(10f, 10f, pressed = true, id = 2),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release,
+            pointers = listOf(
+                touch(50f, 50f, pressed = false, id = 1),
+                touch(10f, 10f, pressed = true, id = 2),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release,
+            pointers = listOf(
+                touch(10f, 10f, pressed = false, id = 2),
+            )
+        )
+    }
+
+    @Test
     fun nonPrimaryButtonClickDoesNotDismissPopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
     ) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -16,24 +16,30 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.*
-import androidx.compose.ui.*
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.FillBox
+import androidx.compose.ui.PopupState
+import androidx.compose.ui.assertReceived
+import androidx.compose.ui.assertReceivedLast
+import androidx.compose.ui.assertReceivedNoEvents
+import androidx.compose.ui.assertThat
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
@@ -406,10 +412,12 @@ class PopupTest {
         )
         scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
         scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+        onNodeWithTag(popup.tag).assertIsDisplayed()
 
         background.events.assertReceived(PointerEventType.Press, Offset(10f, 10f))
-        background.events.assertReceivedLast(PointerEventType.Release, Offset(10f, 10f))
-        onNodeWithTag(popup.tag).assertIsDisplayed()
+        background.events.assertReceived(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Enter, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(10f, 10f))
     }
 
     @Test
@@ -451,6 +459,6 @@ class PopupTest {
 
         scene.sendPointerEvent(PointerEventType.Move, Offset(11f, 11f), buttons = buttons)
         scene.sendPointerEvent(PointerEventType.Release, Offset(11f, 11f), button = PointerButton.Primary)
-        background.events.assertReceivedNoEvents()
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
     }
 }


### PR DESCRIPTION
## Proposed Changes

It's remaining part of #674 with a few additions

  - Do not override `pressOwner` on second simultaneous `Press` event (second touch or second button);
  - Update hover state (send `Enter`/`Exit` events) on `Release` event. It allows to send missing event if updating during `Move` was blocked by `pressOwner`;
  - Replace `onClickOutside` to `onOutsidePointerEvent` to allow specify filtering by event type or by specific mouse button;
  - Dismiss `Popup` and `Dialog` only on mouse primary button click;
  - Dismiss `Dialog` on `Release` instead of `Press` event;

## Testing

Test: run tests from `PopupTest` and `DialogTest`

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3349
