### PR TITLE
Fix Lazy Grid recomposition

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridDsl.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridDsl.kt
@@ -208,14 +208,14 @@ private fun rememberRowHeightSums(
     }
 }
 
-private fun interface LazyGridSlotCalculation {
+private fun interface LazyGridSlotsCalculation {
     fun invoke(density: Density, constraints: Constraints): LazyGridSlots
 }
 
 /** measurement cache to avoid recalculating row/column sizes on each scroll. */
 private class GridSlotCache(
     private val calculation: Density.(Constraints) -> LazyGridSlots
-) : LazyGridSlotCalculation {
+) : LazyGridSlotsCalculation {
     private var cachedConstraints = Constraints()
     private var cachedDensity: Float = 0f
     private var cachedSizes: LazyGridSlots? = null

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridDsl.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGridDsl.kt
@@ -170,7 +170,7 @@ private fun rememberColumnWidthSums(
                 LazyGridSlots(sizes, positions)
             }
         }
-    }
+    }.let { it::invoke }
 }
 
 /** Returns prefix sums of row heights. */
@@ -203,18 +203,24 @@ private fun rememberRowHeightSums(
                 LazyGridSlots(sizes, positions)
             }
         }
+    }.let {
+        it::invoke
     }
 }
 
-/** measurement cache to avoid recalculating row/column sizes on each scroll. */
-private fun GridSlotCache(
-    calculation: Density.(Constraints) -> LazyGridSlots
-) : (Density, Constraints) -> LazyGridSlots {
-    var cachedConstraints = Constraints()
-    var cachedDensity: Float = 0f
-    var cachedSizes: LazyGridSlots? = null
+private fun interface LazyGridSlotCalculation {
+    fun invoke(density: Density, constraints: Constraints): LazyGridSlots
+}
 
-    fun invoke(density: Density, constraints: Constraints): LazyGridSlots {
+/** measurement cache to avoid recalculating row/column sizes on each scroll. */
+private class GridSlotCache(
+    private val calculation: Density.(Constraints) -> LazyGridSlots
+) : LazyGridSlotCalculation {
+    private var cachedConstraints = Constraints()
+    private var cachedDensity: Float = 0f
+    private var cachedSizes: LazyGridSlots? = null
+
+    override fun invoke(density: Density, constraints: Constraints): LazyGridSlots {
         with(density) {
             if (
                 cachedSizes != null &&
@@ -231,8 +237,6 @@ private fun GridSlotCache(
             }
         }
     }
-
-    return ::invoke
 }
 
 /**

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridDsl.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridDsl.kt
@@ -118,7 +118,7 @@ private fun rememberColumnSlots(
                 LazyStaggeredGridSlots(positions, sizes)
             }
         }
-    }
+    }.let { it::invoke }
 }
 
 /**
@@ -206,18 +206,24 @@ private fun rememberRowSlots(
                 LazyStaggeredGridSlots(positions, sizes)
             }
         }
+    }.let {
+        it::invoke
     }
 }
 
-/** measurement cache to avoid recalculating row/column sizes on each scroll. */
-private fun LazyStaggeredGridSlotCache(
-    calculation: Density.(Constraints) -> LazyStaggeredGridSlots
-) : (Density, Constraints) -> LazyStaggeredGridSlots {
-    var cachedConstraints = Constraints()
-    var cachedDensity: Float = 0f
-    var cachedSizes: LazyStaggeredGridSlots? = null
+private fun interface LazyGridStaggeredGridSlotsCalculation {
+    fun invoke(density: Density, constraints: Constraints): LazyStaggeredGridSlots
+}
 
-    fun invoke(density: Density, constraints: Constraints): LazyStaggeredGridSlots {
+/** measurement cache to avoid recalculating row/column sizes on each scroll. */
+private class LazyStaggeredGridSlotCache(
+    private val calculation: Density.(Constraints) -> LazyStaggeredGridSlots
+) : LazyGridStaggeredGridSlotsCalculation {
+    private var cachedConstraints = Constraints()
+    private var cachedDensity: Float = 0f
+    private var cachedSizes: LazyStaggeredGridSlots? = null
+
+    override fun invoke(density: Density, constraints: Constraints): LazyStaggeredGridSlots {
         with(density) {
             if (
                 cachedSizes != null &&
@@ -234,8 +240,6 @@ private fun LazyStaggeredGridSlotCache(
             }
         }
     }
-
-    return ::invoke
 }
 
 /** Dsl marker for [LazyStaggeredGridScope] below **/

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -19,9 +19,9 @@ import androidx.compose.ui.unit.dp
 
 val MainScreen = Screen.Selection(
     "Demo",
+    BugReproducers,
     Screen.Example("Example1") { Example1() },
     Screen.Example("ImageViewer") { ImageViewer() },
-    Screen.Example("RoundedCornerCrashOnJS") { RoundedCornerCrashOnJS() },
     Screen.Example("TextDirection") { TextDirection() },
     Screen.Example("FontFamilies") { FontFamilies() },
     Screen.Example("LottieAnimation") { LottieAnimation() },

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/BugReproducers.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/BugReproducers.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+
+val BugReproducers = Screen.Selection("Bug Reproducers",
+    // https://github.com/JetBrains/compose-multiplatform/issues/3475
+    Screen.Example("No Recomposition in Lazy Grid") { NoRecompositionInLazyGrid() },
+    Screen.Example("RoundedCornerCrashOnJS") { RoundedCornerCrashOnJS() },
+)
+
+@Composable
+fun NoRecompositionInLazyGrid() {
+    var string by remember { mutableStateOf("1") }
+    val value by derivedStateOf {
+        maxOf(string.toIntOrNull() ?: 1, 1)
+    }
+
+    Column(Modifier.fillMaxSize()) {
+        TextField(string, onValueChange = {
+            string = it
+        })
+
+        Box {
+            BoxWithConstraints {
+                val gridItems = (0 until 20).toList()
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(value),
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    itemsIndexed(gridItems) { index, _->
+                        Text("Item index: $index")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOrderModifier.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOrderModifier.kt
@@ -205,6 +205,6 @@ internal class FocusOrderToProperties(
     }
 }
 
-fun interface InvokeOnFocusProperties {
+internal fun interface InvokeOnFocusProperties {
     fun invoke(focusProperties: FocusProperties)
 }


### PR DESCRIPTION
This is a follow up to https://github.com/JetBrains/compose-multiplatform-core/pull/663

This PR adds 2 new private fun interfaces, because k/js doesn't allow classes implementing FunctionN interfaces like `class Abc: () -> Unit`

It fixies https://github.com/JetBrains/compose-multiplatform/issues/3475