### PR TITLE
Update hover state on Release event

### DIFF
--- a/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/skikoTest/kotlin/androidx/compose/ui/test/ComposeUiSkikoTestTest.kt
@@ -162,7 +162,7 @@ class ComposeUiSkikoTestTest {
             press()
             release()
         }
-        assertThat(events).hasSize(2)
+        assertThat(events).hasSize(3)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -174,6 +174,11 @@ class ComposeUiSkikoTestTest {
             assertThat(type).isEqualTo(Release)
             assertThat(button).isEqualTo(PointerButton.Primary)
             assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset.Zero)
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Enter)
             assertThat(changes[0].position).isEqualTo(Offset.Zero)
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
@@ -186,7 +191,7 @@ class ComposeUiSkikoTestTest {
         onNodeWithTag("test").performMouseInput {
             click(Offset(10f, 20f))
         }
-        assertThat(events).hasSize(2)
+        assertThat(events).hasSize(3)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -198,6 +203,11 @@ class ComposeUiSkikoTestTest {
             assertThat(type).isEqualTo(Release)
             assertThat(button).isEqualTo(PointerButton.Primary)
             assertThat(buttons).isEqualTo(PointerButtons(isPrimaryPressed = false))
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[2].apply {
+            assertThat(type).isEqualTo(Enter)
             assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
@@ -215,7 +225,7 @@ class ComposeUiSkikoTestTest {
             release(MouseButton.Tertiary)
             press(MouseButton(3))
         }
-        assertThat(events).hasSize(5)
+        assertThat(events).hasSize(6)
         events[0].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Primary)
@@ -245,6 +255,11 @@ class ComposeUiSkikoTestTest {
             assertThat(changes[0].type).isEqualTo(Mouse)
         }
         events[4].apply {
+            assertThat(type).isEqualTo(Enter)
+            assertThat(changes[0].position).isEqualTo(Offset(10f, 20f))
+            assertThat(changes[0].type).isEqualTo(Mouse)
+        }
+        events[5].apply {
             assertThat(type).isEqualTo(Press)
             assertThat(button).isEqualTo(PointerButton.Back)
             assertThat(buttons).isEqualTo(PointerButtons(isBackPressed = true))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -228,17 +228,19 @@ class ComposeSceneInputTest {
 
         scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 20f))
         background.events.assertReceivedNoEvents()
-        cutPopup.events.assertReceivedLast(
+        cutPopup.events.assertReceived(
             PointerEventType.Release, Offset(20f, 20f) - cutPopup.origin)
-        overlappedPopup.events.assertReceivedNoEvents()
-        independentPopup.events.assertReceivedNoEvents()
-
-        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
-        background.events.assertReceivedNoEvents()
         cutPopup.events.assertReceivedLast(
             PointerEventType.Exit, Offset(20f, 20f) - cutPopup.origin)
         overlappedPopup.events.assertReceivedLast(
             PointerEventType.Enter, Offset(20f, 20f) - overlappedPopup.origin)
+        independentPopup.events.assertReceivedNoEvents()
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
+        background.events.assertReceivedNoEvents()
+        cutPopup.events.assertReceivedNoEvents()
+        overlappedPopup.events.assertReceivedLast(
+            PointerEventType.Move, Offset(20f, 20f) - overlappedPopup.origin)
         independentPopup.events.assertReceivedNoEvents()
 
         scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f))
@@ -257,7 +259,8 @@ class ComposeSceneInputTest {
 
         scene.sendPointerEvent(PointerEventType.Release, Offset(-10f, -10f))
         background.events.assertReceivedNoEvents()
-        cutPopup.events.assertReceivedNoEvents()
+        cutPopup.events.assertReceivedLast(
+            PointerEventType.Enter, Offset(-10f, -10f) - cutPopup.origin)
         overlappedPopup.events.assertReceivedLast(
             PointerEventType.Release, Offset(-10f, -10f) - overlappedPopup.origin
         )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -92,7 +92,9 @@ class DialogTest {
         onNodeWithTag(dialog.tag).assertIsDisplayed()
 
         background.events.assertReceived(PointerEventType.Press, Offset(10f, 10f))
-        background.events.assertReceivedLast(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Enter, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(10f, 10f))
     }
 
     @Test

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -412,10 +412,12 @@ class PopupTest {
         )
         scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = buttons, button = PointerButton.Primary)
         scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+        onNodeWithTag(popup.tag).assertIsDisplayed()
 
         background.events.assertReceived(PointerEventType.Press, Offset(10f, 10f))
-        background.events.assertReceivedLast(PointerEventType.Release, Offset(10f, 10f))
-        onNodeWithTag(popup.tag).assertIsDisplayed()
+        background.events.assertReceived(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Enter, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Exit, Offset(10f, 10f))
     }
 
     @Test
@@ -457,7 +459,7 @@ class PopupTest {
 
         scene.sendPointerEvent(PointerEventType.Move, Offset(11f, 11f), buttons = buttons)
         scene.sendPointerEvent(PointerEventType.Release, Offset(11f, 11f), button = PointerButton.Primary)
-        background.events.assertReceivedNoEvents()
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(11f, 11f))
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

It's the last part of #691

- Update hover state (send Enter/Exit events) on `Release` event. It allows to send missing event if updating during `Move` was blocked by `pressOwner` (`gestureOwner`)
- Some renames to make it more readable: `pressOwner` -> `gestureOwner` and `isAnyPointerDown` -> `isGestureInProgress`

## Testing

Test:  run tests from `PopupTest` and `DialogTest`
