### PR TITLE
Add `WindowInfo.containerSize`

### DIFF
--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ProvidesLocalsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ProvidesLocalsTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.test.junit4.createComposeRule
+import kotlin.test.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+
+class ProvidesLocalsTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Test
+    fun providesWindowInfo() {
+        rule.setContent {
+            val windowInfo = LocalWindowInfo.current
+            assertNotEquals(0, windowInfo.containerSize.width)
+            assertNotEquals(0, windowInfo.containerSize.height)
+        }
+    }
+}

--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowInfo.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowInfo.android.kt
@@ -17,7 +17,9 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.pointer.EmptyPointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -44,16 +46,10 @@ actual interface WindowInfo {
 }
 
 internal class WindowInfoImpl : WindowInfo {
-    private val _isWindowFocused = mutableStateOf(false)
-
-    override var isWindowFocused: Boolean
-        set(value) { _isWindowFocused.value = value }
-        get() = _isWindowFocused.value
+    override var isWindowFocused: Boolean by mutableStateOf(false)
 
     @ExperimentalComposeUiApi
-    override var keyboardModifiers: PointerKeyboardModifiers
-        get() = GlobalKeyboardModifiers.value
-        set(value) { GlobalKeyboardModifiers.value = value }
+    override var keyboardModifiers: PointerKeyboardModifiers by GlobalKeyboardModifiers
 
     companion object {
         // One instance across all windows makes sense, since the state of KeyboardModifiers is

--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowInfo.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowInfo.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,17 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.pointer.EmptyPointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 
 /**
  * Provides information about the Window that is hosting this compose hierarchy.
  */
 @Stable
-expect interface WindowInfo {
+actual interface WindowInfo {
     /**
      * Indicates whether the window hosting this compose hierarchy is in focus.
      *
@@ -36,20 +34,30 @@ expect interface WindowInfo {
      * popup or dialog is visible, this property can be used to determine if the current window
      * is in focus.
      */
-    val isWindowFocused: Boolean
+    actual val isWindowFocused: Boolean
 
     /**
      * Indicates the state of keyboard modifiers (pressed or not).
      */
     @ExperimentalComposeUiApi
-    val keyboardModifiers: PointerKeyboardModifiers
+    actual val keyboardModifiers: PointerKeyboardModifiers
 }
 
-@Composable
-internal fun WindowFocusObserver(onWindowFocusChanged: (isWindowFocused: Boolean) -> Unit) {
-    val windowInfo = LocalWindowInfo.current
-    val callback = rememberUpdatedState(onWindowFocusChanged)
-    LaunchedEffect(windowInfo) {
-        snapshotFlow { windowInfo.isWindowFocused }.collect { callback.value(it) }
+internal class WindowInfoImpl : WindowInfo {
+    private val _isWindowFocused = mutableStateOf(false)
+
+    override var isWindowFocused: Boolean
+        set(value) { _isWindowFocused.value = value }
+        get() = _isWindowFocused.value
+
+    @ExperimentalComposeUiApi
+    override var keyboardModifiers: PointerKeyboardModifiers
+        get() = GlobalKeyboardModifiers.value
+        set(value) { GlobalKeyboardModifiers.value = value }
+
+    companion object {
+        // One instance across all windows makes sense, since the state of KeyboardModifiers is
+        // common for all windows.
+        internal val GlobalKeyboardModifiers = mutableStateOf(EmptyPointerKeyboardModifiers())
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -47,7 +47,6 @@ import javax.accessibility.Accessible
 import javax.swing.JComponent
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
-import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineExceptionHandler
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.*
@@ -305,8 +304,8 @@ internal abstract class ComposeBridge {
     protected fun updateSceneSize() {
         val scale = scene.density.density
         val size = IntSize(
-            width = (component.width * scale).roundToInt(),
-            height = (component.height * scale).roundToInt()
+            width = (component.width * scale).toInt(),
+            height = (component.height * scale).toInt()
         )
         platform.windowInfo.size = size
         scene.constraints = Constraints(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -307,7 +307,7 @@ internal abstract class ComposeBridge {
             width = (component.width * scale).toInt(),
             height = (component.height * scale).toInt()
         )
-        platform.windowInfo.size = size
+        platform.windowInfo.containerSize = size
         scene.constraints = Constraints(
             maxWidth = size.width,
             maxHeight = size.height

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -302,7 +302,7 @@ internal abstract class ComposeBridge {
     }
 
     protected fun updateSceneSize() {
-        val scale = scene.density.density
+        val scale = component.density.density
         val size = IntSize(
             width = (component.width * scale).toInt(),
             height = (component.height * scale).toInt()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.toPointerKeyboardModifiers
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowExceptionHandler
@@ -46,6 +47,7 @@ import javax.accessibility.Accessible
 import javax.swing.JComponent
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineExceptionHandler
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.*
@@ -301,9 +303,15 @@ internal abstract class ComposeBridge {
     }
 
     protected fun updateSceneSize() {
+        val scale = scene.density.density
+        val size = IntSize(
+            width = (component.width * scale).roundToInt(),
+            height = (component.height * scale).roundToInt()
+        )
+        platform.windowInfo.size = size
         scene.constraints = Constraints(
-            maxWidth = (component.width * scene.density.density).toInt(),
-            maxHeight = (component.height * scene.density.density).toInt()
+            maxWidth = size.width,
+            maxHeight = size.height
         )
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.runApplicationTest
@@ -151,6 +152,12 @@ class ComposeWindowTest {
                 assertThat(window.preferredSize).isEqualTo(Dimension(234, 345))
                 window.pack()
                 assertThat(window.size).isEqualTo(Dimension(234, 345))
+
+                assertThat(window.scene.platform.windowInfo.containerSize)
+                    .isEqualTo(IntSize(
+                        width = (234 * window.density.density).toInt(),
+                        height = (345 * window.density.density).toInt(),
+                    ))
             } finally {
                 window.dispose()
             }
@@ -176,6 +183,12 @@ class ComposeWindowTest {
                 window.isVisible = true
                 assertThat(window.preferredSize).isEqualTo(Dimension(300, 400))
                 assertThat(window.size).isEqualTo(Dimension(300, 400))
+
+                assertThat(window.scene.platform.windowInfo.containerSize)
+                    .isEqualTo(IntSize(
+                        width = (300 * window.density.density).toInt(),
+                        height = (400 * window.density.density).toInt(),
+                    ))
             } finally {
                 window.dispose()
             }
@@ -210,6 +223,12 @@ class ComposeWindowTest {
                         )
                     )
                 )
+                
+                assertThat(window.scene.platform.windowInfo.containerSize)
+                    .isEqualTo(IntSize(
+                        width = (300 * window.density.density).toInt(),
+                        height = (400 * window.density.density).toInt(),
+                    ))
             } finally {
                 window.dispose()
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/DesktopWindowInfoTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/DesktopWindowInfoTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.rememberWindowState
+import androidx.compose.ui.window.runApplicationTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopWindowInfoTest {
+
+    @Test
+    fun windowContainerSize() = runApplicationTest {
+        launchTestApplication {
+            val state = rememberWindowState(
+                size = DpSize(123.dp, 321.dp)
+            )
+            Window(onCloseRequest = {}, state = state) {
+                val containerSize = window.scene.platform.windowInfo.containerSize
+                assertEquals(123, containerSize.width)
+                assertEquals(321, containerSize.height)
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -87,7 +87,7 @@ internal actual class ComposeWindow(val canvasId: String)  {
         canvas.setAttribute("tabindex", "0")
         layer.layer.needRedraw()
 
-        _windowInfo.size = IntSize(canvas.width, canvas.height)
+        _windowInfo.containerSize = IntSize(canvas.width, canvas.height)
         layer.setSize(canvas.width, canvas.height)
     }
 
@@ -100,7 +100,7 @@ internal actual class ComposeWindow(val canvasId: String)  {
 
         canvas.width = newSize.width
         canvas.height = newSize.height
-        _windowInfo.size = IntSize(canvas.width, canvas.height)
+        _windowInfo.containerSize = IntSize(canvas.width, canvas.height)
         layer.layer.attachTo(canvas)
         layer.setSize(canvas.width, canvas.height)
         layer.layer.needRedraw()

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.JSTextInputService
 import androidx.compose.ui.platform.Platform
 import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -51,8 +52,12 @@ internal actual class ComposeWindow(val canvasId: String)  {
         fontScale = 1f
     )
 
+    private val _windowInfo = WindowInfoImpl().apply {
+        isWindowFocused = true
+    }
     private val jsTextInputService = JSTextInputService()
     val platform = object : Platform by Platform.Empty {
+        override val windowInfo get() = _windowInfo
         override val textInputService = jsTextInputService
         override val viewConfiguration = object : ViewConfiguration {
             override val longPressTimeoutMillis: Long = 500
@@ -82,6 +87,7 @@ internal actual class ComposeWindow(val canvasId: String)  {
         canvas.setAttribute("tabindex", "0")
         layer.layer.needRedraw()
 
+        _windowInfo.size = IntSize(canvas.width, canvas.height)
         layer.setSize(canvas.width, canvas.height)
     }
 
@@ -94,6 +100,7 @@ internal actual class ComposeWindow(val canvasId: String)  {
 
         canvas.width = newSize.width
         canvas.height = newSize.height
+        _windowInfo.size = IntSize(canvas.width, canvas.height)
         layer.layer.attachTo(canvas)
         layer.setSize(canvas.width, canvas.height)
         layer.layer.needRedraw()

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -68,7 +68,7 @@ internal actual class ComposeWindow actual constructor() {
                 height = (size.height * scale).toInt()
             )
         }
-        _windowInfo.size = size
+        _windowInfo.containerSize = size
         layer.setDensity(Density(scale))
         layer.setSize(size.width, size.height)
     }

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.platform.Platform
 import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
-import kotlin.math.roundToInt
 import platform.AppKit.*
 import platform.Foundation.*
 import kotlinx.cinterop.*
@@ -65,8 +64,8 @@ internal actual class ComposeWindow actual constructor() {
         val scale = nsWindow.backingScaleFactor.toFloat()
         val size = contentRect.useContents {
             IntSize(
-                width = (size.width * scale).roundToInt(),
-                height = (size.height * scale).roundToInt()
+                width = (size.width * scale).toInt(),
+                height = (size.height * scale).toInt()
             )
         }
         _windowInfo.size = size

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
@@ -48,7 +48,6 @@ internal interface Platform {
     val textToolbar: TextToolbar
 
     companion object {
-        @OptIn(ExperimentalComposeUiApi::class)
         val Empty = object : Platform {
             override val windowInfo = WindowInfoImpl().apply {
                 // true is a better default if platform doesn't provide WindowInfo.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
@@ -17,7 +17,9 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.pointer.EmptyPointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -51,22 +53,13 @@ actual interface WindowInfo {
 }
 
 internal class WindowInfoImpl : WindowInfo {
-    private val _isWindowFocused = mutableStateOf(false)
-    private val _size = mutableStateOf(IntSize.Zero)
-
-    override var isWindowFocused: Boolean
-        set(value) { _isWindowFocused.value = value }
-        get() = _isWindowFocused.value
+    override var isWindowFocused: Boolean by mutableStateOf(false)
 
     @ExperimentalComposeUiApi
-    override var keyboardModifiers: PointerKeyboardModifiers
-        get() = GlobalKeyboardModifiers.value
-        set(value) { GlobalKeyboardModifiers.value = value }
+    override var keyboardModifiers: PointerKeyboardModifiers by GlobalKeyboardModifiers
 
     @ExperimentalComposeUiApi
-    override var size: IntSize
-        get() = _size.value
-        set(value) { _size.value = value }
+    override var size: IntSize by mutableStateOf(IntSize.Zero)
 
     companion object {
         // One instance across all windows makes sense, since the state of KeyboardModifiers is

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
@@ -46,10 +46,10 @@ actual interface WindowInfo {
     actual val keyboardModifiers: PointerKeyboardModifiers
 
     /**
-     * Size of the window in pixels.
+     * Size of the window's content container in pixels.
      */
     @ExperimentalComposeUiApi
-    val size: IntSize
+    val containerSize: IntSize
 }
 
 internal class WindowInfoImpl : WindowInfo {
@@ -59,7 +59,7 @@ internal class WindowInfoImpl : WindowInfo {
     override var keyboardModifiers: PointerKeyboardModifiers by GlobalKeyboardModifiers
 
     @ExperimentalComposeUiApi
-    override var size: IntSize by mutableStateOf(IntSize.Zero)
+    override var containerSize: IntSize by mutableStateOf(IntSize.Zero)
 
     companion object {
         // One instance across all windows makes sense, since the state of KeyboardModifiers is

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,18 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.pointer.EmptyPointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.unit.IntSize
 
 /**
  * Provides information about the Window that is hosting this compose hierarchy.
  */
 @Stable
-expect interface WindowInfo {
+actual interface WindowInfo {
     /**
      * Indicates whether the window hosting this compose hierarchy is in focus.
      *
@@ -36,20 +35,37 @@ expect interface WindowInfo {
      * popup or dialog is visible, this property can be used to determine if the current window
      * is in focus.
      */
-    val isWindowFocused: Boolean
+    actual val isWindowFocused: Boolean
 
     /**
      * Indicates the state of keyboard modifiers (pressed or not).
      */
     @ExperimentalComposeUiApi
-    val keyboardModifiers: PointerKeyboardModifiers
+    actual val keyboardModifiers: PointerKeyboardModifiers
+
+    @ExperimentalComposeUiApi
+    val size: IntSize
 }
 
-@Composable
-internal fun WindowFocusObserver(onWindowFocusChanged: (isWindowFocused: Boolean) -> Unit) {
-    val windowInfo = LocalWindowInfo.current
-    val callback = rememberUpdatedState(onWindowFocusChanged)
-    LaunchedEffect(windowInfo) {
-        snapshotFlow { windowInfo.isWindowFocused }.collect { callback.value(it) }
+
+internal class WindowInfoImpl : WindowInfo {
+    private val _isWindowFocused = mutableStateOf(false)
+
+    override var isWindowFocused: Boolean
+        set(value) { _isWindowFocused.value = value }
+        get() = _isWindowFocused.value
+
+    @ExperimentalComposeUiApi
+    override var keyboardModifiers: PointerKeyboardModifiers
+        get() = GlobalKeyboardModifiers.value
+        set(value) { GlobalKeyboardModifiers.value = value }
+
+    @ExperimentalComposeUiApi
+    override var size: IntSize = IntSize.Zero
+
+    companion object {
+        // One instance across all windows makes sense, since the state of KeyboardModifiers is
+        // common for all windows.
+        internal val GlobalKeyboardModifiers = mutableStateOf(EmptyPointerKeyboardModifiers())
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
@@ -43,13 +43,16 @@ actual interface WindowInfo {
     @ExperimentalComposeUiApi
     actual val keyboardModifiers: PointerKeyboardModifiers
 
+    /**
+     * Size of the window in pixels.
+     */
     @ExperimentalComposeUiApi
     val size: IntSize
 }
 
-
 internal class WindowInfoImpl : WindowInfo {
     private val _isWindowFocused = mutableStateOf(false)
+    private val _size = mutableStateOf(IntSize.Zero)
 
     override var isWindowFocused: Boolean
         set(value) { _isWindowFocused.value = value }
@@ -61,7 +64,9 @@ internal class WindowInfoImpl : WindowInfo {
         set(value) { GlobalKeyboardModifiers.value = value }
 
     @ExperimentalComposeUiApi
-    override var size: IntSize = IntSize.Zero
+    override var size: IntSize
+        get() = _size.value
+        set(value) { _size.value = value }
 
     companion object {
         // One instance across all windows makes sense, since the state of KeyboardModifiers is

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHeightIsEqualTo
+import androidx.compose.ui.test.assertWidthIsEqualTo
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class WindowInfoTest {
+
+    @Test
+    fun windowContainerSize() = runSkikoComposeUiTest(
+        size = Size(123f, 321f)
+    ) {
+        setContent {
+            Box(Modifier.fillMaxSize().testTag("box"))
+
+            val containerSize = LocalWindowInfo.current.containerSize
+            assertEquals(123, containerSize.width)
+            assertEquals(321, containerSize.height)
+        }
+        onNodeWithTag("box").assertWidthIsEqualTo(123.dp)
+        onNodeWithTag("box").assertHeightIsEqualTo(321.dp)
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -183,6 +183,10 @@ internal actual class ComposeWindow : UIViewController {
             }
         }
 
+    private val _windowInfo = WindowInfoImpl().apply {
+        isWindowFocused = true
+    }
+
     @OverrideInit
     actual constructor() : super(nibName = null, bundle = null)
 
@@ -341,15 +345,19 @@ internal actual class ComposeWindow : UIViewController {
     }
 
     private fun updateLayout(context: AttachedComposeContext) {
-        context.scene.density = density
-        context.scene.constraints = view.frame.useContents {
-            val scale = density.density
-
-            Constraints(
-                maxWidth = (size.width * scale).roundToInt(),
-                maxHeight = (size.height * scale).roundToInt()
+        val scale = density.density
+        val size = view.frame.useContents {
+            IntSize(
+                width = (size.width * scale).roundToInt(),
+                height = (size.height * scale).roundToInt()
             )
         }
+        _windowInfo.size = size
+        context.scene.density = density
+        context.scene.constraints = Constraints(
+            maxWidth = size.width,
+            maxHeight = size.height
+        )
 
         context.view.needRedraw()
     }
@@ -523,6 +531,8 @@ internal actual class ComposeWindow : UIViewController {
         val inputTraits = inputServices.skikoUITextInputTraits
 
         val platform = object : Platform by Platform.Empty {
+            override val windowInfo: WindowInfo
+                get() = _windowInfo
             override val textInputService: PlatformTextInputService = inputServices
             override val viewConfiguration =
                 object : ViewConfiguration {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -352,7 +352,7 @@ internal actual class ComposeWindow : UIViewController {
                 height = (size.height * scale).roundToInt()
             )
         }
-        _windowInfo.size = size
+        _windowInfo.containerSize = size
         context.scene.density = density
         context.scene.constraints = Constraints(
             maxWidth = size.width,


### PR DESCRIPTION
## Proposed Changes

- Add `WindowInfo.containerSize` public API

It requires for max available space calculation in some material components.

## Testing

Test: Try to get window size via `LocalWindowInfo.current`
