### PR TITLE
cfw: make CanvasBasedWindow apply default styles, set title

### DIFF
--- a/compose/mpp/demo/src/jsMain/resources/index.html
+++ b/compose/mpp/demo/src/jsMain/resources/index.html
@@ -5,21 +5,12 @@
     <title>compose multiplatform web demo</title>
     <script src="skiko.js"> </script>
     <link type="text/css" rel="stylesheet" href="styles.css">
-    <style>
-        html, body {
-            width: 100%;
-            height: 100%;
-            margin: 0;
-            padding: 0;
-            overflow: hidden;
-        }
-    </style>
 </head>
 
 <body>
     <h1>compose multiplatform web demo</h1>
     <div>
-        <canvas id="canvas1" width="800" height="600"></canvas>
+        <canvas id="canvas1"></canvas>
     </div>
     <script src="demo.js"> </script>
 </body>


### PR DESCRIPTION
## Proposed Changes

  - Integrate style settings to use the entire inner window into CanvasBasedWindow for a better out-of-the-box experience, omitting the need for external style declarations.
  - Support setting the HTML title element (parameter was unused before).

## Testing

Test: Adapted the mpp/demo app, tested appearance, resizing, title parameter set/unset.

## Remarks

Style settings are limited to the necessary and sufficient set of styles required by browsers as verified via
- https://www.freecodecamp.org/news/html-page-width-height
- https://developer.mozilla.org/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets
- https://github.com/necolas/normalize.css/blob/master/normalize.css
- https://caniuse.com/