### PR TITLE
iOS Demo, Adapt to 1.5.0 focus behavior.

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/ClearFocusBox.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/ClearFocusBox.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.textfield
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalFocusManager
+
+/**
+ * This wrapper need to control focus behavior on iOS to hide the keyboard.
+ */
+@Composable
+fun ClearFocusBox(content: @Composable () -> Unit) {
+    val focusManager = LocalFocusManager.current
+    Box(
+        Modifier.fillMaxSize()
+            .pointerInput(Unit) {
+                detectTapGestures {
+                    focusManager.clearFocus(force = true)
+                }
+            },
+    ) {
+        content()
+    }
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -16,33 +16,32 @@
 
 package androidx.compose.mpp.demo.textfield
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.TextField
 import androidx.compose.mpp.demo.Screen
-import androidx.compose.mpp.demo.textfield.android.CapitalizationAutoCorrectDemo
-import androidx.compose.mpp.demo.textfield.android.KeyboardTypeDemo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 
 val TextFields = Screen.Selection(
     "TextFields",
     Screen.Example("AlmostFullscreen") {
-        AlmostFullscreen()
+        ClearFocusBox {
+            AlmostFullscreen()
+        }
     },
     Screen.Example("Keyboard Actions") {
-        KeyboardActionsExample()
+        ClearFocusBox {
+            KeyboardActionsExample()
+        }
     },
     Screen.Example("Password Textfield Example") {
-        PasswordTextfieldExample()
-    },
-    Screen.Example("Hide keyboard on click outside") {
-        HideKeyboardOnClickOutside()
+        ClearFocusBox {
+            PasswordTextfieldExample()
+        }
     },
 )
 
@@ -62,20 +61,3 @@ private fun AlmostFullscreen() {
         Modifier.fillMaxSize().padding(vertical = 40.dp)
     )
 }
-
-@Composable
-private fun HideKeyboardOnClickOutside() {
-    val focusManager = LocalFocusManager.current
-    Box(
-        Modifier.fillMaxSize()
-            .pointerInput(Unit) {
-                detectTapGestures {
-                    focusManager.clearFocus(force = true)
-                }
-            },
-    ) {
-        val textState = remember { mutableStateOf("Click outside to hide the keyboard") }
-        TextField(textState.value, { textState.value = it })
-    }
-}
-

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/android/AndroidTextFieldSamples.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/android/AndroidTextFieldSamples.kt
@@ -17,6 +17,7 @@
 package androidx.compose.mpp.demo.textfield.android
 
 import androidx.compose.mpp.demo.Screen
