### PR TITLE
Fix `RootLayout` platform padding usage

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/PopupAndDialog.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/PopupAndDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text as Text3
 import androidx.compose.material3.TextField as TextField3
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -51,10 +52,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.launch
 
@@ -167,9 +172,13 @@ private fun PopupSample() {
     var popup1 by remember { mutableStateOf(0) }
     var popup2 by remember { mutableStateOf(0) }
     var popup3 by remember { mutableStateOf(0) }
+    var popupMax by remember { mutableStateOf(false) }
     Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
         Button(onClick = { popup1++ }) {
             Text("Popup")
+        }
+        Button(onClick = { popupMax = true }) {
+            Text("Popup (max size)")
         }
     }
     if (popup1 > 0) {
@@ -197,6 +206,27 @@ private fun PopupSample() {
             focusable = false,
             onClose = { popup3 = 0 }
         )
+    }
+    if (popupMax) {
+        Popup(
+            popupPositionProvider = object : PopupPositionProvider {
+                override fun calculatePosition(
+                    anchorBounds: IntRect,
+                    windowSize: IntSize,
+                    layoutDirection: LayoutDirection,
+                    popupContentSize: IntSize
+                ): IntOffset {
+                    return IntOffset.Zero
+                }
+            },
+            onDismissRequest = { popupMax = false }
+        ) {
+            Box(Modifier
+                .fillMaxSize()
+                .background(Color.Yellow)
+                .clickable { popupMax = false }
+            )
+        }
     }
 }
 

--- a/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
+++ b/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
@@ -18,8 +18,7 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntOffset
 
 @Composable
-internal actual fun Density.platformOffset(): IntOffset =
-    IntOffset.Zero
+internal actual fun Density.platformPadding(): RootLayoutPadding =
+    RootLayoutPadding.Zero

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.center
 
@@ -178,7 +177,7 @@ private fun DialogLayout(
         val density = LocalDensity.current
         val measurePolicy = rememberDialogMeasurePolicy(
             properties = properties,
-            platformOffset = with(density) { platformOffset() }
+            platformPadding = with(density) { platformPadding() }
         ) {
             owner.bounds = it
         }
@@ -192,14 +191,16 @@ private fun DialogLayout(
 @Composable
 private fun rememberDialogMeasurePolicy(
     properties: DialogProperties,
-    platformOffset: IntOffset,
+    platformPadding: RootLayoutPadding,
     onBoundsChanged: (IntRect) -> Unit
-) = remember(properties, platformOffset, onBoundsChanged) {
+) = remember(properties, platformPadding, onBoundsChanged) {
     RootMeasurePolicy(
-        platformOffset = platformOffset,
+        platformPadding = platformPadding,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { windowSize, contentSize ->
-        val position = windowSize.center - contentSize.center
+        val position = positionWithPadding(platformPadding, windowSize) {
+            it.center - contentSize.center
+        }
         onBoundsChanged(IntRect(position, contentSize))
         position
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -434,7 +434,7 @@ private fun PopupLayout(
         val measurePolicy = rememberPopupMeasurePolicy(
             popupPositionProvider = popupPositionProvider,
             properties = properties,
-            platformOffset = with(density) { platformOffset() },
+            platformPadding = with(density) { platformPadding() },
             layoutDirection = layoutDirection,
             parentBounds = parentBounds
         ) {
@@ -461,18 +461,20 @@ private fun Modifier.parentBoundsInWindow(
 private fun rememberPopupMeasurePolicy(
     popupPositionProvider: PopupPositionProvider,
     properties: PopupProperties,
-    platformOffset: IntOffset,
+    platformPadding: RootLayoutPadding,
     layoutDirection: LayoutDirection,
     parentBounds: IntRect,
     onBoundsChanged: (IntRect) -> Unit
-) = remember(popupPositionProvider, properties, platformOffset, layoutDirection, parentBounds, onBoundsChanged) {
+) = remember(popupPositionProvider, properties, platformPadding, layoutDirection, parentBounds, onBoundsChanged) {
     RootMeasurePolicy(
-        platformOffset = platformOffset,
+        platformPadding = platformPadding,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { windowSize, contentSize ->
-        var position = popupPositionProvider.calculatePosition(
-            parentBounds, windowSize, layoutDirection, contentSize
-        )
+        var position = positionWithPadding(platformPadding, windowSize) {
+            popupPositionProvider.calculatePosition(
+                parentBounds, it, layoutDirection, contentSize
+            )
+        }
         if (properties.clippingEnabled) {
             position = IntOffset(
                 x = position.x.coerceIn(0, windowSize.width - contentSize.width),

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
@@ -20,15 +20,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.ui.uikit.LocalSafeAreaState
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntOffset
-import kotlin.math.max
 
 @OptIn(InternalComposeApi::class)
 @Composable
-internal actual fun Density.platformOffset(): IntOffset =
+internal actual fun Density.platformPadding(): RootLayoutPadding =
     with(LocalSafeAreaState.current.value) {
-        IntOffset(
-            x = max(left.roundToPx(), right.roundToPx()),
-            y = max(top.roundToPx(), bottom.roundToPx())
+        RootLayoutPadding(
+            left = left.roundToPx(),
+            top = top.roundToPx(),
+            right = right.roundToPx(),
+            bottom = bottom.roundToPx()
         )
     }


### PR DESCRIPTION
## Proposed Changes

- Apply more insets in `RootLayout` without assuming that it will be centered
- Center relatively content area instead of screen (matches Android now)

Test | Before | After
--- | --- | ---
`Popup` / max size / zero offset | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/a3bfef0f-002c-4dab-ad85-58f4a8e88060" height="600"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/ec8dd32c-f12b-4e5b-a987-00631678d24c" height="600">
`Dialog` / max size / center | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/ce216f77-5be4-43fa-ae78-df666ee96517" height="600"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/8e9820b4-99cd-44a1-80fc-68d7b4887b53" height="600">

## Testing

Test: run mpp on iOS or try to use maximized `Popup` on device with safe-area

## Issues Fixed

Fixes (partially) https://github.com/JetBrains/compose-multiplatform/issues/3701