### PR TITLE
Propagate LocalLayoutDirection into Window and DialogWindow

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -36,8 +36,8 @@ import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.configureSwingGlobalsForCompose
 import androidx.compose.ui.platform.GlobalSnapshotManager
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -221,7 +221,8 @@ suspend fun awaitApplication(
                             CompositionLocalProvider(
                                 // Resources which are defined at the application level can use
                                 // density to calculate intrinsicSize
-                                LocalDensity provides GlobalDensity
+                                LocalDensity provides GlobalDensity,
+                                LocalLayoutDirection provides GlobalLayoutDirection
                             ) {
                                 applicationScope.content()
                             }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
@@ -28,6 +27,7 @@ import androidx.compose.ui.LocalComposeScene
 import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.ComponentUpdater
@@ -341,6 +341,7 @@ fun DialogWindow(
         LocalWindowExceptionHandlerFactory.current
     )
     val parentScene = LocalComposeScene.current
+    val layoutDirection = LocalLayoutDirection.current
     AwtWindow(
         visible = visible,
         create = {
@@ -358,6 +359,7 @@ fun DialogWindow(
         update = {
             it.compositionLocalContext = compositionLocalContext
             it.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(it)
+            it.scene.mainOwner?.layoutDirection = layoutDirection
 
             val wasDisplayable = it.isDisplayable
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.LocalComposeScene
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.ComponentUpdater
@@ -399,6 +400,7 @@ fun Window(
         LocalWindowExceptionHandlerFactory.current
     )
     val parentScene = LocalComposeScene.current
+    val layoutDirection = LocalLayoutDirection.current
     AwtWindow(
         visible = visible,
         create = {
@@ -416,6 +418,7 @@ fun Window(
         update = {
             it.compositionLocalContext = compositionLocalContext
             it.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(it)
+            it.scene.mainOwner?.layoutDirection = layoutDirection
 
             val wasDisplayable = it.isDisplayable
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -40,8 +40,10 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.window.toSize
 import com.google.common.truth.Truth.assertThat
@@ -578,5 +580,27 @@ class DialogWindowTest {
             canvasSizeModifier = Modifier.size(canvasSize),
             expectedCanvasSize = { canvasSize }
         )
+    }
+
+    @Test
+    fun `pass LayoutDirection to DialogWindow`() = runApplicationTest {
+        lateinit var localLayoutDirection: LayoutDirection
+
+        var layoutDirection by mutableStateOf(LayoutDirection.Rtl)
+        launchTestApplication {
+            CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+                DialogWindow(onCloseRequest = {}) {
+                    localLayoutDirection = LocalLayoutDirection.current
+                }
+            }
+        }
+        awaitIdle()
+
+        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Rtl)
+
+        // Test that changing the local propagates it into the dialog
+        layoutDirection = LayoutDirection.Ltr
+        awaitIdle()
+        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
     }
 }


### PR DESCRIPTION
## Proposed Changes

Set the layout direction of the main owner of the Window/DialogWindow's `ComposeScene` to the local layout direction observed at the point where the window/dialog is created.

See https://github.com/JetBrains/compose-multiplatform-core/pull/558 for why we do it this way rather than just not overwriting it in `ProvideCommonCompositionLocals`.

## Testing

Test: Added relevant unit tests

## Issues Fixed

Fixes:
https://github.com/JetBrains/compose-multiplatform/issues/3382
https://github.com/JetBrains/compose-multiplatform/issues/3571
