### PR TITLE
Use CADisplayLink.targetTimestamp value as an argument for frameClock.sendFrame

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -38,7 +38,9 @@ import androidx.compose.ui.platform.*
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.uikit.*
 import androidx.compose.ui.unit.*
+import kotlin.math.floor
 import kotlin.math.roundToInt
+import kotlin.math.roundToLong
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
@@ -47,7 +49,6 @@ import kotlinx.cinterop.useContents
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.SkikoKeyboardEvent
 import org.jetbrains.skiko.SkikoPointerEvent
-import org.jetbrains.skiko.currentNanoTime
 import platform.CoreGraphics.CGAffineTransformIdentity
 import platform.CoreGraphics.CGAffineTransformInvert
 import platform.CoreGraphics.CGPoint
@@ -637,8 +638,16 @@ internal actual class ComposeWindow : UIViewController {
             override fun retrieveCATransactionCommands(): List<() -> Unit> =
                 interopContext.getActionsAndClear()
 
-            override fun draw(surface: Surface) {
-                scene.render(surface.canvas, currentNanoTime())
+            override fun draw(surface: Surface, targetTimestamp: NSTimeInterval) {
+                // The calculation is split in two instead of
+                // `(targetTimestamp * 1e9).toLong()`
+                // to avoid losing precision for fractional part
+                val integral = floor(targetTimestamp)
+                val fractional = targetTimestamp - integral
+                val secondsToNanos = 1_000_000_000L
+                val nanos = integral.roundToLong() * secondsToNanos + (fractional * 1e9).roundToLong()
+
+                scene.render(surface.canvas, nanos)
             }
         }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -169,6 +169,9 @@ internal class MetalRedrawer(
             displayLinkConditions.needsToBeProactive = value
         }
 
+    /**
+     * null after [dispose] call
+     */
     private var caDisplayLink: CADisplayLink? = CADisplayLink.displayLinkWithTarget(
         target = DisplayLinkProxy {
             this.handleDisplayLinkTick()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -243,12 +243,17 @@ internal class MetalRedrawer(
     private fun draw(reason: DrawReason) {
         check(NSThread.isMainThread)
 
-        val targetTimestamp = caDisplayLink?.targetTimestamp
+        val caDisplayLink = caDisplayLink
 
-        if (targetTimestamp == null) {
+        if (caDisplayLink == null) {
             // TODO: anomaly, log
             // Logger.warn { "caDisplayLink callback called after it was invalidated " }
             return
+        }
+
+        val targetTimestamp = when(reason) {
+            DrawReason.DISPLAY_LINK_CALLBACK -> caDisplayLink.targetTimestamp
+            DrawReason.SYNCHRONOUS_DRAW_REQUEST -> CACurrentMediaTime()
         }
 
         autoreleasepool {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -255,7 +255,7 @@ internal class MetalRedrawer(
             return
         }
 
-        // If called outside of unpaused CADisplayLink scope, targetTimestamp doesn't contain valid value
+        // If called outside of unpaused CADisplayLink scope, targetTimestamp doesn't contain a valid value
         val targetTimestamp = when (reason) {
             DrawReason.DISPLAY_LINK_CALLBACK -> caDisplayLink.targetTimestamp
             DrawReason.SYNCHRONOUS_DRAW_REQUEST -> CACurrentMediaTime()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -31,6 +31,7 @@ import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.darwin.*
 import kotlin.math.roundToInt
 import platform.Foundation.NSThread
+import platform.Foundation.NSTimeInterval
 
 private class DisplayLinkConditions(
     val setPausedCallback: (Boolean) -> Unit
@@ -120,14 +121,24 @@ private enum class DrawReason {
     DISPLAY_LINK_CALLBACK, SYNCHRONOUS_DRAW_REQUEST
 }
 
+internal interface MetalRedrawerCallbacks {
+    /**
+     * Draw into a surface.
+     *
+     * @param surface The surface to be drawn.
+     * @param targetTimestamp Timestamp indicating the expected draw result presentation time. Implementation should forward its internal time clock to this targetTimestamp to achieve smooth visual change cadence.
+     */
+    fun draw(surface: Surface, targetTimestamp: NSTimeInterval)
+
+    /**
+     * Retrieve a list of pending actions which need to be synchronized with Metal rendering using CATransaction mechanism.
+     */
+    fun retrieveCATransactionCommands(): List<() -> Unit>
+}
+
 internal class MetalRedrawer(
     private val metalLayer: CAMetalLayer,
-    private val drawCallback: (Surface) -> Unit,
-    private val retrieveCATransactionCommands: () -> List<() -> Unit>,
-
-    // Used for tests, access to NSRunLoop crashes in test environment
-    addDisplayLinkToRunLoop: ((CADisplayLink) -> Unit)? = null,
-    private val disposeCallback: (MetalRedrawer) -> Unit = { }
+    private val callbacks: MetalRedrawerCallbacks,
 ) {
     // Workaround for KN compiler bug
     // Type mismatch: inferred type is objcnames.protocols.MTLDeviceProtocol but platform.Metal.MTLDeviceProtocol was expected
@@ -191,17 +202,11 @@ internal class MetalRedrawer(
         // so we compare the state with UIApplicationStateBackground instead of UIApplicationStateActive
         displayLinkConditions.isApplicationActive = UIApplication.sharedApplication.applicationState != UIApplicationState.UIApplicationStateBackground
 
-        if (addDisplayLinkToRunLoop == null) {
-            caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
-        } else {
-            addDisplayLinkToRunLoop.invoke(caDisplayLink)
-        }
+        caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
     }
 
     fun dispose() {
         check(caDisplayLink != null) { "MetalRedrawer.dispose() was called more than once" }
-
-        disposeCallback(this)
 
         applicationStateListener.dispose()
 
@@ -238,7 +243,9 @@ internal class MetalRedrawer(
     private fun draw(reason: DrawReason) {
         check(NSThread.isMainThread)
 
-        if (caDisplayLink == null) {
+        val targetTimestamp = caDisplayLink?.targetTimestamp
+
+        if (targetTimestamp == null) {
             // TODO: anomaly, log
             // Logger.warn { "caDisplayLink callback called after it was invalidated " }
             return
@@ -285,10 +292,10 @@ internal class MetalRedrawer(
             }
 
             surface.canvas.clear(Color.WHITE)
-            drawCallback(surface)
+            callbacks.draw(surface, targetTimestamp)
             surface.flushAndSubmit()
 
-            val caTransactionCommands = retrieveCATransactionCommands()
+            val caTransactionCommands = callbacks.retrieveCATransactionCommands()
             val presentsWithTransaction = isForcedToPresentWithTransactionEveryFrame || caTransactionCommands.isNotEmpty()
 
             metalLayer.presentsWithTransaction = presentsWithTransaction

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -255,7 +255,7 @@ internal class MetalRedrawer(
             return
         }
 
-        // If called outside of unpaused CADisplayLink context, targetTimestamp doesn't contain valid values
+        // If called outside of unpaused CADisplayLink scope, targetTimestamp doesn't contain valid value
         val targetTimestamp = when (reason) {
             DrawReason.DISPLAY_LINK_CALLBACK -> caDisplayLink.targetTimestamp
             DrawReason.SYNCHRONOUS_DRAW_REQUEST -> CACurrentMediaTime()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -51,7 +51,7 @@ internal interface SkikoUIViewDelegate {
 
     fun retrieveCATransactionCommands(): List<() -> Unit>
 
-    fun draw(surface: Surface)
+    fun draw(surface: Surface, targetTimestamp: NSTimeInterval)
 }
 
 @Suppress("CONFLICTING_OVERLOADS")
@@ -78,11 +78,13 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
     private var _currentTextMenuActions: TextActions? = null
     private val _redrawer: MetalRedrawer = MetalRedrawer(
         _metalLayer,
-        drawCallback = { surface: Surface ->
-            delegate?.draw(surface)
-        },
-        retrieveCATransactionCommands = {
-            delegate?.retrieveCATransactionCommands() ?: listOf()
+        callbacks = object : MetalRedrawerCallbacks {
+            override fun draw(surface: Surface, targetTimestamp: NSTimeInterval) {
+                delegate?.draw(surface, targetTimestamp)
+            }
+
+            override fun retrieveCATransactionCommands(): List<() -> Unit> =
+                delegate?.retrieveCATransactionCommands() ?: listOf()
         }
     )
 


### PR DESCRIPTION
## Proposed changes

Use `CADisplayLink.targetTimestamp` instead of current immediate timestamp for moving the `ComposeScene.frameClock`.
Aggregate MetalRedrawer callbacks into a single interface object. Remove for-test callbacks, copied from and previously used in skiko tests.

## Testing

Test: N/A

## Issues Fixed

Fixes: `withFrameNanos` depending on actual execution time and not vsync timeline.