### PR TITLE
Fix Compose Role.Tab to correctly translate to Java's AccessibleRole.PAGE_TAB

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
@@ -383,28 +383,25 @@ internal class ComposeAccessible(
 
         override fun getAccessibleRole(): AccessibleRole {
             controller?.notifyIsInUse()
-            when (semanticsNode.config.getOrNull(SemanticsProperties.Role)) {
-                Role.Button -> return AccessibleRole.PUSH_BUTTON
-                Role.Checkbox -> return AccessibleRole.CHECK_BOX
-                Role.RadioButton -> return AccessibleRole.RADIO_BUTTON
+            val fromSemanticRole = when (semanticsNode.config.getOrNull(SemanticsProperties.Role)) {
+                Role.Button -> AccessibleRole.PUSH_BUTTON
+                Role.Checkbox -> AccessibleRole.CHECK_BOX
+                Role.RadioButton -> AccessibleRole.RADIO_BUTTON
                 Role.Tab -> AccessibleRole.PAGE_TAB
+                else -> null
                 // ?
                 //  Role.Switch ->
                 //  Role.Image ->
             }
-            if (isPassword) {
-                return AccessibleRole.PASSWORD_TEXT
+
+            return when {
+                fromSemanticRole != null -> fromSemanticRole
+                isPassword -> AccessibleRole.PASSWORD_TEXT
+                scrollBy != null -> AccessibleRole.SCROLL_PANE
+                setText != null -> AccessibleRole.TEXT
+                text != null -> AccessibleRole.LABEL
+                else -> AccessibleRole.PANEL
             }
-            if (scrollBy != null) {
-                return AccessibleRole.SCROLL_PANE
-            }
-            if (setText != null) {
-                return AccessibleRole.TEXT
-            }
-            if (text != null) {
-                return AccessibleRole.LABEL
-            }
-            return AccessibleRole.PANEL
         }
 
         override fun getAccessibleStateSet(): AccessibleStateSet {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -16,10 +16,15 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.assertThat
+import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleText
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -56,4 +61,24 @@ class AccessibilityTest {
         assertEquals("world", accessibleText.getBeforeIndex(AccessibleText.WORD, 21))
         assertEquals("Hi world", accessibleText.getBeforeIndex(AccessibleText.SENTENCE, 21))
     }
+
+    @Test
+    fun tabHasPageTabAccessibleRole() {
+        rule.setContent {
+            TabRow(selectedTabIndex = 0) {
+                Tab(
+                    selected = true,
+                    onClick = { },
+                    modifier = Modifier.testTag("tab"),
+                    text = { Text("Tab") }
+                )
+            }
+        }
+
+        val node = rule.onNodeWithTag("tab").fetchSemanticsNode()
+        val accessibleNode = ComposeAccessible(node)
+        assertThat(accessibleNode.accessibleContext.accessibleRole)
+            .isEqualTo(AccessibleRole.PAGE_TAB)
+    }
+
 }


### PR DESCRIPTION
Previously there was a missing `return` which caused it to not be translated.

## Testing

Test: Added a test.

## Issues Fixed

Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-184/Role.Tab-is-not-supported