### PR TITLE
Implementation of defaultTimePickerLayoutType

### DIFF
--- a/compose/material3/material3/src/androidMain/kotlin/androidx/compose/material3/TimePicker.android.kt
+++ b/compose/material3/material3/src/androidMain/kotlin/androidx/compose/material3/TimePicker.android.kt
@@ -21,9 +21,10 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalConfiguration
 
 @OptIn(ExperimentalMaterial3Api::class)
-internal actual val defaultTimePickerLayoutType: TimePickerLayoutType
-    @Composable
-    @ReadOnlyComposable get() = with(LocalConfiguration.current) {
+@Composable
+@ReadOnlyComposable
+internal actual fun defaultTimePickerLayoutType(): TimePickerLayoutType =
+    with(LocalConfiguration.current) {
         if (screenHeightDp < screenWidthDp) {
             TimePickerLayoutType.Horizontal
         } else {

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
@@ -1586,7 +1586,7 @@ private enum class LayoutId {
     Selector, InnerCircle,
 }
 
-// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) revert to expect get()
+// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) fix expect composable getter
 @OptIn(ExperimentalMaterial3Api::class)
 internal val defaultTimePickerLayoutType: TimePickerLayoutType
     @Composable

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
@@ -1586,10 +1586,16 @@ private enum class LayoutId {
     Selector, InnerCircle,
 }
 
+// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) revert to expect get()
 @OptIn(ExperimentalMaterial3Api::class)
-internal expect val defaultTimePickerLayoutType: TimePickerLayoutType
+internal val defaultTimePickerLayoutType: TimePickerLayoutType
     @Composable
-    @ReadOnlyComposable get
+    @ReadOnlyComposable get() = defaultTimePickerLayoutType()
+
+@Composable
+@ReadOnlyComposable
+@OptIn(ExperimentalMaterial3Api::class)
+internal expect fun defaultTimePickerLayoutType() : TimePickerLayoutType
 
 @kotlin.jvm.JvmInline
 internal value class Selection private constructor(val value: Int) {

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimePicker.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimePicker.skiko.kt
@@ -16,6 +16,19 @@
 
 package androidx.compose.material3
 
-@OptIn(ExperimentalMaterial3Api::class)
-internal actual val defaultTimePickerLayoutType: TimePickerLayoutType =
-    TimePickerLayoutType.Vertical
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.LocalWindowInfo
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+internal actual val defaultTimePickerLayoutType: TimePickerLayoutType
+    @Composable
+    @ReadOnlyComposable get() = with(LocalWindowInfo.current) {
+        if (containerSize.height < containerSize.width) {
+            TimePickerLayoutType.Horizontal
+        } else {
+            TimePickerLayoutType.Vertical
+        }
+    }
+

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimePicker.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimePicker.skiko.kt
@@ -22,13 +22,15 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalWindowInfo
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
-internal actual val defaultTimePickerLayoutType: TimePickerLayoutType
-    @Composable
-    @ReadOnlyComposable get() = with(LocalWindowInfo.current) {
+@Composable
+@ReadOnlyComposable
+internal actual fun defaultTimePickerLayoutType(): TimePickerLayoutType {
+    return with(LocalWindowInfo.current) {
         if (containerSize.height < containerSize.width) {
             TimePickerLayoutType.Horizontal
         } else {
             TimePickerLayoutType.Vertical
         }
     }
+}
 


### PR DESCRIPTION
## Proposed Changes

Implementation of `defaultTimePickerLayoutType` with the new `WindowInfo` api. 
Copy of the [Android](https://github.com/JetBrains/compose-multiplatform-core/blob/jb-main/compose/material3/material3/src/androidMain/kotlin/androidx/compose/material3/TimePicker.android.kt) implementation.

## Testing

Test: display timepicker with different window aspect ratio

