### PR TITLE
Fix internal-testutils-kmp project sync

### DIFF
--- a/testutils/testutils-kmp/build.gradle
+++ b/testutils/testutils-kmp/build.gradle
@@ -14,18 +14,27 @@
  * limitations under the License.
  */
 
+
+import androidx.build.AndroidXComposePlugin
 import androidx.build.LibraryType
 
 plugins {
     id("AndroidXPlugin")
+    id("AndroidXComposePlugin")
 }
 
-androidXMultiplatform {
-    jvm {}
-    mac()
-    linux()
-    ios()
+AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
 
+androidXComposeMultiplatform {
+    desktop()
+    darwin()
+    js()
+    wasm()
+
+    configureDarwinFlags()
+}
+
+kotlin {
     sourceSets {
         commonMain {
             dependencies {
@@ -59,4 +68,8 @@ androidXMultiplatform {
 
 androidx {
     type = LibraryType.INTERNAL_TEST_LIBRARY
+}
+
+androidxCompose {
+    composeCompilerPluginEnabled = false
 }


### PR DESCRIPTION
It fixes this error during IDE sync:
```
Failed to resolve platform dependency on jsTest
org.gradle.internal.resolve.ModuleVersionResolveException: Could not resolve project :internal-testutils-kmp.
Required by:
    project :compose:foundation:foundation
Caused by: org.gradle.internal.component.NoMatchingConfigurationSelectionException: No matching variant of project :internal-testutils-kmp was found. The consumer was configured to find a library for use during 'kotlin-api', preferably optimized for non-jvm, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'js', attribute 'org.jetbrains.kotlin.js.compiler' with value 'ir' but: