### PR TITLE
Fix  remember calls in k/js decoys

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/SubstituteDecoyCallsTransformer.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/SubstituteDecoyCallsTransformer.kt
@@ -150,7 +150,7 @@ class SubstituteDecoyCallsTransformer(
             constructorTypeArgumentsCount = expression.constructorTypeArgumentsCount
         ).let {
             it.copyTypeAndValueArgumentsFrom(expression)
-            return@let it.copyWithNewTypeParams(callee, actualConstructor)
+            it
         }
 
         return super.visitConstructorCall(updatedCall)
@@ -175,7 +175,7 @@ class SubstituteDecoyCallsTransformer(
             valueArgumentsCount = expression.valueArgumentsCount,
         ).let {
             it.copyTypeAndValueArgumentsFrom(expression)
-            return@let it.copyWithNewTypeParams(callee, actualConstructor)
+            it
         }
 
         return super.visitDelegatingConstructorCall(updatedCall)
@@ -200,7 +200,7 @@ class SubstituteDecoyCallsTransformer(
             superQualifierSymbol = expression.superQualifierSymbol
         ).let {
             it.copyTypeAndValueArgumentsFrom(expression)
-            return@let it.copyWithNewTypeParams(callee, actualFunction)
+            it
         }
         return super.visitCall(updatedCall)
     }
@@ -224,7 +224,7 @@ class SubstituteDecoyCallsTransformer(
             reflectionTarget = expression.reflectionTarget
         ).let {
             it.copyTypeAndValueArgumentsFrom(expression)
-            return@let it.copyWithNewTypeParams(callee, actualFunction)
+            it
         }
         return super.visitFunctionReference(updatedReference)
     }


### PR DESCRIPTION
Such a snippet:

```kotlin
val a = remember { object {} }
```
used to break  `compose:mpp:demo:jsRun` (it would break users apps too when some new components are used)
```
java.lang.IllegalStateException: Not found Idx for androidx.compose.material3/ExposedDropdownMenuBox$composable|1568894224144511070[0]
```

this comitt fixes it.
____

This commit removes extra `copyWithNewTypeParams` for calls. It led to new type generation for an anonymous object which didn't the type of 'val a'.

Note: Run all tests + tried some new cases, and tested with compose:mpp:demo. This change didn't reveal any new issues. But there is chance it can break something we don't know yet.


__
P.S. it's also fixed in the compiler plugin for 1.9.20-Beta - https://github.com/JetBrains/compose-multiplatform-core/commits/release/compiler-integration-1.5.2.1 
