### PR TITLE
iOS wait for the first frame

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
@@ -1,3 +1,4 @@
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -8,6 +9,7 @@ import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.window.ComposeUIViewController
 import platform.UIKit.UINavigationController
@@ -34,7 +36,7 @@ val NativeModalWithNaviationExample = Screen.Example("Native modal with navigati
 }
 @Composable
 private fun NativeModalWithNavigation() {
-    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Box(Modifier.fillMaxSize().background(Color.DarkGray), contentAlignment = Alignment.Center) {
         val viewController = LocalUIViewController.current
         Button(onClick = {
             val navigationController = UINavigationController(rootViewController = ComposeUIViewController {

--- a/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
@@ -52,7 +52,7 @@ private fun NativeModalWithNavigation() {
 
 @Composable
 private fun NativeNavigationPage() {
-    Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
+    Column(Modifier.fillMaxSize().background(Color.DarkGray), verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
         val navigationController = LocalUIViewController.current.navigationController
 
         Button(onClick = {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -534,8 +534,6 @@ internal actual class ComposeWindow : UIViewController {
             AttachedComposeContext(scene, skikoUIView).also {
                 updateLayout(it)
             }
-
-        skikoUIView.drawSynchronously()
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -534,6 +534,8 @@ internal actual class ComposeWindow : UIViewController {
             AttachedComposeContext(scene, skikoUIView).also {
                 updateLayout(it)
             }
+
+        skikoUIView.drawSynchronously()
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -118,8 +118,6 @@ private enum class DrawReason {
     DISPLAY_LINK_CALLBACK, SYNC_WITH_UIKIT
 }
 
-private var avoidFirst = true
-
 internal class MetalRedrawer(
     private val metalLayer: CAMetalLayer,
     private val drawCallback: (Surface) -> Unit,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -29,8 +29,6 @@ import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.darwin.*
 import kotlin.math.roundToInt
-import platform.Metal.MTLCaptureManager
-import platform.Metal.MTLCaptureScopeProtocol
 
 private class DisplayLinkConditions(
     val setPausedCallback: (Boolean) -> Unit

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -29,6 +29,8 @@ import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.darwin.*
 import kotlin.math.roundToInt
+import platform.Metal.MTLCaptureManager
+import platform.Metal.MTLCaptureScopeProtocol
 
 private class DisplayLinkConditions(
     val setPausedCallback: (Boolean) -> Unit
@@ -117,6 +119,8 @@ private class ApplicationStateListener(
 private enum class DrawReason {
     DISPLAY_LINK_CALLBACK, SYNC_WITH_UIKIT
 }
+
+private var avoidFirst = true
 
 internal class MetalRedrawer(
     private val metalLayer: CAMetalLayer,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -210,6 +210,9 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             CGSizeMake(size.width * contentScaleFactor, size.height * contentScaleFactor)
         }
 
+        // If drawableSize is zero in any direction it means that it's a first layout
+        // we need to synchronously dispatch first draw and block until it's presented
+        // so user doesn't have a flicker
         val needsSynchronousDraw = _metalLayer.drawableSize.useContents {
             width == 0.0 || height == 0.0
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -135,6 +135,8 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
     fun needRedraw() = _redrawer.needRedraw()
 
+    fun drawSynchronously() = _redrawer.drawSynchronously()
+
     /**
      * Show copy/paste text menu
      * @param targetRect - rectangle of selected text area

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -135,8 +135,6 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
     fun needRedraw() = _redrawer.needRedraw()
 
-    fun drawSynchronously() = _redrawer.drawSynchronously()
-
     /**
      * Show copy/paste text menu
      * @param targetRect - rectangle of selected text area
@@ -212,7 +210,15 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             CGSizeMake(size.width * contentScaleFactor, size.height * contentScaleFactor)
         }
 
+        val needsSynchronousDraw = _metalLayer.drawableSize.useContents {
+            width == 0.0 || height == 0.0
+        }
+
         _metalLayer.drawableSize = scaledSize
+
+        if (needsSynchronousDraw) {
+            _redrawer.drawSynchronously()
+        }
     }
 
     fun showScreenKeyboard() = becomeFirstResponder()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -86,7 +86,12 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
     private var _pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true }
     private var _inputDelegate: UITextInputDelegateProtocol? = null
     private var _currentTextMenuActions: TextActions? = null
-    private lateinit var _redrawer: MetalRedrawer
+    private val _redrawer: MetalRedrawer = MetalRedrawer(
+        _metalLayer,
+        drawCallback = { surface: Surface ->
+            delegate?.draw(surface)
+        },
+    )
 
     /*
      * When there at least one tracked touch, we need notify redrawer about it. It should schedule CADisplayLink which
@@ -124,13 +129,6 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
         pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true },
     ) : super(frame) {
         _pointInside = pointInside
-
-        _redrawer = MetalRedrawer(
-            _metalLayer,
-            drawCallback = { surface: Surface ->
-                delegate?.draw(surface)
-            },
-        )
     }
 
     fun needRedraw() = _redrawer.needRedraw()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -210,7 +210,7 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             CGSizeMake(size.width * contentScaleFactor, size.height * contentScaleFactor)
         }
 
-        // If drawableSize is zero in any direction it means that it's a first layout
+        // If drawableSize is zero in any dimension it means that it's a first layout
         // we need to synchronously dispatch first draw and block until it's presented
         // so user doesn't have a flicker
         val needsSynchronousDraw = _metalLayer.drawableSize.useContents {


### PR DESCRIPTION
## Proposed Changes

Synchronously wait until first frame is drawn to avoid a flicker when presenting (or initially showing) ComposeWindow.

## Testing

Test: launch the demo app on iOS, push `Native modal with navigation`, present multiple dark content ComposeWindows, ensure that there are no flickers.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3492


https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/0e161bc2-a4b7-4b43-96c2-e6cceae4abd1

