### PR TITLE
Fix `ModalBottomSheetPopup` parameters

### DIFF
--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
@@ -49,6 +49,7 @@ internal actual fun ModalBottomSheetPopup(
         },
         onDismissRequest = onDismissRequest,
         properties = PopupProperties(
+            focusable = true,
             usePlatformInsets = false
         )
     ) {

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
@@ -18,10 +18,9 @@ package androidx.compose.material3
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.exclude
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -29,8 +28,10 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
 
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal actual fun ModalBottomSheetPopup(
     onDismissRequest: () -> Unit,
@@ -46,9 +47,12 @@ internal actual fun ModalBottomSheetPopup(
                 popupContentSize: IntSize
             ) = IntOffset.Zero
         },
-        onDismissRequest = onDismissRequest
+        onDismissRequest = onDismissRequest,
+        properties = PopupProperties(
+            usePlatformInsets = false
+        )
     ) {
-        Box(Modifier.windowInsetsPadding(windowInsets.exclude(WindowInsets.systemBars))) {
+        Box(Modifier.windowInsetsPadding(windowInsets)) {
             content()
         }
     }

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
@@ -18,10 +18,17 @@ package androidx.compose.material3
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 
 
 @Composable
@@ -31,9 +38,17 @@ internal actual fun ModalBottomSheetPopup(
     content: @Composable () -> Unit,
 ) {
     Popup(
+        popupPositionProvider = object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize
+            ) = IntOffset.Zero
+        },
         onDismissRequest = onDismissRequest
     ) {
-        Box(Modifier.windowInsetsPadding(windowInsets)) {
+        Box(Modifier.windowInsetsPadding(windowInsets.exclude(WindowInsets.systemBars))) {
             content()
         }
     }


### PR DESCRIPTION
## Proposed Changes

- Position `ModalBottomSheet` not relative to parent
- Exclude default `Popup`'s insets

Before | After
--- | ---
<img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/fe7b4b1b-8c12-49d7-9f4c-9c72af6d05cd" height="600"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/176a56ec-9469-4603-b0e8-153fa6c9318a" height="600">

## Testing

Test: run mpp on iOS or try to use `ModalBottomSheetPopup` on device with safe-area

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3701, https://github.com/JetBrains/compose-multiplatform/issues/3703
