### PR TITLE
Fix Illegal version 1.5.10-dev1177

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -556,12 +556,6 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
         if (project.multiplatformExtension == null) {
             project.configureNonAndroidProjectForLint(extension)
         }
-        @Suppress("UNUSED_VARIABLE")
-        val apiTaskConfig = if (project.multiplatformExtension != null) {
-            KmpApiTaskConfig
-        } else {
-            JavaApiTaskConfig
-        }
 
         project.afterEvaluate {
             if (extension.shouldRelease()) {

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -510,11 +510,12 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
             }
         }
 
-        // Standard docs, resource API, and Metalava configuration for AndroidX projects.
-        project.configureProjectForApiTasks(
-            LibraryApiTaskConfig(libraryExtension),
-            androidXExtension
-        )
+// commenting, as the jb-fork doesn't have API checks yet, and this can break build in certain cases
+//        // Standard docs, resource API, and Metalava configuration for AndroidX projects.
+//        project.configureProjectForApiTasks(
+//            LibraryApiTaskConfig(libraryExtension),
+//            androidXExtension
+//        )
 
         project.addToProjectMap(androidXExtension)
     }
@@ -562,12 +563,16 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
         if (project.multiplatformExtension == null) {
             project.configureNonAndroidProjectForLint(extension)
         }
+        @Suppress("UNUSED_VARIABLE")
         val apiTaskConfig = if (project.multiplatformExtension != null) {
             KmpApiTaskConfig
         } else {
             JavaApiTaskConfig
         }
-        project.configureProjectForApiTasks(apiTaskConfig, extension)
+
+
+// commenting, as the jb-fork doesn't have API checks yet, and this can break build in certain cases
+//        project.configureProjectForApiTasks(apiTaskConfig, extension)
 
         project.afterEvaluate {
             if (extension.shouldRelease()) {

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -510,13 +510,6 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
             }
         }
 
-// commenting, as the jb-fork doesn't have API checks yet, and this can break build in certain cases
-//        // Standard docs, resource API, and Metalava configuration for AndroidX projects.
-//        project.configureProjectForApiTasks(
-//            LibraryApiTaskConfig(libraryExtension),
-//            androidXExtension
-//        )
-
         project.addToProjectMap(androidXExtension)
     }
 
@@ -569,10 +562,6 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
         } else {
             JavaApiTaskConfig
         }
-
-
-// commenting, as the jb-fork doesn't have API checks yet, and this can break build in certain cases
-//        project.configureProjectForApiTasks(apiTaskConfig, extension)
 
         project.afterEvaluate {
             if (extension.shouldRelease()) {


### PR DESCRIPTION
`configureProjectForApiTasks` calls check of the version and this check prohibits building 1.5.10-dev:

https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_PublishFast_1Compose?mode=builds&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&showLog=4293345_689_567.610&logFilter=debug&logView=flowAware#4293345

The API checks don't work in the fork, and we plan to enable our own in the future.

Test:
export COMPOSE_CUSTOM_VERSION=1.5.10-dev1
./gradlew run1