### PR TITLE
Add UIViewController lifetime hooks

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.kt
@@ -24,6 +24,24 @@ class ComposeUIViewControllerConfiguration {
      * Control Compose behaviour on focus changed inside Compose.
      */
     var onFocusBehavior: OnFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+
+    /**
+     * Reassign this property with an object implementing [ComposeUIViewControllerDelegate] to receive
+     * UIViewController lifetime events.
+     */
+    var delegate = object : ComposeUIViewControllerDelegate {}
+}
+
+/**
+ * Interface for UIViewController specific lifetime callbacks to allow injecting logic without overriding internal ComposeWindow.
+ * All of those callbacks are invoked at the very end of overrided function implementation.
+ */
+interface ComposeUIViewControllerDelegate {
+    fun viewDidLoad() = Unit
+    fun viewWillAppear(animated: Boolean) = Unit
+    fun viewDidAppear(animated: Boolean) = Unit
+    fun viewWillDisappear(animated: Boolean) = Unit
+    fun viewDidDisappear(animated: Boolean) = Unit
 }
 
 sealed interface OnFocusBehavior {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -278,6 +278,12 @@ internal actual class ComposeWindow : UIViewController {
         } // rootView needs to interop with UIKit
     }
 
+    override fun viewDidLoad() {
+        super.viewDidLoad()
+
+        configuration.delegate.viewDidLoad()
+    }
+
     override fun traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -315,10 +321,13 @@ internal actual class ComposeWindow : UIViewController {
         super.viewWillAppear(animated)
 
         attachComposeIfNeeded()
+
+        configuration.delegate.viewWillAppear(animated)
     }
 
     override fun viewDidAppear(animated: Boolean) {
         super.viewDidAppear(animated)
+
         NSNotificationCenter.defaultCenter.addObserver(
             observer = keyboardVisibilityListener,
             selector = NSSelectorFromString(keyboardVisibilityListener::keyboardWillShow.name + ":"),
@@ -331,6 +340,9 @@ internal actual class ComposeWindow : UIViewController {
             name = UIKeyboardWillHideNotification,
             `object` = null
         )
+
+        configuration.delegate.viewDidAppear(animated)
+
     }
 
     // viewDidUnload() is deprecated and not called.
@@ -347,6 +359,8 @@ internal actual class ComposeWindow : UIViewController {
             name = UIKeyboardWillHideNotification,
             `object` = null
         )
+
+        configuration.delegate.viewWillDisappear(animated)
     }
 
     override fun viewDidDisappear(animated: Boolean) {
@@ -357,6 +371,8 @@ internal actual class ComposeWindow : UIViewController {
         dispatch_async(dispatch_get_main_queue()) {
             kotlin.native.internal.GC.collect()
         }
+
+        configuration.delegate.viewDidDisappear(animated)
     }
 
     override fun didReceiveMemoryWarning() {


### PR DESCRIPTION
## API Changes

`ComposeUIViewControllerConfiguration` now contains a `delegate` property which can be reassigned with an implementation conforming to `ComposeUIViewControllerDelegate` to react to `UIViewController` lifetime events.

## Testing

Test: N/A

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3462
