### PR TITLE
Don't send redundant synthetic moves.

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -51,7 +51,6 @@ internal class SyntheticEventSender(
      */
     var needUpdatePointerPosition: Boolean = false
 
-
     fun reset() {
         needUpdatePointerPosition = false
         previousEvent = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -51,6 +51,7 @@ internal class SyntheticEventSender(
      */
     var needUpdatePointerPosition: Boolean = false
 
+
     fun reset() {
         needUpdatePointerPosition = false
         previousEvent = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventData
+import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.util.fastAny
 
 /**
@@ -70,7 +71,7 @@ internal class SyntheticEventSender(
             needUpdatePointerPosition = false
 
             previousEvent?.let { event ->
-                if (event.pointers.fastAny { it.down }) {
+                if (event.pointers.fastAny { it.down || it.type == PointerType.Mouse }) {
                     sendSyntheticMove(event)
                 }
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SyntheticEventSender.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventData
+import androidx.compose.ui.util.fastAny
 
 /**
  * Compose or user code can't work well if we miss some events.
@@ -67,7 +68,12 @@ internal class SyntheticEventSender(
     fun updatePointerPosition() {
         if (needUpdatePointerPosition) {
             needUpdatePointerPosition = false
-            previousEvent?.let { sendSyntheticMove(it) }
+
+            previousEvent?.let { event ->
+                if (event.pointers.fastAny { it.down }) {
+                    sendSyntheticMove(event)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Only send synthetic moves when at least one touch is down or input source is a mouse.

## Testing

Test: N/A

## Issues Fixed

Fixes: redundant computations every frame.
