### PR TITLE
Support singleLine and KeyboardAction on iOS

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -49,10 +49,10 @@ internal class UIKitTextInputService(
     private var currentImeActionHandler: ((ImeAction) -> Unit)? = null
 
     /**
-     * Workaround to prevent IME action from being called multiple times with hardware keyboards..
-     * With hardware return key long press, iOS sends multiple new line characters to the application,
-     * which makes UIKitTextInputService call the current IME action multiple times, since the current
-     * implementation depends on
+     * Workaround to prevent IME action from being called multiple times with hardware keyboards.
+     * When the hardware return key is held down, iOS sends multiple newline characters to the application,
+     * which makes UIKitTextInputService call the current IME action multiple times without an additional
+     * debouncing logic.
      *
      * @see _tempHardwareReturnKeyPressed is set to true when the return key is pressed with a
      * hardware keyboard.

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -396,7 +396,11 @@ internal class UIKitTextInputService(
 
     private fun imeActionRequired(): Boolean =
         currentImeOptions?.run {
-            singleLine || (imeAction != ImeAction.None && imeAction != ImeAction.Default)
+            singleLine || (
+                imeAction != ImeAction.None
+                    && imeAction != ImeAction.Default
+                    && !(imeAction == ImeAction.Search && _tempHardwareReturnKeyPressed)
+                )
         } ?: false
 
     private fun runImeActionIfRequired(): Boolean {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -406,7 +406,11 @@ internal class UIKitTextInputService(
             return false
         }
         if (!_tempImeActionIsCalledWithHardwareReturnKey) {
-            imeActionHandler(imeAction)
+            if (imeAction == ImeAction.Default) {
+                imeActionHandler(ImeAction.Done)
+            } else {
+                imeActionHandler(imeAction)
+            }
         }
         if (_tempHardwareReturnKeyPressed) {
             _tempImeActionIsCalledWithHardwareReturnKey = true

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -328,7 +328,7 @@ internal actual class ComposeWindow : UIViewController {
             input = uiKitTextInputService.skikoInput,
         )
         layer.setContent(
-            onKeyEvent = uiKitTextInputService::onKeyEvent,
+            onPreviewKeyEvent = uiKitTextInputService::onPreviewKeyEvent,
             content = {
                 CompositionLocalProvider(
                     LocalLayerContainer provides rootView,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.createSkiaLayer
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.interop.LocalLayerContainer
@@ -328,18 +327,21 @@ internal actual class ComposeWindow : UIViewController {
             platform = uiKitPlatform,
             input = uiKitTextInputService.skikoInput,
         )
-        layer.setContent(content = {
-            CompositionLocalProvider(
-                LocalLayerContainer provides rootView,
-                LocalUIViewController provides this,
-                LocalKeyboardOverlapHeightState provides keyboardOverlapHeightState,
-                LocalSafeAreaState provides safeAreaState,
-                LocalLayoutMarginsState provides layoutMarginsState,
-                LocalInterfaceOrientationState provides interfaceOrientationState,
-            ) {
-                content()
-            }
-        })
+        layer.setContent(
+            onKeyEvent = uiKitTextInputService::onKeyEvent,
+            content = {
+                CompositionLocalProvider(
+                    LocalLayerContainer provides rootView,
+                    LocalUIViewController provides this,
+                    LocalKeyboardOverlapHeightState provides keyboardOverlapHeightState,
+                    LocalSafeAreaState provides safeAreaState,
+                    LocalLayoutMarginsState provides layoutMarginsState,
+                    LocalInterfaceOrientationState provides interfaceOrientationState,
+                ) {
+                    content()
+                }
+            },
+        )
     }
 
     override fun traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
## Proposed Changes

### For iOS `singleLine` and `KeyboardAction` support 

  - Added `UIKitTextInputService.runImeActionRequired` that checks whether a keyboard action needs to be called and calls it if needed
  - Added `UIKitTextInputService.onPreviewKeyEvent` for hardware keyboard event debouncing
  - Made `UIKitTextInputService.skikoInput.insertText` call `UIKitTextInputService.runImeActionRequired` when the given character is a new line character
  - Prevented `UIKitTextInputService.skikoInput.insertText` from adding a new line character when `singleLine` is `true` or a keyboard action needs to be called
  - Passed `UIKitTextInputService::onPreviewKeyEvent` to `ComposeLayer.setContent` from `ComposeWindow`
  - Added return key press event debouncing logic when calling an IME action

On some Android devices, the behavior of text fields is different when with hardware keyboards and with software keyboards. As you can see in the video below, on Android, the behavior of `ImeAction.Search` with `singleLine = false` is different, where the `Search` action is called with software keyboards while not called with hardware keyboards. Also, on some virtual Android devices (for me, it was Resizable (Experimental) API 33), when `singleLine` is `true` and the current IME action is `ImeAction.Default`, the `Done` action is called with software keyboards while not called with hardware keyboards.

The current behavior of text fields in this PR is as follows. When an IME action is called, the new line character is always prevented from being added. 
<table>
 <tr>
  <th>Actions</th>
  <th><code>singleLine = true</code></th>
  <th><code>singleLine = false</code></th>
 </tr>
 <tr>
  <th><code>ImeAction.Default</code></th>
  <td>Calls the <code>Done</code> action.</td>
  <td>Does nothing</td>
 </tr>
 <tr>
  <th><code>ImeAction.None</code></th>
  <td>Prevents a new line character from being added.</td>
  <td>Does nothing</td>
 </tr>
 <tr>
  <th><code>ImeAction.Search</code></th>
  <td>Calls the <code>Search</code> action.</td>
  <td>Calls the <code>Search</code> action only when the software keyboard is used, does nothing otherwise</td>
 </tr>
 <tr>
  <th>Others</th>
  <td colspan="2">Calls the corresponding action regardless of the value of <code>singleLine</code>.</td>
 </tr>
</table>

### For iOS hardware keyboard bug fix

  - Made `UIKitTextInputService.onPreviewKeyEvent` consume `KEY_ENTER` and `KEY_BACKSPACE` down events to prevent double new line characters or double character removing when using hardware keyboards

## Testing

Test: Tested using the [Android & iOS template](https://github.com/Jetbrains/compose-multiplatform-ios-android-template) with the following configuration:

* (Ground Truth) Galaxy Tab S8 with Samsung Keyboard
* (Ground Truth) Galaxy Tab S8 with a hardware keyboard (via Bluetooth)
* iPad Pro, 11-inch (3rd generation) (iOS 16.5.1) with the system keyboard
* iPad Pro, 11-inch (3rd generation) (iOS 16.5.1) with Magic Keyboard (via [Universal Control](https://support.apple.com/en-us/HT212757), but Bluetooth works the same)

`App.kt` is modified as the code below.

## Issues Fixed

Fixes: JetBrains/compose-multiplatform#2794

## Test Code

```kotlin
private val imeActions = arrayOf(
    ImeAction.Default,
    ImeAction.Done,
    ImeAction.Go,
    ImeAction.Next,
    ImeAction.None,
    ImeAction.Previous,
    ImeAction.Search,
    ImeAction.Send,
)

@Composable
fun App() {
    MaterialTheme {
        var currentAction by remember { mutableStateOf(ImeAction.Default) }
        val (singleLine, setSingleLine) = remember { mutableStateOf(false) }
        val (value, setValue) = remember { mutableStateOf("") }
        val keyboardActionsCalled = remember { mutableStateListOf<String>() }
        LaunchedEffect(keyboardActionsCalled.toTypedArray()) {
            delay(0.5.seconds)
            if (keyboardActionsCalled.isNotEmpty()) {
                keyboardActionsCalled.removeLast()
            }
        }
        Column {
            Row(
                modifier = Modifier.horizontalScroll(rememberScrollState()),
                horizontalArrangement = Arrangement.spacedBy(20.dp),
            ) {
                imeActions.forEach { action ->
                    Row {
                        RadioButton(
                            selected = currentAction == action,
                            onClick = { currentAction = action },
                        )
                        Text(action.toString())
                    }
                }
            }
            Row {
                Checkbox(singleLine, setSingleLine)
                Text("Single Line")
            }
            keyboardActionsCalled.forEach {
                Text("$it is called")
            }
            Row {
                TextField(
                    value = value,
                    onValueChange = setValue,
                    keyboardOptions = KeyboardOptions(
                        imeAction = currentAction
                    ),
                    keyboardActions = KeyboardActions(
                        onDone = { keyboardActionsCalled += "Done" },
                        onGo = { keyboardActionsCalled += "Go" },
                        onNext = { keyboardActionsCalled += "Next" },
                        onPrevious = { keyboardActionsCalled += "Previous" },
                        onSearch = { keyboardActionsCalled += "Search" },
                        onSend = { keyboardActionsCalled += "Send" },
                    ),
                    singleLine = singleLine,
                )
                Button({ setValue("") }) {
                    Text("Clear")
                }
            }
        }
    }
}
```

## Test Results (iOS `singleLine` and `KeyboardAction` support)

https://github.com/JetBrains/compose-multiplatform-core/assets/17005454/153248dd-a542-4e80-883b-7a9fef0e2768

https://github.com/JetBrains/compose-multiplatform-core/assets/17005454/2f416242-8468-4d93-8679-1457c997a7cb

https://github.com/JetBrains/compose-multiplatform-core/assets/17005454/288c2e67-ed34-4a4c-a077-ae4079d3d768

https://github.com/JetBrains/compose-multiplatform-core/assets/17005454/9bc86c0d-c9b9-4490-83d1-e959b0ff9e81

## Test Results (iOS hardware keyboard bug fix)

Tested with `hello <return> <return> world <backspace> <backspace>`.

Before the fix:

https://github.com/JetBrains/compose-multiplatform-core/assets/17005454/6387b86e-1e48-4a99-80b5-b6be5da67d66

After the fix:

https://github.com/JetBrains/compose-multiplatform-core/assets/17005454/13383062-a900-4bc4-955a-3e3a250572c1
