### PR TITLE
Implement sync with UIKit interop

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
@@ -23,4 +23,5 @@ val IosBugs = Screen.Selection(
     UIKitViewAndDropDownMenu,
     KeyboardEmptyWhiteSpace,
     KeyboardPasswordType,
+    UIKitRenderSync
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitRenderSync.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitRenderSync.kt
@@ -25,6 +25,10 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.ComposeUITextField
 import androidx.compose.ui.interop.UIKitView
@@ -36,13 +40,12 @@ import platform.CoreGraphics.CGRectZero
 import platform.UIKit.*
 
 val UIKitRenderSync = Screen.Example("UIKitRenderSync") {
+    var text by remember { mutableStateOf("Type something") }
     LazyColumn(Modifier.fillMaxSize()) {
-
         items(100) { index ->
-            if (index % 2 == 0) {
-                Text("material.Text $index", Modifier.fillMaxSize().height(40.dp))
-            } else {
-                UIKitView(
+            when (index % 4) {
+                0 -> Text("material.Text $index", Modifier.fillMaxSize().height(40.dp))
+                1 -> UIKitView(
                     factory = {
                         val label = UILabel(frame = CGRectZero.readValue())
                         label.text = "UILabel $index"
@@ -51,6 +54,8 @@ val UIKitRenderSync = Screen.Example("UIKitRenderSync") {
                     },
                     modifier = Modifier.fillMaxWidth().height(40.dp)
                 )
+                2 -> TextField(text, onValueChange = { text = it}, Modifier.fillMaxWidth())
+                else -> ComposeUITextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth().height(40.dp))
             }
         }
     }

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitRenderSync.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitRenderSync.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bugs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.ComposeUITextField
+import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRect
+import platform.CoreGraphics.CGRectZero
+import platform.UIKit.*
+
+val UIKitRenderSync = Screen.Example("UIKitRenderSync") {
+    LazyColumn(Modifier.fillMaxSize()) {
+
+        items(100) { index ->
+            if (index % 2 == 0) {
+                Text("material.Text $index", Modifier.fillMaxSize().height(40.dp))
+            } else {
+                UIKitView(
+                    factory = {
+                        val label = UILabel(frame = CGRectZero.readValue())
+                        label.text = "UILabel $index"
+                        label.textColor = UIColor.blackColor
+                        label
+                    },
+                    modifier = Modifier.fillMaxWidth().height(40.dp)
+                )
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
@@ -21,8 +21,6 @@ import platform.UIKit.UITextField
 fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier) {
     val latestOnValueChanged by rememberUpdatedState(onValueChange)
 
-    val interopContext = LocalUIKitInteropContext.current
-
     UIKitView(
         factory = {
             val textField = object : UITextField(CGRectMake(0.0, 0.0, 0.0, 0.0)) {
@@ -40,9 +38,7 @@ fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier:
         },
         modifier = modifier,
         update = { textField ->
-            interopContext.deferAction {
-                textField.text = value
-            }
+            textField.text = value
         }
     )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
@@ -21,6 +21,8 @@ import platform.UIKit.UITextField
 fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier) {
     val latestOnValueChanged by rememberUpdatedState(onValueChange)
 
+    val interopContext = LocalUIKitInteropContext.current
+
     UIKitView(
         factory = {
             val textField = object : UITextField(CGRectMake(0.0, 0.0, 0.0, 0.0)) {
@@ -38,7 +40,9 @@ fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier:
         },
         modifier = modifier,
         update = { textField ->
-            textField.text = value
+            interopContext.addAction {
+                textField.text = value
+            }
         }
     )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/ComposeUITextField.uikit.kt
@@ -40,7 +40,7 @@ fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier:
         },
         modifier = modifier,
         update = { textField ->
-            interopContext.addAction {
+            interopContext.deferAction {
                 textField.text = value
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -23,7 +23,7 @@ import platform.Foundation.NSLock
  * Class which can be used to add actions related to UIKit objects to be executed in sync with compose rendering,
  * Addding deferred actions is threadsafe, but they will be executed in the order of their submission, and on the main thread.
  */
-class UIKitInteropContext(
+internal class UIKitInteropContext(
     val requestRedraw: () -> Unit
 ) {
     private val lock: NSLock = NSLock()
@@ -62,6 +62,6 @@ private inline fun <T> NSLock.doLocked(block: () -> T): T {
     }
 }
 
-val LocalUIKitInteropContext = staticCompositionLocalOf<UIKitInteropContext> {
+internal val LocalUIKitInteropContext = staticCompositionLocalOf<UIKitInteropContext> {
     error("CompositionLocal UIKitInteropContext not provided")
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -22,7 +22,7 @@ import platform.Foundation.NSThread
 
 /**
  * Class which can be used to add actions related to UIKit objects to be executed in sync with compose rendering,
- * It's threadsafe, but all operations will be executed in the order of their submission
+ * It's threadsafe, but all operations will be executed in the order of their submission on the main thread.
  */
 class UIKitInteropContext {
     private val lock: NSLock = NSLock()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -29,7 +29,7 @@ class UIKitInteropContext {
     private val actions = mutableListOf<() -> Unit>()
 
     /**
-     * Add lambda to a list of commands which will be executed later in the same CATransaction, the next rendered Compose frame is presented
+     * Add lambda to a list of commands which will be executed later in the same CATransaction, when the next rendered Compose frame is presented
      */
     fun addAction(action: () -> Unit) = lock.doLocked {
         actions.add(action)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interop
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import platform.Foundation.NSLock
+import platform.Foundation.NSThread
+
+/**
+ * Class which can be used to add actions related to UIKit objects to be executed in sync with compose rendering,
+ * It's threadsafe, but all operations will be executed in the order of their submission
+ */
+class UIKitInteropContext {
+    private val lock: NSLock = NSLock()
+    private val actions = mutableListOf<() -> Unit>()
+
+    /**
+     * Add lambda to a list of commands which will be executed later in the same CATransaction, the next rendered Compose frame is presented
+     */
+    fun addAction(action: () -> Unit) = lock.doLocked {
+        actions.add(action)
+    }
+
+    internal fun getActionsAndClear(): List<() -> Unit> {
+        check(NSThread.isMainThread)
+
+        return lock.doLocked {
+            val result = actions.toList()
+            actions.clear()
+            result
+        }
+    }
+}
+
+private inline fun <T> NSLock.doLocked(block: () -> T): T {
+    lock()
+
+    try {
+        return block()
+    } finally {
+        unlock()
+    }
+}
+
+val LocalUIKitInteropContext = staticCompositionLocalOf<UIKitInteropContext> {
+    error("CompositionLocal UIKitInteropContext not provided")
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -22,7 +22,7 @@ import platform.Foundation.NSThread
 
 /**
  * Class which can be used to add actions related to UIKit objects to be executed in sync with compose rendering,
- * It's threadsafe, but all operations will be executed in the order of their submission, and on the main thread.
+ * Addding deferred actions is threadsafe, but they will be executed in the order of their submission, and on the main thread.
  */
 class UIKitInteropContext(
     val requestRedraw: () -> Unit
@@ -33,12 +33,17 @@ class UIKitInteropContext(
     /**
      * Add lambda to a list of commands which will be executed later in the same CATransaction, when the next rendered Compose frame is presented
      */
-    fun deferAction(action: () -> Unit) = lock.doLocked {
+    fun deferAction(action: () -> Unit) {
         requestRedraw()
 
-        actions.add(action)
+        lock.doLocked {
+            actions.add(action)
+        }
     }
 
+    /**
+     * Return a copy of the list of [actions] and clear it
+     */
     internal fun getActionsAndClear(): List<() -> Unit> {
         check(NSThread.isMainThread)
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -33,7 +33,7 @@ class UIKitInteropContext(
     /**
      * Add lambda to a list of commands which will be executed later in the same CATransaction, when the next rendered Compose frame is presented
      */
-    fun addAction(action: () -> Unit) = lock.doLocked {
+    fun deferAction(action: () -> Unit) = lock.doLocked {
         requestRedraw()
 
         actions.add(action)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.interop
 
 import androidx.compose.runtime.staticCompositionLocalOf
 import platform.Foundation.NSLock
-import platform.Foundation.NSThread
 
 /**
  * Class which can be used to add actions related to UIKit objects to be executed in sync with compose rendering,
@@ -42,11 +41,9 @@ class UIKitInteropContext(
     }
 
     /**
-     * Return a copy of the list of [actions] and clear it
+     * Return a copy of the list of [actions] and clear it.
      */
     internal fun getActionsAndClear(): List<() -> Unit> {
-        check(NSThread.isMainThread)
-
         return lock.doLocked {
             val result = actions.toList()
             actions.clear()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -22,9 +22,11 @@ import platform.Foundation.NSThread
 
 /**
  * Class which can be used to add actions related to UIKit objects to be executed in sync with compose rendering,
- * It's threadsafe, but all operations will be executed in the order of their submission on the main thread.
+ * It's threadsafe, but all operations will be executed in the order of their submission, and on the main thread.
  */
-class UIKitInteropContext {
+class UIKitInteropContext(
+    val requestRedraw: () -> Unit
+) {
     private val lock: NSLock = NSLock()
     private val actions = mutableListOf<() -> Unit>()
 
@@ -32,6 +34,8 @@ class UIKitInteropContext {
      * Add lambda to a list of commands which will be executed later in the same CATransaction, when the next rendered Compose frame is presented
      */
     fun addAction(action: () -> Unit) = lock.doLocked {
+        requestRedraw()
+
         actions.add(action)
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -47,7 +47,6 @@ import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
-import platform.UIKit.backgroundColor
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
@@ -95,12 +94,12 @@ fun <T : UIView> UIKitView(
             if (rectInPixels != newRectInPixels) {
                 val rect = newRectInPixels / density
 
-                interopContext.addAction {
+                interopContext.deferAction {
                     componentInfo.container.setFrame(rect.toCGRect())
                 }
 
                 if (rectInPixels.width != newRectInPixels.width || rectInPixels.height != newRectInPixels.height) {
-                    interopContext.addAction {
+                    interopContext.deferAction {
                         onResize(
                             componentInfo.component,
                             CGRectMake(0.0, 0.0, rect.width.toDouble(), rect.height.toDouble()),
@@ -124,7 +123,7 @@ fun <T : UIView> UIKitView(
         componentInfo.component = factory()
         componentInfo.updater = Updater(componentInfo.component, update)
 
-        interopContext.addAction {
+        interopContext.deferAction {
             componentInfo.container = UIView().apply {
                 addSubview(componentInfo.component)
             }
@@ -132,7 +131,7 @@ fun <T : UIView> UIKitView(
         }
 
         onDispose {
-            interopContext.addAction {
+            interopContext.deferAction {
                 componentInfo.container.removeFromSuperview()
                 componentInfo.updater.dispose()
                 onRelease(componentInfo.component)
@@ -141,7 +140,7 @@ fun <T : UIView> UIKitView(
     }
 
     LaunchedEffect(background) {
-        interopContext.addAction {
+        interopContext.deferAction {
             if (background == Color.Unspecified) {
                 componentInfo.container.backgroundColor = root.backgroundColor
             } else {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -534,7 +534,7 @@ internal actual class ComposeWindow : UIViewController {
                     LocalLayoutMarginsState provides layoutMarginsState,
                     LocalInterfaceOrientationState provides interfaceOrientationState,
                     LocalSystemTheme provides systemTheme.value,
-                    LocalUIKitInteropContext provides interopContext
+                    LocalUIKitInteropContext provides interopContext,
                 ) {
                     content()
                 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -106,7 +106,9 @@ internal actual class ComposeWindow : UIViewController {
     private val keyboardOverlapHeightState = mutableStateOf(0f)
     private val safeAreaState = mutableStateOf(IOSInsets())
     private val layoutMarginsState = mutableStateOf(IOSInsets())
-    private val interopContext = UIKitInteropContext()
+    private val interopContext = UIKitInteropContext(requestRedraw = {
+        attachedComposeContext?.view?.needRedraw()
+    })
 
     /*
      * Initial value is arbitarily chosen to avoid propagating invalid value logic

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.toCompose
 import androidx.compose.ui.interop.LocalLayerContainer
+import androidx.compose.ui.interop.LocalUIKitInteropContext
 import androidx.compose.ui.interop.LocalUIViewController
+import androidx.compose.ui.interop.UIKitInteropContext
 import androidx.compose.ui.native.getMainDispatcher
 import androidx.compose.ui.platform.*
 import androidx.compose.ui.text.input.PlatformTextInputService
@@ -104,6 +106,7 @@ internal actual class ComposeWindow : UIViewController {
     private val keyboardOverlapHeightState = mutableStateOf(0f)
     private val safeAreaState = mutableStateOf(IOSInsets())
     private val layoutMarginsState = mutableStateOf(IOSInsets())
+    private val interopContext = UIKitInteropContext()
 
     /*
      * Initial value is arbitarily chosen to avoid propagating invalid value logic
@@ -383,6 +386,8 @@ internal actual class ComposeWindow : UIViewController {
 
                 !hitsInteropView
             },
+
+            retrieveCATransactionCommands = interopContext::getActionsAndClear
         )
 
         skikoUIView.translatesAutoresizingMaskIntoConstraints = false
@@ -522,7 +527,8 @@ internal actual class ComposeWindow : UIViewController {
                     LocalSafeAreaState provides safeAreaState,
                     LocalLayoutMarginsState provides layoutMarginsState,
                     LocalInterfaceOrientationState provides interfaceOrientationState,
-                    LocalSystemTheme provides systemTheme.value
+                    LocalSystemTheme provides systemTheme.value,
+                    LocalUIKitInteropContext provides interopContext
                 ) {
                     content()
                 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -68,18 +68,6 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
     var input: IOSSkikoInput? = null
     var inputTraits: SkikoUITextInputTraits = object : SkikoUITextInputTraits {}
 
-    /**
-     * Indicates that renderer should wait until the issued command buffer is scheduled for execution, so it can
-     * present the drawable inside the CATransaction to sync it with UIKit changes
-     *
-     * See [relevant doc](https://developer.apple.com/documentation/quartzcore/cametallayer/1478157-presentswithtransaction?language=objc)
-     */
-    var presentsWithTransaction: Boolean
-        get() = _metalLayer.presentsWithTransaction
-        set(value) {
-            _metalLayer.presentsWithTransaction = value
-        }
-
     private val _device: MTLDeviceProtocol =
         MTLCreateSystemDefaultDevice() ?: throw IllegalStateException("Metal is not supported on this system")
     private val _metalLayer: CAMetalLayer get() = layer as CAMetalLayer
@@ -126,9 +114,11 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
     constructor(
         frame: CValue<CGRect> = CGRectNull.readValue(),
-        pointInside: (Point, UIEvent?) -> Boolean = { _, _ -> true },
+        pointInside: (Point, UIEvent?) -> Boolean,
+        retrieveCATransactionCommands: () -> List<() -> Unit>
     ) : super(frame) {
         _pointInside = pointInside
+        _redrawer.retrieveCATransactionCommands = retrieveCATransactionCommands
     }
 
     fun needRedraw() = _redrawer.needRedraw()


### PR DESCRIPTION
## Proposed Changes

Store and defer UIKit commands issued from UIKit interop API to the first available CATransaction during CAMetalDrawable presentation.

## Testing

Test: launch IosBugs/UIKitRenderSync. Ensure that LazyColumn scroll frame changes is correctly synchronised between native interop views and Compose components.

## API changes

New public `CompostionLocal` `UIKitInteropContext` can be used to issue UIKit interop commands which user want to be executed in sync with Compose rendering.

## Videos

### Before
https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/5710e31a-ec9a-4dcf-a34d-4a1c5537a5bd 

### After
https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/35ff8d1d-bc24-4487-983e-0be476cc3507

