### PR TITLE
iOS textfield scroll to caret and one line before

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.android.kt
@@ -19,7 +19,22 @@ package androidx.compose.foundation.text
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 
 @ExperimentalFoundationApi
 @Composable
 internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null
+
+internal actual fun Modifier.textFieldScroll(
+    scrollerPosition: TextFieldScrollerPosition,
+    textFieldValue: TextFieldValue,
+    visualTransformation: VisualTransformation,
+    textLayoutResultProvider: () -> TextLayoutResultProxy?
+): Modifier = defaultTextFieldScroll(
+    scrollerPosition,
+    textFieldValue,
+    visualTransformation,
+    textLayoutResultProvider,
+)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
@@ -126,7 +126,14 @@ private inline fun createScrollableState(
 }
 
 // Layout
-internal fun Modifier.textFieldScroll(
+internal expect fun Modifier.textFieldScroll(
+    scrollerPosition: TextFieldScrollerPosition,
+    textFieldValue: TextFieldValue,
+    visualTransformation: VisualTransformation,
+    textLayoutResultProvider: () -> TextLayoutResultProxy?
+): Modifier
+
+internal fun Modifier.defaultTextFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.desktop.kt
@@ -1,0 +1,17 @@
+package androidx.compose.foundation.text
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+
+internal actual fun Modifier.textFieldScroll(
+    scrollerPosition: TextFieldScrollerPosition,
+    textFieldValue: TextFieldValue,
+    visualTransformation: VisualTransformation,
+    textLayoutResultProvider: () -> TextLayoutResultProxy?
+): Modifier = defaultTextFieldScroll(
+    scrollerPosition,
+    textFieldValue,
+    visualTransformation,
+    textLayoutResultProvider,
+)

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.jsWasm.kt
@@ -19,7 +19,22 @@ package androidx.compose.foundation.text
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 
 @ExperimentalFoundationApi
 @Composable
 internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null
+
+internal actual fun Modifier.textFieldScroll(
+    scrollerPosition: TextFieldScrollerPosition,
+    textFieldValue: TextFieldValue,
+    visualTransformation: VisualTransformation,
+    textLayoutResultProvider: () -> TextLayoutResultProxy?
+): Modifier = defaultTextFieldScroll(
+    scrollerPosition,
+    textFieldValue,
+    visualTransformation,
+    textLayoutResultProvider,
+)

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.macos.kt
@@ -19,7 +19,22 @@ package androidx.compose.foundation.text
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 
 @ExperimentalFoundationApi
 @Composable
 internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = null
+
+internal actual fun Modifier.textFieldScroll(
+    scrollerPosition: TextFieldScrollerPosition,
+    textFieldValue: TextFieldValue,
+    visualTransformation: VisualTransformation,
+    textLayoutResultProvider: () -> TextLayoutResultProxy?
+): Modifier = defaultTextFieldScroll(
+    scrollerPosition,
+    textFieldValue,
+    visualTransformation,
+    textLayoutResultProvider,
+)

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
@@ -57,7 +57,7 @@ internal actual fun Modifier.textFieldScroll(
 
     val layout = when (orientation) {
         Orientation.Vertical ->
-            VerticalScrollLayoutModifier(
+            IOSVerticalScrollLayoutModifier(
                 scrollerPosition,
                 cursorOffset,
                 transformedText,
@@ -65,7 +65,7 @@ internal actual fun Modifier.textFieldScroll(
             )
 
         Orientation.Horizontal ->
-            HorizontalScrollLayoutModifier(
+            IOSHorizontalScrollLayoutModifier(
                 scrollerPosition,
                 cursorOffset,
                 transformedText,
@@ -75,7 +75,7 @@ internal actual fun Modifier.textFieldScroll(
     return this.clipToBounds().then(layout)
 }
 
-private data class VerticalScrollLayoutModifier(
+private data class IOSVerticalScrollLayoutModifier(
     val scrollerPosition: TextFieldScrollerPosition,
     val cursorOffset: Int,
     val transformedText: TransformedText,
@@ -125,7 +125,7 @@ private data class VerticalScrollLayoutModifier(
 /**
  * Copied from commonMain source set.
  */
-private data class HorizontalScrollLayoutModifier(
+private data class IOSHorizontalScrollLayoutModifier(
     val scrollerPosition: TextFieldScrollerPosition,
     val cursorOffset: Int,
     val transformedText: TransformedText,

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
@@ -18,9 +18,182 @@ package androidx.compose.foundation.text
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
+import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 @ExperimentalFoundationApi
 @Composable
-internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? = rememberOverscrollEffect()
+internal actual fun rememberTextFieldOverscrollEffect(): OverscrollEffect? =
+    rememberOverscrollEffect()
+
+internal actual fun Modifier.textFieldScroll(
+    scrollerPosition: TextFieldScrollerPosition,
+    textFieldValue: TextFieldValue,
+    visualTransformation: VisualTransformation,
+    textLayoutResultProvider: () -> TextLayoutResultProxy?
+): Modifier {
+    val orientation = scrollerPosition.orientation
+    val cursorOffset = scrollerPosition.getOffsetToFollow(textFieldValue.selection)
+    scrollerPosition.previousSelection = textFieldValue.selection
+
+    val transformedText = visualTransformation.filterWithValidation(textFieldValue.annotatedString)
+
+    val layout = when (orientation) {
+        Orientation.Vertical ->
+            VerticalScrollLayoutModifier(
+                scrollerPosition,
+                cursorOffset,
+                transformedText,
+                textLayoutResultProvider
+            )
+
+        Orientation.Horizontal ->
+            HorizontalScrollLayoutModifier(
+                scrollerPosition,
+                cursorOffset,
+                transformedText,
+                textLayoutResultProvider
+            )
+    }
+    return this.clipToBounds().then(layout)
+}
+
+private data class VerticalScrollLayoutModifier(
+    val scrollerPosition: TextFieldScrollerPosition,
+    val cursorOffset: Int,
+    val transformedText: TransformedText,
+    val textLayoutResultProvider: () -> TextLayoutResultProxy?
+) : LayoutModifier {
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val childConstraints = constraints.copy(maxHeight = Constraints.Infinity)
+        val placeable = measurable.measure(childConstraints)
+        val height = min(placeable.height, constraints.maxHeight)
+
+        return layout(placeable.width, height) {
+            val textLayoutResult = textLayoutResultProvider()?.value
+            val cursorRect = getCursorRectInScroller(
+                cursorOffset = cursorOffset,
+                transformedText = transformedText,
+                textLayoutResult = textLayoutResult,
+                rtl = false,
+                textFieldWidth = placeable.width
+            )
+
+            val additionalDeltaY = if (textLayoutResult != null) {
+                // On iOS we will scroll to one line before the cursor:
+                val scrollToLine = textLayoutResult.getLineForOffset(cursorOffset) - 1
+                textLayoutResult.multiParagraph.getLineHeight(
+                    lineIndex = scrollToLine.coerceAtLeast(0)
+                )
+            } else {
+                0f
+            }
+
+            scrollerPosition.update(
+                orientation = Orientation.Vertical,
+                cursorRect = cursorRect.copy(top = cursorRect.top - additionalDeltaY),
+                containerSize = height,
+                textFieldSize = placeable.height
+            )
+
+            val offset = -scrollerPosition.offset
+            placeable.placeRelative(0, offset.roundToInt())
+        }
+    }
+}
+
+/**
+ * Copied from commonMain source set.
+ */
+private data class HorizontalScrollLayoutModifier(
+    val scrollerPosition: TextFieldScrollerPosition,
+    val cursorOffset: Int,
+    val transformedText: TransformedText,
+    val textLayoutResultProvider: () -> TextLayoutResultProxy?
+) : LayoutModifier {
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        // If the maxIntrinsicWidth of the children is already smaller than the constraint, pass
+        // the original constraints so that the children has more information to  determine its
+        // size.
+        val maxIntrinsicWidth = measurable.maxIntrinsicWidth(constraints.maxHeight)
+        val childConstraints = if (maxIntrinsicWidth < constraints.maxWidth) {
+            constraints
+        } else {
+            constraints.copy(maxWidth = Constraints.Infinity)
+        }
+        val placeable = measurable.measure(childConstraints)
+        val width = min(placeable.width, constraints.maxWidth)
+
+        return layout(width, placeable.height) {
+            val cursorRect = getCursorRectInScroller(
+                cursorOffset = cursorOffset,
+                transformedText = transformedText,
+                textLayoutResult = textLayoutResultProvider()?.value,
+                rtl = layoutDirection == LayoutDirection.Rtl,
+                textFieldWidth = placeable.width
+            )
+
+            scrollerPosition.update(
+                orientation = Orientation.Horizontal,
+                cursorRect = cursorRect,
+                containerSize = width,
+                textFieldSize = placeable.width
+            )
+
+            val offset = -scrollerPosition.offset
+            placeable.placeRelative(offset.roundToInt(), 0)
+        }
+    }
+}
+
+/**
+ * Copied from commonMain source set.
+ */
+private fun Density.getCursorRectInScroller(
+    cursorOffset: Int,
+    transformedText: TransformedText,
+    textLayoutResult: TextLayoutResult?,
+    rtl: Boolean,
+    textFieldWidth: Int
+): Rect {
+    val cursorRect = textLayoutResult?.getCursorRect(
+        transformedText.offsetMapping.originalToTransformed(cursorOffset)
+    ) ?: Rect.Zero
+    val thickness = DefaultCursorThickness.roundToPx()
+
+    val cursorLeft = if (rtl) {
+        textFieldWidth - cursorRect.left - thickness
+    } else {
+        cursorRect.left
+    }
+
+    val cursorRight = if (rtl) {
+        textFieldWidth - cursorRect.left
+    } else {
+        cursorRect.left + thickness
+    }
+    return cursorRect.copy(left = cursorLeft, right = cursorRight)
+}

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.uikit.kt
@@ -101,10 +101,9 @@ private data class IOSVerticalScrollLayoutModifier(
 
             val additionalDeltaY = if (textLayoutResult != null) {
                 // On iOS we will scroll to one line before the cursor:
-                val scrollToLine = textLayoutResult.getLineForOffset(cursorOffset) - 1
-                textLayoutResult.multiParagraph.getLineHeight(
-                    lineIndex = scrollToLine.coerceAtLeast(0)
-                )
+                val cursorLine = textLayoutResult.getLineForOffset(cursorOffset)
+                val scrollToLine = (cursorLine - 1).coerceAtLeast(0)
+                textLayoutResult.multiParagraph.getLineHeight(scrollToLine)
             } else {
                 0f
             }


### PR DESCRIPTION
## Proposed Changes

  - Change logic when TextField scrolls to carret on iOS

## Testing

Test: 
 - Run iOS Demo
 - Open TextField, Almost Fullscreen example
 - Tap and place carret on 3-th line of text
 - Scroll TextField to the bottom
 - Start typing
 - TextField should be scrolled to 2-nd line of text

## Issues Fixed
https://youtrack.jetbrains.com/issue/COMPOSE-391/M3-iOS-TextField-scroll-to-carret
