### PR TITLE
Enable Metal performance HUD

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -47,8 +47,11 @@ import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import org.jetbrains.skia.Surface
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.SkikoKeyboardEvent
 import org.jetbrains.skiko.SkikoPointerEvent
+import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGAffineTransformIdentity
 import platform.CoreGraphics.CGAffineTransformInvert
 import platform.CoreGraphics.CGPoint
@@ -167,15 +170,9 @@ internal actual class ComposeWindow : UIViewController {
      */
     private val currentInterfaceOrientation: InterfaceOrientation?
         get() {
-            // Flag for checking which API to use
             // Modern: https://developer.apple.com/documentation/uikit/uiwindowscene/3198088-interfaceorientation?language=objc
             // Deprecated: https://developer.apple.com/documentation/uikit/uiapplication/1623026-statusbarorientation?language=objc
-            val supportsWindowSceneApi =
-                NSProcessInfo.processInfo.operatingSystemVersion.useContents {
-                    majorVersion >= 13
-                }
-
-            return if (supportsWindowSceneApi) {
+            return if (available(OS.Ios to OSVersion(13))) {
                 view.window?.windowScene?.interfaceOrientation?.let {
                     InterfaceOrientation.getByRawValue(it)
                 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -16,7 +16,9 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.uikit.PlistSanityCheck
 import androidx.compose.ui.util.fastForEach
+import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.*
 import org.jetbrains.skia.*
 import platform.Foundation.NSNotificationCenter
@@ -30,6 +32,13 @@ import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.darwin.*
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
+import platform.Foundation.NSBundle
+import platform.Foundation.NSNumber
 import platform.Foundation.NSThread
 import platform.Foundation.NSTimeInterval
 
@@ -207,6 +216,8 @@ internal class MetalRedrawer(
             UIApplication.sharedApplication.applicationState != UIApplicationState.UIApplicationStateBackground
 
         caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
+
+        configureMetalHUDIfNeeded()
     }
 
     fun dispose() {
@@ -342,6 +353,23 @@ internal class MetalRedrawer(
 
             if (waitUntilCompletion) {
                 commandBuffer.waitUntilCompleted()
+            }
+        }
+    }
+
+    private fun configureMetalHUDIfNeeded() {
+        if (available(OS.Ios to OSVersion(16))) {
+            val entry = NSBundle
+                .mainBundle
+                .objectForInfoDictionaryKey("MetalHudEnabled") as? NSNumber
+
+            if (entry?.boolValue == true) {
+                dispatch_async(dispatch_get_main_queue()) {
+                    metalLayer.developerHUDProperties = mapOf(
+                        "mode" to "default",
+                        "logging" to "default"
+                    )
+                }
             }
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -364,12 +364,10 @@ internal class MetalRedrawer(
                 .objectForInfoDictionaryKey("MetalHudEnabled") as? NSNumber
 
             if (entry?.boolValue == true) {
-                dispatch_async(dispatch_get_main_queue()) {
-                    metalLayer.developerHUDProperties = mapOf(
-                        "mode" to "default",
-                        "logging" to "default"
-                    )
-                }
+                metalLayer.developerHUDProperties = mapOf(
+                    "mode" to "default",
+                    "logging" to "default"
+                )
             }
         }
     }


### PR DESCRIPTION
## Proposed Changes

If `Info.plist` contains `MetalHudEnabled` set to true, configure CAMetalLayer to show performance hud.
Update availability check logic to use `available` API from skiko in ComposeWindow.

## Testing

Test: N/A

![IMG_3A8D66B7D2B9-1](https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/d12bb049-b0b1-4524-bf2c-093ed875ec07)