+import androidx.compose.mpp.demo.textfield.ClearFocusBox
 
 val AndroidTextFieldSamples = Screen.Selection(
     "Android TextField samples",
@@ -25,44 +26,128 @@ val AndroidTextFieldSamples = Screen.Selection(
        caret doesn’t follow text and shows in a wrong position.
        Manual changing position of the caret leads to changing RTL to LTR editing.
      */
-    Screen.Example("Basic input fields") { InputFieldDemo() },
-    Screen.Example("Capitalization/AutoCorrect") { CapitalizationAutoCorrectDemo() },
-    Screen.Example("Cursor configuration") { TextFieldCursorBlinkingDemo() },
+    Screen.Example("Basic input fields") {
+        ClearFocusBox {
+            InputFieldDemo()
+        }
+    },
+    Screen.Example("Capitalization/AutoCorrect") {
+        ClearFocusBox {
+            CapitalizationAutoCorrectDemo()
+        }
+    },
+    Screen.Example("Cursor configuration") {
+        ClearFocusBox {
+            TextFieldCursorBlinkingDemo()
+        }
+    },
     Screen.Selection(
         "Focus",
         /*
         TODO: Android TextField samples/Focus/Focus transition: focused words should underline
          */
-        Screen.Example("Focus transition") { TextFieldFocusTransition() },
-        Screen.Example("Focus keyboard interaction") { TextFieldFocusKeyboardInteraction() },
+        Screen.Example("Focus transition") {
+            ClearFocusBox {
+                TextFieldFocusTransition()
+            }
+        },
+        Screen.Example("Focus keyboard interaction") {
+            ClearFocusBox {
+                TextFieldFocusKeyboardInteraction()
+            }
+        },
     ),
-    Screen.Example("Full-screen field") { FullScreenTextFieldDemo() },
-    Screen.Example("Ime Action") { ImeActionDemo() },
+    Screen.Example("Full-screen field") {
+        ClearFocusBox {
+            FullScreenTextFieldDemo()
+        }
+    },
+    Screen.Example("Ime Action") {
+        ClearFocusBox {
+            ImeActionDemo()
+        }
+    },
     /*
     TODO: Ime Action / Ime Single Line: Behavior differs from android,
      in multiline textfields return button works as default multiline textfield.
      In android multiline tf with ime action works as singleline (except default)
      */
-    Screen.Example("Ime SingleLine") { ImeSingleLineDemo() },
-    Screen.Example("Inside Dialog") { TextFieldsInDialogDemo() },
-    Screen.Example("Inside scrollable") { TextFieldsInScrollableDemo() },
-    Screen.Example("Keyboard Types") { KeyboardTypeDemo() },
-    Screen.Example("Min/Max Lines") { BasicTextFieldMinMaxDemo() },
-    Screen.Example("Reject Text Change") { RejectTextChangeDemo() },
-    Screen.Example("Scrollable text fields") { ScrollableTextFieldDemo() },
-    Screen.Example("Visual Transformation") { VisualTransformationDemo() },
-    Screen.Example("TextFieldValue") { TextFieldValueDemo() },
-    Screen.Example("Tail Following Text Field") { TailFollowingTextFieldDemo() },
-    Screen.Example("Focus immediately") { FocusTextFieldImmediatelyDemo() },
+    Screen.Example("Ime SingleLine") {
+        ClearFocusBox {
+            ImeSingleLineDemo()
+        }
+    },
+    Screen.Example("Inside Dialog") {
+        ClearFocusBox {
+            TextFieldsInDialogDemo()
+        }
+    },
+    Screen.Example("Inside scrollable") {
+        ClearFocusBox {
+            TextFieldsInScrollableDemo()
+        }
+    },
+    Screen.Example("Keyboard Types") {
+        ClearFocusBox {
+            KeyboardTypeDemo()
+        }
+    },
+    Screen.Example("Min/Max Lines") {
+        ClearFocusBox {
+            BasicTextFieldMinMaxDemo()
+        }
+    },
+    Screen.Example("Reject Text Change") {
+        ClearFocusBox {
+            RejectTextChangeDemo()
+        }
+    },
+    Screen.Example("Scrollable text fields") {
+        ClearFocusBox {
+            ScrollableTextFieldDemo()
+        }
+    },
+    Screen.Example("Visual Transformation") {
+        ClearFocusBox {
+            VisualTransformationDemo()
+        }
+    },
+    Screen.Example("TextFieldValue") {
+        ClearFocusBox {
+            TextFieldValueDemo()
+        }
+    },
+    Screen.Example("Tail Following Text Field") {
+        ClearFocusBox {
+            TailFollowingTextFieldDemo()
+        }
+    },
+    Screen.Example("Focus immediately") {
+        ClearFocusBox {
+            FocusTextFieldImmediatelyDemo()
+        }
+    },
     /*
     TODO: From-scratch textfield doesn't work at all.
      However, on android using this textfield leads to app crash
      */
-    Screen.Example("Secondary input system") { PlatformTextInputAdapterDemo() },
+    Screen.Example("Secondary input system") {
+        ClearFocusBox {
+            PlatformTextInputAdapterDemo()
+        }
+    },
     /*
     TODO: Textfield Focus - iOS doesnt support navigation between textfields via shift + arrow or tab.
       Singleline textfields work with tab
      */
-    Screen.Example("TextField focus") { TextFieldFocusDemo() },
-    Screen.Example("TextFieldBrush") { TextFieldBrush() },
+    Screen.Example("TextField focus") {
+        ClearFocusBox {
+            TextFieldFocusDemo()
+        }
+    },
+    Screen.Example("TextFieldBrush") {
+        ClearFocusBox {
+            TextFieldBrush()
+        }
+    },
 )


### PR DESCRIPTION
## Proposed Changes

 - Added logic to clear focus and hide keyboard on iOS on tap outside TextField.

## Testing

Run and check iOS Demo
