### PR TITLE
Expect `androidx.compose.material.DropdownMenu` in common

### DIFF
--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
@@ -334,6 +334,27 @@ internal data class DropdownMenuPositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize
     ): IntOffset {
+        val isLtr = layoutDirection == LayoutDirection.Ltr
+
+        // Coerce such that this..this+size fits into min..max; if impossible, align with min
+        fun Int.coerceWithSizeIntoRangePreferMin(size: Int, min: Int, max: Int) = when {
+            this < min -> min
+            this + size > max -> max - size
+            else -> this
+        }
+
+        // Coerce such that this..this+size fits into min..max; if impossible, align with max
+        fun Int.coerceWithSizeIntoRangePreferMax(size: Int, min: Int, max: Int) = when {
+            this + size > max -> max - size
+            this < min -> min
+            else -> this
+        }
+
+        fun Int.coerceWithSizeIntoRange(size: Int, min: Int, max: Int) = when {
+            isLtr -> coerceWithSizeIntoRangePreferMin(size, min, max)
+            else -> coerceWithSizeIntoRangePreferMax(size, min, max)
+        }
+
         // The min margin above and below the menu, relative to the screen.
         val verticalMargin = with(density) { MenuVerticalMargin.roundToPx() }
         // The content offset specified using the dropdown offset parameter.
@@ -341,36 +362,24 @@ internal data class DropdownMenuPositionProvider(
         val contentOffsetY = with(density) { contentOffset.y.roundToPx() }
 
         // Compute horizontal position.
-        val toRight = anchorBounds.left + contentOffsetX
-        val toLeft = anchorBounds.right - contentOffsetX - popupContentSize.width
-        val toDisplayRight = windowSize.width - popupContentSize.width
-        val toDisplayLeft = 0
-        val x = if (layoutDirection == LayoutDirection.Ltr) {
-            sequenceOf(
-                toRight,
-                toLeft,
-                // If the anchor gets outside of the window on the left, we want to position
-                // toDisplayLeft for proximity to the anchor. Otherwise, toDisplayRight.
-                if (anchorBounds.left >= 0) toDisplayRight else toDisplayLeft
-            )
-        } else {
-            sequenceOf(
-                toLeft,
-                toRight,
-                // If the anchor gets outside of the window on the right, we want to position
-                // toDisplayRight for proximity to the anchor. Otherwise, toDisplayLeft.
-                if (anchorBounds.right <= windowSize.width) toDisplayLeft else toDisplayRight
-            )
-        }.firstOrNull {
-            it >= 0 && it + popupContentSize.width <= windowSize.width
-        } ?: toLeft
+        val preferredX = if (isLtr) {
+            anchorBounds.left + contentOffsetX
+        }
+        else {
+            anchorBounds.right - contentOffsetX - popupContentSize.width
+        }
+        val x = preferredX.coerceWithSizeIntoRange(
+            size = popupContentSize.width,
+            min = 0,
+            max = windowSize.width
+        )
 
         // Compute vertical position.
         val toBottom = maxOf(anchorBounds.bottom + contentOffsetY, verticalMargin)
         val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
         val toCenter = anchorBounds.top - popupContentSize.height / 2
-        val toDisplayBottom = windowSize.height - popupContentSize.height - verticalMargin
-        var y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
+        val toWindowBottom = windowSize.height - popupContentSize.height - verticalMargin
+        var y = sequenceOf(toBottom, toTop, toCenter, toWindowBottom).firstOrNull {
             it >= verticalMargin &&
                 it + popupContentSize.height <= windowSize.height - verticalMargin
         } ?: toTop

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
@@ -23,6 +23,7 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -34,6 +35,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
@@ -53,9 +55,94 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 import kotlin.math.max
 import kotlin.math.min
+
+
+/**
+ * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
+ *
+ * A dropdown menu is a compact way of displaying multiple choices. It appears upon interaction with
+ * an element (such as an icon or button) or when users perform a specific action.
+ *
+ * ![Menus image](https://developer.android.com/images/reference/androidx/compose/material/menus.png)
+ *
+ * A [DropdownMenu] behaves similarly to a [Popup], and will use the position of the parent layout
+ * to position itself on screen. Commonly a [DropdownMenu] will be placed in a [Box] with a sibling
+ * that will be used as the 'anchor'. Note that a [DropdownMenu] by itself will not take up any
+ * space in a layout, as the menu is displayed in a separate window, on top of other content.
+ *
+ * The [content] of a [DropdownMenu] will typically be [DropdownMenuItem]s, as well as custom
+ * content. Using [DropdownMenuItem]s will result in a menu that matches the Material
+ * specification for menus. Also note that the [content] is placed inside a scrollable [Column],
+ * so using a [LazyColumn] as the root layout inside [content] is unsupported.
+ *
+ * [onDismissRequest] will be called when the menu should close - for example when there is a
+ * tap outside the menu, or when the back key is pressed.
+ *
+ * [DropdownMenu] changes its positioning depending on the available space, always trying to be
+ * fully visible. It will try to expand horizontally, depending on layout direction, to the end of
+ * its parent, then to the start of its parent, and then screen end-aligned. Vertically, it will
+ * try to expand to the bottom of its parent, then from the top of its parent, and then screen
+ * top-aligned. An [offset] can be provided to adjust the positioning of the menu for cases when
+ * the layout bounds of its parent do not coincide with its visual bounds. Note the offset will
+ * be applied in the direction in which the menu will decide to expand.
+ *
+ * Example usage:
+ * @sample androidx.compose.material.samples.MenuSample
+ *
+ * Example usage with a [ScrollState] to control the menu items scroll position:
+ * @sample androidx.compose.material.samples.MenuWithScrollStateSample
+ *
+ * @param expanded whether the menu is expanded or not
+ * @param onDismissRequest called when the user requests to dismiss the menu, such as by tapping
+ * outside the menu's bounds
+ * @param modifier [Modifier] to be applied to the menu's content
+ * @param offset [DpOffset] to be added to the position of the menu
+ * @param scrollState a [ScrollState] to used by the menu's content for items vertical scrolling
+ * @param properties [PopupProperties] for further customization of this popup's behavior
+ * @param content the content of this dropdown menu, typically a [DropdownMenuItem]
+ */
+@Composable
+expect fun DropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset(0.dp, 0.dp),
+    scrollState: ScrollState = rememberScrollState(),
+    properties: PopupProperties = PopupProperties(focusable = true),
+    content: @Composable ColumnScope.() -> Unit
+)
+
+/**
+ * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a> item.
+ *
+ *
+ * Example usage:
+ * @sample androidx.compose.material.samples.MenuSample
+ *
+ * @param onClick Called when the menu item was clicked
+ * @param modifier The modifier to be applied to the menu item
+ * @param enabled Controls the enabled state of the menu item - when `false`, the menu item
+ * will not be clickable and [onClick] will not be invoked
+ * @param contentPadding the padding applied to the content of this menu item
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this DropdownMenuItem. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this DropdownMenuItem in different [Interaction]s.
+ */
+@Composable
+expect fun DropdownMenuItem(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = MenuDefaults.DropdownMenuItemContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable RowScope.() -> Unit
+)
 
 @Composable
 internal fun DropdownMenuContent(

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
@@ -370,10 +370,24 @@ internal data class DropdownMenuPositionProvider(
         val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
         val toCenter = anchorBounds.top - popupContentSize.height / 2
         val toDisplayBottom = windowSize.height - popupContentSize.height - verticalMargin
-        val y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
+        var y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
             it >= verticalMargin &&
                 it + popupContentSize.height <= windowSize.height - verticalMargin
         } ?: toTop
+
+        // Desktop specific vertical position checking
+        val aboveAnchor = anchorBounds.top + contentOffsetY
+        val belowAnchor = windowSize.height - anchorBounds.bottom - contentOffsetY
+
+        if (belowAnchor >= aboveAnchor) {
+            y = anchorBounds.bottom + contentOffsetY
+        }
+
+        if (y + popupContentSize.height > windowSize.height) {
+            y = windowSize.height - popupContentSize.height
+        }
+
+        y = y.coerceAtLeast(0)
 
         onPositionCalculated(
             anchorBounds,

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/Menu.kt
@@ -334,27 +334,6 @@ internal data class DropdownMenuPositionProvider(
         layoutDirection: LayoutDirection,
         popupContentSize: IntSize
     ): IntOffset {
-        val isLtr = layoutDirection == LayoutDirection.Ltr
-
-        // Coerce such that this..this+size fits into min..max; if impossible, align with min
-        fun Int.coerceWithSizeIntoRangePreferMin(size: Int, min: Int, max: Int) = when {
-            this < min -> min
-            this + size > max -> max - size
-            else -> this
-        }
-
-        // Coerce such that this..this+size fits into min..max; if impossible, align with max
-        fun Int.coerceWithSizeIntoRangePreferMax(size: Int, min: Int, max: Int) = when {
-            this + size > max -> max - size
-            this < min -> min
-            else -> this
-        }
-
-        fun Int.coerceWithSizeIntoRange(size: Int, min: Int, max: Int) = when {
-            isLtr -> coerceWithSizeIntoRangePreferMin(size, min, max)
-            else -> coerceWithSizeIntoRangePreferMax(size, min, max)
-        }
-
         // The min margin above and below the menu, relative to the screen.
         val verticalMargin = with(density) { MenuVerticalMargin.roundToPx() }
         // The content offset specified using the dropdown offset parameter.
@@ -362,41 +341,39 @@ internal data class DropdownMenuPositionProvider(
         val contentOffsetY = with(density) { contentOffset.y.roundToPx() }
 
         // Compute horizontal position.
-        val preferredX = if (isLtr) {
-            anchorBounds.left + contentOffsetX
-        }
-        else {
-            anchorBounds.right - contentOffsetX - popupContentSize.width
-        }
-        val x = preferredX.coerceWithSizeIntoRange(
-            size = popupContentSize.width,
-            min = 0,
-            max = windowSize.width
-        )
+        val toRight = anchorBounds.left + contentOffsetX
+        val toLeft = anchorBounds.right - contentOffsetX - popupContentSize.width
+        val toDisplayRight = windowSize.width - popupContentSize.width
+        val toDisplayLeft = 0
+        val x = if (layoutDirection == LayoutDirection.Ltr) {
+            sequenceOf(
+                toRight,
+                toLeft,
+                // If the anchor gets outside of the window on the left, we want to position
+                // toDisplayLeft for proximity to the anchor. Otherwise, toDisplayRight.
+                if (anchorBounds.left >= 0) toDisplayRight else toDisplayLeft
+            )
+        } else {
+            sequenceOf(
+                toLeft,
+                toRight,
+                // If the anchor gets outside of the window on the right, we want to position
+                // toDisplayRight for proximity to the anchor. Otherwise, toDisplayLeft.
+                if (anchorBounds.right <= windowSize.width) toDisplayLeft else toDisplayRight
+            )
+        }.firstOrNull {
+            it >= 0 && it + popupContentSize.width <= windowSize.width
+        } ?: toLeft
 
         // Compute vertical position.
         val toBottom = maxOf(anchorBounds.bottom + contentOffsetY, verticalMargin)
         val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
         val toCenter = anchorBounds.top - popupContentSize.height / 2
-        val toWindowBottom = windowSize.height - popupContentSize.height - verticalMargin
-        var y = sequenceOf(toBottom, toTop, toCenter, toWindowBottom).firstOrNull {
+        val toDisplayBottom = windowSize.height - popupContentSize.height - verticalMargin
+        val y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
             it >= verticalMargin &&
                 it + popupContentSize.height <= windowSize.height - verticalMargin
         } ?: toTop
-
-        // Desktop specific vertical position checking
-        val aboveAnchor = anchorBounds.top + contentOffsetY
-        val belowAnchor = windowSize.height - anchorBounds.bottom - contentOffsetY
-
-        if (belowAnchor >= aboveAnchor) {
-            y = anchorBounds.bottom + contentOffsetY
-        }
-
-        if (y + popupContentSize.height > windowSize.height) {
-            y = windowSize.height - popupContentSize.height
-        }
-
-        y = y.coerceAtLeast(0)
 
         onPositionCalculated(
             anchorBounds,

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -20,10 +20,7 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.contextMenuOpenDetector
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -35,30 +32,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.awtEventOrNull
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.rememberCursorPositionProvider
 import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
-import java.awt.event.KeyEvent
 
 /**
  * A Material Design [dropdown menu](https://material.io/components/menus#dropdown-menu).
@@ -115,10 +101,10 @@ fun DropdownMenu(
 ) = DropdownMenu(
     expanded = expanded,
     onDismissRequest = onDismissRequest,
-    focusable = focusable,
     modifier = modifier,
     offset = offset,
     scrollState = rememberScrollState(),
+    properties = PopupProperties(focusable = focusable),
     content = content
 )
 
@@ -161,6 +147,13 @@ fun DropdownMenu(
  * @param scrollState a [ScrollState] to used by the menu's content for items vertical scrolling
  * @param content the content of this dropdown menu, typically a [DropdownMenuItem]
  */
+@Deprecated(
+    "Replaced by DropdownMenu with properties parameter",
+    ReplaceWith("DropdownMenu(expanded, onDismissRequest, modifier, offset, scrollState," +
+        "androidx.compose.ui.window.PopupProperties(focusable = focusable), " +
+        "content)"),
+    level = DeprecationLevel.WARNING // TODO: Change to DeprecationLevel.HIDDEN in 1.6
+)
 @Composable
 fun DropdownMenu(
     expanded: Boolean,
@@ -170,36 +163,36 @@ fun DropdownMenu(
     offset: DpOffset = DpOffset(0.dp, 0.dp),
     scrollState: ScrollState = rememberScrollState(),
     content: @Composable ColumnScope.() -> Unit
-) {
-    val expandedStates = remember { MutableTransitionState(false) }
-    expandedStates.targetState = expanded
+): Unit = DropdownMenu(
+    expanded = expanded,
+    onDismissRequest = onDismissRequest,
+    modifier = modifier,
+    offset = offset,
+    scrollState = scrollState,
+    properties = PopupProperties(focusable = focusable),
+    content = content
+)
 
-    if (expandedStates.currentState || expandedStates.targetState) {
-        val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
-        val density = LocalDensity.current
-        // The original [DropdownMenuPositionProvider] is not yet suitable for large screen devices,
-        // so we need to make additional checks and adjust the position of the [DropdownMenu] to
-        // avoid content being cut off if the [DropdownMenu] contains too many items.
-        // See: https://github.com/JetBrains/compose-jb/issues/1388
-        val popupPositionProvider = DesktopDropdownMenuPositionProvider(
-            offset,
-            density
-        ) { parentBounds, menuBounds ->
-            transformOriginState.value = calculateTransformOrigin(parentBounds, menuBounds)
-        }
 
-        OpenDropdownMenu(
-            expandedStates = expandedStates,
-            popupPositionProvider = popupPositionProvider,
-            transformOriginState = transformOriginState,
-            scrollState = scrollState,
-            onDismissRequest = onDismissRequest,
-            focusable = focusable,
-            modifier = modifier,
-            content = content
-        )
-    }
-}
+// Workaround for `Overload resolution ambiguity` between old and new overload.
+// TODO: Deprecate with DeprecationLevel.HIDDEN in 1.6
+@Composable
+fun DropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset(0.dp, 0.dp),
+    scrollState: ScrollState = rememberScrollState(),
+    content: @Composable ColumnScope.() -> Unit
+): Unit = DropdownMenu(
+    expanded = expanded,
+    onDismissRequest = onDismissRequest,
+    modifier = modifier,
+    offset = offset,
+    scrollState = scrollState,
+    properties = PopupProperties(focusable = true),
+    content = content
+)
 
 /**
  * A variant of a dropdown menu that accepts a [DropdownMenuState] to allow precise positioning.
@@ -305,9 +298,9 @@ private fun OpenDropdownMenu(
     var focusManager: FocusManager? by mutableStateOf(null)
     var inputModeManager: InputModeManager? by mutableStateOf(null)
     Popup(
-        focusable = focusable,
         onDismissRequest = onDismissRequest,
         popupPositionProvider = popupPositionProvider,
+        properties = PopupProperties(focusable = focusable),
         onKeyEvent = {
             handlePopupOnKeyEvent(it, focusManager!!, inputModeManager!!)
         },
@@ -325,65 +318,6 @@ private fun OpenDropdownMenu(
     }
 }
 
-/**
- * A dropdown menu item, as defined by the Material Design spec.
- *
- * Example usage:
- * @sample androidx.compose.material.samples.MenuSample
- *
- * @param onClick Called when the menu item was clicked
- * @param modifier The modifier to be applied to the menu item
- * @param enabled Controls the enabled state of the menu item - when `false`, the menu item
- * will not be clickable and [onClick] will not be invoked
- * @param contentPadding the padding applied to the content of this menu item
- * @param interactionSource the [MutableInteractionSource] representing the different [Interaction]s
- * present on this DropdownMenuItem. You can create and pass in your own remembered
- * [MutableInteractionSource] if you want to read the [MutableInteractionSource] and customize
- * the appearance / behavior of this DropdownMenuItem in different [Interaction]s.
- */
-@Composable
-fun DropdownMenuItem(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true,
-    contentPadding: PaddingValues = MenuDefaults.DropdownMenuItemContentPadding,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    content: @Composable RowScope.() -> Unit
-) {
-    DropdownMenuItemContent(
-        onClick = onClick,
-        modifier = modifier,
-        enabled = enabled,
-        contentPadding = contentPadding,
-        interactionSource = interactionSource,
-        content = content
-    )
-}
-
-@OptIn(ExperimentalComposeUiApi::class)
-private fun handlePopupOnKeyEvent(
-    keyEvent: androidx.compose.ui.input.key.KeyEvent,
-    focusManager: FocusManager,
-    inputModeManager: InputModeManager
-): Boolean {
-    return if (keyEvent.type == KeyEventType.KeyDown) {
-        when {
-            keyEvent.isDirectionDown -> {
-                inputModeManager.requestInputMode(InputMode.Keyboard)
-                focusManager.moveFocus(FocusDirection.Next)
-                true
-            }
-            keyEvent.isDirectionUp -> {
-                inputModeManager.requestInputMode(InputMode.Keyboard)
-                focusManager.moveFocus(FocusDirection.Previous)
-                true
-            }
-            else -> false
-        }
-    } else {
-        false
-    }
-}
 /**
  * A [CursorDropdownMenu] behaves similarly to [Popup] and will use the current position of the mouse
  * cursor to position itself on screen.
@@ -528,93 +462,5 @@ fun Modifier.contextMenuOpenDetector(
         }
     } else {
         this
-    }
-}
-
-/**
- * Positions a dropdown relative to another widget (its anchor).
- */
-@Immutable
-internal data class DesktopDropdownMenuPositionProvider(
-    val contentOffset: DpOffset,
-    val density: Density,
-    val onPositionCalculated: (IntRect, IntRect) -> Unit = { _, _ -> }
-) : PopupPositionProvider {
-    override fun calculatePosition(
-        anchorBounds: IntRect,
-        windowSize: IntSize,
-        layoutDirection: LayoutDirection,
-        popupContentSize: IntSize
-    ): IntOffset {
-
-        val isLtr = layoutDirection == LayoutDirection.Ltr
-
-        // Coerce such that this..this+size fits into min..max; if impossible, align with min
-        fun Int.coerceWithSizeIntoRangePreferMin(size: Int, min: Int, max: Int) = when {
-            this < min -> min
-            this + size > max -> max - size
-            else -> this
-        }
-
-        // Coerce such that this..this+size fits into min..max; if impossible, align with max
-        fun Int.coerceWithSizeIntoRangePreferMax(size: Int, min: Int, max: Int) = when {
-            this + size > max -> max - size
-            this < min -> min
-            else -> this
-        }
-
-        fun Int.coerceWithSizeIntoRange(size: Int, min: Int, max: Int) = when {
-            isLtr -> coerceWithSizeIntoRangePreferMin(size, min, max)
-            else -> coerceWithSizeIntoRangePreferMax(size, min, max)
-        }
-
-        // The min margin above and below the menu, relative to the screen.
-        val verticalMargin = with(density) { MenuVerticalMargin.roundToPx() }
-        // The content offset specified using the dropdown offset parameter.
-        val contentOffsetX = with(density) { contentOffset.x.roundToPx() }
-        val contentOffsetY = with(density) { contentOffset.y.roundToPx() }
-
-        // Compute horizontal position.
-        val preferredX = if (isLtr) {
-            anchorBounds.left + contentOffsetX
-        }
-        else {
-            anchorBounds.right - contentOffsetX - popupContentSize.width
-        }
-        val x = preferredX.coerceWithSizeIntoRange(
-            size = popupContentSize.width,
-            min = 0,
-            max = windowSize.width
-        )
-
-        // Compute vertical position.
-        val toBottom = maxOf(anchorBounds.bottom + contentOffsetY, verticalMargin)
-        val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
-        val toCenter = anchorBounds.top - popupContentSize.height / 2
-        val toWindowBottom = windowSize.height - popupContentSize.height - verticalMargin
-        var y = sequenceOf(toBottom, toTop, toCenter, toWindowBottom).firstOrNull {
-            it >= verticalMargin &&
-                it + popupContentSize.height <= windowSize.height - verticalMargin
-        } ?: toTop
-
-        // Desktop specific vertical position checking
-        val aboveAnchor = anchorBounds.top + contentOffsetY
-        val belowAnchor = windowSize.height - anchorBounds.bottom - contentOffsetY
-
-        if (belowAnchor >= aboveAnchor) {
-            y = anchorBounds.bottom + contentOffsetY
-        }
-
-        if (y + popupContentSize.height > windowSize.height) {
-            y = windowSize.height - popupContentSize.height
-        }
-
-        y = y.coerceAtLeast(0)
-
-        onPositionCalculated(
-            anchorBounds,
-            IntRect(x, y, x + popupContentSize.width, y + popupContentSize.height)
-        )
-        return IntOffset(x, y)
     }
 }

--- a/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
+++ b/compose/material/material/src/desktopMain/kotlin/androidx/compose/material/DesktopMenu.desktop.kt
@@ -20,7 +20,11 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.contextMenuOpenDetector
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
@@ -316,6 +320,42 @@ private fun OpenDropdownMenu(
             content = content
         )
     }
+}
+
+/**
+ * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a> item.
+ *
+ *
+ * Example usage:
+ * @sample androidx.compose.material.samples.MenuSample
+ *
+ * @param onClick Called when the menu item was clicked
+ * @param modifier The modifier to be applied to the menu item
+ * @param enabled Controls the enabled state of the menu item - when `false`, the menu item
+ * will not be clickable and [onClick] will not be invoked
+ * @param contentPadding the padding applied to the content of this menu item
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this DropdownMenuItem. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this DropdownMenuItem in different [Interaction]s.
+ */
+@Composable
+actual fun DropdownMenuItem(
+    onClick: () -> Unit,
+    modifier: Modifier,
+    enabled: Boolean,
+    contentPadding: PaddingValues,
+    interactionSource: MutableInteractionSource,
+    content: @Composable RowScope.() -> Unit
+) {
+    DropdownMenuItemContent(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
 }
 
 /**

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -18,17 +18,21 @@ package androidx.compose.material
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.internal.keyEvent
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertLeftPositionInRootIsEqualTo
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -42,10 +46,10 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.size
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -160,31 +164,22 @@ class DesktopMenuTest {
     // (RTL) Anchor right is beyond the right of the window, so align popup to the window right
     @Test
     fun menu_positioning_rtl_windowRight_belowAnchor() {
-        val anchorBounds = IntRect(
-            offset = IntOffset(30, 10),
-            size = IntSize(80, 20)
-        )
-        val popupSize = IntSize(50, 70)
-
-        val position = DropdownMenuPositionProvider(
-            DpOffset.Zero,
-            Density(1f)
-        ).calculatePosition(
-            anchorBounds,
-            windowSize,
-            LayoutDirection.Rtl,
-            popupSize
-        )
-
-        assertThat(position).isEqualTo(
-            IntOffset(
-                x = windowSize.width - popupSize.width,
-                y = anchorBounds.bottom
-            )
-        )
+        rule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                Box(Modifier.fillMaxSize().testTag("background")) {
+                    Box(Modifier.offset(x = (-10).dp).size(50.dp)) {
+                        DropdownMenu(true, onDismissRequest = {}) {
+                            Box(Modifier.size(50.dp).testTag("box"))
+                        }
+                    }
+                }
+            }
+        }
+        val windowSize = rule.onNodeWithTag("background").getBoundsInRoot().size
+        rule.onNodeWithTag("box")
+            .assertLeftPositionInRootIsEqualTo(windowSize.width - 50.dp)
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `pressing ESC button invokes onDismissRequest`() {
         var dismissCount = 0
@@ -213,8 +208,6 @@ class DesktopMenuTest {
         }
     }
 
-    @Ignore // TODO: remove ignore when changes from http://r.android.com/2520700 will be merged
-    @OptIn(ExperimentalComposeUiApi::class)
     @Test
     fun `navigate DropDownMenu using arrows`() {
         var item1Clicked = 0

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -61,13 +61,13 @@ class DesktopMenuTest {
     @get:Rule
     val rule = createComposeRule()
 
-    private val windowSize = IntSize(100, 100)
+    private val windowSize = IntSize(200, 200)
 
     // Standard case: enough room to position below the anchor and align left
     @Test
     fun menu_positioning_alignLeft_belowAnchor() {
         val anchorBounds = IntRect(
-            offset = IntOffset(10, 10),
+            offset = IntOffset(10, 50),
             size = IntSize(50, 20)
         )
         val popupSize = IntSize(70, 70)
@@ -89,7 +89,7 @@ class DesktopMenuTest {
     @Test
     fun menu_positioning_rtl_alignRight_belowAnchor() {
         val anchorBounds = IntRect(
-            offset = IntOffset(30, 10),
+            offset = IntOffset(30, 50),
             size = IntSize(50, 20)
         )
         val popupSize = IntSize(70, 70)
@@ -116,7 +116,7 @@ class DesktopMenuTest {
     @Test
     fun menu_positioning_alignLeft_aboveAnchor() {
         val anchorBounds = IntRect(
-            offset = IntOffset(10, 50),
+            offset = IntOffset(10, 150),
             size = IntSize(50, 30)
         )
         val popupSize = IntSize(70, 30)
@@ -143,7 +143,7 @@ class DesktopMenuTest {
     @Test
     fun menu_positioning_windowLeft_belowAnchor() {
         val anchorBounds = IntRect(
-            offset = IntOffset(-10, 10),
+            offset = IntOffset(-10, 50),
             size = IntSize(50, 20)
         )
         val popupSize = IntSize(70, 50)

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -68,7 +68,7 @@ class DesktopMenuTest {
         )
         val popupSize = IntSize(70, 70)
 
-        val position = DesktopDropdownMenuPositionProvider(
+        val position = DropdownMenuPositionProvider(
             DpOffset.Zero,
             Density(1f)
         ).calculatePosition(
@@ -90,7 +90,7 @@ class DesktopMenuTest {
         )
         val popupSize = IntSize(70, 70)
 
-        val position = DesktopDropdownMenuPositionProvider(
+        val position = DropdownMenuPositionProvider(
             DpOffset.Zero,
             Density(1f)
         ).calculatePosition(
@@ -117,7 +117,7 @@ class DesktopMenuTest {
         )
         val popupSize = IntSize(70, 30)
 
-        val position = DesktopDropdownMenuPositionProvider(
+        val position = DropdownMenuPositionProvider(
             DpOffset.Zero,
             Density(1f)
         ).calculatePosition(
@@ -144,7 +144,7 @@ class DesktopMenuTest {
         )
         val popupSize = IntSize(70, 50)
 
-        val position = DesktopDropdownMenuPositionProvider(
+        val position = DropdownMenuPositionProvider(
             DpOffset.Zero,
             Density(1f)
         ).calculatePosition(
@@ -166,7 +166,7 @@ class DesktopMenuTest {
         )
         val popupSize = IntSize(50, 70)
 
-        val position = DesktopDropdownMenuPositionProvider(
+        val position = DropdownMenuPositionProvider(
             DpOffset.Zero,
             Density(1f)
         ).calculatePosition(

--- a/compose/material/material/src/jsNativeMain/kotlin/androidx/compose/material/Menu.jsNative.kt
+++ b/compose/material/material/src/jsNativeMain/kotlin/androidx/compose/material/Menu.jsNative.kt
@@ -1,0 +1,61 @@
+
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a> item.
+ *
+ *
+ * Example usage:
+ * @sample androidx.compose.material.samples.MenuSample
+ *
+ * @param onClick Called when the menu item was clicked
+ * @param modifier The modifier to be applied to the menu item
+ * @param enabled Controls the enabled state of the menu item - when `false`, the menu item
+ * will not be clickable and [onClick] will not be invoked
+ * @param contentPadding the padding applied to the content of this menu item
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this DropdownMenuItem. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this DropdownMenuItem in different [Interaction]s.
+ */
+@Composable
+actual fun DropdownMenuItem(
+    onClick: () -> Unit,
+    modifier: Modifier,
+    enabled: Boolean,
+    contentPadding: PaddingValues,
+    interactionSource: MutableInteractionSource,
+    content: @Composable RowScope.() -> Unit
+) {
+    DropdownMenuItemContent(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
@@ -15,11 +15,6 @@
  * limitations under the License.
  */
 
-/*
- * Keep binary compatibility on Desktop.
- */
-@file:JvmName("DesktopMenu_desktopKt")
-
 package androidx.compose.material
 
 import androidx.compose.animation.core.MutableTransitionState
@@ -142,42 +137,6 @@ actual fun DropdownMenu(
             )
         }
     }
-}
-
-/**
- * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a> item.
- *
- *
- * Example usage:
- * @sample androidx.compose.material.samples.MenuSample
- *
- * @param onClick Called when the menu item was clicked
- * @param modifier The modifier to be applied to the menu item
- * @param enabled Controls the enabled state of the menu item - when `false`, the menu item
- * will not be clickable and [onClick] will not be invoked
- * @param contentPadding the padding applied to the content of this menu item
- * @param interactionSource the [MutableInteractionSource] representing the stream of
- * [Interaction]s for this DropdownMenuItem. You can create and pass in your own remembered
- * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
- * appearance / behavior of this DropdownMenuItem in different [Interaction]s.
- */
-@Composable
-actual fun DropdownMenuItem(
-    onClick: () -> Unit,
-    modifier: Modifier,
-    enabled: Boolean,
-    contentPadding: PaddingValues,
-    interactionSource: MutableInteractionSource,
-    content: @Composable RowScope.() -> Unit
-) {
-    DropdownMenuItemContent(
-        onClick = onClick,
-        modifier = modifier,
-        enabled = enabled,
-        contentPadding = contentPadding,
-        interactionSource = interactionSource,
-        content = content
-    )
 }
 
 @OptIn(ExperimentalComposeUiApi::class)

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
@@ -1,5 +1,6 @@
+
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,81 +24,29 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.DpOffset
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-
-/**
- * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
- *
- * A dropdown menu is a compact way of displaying multiple choices. It appears upon interaction with
- * an element (such as an icon or button) or when users perform a specific action.
- *
- * ![Menus image](https://developer.android.com/images/reference/androidx/compose/material/menus.png)
- *
- * A [DropdownMenu] behaves similarly to a [Popup], and will use the position of the parent layout
- * to position itself on screen. Commonly a [DropdownMenu] will be placed in a [Box] with a sibling
- * that will be used as the 'anchor'. Note that a [DropdownMenu] by itself will not take up any
- * space in a layout, as the menu is displayed in a separate window, on top of other content.
- *
- * The [content] of a [DropdownMenu] will typically be [DropdownMenuItem]s, as well as custom
- * content. Using [DropdownMenuItem]s will result in a menu that matches the Material
- * specification for menus. Also note that the [content] is placed inside a scrollable [Column],
- * so using a [LazyColumn] as the root layout inside [content] is unsupported.
- *
- * [onDismissRequest] will be called when the menu should close - for example when there is a
- * tap outside the menu, or when the back key is pressed.
- *
- * [DropdownMenu] changes its positioning depending on the available space, always trying to be
- * fully visible. It will try to expand horizontally, depending on layout direction, to the end of
- * its parent, then to the start of its parent, and then screen end-aligned. Vertically, it will
- * try to expand to the bottom of its parent, then from the top of its parent, and then screen
- * top-aligned. An [offset] can be provided to adjust the positioning of the menu for cases when
- * the layout bounds of its parent do not coincide with its visual bounds. Note the offset will
- * be applied in the direction in which the menu will decide to expand.
- *
- * Example usage:
- * @sample androidx.compose.material.samples.MenuSample
- *
- * @param expanded Whether the menu is currently open and visible to the user
- * @param onDismissRequest Called when the user requests to dismiss the menu, such as by
- * tapping outside the menu's bounds
- * @param offset [DpOffset] to be added to the position of the menu
- */
-@Deprecated(
-    level = DeprecationLevel.HIDDEN,
-    replaceWith = ReplaceWith(
-        expression = "DropdownMenu(expanded,onDismissRequest, modifier, offset, " +
-            "rememberScrollState(), properties, content)",
-        "androidx.compose.foundation.rememberScrollState"
-    ),
-    message = "Replaced by a DropdownMenu function with a ScrollState parameter"
-)
-@Composable
-fun DropdownMenu(
-    expanded: Boolean,
-    onDismissRequest: () -> Unit,
-    modifier: Modifier = Modifier,
-    offset: DpOffset = DpOffset(0.dp, 0.dp),
-    properties: PopupProperties = PopupProperties(focusable = true),
-    content: @Composable ColumnScope.() -> Unit
-) = DropdownMenu(
-    expanded = expanded,
-    onDismissRequest = onDismissRequest,
-    modifier = modifier,
-    offset = offset,
-    scrollState = rememberScrollState(),
-    properties = properties,
-    content = content
-)
 
 /**
  * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
@@ -166,11 +115,18 @@ actual fun DropdownMenu(
             transformOriginState.value = calculateTransformOrigin(parentBounds, menuBounds)
         }
 
+        var focusManager: FocusManager? by mutableStateOf(null)
+        var inputModeManager: InputModeManager? by mutableStateOf(null)
         Popup(
             onDismissRequest = onDismissRequest,
             popupPositionProvider = popupPositionProvider,
-            properties = properties
+            properties = properties,
+            onKeyEvent = {
+                handlePopupOnKeyEvent(it, focusManager, inputModeManager)
+            },
         ) {
+            focusManager = LocalFocusManager.current
+            inputModeManager = LocalInputModeManager.current
             DropdownMenuContent(
                 expandedStates = expandedStates,
                 transformOriginState = transformOriginState,
@@ -216,4 +172,27 @@ actual fun DropdownMenuItem(
         interactionSource = interactionSource,
         content = content
     )
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun handlePopupOnKeyEvent(
+    keyEvent: KeyEvent,
+    focusManager: FocusManager?,
+    inputModeManager: InputModeManager?
+): Boolean = if (keyEvent.type == KeyEventType.KeyDown) {
+    when (keyEvent.key) {
+        Key.DirectionDown -> {
+            inputModeManager?.requestInputMode(InputMode.Keyboard)
+            focusManager?.moveFocus(FocusDirection.Next)
+            true
+        }
+        Key.DirectionUp -> {
+            inputModeManager?.requestInputMode(InputMode.Keyboard)
+            focusManager?.moveFocus(FocusDirection.Previous)
+            true
+        }
+        else -> false
+    }
+} else {
+    false
 }

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+/*
+ * Keep binary compatibility on Desktop.
+ */
+@file:JvmName("DesktopMenu_desktopKt")
+
 package androidx.compose.material
 
 import androidx.compose.animation.core.MutableTransitionState
@@ -47,6 +52,7 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import kotlin.jvm.JvmName
 
 /**
  * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.


### PR DESCRIPTION
## Proposed Changes

- Expect `DropdownMenu` and `DropdownMenuItem` in common
- Deprecate old overload on desktop
- Add temporary overload without focusable and properties to avoid "Overload resolution ambiguity" error
- Move fixes from `DesktopDropdownMenuPositionProvider` to common (requires upstreaming)

## Testing

Test: try to use `DropdownMenu` and `DropdownMenuItem`

TODO: add to `mpp` demo
