### PR TITLE
Fix keyboard appearance animation regression, add repro

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/BugReproducers.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/BugReproducers.kt
@@ -32,6 +32,7 @@ val BugReproducers = Screen.Selection("Bug Reproducers",
     // https://github.com/JetBrains/compose-multiplatform/issues/3475
     Screen.Example("No Recomposition in Lazy Grid") { NoRecompositionInLazyGrid() },
     Screen.Example("RoundedCornerCrashOnJS") { RoundedCornerCrashOnJS() },
+    Screen.Example("Keyboard animation repro") { KeyboardAnimationRepro() }
 )
 
 @Composable

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/KeyboardAnimationRepro.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/KeyboardAnimationRepro.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+
+private val messageList = MutableStateFlow<List<String>>(emptyList())
+
+private suspend fun sendMessage(text: String) {
+    val newList = messageList.value + text
+    messageList.emit(newList)
+}
+
+@Composable
+fun KeyboardAnimationRepro() {
+    Column(
+        modifier = Modifier.fillMaxSize().background(Color.Black)
+    ) {
+        val coroutineScope = rememberCoroutineScope()
+        val messages = messageList.collectAsState().value
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth().weight(1f)
+        ) {
+            items(messages) {
+                Text(
+                    modifier = Modifier.padding(16.dp),
+                    color = Color.White,
+                    text = it
+                )
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        var text by remember { mutableStateOf<String>("") }
+        Row {
+            OutlinedTextField(
+                modifier = Modifier.weight(1f),
+                value = text,
+                colors = TextFieldDefaults.textFieldColors(
+                    textColor = Color.White
+                ),
+                onValueChange = {
+                    text = it
+                }
+            )
+            Button(
+                modifier = Modifier.wrapContentSize().padding(8.dp),
+                onClick = {
+                    coroutineScope.launch {
+                        sendMessage(text)
+                        text = ""
+                    }
+                }
+            ) {
+                Text(text = "Send")
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -165,7 +165,7 @@ internal actual class ComposeWindow : UIViewController {
     private val keyboardVisibilityListener = object : NSObject() {
         @Suppress("unused")
         @ObjCAction
-        fun keyboardDidShow(arg: NSNotification) {
+        fun keyboardWillShow(arg: NSNotification) {
             val keyboardInfo = arg.userInfo!!["UIKeyboardFrameEndUserInfoKey"] as NSValue
             val keyboardHeight = keyboardInfo.CGRectValue().useContents { size.height }
             val screenHeight = UIScreen.mainScreen.bounds.useContents { size.height }
@@ -301,8 +301,8 @@ internal actual class ComposeWindow : UIViewController {
         super.viewDidAppear(animated)
         NSNotificationCenter.defaultCenter.addObserver(
             observer = keyboardVisibilityListener,
-            selector = NSSelectorFromString(keyboardVisibilityListener::keyboardDidShow.name + ":"),
-            name = UIKeyboardDidShowNotification,
+            selector = NSSelectorFromString(keyboardVisibilityListener::keyboardWillShow.name + ":"),
+            name = UIKeyboardWillShowNotification,
             `object` = null
         )
         NSNotificationCenter.defaultCenter.addObserver(
@@ -319,7 +319,7 @@ internal actual class ComposeWindow : UIViewController {
 
         NSNotificationCenter.defaultCenter.removeObserver(
             observer = keyboardVisibilityListener,
-            name = UIKeyboardDidShowNotification,
+            name = UIKeyboardWillShowNotification,
             `object` = null
         )
         NSNotificationCenter.defaultCenter.removeObserver(


### PR DESCRIPTION
## Proposed Changes

Move layer offset logic back to `UIKeyboardWillShowNotification` to invoke implicit CATransaction animation.

## Testing

Test: N/A

## Issues Fixed

Fixes: Broken smooth animation reported in the [issue](https://github.com/JetBrains/compose-multiplatform/issues/3485).


https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/1dd4535e-b2d3-483d-bf17-47ffebc23872