### PR TITLE
Fix running Compose application after ProGuard optimizations.

### DIFF
--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/SpringEstimation.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/SpringEstimation.kt
@@ -247,8 +247,7 @@ private fun estimateOverDamped(
         // By finding a point between when concavity changes, and when the inflection point is,
         // Newton's method will always converge onto the rightmost point (in this case),
         // the one that we are interested in.
-        val tConcavChange = ln(-(c2 * r2 * r2) / (c1 * r1 * r1)) / (r1 - r2)
-        tCurr = tConcavChange
+        tCurr = ln(-(c2 * r2 * r2) / (c1 * r1 * r1)) / (r1 - r2)
         delta
     }
 


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3387

It is a bug of ProGuard, it can't properly inline variables in some cases.

## Test
1. export COMPOSE_CUSTOM_VERSION=46436.333.66
2. ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=jvm

3. Open https://github.com/JetBrains/compose-multiplatform-desktop-template

4. Insert this code:
```
import androidx.compose.animation.AnimatedVisibility
import androidx.compose.material.Text
import androidx.compose.ui.window.singleWindowApplication

fun main() {
    singleWindowApplication {
        AnimatedVisibility(true) {
            Text("Text")
        }
    }
}
```
5. ./gradlew runReleaseDistributable

It runs without crashes after the fix. Before the fix it crashes with the crash:
```
Exception in thread "main" java.lang.VerifyError: Instruction type does not match stack map
Exception Details:
  Location:
    androidx/compose/animation/AnimatedVisibilityKt.estimateAnimationDurationMillis(FFFFF)J @504: dload
```

Also checked on [codeviewer](https://github.com/JetBrains/compose-multiplatform/tree/bf4130cfab8ad730e17c0f856a3a55848cd75091/examples/codeviewer) example