### PR TITLE
Fix text selection 

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicText.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicText.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ColorProducer
@@ -95,8 +96,12 @@ fun BasicText(
     val selectionRegistrar = LocalSelectionRegistrar.current
     val selectionController = if (selectionRegistrar != null) {
         val backgroundSelectionColor = LocalTextSelectionColors.current.backgroundColor
-        remember(selectionRegistrar, backgroundSelectionColor) {
+        val selectableId = rememberSaveable(selectionRegistrar) {
+            selectionRegistrar.nextSelectableId()
+        }
+        remember(selectableId, selectionRegistrar, backgroundSelectionColor) {
             SelectionController(
+                selectableId,
                 selectionRegistrar,
                 backgroundSelectionColor
             )
@@ -184,8 +189,12 @@ fun BasicText(
     val selectionRegistrar = LocalSelectionRegistrar.current
     val selectionController = if (selectionRegistrar != null) {
         val backgroundSelectionColor = LocalTextSelectionColors.current.backgroundColor
-        remember(selectionRegistrar, backgroundSelectionColor) {
+        val selectableId = rememberSaveable(selectionRegistrar) {
+            selectionRegistrar.nextSelectableId()
+        }
+        remember(selectableId, selectionRegistrar, backgroundSelectionColor) {
             SelectionController(
+                selectableId,
                 selectionRegistrar,
                 backgroundSelectionColor
             )

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectableTextAnnotatedStringNode.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectableTextAnnotatedStringNode.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation.text.modifiers
 
 import androidx.compose.foundation.text.DefaultMinLines
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.ColorProducer
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
@@ -55,11 +56,9 @@ internal class SelectableTextAnnotatedStringNode(
     minLines: Int = DefaultMinLines,
     placeholders: List<AnnotatedString.Range<Placeholder>>? = null,
     onPlaceholderLayout: ((List<Rect?>) -> Unit)? = null,
-    private val selectionController: SelectionController? = null,
+    private var selectionController: SelectionController? = null,
     overrideColor: ColorProducer? = null
 ) : DelegatingNode(), LayoutModifierNode, DrawModifierNode, GlobalPositionAwareModifierNode {
-
-    private var lastKnownLayoutCoordinates: LayoutCoordinates? = null
 
     private val delegate = delegate(
         TextAnnotatedStringNode(
@@ -85,7 +84,6 @@ internal class SelectableTextAnnotatedStringNode(
     }
 
     override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
-        lastKnownLayoutCoordinates = coordinates
         selectionController?.updateGlobalPosition(coordinates)
     }
 
@@ -150,8 +148,7 @@ internal class SelectableTextAnnotatedStringNode(
                 selectionController = selectionController
             ),
         )
-
-        selectionController?.updateGlobalPosition(lastKnownLayoutCoordinates!!)
+        this.selectionController = selectionController
         // we always relayout when we're selectable
         invalidateMeasurement()
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectableTextAnnotatedStringNode.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectableTextAnnotatedStringNode.kt
@@ -59,6 +59,8 @@ internal class SelectableTextAnnotatedStringNode(
     overrideColor: ColorProducer? = null
 ) : DelegatingNode(), LayoutModifierNode, DrawModifierNode, GlobalPositionAwareModifierNode {
 
+    private var lastKnownLayoutCoordinates: LayoutCoordinates? = null
+
     private val delegate = delegate(
         TextAnnotatedStringNode(
             text = text,
@@ -83,6 +85,7 @@ internal class SelectableTextAnnotatedStringNode(
     }
 
     override fun onGloballyPositioned(coordinates: LayoutCoordinates) {
+        lastKnownLayoutCoordinates = coordinates
         selectionController?.updateGlobalPosition(coordinates)
     }
 
@@ -147,6 +150,8 @@ internal class SelectableTextAnnotatedStringNode(
                 selectionController = selectionController
             ),
         )
+
+        selectionController?.updateGlobalPosition(lastKnownLayoutCoordinates!!)
         // we always relayout when we're selectable
         invalidateMeasurement()
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.kt
@@ -76,13 +76,13 @@ internal open class StaticTextSelectionParams(
  */
 // This is _basically_ a Modifier.Node but moved into remember because we need to do pointerInput
 internal class SelectionController(
+    private val selectableId: Long,
     private val selectionRegistrar: SelectionRegistrar,
     private val backgroundSelectionColor: Color,
     // TODO: Move these into Modifer.element eventually
     private var params: StaticTextSelectionParams = StaticTextSelectionParams.Empty
 ) : RememberObserver {
     private var selectable: Selectable? = null
-    private val selectableId = selectionRegistrar.nextSelectableId()
 
     val modifier: Modifier = selectionRegistrar.makeSelectionModifier(
         selectableId = selectableId,

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/BugReproducers.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/BugReproducers.kt
@@ -32,6 +32,7 @@ val BugReproducers = Screen.Selection("Bug Reproducers",
     // https://github.com/JetBrains/compose-multiplatform/issues/3475
     Screen.Example("No Recomposition in Lazy Grid") { NoRecompositionInLazyGrid() },
     Screen.Example("RoundedCornerCrashOnJS") { RoundedCornerCrashOnJS() },
+    Screen.Example("Code Viewer - Selection Reproducer") { CodeViewerReproducer() },
 )
 
 @Composable

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/CodeViewerReproducer.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/CodeViewerReproducer.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+
+// https://github.com/JetBrains/compose-multiplatform/issues/3560
+@Composable
+fun CodeViewerReproducer() {
+    SelectionContainer {
+        LazyColumn {
+            items(100) {
+                Text(text = "Text $it",)
+            }
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/JetBrains/compose-multiplatform/issues/3560

We can use this fix until we have a better solution from JC. 

Investigation:
Apparently this `remember` here executes every time - creates a new instance of SelectionController (even when I remove all keys): https://github.com/JetBrains/compose-multiplatform-core/blob/6d5af6e6c42b835b92f947198bd692ba196ab27c/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicText.kt#L187
or here - https://github.com/JetBrains/compose-multiplatform-core/blob/6d5af6e6c42b835b92f947198bd692ba196ab27c/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicText.kt#L98


Probably there is another issue under the hood with remembering SelectionController / recomposing BasicText.

So we have to update `selectionController` with latest known `LayoutCoordinates`. 