### PR TITLE
Remove ExperimentalComposeUiApi from keyboardModifiers

### DIFF
--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowInfo.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/WindowInfo.android.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
  * Provides information about the Window that is hosting this compose hierarchy.
  */
 @Stable
+@JvmDefaultWithCompatibility
 actual interface WindowInfo {
     /**
      * Indicates whether the window hosting this compose hierarchy is in focus.
@@ -41,8 +42,10 @@ actual interface WindowInfo {
     /**
      * Indicates the state of keyboard modifiers (pressed or not).
      */
-    @ExperimentalComposeUiApi
+    @Suppress("OPT_IN_MARKER_ON_WRONG_TARGET")
+    @get:ExperimentalComposeUiApi
     actual val keyboardModifiers: PointerKeyboardModifiers
+        get() = WindowInfoImpl.GlobalKeyboardModifiers.value
 }
 
 internal class WindowInfoImpl : WindowInfo {

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/WindowInfo.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/WindowInfo.kt
@@ -23,11 +23,13 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.internal.JvmDefaultWithCompatibility
 
 /**
  * Provides information about the Window that is hosting this compose hierarchy.
  */
 @Stable
+@JvmDefaultWithCompatibility
 expect interface WindowInfo {
     /**
      * Indicates whether the window hosting this compose hierarchy is in focus.
@@ -41,8 +43,11 @@ expect interface WindowInfo {
     /**
      * Indicates the state of keyboard modifiers (pressed or not).
      */
-    @ExperimentalComposeUiApi
-    val keyboardModifiers: PointerKeyboardModifiers
+    // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-412/Remove-getExperimentalComposeUiApi-from-val-keyboardModifiers)
+    //  remove get:ExperimentalComposeUiApi, as it actually isn't experimental
+    @Suppress("OPT_IN_MARKER_ON_WRONG_TARGET")
+    @get:ExperimentalComposeUiApi
+    open val keyboardModifiers: PointerKeyboardModifiers
 }
 
 @Composable

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/WindowInfo.skiko.kt
@@ -23,12 +23,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.pointer.EmptyPointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.internal.JvmDefaultWithCompatibility
 import androidx.compose.ui.unit.IntSize
 
 /**
  * Provides information about the Window that is hosting this compose hierarchy.
  */
 @Stable
+@JvmDefaultWithCompatibility
 actual interface WindowInfo {
     /**
      * Indicates whether the window hosting this compose hierarchy is in focus.
@@ -42,14 +44,16 @@ actual interface WindowInfo {
     /**
      * Indicates the state of keyboard modifiers (pressed or not).
      */
-    @ExperimentalComposeUiApi
+    @Suppress("OPT_IN_MARKER_ON_WRONG_TARGET")
+    @get:ExperimentalComposeUiApi
     actual val keyboardModifiers: PointerKeyboardModifiers
+        get() = WindowInfoImpl.GlobalKeyboardModifiers.value
 
     /**
      * Size of the window's content container in pixels.
      */
     @ExperimentalComposeUiApi
-    val containerSize: IntSize
+    val containerSize: IntSize get() = IntSize.Zero
 }
 
 internal class WindowInfoImpl : WindowInfo {


### PR DESCRIPTION
Fixes a CI fail:
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_AllGitHubRelease/4313900?buildTab=dependencies&mode=list&state=failed&type=snapshot&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true&showLog=4313895_245_235.297&logFilter=debug&logView=flowAware#4313895

As it was before https://github.com/JetBrains/compose-multiplatform-core/pull/785

Also:
- add default getters for source compatibility
- add JvmDefaultWithCompatibility to keep binary compatibility on JVM

## Testing
```
import androidx.compose.ui.platform.LocalWindowInfo
import androidx.compose.ui.window.singleWindowApplication

fun main() = singleWindowApplication {
    val modifiers = LocalWindowInfo.current.keyboardModifiers
}

```
This shouldn't require OptIn