### PR TITLE
cfw: Workaround ComposeWindow multiple event listeners on resize

### DIFF
--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -69,7 +69,8 @@ internal actual class ComposeWindow(val canvasId: String)  {
         input = jsTextInputService.input
     )
 
-    val canvas = document.getElementById(canvasId) as HTMLCanvasElement
+    var canvas = document.getElementById(canvasId) as HTMLCanvasElement
+        private set
 
     init {
         layer.layer.attachTo(canvas)
@@ -80,6 +81,12 @@ internal actual class ComposeWindow(val canvasId: String)  {
     }
 
     fun resize(newSize: IntSize) {
+        // TODO: avoid node cloning. We clone now to workaround multiple event listeners being applied on every resize event.
+        //  Consider fixing in skiko.
+        val oldCanvas = canvas
+        canvas = oldCanvas.cloneNode(true) as HTMLCanvasElement
+        oldCanvas.parentElement!!.replaceChild(canvas, oldCanvas)
+
         canvas.width = newSize.width
         canvas.height = newSize.height
         layer.layer.attachTo(canvas)


### PR DESCRIPTION
Updated the resize function in ComposeWindow.js.kt to avoid multiple event listeners being applied on every resize event. Implemented via cloning the old canvas and replacing it with the new one. This is a workaround solution and a better strategy to fix this in skiko will be considered in the future.

P.S. I'd like it to be inclided in 1.5.0-beta