### PR TITLE
iOS prevent keyboard password type issue

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
@@ -22,4 +22,5 @@ val IosBugs = Screen.Selection(
     "IosBugs",
     UIKitViewAndDropDownMenu,
     KeyboardEmptyWhiteSpace,
+    KeyboardPasswordType,
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/KeyboardPasswordType.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/KeyboardPasswordType.kt
@@ -16,6 +16,7 @@
 
 package bugs
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -25,14 +26,16 @@ import androidx.compose.ui.text.input.KeyboardType
 val KeyboardPasswordType = Screen.Example("KeyboardPasswordType") {
     //TODO: https://youtrack.jetbrains.com/issue/COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds
     // Need to uncomment code in textContentType() and isSecureTextEntry()
-    Text("Issue COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds")
-    TextField(
-        "Password", {  },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
-    )
-    TextField("No options", {  })
-    TextField(
-        "Ascii", {  },
-        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii)
-    )
+    Column {
+        Text("Issue COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds")
+        TextField(
+            "Password", { },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+        )
+        TextField("No options", { })
+        TextField(
+            "Ascii", { },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii)
+        )
+    }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/KeyboardPasswordType.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/KeyboardPasswordType.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bugs
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.ui.text.input.KeyboardType
+
+val KeyboardPasswordType = Screen.Example("KeyboardPasswordType") {
+    //TODO: https://youtrack.jetbrains.com/issue/COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds
+    // Need to uncomment code in textContentType() and isSecureTextEntry()
+    Text("Issue COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds")
+    TextField(
+        "Password", {  },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+    )
+    TextField("No options", {  })
+    TextField(
+        "Ascii", {  },
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii)
+    )
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -329,19 +329,21 @@ internal class UIKitTextInputService(
                 else -> UIReturnKeyType.UIReturnKeyDefault
             }
 
-        override fun textContentType(): UITextContentType? =
-            when (currentImeOptions?.keyboardType) {
-                KeyboardType.Password, KeyboardType.NumberPassword -> UITextContentTypePassword
-                KeyboardType.Email -> UITextContentTypeEmailAddress
-                KeyboardType.Phone -> UITextContentTypeTelephoneNumber
-                else -> null
-            }
+        override fun textContentType(): UITextContentType? = null
+//           TODO: Prevent Issue https://youtrack.jetbrains.com/issue/COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds
+//            when (currentImeOptions?.keyboardType) {
+//                KeyboardType.Password, KeyboardType.NumberPassword -> UITextContentTypePassword
+//                KeyboardType.Email -> UITextContentTypeEmailAddress
+//                KeyboardType.Phone -> UITextContentTypeTelephoneNumber
+//                else -> null
+//            }
 
-        override fun isSecureTextEntry(): Boolean =
-            when (currentImeOptions?.keyboardType) {
-                KeyboardType.Password, KeyboardType.NumberPassword -> true
-                else -> false
-            }
+        override fun isSecureTextEntry(): Boolean = false
+//           TODO: Prevent Issue https://youtrack.jetbrains.com/issue/COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds
+//            when (currentImeOptions?.keyboardType) {
+//                KeyboardType.Password, KeyboardType.NumberPassword -> true
+//                else -> false
+//            }
 
         override fun enablesReturnKeyAutomatically(): Boolean = false
 


### PR DESCRIPTION
Ignoring of feature to password suggestion of iOS keychain.

Issue https://youtrack.jetbrains.com/issue/COMPOSE-319/iOS-Bug-password-TextField-changes-behavior-for-all-other-TextFieds

## Testing

Run iOS Demo, and go to `IosBugs/KeyboardPasswordType`
TextFields should not contains Issue https://youtrack.jetbrains.com/issue/COMPOSE-319

@igordmn Need to cherry pick it to 1.5.0 release branch