### PR TITLE
Fix scrolling when we change LazyListState

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -20,7 +20,6 @@ import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateTo
 import androidx.compose.animation.core.tween
-import androidx.compose.runtime.State
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.node.DelegatingNode
@@ -38,27 +37,26 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-
 internal class MouseWheelScrollableElement(
-    val scrollingLogicState: State<ScrollingLogic>,
+    val scrollingLogic: ScrollingLogic,
     val mouseWheelScrollConfig: ScrollConfig,
-    val density: Float
+    val density: Float,
 ) : ModifierNodeElement<MouseWheelScrollNode>() {
     override fun create(): MouseWheelScrollNode {
         return if (mouseWheelScrollConfig.isSmoothScrollingEnabled) {
-            AnimatedMouseWheelScrollNode(scrollingLogicState.value, mouseWheelScrollConfig, density)
+            AnimatedMouseWheelScrollNode(scrollingLogic, mouseWheelScrollConfig, density)
         } else {
-            RawMouseWheelScrollNode(scrollingLogicState.value, mouseWheelScrollConfig)
+            RawMouseWheelScrollNode(scrollingLogic, mouseWheelScrollConfig)
         }
     }
 
     override fun update(node: MouseWheelScrollNode) {
-        node.scrollingLogic = scrollingLogicState.value
+        node.scrollingLogic = scrollingLogic
         node.mouseWheelScrollConfig = mouseWheelScrollConfig
     }
 
     override fun hashCode(): Int {
-        var result = scrollingLogicState.hashCode()
+        var result = scrollingLogic.hashCode()
         result = 31 * result + mouseWheelScrollConfig.hashCode()
         return result
     }
@@ -67,7 +65,7 @@ internal class MouseWheelScrollableElement(
         if (this === other) return true
         if (other !is MouseWheelScrollableElement) return false
 
-        if (scrollingLogicState != other.scrollingLogicState) return false
+        if (scrollingLogic != other.scrollingLogic) return false
         if (mouseWheelScrollConfig != other.mouseWheelScrollConfig) return false
         return true
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -250,7 +250,7 @@ private fun Modifier.pointerScrollable(
 ): Modifier {
     val fling = flingBehavior ?: ScrollableDefaults.flingBehavior()
     val nestedScrollDispatcher = remember { mutableStateOf(NestedScrollDispatcher()) }
-    val scrollLogic = rememberUpdatedState(
+    val scrollLogicValue =
         ScrollingLogic(
             orientation,
             reverseDirection,
@@ -259,7 +259,7 @@ private fun Modifier.pointerScrollable(
             fling,
             overscrollEffect
         )
-    )
+    val scrollLogic = rememberUpdatedState(scrollLogicValue)
     val nestedScrollConnection = remember(enabled) {
         scrollableNestedScrollConnection(scrollLogic, enabled)
     }
@@ -283,7 +283,7 @@ private fun Modifier.pointerScrollable(
             },
             canDrag = { down -> down.type != PointerType.Mouse }
         ))
-        .then(MouseWheelScrollableElement(scrollLogic, scrollConfig, density))
+        .then(MouseWheelScrollableElement(scrollLogicValue, scrollConfig, density))
         .nestedScroll(nestedScrollConnection, nestedScrollDispatcher.value)
 }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -251,7 +251,7 @@ private fun Modifier.pointerScrollable(
     val fling = flingBehavior ?: ScrollableDefaults.flingBehavior()
     val nestedScrollDispatcher = remember { mutableStateOf(NestedScrollDispatcher()) }
     val scrollLogicValue =
-        ScrollingLogic(
+        rememberScrollingLogic(
             orientation,
             reverseDirection,
             nestedScrollDispatcher,
@@ -289,6 +289,32 @@ private fun Modifier.pointerScrollable(
 
 // {} isn't being memoized for us, so extract this to make sure we compare equally on recomposition.
 private val NoOpOnDragStarted: suspend CoroutineScope.(startedPosition: Offset) -> Unit = {}
+
+@Composable
+private fun rememberScrollingLogic(
+    orientation: Orientation,
+    reverseDirection: Boolean,
+    nestedScrollDispatcher: State<NestedScrollDispatcher>,
+    scrollableState: ScrollableState,
+    flingBehavior: FlingBehavior,
+    overscrollEffect: OverscrollEffect?
+) = remember(
+    orientation,
+    reverseDirection,
+    nestedScrollDispatcher,
+    scrollableState,
+    flingBehavior,
+    overscrollEffect
+) {
+    ScrollingLogic(
+        orientation,
+        reverseDirection,
+        nestedScrollDispatcher,
+        scrollableState,
+        flingBehavior,
+        overscrollEffect
+    )
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 internal class ScrollingLogic(

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.gestures
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.ScrollWheel
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SkikoScrollableTest {
+    // bug https://github.com/JetBrains/compose-multiplatform/issues/3551 (mouse didn't work)
+    @Test
+    fun recreating_list_state_shouldn_t_break_mouse_scrolling() = runComposeUiTest {
+        var state by mutableStateOf(LazyListState())
+        setContent {
+            LazyColumn(state = state, modifier = Modifier.testTag("list").fillMaxSize()) {
+                items(1000) {
+                    Box(Modifier.size(50.dp))
+                }
+            }
+        }
+
+        runOnIdle { assertTrue(state.firstVisibleItemIndex == 0) }
+
+        onNodeWithTag("list").performMouseInput {
+            scroll(1000f, ScrollWheel.Vertical)
+        }
+        runOnIdle { assertTrue(state.firstVisibleItemIndex > 0) }
+
+        state = LazyListState()
+        runOnIdle { assertTrue(state.firstVisibleItemIndex == 0) }
+
+        onNodeWithTag("list").performMouseInput {
+            scroll(1000f, ScrollWheel.Vertical)
+        }
+        runOnIdle { assertTrue(state.firstVisibleItemIndex > 0) }
+    }
+
+    // bug https://github.com/JetBrains/compose-multiplatform/issues/3551 (touch always worked)
+    @Test
+    fun recreating_list_state_shouldn_t_break_touch_scrolling() = runComposeUiTest {
+        var state by mutableStateOf(LazyListState())
+        setContent {
+            LazyColumn(state = state, modifier = Modifier.testTag("list").fillMaxSize()) {
+                items(1000) {
+                    Box(Modifier.size(50.dp))
+                }
+            }
+        }
+
+        runOnIdle { assertTrue(state.firstVisibleItemIndex == 0) }
+
+        onNodeWithTag("list").performTouchInput {
+            swipe(Offset(30f, 30f), Offset(30f, 10f))
+        }
+        runOnIdle { assertTrue(state.firstVisibleItemIndex > 0) }
+
+        state = LazyListState()
+        runOnIdle { assertTrue(state.firstVisibleItemIndex == 0) }
+
+        onNodeWithTag("list").performTouchInput {
+            swipe(Offset(30f, 30f), Offset(30f, 10f))
+        }
+        runOnIdle { assertTrue(state.firstVisibleItemIndex > 0) }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3551

When the new state is passed to LazyList, it goes down to `Modifier.pointerScrollable` as `controller: ScrollableState`, and wraps to `rememberUpdatedState`, which is always the same instance. Because it is the same instance, MouseWheelScrollableElement.update is never called.

Passing it is as a value now, as MouseWheelScrollableElement doesn't need a state.

## Testing

- Run SkikoScrollableTest
- Run the snippet from the issue