### PR TITLE
Implement iOS native feel scrolls for large text fields

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.android.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.runtime.Composable
+
+@ExperimentalFoundationApi
+@Composable
+internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.jsWasm.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.runtime.Composable
+
+@ExperimentalFoundationApi
+@Composable
+internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.jvm.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.runtime.Composable
+
+@ExperimentalFoundationApi
+@Composable
+internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.macos.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.runtime.Composable
+
+@ExperimentalFoundationApi
+@Composable
+internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -349,6 +349,7 @@ class CupertinoOverscrollEffect(
             animationSpec = spec
         ) {
             overscrollOffset = (value * density).toOffset()
+            println(overscrollOffset)
             currentVelocity = velocity * density
 
             // If it was fling from overscroll, cancel animation and return velocity

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -349,7 +349,6 @@ class CupertinoOverscrollEffect(
             animationSpec = spec
         ) {
             overscrollOffset = (value * density).toOffset()
-            println(overscrollOffset)
             currentVelocity = velocity * density
 
             // If it was fling from overscroll, cancel animation and return velocity

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.foundation.rememberOverscrollEffect
+import androidx.compose.runtime.Composable
+
+@ExperimentalFoundationApi
+@Composable
+internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = rememberOverscrollEffect()


### PR DESCRIPTION
## Proposed Changes

Construct and pass CupertinoOverscrollEffect inside Modifier.textFieldScrollable. Adapt non-null OverscrollEffect logic in text field to mimic behavior of LazyList to avoid text clipping through the container.

## Testing

Test: TBD

## Issues Fixed

Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-336/iOS-native-scroll-physics-for-long-TextField

## Note

TextFieldDecorationBox uses padding to layout internal text. textFieldScrollable is applied to entire container (with decoration box) and is not aware of it, so it can't do proper clipping when Modifier.offset is applied without a breaking internal API change.

## Videos

https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/1c0a5f5e-ad50-4823-bb60-d44f02004c6f

https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/64fdee76-f5d2-4dfd-a2ac-ae785644c509