### PR TITLE
Expect missing properties in common (temporary hack)

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Dialog.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Dialog.kt
@@ -32,10 +32,20 @@ import androidx.compose.runtime.Immutable
 @Immutable
 expect class DialogProperties(
     dismissOnBackPress: Boolean = true,
-    dismissOnClickOutside: Boolean = true
+    dismissOnClickOutside: Boolean = true,
+
+    /*
+     * Temporary hack to skip unsupported arguments from Android source set.
+     * Should be removed after upstreaming changes from JetBrains' fork.
+     */
+    @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
+    vararg unsupported: Nothing,
+
+    usePlatformDefaultWidth: Boolean = true,
 ) {
     val dismissOnBackPress: Boolean
     val dismissOnClickOutside: Boolean
+    val usePlatformDefaultWidth: Boolean
 }
 
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Dialog.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Dialog.kt
@@ -37,6 +37,8 @@ expect class DialogProperties(
     /*
      * Temporary hack to skip unsupported arguments from Android source set.
      * Should be removed after upstreaming changes from JetBrains' fork.
+     *
+     * Please use explicit labels for following arguments.
      */
     @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
     vararg unsupported: Nothing,

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Dialog.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Dialog.kt
@@ -28,6 +28,9 @@ import androidx.compose.runtime.Immutable
  * If true, pressing the back button will call onDismissRequest.
  * @property dismissOnClickOutside whether the dialog can be dismissed by clicking outside the
  * dialog's bounds. If true, clicking outside the dialog will call onDismissRequest.
+ * @property usePlatformDefaultWidth Whether the width of the dialog's content should be limited to
+ * the platform default, which is smaller than the screen width.
+ * **Might be used only as named argument**.
  */
 @Immutable
 expect class DialogProperties(
@@ -38,7 +41,7 @@ expect class DialogProperties(
      * Temporary hack to skip unsupported arguments from Android source set.
      * Should be removed after upstreaming changes from JetBrains' fork.
      *
-     * Please use explicit labels for following arguments.
+     * After skip this unsupported argument, you must name all subsequent arguments.
      */
     @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
     vararg unsupported: Nothing,

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
@@ -47,6 +47,8 @@ expect class PopupProperties(
     /*
      * Temporary hack to skip unsupported arguments from Android source set.
      * Should be removed after upstreaming changes from JetBrains' fork.
+     *
+     * Please use explicit labels for following arguments.
      */
     @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
     vararg unsupported: Nothing,

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
@@ -42,11 +42,21 @@ import androidx.compose.ui.unit.LayoutDirection
 expect class PopupProperties(
     focusable: Boolean = false,
     dismissOnBackPress: Boolean = true,
-    dismissOnClickOutside: Boolean = true
+    dismissOnClickOutside: Boolean = true,
+
+    /*
+     * Temporary hack to skip unsupported arguments from Android source set.
+     * Should be removed after upstreaming changes from JetBrains' fork.
+     */
+    @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
+    vararg unsupported: Nothing,
+
+    clippingEnabled: Boolean = true,
 ) {
     val focusable: Boolean
     val dismissOnBackPress: Boolean
     val dismissOnClickOutside: Boolean
+    val clippingEnabled: Boolean
 }
 
 /**

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/Popup.kt
@@ -37,6 +37,11 @@ import androidx.compose.ui.unit.LayoutDirection
  * focusable then this property does nothing.
  * @property dismissOnClickOutside Whether the popup can be dismissed by clicking outside the
  * popup's bounds. If true, clicking outside the popup will call onDismissRequest.
+ * @property clippingEnabled Whether to allow the popup window to extend beyond the bounds of the
+ * screen. By default the window is clipped to the screen boundaries. Setting this to false will
+ * allow windows to be accurately positioned.
+ * The default value is true.
+ * **Might be used only as named argument**.
  */
 @Immutable
 expect class PopupProperties(
@@ -48,7 +53,7 @@ expect class PopupProperties(
      * Temporary hack to skip unsupported arguments from Android source set.
      * Should be removed after upstreaming changes from JetBrains' fork.
      *
-     * Please use explicit labels for following arguments.
+     * After skip this unsupported argument, you must name all subsequent arguments.
      */
     @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
     vararg unsupported: Nothing,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -63,16 +63,37 @@ private val DefaultScrimColor = Color.Black.copy(alpha = DefaultScrimOpacity)
 actual class DialogProperties @ExperimentalComposeUiApi constructor(
     actual val dismissOnBackPress: Boolean = true,
     actual val dismissOnClickOutside: Boolean = true,
-    val usePlatformDefaultWidth: Boolean = true,
+    actual val usePlatformDefaultWidth: Boolean = true,
     val scrimColor: Color = DefaultScrimColor,
 ) {
-    actual constructor(
-        dismissOnBackPress: Boolean,
-        dismissOnClickOutside: Boolean
+    // Constructor with all non-experimental arguments.
+    constructor(
+        dismissOnBackPress: Boolean = true,
+        dismissOnClickOutside: Boolean = true,
+        usePlatformDefaultWidth: Boolean = true,
     ) : this(
         dismissOnBackPress = dismissOnBackPress,
         dismissOnClickOutside = dismissOnClickOutside,
-        usePlatformDefaultWidth = true,
+        usePlatformDefaultWidth = usePlatformDefaultWidth,
+        scrimColor = DefaultScrimColor
+    )
+
+    actual constructor(
+        dismissOnBackPress: Boolean,
+        dismissOnClickOutside: Boolean,
+
+        /*
+         * Temporary hack to skip unsupported arguments from Android source set.
+         * Should be removed after upstreaming changes from JetBrains' fork.
+         */
+        @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
+        vararg unsupported: Nothing,
+
+        usePlatformDefaultWidth: Boolean,
+    ) : this(
+        dismissOnBackPress = dismissOnBackPress,
+        dismissOnClickOutside = dismissOnClickOutside,
+        usePlatformDefaultWidth = usePlatformDefaultWidth,
         scrimColor = DefaultScrimColor
     )
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -86,7 +86,7 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
          * Temporary hack to skip unsupported arguments from Android source set.
          * Should be removed after upstreaming changes from JetBrains' fork.
          *
-         * Please use explicit labels for following arguments.
+         * After skip this unsupported argument, you must name all subsequent arguments.
          */
         @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
         vararg unsupported: Nothing,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -85,6 +85,8 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
         /*
          * Temporary hack to skip unsupported arguments from Android source set.
          * Should be removed after upstreaming changes from JetBrains' fork.
+         *
+         * Please use explicit labels for following arguments.
          */
         @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
         vararg unsupported: Nothing,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -95,7 +95,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
          * Temporary hack to skip unsupported arguments from Android source set.
          * Should be removed after upstreaming changes from JetBrains' fork.
          *
-         * Please use explicit labels for following arguments.
+         * After skip this unsupported argument, you must name all subsequent arguments.
          */
         @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
         vararg unsupported: Nothing,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -94,6 +94,8 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
         /*
          * Temporary hack to skip unsupported arguments from Android source set.
          * Should be removed after upstreaming changes from JetBrains' fork.
+         *
+         * Please use explicit labels for following arguments.
          */
         @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
         vararg unsupported: Nothing,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -69,17 +69,41 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
     actual val focusable: Boolean = false,
     actual val dismissOnBackPress: Boolean = true,
     actual val dismissOnClickOutside: Boolean = true,
-    val clippingEnabled: Boolean = true,
+    actual val clippingEnabled: Boolean = true,
     val usePlatformDefaultWidth: Boolean = false,
 ) {
-    actual constructor(
-        focusable: Boolean,
-        dismissOnBackPress: Boolean,
-        dismissOnClickOutside: Boolean
+    // Constructor with all non-experimental arguments.
+    constructor(
+        focusable: Boolean = false,
+        dismissOnBackPress: Boolean = true,
+        dismissOnClickOutside: Boolean = true,
+        clippingEnabled: Boolean = true,
     ) : this(
         focusable = focusable,
         dismissOnBackPress = dismissOnBackPress,
         dismissOnClickOutside = dismissOnClickOutside,
+        clippingEnabled = clippingEnabled,
+        usePlatformDefaultWidth = false,
+    )
+
+    actual constructor(
+        focusable: Boolean,
+        dismissOnBackPress: Boolean,
+        dismissOnClickOutside: Boolean,
+
+        /*
+         * Temporary hack to skip unsupported arguments from Android source set.
+         * Should be removed after upstreaming changes from JetBrains' fork.
+         */
+        @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
+        vararg unsupported: Nothing,
+
+        clippingEnabled: Boolean,
+    ) : this(
+        focusable = focusable,
+        dismissOnBackPress = dismissOnBackPress,
+        dismissOnClickOutside = dismissOnClickOutside,
+        clippingEnabled = clippingEnabled,
         usePlatformDefaultWidth = false,
     )
 


### PR DESCRIPTION
## Proposed Changes

- Add `DialogProperties.usePlatformDefaultWidth` setting in common `expect` constructor
- Add `PopupProperties. clippingEnabled` setting in common `expect` constructor
- Use temporary hack with `Nothing` to skip unsupported arguments from Android source set

## Testing

Test: Try to use it from common
