### PR TITLE
Popup. Fix overriding `pressOwner` on multitouch

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -172,10 +172,10 @@ class ComposeScene internal constructor(
         }
     }
 
-    private inline fun <T> reversedOwners(action: (List<SkiaBasedOwner>) -> T): T {
+    private inline fun forEachOwnerReversed(action: (SkiaBasedOwner) -> Unit) {
         listCopy.addAll(owners)
         try {
-            return action(listCopy.asReversed())
+            listCopy.asReversed().forEach(action)
         } finally {
             listCopy.clear()
         }
@@ -600,11 +600,12 @@ class ComposeScene internal constructor(
     }
 
     private fun processPress(event: PointerInputEvent) {
-        val owner = reversedOwners {
-            for (owner in it) {
+        forEachOwnerReversed { owner ->
             if (owner.isHovered(event)) {
                 // Stop once the position of in bounds of the owner
-                    return@reversedOwners owner
+                owner.processPointerInput(event)
+                pressOwner = owner
+                return@processPress
             }
             owner.onClickOutside?.invoke()
             if (owner == focusedOwner) {
@@ -612,10 +613,6 @@ class ComposeScene internal constructor(
                 return@processPress
             }
         }
-            return@reversedOwners null
-        }
-        owner?.processPointerInput(event)
-        pressOwner = owner
     }
 
     private fun processRelease(event: PointerInputEvent) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -600,6 +600,11 @@ class ComposeScene internal constructor(
     }
 
     private fun processPress(event: PointerInputEvent) {
+        val previousPressOwner = pressOwner
+        if (previousPressOwner != null) {
+            previousPressOwner.processPointerInput(event)
+            return
+        }
         forEachOwnerReversed { owner ->
             if (owner.isHovered(event)) {
                 // Stop once the position of in bounds of the owner

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.platform.*
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachReversed
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.Volatile
 import kotlinx.coroutines.*
@@ -166,7 +168,7 @@ class ComposeScene internal constructor(
     private inline fun forEachOwner(action: (SkiaBasedOwner) -> Unit) {
         listCopy.addAll(owners)
         try {
-            listCopy.forEach(action)
+            listCopy.fastForEach(action)
         } finally {
             listCopy.clear()
         }
@@ -175,7 +177,7 @@ class ComposeScene internal constructor(
     private inline fun forEachOwnerReversed(action: (SkiaBasedOwner) -> Unit) {
         listCopy.addAll(owners)
         try {
-            listCopy.asReversed().forEach(action)
+            listCopy.fastForEachReversed(action)
         } finally {
             listCopy.clear()
         }
@@ -648,7 +650,7 @@ class ComposeScene internal constructor(
      * events. Returns true if [event] is consumed.
      */
     private fun processHover(event: PointerInputEvent, owner: SkiaBasedOwner?): Boolean {
-        if (!event.pointers.fastAny { it.type == PointerType.Mouse }) {
+        if (event.pointers.fastAny { it.type != PointerType.Mouse }) {
             // Track hover only for mouse
             return false
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -323,8 +323,8 @@ class ComposeScene internal constructor(
         if (owner == focusedOwner) {
             focusedOwner = owners.lastOrNull { it.focusable }
         }
-        if (owner == lastMoveOwner) {
-            lastMoveOwner = null
+        if (owner == lastHoverOwner) {
+            lastHoverOwner = null
         }
         if (owner == pressOwner) {
             pressOwner = null
@@ -455,7 +455,7 @@ class ComposeScene internal constructor(
 
     private var focusedOwner: SkiaBasedOwner? = null
     private var pressOwner: SkiaBasedOwner? = null
-    private var lastMoveOwner: SkiaBasedOwner? = null
+    private var lastHoverOwner: SkiaBasedOwner? = null
     private fun hoveredOwner(event: PointerInputEvent): SkiaBasedOwner? =
         owners.lastOrNull { it.isHovered(event) }
 
@@ -602,16 +602,16 @@ class ComposeScene internal constructor(
     private fun processPress(event: PointerInputEvent) {
         val owner = reversedOwners {
             for (owner in it) {
-                if (owner.isHovered(event)) {
-                    // Stop once the position of in bounds of the owner
+            if (owner.isHovered(event)) {
+                // Stop once the position of in bounds of the owner
                     return@reversedOwners owner
-                }
-                owner.onClickOutside?.invoke()
-                if (owner == focusedOwner) {
-                    // Stop if it's in focus, do not pass the event to hovered owner
-                    return@processPress
-                }
             }
+            owner.onClickOutside?.invoke()
+            if (owner == focusedOwner) {
+                // Stop if it's in focus, do not pass the event to hovered owner
+                return@processPress
+            }
+        }
             return@reversedOwners null
         }
         owner?.processPointerInput(event)
@@ -633,28 +633,43 @@ class ComposeScene internal constructor(
             // If pressOwner is under focusedOwner, hover state must be updated
             owner = null
         }
+        if (processHover(event, owner)) {
+            return
+        }
+        owner?.processPointerInput(
+            event.copy(eventType = PointerEventType.Move)
+        )
+    }
 
+    /**
+     * Updates hover state and generates [PointerEventType.Enter] and [PointerEventType.Exit]
+     * events. Returns true if [event] is consumed.
+     */
+    private fun processHover(event: PointerInputEvent, owner: SkiaBasedOwner?): Boolean {
+        if (!event.pointers.fastAny { it.type == PointerType.Mouse }) {
+            // Track hover only for mouse
+            return false
+        }
         // Cases:
         // - move from outside to the window (owner != null, lastMoveOwner == null): Enter
         // - move from the window to outside (owner == null, lastMoveOwner != null): Exit
         // - move from one point of the window to another (owner == lastMoveOwner): Move
         // - move from one popup to another (owner != lastMoveOwner): [Popup 1] Exit, [Popup 2] Enter
-
-        if (owner != lastMoveOwner && event.pointers.fastAny { it.type == PointerType.Mouse }) {
-            lastMoveOwner?.processPointerInput(
-                event.copy(eventType = PointerEventType.Exit),
-                isInBounds = false
-            )
-            owner?.processPointerInput(
-                event.copy(eventType = PointerEventType.Enter)
-            )
-        } else {
-            owner?.processPointerInput(
-                event.copy(eventType = PointerEventType.Move)
-            )
+        if (owner == lastHoverOwner) {
+            // Owner wasn't changed
+            return false
         }
+        lastHoverOwner?.processPointerInput(
+            event.copy(eventType = PointerEventType.Exit),
+            isInBounds = false
+        )
+        owner?.processPointerInput(
+            event.copy(eventType = PointerEventType.Enter)
+        )
+        lastHoverOwner = owner
 
-        lastMoveOwner = owner
+        // Changing hovering state replaces Move event, so treat it as consumed
+        return true
     }
 
     private fun processScroll(event: PointerInputEvent) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -16,25 +16,31 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.runtime.*
-import androidx.compose.ui.*
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.FillBox
+import androidx.compose.ui.PopupState
+import androidx.compose.ui.assertReceived
+import androidx.compose.ui.assertReceivedLast
+import androidx.compose.ui.assertReceivedNoEvents
+import androidx.compose.ui.assertThat
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.touch
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
@@ -452,5 +458,49 @@ class PopupTest {
         scene.sendPointerEvent(PointerEventType.Move, Offset(11f, 11f), buttons = buttons)
         scene.sendPointerEvent(PointerEventType.Release, Offset(11f, 11f), button = PointerButton.Primary)
         background.events.assertReceivedNoEvents()
+    }
+
+    @Test
+    fun secondClickDoesNotDismissPopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val popup = PopupState(
+            IntRect(20, 20, 60, 60),
+            dismissOnClickOutside = true,
+            onDismissRequest = { fail() }
+        )
+
+        setContent {
+            background.Content()
+            popup.Content()
+        }
+
+        scene.sendPointerEvent(
+            PointerEventType.Press,
+            pointers = listOf(
+                touch(50f, 50f, pressed = true, id = 1),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Press,
+            pointers = listOf(
+                touch(50f, 50f, pressed = true, id = 1),
+                touch(10f, 10f, pressed = true, id = 2),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release,
+            pointers = listOf(
+                touch(50f, 50f, pressed = false, id = 1),
+                touch(10f, 10f, pressed = true, id = 2),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release,
+            pointers = listOf(
+                touch(10f, 10f, pressed = false, id = 2),
+            )
+        )
     }
 }


### PR DESCRIPTION
## Proposed Changes

It's part of #691

- Do not override `pressOwner` on second simultaneous `Press` event (second touch or second button);
- Refactor handling hover owner (move to separate function for future re-use). No behaviour change here.

## Testing

Test: run tests from `PopupTest` or play with `Popup` in test application.

This video shows expected behaviour (on Android). It does NOT dismiss `Popup` and does not send events to background if they initiated by _second_ touch while first touch belongs to `Popup`

https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/b0675947-a7f1-44cf-8d03-af70cde8d999

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3349
