### PR TITLE
Add DerivedData to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,8 @@ jacoco.exec
 captures/
 __pycache__
 
+# Xcode cache for demo project
+DerivedData/
+
 # Don't ignore src files under build package
 !**/src/**/build

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,5 @@ jacoco.exec
 captures/
 __pycache__
 
-# Xcode cache for demo project
-DerivedData/
-
 # Don't ignore src files under build package
 !**/src/**/build

--- a/compose/mpp/demo/.gitignore
+++ b/compose/mpp/demo/.gitignore
@@ -1,3 +1,6 @@
 *.xcodeproj
 plists
 project.generated.yml
+
+# Xcode cache for demo project
+DerivedData/


### PR DESCRIPTION
## Testing

Test: configure Xcode to keep it's cache in a default relative folder - DerivedData, cache generated by demo project shouldn't be tracked by git.
