### PR TITLE
Fix dialog position provider 

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -28,6 +28,7 @@ val MainScreen = Screen.Selection(
     Screen.FullscreenExample("ApplicationLayouts") { ApplicationLayouts(it) },
     Screen.Example("GraphicsLayerSettings") { GraphicsLayerSettings() },
     Screen.Example("Blending") { Blending() },
+    Screen.Example("Popup & Dialog") { PopupAndDialog() },
     LazyLayouts,
     TextFields,
     AndroidTextFieldSamples,

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/PopupAndDialog.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/PopupAndDialog.kt
@@ -1,0 +1,161 @@
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+
+@Composable
+fun PopupAndDialog() {
+    Column(Modifier.padding(5.dp)) {
+        PopupSample()
+        DialogSample()
+    }
+}
+
+@Composable
+private fun PopupSample() {
+    var popup1 by remember { mutableStateOf(0) }
+    var popup2 by remember { mutableStateOf(0) }
+    var popup3 by remember { mutableStateOf(0) }
+    Button(onClick = { popup1++ }) {
+        Text("Popup")
+    }
+    if (popup1 > 0) {
+        MyPopup(
+            text = "Click count = $popup1",
+            offset = IntOffset(50, 50),
+            focusable = false,
+            onClose = { popup1 = 0 },
+            onNext = { popup2++ }
+        )
+    }
+
+    if (popup2 > 0) {
+        MyPopup(
+            text = "Click count = $popup2",
+            offset = IntOffset(200, 100),
+            focusable = true,
+            onClose = { popup2 = 0 },
+            onNext = { popup3++ }
+        )
+    }
+
+    if (popup3 > 0) {
+        MyPopup(
+            text = "Click count = $popup3",
+            offset = IntOffset(100, 200),
+            focusable = false,
+            onClose = { popup3 = 0 }
+        )
+    }
+}
+
+@Composable
+private fun MyPopup(
+    text: String,
+    offset: IntOffset,
+    focusable: Boolean,
+    onClose: () -> Unit,
+    onNext: (() -> Unit)? = null
+) {
+    val properties = PopupProperties(
+        focusable = focusable,
+        dismissOnBackPress = true,
+        dismissOnClickOutside = true
+    )
+    Popup(
+        offset = offset,
+        onDismissRequest = onClose,
+        properties = properties
+    ) {
+        Surface(
+            color = MaterialTheme.colors.background,
+            modifier = Modifier
+                .size(300.dp, 200.dp)
+                .border(1.dp, Color.Black)
+        ) {
+            Column(Modifier.padding(5.dp)) {
+                Text(text = text)
+                Text(text = "focusable = $focusable")
+                Text(text = "dismissOnBackPress = ${properties.dismissOnBackPress}")
+                Text(text = "dismissOnClickOutside = ${properties.dismissOnClickOutside}")
+                Spacer(modifier = Modifier.weight(1f))
+                Row {
+                    Button(
+                        modifier = Modifier.weight(1f),
+                        onClick = onClose
+                    ) {
+                        Text(text = "Close")
+                    }
+                    if (onNext != null) {
+                        Spacer(Modifier.size(5.dp))
+                        Button(
+                            modifier = Modifier.weight(1f),
+                            onClick = onNext
+                        ) {
+                            Text(text = "Next")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+@Composable
+private fun DialogSample() {
+    var showDialog by remember { mutableStateOf(false) }
+    if (showDialog) {
+        Dialog(
+            onDismissRequest = { showDialog = false },
+            properties = DialogProperties(
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true
+            )
+        ) {
+            Surface(
+                modifier = Modifier
+                    .size(400.dp, 300.dp),
+                shape = RoundedCornerShape(16.dp),
+                color = Color.Yellow
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center
+                ) {
+                    Button(
+                        onClick = { showDialog = false }
+                    ) {
+                        Text(text = "Close")
+                    }
+                }
+            }
+        }
+    }
+    Button(
+        onClick = { showDialog = true }
+    ) {
+        Text(text = "Dialog")
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -19,8 +19,6 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
@@ -34,6 +32,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.center
 
 @Immutable
 actual class DialogProperties actual constructor(
@@ -63,9 +62,8 @@ actual fun Dialog(
     properties: DialogProperties,
     content: @Composable () -> Unit
 ) {
-    val popupPositioner = remember { WindowCenterPositionProvider() }
     PopupLayout(
-        popupPositionProvider = popupPositioner,
+        popupPositionProvider = WindowCenterPositionProvider,
         focusable = true,
         if (properties.dismissOnClickOutside) onDismissRequest else null,
         modifier = Modifier
@@ -89,34 +87,11 @@ actual fun Dialog(
     )
 }
 
-private class WindowCenterPositionProvider : PopupPositionProvider {
+private object WindowCenterPositionProvider : PopupPositionProvider {
     override fun calculatePosition(
         anchorBounds: IntRect,
         windowSize: IntSize,
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize
-    ): IntOffset {
-        var popupPosition = IntOffset(0, 0)
-
-        // Get the aligned point inside the parent
-        val windowAlignmentPoint = Alignment.Center.align(
-            IntSize.Zero,
-            windowSize,
-            layoutDirection
-        )
-        // Get the aligned point inside the child
-        val relativePopupPos = Alignment.Center.align(
-            IntSize.Zero,
-            IntSize(popupContentSize.width, popupContentSize.height),
-            layoutDirection
-        )
-
-        // Add the distance between the parent's top left corner and the alignment point
-        popupPosition += windowAlignmentPoint
-
-        // Subtract the distance between the children's top left corner and the alignment point
-        popupPosition -= IntOffset(relativePopupPos.x, relativePopupPos.y)
-
-        return popupPosition
-    }
+    ): IntOffset = windowSize.center - popupContentSize.center
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
@@ -157,6 +159,34 @@ class PopupState(
                 Box(
                     Modifier
                         .requiredSize(bounds.width.toDp(), bounds.height.toDp())
+                        .collectEvents(events)
+                        .testTag(tag)
+                )
+            }
+        }
+    }
+}
+
+class DialogState(
+    val size: IntSize,
+    private val dismissOnClickOutside: Boolean = true,
+    private val onDismissRequest: () -> Unit = {}
+) {
+    val events = Events()
+    val tag = "dialog"
+
+    @Composable
+    fun Content() {
+        Dialog(
+            onDismissRequest = onDismissRequest,
+            properties = DialogProperties(
+                dismissOnClickOutside = dismissOnClickOutside
+            )
+        ) {
+            with(LocalDensity.current) {
+                Box(
+                    Modifier
+                        .requiredSize(size.width.toDp(), size.height.toDp())
                         .collectEvents(events)
                         .testTag(tag)
                 )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -33,7 +33,7 @@ import kotlin.test.Test
 class DialogTest {
 
     @Test
-    fun centerDialog() = runSkikoComposeUiTest(
+    fun dialogIsCenteredInWindow() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
     ) {
         val dialog = DialogState(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.DialogState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertPositionInRootIsEqualTo
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DialogTest {
+
+    @Test
+    fun centerDialog() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val dialog = DialogState(
+            IntSize(40, 40)
+        )
+
+        setContent {
+            Box(Modifier.size(10.dp)) {
+                dialog.Content()
+            }
+        }
+        onNodeWithTag(dialog.tag).assertPositionInRootIsEqualTo(30.dp, 30.dp)
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Fix calculating center position of `Dialog` - it's center of window instead of parent now;
- Add "Popup & Dialog" page to mpp demo app

## Testing

Test: run `DialogTest` or mpp app
