### PR TITLE
Localization for hour cycles

### DIFF
--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
@@ -104,4 +104,10 @@ internal actual object PlatformDateFormat {
     private fun firstDayOfWeek(): Int {
         return (NSCalendar.currentCalendar.firstWeekday.toInt() - 1).takeIf { it > 0 } ?: 7
     }
+
+    actual fun is24HourFormat(locale: CalendarLocale): Boolean {
+        return NSDateFormatter
+            .dateFormatFromTemplate("j",0, locale)
+            ?.contains('a') == false
+    }
 }

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
@@ -105,9 +105,13 @@ internal actual object PlatformDateFormat {
         return (NSCalendar.currentCalendar.firstWeekday.toInt() - 1).takeIf { it > 0 } ?: 7
     }
 
+    // See http://www.unicode.org/reports/tr35/tr35-31/tr35-dates.html#Date_Format_Patterns
+    //
+    // 'j' template requests the preferred hour format for the locale.
+    // 'a' is a pattern for AM\PM symbol. Presence of this symbol means that locale has 12h format.
     actual fun is24HourFormat(locale: CalendarLocale): Boolean {
         return NSDateFormatter
-            .dateFormatFromTemplate("j",0, locale)
+            .dateFormatFromTemplate("j", 0, locale)
             ?.contains('a') == false
     }
 }

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -16,6 +16,10 @@
 
 package androidx.compose.material3
 
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+
+
 internal actual object PlatformDateFormat {
 
     private val delegate = LegacyCalendarModelImpl()
@@ -61,5 +65,17 @@ internal actual object PlatformDateFormat {
 
     actual fun weekdayNames(locale: CalendarLocale): List<Pair<String, String>>? {
         return delegate.weekdayNames(locale)
+    }
+
+    // https://android.googlesource.com/platform/frameworks/base/+/jb-release/core/java/android/text/format/DateFormat.java
+    //
+    // public static boolean is24HourFormat(Context context) -- used by Android date format
+    actual fun is24HourFormat(locale : CalendarLocale) : Boolean {
+        val dateFormat = DateFormat.getTimeInstance(DateFormat.LONG, locale)
+
+        if (dateFormat !is SimpleDateFormat)
+            return false
+
+        return 'H' in dateFormat.toPattern()
     }
 }

--- a/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
@@ -197,11 +197,12 @@ internal actual object PlatformDateFormat {
         return longAndShortWeekDays[0].zip(longAndShortWeekDays[1])
     }
 
+    // supported by most of browsers except Firefox since 2022
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
+    private val isIntlSupported = js("typeof(Intl) != undefined")
+        .unsafeCast<Boolean>()
+
     private fun firstDayOfWeek() : Int{
-        // supported by most of browsers except Firefox since 2022
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
-        val isIntlSupported = js("typeof(Intl) != undefined")
-            .unsafeCast<Boolean>()
 
         if (!isIntlSupported)
             return firstDaysOfWeekByRegionCode[Locale.current.region.uppercase()] ?: 1
@@ -210,6 +211,19 @@ internal actual object PlatformDateFormat {
         val locale = Locale.current.toLanguageTag()
 
         return js("new Intl.Locale(locale).weekInfo.firstDay").unsafeCast<Int>()
+    }
+
+    actual fun is24HourFormat(locale: CalendarLocale): Boolean {
+
+        if (!isIntlSupported)
+            return false
+
+        @Suppress("UNUSED_VARIABLE")
+        val localeTag = locale.toLanguageTag()
+
+        //hourCycles is a list containing 'h24' or 'h23'
+        return js("new Intl.Locale(localeTag).hourCycles.join().indexOf('h2') >= 0")
+            .unsafeCast<Boolean>()
     }
 }
 

--- a/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
@@ -45,10 +45,6 @@ internal actual object PlatformDateFormat {
         listOf("AE", "AG", "AL", "AS", "AU", "BB", "BD", "BH", "BM", "BN", "BS", "BT", "CA", "CN", "CO", "CY", "DJ", "DM", "DO", "DZ", "EG", "EH", "ER", "ET", "FJ", "FM", "GD", "GH", "GM", "GR", "GU", "GY", "HK", "IN", "IQ", "JM", "JO", "KH", "KI", "KN", "KP", "KR", "KW", "KY", "LB", "LC", "LR", "LS", "LY", "MH", "MO", "MP", "MR", "MW", "MY", "NA", "NZ", "OM", "PA", "PG", "PH", "PK", "PR", "PS", "PW", "QA", "SA", "SB", "SD", "SG", "SL", "SO", "SS", "SY", "SZ", "TC", "TD", "TN", "TO", "TT", "TW", "UM", "US", "VC", "VE", "VG", "VI", "VU", "WS", "YE", "ZM")
     }
 
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl
-    private val isIntlSupported = js("typeof(Intl) != undefined")
-        .unsafeCast<Boolean>()
-
     //TODO: replace formatting with kotlinx datetime when supported (see https://github.com/Kotlin/kotlinx-datetime/pull/251)
     actual fun formatWithPattern(
         utcTimeMillis: Long,
@@ -207,9 +203,6 @@ internal actual object PlatformDateFormat {
 
     private fun firstDayOfWeek(): Int {
 
-        if (!isIntlSupported)
-            return fallbackFirstDayOfWeek()
-
         @Suppress("UNUSED_VARIABLE")
         val locale = Locale.current.toLanguageTag()
 
@@ -225,23 +218,22 @@ internal actual object PlatformDateFormat {
 
     actual fun is24HourFormat(locale: CalendarLocale): Boolean {
 
-        if (!isIntlSupported)
-            return fallbackIs24HourFormat(locale)
-
         @Suppress("UNUSED_VARIABLE")
         val localeTag = locale.toLanguageTag()
 
-        return runCatching {
+        runCatching {
             // unsupported in Firefox and old browsers
-            js("new Intl.Locale(localeTag).hourCycles.join().indexOf('h2') >= 0")
+            return js("new Intl.Locale(localeTag).hourCycles.join().indexOf('h2') >= 0")
                 .unsafeCast<Boolean>()
-        }.getOrElse {
-            runCatching {
-                // unsupported in old browsers
-                js("new Intl.Locale(localeTag).hourCycle.indexOf('h2') >= 0")
-                    .unsafeCast<Boolean>()
-            }.getOrDefault(fallbackIs24HourFormat(locale))
         }
+
+        runCatching {
+            // unsupported in old browsers
+            return js("new Intl.Locale(localeTag).hourCycle.indexOf('h2') >= 0")
+                .unsafeCast<Boolean>()
+        }
+
+        return fallbackIs24HourFormat(locale)
     }
 
     private fun fallbackIs24HourFormat(locale: CalendarLocale) : Boolean {

--- a/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
@@ -36,82 +36,8 @@ internal actual object PlatformDateFormat {
 
     private val firstDaysOfWeekByRegionCode: Map<String, Int> by lazy {
         listOf(
-            7 to listOf(
-                "TH",
-                "ET",
-                "SG",
-                "JM",
-                "BT",
-                "IN",
-                "US",
-                "MO",
-                "KE",
-                "DO",
-                "AU",
-                "IL",
-                "AS",
-                "TW",
-                "MZ",
-                "MM",
-                "CN",
-                "PR",
-                "PK",
-                "BD",
-                "NP",
-                "HN",
-                "BR",
-                "HK",
-                "TT",
-                "ZA",
-                "VE",
-                "MT",
-                "PH",
-                "PE",
-                "ID",
-                "DM",
-                "WS",
-                "ZW",
-                "UM",
-                "LA",
-                "BZ",
-                "JP",
-                "SV",
-                "SA",
-                "CO",
-                "GT",
-                "BW",
-                "KR",
-                "PA",
-                "YE",
-                "BS",
-                "MX",
-                "MH",
-                "GU",
-                "PY",
-                "AG",
-                "CA",
-                "KH",
-                "PT",
-                "VI",
-                "NI"
-            ),
-            6 to listOf(
-                "EG",
-                "AF",
-                "SY",
-                "IR",
-                "OM",
-                "IQ",
-                "DZ",
-                "DJ",
-                "AE",
-                "SD",
-                "KW",
-                "JO",
-                "BH",
-                "QA",
-                "LY"
-            )
+            7 to listOf("TH", "ET", "SG", "JM", "BT", "IN", "US", "MO", "KE", "DO", "AU", "IL", "AS", "TW", "MZ", "MM", "CN", "PR", "PK", "BD", "NP", "HN", "BR", "HK", "TT", "ZA", "VE", "MT", "PH", "PE", "ID", "DM", "WS", "ZW", "UM", "LA", "BZ", "JP", "SV", "SA", "CO", "GT", "BW", "KR", "PA", "YE", "BS", "MX", "MH", "GU", "PY", "AG", "CA", "KH", "PT", "VI", "NI"),
+            6 to listOf("EG", "AF", "SY", "IR", "OM", "IQ", "DZ", "DJ", "AE", "SD", "KW", "JO", "BH", "QA", "LY")
         ).map { (day, tags) -> tags.map { it to day } }.flatten().toMap()
     }
 
@@ -283,7 +209,7 @@ internal actual object PlatformDateFormat {
         @Suppress("UNUSED_VARIABLE")
         val locale = Locale.current.toLanguageTag()
 
-        return kotlin.runCatching {
+        return runCatching {
             // unsupported in Firefox
             js("new Intl.Locale(locale).weekInfo.firstDay").unsafeCast<Int>()
         }.getOrDefault(1)
@@ -304,7 +230,7 @@ internal actual object PlatformDateFormat {
                 .unsafeCast<Boolean>()
         }.getOrElse {
             runCatching {
-                // unsupported old browsers
+                // unsupported in old browsers
                 js("new Intl.Locale(localeTag).hourCycle.indexOf('h2') >= 0")
                     .unsafeCast<Boolean>()
             }.getOrDefault(false)

--- a/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
@@ -209,7 +209,9 @@ internal actual object PlatformDateFormat {
         return runCatching {
             // unsupported in Firefox
             js("new Intl.Locale(locale).weekInfo.firstDay").unsafeCast<Int>()
-        }.getOrDefault(fallbackFirstDayOfWeek())
+        }.getOrElse {
+            fallbackFirstDayOfWeek()
+        }
     }
 
     private fun fallbackFirstDayOfWeek() : Int {

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/PlatformDateFormat.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/PlatformDateFormat.kt
@@ -18,6 +18,7 @@ package androidx.compose.material3
 
 internal expect object PlatformDateFormat{
 
+
     val firstDayOfWeek : Int
 
     /**
@@ -41,4 +42,7 @@ internal expect object PlatformDateFormat{
     fun parse(date: String, pattern: String): CalendarDate?
 
     fun getDateInputFormat(locale: CalendarLocale): DateInputFormat
+
+    fun is24HourFormat(locale: CalendarLocale) : Boolean
+
 }

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/PlatformDateFormatTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/PlatformDateFormatTest.kt
@@ -27,10 +27,22 @@ internal class PlatformDateFormatTest {
         var locale = calendarLocale("en","US")
         assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(false)
 
+        locale = calendarLocale("en","CA")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(false)
+
+        locale = calendarLocale("ar","EG")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(false)
+
+        locale = calendarLocale("ko","KR")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(false)
+
         locale = calendarLocale("en","GB")
         assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(true)
 
         locale = calendarLocale("ru","RU")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(true)
+
+        locale = calendarLocale("de","DE")
         assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(true)
     }
 

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/PlatformDateFormatTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/PlatformDateFormatTest.kt
@@ -16,10 +16,22 @@
 
 package androidx.compose.material3
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
+import kotlin.test.Test
 
-@Composable
-@ReadOnlyComposable
-internal actual fun is24HourFormat(): Boolean =
-    PlatformDateFormat.is24HourFormat(defaultLocale())
+
+@OptIn(ExperimentalMaterial3Api::class)
+internal class PlatformDateFormatTest {
+
+    @Test
+    fun hourCycleLocalization() {
+        var locale = calendarLocale("en","US")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(false)
+
+        locale = calendarLocale("en","GB")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(true)
+
+        locale = calendarLocale("ru","RU")
+        assertThat(PlatformDateFormat.is24HourFormat(locale)).isEqualTo(true)
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes

Implemented localized `is24HourFormat`.

`TimePicker`s layout now depends on 12/24 hour format of the current locale

## Testing

Test: `PlatformDateFormatTest`
