### PR TITLE
Handle scroll cancellation exception

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/LazyLayouts.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/LazyLayouts.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.random.Random
+import kotlinx.coroutines.CancellationException
 
 val LazyLayouts = Screen.Selection(
     "LazyLayouts",
@@ -52,7 +53,11 @@ private fun ExampleLazyColumn() {
     LaunchedEffect(Unit) {
         while (true) {
             withFrameMillis { }
-            state.scrollBy(2f)
+            try {
+                state.scrollBy(2f)
+            } catch (ignore: CancellationException) {
+                // Ignore cancelling by manual input
+            }
         }
     }
     LazyColumn(Modifier.fillMaxSize(), state = state) {


### PR DESCRIPTION
## Proposed Changes

`scroll` block can be interrupted by other scroll animation or manual input. Handling wheel input cycle shouldn't be interrupted by that.

PS review with whitespace ignored

## Testing

Test: run mpp `LazyColumn` sample

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3366
