### PR TITLE
iOS fix scroll issues

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/InternalPointerInput.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/InternalPointerInput.kt
@@ -48,7 +48,7 @@ internal data class PointerInputEventData(
     val pressure: Float,
     val type: PointerType,
     val issuesEnterExit: Boolean = false,
-    val historical: List<HistoricalChange> = mutableListOf(),
+    val historical: List<HistoricalChange>,
     val scrollDelta: Offset = Offset.Zero
 )
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/util/VelocityTracker.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/util/VelocityTracker.kt
@@ -205,23 +205,16 @@ class VelocityTracker1D internal constructor(
             val age: Float = (newestSample.time - sample.time).toFloat()
             val delta: Float =
                 abs(sample.time - previousSample.time).toFloat()
-
+            previousSample = sample
             if (age > HorizonMilliseconds || delta > AssumePointerMoveStoppedMilliseconds) {
                 break
             }
 
-            // TODO: workaround for duplicating timestamps on iOS from synthetic events, leading to inadequate lsq2 solution
-            val eps = 0.5f // low age delta will discard dataPoint
-
-            if (delta > eps) {
-                previousSample = sample
-
-                dataPoints[sampleCount] = sample.dataPoint
-                time[sampleCount] = -age
-                sampleCount += 1
-            }
-
+            dataPoints[sampleCount] = sample.dataPoint
+            time[sampleCount] = -age
             index = (if (index == 0) HistorySize else index) - 1
+
+            sampleCount += 1
         } while (sampleCount < HistorySize)
 
         if (sampleCount >= minSampleSize) {
@@ -259,10 +252,6 @@ class VelocityTracker1D internal constructor(
         time: FloatArray,
         sampleCount: Int
     ): Float {
-        println("Points:")
-        for (i in 0 until sampleCount) {
-            println("${time[i]} ${dataPoints[i]}")
-        }
         // The 2nd coefficient is the derivative of the quadratic polynomial at
         // x = 0, and that happens to be the last timestamp that we end up
         // passing to polyFitLeastSquares.

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/util/VelocityTracker.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/util/VelocityTracker.kt
@@ -219,8 +219,6 @@ class VelocityTracker1D internal constructor(
                 dataPoints[sampleCount] = sample.dataPoint
                 time[sampleCount] = -age
                 sampleCount += 1
-            } else {
-                println("$age $delta discarded")
             }
 
             index = (if (index == 0) HistorySize else index) - 1

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -889,7 +889,6 @@ class ComposeScene internal constructor(
          */
         val pressure: Float = 1.0f,
 
-
         val historical: List<HistoricalChange> = mutableListOf()
     ) {
         override fun equals(other: Any?): Boolean {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -889,7 +889,7 @@ class ComposeScene internal constructor(
          */
         val pressure: Float = 1.0f,
 
-        val historical: List<HistoricalChange> = listOf()
+        val historical: List<HistoricalChange> = emptyList()
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -599,7 +599,7 @@ class ComposeScene internal constructor(
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
-        button: PointerButton? = null
+        button: PointerButton? = null,
     ) {
         defaultPointerStateTracker.onPointerEvent(button, eventType)
 
@@ -889,7 +889,7 @@ class ComposeScene internal constructor(
          */
         val pressure: Float = 1.0f,
 
-        val historical: List<HistoricalChange> = mutableListOf()
+        val historical: List<HistoricalChange> = listOf()
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -599,7 +599,7 @@ class ComposeScene internal constructor(
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
-        button: PointerButton? = null,
+        button: PointerButton? = null
     ) {
         defaultPointerStateTracker.onPointerEvent(button, eventType)
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -888,6 +888,9 @@ class ComposeScene internal constructor(
          * Pressure of the pointer. 0.0 - no pressure, 1.0 - average pressure
          */
         val pressure: Float = 1.0f,
+
+
+        val historical: List<HistoricalChange> = mutableListOf()
     ) {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
@@ -961,6 +964,7 @@ private fun pointerInputEvent(
                 it.pressed,
                 it.pressure,
                 it.type,
+                historical = it.historical,
                 scrollDelta = scrollDelta
             )
         },

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -214,6 +214,6 @@ internal class SyntheticEventSender(
         type,
         issuesEnterExit,
         scrollDelta = Offset(0f, 0f),
-        historical = listOf() // we don't copy historical for synthetic
+        historical = emptyList() // we don't copy historical for synthetic
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -214,5 +214,6 @@ internal class SyntheticEventSender(
         type,
         issuesEnterExit,
         scrollDelta = Offset(0f, 0f),
+        historical = listOf() // we don't copy historical for synthetic
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/TestPointerInputEventData.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/TestPointerInputEventData.skiko.kt
@@ -41,6 +41,7 @@ class TestPointerInputEventData(
             position,
             down,
             pressure = 1.0f,
-            PointerType.Mouse
+            PointerType.Mouse,
+            historical = listOf()
         )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -697,8 +697,8 @@ private fun UITouch.offsetInView(view: UIView, density: Float) =
         Offset(x.toFloat() * density, y.toFloat() * density)
     }
 
-private fun UIEvent.historicalChangesForTouch(touch: UITouch, view: UIView, density: Float): MutableList<HistoricalChange> {
-    val touches = coalescedTouchesForTouch(touch) ?: return mutableListOf()
+private fun UIEvent.historicalChangesForTouch(touch: UITouch, view: UIView, density: Float): List<HistoricalChange> {
+    val touches = coalescedTouchesForTouch(touch) ?: return emptyList()
 
     return if (touches.size > 1) {
         // subList last index is exclusive, so the last touch in the list is not included
@@ -709,9 +709,9 @@ private fun UIEvent.historicalChangesForTouch(touch: UITouch, view: UIView, dens
                 uptimeMillis = (historicalTouch.timestamp * 1e3).toLong(),
                 position = historicalTouch.offsetInView(view, density)
             )
-        }.toMutableList()
+        }
     } else {
-        mutableListOf()
+        emptyList()
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -692,7 +692,7 @@ internal actual class ComposeWindow : UIViewController {
     }
 }
 
-private fun UITouch.offsetInView(view: UIView, density: Float) =
+private fun UITouch.offsetInView(view: UIView, density: Float): Offset =
     locationInView(view).useContents {
         Offset(x.toFloat() * density, y.toFloat() * density)
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -641,7 +641,7 @@ internal actual class ComposeWindow : UIViewController {
                             pressure = touch.force.toFloat(),
                             historical = event.historicalChangesForTouch(touch, view, density)
                         )
-                    } ?: listOf(),
+                    } ?: emptyList(),
                     timeMillis = (event.timestamp * 1e3).toLong(),
                     nativeEvent = event
                 )

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -326,30 +326,6 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
         }
     }
 
-//    private fun UIEvent.toSkikoPointerEvent(kind: SkikoPointerEventKind): SkikoPointerEvent {
-//        val pointers = touchesForView(this@SkikoUIView).orEmpty().map {
-//            val touch = it as UITouch
-//            val (x, y) = touch.locationInView(this@SkikoUIView).useContents { x to y }
-//            SkikoPointer(
-//                x = x,
-//                y = y,
-//                pressed = touch.isPressed,
-//                device = SkikoPointerDevice.TOUCH,
-//                id = touch.hashCode().toLong(),
-//                pressure = touch.force
-//            )
-//        }
-//
-//        return SkikoPointerEvent(
-//            x = pointers.centroidX,
-//            y = pointers.centroidY,
-//            kind = kind,
-//            timestamp = (timestamp * 1_000).toLong(),
-//            pointers = pointers,
-//            platform = this
-//        )
-//    }
-
     override fun inputDelegate(): UITextInputDelegateProtocol? {
         return _inputDelegate
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -48,11 +48,15 @@ internal interface SkikoUIViewDelegate {
 
     fun pointInside(point: CValue<CGPoint>, event: UIEvent?): Boolean
 
-    fun onPointerEvent(event: SkikoPointerEvent)
+    fun onTouchesEvent(view: UIView, event: UIEvent, phase: UITouchesEventPhase)
 
     fun retrieveInteropTransaction(): UIKitInteropTransaction
 
     fun render(canvas: Canvas, targetTimestamp: NSTimeInterval)
+}
+
+internal enum class UITouchesEventPhase {
+    BEGAN, MOVED, ENDED, CANCELLED
 }
 
 @Suppress("CONFLICTING_OVERLOADS")
@@ -289,8 +293,8 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
         _touchesCount += touches.size
 
-        withEvent?.let {
-            delegate?.onPointerEvent(it.toSkikoPointerEvent(SkikoPointerEventKind.DOWN))
+        withEvent?.let { event ->
+            delegate?.onTouchesEvent(this, event, UITouchesEventPhase.BEGAN)
         }
     }
 
@@ -299,16 +303,16 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
         _touchesCount -= touches.size
 
-        withEvent?.let {
-            delegate?.onPointerEvent(it.toSkikoPointerEvent(SkikoPointerEventKind.UP))
+        withEvent?.let { event ->
+            delegate?.onTouchesEvent(this, event, UITouchesEventPhase.ENDED)
         }
     }
 
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent?) {
         super.touchesMoved(touches, withEvent)
 
-        withEvent?.let {
-            delegate?.onPointerEvent(it.toSkikoPointerEvent(SkikoPointerEventKind.MOVE))
+        withEvent?.let { event ->
+            delegate?.onTouchesEvent(this, event, UITouchesEventPhase.MOVED)
         }
     }
 
@@ -317,34 +321,34 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
         _touchesCount -= touches.size
 
-        withEvent?.let {
-            delegate?.onPointerEvent(it.toSkikoPointerEvent(SkikoPointerEventKind.UP))
+        withEvent?.let { event ->
+            delegate?.onTouchesEvent(this, event, UITouchesEventPhase.CANCELLED)
         }
     }
 
-    private fun UIEvent.toSkikoPointerEvent(kind: SkikoPointerEventKind): SkikoPointerEvent {
-        val pointers = touchesForView(this@SkikoUIView).orEmpty().map {
-            val touch = it as UITouch
-            val (x, y) = touch.locationInView(this@SkikoUIView).useContents { x to y }
-            SkikoPointer(
-                x = x,
-                y = y,
-                pressed = touch.isPressed,
-                device = SkikoPointerDevice.TOUCH,
-                id = touch.hashCode().toLong(),
-                pressure = touch.force
-            )
-        }
-
-        return SkikoPointerEvent(
-            x = pointers.centroidX,
-            y = pointers.centroidY,
-            kind = kind,
-            timestamp = (timestamp * 1_000).toLong(),
-            pointers = pointers,
-            platform = this
-        )
-    }
+//    private fun UIEvent.toSkikoPointerEvent(kind: SkikoPointerEventKind): SkikoPointerEvent {
+//        val pointers = touchesForView(this@SkikoUIView).orEmpty().map {
+//            val touch = it as UITouch
+//            val (x, y) = touch.locationInView(this@SkikoUIView).useContents { x to y }
+//            SkikoPointer(
+//                x = x,
+//                y = y,
+//                pressed = touch.isPressed,
+//                device = SkikoPointerDevice.TOUCH,
+//                id = touch.hashCode().toLong(),
+//                pressure = touch.force
+//            )
+//        }
+//
+//        return SkikoPointerEvent(
+//            x = pointers.centroidX,
+//            y = pointers.centroidY,
+//            kind = kind,
+//            timestamp = (timestamp * 1_000).toLong(),
+//            pointers = pointers,
+//            platform = this
+//        )
+//    }
 
     override fun inputDelegate(): UITextInputDelegateProtocol? {
         return _inputDelegate
@@ -754,14 +758,6 @@ private fun NSWritingDirection.directionToStr() =
         UITextLayoutDirectionDown -> "Down"
         else -> "unknown direction"
     }
-
-private val UITouch.isPressed
-    get() =
-        phase != UITouchPhase.UITouchPhaseEnded &&
-            phase != UITouchPhase.UITouchPhaseCancelled
-
-private val Iterable<SkikoPointer>.centroidX get() = asSequence().map { it.x }.average()
-private val Iterable<SkikoPointer>.centroidY get() = asSequence().map { it.y }.average()
 
 private fun toSkikoKeyboardEvent(
     event: UIPress,


### PR DESCRIPTION
## PR scope changed
The velocity calculation formula is a separate issue now, it will take all iOS platform specific datapoints into account, so no input data correction is needed.
Duplicating data points will be fixed in https://github.com/JetBrains/compose-multiplatform-core/pull/752.
 
## Proposed Changes
1. Refactor touch sending on iOS, throw SkikoPointerEvent out as redundant
2. Send coalesced touches(higher than display refresh rate touches) as historical data (don't send them for synthetics). Users can retrieve it now and use in case they need accurate touches data.
3. ~Adjust velocity calculator to filter duplicated data points in a single timestamp (because synthetic touches), leading to inadequate velocity (unexpected scrolls to top)~
4. ~Override position reported in the `ended` phase with last known position of the touch. Solves two problems~:
4.1. ~Current velocity calculator plays bad with that value, because it's slightly exaggerated to help UIKit with proper fling calculation (opaque implementation detail) and since iOS can report two events in the same frame (`moved` and `ended` with exaggerated position with small timestamp delta, it causes awkward unexpected motions in the end of scroll which was not supposed to lead to a fling)~
4.2. ~Delta in `ended` phase is not taken into consideration when scrolling UIScrollView (proved by reverse engineering). Passing that metadata in call tree of Draggable implementation will require internal common API changes.~

## Testing

Test: N/A

## Issues Fixed

Fixes: [inadequate fling velocity during "quick-drag-and-stop" touch events sequence](https://github.com/JetBrains/compose-multiplatform/issues/3335). ~Awkward motion caused by `ended` delta in the end of the drag without a fling~.

## API Change

`ComposeScene.Pointer` now has a new constructor argument `val historical: List<HistoricalChange> = emptyList()`

## Video
~https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/bd5f530f-d26e-4a65-ab54-8085b22b5e1d~

