### PR TITLE
Fix SearchBar key event condition

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SearchBar.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SearchBar.kt
@@ -80,8 +80,10 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
@@ -457,7 +459,7 @@ private fun SearchBarInputField(
             .focusRequester(focusRequester)
             .onFocusChanged { if (it.isFocused) onActiveChange(true) }
             .onKeyEvent {
-                if (it.key == Key.Escape) {
+                if (it.key == Key.Escape && it.type == KeyEventType.KeyDown) {
                     onActiveChange(false)
                     true
                 } else {


### PR DESCRIPTION
## Proposed Changes

Addition to #801

## Testing

Test: Don't change the state in `onActiveChange`, press `Esc` - it was called twice
