### PR TITLE
ComposeScene.roots to return child compose scenes created for Window and DialogWindow

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/AssertionsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/AssertionsTest.kt
@@ -20,7 +20,10 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -31,6 +34,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogWindow
+import androidx.compose.ui.window.Window
 import kotlin.test.assertFails
 import org.junit.Rule
 import org.junit.Test
@@ -541,5 +546,49 @@ class AssertionsTest {
         assertFails {
             rule.onAllNodesWithTag("tag").assertAll(hasText("World", substring = true))
         }
+    }
+
+    @Test
+    fun testNodeInDialogWindow() {
+        var show by mutableStateOf(true)
+        rule.setContent {
+            if (show) {
+                DialogWindow(
+                    onCloseRequest = {},
+                ) {
+                    Text(
+                        text = "Text",
+                        modifier = Modifier.testTag("tag")
+                    )
+                }
+            }
+        }
+
+        rule.onNodeWithTag("tag").assertExists()
+
+        show = false
+        rule.onNodeWithTag("tag").assertDoesNotExist()
+    }
+
+    @Test
+    fun testNodeInWindow() {
+        var show by mutableStateOf(true)
+        rule.setContent {
+            if (show) {
+                Window(
+                    onCloseRequest = {},
+                ) {
+                    Text(
+                        text = "Text",
+                        modifier = Modifier.testTag("tag")
+                    )
+                }
+            }
+        }
+
+        rule.onNodeWithTag("tag").assertExists()
+
+        show = false
+        rule.onNodeWithTag("tag").assertDoesNotExist()
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -17,6 +17,7 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.DialogWindowScope
@@ -40,6 +41,9 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 class ComposeDialog : JDialog {
     private val skiaLayerAnalytics: SkiaLayerAnalytics
     private val delegate: ComposeWindowDelegate
+
+    internal val scene: ComposeScene
+        get() = delegate.scene
 
     constructor(
         owner: Window?,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -17,6 +17,7 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.FrameWindowScope
@@ -59,6 +60,9 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     ) : this(graphicsConfiguration, SkiaLayerAnalytics.Empty)
 
     private val delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+
+    internal val scene: ComposeScene
+        get() = delegate.scene
 
     // Don't override the accessible context of JFrame, since accessibility work through HardwareLayer
     internal val windowAccessible: Accessible

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.awt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
@@ -54,6 +55,8 @@ internal class ComposeWindowDelegate(
         get() = requireNotNull(_bridge) {
             "ComposeBridge is disposed"
         }
+    internal val scene: ComposeScene
+        get() = bridge.scene
     internal val windowAccessible: Accessible
         get() = bridge.sceneAccessible
     val undecoratedWindowResizer = UndecoratedWindowResizer(window)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LocalComposeScene
+import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
@@ -37,7 +38,7 @@ import kotlin.math.roundToInt
  */
 @Composable
 private fun rememberCursorPosition(): Offset? {
-    val scene = LocalComposeScene.current
+    val scene = LocalComposeScene.requireCurrent()
     return remember { scene.pointerPositions.values.firstOrNull() }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -37,8 +37,13 @@ import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.currentNanoTime
 
-internal val LocalComposeScene = staticCompositionLocalOf<ComposeScene> {
-    error("CompositionLocal LocalComposeScene not provided")
+internal val LocalComposeScene = staticCompositionLocalOf<ComposeScene?> { null }
+
+/**
+ * The local [ComposeScene] is typically not-null. This extension can be used in these cases.
+ */
+internal fun CompositionLocal<ComposeScene?>.requireCurrent(): ComposeScene {
+    return current ?: error("CompositionLocal LocalComposeScene not provided")
 }
 
 /**
@@ -175,12 +180,43 @@ class ComposeScene internal constructor(
         }
     }
 
+    private val childScenes = mutableSetOf<ComposeScene>()
+
+    /**
+     * Adds a child [ComposeScene], so that nodes in it can be found in tests.
+     */
+    internal fun addChildScene(scene: ComposeScene) {
+        check(!isClosed) { "ComposeScene is closed" }
+        childScenes.add(scene)
+    }
+
+    /**
+     * Removes a child [ComposeScene].
+     */
+    internal fun removeChildScene(scene: ComposeScene) {
+        check(!isClosed) { "ComposeScene is closed" }
+        childScenes.remove(scene)
+    }
+
+    /**
+     * Adds this scene's [RootForTest]s, including any of its child scenes, into the given set.
+     */
+    private fun addRootsForTestTo(target: MutableSet<RootForTest>) {
+        target.addAll(owners)
+        for (child in childScenes) {
+            child.addRootsForTestTo(target)
+        }
+    }
+
     /**
      * All currently registered [RootForTest]s. After calling [setContent] the first root
      * will be added. If there is an any [Popup] is present in the content, it will be added as
      * another [RootForTest]
      */
-    val roots: Set<RootForTest> get() = owners.toSet()
+    val roots: Set<RootForTest>
+        get() = buildSet(owners.size) {
+            addRootsForTestTo(this)
+        }
 
     private val defaultPointerStateTracker = DefaultPointerStateTracker()
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.*
 import androidx.compose.ui.LocalComposeScene
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.Layout
@@ -41,7 +42,7 @@ internal fun PopupLayout(
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     content: @Composable () -> Unit
 ) {
-    val scene = LocalComposeScene.current
+    val scene = LocalComposeScene.requireCurrent()
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
 


### PR DESCRIPTION
Currently, the `ComposeScene` created for a `Window` or a `DialogWindow` can't be reached by semantic node fetching, because we don't return their owners from `testOwner.getRoots` (in `ComposeScene.roots`). So for example, this will fail:

```
    @Test
    fun testNodeInWindow() {
        rule.setContent {
            Window(
                onCloseRequest = {},
            ) {
                Text(
                    text = "Text",
                    modifier = Modifier.testTag("tag")
                )
            }
        }

        rule.onNodeWithTag("tag").assertExists()
    }
```

## Proposed Changes

  - When a `Window` or `DialogWindow` is created, it will add its `ComposeScene` as a child scene to its parent.
  - `ComposeScene.roots` will return its own `owners` and all of its descendent's `owners`.
 

## Testing

Test: Added unit tests to verify that nodes inside `Window` and `DialogWindow` can be found.
