### PR TITLE
Fix bug in calendar model 

### DIFF
--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
@@ -43,8 +43,8 @@ internal actual object PlatformDateFormat {
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
         return NSDateFormatter().apply {
-            setDateFormat(pattern)
             setLocale(locale)
+            setDateFormat(pattern)
         }.stringFromDate(nsDate)
     }
 
@@ -57,8 +57,8 @@ internal actual object PlatformDateFormat {
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
         return NSDateFormatter().apply {
-            setLocalizedDateFormatFromTemplate(skeleton)
             setLocale(locale)
+            setLocalizedDateFormatFromTemplate(skeleton)
         }.stringFromDate(nsDate)
     }
 
@@ -68,8 +68,8 @@ internal actual object PlatformDateFormat {
     ): CalendarDate? {
 
         val nsDate = NSDateFormatter().apply {
-            setDateFormat(pattern)
             setTimeZone(TimeZone.UTC.toNSTimeZone())
+            setDateFormat(pattern)
         }.dateFromString(date) ?: return null
 
         return Instant

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -47,8 +47,8 @@ internal actual object PlatformDateFormat {
         // stub: not localized but at least readable variant
         val pattern = when(skeleton){
             DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"
-            DatePickerDefaults.YearAbbrMonthDaySkeleton -> "dd MMM yyyy"
-            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> "EEEE dd MMMM yyyy"
+            DatePickerDefaults.YearAbbrMonthDaySkeleton -> "d MMM yyyy"
+            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> "EEEE, d MMMM yyyy"
             else -> skeleton
         }
         return formatWithPattern(utcTimeMillis, pattern, locale)

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -43,7 +43,15 @@ internal actual object PlatformDateFormat {
         // TODO: support ICU skeleton on JVM
         // Maybe it will be supported in kotlinx.datetime in the future.
         // See https://github.com/Kotlin/kotlinx-datetime/pull/251
-        return formatWithPattern(utcTimeMillis, skeleton, locale)
+
+        // stub: not localized but at least readable variant
+        val pattern = when(skeleton){
+            DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"
+            DatePickerDefaults.YearAbbrMonthDaySkeleton -> "dd MMM yyyy"
+            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> "EEEE dd MMMM yyyy"
+            else -> skeleton
+        }
+        return formatWithPattern(utcTimeMillis, pattern, locale)
     }
 
     actual fun parse(

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -47,8 +47,8 @@ internal actual object PlatformDateFormat {
         // stub: not localized but at least readable variant
         val pattern = when(skeleton){
             DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"
-            DatePickerDefaults.YearAbbrMonthDaySkeleton -> "d MMM yyyy"
-            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> "EEEE, d MMMM yyyy"
+            DatePickerDefaults.YearAbbrMonthDaySkeleton -> "MMM d, yyyy"
+            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> "EEEE, MMMM d, yyyy"
             else -> skeleton
         }
         return formatWithPattern(utcTimeMillis, pattern, locale)

--- a/compose/material3/material3/src/desktopTest/kotlin/androidx/compose/material3/CalendarModel.desktop.kt
+++ b/compose/material3/material3/src/desktopTest/kotlin/androidx/compose/material3/CalendarModel.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.material3
 
 import java.util.Locale
+import java.util.TimeZone
 
 actual fun calendarLocale(language : String, country : String) : CalendarLocale{
     return Locale(language, country)
@@ -24,3 +25,11 @@ actual fun calendarLocale(language : String, country : String) : CalendarLocale{
 
 actual val supportsDateSkeleton: Boolean
     get() = false
+
+actual fun setTimeZone(id: String) {
+    TimeZone.setDefault(TimeZone.getTimeZone(id))
+}
+
+actual fun getTimeZone(): String {
+    return TimeZone.getDefault().id
+}

--- a/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
@@ -148,7 +148,7 @@ internal actual object PlatformDateFormat {
         return LocalDate(
             year, month, day
         ).atStartOfDayIn(TimeZone.UTC)
-            .toCalendarDate()
+            .toCalendarDate(TimeZone.UTC)
     }
 
     private fun parseSegment(date: String, pattern: String, segmentPattern: String): Int? {

--- a/compose/material3/material3/src/jsWasmTest/kotlin/androidx/compose/material3/CalendarModel.js.kt
+++ b/compose/material3/material3/src/jsWasmTest/kotlin/androidx/compose/material3/CalendarModel.js.kt
@@ -24,3 +24,12 @@ actual fun calendarLocale(language: String, country : String): CalendarLocale {
 
 actual val supportsDateSkeleton: Boolean
     get() = true
+
+// not implemented
+actual fun setTimeZone(id: String) {
+}
+
+// not implemented
+actual fun getTimeZone(): String {
+    return ""
+}

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModel.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModel.kt
@@ -57,13 +57,13 @@ internal class KotlinxDatetimeCalendarModel : CalendarModel {
             .toLocalDateTime(TimeZone.UTC)
             .date
             .atStartOfDayIn(TimeZone.UTC)
-            .toCalendarDate()
+            .toCalendarDate(TimeZone.UTC)
     }
 
     override fun getMonth(timeInMillis: Long): CalendarMonth {
         return Instant
             .fromEpochMilliseconds(timeInMillis)
-            .toCalendarMonth()
+            .toCalendarMonth(TimeZone.UTC)
     }
 
     override fun getMonth(date: CalendarDate): CalendarMonth {
@@ -75,7 +75,7 @@ internal class KotlinxDatetimeCalendarModel : CalendarModel {
             year = year,
             monthNumber = month,
             dayOfMonth = 1,
-        ).atStartOfDayIn(systemTZ)
+        ).atStartOfDayIn(TimeZone.UTC)
 
         return getMonth(instant.toEpochMilliseconds())
     }
@@ -90,11 +90,11 @@ internal class KotlinxDatetimeCalendarModel : CalendarModel {
     override fun plusMonths(from: CalendarMonth, addedMonthsCount: Int): CalendarMonth {
         return Instant
             .fromEpochMilliseconds(from.startUtcTimeMillis)
-            .toLocalDateTime(systemTZ)
+            .toLocalDateTime(TimeZone.UTC)
             .date
             .plus(DatePeriod(months = addedMonthsCount))
-            .atStartOfDayIn(systemTZ)
-            .toCalendarMonth()
+            .atStartOfDayIn(TimeZone.UTC)
+            .toCalendarMonth(TimeZone.UTC)
     }
 
     override fun minusMonths(from: CalendarMonth, subtractedMonthsCount: Int): CalendarMonth {

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModel.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModel.kt
@@ -114,7 +114,7 @@ internal class KotlinxDatetimeCalendarModel : CalendarModel {
     }
 
     private fun Instant.toCalendarMonth(
-        timeZone : TimeZone = systemTZ
+        timeZone : TimeZone
     ) : CalendarMonth {
 
         val dateTime = toLocalDateTime(timeZone)

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModel.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModel.kt
@@ -30,7 +30,7 @@ import kotlinx.datetime.toLocalDateTime
 internal class KotlinxDatetimeCalendarModel : CalendarModel {
 
     override val today: CalendarDate
-        get() = Clock.System.now().toCalendarDate()
+        get() = Clock.System.now().toCalendarDate(systemTZ)
 
     override val firstDayOfWeek: Int
         get() = PlatformDateFormat.firstDayOfWeek
@@ -192,7 +192,7 @@ private val EnglishWeekdaysNames = listOf(
 )
 
 internal fun Instant.toCalendarDate(
-    timeZone : TimeZone = TimeZone.currentSystemDefault()
+    timeZone : TimeZone
 ) : CalendarDate {
 
     val dateTime = toLocalDateTime(timeZone)

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
@@ -43,25 +43,6 @@ internal class KotlinxDatetimeCalendarModelTest {
     }
 
     @Test
-    fun getMonths_differentTZ(){
-        val defaultTz = getTimeZone()
-
-        setTimeZone("GMT-5")
-
-        var date = model.getMonth(January2022Millis) // 1/1/2022
-        assertThat(date.year).isEqualTo(2022)
-        assertThat(date.month).isEqualTo(1)
-
-        setTimeZone("GMT+5")
-
-        date = model.getMonth(January2022Millis) // 1/1/2022
-        assertThat(date.year).isEqualTo(2022)
-        assertThat(date.month).isEqualTo(1)
-
-        setTimeZone(defaultTz)
-    }
-
-    @Test
     fun dateCreation_differentTZ() {
 
         val defaultTz = getTimeZone()
@@ -150,6 +131,37 @@ internal class KotlinxDatetimeCalendarModelTest {
     }
 
     @Test
+    fun monthCreation_differentTz() {
+        val defaultTz = getTimeZone()
+
+        setTimeZone("GMT-5")
+
+        val date =
+            CalendarDate(
+                year = 2022,
+                month = 1,
+                dayOfMonth = 1,
+                utcTimeMillis = January2022Millis
+            )
+
+        var monthFromDate = model.getMonth(date)
+        var monthFromMilli = model.getMonth(January2022Millis)
+        var monthFromYearMonth = model.getMonth(year = 2022, month = 1)
+        assertThat(monthFromDate).isEqualTo(monthFromMilli)
+        assertThat(monthFromDate).isEqualTo(monthFromYearMonth)
+
+        setTimeZone("GMT+5")
+
+        monthFromDate = model.getMonth(date)
+        monthFromMilli = model.getMonth(January2022Millis)
+        monthFromYearMonth = model.getMonth(year = 2022, month = 1)
+        assertThat(monthFromDate).isEqualTo(monthFromMilli)
+        assertThat(monthFromDate).isEqualTo(monthFromYearMonth)
+
+        setTimeZone(defaultTz)
+    }
+
+    @Test
     fun monthCreation_withRounding() {
         val date =
             CalendarDate(
@@ -162,6 +174,36 @@ internal class KotlinxDatetimeCalendarModelTest {
         val monthFromMilli = model.getMonth(January2022Millis + 10000)
         assertThat(monthFromDate).isEqualTo(monthFromMilli)
     }
+
+    @Test
+    fun monthCreation_withRounding_differentTZ() {
+
+        val defaultTz = getTimeZone()
+
+        val date =
+            CalendarDate(
+                year = 2022,
+                month = 1,
+                dayOfMonth = 1,
+                utcTimeMillis = January2022Millis
+            )
+
+        setTimeZone("GMT-5")
+
+
+        var monthFromDate = model.getMonth(date)
+        var monthFromMilli = model.getMonth(January2022Millis + 10000)
+        assertThat(monthFromDate).isEqualTo(monthFromMilli)
+
+        setTimeZone("GMT+5")
+
+        monthFromDate = model.getMonth(date)
+        monthFromMilli = model.getMonth(January2022Millis + 10000)
+        assertThat(monthFromDate).isEqualTo(monthFromMilli)
+
+        setTimeZone(defaultTz)
+    }
+
 
     @Test
     fun monthRestore() {

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
@@ -43,6 +43,25 @@ internal class KotlinxDatetimeCalendarModelTest {
     }
 
     @Test
+    fun getMonths_differentTZ(){
+        val defaultTz = getTimeZone()
+
+        setTimeZone("GMT-5")
+
+        var date = model.getMonth(January2022Millis) // 1/1/2022
+        assertThat(date.year).isEqualTo(2022)
+        assertThat(date.month).isEqualTo(1)
+
+        setTimeZone("GMT+5")
+
+        date = model.getMonth(January2022Millis) // 1/1/2022
+        assertThat(date.year).isEqualTo(2022)
+        assertThat(date.month).isEqualTo(1)
+
+        setTimeZone(defaultTz)
+    }
+
+    @Test
     fun dateCreation_differentTZ() {
 
         val defaultTz = getTimeZone()

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
@@ -23,6 +23,8 @@ import kotlin.test.Test
 // Remove this condition or set it to true in desktopTest when supported
 expect val supportsDateSkeleton : Boolean
 
+expect fun getTimeZone() : String
+expect fun setTimeZone(id : String)
 
 // Tests were copied from Android CalendarModelTest and adopted to multiplatform
 @OptIn(ExperimentalMaterial3Api::class)
@@ -32,11 +34,36 @@ internal class KotlinxDatetimeCalendarModelTest {
 
     @Test
     fun dateCreation() {
+
         val date = model.getCanonicalDate(January2022Millis) // 1/1/2022
         assertThat(date.year).isEqualTo(2022)
         assertThat(date.month).isEqualTo(1)
         assertThat(date.dayOfMonth).isEqualTo(1)
         assertThat(date.utcTimeMillis).isEqualTo(January2022Millis)
+    }
+
+    @Test
+    fun dateCreation_differentTZ() {
+
+        val defaultTz = getTimeZone()
+
+        setTimeZone("GMT-5")
+
+        var date = model.getCanonicalDate(January2022Millis) // 1/1/2022
+        assertThat(date.year).isEqualTo(2022)
+        assertThat(date.month).isEqualTo(1)
+        assertThat(date.dayOfMonth).isEqualTo(1)
+        assertThat(date.utcTimeMillis).isEqualTo(January2022Millis)
+
+        setTimeZone("GMT+5")
+
+        date = model.getCanonicalDate(January2022Millis) // 1/1/2022
+        assertThat(date.year).isEqualTo(2022)
+        assertThat(date.month).isEqualTo(1)
+        assertThat(date.dayOfMonth).isEqualTo(1)
+        assertThat(date.utcTimeMillis).isEqualTo(January2022Millis)
+
+        setTimeZone(defaultTz)
     }
 
     @Test
@@ -47,6 +74,32 @@ internal class KotlinxDatetimeCalendarModelTest {
         assertThat(date.dayOfMonth).isEqualTo(1)
         // Check that the milliseconds represent the start of the day.
         assertThat(date.utcTimeMillis).isEqualTo(January2022Millis)
+    }
+
+    @Test
+    fun dateCreation_withRounding_differentTz() {
+
+        val defaultTz = getTimeZone()
+
+        setTimeZone("GMT-5")
+
+        var date = model.getCanonicalDate(January2022Millis + 30000) // 1/1/2022 + 30000 millis
+        assertThat(date.year).isEqualTo(2022)
+        assertThat(date.month).isEqualTo(1)
+        assertThat(date.dayOfMonth).isEqualTo(1)
+        // Check that the milliseconds represent the start of the day.
+        assertThat(date.utcTimeMillis).isEqualTo(January2022Millis)
+
+        setTimeZone("GMT+5")
+
+        date = model.getCanonicalDate(January2022Millis + 30000) // 1/1/2022 + 30000 millis
+        assertThat(date.year).isEqualTo(2022)
+        assertThat(date.month).isEqualTo(1)
+        assertThat(date.dayOfMonth).isEqualTo(1)
+        // Check that the milliseconds represent the start of the day.
+        assertThat(date.utcTimeMillis).isEqualTo(January2022Millis)
+
+        setTimeZone(defaultTz)
     }
 
     @Test

--- a/compose/material3/material3/src/uikitTest/kotlin/androidx/compose/material3/CalendarModel.uikit.kt
+++ b/compose/material3/material3/src/uikitTest/kotlin/androidx/compose/material3/CalendarModel.uikit.kt
@@ -17,9 +17,21 @@
 package androidx.compose.material3
 
 import platform.Foundation.NSLocale
+import platform.Foundation.NSTimeZone
+import platform.Foundation.defaultTimeZone
+import platform.Foundation.setDefaultTimeZone
+import platform.Foundation.timeZoneWithName
 
 actual fun calendarLocale(language : String, country : String) : CalendarLocale =
     NSLocale("$language-${country}")
 
 actual val supportsDateSkeleton: Boolean
     get() = true
+
+actual fun setTimeZone(id: String) {
+    NSTimeZone.setDefaultTimeZone(NSTimeZone.timeZoneWithName(id)!!)
+}
+
+actual fun getTimeZone(): String {
+    return NSTimeZone.defaultTimeZone().name
+}


### PR DESCRIPTION
## Proposed Changes

Fixed bug from https://github.com/JetBrains/compose-multiplatform-core/pull/717 described in https://kotlinlang.slack.com/archives/CJLTWPH7S/p1692632685323839 (you can reproduce it if you set `TimeZone.setDefault(TimeZone.getTimeZone("GMT-5"))` on desktop)

`getMonth` and `getCannonicalDate` should not be converted to local time zone. It should retain UTC (you can see it in legacy impl). The only method that uses system TZ should be `getDayOfWeek`

By mistake my GMT+3 time zone and time zone on CI somehow passed all the tests copied from android source set. But it was not the case for example for the GMT-5. I apologise for that.

---

Added non-localized format for desktop instead of ugly skeleton-format without spaces  (https://github.com/JetBrains/compose-multiplatform-core/pull/717#issuecomment-1665873964)  until it properly implemented.

Reordered locale and pattern paremeters for dawin. Locale should be applied before pattern.

## Testing

Test: 4 new tests in `KotlinxDatetimeCalendarModel` performed in different time zones
