### PR TITLE
All `Popup` overloads call dismiss on `Esc` key by default

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -115,10 +115,6 @@ class DefaultContextMenuRepresentation(
                 onKeyEvent = {
                     if (it.type == KeyEventType.KeyDown) {
                         when (it.key.nativeKeyCode) {
-                            java.awt.event.KeyEvent.VK_ESCAPE -> {
-                                state.status = ContextMenuState.Status.Closed
-                                true
-                            }
                             java.awt.event.KeyEvent.VK_DOWN  -> {
                                 inputModeManager!!.requestInputMode(InputMode.Keyboard)
                                 focusManager!!.moveFocus(FocusDirection.Next)

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopAlertDialog.desktop.kt
@@ -368,14 +368,6 @@ object PopupAlertDialogProvider : AlertDialogProvider {
             },
             focusable = true,
             onDismissRequest = onDismissRequest,
-            onKeyEvent = {
-                if (it.type == KeyEventType.KeyDown && it.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
-                    onDismissRequest()
-                    true
-                } else {
-                    false
-                }
-            },
         ) {
             val scrimColor = Color.Black.copy(alpha = 0.32f) //todo configure scrim color in function arguments
             Box(

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -309,7 +309,7 @@ private fun OpenDropdownMenu(
         onDismissRequest = onDismissRequest,
         popupPositionProvider = popupPositionProvider,
         onKeyEvent = {
-            handlePopupOnKeyEvent(it, onDismissRequest, focusManager!!, inputModeManager!!)
+            handlePopupOnKeyEvent(it, focusManager!!, inputModeManager!!)
         },
     ) {
         focusManager = LocalFocusManager.current
@@ -363,14 +363,10 @@ fun DropdownMenuItem(
 @OptIn(ExperimentalComposeUiApi::class)
 private fun handlePopupOnKeyEvent(
     keyEvent: androidx.compose.ui.input.key.KeyEvent,
-    onDismissRequest: () -> Unit,
     focusManager: FocusManager,
     inputModeManager: InputModeManager
 ): Boolean {
-    return if (keyEvent.type == KeyEventType.KeyDown && keyEvent.awtEventOrNull?.keyCode == KeyEvent.VK_ESCAPE) {
-        onDismissRequest()
-        true
-    } else if (keyEvent.type == KeyEventType.KeyDown) {
+    return if (keyEvent.type == KeyEventType.KeyDown) {
         when {
             keyEvent.isDirectionDown -> {
                 inputModeManager.requestInputMode(InputMode.Keyboard)

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/SkikoMenu.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/SkikoMenu.skiko.kt
@@ -124,7 +124,7 @@ fun DropdownMenu(
             onDismissRequest = onDismissRequest,
             popupPositionProvider = popupPositionProvider,
             onKeyEvent = {
-                handlePopupOnKeyEvent(it, onDismissRequest, focusManager!!, inputModeManager!!)
+                handlePopupOnKeyEvent(it, focusManager!!, inputModeManager!!)
             },
         ) {
             focusManager = LocalFocusManager.current
@@ -195,21 +195,17 @@ fun DropdownMenuItem(
 @ExperimentalComposeUiApi
 private fun handlePopupOnKeyEvent(
     keyEvent: KeyEvent,
-    onDismissRequest: () -> Unit,
     focusManager: FocusManager,
     inputModeManager: InputModeManager
 ): Boolean {
-    return if (keyEvent.type == KeyEventType.KeyDown && keyEvent.key == Key.Escape) {
-        onDismissRequest()
-        true
-    } else if (keyEvent.type == KeyEventType.KeyDown) {
-        when {
-            keyEvent.key == Key.DirectionDown -> {
+    return if (keyEvent.type == KeyEventType.KeyDown) {
+        when (keyEvent.key) {
+            Key.DirectionDown -> {
                 inputModeManager.requestInputMode(InputMode.Keyboard)
                 focusManager.moveFocus(FocusDirection.Next)
                 true
             }
-            keyEvent.key == Key.DirectionUp -> {
+            Key.DirectionUp -> {
                 inputModeManager.requestInputMode(InputMode.Keyboard)
                 focusManager.moveFocus(FocusDirection.Previous)
                 true

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/key/KeyInputModifier.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/key/KeyInputModifier.kt
@@ -50,7 +50,7 @@ fun Modifier.onPreviewKeyEvent(
     onPreviewKeyEvent: (KeyEvent) -> Boolean
 ): Modifier = this then KeyInputElement(onKeyEvent = null, onPreKeyEvent = onPreviewKeyEvent)
 
-private data class KeyInputElement(
+internal data class KeyInputElement(
     val onKeyEvent: ((KeyEvent) -> Boolean)?,
     val onPreKeyEvent: ((KeyEvent) -> Boolean)?
 ) : ModifierNodeElement<KeyInputNode>() {
@@ -73,7 +73,7 @@ private data class KeyInputElement(
     }
 }
 
-private class KeyInputNode(
+internal class KeyInputNode(
     var onEvent: ((KeyEvent) -> Boolean)?,
     var onPreEvent: ((KeyEvent) -> Boolean)?
 ) : KeyInputModifierNode, Modifier.Node() {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -23,8 +23,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.*
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.keyEvent
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyPress
+import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import org.junit.Rule
@@ -146,5 +155,101 @@ class DesktopPopupTest {
         }
 
         rule.waitForIdle()
+    }
+
+    @Test
+    fun dismissPopupByEscWithBackPressProperty() {
+        var onDismissRequestCallCount = 0
+        rule.setContent {
+            Popup(
+                onDismissRequest = { onDismissRequestCallCount++ },
+                properties = PopupProperties(
+                    focusable = true,
+                    dismissOnBackPress = true
+                )
+            ) {
+                Box(Modifier)
+            }
+        }
+
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyDown))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(1)
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyUp))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun doNotDismissPopupByEscWithoutBackPressProperty() {
+        var onDismissRequestCallCount = 0
+        rule.setContent {
+            Popup(
+                onDismissRequest = { onDismissRequestCallCount++ },
+                properties = PopupProperties(
+                    focusable = true,
+                    dismissOnBackPress = false
+                )
+            ) {
+                Box(Modifier)
+            }
+        }
+
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyDown))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(0)
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyUp))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(0)
+    }
+
+    @Test
+    fun dismissPopupByEscOnNotConsumedKeyEvent() {
+        var onDismissRequestCallCount = 0
+        rule.setContent {
+            Popup(
+                focusable = true,
+                onDismissRequest = { onDismissRequestCallCount++ },
+                onKeyEvent = { false }
+            ) {
+                Box(Modifier)
+            }
+        }
+
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyDown))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(1)
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyUp))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(1)
+    }
+
+    @Test
+    fun doNotDismissPopupByEscOnConsumedKeyEvent() {
+        var onDismissRequestCallCount = 0
+        rule.setContent {
+            Popup(
+                focusable = true,
+                onDismissRequest = { onDismissRequestCallCount++ },
+                onKeyEvent = { true }
+            ) {
+                Box(Modifier)
+            }
+        }
+
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyDown))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(0)
+        rule.onNode(isPopup())
+            .performKeyPress(keyEvent(Key.Escape, KeyEventType.KeyUp))
+        rule.waitForIdle()
+        assertThat(onDismissRequestCallCount).isEqualTo(0)
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyInputElement
 import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -392,9 +393,7 @@ class ComposeScene internal constructor(
             initDensity = density,
             coroutineContext = recomposer.effectCoroutineContext,
             bounds = IntSize(constraints.maxWidth, constraints.maxHeight).toIntRect(),
-            modifier = Modifier
-                .onPreviewKeyEvent(onPreviewKeyEvent)
-                .onKeyEvent(onKeyEvent),
+            modifier = KeyInputElement(onKeyEvent = onKeyEvent, onPreKeyEvent = onPreviewKeyEvent)
         )
         attach(mainOwner)
         composition = mainOwner.setContent(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.NativeKeyEvent
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootForTest
@@ -390,8 +392,9 @@ class ComposeScene internal constructor(
             initDensity = density,
             coroutineContext = recomposer.effectCoroutineContext,
             bounds = IntSize(constraints.maxWidth, constraints.maxHeight).toIntRect(),
-            onPreviewKeyEvent = onPreviewKeyEvent,
-            onKeyEvent = onKeyEvent,
+            modifier = Modifier
+                .onPreviewKeyEvent(onPreviewKeyEvent)
+                .onKeyEvent(onKeyEvent),
         )
         attach(mainOwner)
         composition = mainOwner.setContent(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.layout.RootMeasurePolicy
 import androidx.compose.ui.modifier.ModifierLocalManager
 import androidx.compose.ui.node.*
-import androidx.compose.ui.semantics.EmptySemanticsElement
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.InternalTextApi
@@ -76,8 +75,7 @@ internal class SkiaBasedOwner(
     bounds: IntRect = IntRect.Zero,
     val focusable: Boolean = true,
     val onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
-    private val onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
-    private val onKeyEvent: (KeyEvent) -> Boolean = { false },
+    modifier: Modifier = Modifier,
 ) : Owner, RootForTest, SkiaRootForTest, PositionCalculator {
     override val windowInfo: WindowInfo get() = platform.windowInfo
 
@@ -101,8 +99,6 @@ internal class SkiaBasedOwner(
         }
 
     override val sharedDrawScope = LayoutNodeDrawScope()
-
-    private val semanticsModifier = EmptySemanticsElement
 
     // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2944)
     //  Check if ComposePanel/SwingPanel focus interop work correctly with new features of
@@ -136,11 +132,9 @@ internal class SkiaBasedOwner(
     override val root = LayoutNode().also {
         it.layoutDirection = layoutDirection
         it.measurePolicy = RootMeasurePolicy
-        it.modifier = semanticsModifier
+        it.modifier = modifier
             .then(focusOwner.modifier)
             .then(keyInputModifier)
-            .onPreviewKeyEvent(onPreviewKeyEvent)
-            .onKeyEvent(onKeyEvent)
     }
 
     override val coroutineContext: CoroutineContext = coroutineContext

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.layout.RootMeasurePolicy
 import androidx.compose.ui.modifier.ModifierLocalManager
 import androidx.compose.ui.node.*
+import androidx.compose.ui.semantics.EmptySemanticsElement
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.InternalTextApi
@@ -132,9 +133,10 @@ internal class SkiaBasedOwner(
     override val root = LayoutNode().also {
         it.layoutDirection = layoutDirection
         it.measurePolicy = RootMeasurePolicy
-        it.modifier = modifier
+        it.modifier = EmptySemanticsElement
             .then(focusOwner.modifier)
             .then(keyInputModifier)
+            .then(modifier)
     }
 
     override val coroutineContext: CoroutineContext = coroutineContext

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -66,8 +66,13 @@ actual fun Dialog(
     properties: DialogProperties,
     content: @Composable () -> Unit
 ) {
-    val onKeyEvent = if (properties.dismissOnBackPress) {
-        { event: KeyEvent ->
+    var modifier = Modifier
+        .semantics { dialog() }
+        .drawBehind {
+            drawRect(Color.Black.copy(alpha = 0.4f))
+        }
+    if (properties.dismissOnBackPress) {
+        modifier = modifier.onKeyEvent { event: KeyEvent ->
             if (event.isDismissRequest()) {
                 onDismissRequest()
                 true
@@ -75,8 +80,6 @@ actual fun Dialog(
                 false
             }
         }
-    } else {
-        { false }
     }
     val onOutsidePointerEvent = if (properties.dismissOnClickOutside) {
         { event: PointerInputEvent ->
@@ -90,12 +93,7 @@ actual fun Dialog(
     PopupLayout(
         popupPositionProvider = WindowCenterPositionProvider,
         focusable = true,
-        modifier = Modifier
-            .drawBehind {
-                drawRect(Color.Black.copy(alpha = 0.4f))
-            }
-            .semantics { dialog() }
-            .onKeyEvent(onKeyEvent),
+        modifier = modifier,
         onOutsidePointerEvent = onOutsidePointerEvent,
         content = content
     )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -132,12 +132,11 @@ fun Popup(
     focusable: Boolean = false,
     content: @Composable () -> Unit
 ) {
-    val overriddenOnKeyEvent = { event: KeyEvent ->
-        val consumed = onKeyEvent(event)
-        if (!consumed && event.isDismissRequest() && onDismissRequest != null) {
+    val dismissOnEsc = { event: KeyEvent ->
+        if (event.isDismissRequest() && onDismissRequest != null) {
             onDismissRequest()
             true
-        } else consumed
+        } else false
     }
     val onOutsidePointerEvent = if (focusable) {
         { _: PointerInputEvent ->
@@ -153,8 +152,9 @@ fun Popup(
         focusable = focusable,
         modifier = Modifier
             .semantics { popup() }
+            .onKeyEvent(dismissOnEsc)
             .then(KeyInputElement(
-                onKeyEvent = overriddenOnKeyEvent,
+                onKeyEvent = onKeyEvent,
                 onPreKeyEvent = onPreviewKeyEvent)),
         onOutsidePointerEvent = onOutsidePointerEvent,
         content = content

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -20,11 +20,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.*
-import androidx.compose.ui.input.pointer.PointerButton
-import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
@@ -135,6 +132,13 @@ fun Popup(
     focusable: Boolean = false,
     content: @Composable () -> Unit
 ) {
+    val overriddenOnKeyEvent = { event: KeyEvent ->
+        val consumed = onKeyEvent(event)
+        if (!consumed && event.isDismissRequest() && onDismissRequest != null) {
+            onDismissRequest()
+            true
+        } else consumed
+    }
     val onOutsidePointerEvent = if (focusable) {
         { _: PointerInputEvent ->
             if (onDismissRequest != null) {
@@ -150,7 +154,7 @@ fun Popup(
         modifier = Modifier
             .semantics { popup() }
             .then(KeyInputElement(
-                onKeyEvent = onKeyEvent,
+                onKeyEvent = overriddenOnKeyEvent,
                 onPreKeyEvent = onPreviewKeyEvent)),
         onOutsidePointerEvent = onOutsidePointerEvent,
         content = content
@@ -212,7 +216,6 @@ actual fun Popup(
  * @param properties [PopupProperties] for further customization of this popup's behavior.
  * @param content The content to be displayed inside the popup.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 actual fun Popup(
     popupPositionProvider: PopupPositionProvider,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -147,10 +147,11 @@ fun Popup(
     PopupLayout(
         popupPositionProvider = popupPositionProvider,
         focusable = focusable,
-        modifier = Modifier.semantics { popup() },
+        modifier = Modifier
+            .semantics { popup() }
+            .onKeyEvent(onKeyEvent)
+            .onPreviewKeyEvent(onPreviewKeyEvent),
         onOutsidePointerEvent = onOutsidePointerEvent,
-        onPreviewKeyEvent = onPreviewKeyEvent,
-        onKeyEvent = onKeyEvent,
         content = content
     )
 }
@@ -218,6 +219,18 @@ actual fun Popup(
     properties: PopupProperties,
     content: @Composable () -> Unit
 ) {
+    val onKeyEvent = if (properties.dismissOnBackPress) {
+        { event: KeyEvent ->
+            if (event.isDismissRequest() && onDismissRequest != null) {
+                onDismissRequest()
+                true
+            } else {
+                false
+            }
+        }
+    } else {
+        { false }
+    }
     val onOutsidePointerEvent = if (properties.dismissOnClickOutside) {
         { _: PointerInputEvent ->
             if (onDismissRequest != null) {
@@ -230,18 +243,14 @@ actual fun Popup(
     PopupLayout(
         popupPositionProvider = popupPositionProvider,
         focusable = properties.focusable,
-        modifier = Modifier.semantics { popup() },
+        modifier = Modifier
+            .semantics { popup() }
+            .onKeyEvent(onKeyEvent),
         onOutsidePointerEvent = onOutsidePointerEvent,
-        onKeyEvent = {
-            if (properties.dismissOnBackPress &&
-                it.type == KeyEventType.KeyDown && it.key == Key.Escape &&
-                onDismissRequest != null) {
-                onDismissRequest()
-                true
-            } else {
-                false
-            }
-        },
         content = content
     )
 }
+
+private fun KeyEvent.isDismissRequest() =
+    type == KeyEventType.KeyDown && key == Key.Escape
+

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -149,8 +149,9 @@ fun Popup(
         focusable = focusable,
         modifier = Modifier
             .semantics { popup() }
-            .onKeyEvent(onKeyEvent)
-            .onPreviewKeyEvent(onPreviewKeyEvent),
+            .then(KeyInputElement(
+                onKeyEvent = onKeyEvent,
+                onPreKeyEvent = onPreviewKeyEvent)),
         onOutsidePointerEvent = onOutsidePointerEvent,
         content = content
     )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -223,8 +223,9 @@ actual fun Popup(
     properties: PopupProperties,
     content: @Composable () -> Unit
 ) {
-    val onKeyEvent = if (properties.dismissOnBackPress) {
-        { event: KeyEvent ->
+    var modifier = Modifier.semantics { popup() }
+    if (properties.dismissOnBackPress) {
+        modifier = modifier.onKeyEvent { event: KeyEvent ->
             if (event.isDismissRequest() && onDismissRequest != null) {
                 onDismissRequest()
                 true
@@ -232,8 +233,6 @@ actual fun Popup(
                 false
             }
         }
-    } else {
-        { false }
     }
     val onOutsidePointerEvent = if (properties.dismissOnClickOutside) {
         { _: PointerInputEvent ->
@@ -247,9 +246,7 @@ actual fun Popup(
     PopupLayout(
         popupPositionProvider = popupPositionProvider,
         focusable = properties.focusable,
-        modifier = Modifier
-            .semantics { popup() }
-            .onKeyEvent(onKeyEvent),
+        modifier = modifier,
         onOutsidePointerEvent = onOutsidePointerEvent,
         content = content
     )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/PopupLayout.skiko.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.LocalComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -39,8 +38,6 @@ internal fun PopupLayout(
     focusable: Boolean,
     modifier: Modifier = Modifier,
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
-    onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
-    onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     content: @Composable () -> Unit
 ) {
     val scene = LocalComposeScene.requireCurrent()
@@ -75,15 +72,13 @@ internal fun PopupLayout(
             initLayoutDirection = layoutDirection,
             focusable = focusable,
             onOutsidePointerEvent = onOutsidePointerEvent,
-            onPreviewKeyEvent = onPreviewKeyEvent,
-            onKeyEvent = onKeyEvent
+            modifier = modifier
         )
         scene.attach(owner)
 
         val composition = owner.setContent(parent = parentComposition) {
             Layout(
                 content = content,
-                modifier = modifier,
                 measurePolicy = { measurables, constraints ->
                     val width = constraints.maxWidth
                     val height = constraints.maxHeight


### PR DESCRIPTION
## Proposed Changes

- Override key event on old desktop `Popup` to match default behaviour - It calls `onDismissRequest` on `Esc` key by default now.
- Expose (internally) root modifier instead of key events from `SkiaBasedOwner`. It allows not only optimize modifier count, but also applying semantics into root node
- Make `KeyInputElement` `internal` to reduce modifier count on pair keyboard events

## Testing

Test: create `Popup` via old overload, it closes by `Esc` now. Consume event to prevent this

