### PR TITLE
material3. fix JS Compilation crash

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SystemBarsDefaultInsets.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SystemBarsDefaultInsets.kt
@@ -19,5 +19,9 @@ package androidx.compose.material3
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 
-internal expect val WindowInsets.Companion.systemBarsForVisualComponents: WindowInsets
-    @Composable get
+// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) revert to expect get()
+internal val WindowInsets.Companion.systemBarsForVisualComponents: WindowInsets
+    @Composable get() = systemBarsForVisualComponents()
+
+@Composable
+internal expect fun WindowInsets.Companion.systemBarsForVisualComponents(): WindowInsets

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimeFormat.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimeFormat.kt
@@ -19,6 +19,11 @@ package androidx.compose.material3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 
-internal expect val is24HourFormat: Boolean
+// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) revert to expect get()
+internal val is24HourFormat: Boolean
   @Composable
-  @ReadOnlyComposable get
+  @ReadOnlyComposable get() = is24HourFormat()
+
+@Composable
+@ReadOnlyComposable
+internal expect fun is24HourFormat(): Boolean

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/SystemBarsDefaultInsets.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/SystemBarsDefaultInsets.skiko.kt
@@ -21,6 +21,6 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 
 // TODO upstream to commonMain
-internal actual val WindowInsets.Companion.systemBarsForVisualComponents: WindowInsets
-    @Composable
-    get() = WindowInsets.systemBars
+@Composable
+internal actual fun WindowInsets.Companion.systemBarsForVisualComponents(): WindowInsets =
+    WindowInsets.systemBars

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimeFormat.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimeFormat.skiko.kt
@@ -19,6 +19,6 @@ package androidx.compose.material3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 
-internal actual val is24HourFormat: Boolean
-    @Composable
-    @ReadOnlyComposable get() = false
+@Composable
+@ReadOnlyComposable
+internal actual fun is24HourFormat(): Boolean = false


### PR DESCRIPTION
Revert after fixing https://github.com/JetBrains/compose-multiplatform/issues/3373

The crash:
```
e: java.lang.IllegalStateException: IdSignature clash: androidx.compose.material3/$get-systemBarsForVisualComponents$$composable|-1468794648185972111[0]; Existed declaration FUN name:$get-systemBarsForVisualComponents$$composable visibility:internal modality:FINAL <> ($receiver:androidx.compose.foundation.layout.WindowInsets.Companion, $composer:androidx.compose.runtime.Composer?, $changed:kotlin.Int) returnType:androidx.compose.foundation.layout.WindowInsets clashed with new FUN DEFAULT_PROPERTY_ACCESSOR name:$get-systemBarsForVisualComponents$$composable visibility:internal modality:FINAL <> ($receiver:androidx.compose.foundation.layout.WindowInsets.Companion, $composer:androidx.compose.runtime.Composer?, $changed:kotlin.Int) returnType:androidx.compose.foundation.layout.WindowInsets
  at org.jetbrains.kotlin.ir.backend.js.lower.serialization.ir.JsUniqIdClashTracker.commit(JsDeclarationTable.kt:27)
  at org.jetbrains.kotlin.backend.common.serialization.GlobalDeclarationTable.computeSignatureByDeclaration(DeclarationTable.kt:48)
  at org.jetbrains.kotlin.backend.common.serialization.DeclarationTable.computeSignatureByDeclaration(DeclarationTable.kt:83)
  at org.jetbrains.kotlin.backend.common.serialization.DeclarationTable.signatureByDeclaration(DeclarationTable.kt:92)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.protoIdSignature(IrFileSerializer.kt:290)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeIrSymbol(IrFileSerializer.kt:353)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeIrDeclarationBase(IrFileSerializer.kt:1096)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeIrFunctionBase(IrFileSerializer.kt:1135)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeIrFunction(IrFileSerializer.kt:1165)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeDeclaration(IrFileSerializer.kt:1322)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeIrFileImpl(IrFileSerializer.kt:1431)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.access$serializeIrFileImpl(IrFileSerializer.kt:115)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer$serializeIrFile$1.invoke(IrFileSerializer.kt:1411)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer$serializeIrFile$1.invoke(IrFileSerializer.kt:1410)
  at org.jetbrains.kotlin.backend.common.serialization.signature.PublicIdSignatureComputer.inFile(IdSignatureSerializer.kt:45)
  at org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureSerializer.inFile(IdSignatureSerializer.kt:229)
  at org.jetbrains.kotlin.backend.common.serialization.DeclarationTable.inFile(DeclarationTable.kt:62)
  at org.jetbrains.kotlin.backend.common.serialization.IrFileSerializer.serializeIrFile(IrFileSerializer.kt:1410)
  at org.jetbrains.kotlin.backend.common.serialization.IrModuleSerializer.serializeIrFile(IrModuleSerializer.kt:28)
  at org.jetbrains.kotlin.backend.common.serialization.IrModuleSerializer.serializedIrModule(IrModuleSerializer.kt:35)
  at org.jetbrains.kotlin.ir.backend.js.KlibKt.serializeModuleIntoKlib(klib.kt:621)
  at org.jetbrains.kotlin.ir.backend.js.KlibKt.generateKLib(klib.kt:134)
  at org.jetbrains.kotlin.ir.backend.js.KlibKt.generateKLib$default(klib.kt:118)
  at org.jetbrains.kotlin.cli.js.K2JsIrCompiler.processSourceModule(K2JsIrCompiler.kt:471)
  at org.jetbrains.kotlin.cli.js.K2JsIrCompiler.doExecute(K2JsIrCompiler.kt:295)
  at org.jetbrains.kotlin.cli.js.K2JSCompiler.doExecute(K2JSCompiler.java:181)
  at org.jetbrains.kotlin.cli.js.K2JSCompiler.doExecute(K2JSCompiler.java:72)
  at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:100)
  at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:46)
  at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:101)
  at org.jetbrains.kotlin.incremental.IncrementalJsCompilerRunner.runCompiler(IncrementalJsCompilerRunner.kt:213)
  at org.jetbrains.kotlin.incremental.IncrementalJsCompilerRunner.runCompiler(IncrementalJsCompilerRunner.kt:84)
  at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.doCompile(IncrementalCompilerRunner.kt:486)
  at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:409)
  at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileNonIncrementally(IncrementalCompilerRunner.kt:290)
  at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:112)
  at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile$default(IncrementalCompilerRunner.kt:94)
  at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execJsIncrementalCompiler(CompileServiceImpl.kt:567)
  at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execJsIncrementalCompiler(CompileServiceImpl.kt:101)
  at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1678)
  at jdk.internal.reflect.GeneratedMethodAccessor94.invoke(Unknown Source)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360)
  at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200)
  at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:712)
  at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196)
  at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587)
  at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828)
  at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
  at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704)
  at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
  at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
  at java.base/java.lang.Thread.run(Thread.java:833)
```

## Testing
./gradlew :compose:material3:material3:compileKotlinJs