### PR TITLE
Add actual Trace implementation for darwin source set

### DIFF
--- a/compose/runtime/runtime/src/darwinMain/kotlin/androidx/compose/runtime/Trace.darwin.kt
+++ b/compose/runtime/runtime/src/darwinMain/kotlin/androidx/compose/runtime/Trace.darwin.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.usePinned
+import platform.darwin.OS_SIGNPOST_INTERVAL_BEGIN
+import platform.darwin.OS_SIGNPOST_INTERVAL_END
+import platform.darwin.__dso_handle
+import platform.darwin._os_signpost_emit_with_name_impl
+import platform.darwin.os_log_create
+import platform.darwin.os_signpost_enabled
+import platform.darwin.os_signpost_id_generate
+import platform.darwin.os_signpost_id_t
+import platform.darwin.os_signpost_type_t
+
+data class DarwinSignpostInterval(
+    val name: String,
+    val id: os_signpost_id_t
+)
+
+internal class DarwinSignposter(category: String) {
+    private val log = os_log_create(subsystem = "androidx.compose", category = category)
+    private val buf = UByteArray(1024)
+    private fun event(id: os_signpost_id_t, name: String, type: os_signpost_type_t) {
+        buf.usePinned { pinned ->
+            _os_signpost_emit_with_name_impl(
+                __dso_handle.ptr,
+                log,
+                type,
+                id,
+                name,
+                format = "",
+                buf = pinned.addressOf(0),
+                size = 1024u
+            )
+        }
+    }
+
+    fun begin(name: String) = if (os_signpost_enabled(log)) {
+        os_signpost_id_generate(log).let { id ->
+            event(id, name, OS_SIGNPOST_INTERVAL_BEGIN)
+
+            DarwinSignpostInterval(name, id)
+        }
+    } else {
+        null
+    }
+
+    fun end(interval: DarwinSignpostInterval) {
+        event(interval.id, interval.name, OS_SIGNPOST_INTERVAL_END)
+    }
+}
+
+internal actual object Trace {
+    val signposter = DarwinSignposter(category = "runtime")
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    actual fun beginSection(name: String): Any? =
+        signposter.begin(name)
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    actual fun endSection(token: Any?) {
+        if (token != null) {
+            signposter.end(token as DarwinSignpostInterval)
+        }
+    }
+}

--- a/compose/runtime/runtime/src/darwinMain/kotlin/androidx/compose/runtime/Trace.darwin.kt
+++ b/compose/runtime/runtime/src/darwinMain/kotlin/androidx/compose/runtime/Trace.darwin.kt
@@ -29,12 +29,12 @@ import platform.darwin.os_signpost_id_generate
 import platform.darwin.os_signpost_id_t
 import platform.darwin.os_signpost_type_t
 
