### PR TITLE
Update mouse pointer icon when hovered element goes away

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -104,6 +105,15 @@ fun Modifier.pointerHoverIcon(icon: PointerIcon, overrideDescendants: Boolean = 
                     overrideDescendants = overrideDescendants,
                     onSetIcon = onSetIcon
                 )
+            }
+            // Temporary fix for b/293219235
+            // TODO: Replace it with the fix from upstream
+            DisposableEffect(Unit) {
+                onDispose {
+                    if (pointerIconModifierLocal.isHovered) {
+                        pointerIconModifierLocal.exit()
+                    }
+                }
             }
             val pointerInputModifier = if (pointerIconModifierLocal.shouldUpdatePointerIcon()) {
                 pointerInput(pointerIconModifierLocal) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -17,9 +17,12 @@
 package androidx.compose.ui.input.pointer
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
@@ -282,6 +285,36 @@ class PointerIconTest {
             frameDispatcher.cancel()
         }
     }
+
+    @Test
+    fun resetsToDefault() = ImageComposeScene(
+        width = 100, height = 100
+    ).use { scene ->
+        var show by mutableStateOf(true)
+        scene.setContent {
+            CompositionLocalProvider(LocalPointerIconService provides iconService) {
+                Box(Modifier.fillMaxSize()) {
+                    if (show) {
+                        Box(
+                            modifier = Modifier
+                                .pointerHoverIcon(PointerIcon.Text)
+                                .size(10.dp, 10.dp)
+                        )
+                    }
+                }
+            }
+        }
+
+        assertThat(iconService.getIcon()).isEqualTo(PointerIcon.Default)
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(5f, 5f))
+        assertThat(iconService.getIcon()).isEqualTo(PointerIcon.Text)
+
+        show = false
+        scene.render()
+        assertThat(iconService.getIcon()).isEqualTo(PointerIcon.Default)
+    }
+
 
     private class IconPlatform : Platform by Platform.Empty {
         @Suppress("PropertyName")


### PR DESCRIPTION
When a hovered element with `Modifier.pointerHoverIcon` is removed, the pointer isn't being reset to the default one. 
See https://issuetracker.google.com/issues/293219235 for more details.

## Proposed Changes

Call `pointerIconModifierLocal.exit()` when the `Modifier.pointerHoverIcon` modifier is being disposed.

## Testing

Test: Added a new unit test.
