### PR TITLE
Remove Platform.layoutDirection and have it specified directly

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
-import androidx.compose.ui.window.layoutDirection
 import java.awt.*
 import java.awt.Cursor
 import java.awt.event.*

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -56,7 +56,9 @@ import org.jetbrains.skiko.*
  *
  * Inheritors should call [attachComposeToComponent], so events that came to [component] will be transferred to [ComposeScene]
  */
-internal abstract class ComposeBridge {
+internal abstract class ComposeBridge(
+    layoutDirection: LayoutDirection
+) {
     private var isDisposed = false
 
     val sceneAccessible = ComposeSceneAccessible(
@@ -135,6 +137,7 @@ internal abstract class ComposeBridge {
         MainUIDispatcher + coroutineExceptionHandler,
         platform,
         Density(1f),
+        layoutDirection,
         invalidate = {
             onComposeInvalidation()
         },
@@ -340,9 +343,6 @@ internal abstract class ComposeBridge {
         override val windowInfo = WindowInfoImpl()
 
         override val textInputService = PlatformInput(platformComponent)
-
-        override val layoutDirection: LayoutDirection
-            get() = component.layoutDirection
 
         override val focusManager = object : FocusManager {
             override fun clearFocus(force: Boolean) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -23,11 +23,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.DialogWindowScope
 import androidx.compose.ui.window.WindowExceptionHandler
+import androidx.compose.ui.window.layoutDirection
 import org.jetbrains.skiko.GraphicsApi
 import java.awt.Component
-import java.awt.Dialog
 import java.awt.Frame
 import java.awt.GraphicsConfiguration
 import java.awt.Window
@@ -48,13 +49,29 @@ class ComposeDialog : JDialog {
     internal val scene: ComposeScene
         get() = delegate.scene
 
+    @ExperimentalComposeUiApi
+    var layoutDirection: LayoutDirection
+        // Can't use `by scene::layoutDirection` because `delegate` hasn't been created yet
+        // when this property is initialized
+        get() = scene.layoutDirection
+        set(value) {
+            scene.layoutDirection = value
+        }
+
+    private fun createDelegate() = ComposeWindowDelegate(
+        window = this,
+        isUndecorated = ::isUndecorated,
+        skiaLayerAnalytics = skiaLayerAnalytics,
+        layoutDirection = (this as Component).layoutDirection,
+    )
+
     constructor(
         owner: Window?,
         modalityType: ModalityType = ModalityType.MODELESS,
         graphicsConfiguration: GraphicsConfiguration? = null
     ) : super(owner, "", modalityType, graphicsConfiguration) {
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty
-        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        delegate = createDelegate()
         contentPane.add(delegate.pane)
     }
 
@@ -74,7 +91,7 @@ class ComposeDialog : JDialog {
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
     ) : super(owner, "", modalityType, graphicsConfiguration) {
         this.skiaLayerAnalytics = skiaLayerAnalytics
-        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        delegate = createDelegate()
         contentPane.add(delegate.pane)
     }
 
@@ -91,7 +108,7 @@ class ComposeDialog : JDialog {
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty
     ) : super() {
         this.skiaLayerAnalytics = skiaLayerAnalytics
-        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        delegate = createDelegate()
         contentPane.add(delegate.pane)
     }
 
@@ -100,14 +117,14 @@ class ComposeDialog : JDialog {
         modalityType: ModalityType = ModalityType.MODELESS
     ) : super(null, modalityType) {
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty
-        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        delegate = createDelegate()
         contentPane.add(delegate.pane)
     }
 
     constructor(graphicsConfiguration: GraphicsConfiguration? = null) :
         super(null as Frame?, "", false, graphicsConfiguration) {
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty
-        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        delegate = createDelegate()
         contentPane.add(delegate.pane)
     }
 
@@ -116,7 +133,7 @@ class ComposeDialog : JDialog {
     // Dialog's shouldn't be appeared in the taskbar.
     constructor() : super() {
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty
-        delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+        delegate = createDelegate()
         contentPane.add(delegate.pane)
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -20,10 +20,11 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.window.WindowExceptionHandler
-import androidx.compose.ui.window.layoutDirection
+import androidx.compose.ui.window.layoutDirectionFor
 import java.awt.*
 import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
+import java.util.*
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities.isEventDispatchThread
 import org.jetbrains.skiko.ClipComponent
@@ -189,9 +190,9 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private fun createComposeBridge(): ComposeBridge {
         val renderOnGraphics = System.getProperty("compose.swing.render.on.graphics").toBoolean()
         val bridge: ComposeBridge = if (renderOnGraphics) {
-            SwingComposeBridge(skiaLayerAnalytics, layoutDirection)
+            SwingComposeBridge(skiaLayerAnalytics, layoutDirectionFor(this))
         } else {
-            WindowComposeBridge(skiaLayerAnalytics, layoutDirection)
+            WindowComposeBridge(skiaLayerAnalytics, layoutDirectionFor(this))
         }
         return bridge.apply {
             scene.releaseFocus()
@@ -231,6 +232,22 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             dispose()
         }
         super.removeNotify()
+    }
+
+    override fun setComponentOrientation(o: ComponentOrientation?) {
+        super.setComponentOrientation(o)
+
+        updateLayoutDirection()
+    }
+
+    override fun setLocale(l: Locale?) {
+        super.setLocale(l)
+
+        updateLayoutDirection()
+    }
+
+    private fun updateLayoutDirection() {
+        bridge?.scene?.layoutDirection = layoutDirectionFor(this)
     }
 
     override fun addFocusListener(l: FocusListener?) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.window.WindowExceptionHandler
+import androidx.compose.ui.window.layoutDirection
 import java.awt.*
 import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
@@ -39,7 +40,6 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 class ComposePanel @ExperimentalComposeUiApi constructor(
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
 ) : JLayeredPane() {
-    @OptIn(ExperimentalComposeUiApi::class)
     constructor() : this(SkiaLayerAnalytics.Empty)
 
     init {
@@ -189,9 +189,9 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private fun createComposeBridge(): ComposeBridge {
         val renderOnGraphics = System.getProperty("compose.swing.render.on.graphics").toBoolean()
         val bridge: ComposeBridge = if (renderOnGraphics) {
-            SwingComposeBridge(skiaLayerAnalytics)
+            SwingComposeBridge(skiaLayerAnalytics, layoutDirection)
         } else {
-            WindowComposeBridge(skiaLayerAnalytics)
+            WindowComposeBridge(skiaLayerAnalytics, layoutDirection)
         }
         return bridge.apply {
             scene.releaseFocus()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeSwingLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeSwingLayer.desktop.kt
@@ -19,6 +19,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.unit.LayoutDirection
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.Graphics
@@ -41,8 +42,9 @@ import org.jetbrains.skiko.swing.SkiaSwingLayer
  */
 @OptIn(ExperimentalSkikoApi::class)
 internal class SwingComposeBridge(
-    private val skiaLayerAnalytics: SkiaLayerAnalytics
-) : ComposeBridge() {
+    private val skiaLayerAnalytics: SkiaLayerAnalytics,
+    layoutDirection: LayoutDirection
+) : ComposeBridge(layoutDirection) {
     /**
      * See also backendLayer for standalone Compose in [androidx.compose.ui.awt.WindowComposeBridge]
      */

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.layoutDirection
 import java.awt.Component
 import java.awt.GraphicsConfiguration
 import java.awt.event.MouseListener
@@ -54,15 +55,22 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
      * @param graphicsConfiguration the GraphicsConfiguration that is used to construct the new window.
      * If null, the system default GraphicsConfiguration is assumed.
      */
-    @OptIn(ExperimentalComposeUiApi::class)
     constructor(
         graphicsConfiguration: GraphicsConfiguration? = null
     ) : this(graphicsConfiguration, SkiaLayerAnalytics.Empty)
 
-    private val delegate = ComposeWindowDelegate(this, ::isUndecorated, skiaLayerAnalytics)
+    private val delegate = ComposeWindowDelegate(
+        window = this,
+        isUndecorated = ::isUndecorated,
+        skiaLayerAnalytics = skiaLayerAnalytics,
+        layoutDirection = (this as Component).layoutDirection,
+    )
 
     internal val scene: ComposeScene
         get() = delegate.scene
+
+    @ExperimentalComposeUiApi
+    var layoutDirection by scene::layoutDirection
 
     // Don't override the accessible context of JFrame, since accessibility work through HardwareLayer
     internal val windowAccessible: Accessible

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.window.LocalWindow
 import androidx.compose.ui.window.UndecoratedWindowResizer
@@ -42,7 +43,8 @@ import org.jetbrains.skiko.*
 internal class ComposeWindowDelegate(
     private val window: Window,
     private val isUndecorated: () -> Boolean,
-    private val skiaLayerAnalytics: SkiaLayerAnalytics
+    skiaLayerAnalytics: SkiaLayerAnalytics,
+    layoutDirection: LayoutDirection
 ) {
     private var isDisposed = false
 
@@ -50,7 +52,8 @@ internal class ComposeWindowDelegate(
     // (see https://github.com/JetBrains/compose-jb/issues/1688),
     // so we nullify bridge on dispose, to prevent keeping
     // big objects in memory (like the whole LayoutNode tree of the window)
-    private var _bridge: WindowComposeBridge? = WindowComposeBridge(skiaLayerAnalytics)
+    private var _bridge: WindowComposeBridge? =
+        WindowComposeBridge(skiaLayerAnalytics, layoutDirection)
     private val bridge
         get() = requireNotNull(_bridge) {
             "ComposeBridge is disposed"

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowComposeBridge.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.awt
 
+import androidx.compose.ui.unit.LayoutDirection
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.Graphics
@@ -32,8 +33,9 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * If smooth interop with Swing is needed, consider using [androidx.compose.ui.awt.SwingComposeBridge]
  */
 internal class WindowComposeBridge(
-    private val skiaLayerAnalytics: SkiaLayerAnalytics
-) : ComposeBridge() {
+    private val skiaLayerAnalytics: SkiaLayerAnalytics,
+    layoutDirection: LayoutDirection
+) : ComposeBridge(layoutDirection) {
     /**
      * See also backend layer for swing interop in [androidx.compose.ui.awt.SwingComposeBridge]
      */

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.layoutDirection
+import androidx.compose.ui.window.layoutDirectionFor
 import java.awt.Component
 import java.awt.Dialog
 import java.awt.Dimension
@@ -176,7 +177,7 @@ internal fun Dialog.setUndecoratedSafely(value: Boolean) {
 private val iconSize = Size(32f, 32f)
 
 internal fun Window.setIcon(painter: Painter?) {
-    setIconImage(painter?.toAwtImage(density, layoutDirection, iconSize))
+    setIconImage(painter?.toAwtImage(density, layoutDirectionFor(this), iconSize))
 }
 
 internal class ListenerOnWindowRef<T>(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -359,7 +359,7 @@ fun DialogWindow(
         update = {
             it.compositionLocalContext = compositionLocalContext
             it.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(it)
-            it.scene.mainOwner?.layoutDirection = layoutDirection
+            it.layoutDirection = layoutDirection
 
             val wasDisplayable = it.isDisplayable
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -359,7 +359,7 @@ fun DialogWindow(
         update = {
             it.compositionLocalContext = compositionLocalContext
             it.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(it)
-            it.layoutDirection = layoutDirection
+            it.componentOrientation = layoutDirection.componentOrientation
 
             val wasDisplayable = it.isDisplayable
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt
@@ -50,9 +50,6 @@ internal val GlobalLayoutDirection get() = Locale.getDefault().layoutDirection
 internal val Locale.layoutDirection: LayoutDirection
     get() = ComponentOrientation.getOrientation(this).layoutDirection
 
-internal val Component.layoutDirection: LayoutDirection
-    get() = this.componentOrientation.layoutDirection
-
 internal val ComponentOrientation.layoutDirection: LayoutDirection
     get() = when {
         isLeftToRight -> LayoutDirection.Ltr
@@ -65,3 +62,17 @@ internal val LayoutDirection.componentOrientation: ComponentOrientation
         LayoutDirection.Ltr -> ComponentOrientation.LEFT_TO_RIGHT
         LayoutDirection.Rtl -> ComponentOrientation.RIGHT_TO_LEFT
     }
+
+/**
+ * Compute the [LayoutDirection] the given AWT/Swing component should have, based on its own,
+ * non-Compose attributes.
+ */
+internal fun layoutDirectionFor(component: Component): LayoutDirection {
+    val orientation = component.componentOrientation
+    return if (orientation != ComponentOrientation.UNKNOWN) {
+        orientation.layoutDirection
+    } else {
+        // To preserve backwards compatibility we fall back to the locale
+        return component.locale.layoutDirection
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt
@@ -47,12 +47,21 @@ private val GraphicsConfiguration.density: Density get() = Density(
 
 internal val GlobalLayoutDirection get() = Locale.getDefault().layoutDirection
 
-internal val Component.layoutDirection: LayoutDirection
-    get() = this.locale.layoutDirection
-
 internal val Locale.layoutDirection: LayoutDirection
-    get() = if (ComponentOrientation.getOrientation(this).isLeftToRight) {
-        LayoutDirection.Ltr
-    } else {
-        LayoutDirection.Rtl
+    get() = ComponentOrientation.getOrientation(this).layoutDirection
+
+internal val Component.layoutDirection: LayoutDirection
+    get() = this.componentOrientation.layoutDirection
+
+internal val ComponentOrientation.layoutDirection: LayoutDirection
+    get() = when {
+        isLeftToRight -> LayoutDirection.Ltr
+        isHorizontal -> LayoutDirection.Rtl
+        else -> LayoutDirection.Ltr
+    }
+
+internal val LayoutDirection.componentOrientation: ComponentOrientation
+    get() = when(this) {
+        LayoutDirection.Ltr -> ComponentOrientation.LEFT_TO_RIGHT
+        LayoutDirection.Rtl -> ComponentOrientation.RIGHT_TO_LEFT
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -418,7 +418,7 @@ fun Window(
         update = {
             it.compositionLocalContext = compositionLocalContext
             it.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(it)
-            it.layoutDirection = layoutDirection
+            it.componentOrientation = layoutDirection.componentOrientation
 
             val wasDisplayable = it.isDisplayable
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -418,7 +418,7 @@ fun Window(
         update = {
             it.compositionLocalContext = compositionLocalContext
             it.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(it)
-            it.scene.mainOwner?.layoutDirection = layoutDirection
+            it.layoutDirection = layoutDirection
 
             val wasDisplayable = it.isDisplayable
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -24,11 +24,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.ComponentTestMethods
+import androidx.compose.ui.window.componentOrientationModifiesLayoutDirection
+import androidx.compose.ui.window.componentOrientationOverridesLocaleForLayoutDirection
 import androidx.compose.ui.window.density
+import androidx.compose.ui.window.localeDoesNotOverrideComponentOrientationForLayoutDirection
+import androidx.compose.ui.window.localeModifiesLayoutDirection
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import javax.swing.JFrame
+import javax.swing.SwingUtilities
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -249,4 +255,35 @@ class ComposePanelTest {
             }
         }
     }
+
+
+    private val PanelTestMethods = ComponentTestMethods(
+        create = {
+            val frame = JFrame("Hello")
+            val panel = ComposePanel()
+            frame.contentPane.add(panel)
+            panel
+        },
+        setContent = { setContent{ it() } },
+        display = {
+            SwingUtilities.getWindowAncestor(this).isVisible = true
+        },
+        dispose = { SwingUtilities.getWindowAncestor(this).dispose() }
+    )
+
+    @Test
+    fun `componentOrientation modifies LayoutDirection`() =
+        componentOrientationModifiesLayoutDirection(PanelTestMethods)
+
+    @Test
+    fun `locale modifies LayoutDirection`() =
+        localeModifiesLayoutDirection(PanelTestMethods)
+
+    @Test
+    fun `component orientation overrides locale for LayoutDirection`() =
+        componentOrientationOverridesLocaleForLayoutDirection(PanelTestMethods)
+
+    @Test
+    fun `locale does not override component orientation for LayoutDirection`() =
+        localeDoesNotOverrideComponentOrientationForLayoutDirection(PanelTestMethods)
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -47,12 +47,10 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.window.toSize
 import com.google.common.truth.Truth.assertThat
-import java.awt.ComponentOrientation
 import java.awt.Dimension
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
-import java.util.*
 import kotlin.test.assertEquals
 import org.junit.Test
 
@@ -606,62 +604,26 @@ class DialogWindowTest {
         assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
     }
 
-    @Test
-    fun `dialog changes LayoutDirection from ComponentOrientation`() = runApplicationTest {
-        lateinit var localLayoutDirection: LayoutDirection
-        lateinit var dialog: ComposeDialog
-
-        launchTestApplication {
-            dialog = ComposeDialog()
-            dialog.componentOrientation = ComponentOrientation.RIGHT_TO_LEFT
-
-            dialog.setContent {
-                localLayoutDirection = LocalLayoutDirection.current
-            }
-            dialog.isVisible = true
-        }
-        awaitIdle()
-
-        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Rtl)
-
-        // Test that changing the orientation changes the local
-        dialog.componentOrientation = ComponentOrientation.LEFT_TO_RIGHT
-        awaitIdle()
-        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
-
-        dialog.isVisible = false
-    }
+    private val DialogWindowTestMethods = ComponentTestMethods(
+        create = { ComposeDialog() },
+        setContent = { setContent{ it() } },
+        display = { isVisible = true },
+        dispose = { dispose() }
+    )
 
     @Test
-    fun `locale determines default layout direction for dialog`() = runApplicationTest {
-        lateinit var rtlDialogLayoutDirection: LayoutDirection
-        lateinit var ltrDialogLayoutDirection: LayoutDirection
-        lateinit var rtlDialog: ComposeDialog
-        lateinit var ltrDialog: ComposeDialog
+    fun `componentOrientation modifies LayoutDirection`() =
+        componentOrientationModifiesLayoutDirection(DialogWindowTestMethods)
 
-        launchTestApplication {
-            ltrDialog = ComposeDialog()
-            ltrDialog.locale = Locale("en")
+    @Test
+    fun `locale modifies LayoutDirection`() =
+        localeModifiesLayoutDirection(DialogWindowTestMethods)
 
-            ltrDialog.setContent {
-                ltrDialogLayoutDirection = LocalLayoutDirection.current
-            }
-            ltrDialog.isVisible = true
+    @Test
+    fun `component orientation overrides locale for LayoutDirection`() =
+        componentOrientationOverridesLocaleForLayoutDirection(DialogWindowTestMethods)
 
-            rtlDialog = ComposeDialog()
-            rtlDialog.locale = Locale("he")
-
-            rtlDialog.setContent {
-                rtlDialogLayoutDirection = LocalLayoutDirection.current
-            }
-            rtlDialog.isVisible = true
-        }
-        awaitIdle()
-
-        assertThat(ltrDialogLayoutDirection).isEqualTo(LayoutDirection.Ltr)
-        assertThat(rtlDialogLayoutDirection).isEqualTo(LayoutDirection.Rtl)
-
-        ltrDialog.dispose()
-        rtlDialog.dispose()
-    }
+    @Test
+    fun `locale does not override component orientation for LayoutDirection`() =
+        localeDoesNotOverrideComponentOrientationForLayoutDirection(DialogWindowTestMethods)
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -47,10 +47,12 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.window.toSize
 import com.google.common.truth.Truth.assertThat
+import java.awt.ComponentOrientation
 import java.awt.Dimension
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import java.util.*
 import kotlin.test.assertEquals
 import org.junit.Test
 
@@ -602,5 +604,64 @@ class DialogWindowTest {
         layoutDirection = LayoutDirection.Ltr
         awaitIdle()
         assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
+    }
+
+    @Test
+    fun `dialog changes LayoutDirection from ComponentOrientation`() = runApplicationTest {
+        lateinit var localLayoutDirection: LayoutDirection
+        lateinit var dialog: ComposeDialog
+
+        launchTestApplication {
+            dialog = ComposeDialog()
+            dialog.componentOrientation = ComponentOrientation.RIGHT_TO_LEFT
+
+            dialog.setContent {
+                localLayoutDirection = LocalLayoutDirection.current
+            }
+            dialog.isVisible = true
+        }
+        awaitIdle()
+
+        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Rtl)
+
+        // Test that changing the orientation changes the local
+        dialog.componentOrientation = ComponentOrientation.LEFT_TO_RIGHT
+        awaitIdle()
+        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
+
+        dialog.isVisible = false
+    }
+
+    @Test
+    fun `locale determines default layout direction for dialog`() = runApplicationTest {
+        lateinit var rtlDialogLayoutDirection: LayoutDirection
+        lateinit var ltrDialogLayoutDirection: LayoutDirection
+        lateinit var rtlDialog: ComposeDialog
+        lateinit var ltrDialog: ComposeDialog
+
+        launchTestApplication {
+            ltrDialog = ComposeDialog()
+            ltrDialog.locale = Locale("en")
+
+            ltrDialog.setContent {
+                ltrDialogLayoutDirection = LocalLayoutDirection.current
+            }
+            ltrDialog.isVisible = true
+
+            rtlDialog = ComposeDialog()
+            rtlDialog.locale = Locale("he")
+
+            rtlDialog.setContent {
+                rtlDialogLayoutDirection = LocalLayoutDirection.current
+            }
+            rtlDialog.isVisible = true
+        }
+        awaitIdle()
+
+        assertThat(ltrDialogLayoutDirection).isEqualTo(LayoutDirection.Ltr)
+        assertThat(rtlDialogLayoutDirection).isEqualTo(LayoutDirection.Rtl)
+
+        ltrDialog.dispose()
+        rtlDialog.dispose()
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -44,13 +44,11 @@ import androidx.compose.ui.unit.*
 import androidx.compose.ui.window.*
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
-import java.awt.ComponentOrientation
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.Toolkit
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
-import java.util.*
 import kotlin.test.assertEquals
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -693,62 +691,26 @@ class WindowTest {
         assertThat(popupLayoutDirectionResult).isEqualTo(LayoutDirection.Rtl)
     }
 
-    @Test
-    fun `window changes LayoutDirection from ComponentOrientation`() = runApplicationTest {
-        lateinit var localLayoutDirection: LayoutDirection
-        lateinit var window: ComposeWindow
-
-        launchTestApplication {
-            window = ComposeWindow()
-            window.componentOrientation = ComponentOrientation.RIGHT_TO_LEFT
-
-            window.setContent {
-                localLayoutDirection = LocalLayoutDirection.current
-            }
-            window.isVisible = true
-        }
-        awaitIdle()
-
-        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Rtl)
-
-        // Test that changing the orientation changes the local
-        window.componentOrientation = ComponentOrientation.LEFT_TO_RIGHT
-        awaitIdle()
-        assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
-
-        window.dispose()
-    }
+    private val WindowTestMethods = ComponentTestMethods(
+        create = { ComposeWindow() },
+        setContent = { setContent{ it() } },
+        display = { isVisible = true },
+        dispose = { dispose() }
+    )
 
     @Test
-    fun `locale determines default layout direction for window`() = runApplicationTest {
-        lateinit var rtlWindowLayoutDirection: LayoutDirection
-        lateinit var ltrWindowLayoutDirection: LayoutDirection
-        lateinit var rtlWindow: ComposeWindow
-        lateinit var ltrWindow: ComposeWindow
+    fun `componentOrientation modifies LayoutDirection`() =
+        componentOrientationModifiesLayoutDirection(WindowTestMethods)
 
-        launchTestApplication {
-            ltrWindow = ComposeWindow()
-            ltrWindow.locale = Locale("en")
+    @Test
+    fun `locale modifies LayoutDirection`() =
+        localeModifiesLayoutDirection(WindowTestMethods)
 
-            ltrWindow.setContent {
-                ltrWindowLayoutDirection = LocalLayoutDirection.current
-            }
-            ltrWindow.isVisible = true
+    @Test
+    fun `component orientation overrides locale for LayoutDirection`() =
+        componentOrientationOverridesLocaleForLayoutDirection(WindowTestMethods)
 
-            rtlWindow = ComposeWindow()
-            rtlWindow.locale = Locale("he")
-
-            rtlWindow.setContent {
-                rtlWindowLayoutDirection = LocalLayoutDirection.current
-            }
-            rtlWindow.isVisible = true
-        }
-        awaitIdle()
-
-        assertThat(ltrWindowLayoutDirection).isEqualTo(LayoutDirection.Ltr)
-        assertThat(rtlWindowLayoutDirection).isEqualTo(LayoutDirection.Rtl)
-
-        ltrWindow.dispose()
-        rtlWindow.dispose()
-    }
+    @Test
+    fun `locale does not override component orientation for LayoutDirection`() =
+        localeDoesNotOverrideComponentOrientationForLayoutDirection(WindowTestMethods)
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -69,8 +69,63 @@ class ComposeScene internal constructor(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     internal val platform: Platform,
     density: Density = Density(1f),
+    layoutDirection: LayoutDirection = LayoutDirection.Ltr,
     private val invalidate: () -> Unit = {}
 ) {
+    /**
+     * Constructs [ComposeScene]
+     *
+     * @param coroutineContext Context which will be used to launch effects ([LaunchedEffect],
+     * [rememberCoroutineScope]) and run recompositions.
+     * @param density Initial density of the content which will be used to convert [dp] units.
+     * @param layoutDirection Initial layout direction of the content.
+     * @param invalidate Callback which will be called when the content need to be recomposed or
+     * rerendered. If you draw your content using [render] method, in this callback you should
+     * schedule the next [render] in your rendering loop.
+     */
+    @ExperimentalComposeUiApi
+    constructor(
+        coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+        density: Density = Density(1f),
+        layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+        invalidate: () -> Unit = {}
+    ) : this(
+        coroutineContext,
+        Platform.Empty,
+        density,
+        layoutDirection,
+        invalidate
+    )
+
+    /**
+     * Constructs [ComposeScene]
+     *
+     * @param textInputService Platform specific text input service
+     * @param coroutineContext Context which will be used to launch effects ([LaunchedEffect],
+     * [rememberCoroutineScope]) and run recompositions.
+     * @param density Initial density of the content which will be used to convert [dp] units.
+     * @param layoutDirection Initial layout direction of the content.
+     * @param invalidate Callback which will be called when the content need to be recomposed or
+     * rerendered. If you draw your content using [render] method, in this callback you should
+     * schedule the next [render] in your rendering loop.
+     */
+    @ExperimentalComposeUiApi
+    constructor(
+        textInputService: PlatformTextInputService,
+        coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+        density: Density = Density(1f),
+        layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+        invalidate: () -> Unit = {}
+    ) : this(
+        coroutineContext,
+        object : Platform by Platform.Empty {
+            override val textInputService: PlatformTextInputService get() = textInputService
+        },
+        density,
+        layoutDirection,
+        invalidate,
+    )
+
     /**
      * Constructs [ComposeScene]
      *
@@ -87,8 +142,8 @@ class ComposeScene internal constructor(
         invalidate: () -> Unit = {}
     ) : this(
         coroutineContext,
-        Platform.Empty,
         density,
+        LayoutDirection.Ltr,
         invalidate
     )
 
@@ -109,11 +164,10 @@ class ComposeScene internal constructor(
         density: Density = Density(1f),
         invalidate: () -> Unit = {}
     ) : this(
+        textInputService,
         coroutineContext,
-        object : Platform by Platform.Empty {
-            override val textInputService: PlatformTextInputService get() = textInputService
-        },
         density,
+        LayoutDirection.Ltr,
         invalidate,
     )
 
@@ -257,6 +311,17 @@ class ComposeScene internal constructor(
             mainOwner?.density = value
         }
 
+    /**
+     * The layout direction of the content, provided to the composition via [LocalLayoutDirection].
+     */
+    @ExperimentalComposeUiApi
+    var layoutDirection: LayoutDirection = layoutDirection
+        get() = mainOwner?.layoutDirection ?: field
+        set(value) {
+            field = value
+            mainOwner?.layoutDirection = value
+        }
+
     private var isClosed = false
 
     /**
@@ -395,6 +460,7 @@ class ComposeScene internal constructor(
             platform,
             platform.focusManager,
             initDensity = density,
+            initLayoutDirection = layoutDirection,
             coroutineContext = recomposer.effectCoroutineContext,
             bounds = IntSize(constraints.maxWidth, constraints.maxHeight).toIntRect(),
             onPointerUpdate = ::onPointerUpdate,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -316,8 +316,8 @@ class ComposeScene internal constructor(
      */
     @ExperimentalComposeUiApi
     var layoutDirection: LayoutDirection = layoutDirection
-        get() = mainOwner?.layoutDirection ?: field
         set(value) {
+            check(!isClosed) { "ComposeScene is closed" }
             field = value
             mainOwner?.layoutDirection = value
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -38,7 +38,6 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.DurationUnit.NANOSECONDS
 import kotlin.time.ExperimentalTime
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.skia.Color
 import org.jetbrains.skia.Image

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
@@ -103,22 +104,46 @@ inline fun <R> ImageComposeScene.use(
  * [rememberCoroutineScope]) and run recompositions.
  * @param content Composable content which needed to be rendered.
  */
-class ImageComposeScene(
+class ImageComposeScene @ExperimentalComposeUiApi constructor(
     width: Int,
     height: Int,
     density: Density = Density(1f),
+    layoutDirection: LayoutDirection = LayoutDirection.Ltr,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     content: @Composable () -> Unit = {},
 ) {
+
+    constructor(
+        width: Int,
+        height: Int,
+        density: Density = Density(1f),
+        coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+        content: @Composable () -> Unit = {},
+    ): this(
+        width,
+        height,
+        density,
+        LayoutDirection.Ltr,
+        coroutineContext,
+        content
+    )
+
     private val surface = Surface.makeRasterN32Premul(width, height)
 
     private val scene = ComposeScene(
         density = density,
+        layoutDirection = layoutDirection,
         coroutineContext = coroutineContext
     ).apply {
         constraints = Constraints(maxWidth = surface.width, maxHeight = surface.height)
         setContent(content = content)
     }
+
+    /**
+     * The default direction of layout for content.
+     */
+    @ExperimentalComposeUiApi
+    var layoutDirection: LayoutDirection by scene::layoutDirection
 
     /**
      * Close all resources and subscriptions. Not calling this method when [ImageComposeScene] is no

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
@@ -15,7 +15,6 @@
  */
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Rect
@@ -30,15 +29,12 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.LayoutDirection
 
 // TODO(demin): make it public when we stabilize it after implementing it for uikit and js
 internal interface Platform {
     val windowInfo: WindowInfo
     val focusManager: FocusManager
     val inputModeManager: InputModeManager
-    val layoutDirection: LayoutDirection
-        get() = LayoutDirection.Ltr
 
     fun requestFocusForOwner(): Boolean
     val textInputService: PlatformTextInputService
@@ -48,7 +44,6 @@ internal interface Platform {
     val textToolbar: TextToolbar
 
     companion object {
-        @OptIn(ExperimentalComposeUiApi::class)
         val Empty = object : Platform {
             override val windowInfo = WindowInfoImpl().apply {
                 // true is a better default if platform doesn't provide WindowInfo.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -79,7 +79,7 @@ internal class SkiaBasedOwner(
     parentFocusManager: FocusManager = EmptyFocusManager,
     initDensity: Density = Density(1f, 1f),
     coroutineContext: CoroutineContext,
-    initLayoutDirection: LayoutDirection = platform.layoutDirection,
+    initLayoutDirection: LayoutDirection,
     bounds: IntRect = IntRect.Zero,
     val focusable: Boolean = true,
     val onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,


### PR DESCRIPTION
## Proposed Changes

  - Remove `Platform.layoutDirection`
  - Add `ComposeWindow.layoutDirection` and `ComposeDialog.layoutDirection` which delegate to `ComposeScene.layoutDirection`.
  - Add `ComposeScene.layoutDirection` which delegates to the main owner's layout direction.

## Testing

Test: Ran tests
