### PR TITLE
Rename internal class: `SkiaLayer`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/RenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/RenderNodeLayer.skiko.kt
@@ -27,7 +27,7 @@ import kotlin.math.abs
 import kotlin.math.max
 import org.jetbrains.skia.*
 
-internal class SkiaLayer(
+internal class RenderNodeLayer(
     private var density: Density,
     private val invalidateParentLayer: () -> Unit,
     private val drawBlock: (Canvas) -> Unit,
@@ -258,7 +258,7 @@ internal class SkiaLayer(
                 canvas.saveLayer(
                     bounds,
                     Paint().apply {
-                        alpha = this@SkiaLayer.alpha
+                        alpha = this@RenderNodeLayer.alpha
                         asFrameworkPaint().imageFilter = currentRenderEffect?.asSkiaImageFilter()
                     }
                 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -313,7 +313,7 @@ internal class SkiaBasedOwner(
     override fun createLayer(
         drawBlock: (Canvas) -> Unit,
         invalidateParentLayer: () -> Unit
-    ) = SkiaLayer(
+    ) = RenderNodeLayer(
         density,
         invalidateParentLayer = {
             invalidateParentLayer()

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderNodeLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderNodeLayerTest.kt
@@ -27,9 +27,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class SkiaLayerTest {
+class RenderNodeLayerTest {
 
-    private val layer = TestSkiaLayer()
+    private val layer = TestRenderNodeLayer()
     private val cos45 = cos(PI / 4).toFloat()
 
     private val matrix get() = layer.matrix
@@ -464,7 +464,7 @@ class SkiaLayerTest {
         assertTrue(layer.isInLayer(Offset(50f, 100f)))
     }
 
-    private fun TestSkiaLayer() = SkiaLayer(
+    private fun TestRenderNodeLayer() = RenderNodeLayer(
         Density(1f, 1f),
         invalidateParentLayer = {},
         drawBlock = {}
@@ -481,7 +481,7 @@ class SkiaLayerTest {
         assertEquals(expected.y, actual.y, absoluteTolerance, message)
     }
 
-    private fun SkiaLayer.updateProperties(
+    private fun RenderNodeLayer.updateProperties(
         scaleX: Float = 1f,
         scaleY: Float = 1f,
         alpha: Float = 1f,


### PR DESCRIPTION
## Proposed Changes

- Rename internal class `SkiaLayer` to `RenderNodeLayer` (avoid messing up with `org.jetbrains.skiko.SkiaLayer`). This component has `RenderNodeLayer` name on Android sourceset too. 

## Testing

Test: N/A
