### PR TITLE
Replace function interface inheritance by fun interface

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/FocusedBounds.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/FocusedBounds.kt
@@ -68,25 +68,22 @@ private class FocusedBoundsObserverElement(
     }
 }
 
-private fun interface InvokeOnLayoutCoordinates {
-    fun invoke(focusedBounds: LayoutCoordinates?)
-}
-
-private class FocusedBoundsObserverNode(
+internal class FocusedBoundsObserverNode(
     var onPositioned: (LayoutCoordinates?) -> Unit
-) : Modifier.Node(), ModifierLocalModifierNode, InvokeOnLayoutCoordinates {
+) : Modifier.Node(), ModifierLocalModifierNode {
     private val parent: ((LayoutCoordinates?) -> Unit)?
         get() = if (isAttached) ModifierLocalFocusedBoundsObserver.current else null
 
-    override val providedValues: ModifierLocalMap =
-        modifierLocalMapOf(entry = ModifierLocalFocusedBoundsObserver to { invoke(it) })
-
     /** Called when a child gains/loses focus or is focused and changes position. */
-    override fun invoke(focusedBounds: LayoutCoordinates?) {
-        if (!isAttached) return
-        onPositioned(focusedBounds)
-        parent?.invoke(focusedBounds)
+    private val focusBoundsObserver: (LayoutCoordinates?) -> Unit = { focusedBounds ->
+        if (isAttached) {
+            onPositioned(focusedBounds)
+            parent?.invoke(focusedBounds)
+        }
     }
+
+    override val providedValues: ModifierLocalMap =
+        modifierLocalMapOf(entry = ModifierLocalFocusedBoundsObserver to focusBoundsObserver)
 }
 
 /**

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGrid.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/grid/LazyGrid.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
@@ -56,7 +55,7 @@ internal fun LazyGrid(
     /** State controlling the scroll position */
     state: LazyGridState,
     /** Prefix sums of cross axis sizes of slots per line, e.g. the columns for vertical grid. */
-    slots: Density.(Constraints) -> LazyGridSlots,
+    slots: LazyGridSlotsProvider,
     /** The inner padding to be added for the whole content (not for each individual item) */
     contentPadding: PaddingValues = PaddingValues(0.dp),
     /** reverse the direction of scrolling and layout */
@@ -160,7 +159,7 @@ private fun rememberLazyGridMeasurePolicy(
     /** The state of the list. */
     state: LazyGridState,
     /** Prefix sums of cross axis sizes of slots of the grid. */
-    slots: Density.(Constraints) -> LazyGridSlots,
+    slots: LazyGridSlotsProvider,
     /** The inner padding to be added for the whole content(nor for each individual item) */
     contentPadding: PaddingValues,
     /** reverse the direction of scrolling and layout */
@@ -219,7 +218,7 @@ private fun rememberLazyGridMeasurePolicy(
 
         val itemProvider = itemProviderLambda()
         val spanLayoutProvider = itemProvider.spanLayoutProvider
-        val resolvedSlots = slots(containerConstraints)
+        val resolvedSlots = slots.invoke(density = this, constraints = containerConstraints)
         val slotsPerLine = resolvedSlots.sizes.size
         spanLayoutProvider.slotsPerLine = slotsPerLine
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGrid.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGrid.kt
@@ -30,8 +30,6 @@ import androidx.compose.foundation.overscroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -43,7 +41,7 @@ internal fun LazyStaggeredGrid(
     /** The layout orientation of the grid */
     orientation: Orientation,
     /** Cross axis positions and sizes of slots per line, e.g. the columns for vertical grid. */
-    slots: Density.(Constraints) -> LazyStaggeredGridSlots,
+    slots: LazyGridStaggeredGridSlotsProvider,
     /** Modifier to be applied for the inner layout */
     modifier: Modifier = Modifier,
     /** The inner padding to be added for the whole content (not for each individual item) */

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasurePolicy.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/staggeredgrid/LazyStaggeredGridMeasurePolicy.kt
@@ -27,12 +27,12 @@ import androidx.compose.foundation.lazy.layout.calculateLazyLayoutPinnedIndices
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.constrainHeight
 import androidx.compose.ui.unit.constrainWidth
+import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -44,7 +44,7 @@ internal fun rememberStaggeredGridMeasurePolicy(
     orientation: Orientation,
     mainAxisSpacing: Dp,
     crossAxisSpacing: Dp,
-    slots: Density.(Constraints) -> LazyStaggeredGridSlots
+    slots: LazyGridStaggeredGridSlotsProvider
 ): LazyLayoutMeasureScope.(Constraints) -> LazyStaggeredGridMeasureResult = remember(
     state,
     itemProviderLambda,
@@ -60,7 +60,7 @@ internal fun rememberStaggeredGridMeasurePolicy(
             constraints,
             orientation
         )
-        val resolvedSlots = slots(this, constraints)
+        val resolvedSlots = slots.invoke(density = this, constraints = constraints)
         val isVertical = orientation == Orientation.Vertical
         val itemProvider = itemProviderLambda()
 

--- a/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/focus/CustomFocusTraversalTest.kt
+++ b/compose/ui/ui/src/androidAndroidTest/kotlin/androidx/compose/ui/focus/CustomFocusTraversalTest.kt
@@ -893,7 +893,8 @@ class CustomFocusTraversalTest(
         if (useFocusOrderModifier) {
             this.then(ReceiverFocusOrderModifier(block))
         } else {
-            focusProperties(FocusOrderToProperties(block))
+            val scope = FocusOrderToProperties(block)
+            focusProperties { scope.apply(this) }
         }
 
     @Suppress("DEPRECATION")

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOrderModifier.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOrderModifier.kt
@@ -158,10 +158,10 @@ class FocusOrder internal constructor(private val focusProperties: FocusProperti
 fun Modifier.focusOrder(
     @Suppress("DEPRECATION")
     focusOrderReceiver: FocusOrder.() -> Unit
-): Modifier =
-    focusProperties({
-        FocusOrderToProperties(focusOrderReceiver).invoke(this)
-    })
+): Modifier {
+    val scope = FocusOrderToProperties(focusOrderReceiver)
+    return focusProperties { scope.apply(this) }
+}
 
 /**
  * A modifier that lets you specify a [FocusRequester] for the current composable so that this
@@ -190,21 +190,24 @@ fun Modifier.focusOrder(
     focusRequester: FocusRequester,
     @Suppress("DEPRECATION")
     focusOrderReceiver: FocusOrder.() -> Unit
-): Modifier = this
-    .focusRequester(focusRequester)
-    .focusProperties({
-        FocusOrderToProperties(focusOrderReceiver).invoke(this)
-    })
+): Modifier {
+    val scope = FocusOrderToProperties(focusOrderReceiver)
+    return this
+        .focusRequester(focusRequester)
+        .focusProperties { scope.apply(this) }
+}
 
 @Suppress("DEPRECATION")
 internal class FocusOrderToProperties(
     val focusOrderReceiver: FocusOrder.() -> Unit
-) : InvokeOnFocusProperties {
-    override fun invoke(focusProperties: FocusProperties) {
+) : FocusPropertiesScope {
+    override fun apply(focusProperties: FocusProperties) {
         focusOrderReceiver(FocusOrder(focusProperties))
     }
 }
 
-fun interface InvokeOnFocusProperties {
-    fun invoke(focusProperties: FocusProperties)
+// Note: Implementing function interface is prohibited in K/JS (class A: () -> Unit)
+// therefore we workaround this limitation by inheriting a fun interface instead
+internal fun interface FocusPropertiesScope {
+    fun apply(focusProperties: FocusProperties)
 }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusProperties.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusProperties.kt
@@ -182,7 +182,7 @@ fun Modifier.focusProperties(
 ): Modifier = this then FocusPropertiesElement(scope)
 
 private data class FocusPropertiesElement(
-    val scope: InvokeOnFocusProperties
+    val scope: FocusPropertiesScope
 ) : ModifierNodeElement<FocusPropertiesNode>() {
     override fun create() = FocusPropertiesNode(scope)
 
@@ -197,10 +197,10 @@ private data class FocusPropertiesElement(
 }
 
 private class FocusPropertiesNode(
-    var focusPropertiesScope: InvokeOnFocusProperties,
+    var focusPropertiesScope: FocusPropertiesScope,
 ) : FocusPropertiesModifierNode, Modifier.Node() {
 
     override fun applyFocusProperties(focusProperties: FocusProperties) {
-        focusPropertiesScope.invoke(focusProperties)
+        focusPropertiesScope.apply(focusProperties)
     }
 }


### PR DESCRIPTION
Cherry-pick: https://android-review.googlesource.com/c/platform/frameworks/support/+/2701096

The reason is "Implementing function interface is prohibited in JavaScript". K/JS target is enabled in JB fork.

This CL affects foundation:foundation and ui:ui compose modules

Test: existing tests in ui:ui and foundation:foundation
Change-Id: Iaa8345046e0369b0f707b3f30ec259dd4d0d8f87

