### PR TITLE
Rename BringIntoViewChildNode.parent property (WA for KT-60635)

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/relocation/BringIntoView.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/relocation/BringIntoView.kt
@@ -79,7 +79,10 @@ internal abstract class BringIntoViewChildNode : Modifier.Node(),
         get() = field?.takeIf { it.isAttached }
         private set
 
-    protected val parent: BringIntoViewParent
+    // TODO(o.karpovich): in JC this property is called `parent`, but we have to workaround a bug:
+    // https://youtrack.jetbrains.com/issue/KT-60635
+    // Also: https://github.com/JetBrains/compose-multiplatform/issues/3463
+    protected val bringIntoViewParent: BringIntoViewParent
         get() = localParent ?: defaultParent
 
     override fun onPlaced(coordinates: LayoutCoordinates) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/relocation/BringIntoViewRequester.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/relocation/BringIntoViewRequester.kt
@@ -175,10 +175,10 @@ internal class BringIntoViewRequesterNode(
 
     /**
      * Requests that [rect] (if non-null) or the entire bounds of this modifier's node (if [rect]
-     * is null) be brought into view by the [parent]&nbsp;[BringIntoViewParent].
+     * is null) be brought into view by the [bringIntoViewParent]&nbsp;[BringIntoViewParent].
      */
     suspend fun bringIntoView(rect: Rect?) {
-        parent.bringChildIntoView(layoutCoordinates ?: return) {
+        bringIntoViewParent.bringChildIntoView(layoutCoordinates ?: return) {
             // If the rect is not specified, use a rectangle representing the entire composable.
             // If the coordinates are detached when this call is made, we don't bother even
             // submitting the request, but if the coordinates become detached while the request

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/relocation/BringIntoViewResponder.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/relocation/BringIntoViewResponder.kt
@@ -141,7 +141,7 @@ private class BringIntoViewResponderNode(
 
     /**
      * Responds to a child's request by first converting [boundsProvider] into this node's [LayoutCoordinates]
-     * and then, concurrently, calling the [responder] and the [parent] to handle the request.
+     * and then, concurrently, calling the [responder] and the [bringIntoViewParent] to handle the request.
      */
     override suspend fun bringChildIntoView(
         childCoordinates: LayoutCoordinates,
@@ -176,7 +176,7 @@ private class BringIntoViewResponderNode(
             // CancellationException, it will cancel this coroutineScope, which will also cancel the
             // responder's coroutine.
             launch {
-                parent.bringChildIntoView(layoutCoordinates ?: return@launch, parentRect)
+                bringIntoViewParent.bringChildIntoView(layoutCoordinates ?: return@launch, parentRect)
             }
         }
     }


### PR DESCRIPTION
It's a workaround for an issue in non-jvm targets: https://youtrack.jetbrains.com/issue/KT-60635

Given that the class is internal, this change should be safe.

It affected compoes users: https://github.com/JetBrains/compose-multiplatform/issues/3463
