### PR TITLE
Improve iOS scroll UX

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/FlingBehavior.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/FlingBehavior.uikit.kt
@@ -27,6 +27,11 @@ internal actual fun rememberFlingBehavior(): FlingBehavior {
     val density = LocalDensity.current.density
 
     return remember(density) {
-        DefaultFlingBehavior(CupertinoScrollDecayAnimationSpec().generateDecayAnimationSpec())
+        val velocityThreshold = 500f * density
+
+        DefaultFlingBehavior(
+            flingDecay = CupertinoScrollDecayAnimationSpec().generateDecayAnimationSpec(),
+            velocityThreshold = velocityThreshold
+        )
     }
 }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/FlingBehavior.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/FlingBehavior.uikit.kt
@@ -27,6 +27,7 @@ internal actual fun rememberFlingBehavior(): FlingBehavior {
     val density = LocalDensity.current.density
 
     return remember(density) {
+        // this value is determined by iOS 16 fling behavior reverse-engenering
         val velocityThreshold = 500f * density
 
         DefaultFlingBehavior(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -280,6 +280,7 @@ internal actual class ComposeWindow : UIViewController {
                     override val longPressTimeoutMillis: Long get() = 500
                     override val doubleTapTimeoutMillis: Long get() = 300
                     override val doubleTapMinTimeMillis: Long get() = 40
+                    // this value is determined by iOS 16 drag behavior reverse-engenering
                     override val touchSlop: Float get() = with(density) { 10.dp.toPx() }
                 }
             override val textToolbar = object : TextToolbar {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -280,7 +280,7 @@ internal actual class ComposeWindow : UIViewController {
                     override val longPressTimeoutMillis: Long get() = 500
                     override val doubleTapTimeoutMillis: Long get() = 300
                     override val doubleTapMinTimeMillis: Long get() = 40
-                    override val touchSlop: Float get() = with(density) { 3.dp.toPx() }
+                    override val touchSlop: Float get() = with(density) { 10.dp.toPx() }
                 }
             override val textToolbar = object : TextToolbar {
                 override fun showMenu(


### PR DESCRIPTION
## Proposed Changes

Make touchSlop match native UIPanGestureRecognizer on iOS.
Add fling min velocity threshold for iOS.

## Testing

Test: scrolling should feel better, there shouldn't be unwanted scroll [except invalid quadratic fit bug (second video)](https://github.com/JetBrains/compose-multiplatform/issues/3335) during drag-stop-up touch sequence.

## Fixes

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3397, and a part of the aforementioned issue.