### PR TITLE
Expect `DatePickerDialog` in common

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePickerDialog.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePickerDialog.kt
@@ -16,24 +16,11 @@
 
 package androidx.compose.material3
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material3.tokens.DatePickerModalTokens
-import androidx.compose.material3.tokens.DialogTokens
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 
 /**
@@ -62,59 +49,14 @@ import androidx.compose.ui.window.DialogProperties
  */
 @ExperimentalMaterial3Api
 @Composable
-actual fun DatePickerDialog(
+expect fun DatePickerDialog(
     onDismissRequest: () -> Unit,
     confirmButton: @Composable () -> Unit,
-    modifier: Modifier,
-    dismissButton: @Composable (() -> Unit)?,
-    shape: Shape,
-    tonalElevation: Dp,
-    colors: DatePickerColors,
-    properties: DialogProperties,
+    modifier: Modifier = Modifier,
+    dismissButton: @Composable (() -> Unit)? = null,
+    shape: Shape = DatePickerDefaults.shape,
+    tonalElevation: Dp = DatePickerDefaults.TonalElevation,
+    colors: DatePickerColors = DatePickerDefaults.colors(),
+    properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
     content: @Composable ColumnScope.() -> Unit
-) {
-    AlertDialog(
-        onDismissRequest = onDismissRequest,
-        modifier = modifier.wrapContentHeight(),
-        properties = properties
-    ) {
-        Surface(
-            modifier = Modifier
-                .requiredWidth(DatePickerModalTokens.ContainerWidth)
-                .heightIn(max = DatePickerModalTokens.ContainerHeight),
-            shape = shape,
-            color = colors.containerColor,
-            tonalElevation = tonalElevation,
-        ) {
-            Column(verticalArrangement = Arrangement.SpaceBetween) {
-                content()
-                // Buttons
-                Box(
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .padding(DialogButtonsPadding)
-                ) {
-                    CompositionLocalProvider(
-                        LocalContentColor provides DialogTokens.ActionLabelTextColor.toColor()
-                    ) {
-                        val textStyle =
-                            MaterialTheme.typography.fromToken(DialogTokens.ActionLabelTextFont)
-                        ProvideTextStyle(value = textStyle) {
-                            AlertDialogFlowRow(
-                                mainAxisSpacing = DialogButtonsMainAxisSpacing,
-                                crossAxisSpacing = DialogButtonsCrossAxisSpacing
-                            ) {
-                                dismissButton?.invoke()
-                                confirmButton()
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-private val DialogButtonsPadding = PaddingValues(bottom = 8.dp, end = 6.dp)
-private val DialogButtonsMainAxisSpacing = 8.dp
-private val DialogButtonsCrossAxisSpacing = 12.dp
+)

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/DatePickerDialog.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/DatePickerDialog.skiko.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material3
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.tokens.DatePickerModalTokens
+import androidx.compose.material3.tokens.DialogTokens
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+
+/**
+ * <a href="https://m3.material.io/components/date-pickers/overview" class="external" target="_blank">Material Design date picker dialog</a>.
+ *
+ * A dialog for displaying a [DatePicker]. Date pickers let people select a date.
+ *
+ * A sample for displaying a [DatePicker] in a dialog:
+ * @sample androidx.compose.material3.samples.DatePickerDialogSample
+ *
+ * @param onDismissRequest called when the user tries to dismiss the Dialog by clicking outside
+ * or pressing the back button. This is not called when the dismiss button is clicked.
+ * @param confirmButton button which is meant to confirm a proposed action, thus resolving what
+ * triggered the dialog. The dialog does not set up any events for this button, nor does it control
+ * its enablement, so those need to be set up by the caller.
+ * @param modifier the [Modifier] to be applied to this dialog's content.
+ * @param dismissButton button which is meant to dismiss the dialog. The dialog does not set up any
+ * events for this button so they need to be set up by the caller.
+ * @param shape defines the dialog's surface shape as well its shadow
+ * @param tonalElevation when [DatePickerColors.containerColor] is [ColorScheme.surface], a higher
+ * the elevation will result in a darker color in light theme and lighter color in dark theme
+ * @param colors [DatePickerColors] that will be used to resolve the colors used for this date
+ * picker in different states. See [DatePickerDefaults.colors].
+ * @param properties typically platform specific properties to further configure the dialog
+ * @param content the content of the dialog (i.e. a [DatePicker], for example)
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+@ExperimentalMaterial3Api
+@Composable
+fun DatePickerDialog(
+    onDismissRequest: () -> Unit,
+    confirmButton: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    dismissButton: @Composable (() -> Unit)? = null,
+    shape: Shape = DatePickerDefaults.shape,
+    tonalElevation: Dp = DatePickerDefaults.TonalElevation,
+    colors: DatePickerColors = DatePickerDefaults.colors(),
+    properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+    content: @Composable ColumnScope.() -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        modifier = modifier.wrapContentHeight(),
+        properties = properties
+    ) {
+        Surface(
+            modifier = Modifier
+                .requiredWidth(DatePickerModalTokens.ContainerWidth)
+                .heightIn(max = DatePickerModalTokens.ContainerHeight),
+            shape = shape,
+            color = colors.containerColor,
+            tonalElevation = tonalElevation,
+        ) {
+            Column(verticalArrangement = Arrangement.SpaceBetween) {
+                content()
+                // Buttons
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(DialogButtonsPadding)
+                ) {
+                    CompositionLocalProvider(
+                        LocalContentColor provides DialogTokens.ActionLabelTextColor.toColor()
+                    ) {
+                        val textStyle =
+                            MaterialTheme.typography.fromToken(DialogTokens.ActionLabelTextFont)
+                        ProvideTextStyle(value = textStyle) {
+                            AlertDialogFlowRow(
+                                mainAxisSpacing = DialogButtonsMainAxisSpacing,
+                                crossAxisSpacing = DialogButtonsCrossAxisSpacing
+                            ) {
+                                dismissButton?.invoke()
+                                confirmButton()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private val DialogButtonsPadding = PaddingValues(bottom = 8.dp, end = 6.dp)
+private val DialogButtonsMainAxisSpacing = 8.dp
+private val DialogButtonsCrossAxisSpacing = 12.dp

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/DatePickerDialog.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/DatePickerDialog.skiko.kt
@@ -61,18 +61,17 @@ import androidx.compose.ui.window.DialogProperties
  * @param properties typically platform specific properties to further configure the dialog
  * @param content the content of the dialog (i.e. a [DatePicker], for example)
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @ExperimentalMaterial3Api
 @Composable
-fun DatePickerDialog(
+actual fun DatePickerDialog(
     onDismissRequest: () -> Unit,
     confirmButton: @Composable () -> Unit,
-    modifier: Modifier = Modifier,
-    dismissButton: @Composable (() -> Unit)? = null,
-    shape: Shape = DatePickerDefaults.shape,
-    tonalElevation: Dp = DatePickerDefaults.TonalElevation,
-    colors: DatePickerColors = DatePickerDefaults.colors(),
-    properties: DialogProperties = DialogProperties(usePlatformDefaultWidth = false),
+    modifier: Modifier,
+    dismissButton: @Composable (() -> Unit)?,
+    shape: Shape,
+    tonalElevation: Dp,
+    colors: DatePickerColors,
+    properties: DialogProperties,
     content: @Composable ColumnScope.() -> Unit
 ) {
     AlertDialog(

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/DateTimePickers.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/DateTimePickers.kt
@@ -16,33 +16,71 @@
 
 package androidx.compose.mpp.demo
 
-import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DateTimePickers() {
     Column(
         modifier = Modifier
+            .padding(5.dp)
             .fillMaxWidth()
-            .verticalScroll(rememberScrollState()),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .verticalScroll(rememberScrollState())
     ) {
-        val dpState = rememberDatePickerState()
-        val tpState = rememberTimePickerState()
+        Text("DatePicker:")
+        Box(Modifier.border(1.dp, Color.Black)) {
+            val state = rememberDatePickerState()
+            DatePicker(state)
+        }
 
-        DatePicker(dpState)
-        TimePicker(tpState)
+        Text("TimePicker:")
+        Box(Modifier.border(1.dp, Color.Black)) {
+            val state = rememberTimePickerState()
+            TimePicker(state)
+        }
+
+        var openDialog by remember { mutableStateOf(false) }
+        Button(onClick = { openDialog = true }) {
+            Text("DatePickerDialog")
+        }
+        if (openDialog) {
+            val state = rememberDatePickerState()
+            DatePickerDialog(
+                onDismissRequest = { openDialog = false },
+                confirmButton = {
+                    Button(onClick = {
+                        openDialog = false
+                        println("Selected date timestamp: ${state.selectedDateMillis}")
+                    }) {
+                        Text("Confirm")
+                    }
+                },
+                content = {
+                    DatePicker(state)
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Copy `DatePickerDialog` implementation from Android. ~This cannot be in common yet (see #736) because of `usePlatformDefaultWidth` parameter in default arguments.~  Solved in #746

## Testing

Test: Try to use `DatePickerDialog` in common

## Issues Fixed

Fixes (partially) https://github.com/JetBrains/compose-multiplatform/issues/2037#issuecomment-1665372193
