### PR TITLE
Fix building material icons

### DIFF
--- a/compose/material/material/icons/generator/src/main/kotlin/androidx/compose/material/icons/generator/tasks/IconGenerationTask.kt
+++ b/compose/material/material/icons/generator/src/main/kotlin/androidx/compose/material/icons/generator/tasks/IconGenerationTask.kt
@@ -155,13 +155,12 @@ abstract class IconGenerationTask : DefaultTask() {
          * bitmap comparison test for every icon in both the core and extended project.
          */
         @JvmStatic
+        @Suppress("UNUSED_PARAMETER")
         fun registerExtendedIconThemeProject(
             project: Project,
             libraryExtension: LibraryExtension
         ) {
-            libraryExtension.libraryVariants.all { variant ->
-                ExtendedIconGenerationTask.register(project, variant)
-            }
+            ExtendedIconGenerationTask.register(project, null)
 
             // b/175401659 - disable lint as it takes a long time, and most errors should
             // be caught by lint on material-icons-core anyway


### PR DESCRIPTION
Stacktrace:
```
* What went wrong:
Execution failed for task ':compose:material:material-icons-extended:generateMetadataFileForUikitArm64Publication'.
> java.io.FileNotFoundException: /opt/buildAgent/work/5b4bef35b35b9f12/out/androidx/compose/material/material-icons-extended/build/classes/kotlin/uikitArm64/main/klib/material-icons-extended.klib (No such file or directory)
```

See https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_All_2/4235476?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildTestsSection=true&expandBuildProblemsSection=true

Reverting to the state that was before the 1.5.0-beta03 merge