### PR TITLE
Add semantic properties to DialogWindow, Popup and Dialog

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/FiltersTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/FiltersTest.kt
@@ -26,9 +26,9 @@ import androidx.compose.material.TextField
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.Popup
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -42,12 +42,11 @@ class FiltersTest {
     val rule = createComposeRule()
 
     @Test
-    @Ignore  // TODO: Fix Dialog to have the dialog() semantic property
-    fun testIsDialog() {
+    fun testIsDialogOnDialogWindow() {
         rule.setContent {
             DialogWindow(
                 onCloseRequest = {},
-            ){
+            ) {
                 Text(
                     text = "Text",
                     modifier = Modifier.testTag("tag")
@@ -60,15 +59,30 @@ class FiltersTest {
     }
 
     @Test
-    @Ignore  // TODO: Fix Popup to have the popup() semantic property
-    fun testIsPopup() {
+    fun testIsDialogOnDialog() {
         rule.setContent {
-            Popup{
+            Dialog(
+                onDismissRequest = {}
+            ) {
                 Text(
                     text = "Text",
                     modifier = Modifier.testTag("tag")
                 )
 
+            }
+        }
+
+        rule.onNodeWithTag("tag").assert(hasAnyAncestor(isDialog()))
+    }
+
+    @Test
+    fun testIsPopup() {
+        rule.setContent {
+            Popup {
+                Text(
+                    text = "Text",
+                    modifier = Modifier.testTag("tag")
+                )
             }
         }
 
@@ -78,7 +92,7 @@ class FiltersTest {
     @Test
     fun testHasAnyChild() {
         rule.setContent {
-            Box(Modifier.testTag("box")){
+            Box(Modifier.testTag("box")) {
                 Text(text = "text")
             }
         }
@@ -89,8 +103,8 @@ class FiltersTest {
     @Test
     fun testHasAnyAncestor() {
         rule.setContent {
-            Box(Modifier.testTag("ancestor1")){
-                Box(Modifier.testTag("ancestor2")){
+            Box(Modifier.testTag("ancestor1")) {
+                Box(Modifier.testTag("ancestor2")) {
                     Text(text = "text")
                 }
             }
@@ -103,7 +117,7 @@ class FiltersTest {
     @Test
     fun testHasAnyParent() {
         rule.setContent {
-            Box(Modifier.testTag("parent")){
+            Box(Modifier.testTag("parent")) {
                 Text(text = "text")
             }
         }
@@ -114,7 +128,7 @@ class FiltersTest {
     @Test
     fun testHasAnySibling() {
         rule.setContent {
-            Box{
+            Box {
                 Text(text = "text1")
                 Text(text = "text2")
             }
@@ -180,7 +194,7 @@ class FiltersTest {
             LazyColumn(
                 Modifier.testTag("tag")
             ) {
-                items(2){
+                items(2) {
                     Text("$it")
                 }
             }
@@ -195,7 +209,7 @@ class FiltersTest {
             LazyColumn(
                 Modifier.testTag("tag")
             ) {
-                items(2){
+                items(2) {
                     Text("$it")
                 }
             }
@@ -210,7 +224,7 @@ class FiltersTest {
             LazyColumn(
                 Modifier.testTag("tag")
             ) {
-                items(2){
+                items(2) {
                     Text("$it")
                 }
             }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/KeyInputTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/KeyInputTest.kt
@@ -50,7 +50,7 @@ class KeyInputTest {
     @Composable
     private fun FocusedBox(
         onKeyEvent: ((KeyEvent) -> Unit)? = null
-    ){
+    ) {
         val focusRequester = remember { FocusRequester() }
         Box(
             Modifier
@@ -58,13 +58,13 @@ class KeyInputTest {
                 .size(100.dp)
                 .focusRequester(focusRequester)
                 .focusable()
-                .onKeyEvent{
+                .onKeyEvent {
                     onKeyEvent?.invoke(it)
                     true
                 }
         )
 
-        LaunchedEffect(Unit){
+        LaunchedEffect(Unit) {
             focusRequester.requestFocus()
         }
     }
@@ -79,7 +79,7 @@ class KeyInputTest {
             }
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             performKeyInput {
                 keyDown(Key.C)
             }
@@ -107,7 +107,7 @@ class KeyInputTest {
             FocusedBox()
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             performKeyInput {
                 keyDown(Key.C)
                 assertTrue(isKeyDown(Key.C), "Key is not down")
@@ -128,7 +128,7 @@ class KeyInputTest {
             }
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             performKeyInput {
                 pressKey(Key.C)
             }
@@ -154,9 +154,9 @@ class KeyInputTest {
             }
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             performKeyInput {
-                withKeyDown(Key.ShiftLeft){
+                withKeyDown(Key.ShiftLeft) {
                     pressKey(Key.C)
                 }
             }
@@ -192,9 +192,9 @@ class KeyInputTest {
             }
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             performKeyInput {
-                withKeyToggled(Key.CapsLock){
+                withKeyToggled(Key.CapsLock) {
                     assertTrue(isCapsLockOn)
                     pressKey(Key.C)
                 }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/MouseInputTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/MouseInputTest.kt
@@ -376,7 +376,7 @@ class MouseInputTest {
                 Modifier
                     .testTag("tag")
                     .size(100.dp)
-                    .pointerInput(Unit){
+                    .pointerInput(Unit) {
                         detectDragGestures { _, dragAmount ->
                             dragOffset += dragAmount
                         }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -54,7 +54,7 @@ class TestBasicsTest {
         runSkikoComposeUiTest {
             var globalValue by atomic(0)
             setContent {
-                var localValue by remember{ mutableStateOf(0) }
+                var localValue by remember { mutableStateOf(0) }
 
                 remember(localValue) {
                     globalValue = localValue
@@ -94,7 +94,7 @@ class TestBasicsTest {
             var text by remember { mutableStateOf("1") }
             Text(text, modifier = Modifier.testTag("text"))
 
-            LaunchedEffect(Unit){
+            LaunchedEffect(Unit) {
                 delay(1_000)
                 text = "2"
             }
@@ -132,7 +132,7 @@ class TestBasicsTest {
         assertEquals(20, screenshot.width)
         assertEquals(20, screenshot.height)
 
-        IntArray(20*20).let { buffer ->
+        IntArray(20 * 20).let { buffer ->
             screenshot.readPixels(buffer)
             val expectedPixel = color.toArgb()
             for (pixel in buffer) {
@@ -152,7 +152,7 @@ class TestBasicsTest {
         }
 
         var isIdle = true
-        val idlingResource = object: IdlingResource {
+        val idlingResource = object : IdlingResource {
             override val isIdleNow: Boolean
                 get() = isIdle
         }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TextActionsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TextActionsTest.kt
@@ -51,7 +51,7 @@ class TextActionsTest {
             TestTextField("hello")
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             assertTextEquals("hello")
             performTextClearance()
             assertTextEquals("")
@@ -64,7 +64,7 @@ class TextActionsTest {
             TestTextField("hello")
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             assertTextEquals("hello")
             performTextReplacement("compose")
             assertTextEquals("compose")
@@ -77,7 +77,7 @@ class TextActionsTest {
             TestTextField("compose")
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             assertTextEquals("compose")
             performTextInput("hello ")
             assertTextEquals("hello compose")  // The caret is at 0 initially
@@ -90,7 +90,7 @@ class TextActionsTest {
             TestTextField("hello")
         }
 
-        with(rule.onNodeWithTag("tag")){
+        with(rule.onNodeWithTag("tag")) {
             assertTextEquals("hello")
             performTextInputSelection(TextRange(5))
             performTextInput(" compose")

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -19,7 +19,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.WindowExceptionHandler
 import org.jetbrains.skiko.GraphicsApi
@@ -181,8 +184,9 @@ class ComposeDialog : JDialog {
             override val window: ComposeDialog get() = this@ComposeDialog
         }
         delegate.setContent(
-            onPreviewKeyEvent,
-            onKeyEvent,
+            onPreviewKeyEvent = onPreviewKeyEvent,
+            onKeyEvent = onKeyEvent,
+            modifier = Modifier.semantics { dialog() },
         ) {
             scope.content()
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -137,6 +137,7 @@ internal class ComposeWindowDelegate(
     fun setContent(
         onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
         onKeyEvent: (KeyEvent) -> Boolean = { false },
+        modifier: Modifier = Modifier,
         content: @Composable () -> Unit
     ) {
         bridge.setContent(
@@ -147,13 +148,14 @@ internal class ComposeWindowDelegate(
                 LocalWindow provides window,
                 LocalLayerContainer provides _pane
             ) {
-                WindowContentLayout(content)
+                WindowContentLayout(modifier, content)
             }
         }
     }
 
     @Composable
     private fun WindowContentLayout(
+        modifier: Modifier = Modifier,
         content: @Composable () -> Unit
     ){
         Layout(
@@ -163,6 +165,7 @@ internal class ComposeWindowDelegate(
                     modifier = Modifier.layoutId("UndecoratedWindowResizer")
                 )
             },
+            modifier = modifier,
             measurePolicy = { measurables, constraints ->
                 val resizerMeasurable = measurables.lastOrNull()?.let {
                     if (it.layoutId == "UndecoratedWindowResizer") it else null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.semantics.dialog
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 
 @Immutable
@@ -69,9 +71,13 @@ actual fun Dialog(
         popupPositionProvider = popupPositioner,
         focusable = true,
         if (properties.dismissOnClickOutside) onDismissRequest else null,
-        modifier = Modifier.drawBehind {
-            drawRect(Color.Black.copy(alpha = 0.4f))
-        },
+        modifier = Modifier
+            .drawBehind {
+                drawRect(Color.Black.copy(alpha = 0.4f))
+            }
+            .semantics {
+                dialog()
+            },
         onKeyEvent = {
             if (properties.dismissOnBackPress &&
                 it.type == KeyEventType.KeyDown && it.key == Key.Escape

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -21,7 +21,10 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.*
+import androidx.compose.ui.semantics.popup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 
 @Immutable
@@ -132,6 +135,7 @@ fun Popup(
     popupPositionProvider = popupPositionProvider,
     focusable = focusable,
     onClickOutside = if (focusable) onDismissRequest else null,
+    modifier = Modifier.semantics { popup() },
     onPreviewKeyEvent = onPreviewKeyEvent,
     onKeyEvent = onKeyEvent,
     content = content
@@ -201,9 +205,10 @@ actual fun Popup(
     content: @Composable () -> Unit
 ) {
     PopupLayout(
-        popupPositionProvider,
-        properties.focusable,
-        if (properties.dismissOnClickOutside) onDismissRequest else null,
+        popupPositionProvider = popupPositionProvider,
+        focusable = properties.focusable,
+        onClickOutside = if (properties.dismissOnClickOutside) onDismissRequest else null,
+        modifier = Modifier.semantics { popup() },
         onKeyEvent = {
             if (properties.dismissOnBackPress &&
                 it.type == KeyEventType.KeyDown && it.key == Key.Escape &&


### PR DESCRIPTION
## Proposed Changes

  - Add `dialog()` semantic property to `DialogWindow`.
  - Add `dialog()` semantic property to `Dialog`
  - Add `popup()` semantic property to `Popup`.
  

## Testing

Test: Added (and enabled) unit tests for this.
