### PR TITLE
Fix click outside dialog behaviour

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -641,20 +641,27 @@ class ComposeScene internal constructor(
     }
 
     private fun processRelease(event: PointerInputEvent) {
-        // Send Release to pressOwner even if is not hovered or under focused
-        pressOwner?.processPointerInput(event)
+        fun isOutsideFocusedOwner(): Boolean {
+            if (pressOwner != null) {
+                // The gesture started not outside of owner
+                return false
+            }
+            if (event.isAnyPointerDown) {
+                // The last pointer was not released yet
+                return false
+            }
 
-        // Process further only if last pointer was released or had pressOwner
-        if (event.isAnyPointerDown || pressOwner != null) {
-            return
-        }
-
-        val owner = hoveredOwner(event)
-        if (!isInteractive(owner)) {
             // If hovered owner is not interactive, then it means that
             // - It's not focusedOwner
             // - It placed under focusedOwner or not exist at all
             // In all these cases the even happened outside focused owner bounds
+            val owner = hoveredOwner(event)
+            return !isInteractive(owner)
+        }
+
+        // Send Release to pressOwner even if is not hovered or under focusedOwner
+        pressOwner?.processPointerInput(event)
+        if (isOutsideFocusedOwner()) {
             focusedOwner?.onOutsidePointerEvent?.invoke(event)
         }
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -307,6 +307,8 @@ class ComposeScene internal constructor(
         invalidateIfNeeded()
         if (owner.focusable) {
             focusedOwner = owner
+
+            // Exit event to lastHoverOwner will be sent via synthetic event on next frame
         }
         if (isFocused) {
             owner.focusOwner.takeFocus()
@@ -458,12 +460,22 @@ class ComposeScene internal constructor(
     private var focusedOwner: SkiaBasedOwner? = null
     private var pressOwner: SkiaBasedOwner? = null
     private var lastHoverOwner: SkiaBasedOwner? = null
-    private fun hoveredOwner(event: PointerInputEvent): SkiaBasedOwner? =
-        owners.lastOrNull { it.isHovered(event) }
 
-    private fun SkiaBasedOwner?.isAbove(
-        targetOwner: SkiaBasedOwner?
-    ) = this != null && targetOwner != null && owners.indexOf(this) > owners.indexOf(targetOwner)
+    /**
+     * Find hovered owner for position of first pointer.
+     */
+    private fun hoveredOwner(event: PointerInputEvent): SkiaBasedOwner? {
+        val position = event.pointers.first().position
+        return owners.lastOrNull { it.isInBounds(position) }
+    }
+
+    /**
+     * Check if [focusedOwner] blocks input for this owner.
+     */
+    private fun isInteractive(owner: SkiaBasedOwner?) =
+        focusedOwner == null || owner == null ||
+            owners.indexOf(focusedOwner) <= owners.indexOf(owner)
+
 
     // TODO(demin): return Boolean (when it is consumed)
     /**
@@ -596,6 +608,7 @@ class ComposeScene internal constructor(
             PointerEventType.Scroll -> processScroll(event)
         }
 
+        // Clean pressOwner when there is no pressed pointers/buttons
         if (!event.isAnyPointerDown) {
             pressOwner = null
         }
@@ -607,34 +620,59 @@ class ComposeScene internal constructor(
             previousPressOwner.processPointerInput(event)
             return
         }
+        val position = event.pointers.first().position
         forEachOwnerReversed { owner ->
-            if (owner.isHovered(event)) {
-                // Stop once the position of in bounds of the owner
+
+            // If the position of in bounds of the owner - send event to it and stop processing
+            if (owner.isInBounds(position)) {
                 owner.processPointerInput(event)
                 pressOwner = owner
-                return@processPress
+                return
             }
-            owner.onClickOutside?.invoke()
+
+            // Input event is out of bounds - send click outside notification
+            owner.onOutsidePointerEvent?.invoke(event)
+
+            // if the owner is in focus, do not pass the event to underlying owners
             if (owner == focusedOwner) {
-                // Stop if it's in focus, do not pass the event to hovered owner
-                return@processPress
+                return
             }
         }
     }
 
     private fun processRelease(event: PointerInputEvent) {
-        // Send Release to pressOwner even if is not hovered or under focused.
+        // Send Release to pressOwner even if is not hovered or under focused
         pressOwner?.processPointerInput(event)
+
+        // Process further only if last pointer was released or had pressOwner
+        if (event.isAnyPointerDown || pressOwner != null) {
+            return
+        }
+
+        val owner = hoveredOwner(event)
+        if (!isInteractive(owner)) {
+            // If hovered owner is not interactive, then it means that
+            // - It's not focusedOwner
+            // - It placed under focusedOwner or not exist at all
+            // In all these cases the even happened outside focused owner bounds
+            focusedOwner?.onOutsidePointerEvent?.invoke(event)
+        }
     }
 
     private fun processMove(event: PointerInputEvent) {
         var owner = when {
+            // All touch events or mouse with pressed button(s)
             event.isAnyPointerDown -> pressOwner
+
+            // Do not generate Enter and Move
             event.eventType == PointerEventType.Exit -> null
+
+            // Find owner under mouse position
             else -> hoveredOwner(event)
         }
-        if (focusedOwner.isAbove(owner)) {
-            // If pressOwner is under focusedOwner, hover state must be updated
+
+        // Even if the owner is not interactive, hover state still need to be updated
+        if (!isInteractive(owner)) {
             owner = null
         }
         if (processHover(event, owner)) {
@@ -678,10 +716,9 @@ class ComposeScene internal constructor(
 
     private fun processScroll(event: PointerInputEvent) {
         val owner = hoveredOwner(event)
-        if (focusedOwner.isAbove(owner)) {
-            return
+        if (isInteractive(owner)) {
+            owner?.processPointerInput(event)
         }
-        owner?.processPointerInput(event)
     }
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -75,16 +75,13 @@ internal class SkiaBasedOwner(
     initLayoutDirection: LayoutDirection = platform.layoutDirection,
     bounds: IntRect = IntRect.Zero,
     val focusable: Boolean = true,
-    val onClickOutside: (() -> Unit)? = null,
+    val onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     private val onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
     private val onKeyEvent: (KeyEvent) -> Boolean = { false },
 ) : Owner, RootForTest, SkiaRootForTest, PositionCalculator {
     override val windowInfo: WindowInfo get() = platform.windowInfo
 
-    fun isHovered(event: PointerInputEvent) =
-        isHovered(event.pointers.first().position)
-
-    private fun isHovered(point: Offset): Boolean {
+    fun isInBounds(point: Offset): Boolean {
         val intOffset = IntOffset(point.x.toInt(), point.y.toInt())
         return bounds.contains(intOffset)
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
@@ -36,8 +37,8 @@ import androidx.compose.ui.unit.round
 internal fun PopupLayout(
     popupPositionProvider: PopupPositionProvider,
     focusable: Boolean,
-    onClickOutside: (() -> Unit)?,
     modifier: Modifier = Modifier,
+    onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     content: @Composable () -> Unit
@@ -73,7 +74,7 @@ internal fun PopupLayout(
             initDensity = density,
             initLayoutDirection = layoutDirection,
             focusable = focusable,
-            onClickOutside = onClickOutside,
+            onOutsidePointerEvent = onOutsidePointerEvent,
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = onKeyEvent
         )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -18,16 +18,27 @@ package androidx.compose.ui.window
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.DialogState
+import androidx.compose.ui.FillBox
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.assertReceived
+import androidx.compose.ui.assertReceivedLast
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertPositionInRootIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.touch
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.fail
 
 @OptIn(ExperimentalTestApi::class)
 class DialogTest {
@@ -46,5 +57,151 @@ class DialogTest {
             }
         }
         onNodeWithTag(dialog.tag).assertPositionInRootIsEqualTo(30.dp, 30.dp)
+    }
+
+    @Test
+    fun openDialog() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val openDialog = mutableStateOf(false)
+        val background = FillBox {
+            openDialog.value = true
+        }
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = {
+                openDialog.value = false
+            }
+        )
+
+        setContent {
+            background.Content()
+            if (openDialog.value) {
+                dialog.Content()
+            }
+        }
+
+        // Click (Press-Release cycle) opens popup and sends all events to "background"
+        val buttons = PointerButtons(
+            isPrimaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+        onNodeWithTag(dialog.tag).assertIsDisplayed()
+
+        background.events.assertReceived(PointerEventType.Press, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Release, Offset(10f, 10f))
+    }
+
+    @Test
+    fun closeDialog() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val openDialog = mutableStateOf(false)
+        val background = FillBox {
+            openDialog.value = true
+        }
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = {
+                openDialog.value = false
+            }
+        )
+
+        setContent {
+            background.Content()
+            if (openDialog.value) {
+                dialog.Content()
+            }
+        }
+
+        // Moving without popup generates Enter because it's in bounds
+        scene.sendPointerEvent(PointerEventType.Move, Offset(15f, 15f))
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(15f, 15f))
+
+        // Open dialog
+        openDialog.value = true
+        onNodeWithTag(dialog.tag).assertIsDisplayed()
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(15f, 15f))
+
+        // Click (Press-Move-Release cycle) outside closes popup and sends only Enter event to background
+        val buttons = PointerButtons(
+            isPrimaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
+        onNodeWithTag(dialog.tag).assertIsDisplayed() // Close should happen only on Release event
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(11f, 11f), buttons = buttons)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(11f, 11f), button = PointerButton.Primary)
+        onNodeWithTag(dialog.tag).assertDoesNotExist()
+
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
+    }
+
+    @Test
+    fun secondClickDoesNotDismissPopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = {
+                fail()
+            }
+        )
+
+        setContent {
+            background.Content()
+            dialog.Content()
+        }
+
+        scene.sendPointerEvent(
+            PointerEventType.Press,
+            pointers = listOf(
+                touch(50f, 50f, pressed = true, id = 1),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Press,
+            pointers = listOf(
+                touch(50f, 50f, pressed = true, id = 1),
+                touch(10f, 10f, pressed = true, id = 2),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release,
+            pointers = listOf(
+                touch(50f, 50f, pressed = false, id = 1),
+                touch(10f, 10f, pressed = true, id = 2),
+            )
+        )
+        scene.sendPointerEvent(
+            PointerEventType.Release,
+            pointers = listOf(
+                touch(10f, 10f, pressed = false, id = 2),
+            )
+        )
+    }
+
+    @Test
+    fun nonPrimaryButtonClickDoesNotDismissDialog() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val dialog = DialogState(
+            IntSize(40, 40),
+            onDismissRequest = { fail() }
+        )
+
+        setContent {
+            background.Content()
+            dialog.Content()
+        }
+
+        val buttons = PointerButtons(
+            isSecondaryPressed = true
+        )
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Secondary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Secondary)
     }
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -81,6 +81,8 @@ class DialogTest {
             }
         }
 
+        onNodeWithTag(dialog.tag).assertDoesNotExist()
+
         // Click (Press-Release cycle) opens popup and sends all events to "background"
         val buttons = PointerButtons(
             isPrimaryPressed = true


### PR DESCRIPTION
## Proposed Changes

It's part of #691

- Replace `onClickOutside` to `onOutsidePointerEvent` to allow specify filtering by event type or by specific mouse button;
- Dismiss `Dialog` only on mouse primary button click;
- Dismiss `Dialog` on `Release` instead of `Press` event;

Internal refactor:

- `focusedOwner.isAbove` -> `isInteractive`
- More comments
- Add `DialogTest`

## Testing

Test: run tests from `PopupTest` and `DialogTest`
