### PR TITLE
iOS TextField fast delete

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/FastDelete.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/FastDelete.kt
@@ -1,0 +1,23 @@
+package androidx.compose.mpp.demo.textfield
+
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+
+@Composable
+fun FastDelete() {
+    val textState = remember {
+        mutableStateOf(
+            """
+                Place carret at the end of this TextField. Press and hold delete previous button.
+                Where are 21 digits at the end. After sequentially removing 21 symbols, iOS starts to remove bigger token.
+                For example 2 words simultaneously.
+                And some emoji 👨‍👩‍👧‍👦 👨 👩 👧 👦.
+                Check    a    lot    of     spaces     in    once      sentence          here.
+                Aaa aaa bbb bbb ccc ccc ddd ddd eee eee fff fff 012345678901234567890
+            """.trimIndent()
+        )
+    }
+    TextField(textState.value, { textState.value = it })
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -53,7 +53,12 @@ val TextFields = Screen.Selection(
         ClearFocusBox {
             EmojiExample()
         }
-    }
+    },
+    Screen.Example("FastDelete") {
+        ClearFocusBox {
+            FastDelete()
+        }
+    },
 )
 
 @Composable

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
@@ -16,6 +16,9 @@
 
 package androidx.compose.ui.platform
 
+import platform.UIKit.UITextDirection
+import platform.UIKit.UITextGranularity
+
 internal interface IOSSkikoInput {
 
     /**
@@ -107,6 +110,21 @@ internal interface IOSSkikoInput {
      */
     fun positionFromPosition(position: Long, offset: Long): Long
 
+    /**
+     * Return the range for the text enclosing a text position in a text unit of a given granularity in a given direction.
+     * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614464-rangeenclosingposition?language=objc
+     * @param position
+     * A text-position object that represents a location in a document.
+     * @param granularity
+     * A constant that indicates a certain granularity of text unit.
+     * @param direction
+     * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+     * @return
+     * A text-range representing a text unit of the given granularity in the given direction, or nil if there is no such enclosing unit.
+     * Whether a boundary position is enclosed depends on the given direction, using the same rule as the isPosition:withinTextUnit:inDirection: method.
+     */
+    fun rangeEnclosingPosition(position: Int, withGranularity: UITextGranularity, inDirection: UITextDirection): IntRange?
+
     object Empty : IOSSkikoInput {
         override fun hasText(): Boolean = false
         override fun insertText(text: String) = Unit
@@ -121,5 +139,10 @@ internal interface IOSSkikoInput {
         override fun markedTextRange(): IntRange? = null
         override fun unmarkText() = Unit
         override fun positionFromPosition(position: Long, offset: Long): Long = 0
+        override fun rangeEnclosingPosition(
+            position: Int,
+            withGranularity: UITextGranularity,
+            inDirection: UITextDirection
+        ): IntRange? = null
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -510,8 +510,89 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
         return to.position - fromPosition.position
     }
 
-    override fun tokenizer(): UITextInputTokenizerProtocol {
-        return UITextInputStringTokenizer()
+    override fun tokenizer(): UITextInputTokenizerProtocol = @Suppress("CONFLICTING_OVERLOADS") object : UITextInputStringTokenizer() {
+
+        /**
+         * Return whether a text position is at a boundary of a text unit of a specified granularity in a specified direction.
+         * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614553-isposition?language=objc
+         * @param position
+         * A text-position object that represents a location in a document.
+         * @param granularity
+         * A constant that indicates a certain granularity of text unit.
+         * @param direction
+         * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+         * @return
+         * TRUE if the text position is at the given text-unit boundary in the given direction; FALSE if it is not at the boundary.
+         */
+        override fun isPosition(
+            position: UITextPosition,
+            atBoundary: UITextGranularity,
+            inDirection: UITextDirection
+        ): Boolean = TODO("implement isPosition")
+
+        /**
+         * Return whether a text position is within a text unit of a specified granularity in a specified direction.
+         * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition?language=objc
+         * @param position
+         * A text-position object that represents a location in a document.
+         * @param granularity
+         * A constant that indicates a certain granularity of text unit.
+         * @param direction
+         * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+         * @return
+         * TRUE if the text position is within a text unit of the specified granularity in the specified direction; otherwise, return FALSE.
+         * If the text position is at a boundary, return TRUE only if the boundary is part of the text unit in the given direction.
+         */
+        override fun isPosition(
+            position: UITextPosition,
+            withinTextUnit: UITextGranularity,
+            inDirection: UITextDirection
+        ): Boolean = TODO("implement isPosition")
+
+        /**
+         * Return the next text position at a boundary of a text unit of the given granularity in a given direction.
+         * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614513-positionfromposition?language=objc
+         * @param position
+         * A text-position object that represents a location in a document.
+         * @param granularity
+         * A constant that indicates a certain granularity of text unit.
+         * @param direction
+         * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+         * @return
+         * The next boundary position of a text unit of the given granularity in the given direction, or nil if there is no such position.
+         */
+        override fun positionFromPosition(
+            position: UITextPosition,
+            toBoundary: UITextGranularity,
+            inDirection: UITextDirection
+        ): UITextPosition? = null
+
+        /**
+         * Return the range for the text enclosing a text position in a text unit of a given granularity in a given direction.
+         * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614464-rangeenclosingposition?language=objc
+         * @param position
+         * A text-position object that represents a location in a document.
+         * @param granularity
+         * A constant that indicates a certain granularity of text unit.
+         * @param direction
+         * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+         * @return
+         * A text-range representing a text unit of the given granularity in the given direction, or nil if there is no such enclosing unit.
+         * Whether a boundary position is enclosed depends on the given direction, using the same rule as the isPosition:withinTextUnit:inDirection: method.
+         */
+        override fun rangeEnclosingPosition(
+            position: UITextPosition,
+            withGranularity: UITextGranularity,
+            inDirection: UITextDirection
+        ): UITextRange? {
+            position as IntermediateTextPosition
+            return input?.rangeEnclosingPosition(
+                position = position.position.toInt(),
+                withGranularity = withGranularity,
+                inDirection = inDirection
+            )?.toUITextRange()
+        }
+
     }
 
     override fun positionWithinRange(range: UITextRange, atCharacterOffset: NSInteger): UITextPosition? =


### PR DESCRIPTION
## Proposed Changes

  - Added fast delete feature after removing simultaneously 21 characters with software keybaord.

## Testing

Open example TextFields / Fast delete

## Issues Fixed

https://youtrack.jetbrains.com/issue/COMPOSE-395/M3-TextField-fast-delete-turbo-mode