-data class DarwinSignpostInterval(
+internal data class DarwinSignpostInterval(
     val name: String,
     val id: os_signpost_id_t
 )
 
-class DarwinSignposter(category: String) {
+internal class DarwinSignposter(category: String) {
     private val log = os_log_create(subsystem = "androidx.compose", category = category)
     private val buf = UByteArray(1024)
     private fun event(id: os_signpost_id_t, name: String, type: os_signpost_type_t) {

--- a/compose/runtime/runtime/src/linuxX64Main/kotlin/androidx/compose/runtime/Trace.linuxX64.kt
+++ b/compose/runtime/runtime/src/linuxX64Main/kotlin/androidx/compose/runtime/Trace.linuxX64.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+internal actual object Trace {
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    actual fun beginSection(name: String): Any? {
+        return null
+    }
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    actual fun endSection(token: Any?) {
+    }
+
+}

--- a/compose/runtime/runtime/src/mingwX64Main/kotlin/androidx/compose/runtime/Trace.mingwX64.kt
+++ b/compose/runtime/runtime/src/mingwX64Main/kotlin/androidx/compose/runtime/Trace.mingwX64.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+internal actual object Trace {
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    actual fun beginSection(name: String): Any? {
+        return null
+    }
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    actual fun endSection(token: Any?) {
+    }
+
+}

--- a/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/ActualNative.native.kt
+++ b/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/ActualNative.native.kt
@@ -92,15 +92,6 @@ private class MonotonicClockImpl : MonotonicFrameClock {
     }
 }
 
-internal actual object Trace {
-    actual fun beginSection(name: String): Any? {
-        return null
-    }
-
-    actual fun endSection(token: Any?) {
-    }
-}
-
 actual annotation class CheckResult actual constructor(actual val suggest: String)
 
 @ExperimentalComposeApi

--- a/compose/ui/ui/src/darwinMain/kotlin/androidx/compose/ui/Trace.darwin.kt
+++ b/compose/ui/ui/src/darwinMain/kotlin/androidx/compose/ui/Trace.darwin.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.runtime.DarwinSignpostInterval
+import androidx.compose.runtime.DarwinSignposter
+
+// Copy of compose.runtime.Trace
+internal actual object Trace {
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    actual fun beginSection(name: String): Any? =
+        DarwinSignposter.runtime.begin(name)
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    actual fun endSection(token: Any?) {
+        if (token != null) {
+            DarwinSignposter.runtime.end(token as DarwinSignpostInterval)
+        }
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/Trace.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/Trace.desktop.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+// Copy of compose.runtime.Trace
+internal actual object Trace {
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    actual fun beginSection(name: String): Any? {
+        return null
+    }
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    actual fun endSection(token: Any?) {
+    }
+
+}

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/Trace.jsWasm.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/Trace.jsWasm.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+// Copy of compose.runtime.Trace
+internal actual object Trace {
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    actual fun beginSection(name: String): Any? {
+        return null
+    }
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    actual fun endSection(token: Any?) {
+    }
+
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -696,7 +696,7 @@ class ComposeScene internal constructor(
         }
     }
 
-    private fun processPointerInput(event: PointerInputEvent) {
+    private fun processPointerInput(event: PointerInputEvent) = trace("ComposeScene:processPointerInput") {
         when (event.eventType) {
             PointerEventType.Press -> processPress(event)
             PointerEventType.Release -> processRelease(event)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -512,7 +512,6 @@ class ComposeScene internal constructor(
         trace("ComposeScene:sendAndPerformSnapshotChanges") {
             Snapshot.sendApplyNotifications()
             snapshotChanges.perform()
-
         }
 
     internal fun hitTestInteropView(position: Offset): Boolean {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -541,18 +541,18 @@ class ComposeScene internal constructor(
      * animations in the content (or any other code, which uses [withFrameNanos]
      */
     fun render(canvas: Canvas, nanoTime: Long): Unit = postponeInvalidation {
-        trace("ComposeScene:render") {
-            recomposeDispatcher.flush()
+        recomposeDispatcher.flush()
+        trace("BroadcastFrameClock:sendFrame") {
             frameClock.sendFrame(nanoTime) // Recomposition
-            sendAndPerformSnapshotChanges() // Apply changes from recomposition phase to layout phase
-            needLayout = false
-            forEachOwner { it.measureAndLayout() }
-            syntheticEventSender.updatePointerPosition()
-            sendAndPerformSnapshotChanges()  // Apply changes from layout phase to draw phase
-            needDraw = false
-            forEachOwner { it.draw(canvas) }
-            forEachOwner { it.clearInvalidObservations() }
         }
+        sendAndPerformSnapshotChanges() // Apply changes from recomposition phase to layout phase
+        needLayout = false
+        forEachOwner { it.measureAndLayout() }
+        syntheticEventSender.updatePointerPosition()
+        sendAndPerformSnapshotChanges()  // Apply changes from layout phase to draw phase
+        needDraw = false
+        forEachOwner { it.draw(canvas) }
+        forEachOwner { it.clearInvalidObservations() }
     }
 
     private var focusedOwner: SkiaBasedOwner? = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -508,12 +508,12 @@ class ComposeScene internal constructor(
     /**
      * Sends any pending apply notifications and performs the changes they cause.
      */
-    private fun sendAndPerformSnapshotChanges() {
+    private fun sendAndPerformSnapshotChanges() =
         trace("ComposeScene:sendAndPerformSnapshotChanges") {
             Snapshot.sendApplyNotifications()
             snapshotChanges.perform()
+
         }
-    }
 
     internal fun hitTestInteropView(position: Offset): Boolean {
         // TODO:

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -509,8 +509,10 @@ class ComposeScene internal constructor(
      * Sends any pending apply notifications and performs the changes they cause.
      */
     private fun sendAndPerformSnapshotChanges() {
-        Snapshot.sendApplyNotifications()
-        snapshotChanges.perform()
+        trace("ComposeScene:sendAndPerformSnapshotChanges") {
+            Snapshot.sendApplyNotifications()
+            snapshotChanges.perform()
+        }
     }
 
     internal fun hitTestInteropView(position: Offset): Boolean {
@@ -539,16 +541,18 @@ class ComposeScene internal constructor(
      * animations in the content (or any other code, which uses [withFrameNanos]
      */
     fun render(canvas: Canvas, nanoTime: Long): Unit = postponeInvalidation {
-        recomposeDispatcher.flush()
-        frameClock.sendFrame(nanoTime) // Recomposition
-        sendAndPerformSnapshotChanges() // Apply changes from recomposition phase to layout phase
-        needLayout = false
-        forEachOwner { it.measureAndLayout() }
-        syntheticEventSender.updatePointerPosition()
-        sendAndPerformSnapshotChanges()  // Apply changes from layout phase to draw phase
-        needDraw = false
-        forEachOwner { it.draw(canvas) }
-        forEachOwner { it.clearInvalidObservations() }
+        trace("ComposeScene:render") {
+            recomposeDispatcher.flush()
+            frameClock.sendFrame(nanoTime) // Recomposition
+            sendAndPerformSnapshotChanges() // Apply changes from recomposition phase to layout phase
+            needLayout = false
+            forEachOwner { it.measureAndLayout() }
+            syntheticEventSender.updatePointerPosition()
+            sendAndPerformSnapshotChanges()  // Apply changes from layout phase to draw phase
+            needDraw = false
+            forEachOwner { it.draw(canvas) }
+            forEachOwner { it.clearInvalidObservations() }
+        }
     }
 
     private var focusedOwner: SkiaBasedOwner? = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -83,7 +83,7 @@ internal class SyntheticEventSender(
         sendInternal(event)
     }
 
-    fun updatePointerPosition() {
+    fun updatePointerPosition() = trace("SyntheticEventSender::updatePointerPosition") {
         if (needUpdatePointerPosition) {
             needUpdatePointerPosition = false
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/Trace.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/Trace.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+// Copy of compose.runtime.Trace
+internal expect object Trace {
+    /**
+     * Writes a trace message to indicate that a given section of code has begun.
+     * This call must be followed by a corresponding call to [endSection] on the same thread.
+     *
+     * @return An arbitrary token which will be supplied to the corresponding call
+     * to [endSection]. May be null.
+     */
+    fun beginSection(name: String): Any?
+
+    /**
+     * Writes a trace message to indicate that a given section of code has ended.
+     * This call must be preceded by a corresponding call to [beginSection].
+     * Calling this method will mark the end of the most recently begun section of code, so care
+     * must be taken to ensure that `beginSection` / `endSection` pairs are properly nested and
+     * called from the same thread.
+     *
+     * @param token The instance returned from the corresponding call to [beginSection].
+     */
+    fun endSection(token: Any?)
+}
+
+/**
+ * Wrap the specified [block] in calls to [Trace.beginSection] (with the supplied [sectionName])
+ * and [Trace.endSection].
+ */
+internal inline fun <T> trace(sectionName: String, block: () -> T): T {
+    val token = Trace.beginSection(sectionName)
+    try {
+        return block()
+    } finally {
+        Trace.endSection(token)
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.synchronized
 import androidx.compose.ui.createSynchronizedObject
+import androidx.compose.ui.trace
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -76,12 +77,14 @@ internal class FlushCoroutineDispatcher(
      * performing in the [scope]
      */
     fun flush() = performRun {
-        synchronized(tasksLock) {
-            tasksCopy.addAll(tasks)
-            tasks.clear()
+        trace("FlushCoroutineDispatcher:flush") {
+            synchronized(tasksLock) {
+                tasksCopy.addAll(tasks)
+                tasks.clear()
+            }
+            tasksCopy.forEach(Runnable::run)
+            tasksCopy.clear()
         }
-        tasksCopy.forEach(Runnable::run)
-        tasksCopy.clear()
     }
 
     // the lock is needed to be certain that all tasks will be completed after `flush` method

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -241,18 +241,20 @@ internal class SkiaBasedOwner(
         private set
 
     override fun measureAndLayout(sendPointerUpdate: Boolean) {
-        measureAndLayoutDelegate.updateRootConstraints(constraints)
-        if (
-            measureAndLayoutDelegate.measureAndLayout {
-                if (sendPointerUpdate) {
-                    onPointerUpdate()
+        trace("SkiaBasedOwner:measureAndLayout") {
+            measureAndLayoutDelegate.updateRootConstraints(constraints)
+            if (
+                measureAndLayoutDelegate.measureAndLayout {
+                    if (sendPointerUpdate) {
+                        onPointerUpdate()
+                    }
                 }
+            ) {
+                requestDraw?.invoke()
             }
-        ) {
-            requestDraw?.invoke()
+            measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
+            contentSize = computeContentSize()
         }
-        measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
-        contentSize = computeContentSize()
     }
 
     override fun measureAndLayout(layoutNode: LayoutNode, constraints: Constraints) {
@@ -349,7 +351,9 @@ internal class SkiaBasedOwner(
     override fun screenToLocal(positionOnScreen: Offset): Offset = positionOnScreen
 
     fun draw(canvas: org.jetbrains.skia.Canvas) {
-        root.draw(canvas.asComposeCanvas())
+        trace("SkiaBasedOwner:draw") {
+            root.draw(canvas.asComposeCanvas())
+        }
     }
 
     internal fun processPointerInput(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -230,7 +230,7 @@ internal class SkiaBasedOwner(
 
     private var needClearObservations = false
 
-    fun clearInvalidObservations() {
+    fun clearInvalidObservations() = trace("SkiaBasedOwner:clearInvalidObservations") {
         if (needClearObservations) {
             snapshotObserver.clearInvalidObservations()
             needClearObservations = false

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -240,21 +240,19 @@ internal class SkiaBasedOwner(
     var contentSize = IntSize.Zero
         private set
 
-    override fun measureAndLayout(sendPointerUpdate: Boolean) {
-        trace("SkiaBasedOwner:measureAndLayout") {
-            measureAndLayoutDelegate.updateRootConstraints(constraints)
-            if (
-                measureAndLayoutDelegate.measureAndLayout {
-                    if (sendPointerUpdate) {
-                        onPointerUpdate()
-                    }
+    override fun measureAndLayout(sendPointerUpdate: Boolean) = trace("SkiaBasedOwner:measureAndLayout") {
+        measureAndLayoutDelegate.updateRootConstraints(constraints)
+        if (
+            measureAndLayoutDelegate.measureAndLayout {
+                if (sendPointerUpdate) {
+                    onPointerUpdate()
                 }
-            ) {
-                requestDraw?.invoke()
             }
-            measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
-            contentSize = computeContentSize()
+        ) {
+            requestDraw?.invoke()
         }
+        measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
+        contentSize = computeContentSize()
     }
 
     override fun measureAndLayout(layoutNode: LayoutNode, constraints: Constraints) {
@@ -350,10 +348,8 @@ internal class SkiaBasedOwner(
 
     override fun screenToLocal(positionOnScreen: Offset): Offset = positionOnScreen
 
-    fun draw(canvas: org.jetbrains.skia.Canvas) {
-        trace("SkiaBasedOwner:draw") {
-            root.draw(canvas.asComposeCanvas())
-        }
+    fun draw(canvas: org.jetbrains.skia.Canvas) = trace("SkiaBasedOwner:draw") {
+        root.draw(canvas.asComposeCanvas())
     }
 
     internal fun processPointerInput(


### PR DESCRIPTION
## Proposed Changes

Add `os_signpost` implementation for `compose.runtime.Trace` for `darwin` source set.
Copy `Trace` implementation to the `skiko` source set for `compose.ui` (it's internal in `compose.runtime`). Add traces to some hot paths of the `skiko` source set.
Allows us to perform fine-grain performance analysis in Xcode Instruments:
<img width="541" alt="Screenshot 2023-09-05 at 11 11 58" src="https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/1b759c55-79e2-49b2-a3f2-195b666b8636">

## Testing

Test: N/A