### PR TITLE
Move iOS-related classes from Skiko

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+interface IOSSkikoInput {
+
+    /**
+     * A Boolean value that indicates whether the text-entry object has any text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614457-hastext
+     */
+    fun hasText(): Boolean
+
+    /**
+     * Inserts a character into the displayed text.
+     * Add the character text to your class’s backing store at the index corresponding to the cursor and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
+     * @param text A string object representing the character typed on the system keyboard.
+     */
+    fun insertText(text: String)
+
+    /**
+     * Deletes a character from the displayed text.
+     * Remove the character just before the cursor from your class’s backing store and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614572-deletebackward
+     */
+    fun deleteBackward()
+
+    /**
+     * The text position for the end of a document.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
+     */
+    fun endOfDocument(): Long
+
+    /**
+     * The range of selected text in a document.
+     * If the text range has a length, it indicates the currently selected text.
+     * If it has zero length, it indicates the caret (insertion point).
+     * If the text-range object is nil, it indicates that there is no current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange
+     */
+    fun getSelectedTextRange(): IntRange?
+
+    fun setSelectedTextRange(range: IntRange?)
+
+    fun selectAll()
+
+    /**
+     * Returns the text in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614527-text
+     * @param range A range of text in a document.
+     * @return A substring of a document that falls within the specified range.
+     */
+    fun textInRange(range: IntRange): String
+
+    /**
+     * Replaces the text in a document that is in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614558-replace
+     * @param range A range of text in a document.
+     * @param text A string to replace the text in range.
+     */
+    fun replaceRange(range: IntRange, text: String)
+
+    /**
+     * Inserts the provided text and marks it to indicate that it is part of an active input session.
+     * Setting marked text either replaces the existing marked text or,
+     * if none is present, inserts it in place of the current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614465-setmarkedtext
+     * @param markedText The text to be marked.
+     * @param selectedRange A range within markedText that indicates the current selection.
+     * This range is always relative to markedText.
+     */
+    fun setMarkedText(markedText: String?, selectedRange: IntRange)
+
+    /**
+     * The range of currently marked text in a document.
+     * If there is no marked text, the value of the property is nil.
+     * Marked text is provisionally inserted text that requires user confirmation;
+     * it occurs in multistage text input.
+     * The current selection, which can be a caret or an extended range, always occurs within the marked text.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange
+     */
+    fun markedTextRange(): IntRange?
+
+    /**
+     * Unmarks the currently marked text.
+     * After this method is called, the value of markedTextRange is nil.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614512-unmarktext
+     */
+    fun unmarkText()
+
+    object Empty : IOSSkikoInput {
+        override fun hasText(): Boolean = false
+        override fun insertText(text: String) = Unit
+        override fun deleteBackward() = Unit
+        override fun endOfDocument(): Long = 0L
+        override fun getSelectedTextRange(): IntRange? = null
+        override fun setSelectedTextRange(range: IntRange?) = Unit
+        override fun selectAll() = Unit
+        override fun textInRange(range: IntRange): String = ""
+        override fun replaceRange(range: IntRange, text: String) = Unit
+        override fun setMarkedText(markedText: String?, selectedRange: IntRange) = Unit
+        override fun markedTextRange(): IntRange? = null
+        override fun unmarkText() = Unit
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.platform
 
-interface IOSSkikoInput {
+internal interface IOSSkikoInput {
 
     /**
      * A Boolean value that indicates whether the text-entry object has any text.

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import platform.UIKit.UIKeyboardAppearance
+import platform.UIKit.UIKeyboardAppearanceDefault
+import platform.UIKit.UIKeyboardType
+import platform.UIKit.UIKeyboardTypeDefault
+import platform.UIKit.UIReturnKeyType
+import platform.UIKit.UITextAutocapitalizationType
+import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.UITextContentType
+import platform.UIKit.UITextSmartDashesType
+import platform.UIKit.UITextSmartInsertDeleteType
+import platform.UIKit.UITextSmartQuotesType
+import platform.UIKit.UITextSpellCheckingType
+
+internal interface SkikoUITextInputTraits {
+    fun keyboardType(): UIKeyboardType =
+        UIKeyboardTypeDefault
+
+    fun keyboardAppearance(): UIKeyboardAppearance =
+        UIKeyboardAppearanceDefault
+
+    fun returnKeyType(): UIReturnKeyType =
+        UIReturnKeyType.UIReturnKeyDefault
+
+    fun textContentType(): UITextContentType? =
+        null
+
+    fun isSecureTextEntry(): Boolean =
+        false
+
+    fun enablesReturnKeyAutomatically(): Boolean =
+        false
+
+    fun autocapitalizationType(): UITextAutocapitalizationType =
+        UITextAutocapitalizationType.UITextAutocapitalizationTypeSentences
+
+    fun autocorrectionType(): UITextAutocorrectionType =
+        UITextAutocorrectionType.UITextAutocorrectionTypeYes
+
+    fun spellCheckingType(): UITextSpellCheckingType =
+        UITextSpellCheckingType.UITextSpellCheckingTypeDefault
+
+    fun smartQuotesType(): UITextSmartQuotesType =
+        UITextSmartQuotesType.UITextSmartQuotesTypeDefault
+
+    fun smartDashesType(): UITextSmartDashesType =
+        UITextSmartDashesType.UITextSmartDashesTypeDefault
+
+    fun smartInsertDeleteType(): UITextSmartInsertDeleteType =
+        UITextSmartInsertDeleteType.UITextSmartInsertDeleteTypeDefault
+
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/TextActions.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/TextActions.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+interface TextActions {
+    /**
+     * Copy action. If null, then copy is not possible in current context
+     */
+    val copy: (() -> Unit)?
+
+    /**
+     * Paste action. If null, then paste is not possible in current context
+     */
+    val paste: (() -> Unit)?
+
+    /**
+     * Cut action. If null, then cut is not possible in current context
+     */
+    val cut: (() -> Unit)?
+
+    /**
+     * SelectAll action. If null, then select all is not possible in current context
+     */
+    val selectAll: (() -> Unit)?
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/TextActions.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/TextActions.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.platform
 
-interface TextActions {
+internal interface TextActions {
     /**
      * Copy action. If null, then copy is not possible in current context
      */

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -20,11 +20,8 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.text.input.*
 import kotlin.math.min
-import org.jetbrains.skiko.SkikoInput
 import org.jetbrains.skiko.SkikoKey
 import org.jetbrains.skiko.SkikoKeyboardEventKind
-import org.jetbrains.skiko.ios.SkikoUITextInputTraits
-
 import platform.UIKit.*
 
 internal class UIKitTextInputService(
@@ -152,7 +149,7 @@ internal class UIKitTextInputService(
         }
     }
 
-    val skikoInput = object : SkikoInput {
+    val skikoInput = object : IOSSkikoInput {
 
         /**
          * A Boolean value that indicates whether the text-entry object has any text.

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/DelegateSkikoUITextInputTraits.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/DelegateSkikoUITextInputTraits.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.uikit
 
-import org.jetbrains.skiko.ios.SkikoUITextInputTraits
+import androidx.compose.ui.platform.SkikoUITextInputTraits
 
 internal class DelegateSkikoUITextInputTraits(
     val getDelegate: () -> SkikoUITextInputTraits?

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -357,7 +357,7 @@ internal actual class ComposeWindow : UIViewController {
 
         val skiaLayer = IOSSkiaLayer()
         val skikoUIView = SkikoUIView(
-            IOSSkiaLayer = skiaLayer,
+            skiaLayer = skiaLayer,
             pointInside = { point, _ ->
                 val composeLayer = attachedComposeContext?.composeLayer
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -22,12 +22,10 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.SystemTheme
-import androidx.compose.ui.createSkiaLayer
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.interop.LocalLayerContainer
 import androidx.compose.ui.interop.LocalUIViewController
-import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.*
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.uikit.*
@@ -36,10 +34,7 @@ import kotlin.math.roundToInt
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
-import org.jetbrains.skiko.SkikoUIView
 import org.jetbrains.skiko.TextActions
-import org.jetbrains.skiko.currentSystemTheme
-import org.jetbrains.skiko.ios.SkikoUITextInputTraits
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
 import platform.Foundation.*
@@ -83,8 +78,8 @@ fun ComposeUIViewController(
     }
 
 private class AttachedComposeContext(
-    val composeLayer: ComposeLayer,
-    val skiaLayer: org.jetbrains.skiko.SkiaLayer,
+    val composeLayer: IOSComposeLayer,
+    val skiaLayer: IOSSkiaLayer,
     val view: SkikoUIView,
     val inputTraits: SkikoUITextInputTraits,
     val platform: Platform
@@ -361,9 +356,9 @@ internal actual class ComposeWindow : UIViewController {
             return // already attached
         }
 
-        val skiaLayer = createSkiaLayer()
+        val skiaLayer = IOSSkiaLayer()
         val skikoUIView = SkikoUIView(
-            skiaLayer = skiaLayer,
+            IOSSkiaLayer = skiaLayer,
             pointInside = { point, _ ->
                 val composeLayer = attachedComposeContext?.composeLayer
 
@@ -459,7 +454,7 @@ internal actual class ComposeWindow : UIViewController {
 
             override val inputModeManager = DefaultInputModeManager(InputMode.Touch)
         }
-        val composeLayer = ComposeLayer(
+        val composeLayer = IOSComposeLayer(
             layer = skiaLayer,
             platform = platform,
             input = inputServices.skikoInput,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -34,7 +34,6 @@ import kotlin.math.roundToInt
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
-import org.jetbrains.skiko.TextActions
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectMake
 import platform.Foundation.*

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSComposeLayer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSComposeLayer.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.ComposeScene
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.toCompose
+import androidx.compose.ui.native.getMainDispatcher
+import androidx.compose.ui.native.getScrollDelta
+import androidx.compose.ui.native.supportsMultitouch
+import androidx.compose.ui.platform.IOSSkikoInput
+import androidx.compose.ui.platform.Platform
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.toDpRect
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skia.Point
+import org.jetbrains.skiko.SkikoKeyboardEvent
+import org.jetbrains.skiko.SkikoPointerEvent
+import org.jetbrains.skiko.currentNanoTime
+
+// TODO: refactor candidate on iOS, proxies everything and doesn't contain any logic
+internal class IOSComposeLayer(
+    internal val layer: IOSSkiaLayer,
+    platform: Platform,
+    private val input: IOSSkikoInput,
+) {
+    private var isDisposed = false
+
+    // Should be set to an actual value by ComposeWindow implementation
+    private var density = Density(1f)
+
+    inner class ComponentImpl : IOSSkikoView {
+        override val input = this@IOSComposeLayer.input
+
+        override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
+            scene.render(canvas, nanoTime)
+        }
+
+        override fun onKeyboardEvent(event: SkikoKeyboardEvent) {
+            if (isDisposed) return
+            scene.sendKeyEvent(KeyEvent(event))
+        }
+
+        @OptIn(ExperimentalComposeUiApi::class)
+        override fun onPointerEvent(event: SkikoPointerEvent) {
+            if (supportsMultitouch) {
+                onPointerEventWithMultitouch(event)
+            } else {
+                // macos and web don't work properly when using onPointerEventWithMultitouch
+                onPointerEventNoMultitouch(event)
+            }
+        }
+
+        @OptIn(ExperimentalComposeUiApi::class)
+        private fun onPointerEventWithMultitouch(event: SkikoPointerEvent) {
+            val scale = density.density
+
+            scene.sendPointerEvent(
+                eventType = event.kind.toCompose(),
+                pointers = event.pointers.map {
+                    ComposeScene.Pointer(
+                        id = PointerId(it.id),
+                        position = Offset(
+                            x = it.x.toFloat() * scale,
+                            y = it.y.toFloat() * scale
+                        ),
+                        pressed = it.pressed,
+                        type = it.device.toCompose(),
+                        pressure = it.pressure.toFloat(),
+                    )
+                },
+                timeMillis = event.timestamp,
+                nativeEvent = event
+            )
+        }
+
+        private fun onPointerEventNoMultitouch(event: SkikoPointerEvent) {
+            val scale = density.density
+            scene.sendPointerEvent(
+                eventType = event.kind.toCompose(),
+                scrollDelta = event.getScrollDelta(),
+                position = Offset(
+                    x = event.x.toFloat() * scale,
+                    y = event.y.toFloat() * scale
+                ),
+                timeMillis = currentMillis(),
+                type = PointerType.Mouse,
+                nativeEvent = event
+            )
+        }
+    }
+
+    private val view = ComponentImpl()
+
+    init {
+        layer.skikoView = view
+    }
+
+    private val scene = ComposeScene(
+        coroutineContext = getMainDispatcher(),
+        platform = platform,
+        density = density,
+        invalidate = layer::needRedraw,
+    )
+
+    fun setDensity(newDensity: Density) {
+        density = newDensity
+        scene.density = newDensity
+    }
+
+    fun dispose() {
+        check(!isDisposed)
+        layer.detach()
+        scene.close()
+        _initContent = null
+        isDisposed = true
+    }
+
+    fun setSize(width: Int, height: Int) {
+        scene.constraints = Constraints(maxWidth = width, maxHeight = height)
+
+        layer.needRedraw()
+    }
+
+    fun getActiveFocusRect(): DpRect? {
+        val focusRect = scene.mainOwner?.focusOwner?.getFocusRect() ?: return null
+        return focusRect.toDpRect(density)
+    }
+
+    fun hitInteropView(point: Point, isTouchEvent: Boolean): Boolean =
+        scene.mainOwner?.hitInteropView(
+            pointerPosition = Offset(point.x * density.density, point.y * density.density),
+            isTouchEvent = isTouchEvent,
+        ) ?: false
+
+    fun setContent(
+        onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
+        onKeyEvent: (KeyEvent) -> Boolean = { false },
+        content: @Composable () -> Unit
+    ) {
+        // If we call it before attaching, everything probably will be fine,
+        // but the first composition will be useless, as we set density=1
+        // (we don't know the real density if we have unattached component)
+        _initContent = {
+            scene.setContent(
+                onPreviewKeyEvent = onPreviewKeyEvent,
+                onKeyEvent = onKeyEvent,
+                content = content
+            )
+        }
+
+        initContent()
+    }
+
+    private var _initContent: (() -> Unit)? = null
+
+    private fun initContent() {
+        // TODO: do we need isDisplayable on SkiaLyer?
+        // if (layer.isDisplayable) {
+        _initContent?.invoke()
+        _initContent = null
+        // }
+    }
+}
+
+private fun currentMillis() = (currentNanoTime() / 1E6).toLong()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSSkiaLayer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSSkiaLayer.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import kotlinx.cinterop.useContents
+import kotlin.system.getTimeNanos
+import org.jetbrains.skia.PixelGeometry
+import org.jetbrains.skia.Surface
+import org.jetbrains.skiko.GraphicsApi
+
+// TODO: refactor candidate on iOS, proxies everything and doesn't contain any logic
+internal class IOSSkiaLayer {
+    var needRedrawCallback: () -> Unit = {}
+
+    var renderApi: GraphicsApi
+        get() = GraphicsApi.METAL
+        set(_) { throw UnsupportedOperationException() }
+
+    val contentScale: Float
+        get() = view!!.contentScaleFactor.toFloat()
+
+    var fullscreen: Boolean
+        get() = true
+        set(_) { throw UnsupportedOperationException() }
+
+    var transparency: Boolean
+        get() = false
+        set(_) { throw UnsupportedOperationException() }
+
+    fun needRedraw() {
+        needRedrawCallback.invoke()
+    }
+
+    val component: Any?
+        get() = this.view
+
+    val width: Float
+        get() = view!!.frame.useContents {
+            return@useContents size.width.toFloat()
+        }
+
+    val height: Float
+        get() = view!!.frame.useContents {
+            return@useContents size.height.toFloat()
+        }
+
+    internal var view: SkikoUIView? = null
+
+    fun attachTo(container: Any) {
+        view = container as SkikoUIView
+    }
+
+    fun detach() {
+        view?.detach()
+
+        // GC bug? fixes leak on iOS
+        view = null
+        skikoView = null
+    }
+
+    var skikoView: IOSSkikoView? = null
+
+    internal fun draw(surface: Surface) {
+        skikoView?.onRender(surface.canvas, surface.width, surface.height, getTimeNanos())
+    }
+
+    val pixelGeometry: PixelGeometry
+        get() = PixelGeometry.UNKNOWN
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSSkikoView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSSkikoView.kt
@@ -24,7 +24,7 @@ import org.jetbrains.skiko.SkikoKeyboardEvent
 import org.jetbrains.skiko.SkikoPointerEvent
 
 // TODO: candidate for refactor
-interface IOSSkikoView {
+internal interface IOSSkikoView {
     // Input
     fun onKeyboardEvent(event: SkikoKeyboardEvent) = Unit
     fun onPointerEvent(event: SkikoPointerEvent) = Unit

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSSkikoView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IOSSkikoView.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.platform.IOSSkikoInput
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skiko.SkikoGestureEvent
+import org.jetbrains.skiko.SkikoInputEvent
+import org.jetbrains.skiko.SkikoKeyboardEvent
+import org.jetbrains.skiko.SkikoPointerEvent
+
+// TODO: candidate for refactor
+interface IOSSkikoView {
+    // Input
+    fun onKeyboardEvent(event: SkikoKeyboardEvent) = Unit
+    fun onPointerEvent(event: SkikoPointerEvent) = Unit
+
+    @Deprecated("This method will be removed. Use override val input: SkikoInput")
+    fun onInputEvent(event: SkikoInputEvent) = Unit
+    val input: IOSSkikoInput get() = IOSSkikoInput.Empty
+    fun onGestureEvent(event: SkikoGestureEvent) = Unit
+
+    // Rendering
+    fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long)
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import kotlinx.cinterop.*
+import org.jetbrains.skia.*
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSRunLoop
+import platform.Foundation.NSSelectorFromString
+import platform.Metal.MTLCommandBufferProtocol
+import platform.QuartzCore.*
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationState
+import platform.UIKit.UIApplicationWillEnterForegroundNotification
+import platform.darwin.*
+import kotlin.math.roundToInt
+
+private class DisplayLinkConditions(
+    val setPausedCallback: (Boolean) -> Unit
+) {
+    /**
+     * see [MetalRedrawer.needsProactiveDisplayLink]
+     */
+    var needsToBeProactive: Boolean = false
+        set(value) {
+            field = value
+
+            update()
+        }
+
+    /**
+     * Indicates that scene is invalidated and next display link callback will draw
+     */
+    var needsRedrawOnNextVsync: Boolean = false
+        set(value) {
+            field = value
+
+            update()
+        }
+
+    /**
+     * Indicates that application is running foreground now
+     */
+    var isApplicationActive: Boolean = false
+        set(value) {
+            field = value
+
+            update()
+        }
+
+    private fun update() {
+        val isUnpaused = isApplicationActive && (needsToBeProactive || needsRedrawOnNextVsync)
+        setPausedCallback(!isUnpaused)
+    }
+}
+
+private class ApplicationStateListener(
+    /**
+     * Callback which will be called with `true` when the app becomes active, and `false` when the app goes background
+     */
+    private val callback: (Boolean) -> Unit
+) : NSObject() {
+    init {
+        val notificationCenter = NSNotificationCenter.defaultCenter
+
+        notificationCenter.addObserver(
+            this,
+            NSSelectorFromString(::applicationWillEnterForeground.name),
+            UIApplicationWillEnterForegroundNotification,
+            null
+        )
+
+        notificationCenter.addObserver(
+            this,
+            NSSelectorFromString(::applicationDidEnterBackground.name),
+            UIApplicationDidEnterBackgroundNotification,
+            null
+        )
+    }
+
+    @ObjCAction
+    fun applicationWillEnterForeground() {
+        callback(true)
+    }
+
+    @ObjCAction
+    fun applicationDidEnterBackground() {
+        callback(false)
+    }
+
+    /**
+     * Deregister from [NSNotificationCenter]
+     */
+    fun dispose() {
+        val notificationCenter = NSNotificationCenter.defaultCenter
+
+        notificationCenter.removeObserver(this, UIApplicationWillEnterForegroundNotification, null)
+        notificationCenter.removeObserver(this, UIApplicationDidEnterBackgroundNotification, null)
+    }
+}
+
+internal class MetalRedrawer(
+    private val metalLayer: CAMetalLayer,
+    private val drawCallback: (Surface) -> Unit,
+
+    // Used for tests, access to NSRunLoop crashes in test environment
+    addDisplayLinkToRunLoop: ((CADisplayLink) -> Unit)? = null,
+    private val disposeCallback: (MetalRedrawer) -> Unit = { }
+) {
+    // Workaround for KN compiler bug
+    // Type mismatch: inferred type is objcnames.protocols.MTLDeviceProtocol but platform.Metal.MTLDeviceProtocol was expected
+    @Suppress("USELESS_CAST")
+    private val device = metalLayer.device as platform.Metal.MTLDeviceProtocol?
+        ?: throw IllegalStateException("CAMetalLayer.device can not be null")
+    private val queue = device.newCommandQueue() ?: throw IllegalStateException("Couldn't create Metal command queue")
+    private val context = DirectContext.makeMetal(device.objcPtr(), queue.objcPtr())
+    private val inflightCommandBuffers = mutableListOf<MTLCommandBufferProtocol>()
+
+    // Semaphore for preventing command buffers count more than swapchain size to be scheduled/executed at the same time
+    private val inflightSemaphore = dispatch_semaphore_create(metalLayer.maximumDrawableCount.toLong())
+
+    internal var maximumFramesPerSecond: NSInteger
+        get() = caDisplayLink?.preferredFramesPerSecond ?: 0
+        set(value) {
+            caDisplayLink?.preferredFramesPerSecond = value
+        }
+
+    /**
+     * Needs scheduling displayLink for forcing UITouch events to come at the fastest possible cadence.
+     * Otherwise, touch events can come at rate lower than actual display refresh rate.
+     */
+    var needsProactiveDisplayLink: Boolean
+        get() = displayLinkConditions.needsToBeProactive
+        set(value) {
+            displayLinkConditions.needsToBeProactive = value
+        }
+
+    private var caDisplayLink: CADisplayLink? = CADisplayLink.displayLinkWithTarget(
+        target = DisplayLinkProxy {
+            this.handleDisplayLinkTick()
+        },
+        selector = NSSelectorFromString(DisplayLinkProxy::handleDisplayLinkTick.name)
+    )
+
+    private val displayLinkConditions = DisplayLinkConditions { paused ->
+        caDisplayLink?.setPaused(paused)
+    }
+
+    private val applicationStateListener = ApplicationStateListener { isApplicationActive ->
+        displayLinkConditions.isApplicationActive = isApplicationActive
+
+        if (!isApplicationActive) {
+            // If application goes background, synchronously schedule all inflightCommandBuffers, as per
+            // https://developer.apple.com/documentation/metal/gpu_devices_and_work_submission/preparing_your_metal_app_to_run_in_the_background?language=objc
+            inflightCommandBuffers.forEach {
+                // Will immediately return for MTLCommandBuffer's which are not in `Commited` status
+                it.waitUntilScheduled()
+            }
+        }
+    }
+
+    init {
+        val caDisplayLink = caDisplayLink ?: throw IllegalStateException("caDisplayLink is null during redrawer init")
+
+        // UIApplication can be in UIApplicationStateInactive state (during app launch before it gives control back to run loop)
+        // and won't receive UIApplicationWillEnterForegroundNotification
+        // so we compare the state with UIApplicationStateBackground instead of UIApplicationStateActive
+        displayLinkConditions.isApplicationActive = UIApplication.sharedApplication.applicationState != UIApplicationState.UIApplicationStateBackground
+
+        if (addDisplayLinkToRunLoop == null) {
+            caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
+        } else {
+            addDisplayLinkToRunLoop.invoke(caDisplayLink)
+        }
+    }
+
+    internal fun dispose() {
+        check(caDisplayLink != null) { "MetalRedrawer.dispose() was called more than once" }
+
+        disposeCallback(this)
+
+        applicationStateListener.dispose()
+
+        caDisplayLink?.invalidate()
+        caDisplayLink = null
+
+        context.flush()
+        context.close()
+    }
+
+    internal fun needRedraw() {
+        displayLinkConditions.needsRedrawOnNextVsync = true
+    }
+
+    private fun handleDisplayLinkTick() {
+        if (displayLinkConditions.needsRedrawOnNextVsync) {
+            displayLinkConditions.needsRedrawOnNextVsync = false
+
+            draw()
+        }
+    }
+
+    private fun draw() {
+        if (caDisplayLink == null) {
+            // TODO: anomaly, log
+            // Logger.warn { "caDisplayLink callback called after it was invalidated " }
+            return
+        }
+
+        autoreleasepool {
+            val (width, height) = metalLayer.drawableSize.useContents {
+                width.roundToInt() to height.roundToInt()
+            }
+
+            if (width <= 0 || height <= 0) {
+                return@autoreleasepool
+            }
+
+            dispatch_semaphore_wait(inflightSemaphore, DISPATCH_TIME_FOREVER)
+
+            val metalDrawable = metalLayer.nextDrawable()
+
+            if (metalDrawable == null) {
+                // TODO: anomaly, log
+                // Logger.warn { "'metalLayer.nextDrawable()' returned null. 'metalLayer.allowsNextDrawableTimeout' should be set to false. Skipping the frame." }
+                dispatch_semaphore_signal(inflightSemaphore)
+                return@autoreleasepool
+            }
+
+            val renderTarget = BackendRenderTarget.makeMetal(width, height, metalDrawable.texture.objcPtr())
+
+            val surface = Surface.makeFromBackendRenderTarget(
+                context,
+                renderTarget,
+                SurfaceOrigin.TOP_LEFT,
+                SurfaceColorFormat.BGRA_8888,
+                ColorSpace.sRGB,
+                SurfaceProps(pixelGeometry = PixelGeometry.UNKNOWN)
+            )
+
+            if (surface == null) {
+                // TODO: anomaly, log
+                // Logger.warn { "'Surface.makeFromBackendRenderTarget' returned null. Skipping the frame." }
+                renderTarget.close()
+                // TODO: manually release metalDrawable when K/N API arrives
+                dispatch_semaphore_signal(inflightSemaphore)
+                return@autoreleasepool
+            }
+
+            surface.canvas.clear(Color.WHITE)
+            drawCallback(surface)
+            surface.flushAndSubmit()
+
+            val commandBuffer = queue.commandBuffer()!!
+            commandBuffer.label = "Present"
+            commandBuffer.presentDrawable(metalDrawable)
+            commandBuffer.addCompletedHandler {
+                // Signal work finish, allow a new command buffer to be scheduled
+                dispatch_semaphore_signal(inflightSemaphore)
+            }
+            commandBuffer.commit()
+
+            surface.close()
+            renderTarget.close()
+            // TODO manually release metalDrawable when K/N API arrives
+
+            // Track current inflight command buffers to synchronously wait for their schedule in case app goes background
+            if (inflightCommandBuffers.size == metalLayer.maximumDrawableCount.toInt()) {
+                inflightCommandBuffers.removeAt(0)
+            }
+
+            inflightCommandBuffers.add(commandBuffer)
+        }
+    }
+}
+
+private class DisplayLinkProxy(
+    private val callback: () -> Unit
+) : NSObject() {
+    @ObjCAction
+    fun handleDisplayLinkTick() {
+        callback()
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -113,26 +113,26 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
     // https://youtrack.jetbrains.com/issue/KT-60399
     @Suppress("UNUSED") // public API
     constructor(
-        IOSSkiaLayer: IOSSkiaLayer,
+        skiaLayer: IOSSkiaLayer,
         frame: CValue<CGRect> = CGRectNull.readValue(),
         pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
-    ) : this(IOSSkiaLayer, frame, pointInside, skikoUITextInputTrains = object :
+    ) : this(skiaLayer, frame, pointInside, skikoUITextInputTrains = object :
         SkikoUITextInputTraits {})
 
     constructor(
-        IOSSkiaLayer: IOSSkiaLayer,
+        skiaLayer: IOSSkiaLayer,
         frame: CValue<CGRect> = CGRectNull.readValue(),
         pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true },
         skikoUITextInputTrains: SkikoUITextInputTraits,
         drawCompletionCallback: () -> Unit = { }
     ) : super(frame) {
-        _skiaLayer = IOSSkiaLayer
+        _skiaLayer = skiaLayer
         _pointInside = pointInside
         _skikoUITextInputTrains = skikoUITextInputTrains
 
 
         // TODO: remove weak wrapper if we are not going to implement lifecycle-bound behavior
-        val weakSkiaLayer = WeakReference(IOSSkiaLayer)
+        val weakSkiaLayer = WeakReference(skiaLayer)
 
         _redrawer = MetalRedrawer(
             _metalLayer,
@@ -141,8 +141,8 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             },
         )
 
-        IOSSkiaLayer.needRedrawCallback = _redrawer::needRedraw
-        IOSSkiaLayer.view = this
+        skiaLayer.needRedrawCallback = _redrawer::needRedraw
+        skiaLayer.view = this
     }
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -1,0 +1,674 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.platform.SkikoUITextInputTraits
+import androidx.compose.ui.platform.TextActions
+import kotlinx.cinterop.*
+import org.jetbrains.skia.Point
+import org.jetbrains.skia.Rect
+import platform.CoreGraphics.*
+import platform.Foundation.*
+import platform.Metal.MTLCreateSystemDefaultDevice
+import platform.Metal.MTLDeviceProtocol
+import platform.Metal.MTLPixelFormatBGRA8Unorm
+import platform.QuartzCore.CAMetalLayer
+import platform.UIKit.*
+import platform.darwin.NSInteger
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.native.ref.WeakReference
+import org.jetbrains.skiko.SkikoKeyboardEventKind
+import org.jetbrains.skiko.SkikoPointer
+import org.jetbrains.skiko.SkikoPointerDevice
+import org.jetbrains.skiko.SkikoPointerEvent
+import org.jetbrains.skiko.SkikoPointerEventKind
+import org.jetbrains.skiko.toSkikoKeyboardEvent
+
+@Suppress("CONFLICTING_OVERLOADS")
+@ExportObjCClass
+internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
+    companion object : UIViewMeta() {
+        override fun layerClass() = CAMetalLayer
+    }
+
+    @Suppress("UNUSED") // required for Objective-C
+    @OverrideInit
+    constructor(coder: NSCoder) : super(coder) {
+        throw UnsupportedOperationException("init(coder: NSCoder) is not supported for SkikoUIView")
+    }
+
+    /**
+     * Indicates that renderer should wait until the issued command buffer is scheduled for execution, so it can
+     * present the drawable inside the CATransaction to sync it with UIKit changes
+     *
+     * See [relevant doc](https://developer.apple.com/documentation/quartzcore/cametallayer/1478157-presentswithtransaction?language=objc)
+     */
+    @Suppress("UNUSED") // Part of public API
+    var presentsWithTransaction: Boolean
+        get() = _metalLayer.presentsWithTransaction
+        set(value) {
+            _metalLayer.presentsWithTransaction = value
+        }
+
+    private val _device: MTLDeviceProtocol =
+        MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
+    private val _metalLayer: CAMetalLayer get() = layer as CAMetalLayer
+    private var _skiaLayer: IOSSkiaLayer? = null
+    private var _pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
+    private var _skikoUITextInputTrains: SkikoUITextInputTraits = object : SkikoUITextInputTraits {}
+    private var _inputDelegate: UITextInputDelegateProtocol? = null
+    private var _currentTextMenuActions: TextActions? = null
+    private lateinit var _redrawer: MetalRedrawer
+
+    /*
+     * When there at least one tracked touch, we need notify redrawer about it. It should schedule CADisplayLink which
+     * affects frequency of polling UITouch events on high frequency display and forces it to match display refresh rate.
+     */
+    private var _touchesCount = 0
+        set(value) {
+            field = value
+
+            val needHighFrequencyPolling = value > 0
+
+            _redrawer.needsProactiveDisplayLink = needHighFrequencyPolling
+        }
+
+    init {
+        multipleTouchEnabled = true
+        opaque = false // For UIKit interop through a "Hole"
+
+        _metalLayer.also {
+            // Workaround for KN compiler bug
+            // Type mismatch: inferred type is platform.Metal.MTLDeviceProtocol but objcnames.protocols.MTLDeviceProtocol? was expected
+            @Suppress("USELESS_CAST")
+            it.device = _device as objcnames.protocols.MTLDeviceProtocol?
+
+            it.pixelFormat = MTLPixelFormatBGRA8Unorm
+            doubleArrayOf(0.0, 0.0, 0.0, 0.0).usePinned { pinned ->
+                it.backgroundColor = CGColorCreate(CGColorSpaceCreateDeviceRGB(), pinned.addressOf(0))
+            }
+            it.framebufferOnly = false
+        }
+    }
+
+    // merging two constructors might cause a binary incompatibility, which will result in a unclear linking error,
+    // if a project using newer compose depends on an older compose transitively
+    // https://youtrack.jetbrains.com/issue/KT-60399
+    @Suppress("UNUSED") // public API
+    constructor(
+        IOSSkiaLayer: IOSSkiaLayer,
+        frame: CValue<CGRect> = CGRectNull.readValue(),
+        pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
+    ) : this(IOSSkiaLayer, frame, pointInside, skikoUITextInputTrains = object :
+        SkikoUITextInputTraits {})
+
+    constructor(
+        IOSSkiaLayer: IOSSkiaLayer,
+        frame: CValue<CGRect> = CGRectNull.readValue(),
+        pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true },
+        skikoUITextInputTrains: SkikoUITextInputTraits,
+        drawCompletionCallback: () -> Unit = { }
+    ) : super(frame) {
+        _skiaLayer = IOSSkiaLayer
+        _pointInside = pointInside
+        _skikoUITextInputTrains = skikoUITextInputTrains
+
+
+        // TODO: remove weak wrapper if we are not going to implement lifecycle-bound behavior
+        val weakSkiaLayer = WeakReference(IOSSkiaLayer)
+
+        _redrawer = MetalRedrawer(
+            _metalLayer,
+            drawCallback = { surface ->
+                weakSkiaLayer.get()?.draw(surface)
+            },
+        )
+
+        IOSSkiaLayer.needRedrawCallback = _redrawer::needRedraw
+        IOSSkiaLayer.view = this
+    }
+
+    /**
+     * Show copy/paste text menu
+     * @param targetRect - rectangle of selected text area
+     * @param textActions - available (not null) actions in text menu
+     */
+    fun showTextMenu(targetRect: Rect, textActions: TextActions) {
+        _currentTextMenuActions = textActions
+        val menu: UIMenuController = UIMenuController.sharedMenuController()
+        val cgRect = CGRectMake(
+            x = targetRect.left.toDouble(),
+            y = targetRect.top.toDouble(),
+            width = targetRect.width.toDouble(),
+            height = targetRect.height.toDouble()
+        )
+        val isTargetVisible = CGRectIntersectsRect(bounds, cgRect)
+        if (isTargetVisible) {
+            if (menu.isMenuVisible()) {
+                menu.setTargetRect(cgRect, this)
+            } else {
+                menu.showMenuFromView(this, cgRect)
+            }
+        } else {
+            if (menu.isMenuVisible()) {
+                menu.hideMenu()
+            }
+        }
+    }
+
+    fun hideTextMenu() {
+        _currentTextMenuActions = null
+        val menu: UIMenuController = UIMenuController.sharedMenuController()
+        menu.hideMenu()
+    }
+
+    fun isTextMenuShown(): Boolean {
+        return _currentTextMenuActions != null
+    }
+
+    override fun copy(sender: Any?) {
+        _currentTextMenuActions?.copy?.invoke()
+    }
+
+    override fun paste(sender: Any?) {
+        _currentTextMenuActions?.paste?.invoke()
+    }
+
+    override fun cut(sender: Any?) {
+        _currentTextMenuActions?.cut?.invoke()
+    }
+
+    override fun selectAll(sender: Any?) {
+        _currentTextMenuActions?.selectAll?.invoke()
+    }
+
+    internal fun detach() {
+        _redrawer.dispose()
+    }
+
+    fun load(): SkikoUIView {
+        // TODO: redundant, remove in next refactor pass
+        return this
+    }
+
+    override fun didMoveToWindow() {
+        super.didMoveToWindow()
+
+        window?.screen?.let {
+            contentScaleFactor = it.scale
+            _redrawer.maximumFramesPerSecond = it.maximumFramesPerSecond
+        }
+    }
+
+    override fun layoutSubviews() {
+        super.layoutSubviews()
+
+        val scaledSize = bounds.useContents {
+            CGSizeMake(size.width * contentScaleFactor, size.height * contentScaleFactor)
+        }
+
+        _metalLayer.drawableSize = scaledSize
+    }
+
+    fun showScreenKeyboard() = becomeFirstResponder()
+    fun hideScreenKeyboard() = resignFirstResponder()
+    fun isScreenKeyboardOpen() = isFirstResponder
+
+    /**
+     * A Boolean value that indicates whether the text-entry object has any text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614457-hastext
+     */
+    override fun hasText(): Boolean {
+        return _skiaLayer?.skikoView?.input?.hasText() ?: false
+    }
+
+    /**
+     * Inserts a character into the displayed text.
+     * Add the character text to your class’s backing store at the index corresponding to the cursor and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614543-inserttext
+     * @param text A string object representing the character typed on the system keyboard.
+     */
+    override fun insertText(text: String) {
+        _skiaLayer?.skikoView?.input?.insertText(text)
+    }
+
+    /**
+     * Deletes a character from the displayed text.
+     * Remove the character just before the cursor from your class’s backing store and redisplay the text.
+     * https://developer.apple.com/documentation/uikit/uikeyinput/1614572-deletebackward
+     */
+    override fun deleteBackward() {
+        _skiaLayer?.skikoView?.input?.deleteBackward()
+    }
+
+    override fun canBecomeFirstResponder() = true
+
+    override fun pressesBegan(presses: Set<*>, withEvent: UIPressesEvent?) {
+        if (withEvent != null) {
+            for (press in withEvent.allPresses) {
+                val uiPress = press as? UIPress
+                if (uiPress != null) {
+                    _skiaLayer?.skikoView?.onKeyboardEvent(
+                        toSkikoKeyboardEvent(press, SkikoKeyboardEventKind.DOWN)
+                    )
+                }
+            }
+        }
+        super.pressesBegan(presses, withEvent)
+    }
+
+    override fun pressesEnded(presses: Set<*>, withEvent: UIPressesEvent?) {
+        if (withEvent != null) {
+            for (press in withEvent.allPresses) {
+                val uiPress = press as? UIPress
+                if (uiPress != null) {
+                    _skiaLayer?.skikoView?.onKeyboardEvent(
+                        toSkikoKeyboardEvent(press, SkikoKeyboardEventKind.UP)
+                    )
+                }
+            }
+        }
+        super.pressesEnded(presses, withEvent)
+    }
+
+    /**
+     * https://developer.apple.com/documentation/uikit/uiview/1622533-point
+     */
+    override fun pointInside(point: CValue<CGPoint>, withEvent: UIEvent?): Boolean {
+        val skiaPoint: Point = point.useContents { Point(x.toFloat(), y.toFloat()) }
+        return _pointInside(skiaPoint, withEvent)
+    }
+
+    override fun touchesBegan(touches: Set<*>, withEvent: UIEvent?) {
+        super.touchesBegan(touches, withEvent)
+
+        _touchesCount += touches.size
+
+        sendTouchEventToSkikoView(withEvent!!, SkikoPointerEventKind.DOWN)
+    }
+
+    override fun touchesEnded(touches: Set<*>, withEvent: UIEvent?) {
+        super.touchesEnded(touches, withEvent)
+
+        _touchesCount -= touches.size
+
+        sendTouchEventToSkikoView(withEvent!!, SkikoPointerEventKind.UP)
+    }
+
+    override fun touchesMoved(touches: Set<*>, withEvent: UIEvent?) {
+        super.touchesMoved(touches, withEvent)
+        sendTouchEventToSkikoView(withEvent!!, SkikoPointerEventKind.MOVE)
+    }
+
+    override fun touchesCancelled(touches: Set<*>, withEvent: UIEvent?) {
+        super.touchesCancelled(touches, withEvent)
+
+        _touchesCount -= touches.size
+
+        sendTouchEventToSkikoView(withEvent!!, SkikoPointerEventKind.UP)
+    }
+
+    private fun sendTouchEventToSkikoView(event: UIEvent, kind: SkikoPointerEventKind) {
+        val pointers = event.touchesForView(this).orEmpty().map {
+            val touch = it as UITouch
+            val (x, y) = touch.locationInView(this).useContents { x to y }
+            SkikoPointer(
+                x = x,
+                y = y,
+                pressed = touch.isPressed,
+                device = SkikoPointerDevice.TOUCH,
+                id = touch.hashCode().toLong(),
+                pressure = touch.force
+            )
+        }
+
+        _skiaLayer?.skikoView?.onPointerEvent(
+            SkikoPointerEvent(
+                x = pointers.centroidX,
+                y = pointers.centroidY,
+                kind = kind,
+                timestamp = (event.timestamp * 1_000).toLong(),
+                pointers = pointers,
+                platform = event
+            )
+        )
+    }
+
+    override fun inputDelegate(): UITextInputDelegateProtocol? {
+        return _inputDelegate
+    }
+
+    override fun setInputDelegate(inputDelegate: UITextInputDelegateProtocol?) {
+        _inputDelegate = inputDelegate
+    }
+
+    /**
+     * Returns the text in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614527-text
+     * @param range A range of text in a document.
+     * @return A substring of a document that falls within the specified range.
+     */
+    override fun textInRange(range: UITextRange): String? {
+        return _skiaLayer?.skikoView?.input?.textInRange(range.toIntRange())
+    }
+
+    /**
+     * Replaces the text in a document that is in the specified range.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614558-replace
+     * @param range A range of text in a document.
+     * @param withText A string to replace the text in range.
+     */
+    override fun replaceRange(range: UITextRange, withText: String) {
+        _skiaLayer?.skikoView?.input?.replaceRange(range.toIntRange(), withText)
+    }
+
+    override fun setSelectedTextRange(selectedTextRange: UITextRange?) {
+        _skiaLayer?.skikoView?.input?.setSelectedTextRange(selectedTextRange?.toIntRange())
+    }
+
+    /**
+     * The range of selected text in a document.
+     * If the text range has a length, it indicates the currently selected text.
+     * If it has zero length, it indicates the caret (insertion point).
+     * If the text-range object is nil, it indicates that there is no current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614541-selectedtextrange
+     */
+    override fun selectedTextRange(): UITextRange? {
+        return _skiaLayer?.skikoView?.input?.getSelectedTextRange()?.toUITextRange()
+    }
+
+    /**
+     * The range of currently marked text in a document.
+     * If there is no marked text, the value of the property is nil.
+     * Marked text is provisionally inserted text that requires user confirmation;
+     * it occurs in multistage text input.
+     * The current selection, which can be a caret or an extended range, always occurs within the marked text.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614489-markedtextrange
+     */
+    override fun markedTextRange(): UITextRange? {
+        return _skiaLayer?.skikoView?.input?.markedTextRange()?.toUITextRange()
+    }
+
+    override fun setMarkedTextStyle(markedTextStyle: Map<Any?, *>?) {
+        // do nothing
+    }
+
+    override fun markedTextStyle(): Map<Any?, *>? {
+        return null
+    }
+
+    /**
+     * Inserts the provided text and marks it to indicate that it is part of an active input session.
+     * Setting marked text either replaces the existing marked text or,
+     * if none is present, inserts it in place of the current selection.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614465-setmarkedtext
+     * @param markedText The text to be marked.
+     * @param selectedRange A range within markedText that indicates the current selection.
+     * This range is always relative to markedText.
+     */
+    override fun setMarkedText(markedText: String?, selectedRange: CValue<NSRange>) {
+        val (locationRelative, lengthRelative) = selectedRange.useContents {
+            location.toInt() to length.toInt()
+        }
+        val relativeTextRange = locationRelative until locationRelative + lengthRelative
+        _skiaLayer?.skikoView?.input?.setMarkedText(markedText, relativeTextRange)
+    }
+
+    /**
+     * Unmarks the currently marked text.
+     * After this method is called, the value of markedTextRange is nil.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614512-unmarktext
+     */
+    override fun unmarkText() {
+        _skiaLayer?.skikoView?.input?.unmarkText()
+    }
+
+    override fun beginningOfDocument(): UITextPosition {
+        return IntermediateTextPosition(0)
+    }
+
+    /**
+     * The text position for the end of a document.
+     * https://developer.apple.com/documentation/uikit/uitextinput/1614555-endofdocument
+     */
+    override fun endOfDocument(): UITextPosition {
+        return IntermediateTextPosition(_skiaLayer?.skikoView?.input?.endOfDocument() ?: 0)
+    }
+
+    /**
+     * Attention! fromPosition and toPosition may be null
+     */
+    override fun textRangeFromPosition(fromPosition: UITextPosition, toPosition: UITextPosition): UITextRange? {
+        val from = (fromPosition as? IntermediateTextPosition)?.position ?: 0
+        val to = (toPosition as? IntermediateTextPosition)?.position ?: 0
+        return IntermediateTextRange(
+            IntermediateTextPosition(minOf(from, to)),
+            IntermediateTextPosition(maxOf(from, to))
+        )
+    }
+
+    /**
+     * Attention! position may be null
+     */
+    override fun positionFromPosition(position: UITextPosition, offset: NSInteger): UITextPosition? {
+        val p = (position as? IntermediateTextPosition)?.position ?: return null
+        val endOfDocument = _skiaLayer?.skikoView?.input?.endOfDocument()
+        return if (endOfDocument != null) {
+            IntermediateTextPosition(max(min(p + offset, endOfDocument), 0))
+        } else {
+            null
+        }
+    }
+
+    override fun positionFromPosition(
+        position: UITextPosition,
+        inDirection: UITextLayoutDirection,
+        offset: NSInteger
+    ): UITextPosition? {
+        return when (inDirection) {
+            UITextLayoutDirectionLeft, UITextLayoutDirectionUp -> {
+                positionFromPosition(position, -offset)
+            }
+
+            else -> positionFromPosition(position, offset)
+        }
+    }
+
+    /**
+     * Attention! position and toPosition may be null
+     */
+    override fun comparePosition(position: UITextPosition, toPosition: UITextPosition): NSComparisonResult {
+        val from = (position as? IntermediateTextPosition)?.position ?: 0
+        val to = (toPosition as? IntermediateTextPosition)?.position ?: 0
+        val result = if (from < to) {
+            NSOrderedAscending
+        } else if (from > to) {
+            NSOrderedDescending
+        } else {
+            NSOrderedSame
+        }
+        return result
+    }
+
+    override fun offsetFromPosition(from: UITextPosition, toPosition: UITextPosition): NSInteger {
+        val fromPosition = from as IntermediateTextPosition
+        val to = toPosition as IntermediateTextPosition
+        return to.position - fromPosition.position
+    }
+
+    override fun tokenizer(): UITextInputTokenizerProtocol {
+        return UITextInputStringTokenizer()
+    }
+
+    override fun positionWithinRange(range: UITextRange, atCharacterOffset: NSInteger): UITextPosition? =
+        TODO("positionWithinRange range: $range, atCharacterOffset: $atCharacterOffset")
+
+    override fun positionWithinRange(range: UITextRange, farthestInDirection: UITextLayoutDirection): UITextPosition? =
+        TODO("positionWithinRange, farthestInDirection: ${farthestInDirection.directionToStr()}")
+
+    override fun characterRangeByExtendingPosition(
+        position: UITextPosition,
+        inDirection: UITextLayoutDirection
+    ): UITextRange? {
+        TODO("characterRangeByExtendingPosition, inDirection: ${inDirection.directionToStr()}")
+    }
+
+    override fun baseWritingDirectionForPosition(
+        position: UITextPosition,
+        inDirection: UITextStorageDirection
+    ): NSWritingDirection {
+        return NSWritingDirectionLeftToRight // TODO support RTL text direction
+    }
+
+    override fun setBaseWritingDirection(writingDirection: NSWritingDirection, forRange: UITextRange) {
+        // TODO support RTL text direction
+    }
+
+    //Working with Geometry and Hit-Testing. All methods return stubs for now.
+    override fun firstRectForRange(range: UITextRange): CValue<CGRect> = CGRectNull.readValue()
+    override fun caretRectForPosition(position: UITextPosition): CValue<CGRect> = CGRectNull.readValue()
+    override fun selectionRectsForRange(range: UITextRange): List<*> = listOf<UITextSelectionRect>()
+    override fun closestPositionToPoint(point: CValue<CGPoint>): UITextPosition? = null
+    override fun closestPositionToPoint(point: CValue<CGPoint>, withinRange: UITextRange): UITextPosition? = null
+    override fun characterRangeAtPoint(point: CValue<CGPoint>): UITextRange? = null
+
+    override fun textStylingAtPosition(position: UITextPosition, inDirection: UITextStorageDirection): Map<Any?, *>? {
+        return NSDictionary.dictionary()
+    }
+
+    override fun characterOffsetOfPosition(position: UITextPosition, withinRange: UITextRange): NSInteger {
+        TODO("characterOffsetOfPosition")
+    }
+
+    override fun shouldChangeTextInRange(range: UITextRange, replacementText: String): Boolean {
+        // Here we should decide to replace text in range or not.
+        // By default, this method returns true.
+        return true
+    }
+
+    override fun textInputView(): UIView {
+        return this
+    }
+
+    override fun canPerformAction(action: COpaquePointer?, withSender: Any?): Boolean =
+        when (action) {
+            NSSelectorFromString(UIResponderStandardEditActionsProtocol::copy.name + ":") ->
+                _currentTextMenuActions?.copy != null
+
+            NSSelectorFromString(UIResponderStandardEditActionsProtocol::cut.name + ":") ->
+                _currentTextMenuActions?.cut != null
+
+            NSSelectorFromString(UIResponderStandardEditActionsProtocol::paste.name + ":") ->
+                _currentTextMenuActions?.paste != null
+
+            NSSelectorFromString(UIResponderStandardEditActionsProtocol::selectAll.name + ":") ->
+                _currentTextMenuActions?.selectAll != null
+
+            else -> false
+        }
+
+    override fun keyboardType(): UIKeyboardType = _skikoUITextInputTrains.keyboardType()
+    override fun keyboardAppearance(): UIKeyboardAppearance = _skikoUITextInputTrains.keyboardAppearance()
+    override fun returnKeyType(): UIReturnKeyType = _skikoUITextInputTrains.returnKeyType()
+    override fun textContentType(): UITextContentType? = _skikoUITextInputTrains.textContentType()
+    override fun isSecureTextEntry(): Boolean = _skikoUITextInputTrains.isSecureTextEntry()
+    override fun enablesReturnKeyAutomatically(): Boolean = _skikoUITextInputTrains.enablesReturnKeyAutomatically()
+    override fun autocapitalizationType(): UITextAutocapitalizationType =
+        _skikoUITextInputTrains.autocapitalizationType()
+
+    override fun autocorrectionType(): UITextAutocorrectionType = _skikoUITextInputTrains.autocorrectionType()
+
+    override fun dictationRecognitionFailed() {
+        //todo may be useful
+    }
+
+    override fun dictationRecordingDidEnd() {
+        //todo may be useful
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun textWillChange() {
+        _inputDelegate?.textWillChange(this)
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun textDidChange() {
+        _inputDelegate?.textDidChange(this)
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun selectionWillChange() {
+        _inputDelegate?.selectionWillChange(this)
+    }
+
+    /**
+     * Call when something changes in text data
+     */
+    fun selectionDidChange() {
+        _inputDelegate?.selectionDidChange(this)
+    }
+}
+
+private class IntermediateTextPosition(val position: Long = 0) : UITextPosition()
+
+private fun IntermediateTextRange(start: Int, end: Int) =
+    IntermediateTextRange(
+        _start = IntermediateTextPosition(start.toLong()),
+        _end = IntermediateTextPosition(end.toLong())
+    )
+
+private class IntermediateTextRange(
+    private val _start: IntermediateTextPosition,
+    private val _end: IntermediateTextPosition
+) : UITextRange() {
+    override fun isEmpty() = (_end.position - _start.position) <= 0
+    override fun start(): UITextPosition = _start
+    override fun end(): UITextPosition = _end
+}
+
+private fun UITextRange.toIntRange(): IntRange {
+    val start = (start() as IntermediateTextPosition).position.toInt()
+    val end = (end() as IntermediateTextPosition).position.toInt()
+    return start until end
+}
+
+private fun IntRange.toUITextRange(): UITextRange =
+    IntermediateTextRange(start = start, end = endInclusive + 1)
+
+private fun NSWritingDirection.directionToStr() =
+    when (this) {
+        UITextLayoutDirectionLeft -> "Left"
+        UITextLayoutDirectionRight -> "Right"
+        UITextLayoutDirectionUp -> "Up"
+        UITextLayoutDirectionDown -> "Down"
+        else -> "unknown direction"
+    }
+
+private val UITouch.isPressed
+    get() =
+        phase != UITouchPhase.UITouchPhaseEnded &&
+            phase != UITouchPhase.UITouchPhaseCancelled
+
+private val Iterable<SkikoPointer>.centroidX get() = asSequence().map { it.x }.average()
+private val Iterable<SkikoPointer>.centroidY get() = asSequence().map { it.y }.average()


### PR DESCRIPTION
## Proposed Changes

Copy all iOS-specific types from Skiko.
Copy-paste types, that are needlessly hidden behind expect interfaces, and types dependent on former ones.
Update imports to depend on local types instead skiko-imported ones.

## Testing

Test: N/A