### PR TITLE
Fix applying `WindowInsets` inside `Popup`/`Dialog`

### DIFF
--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalLayoutMargins
 import androidx.compose.ui.platform.LocalSafeArea
 import androidx.compose.ui.platform.PlatformInsets
@@ -32,7 +33,7 @@ import androidx.compose.ui.unit.dp
 
 private val ZeroInsets = WindowInsets(0, 0, 0, 0)
 
-@OptIn(InternalComposeApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Stable
 private class PlatformWindowInsets(
     private val provider: ProvidableCompositionLocal<PlatformInsets>
@@ -69,7 +70,7 @@ private class PlatformWindowInsets(
  */
 private val WindowInsets.Companion.iosSafeArea: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class)
+    @OptIn(InternalComposeApi::class, ExperimentalComposeUiApi::class)
     get() = PlatformWindowInsets(LocalSafeArea)
 
 /**
@@ -77,7 +78,7 @@ private val WindowInsets.Companion.iosSafeArea: WindowInsets
  */
 private val WindowInsets.Companion.layoutMargins: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class)
+    @OptIn(InternalComposeApi::class, ExperimentalComposeUiApi::class)
     get() = PlatformWindowInsets(LocalLayoutMargins)
 
 /**

--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -37,7 +37,7 @@ private fun IOSInsets.toWindowInsets() = WindowInsets(
 private val WindowInsets.Companion.iosSafeArea: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class)
-    get() = LocalSafeAreaState.current.value.toWindowInsets()
+    get() = LocalSafeArea.current.toWindowInsets()
 
 /**
  * This insets represents iOS layoutMargins.
@@ -45,7 +45,7 @@ private val WindowInsets.Companion.iosSafeArea: WindowInsets
 private val WindowInsets.Companion.layoutMargins: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class)
-    get() = LocalLayoutMarginsState.current.value.toWindowInsets()
+    get() = LocalLayoutMargins.current.toWindowInsets()
 
 /**
  * An insets type representing the window of a caption bar.

--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -18,52 +18,22 @@ package androidx.compose.foundation.layout
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.InternalComposeApi
-import androidx.compose.runtime.ProvidableCompositionLocal
-import androidx.compose.runtime.Stable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalLayoutMargins
 import androidx.compose.ui.platform.LocalSafeArea
 import androidx.compose.ui.platform.PlatformInsets
-import androidx.compose.ui.uikit.InterfaceOrientation
-import androidx.compose.ui.uikit.LocalInterfaceOrientationState
-import androidx.compose.ui.uikit.LocalKeyboardOverlapHeightState
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.uikit.*
 import androidx.compose.ui.unit.dp
 
 private val ZeroInsets = WindowInsets(0, 0, 0, 0)
 
 @OptIn(ExperimentalComposeUiApi::class)
-@Stable
-private class PlatformWindowInsets(
-    private val provider: ProvidableCompositionLocal<PlatformInsets>
-) : WindowInsets {
-    private val insets
-        get() = provider.current
-
-    override fun getLeft(density: Density, layoutDirection: LayoutDirection): Int =
-        with(density) { insets.left.roundToPx() }
-
-    override fun getTop(density: Density): Int =
-        with(density) { insets.top.roundToPx() }
-
-    override fun getRight(density: Density, layoutDirection: LayoutDirection): Int =
-        with(density) { insets.right.roundToPx() }
-
-    override fun getBottom(density: Density): Int =
-        with(density) { insets.bottom.roundToPx() }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is PlatformWindowInsets) return false
-
-        return provider == other.provider
-    }
-
-    override fun hashCode(): Int = provider.hashCode()
-
-    override fun toString(): String = insets.toString()
-}
+private fun PlatformInsets.toWindowInsets() = WindowInsets(
+    top = top,
+    bottom = bottom,
+    left = left,
+    right = right,
+)
 
 /**
  * This insets represents iOS SafeAreas.
@@ -71,7 +41,7 @@ private class PlatformWindowInsets(
 private val WindowInsets.Companion.iosSafeArea: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class, ExperimentalComposeUiApi::class)
-    get() = PlatformWindowInsets(LocalSafeArea)
+    get() = LocalSafeArea.current.toWindowInsets()
 
 /**
  * This insets represents iOS layoutMargins.
@@ -79,7 +49,7 @@ private val WindowInsets.Companion.iosSafeArea: WindowInsets
 private val WindowInsets.Companion.layoutMargins: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class, ExperimentalComposeUiApi::class)
-    get() = PlatformWindowInsets(LocalLayoutMargins)
+    get() = LocalLayoutMargins.current.toWindowInsets()
 
 /**
  * An insets type representing the window of a caption bar.

--- a/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
+++ b/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
@@ -17,8 +17,12 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.unit.Density
 
 @Composable
-internal actual fun Density.platformPadding(): RootLayoutPadding =
+internal actual fun platformPadding(): RootLayoutPadding =
     RootLayoutPadding.Zero
+
+@Composable
+internal actual fun platformOwnerContent(content: @Composable () -> Unit) {
+    content()
+}

--- a/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
+++ b/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
@@ -17,10 +17,13 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.ui.platform.PlatformInsets
 
+@OptIn(InternalComposeApi::class)
 @Composable
-internal actual fun platformPadding(): RootLayoutPadding =
-    RootLayoutPadding.Zero
+internal actual fun platformInsets(): PlatformInsets =
+    PlatformInsets.Zero
 
 @Composable
 internal actual fun platformOwnerContent(content: @Composable () -> Unit) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformInsets.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformInsets.skiko.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * This class represents platform insets.
+ */
+@Immutable
+@InternalComposeApi
+class PlatformInsets(
+    @Stable
+    val top: Dp = 0.dp,
+    @Stable
+    val bottom: Dp = 0.dp,
+    @Stable
+    val left: Dp = 0.dp,
+    @Stable
+    val right: Dp = 0.dp,
+) {
+    companion object {
+        val Zero = PlatformInsets(0.dp, 0.dp, 0.dp, 0.dp)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlatformInsets) return false
+
+        if (top != other.top) return false
+        if (bottom != other.bottom) return false
+        if (left != other.left) return false
+        if (right != other.right) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = top.hashCode()
+        result = 31 * result + bottom.hashCode()
+        result = 31 * result + left.hashCode()
+        result = 31 * result + right.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "PlatformInsets(top=$top, bottom=$bottom, left=$left, right=$right)"
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformInsets.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformInsets.skiko.kt
@@ -17,16 +17,16 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.Stable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 /**
  * This class represents platform insets.
  */
+@ExperimentalComposeUiApi
 @Immutable
-@InternalComposeApi
 class PlatformInsets(
     @Stable
     val top: Dp = 0.dp,
@@ -65,3 +65,10 @@ class PlatformInsets(
         return "PlatformInsets(top=$top, bottom=$bottom, left=$left, right=$right)"
     }
 }
+
+internal fun PlatformInsets.exclude(insets: PlatformInsets) = PlatformInsets(
+    left = (left - insets.left).coerceAtLeast(0.dp),
+    top = (top - insets.top).coerceAtLeast(0.dp),
+    right = (right - insets.right).coerceAtLeast(0.dp),
+    bottom = (bottom - insets.bottom).coerceAtLeast(0.dp)
+)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
@@ -169,7 +170,7 @@ private fun DialogLayout(
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
-    val platformPadding = platformPadding()
+    val platformInsets = platformInsets()
     RootLayout(
         modifier = modifier,
         focusable = true,
@@ -177,7 +178,7 @@ private fun DialogLayout(
     ) { owner ->
         val measurePolicy = rememberDialogMeasurePolicy(
             properties = properties,
-            platformPadding = platformPadding
+            platformInsets = platformInsets
         ) {
             owner.bounds = it
         }
@@ -191,14 +192,14 @@ private fun DialogLayout(
 @Composable
 private fun rememberDialogMeasurePolicy(
     properties: DialogProperties,
-    platformPadding: RootLayoutPadding,
+    platformInsets: PlatformInsets,
     onBoundsChanged: (IntRect) -> Unit
-) = remember(properties, platformPadding, onBoundsChanged) {
+) = remember(properties, platformInsets, onBoundsChanged) {
     RootMeasurePolicy(
-        platformPadding = platformPadding,
+        platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { windowSize, contentSize ->
-        val position = positionWithPadding(platformPadding, windowSize) {
+        val position = positionWithInsets(platformInsets, windowSize) {
             it.center - contentSize.center
         }
         onBoundsChanged(IntRect(position, contentSize))

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -169,15 +169,15 @@ private fun DialogLayout(
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
+    val platformPadding = platformPadding()
     RootLayout(
         modifier = modifier,
         focusable = true,
         onOutsidePointerEvent = onOutsidePointerEvent
     ) { owner ->
-        val density = LocalDensity.current
         val measurePolicy = rememberDialogMeasurePolicy(
             properties = properties,
-            platformPadding = with(density) { platformPadding() }
+            platformPadding = platformPadding
         ) {
             owner.bounds = it
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
@@ -420,7 +421,7 @@ private fun PopupLayout(
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
-    val platformPadding = platformPadding()
+    val platformInsets = platformInsets()
     var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
     EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
     RootLayout(
@@ -433,7 +434,7 @@ private fun PopupLayout(
         val measurePolicy = rememberPopupMeasurePolicy(
             popupPositionProvider = popupPositionProvider,
             properties = properties,
-            platformPadding = platformPadding,
+            platformInsets = platformInsets,
             layoutDirection = layoutDirection,
             parentBounds = parentBounds
         ) {
@@ -460,16 +461,16 @@ private fun Modifier.parentBoundsInWindow(
 private fun rememberPopupMeasurePolicy(
     popupPositionProvider: PopupPositionProvider,
     properties: PopupProperties,
-    platformPadding: RootLayoutPadding,
+    platformInsets: PlatformInsets,
     layoutDirection: LayoutDirection,
     parentBounds: IntRect,
     onBoundsChanged: (IntRect) -> Unit
-) = remember(popupPositionProvider, properties, platformPadding, layoutDirection, parentBounds, onBoundsChanged) {
+) = remember(popupPositionProvider, properties, platformInsets, layoutDirection, parentBounds, onBoundsChanged) {
     RootMeasurePolicy(
-        platformPadding = platformPadding,
+        platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { windowSize, contentSize ->
-        var position = positionWithPadding(platformPadding, windowSize) {
+        var position = positionWithInsets(platformInsets, windowSize) {
             popupPositionProvider.calculatePosition(
                 parentBounds, it, layoutDirection, contentSize
             )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
@@ -421,6 +420,7 @@ private fun PopupLayout(
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
+    val platformPadding = platformPadding()
     var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
     EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
     RootLayout(
@@ -429,12 +429,11 @@ private fun PopupLayout(
         onOutsidePointerEvent = onOutsidePointerEvent
     ) { owner ->
         val parentBounds = layoutParentBoundsInWindow ?: return@RootLayout
-        val density = LocalDensity.current
         val layoutDirection = LocalLayoutDirection.current
         val measurePolicy = rememberPopupMeasurePolicy(
             popupPositionProvider = popupPositionProvider,
             properties = properties,
-            platformPadding = with(density) { platformPadding() },
+            platformPadding = platformPadding,
             layoutDirection = layoutDirection,
             parentBounds = parentBounds
         ) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootLayout.skiko.kt
@@ -71,7 +71,9 @@ internal fun RootLayout(
         )
         scene.attach(owner)
         owner to owner.setContent(parent = parentComposition) {
-            content(owner)
+            platformOwnerContent {
+                content(owner)
+            }
         }
     }
     DisposableEffect(Unit) {
@@ -125,10 +127,7 @@ private fun Density.applyPlatformConstrains(
     platformPadding: RootLayoutPadding,
     usePlatformDefaultWidth: Boolean
 ): Constraints {
-    val platformConstraints = constraints.offset(
-        horizontal = -(platformPadding.left + platformPadding.right),
-        vertical = -(platformPadding.top + platformPadding.bottom)
-    )
+    val platformConstraints = constraints.offset(platformPadding)
     return if (usePlatformDefaultWidth) {
         platformConstraints.constrain(
             platformDefaultConstrains(constraints)
@@ -136,6 +135,12 @@ private fun Density.applyPlatformConstrains(
     } else {
         platformConstraints
     }
+}
+
+private fun Constraints.offset(platformPadding: RootLayoutPadding): Constraints {
+    val horizontal = platformPadding.left + platformPadding.right
+    val vertical = platformPadding.top + platformPadding.bottom
+    return offset(-horizontal, -vertical)
 }
 
 internal data class RootLayoutPadding(
@@ -163,7 +168,10 @@ internal fun positionWithPadding(
 }
 
 @Composable
-internal expect fun Density.platformPadding(): RootLayoutPadding
+internal expect fun platformPadding(): RootLayoutPadding
+
+@Composable
+internal expect fun platformOwnerContent(content: @Composable () -> Unit)
 
 private fun Density.platformDefaultConstrains(
     constraints: Constraints

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
@@ -14,19 +14,16 @@
  * limitations under the License.
  */
 
-package androidx.compose.ui.uikit
+package androidx.compose.ui.platform
 
-import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 
 /**
  * Composition local for SafeArea of ComposeUIViewController
  */
 @InternalComposeApi
-val LocalSafeArea = staticCompositionLocalOf<IOSInsets> {
+val LocalSafeArea = staticCompositionLocalOf<PlatformInsets> {
     error("CompositionLocal LocalSafeArea not present")
 }
 
@@ -34,19 +31,6 @@ val LocalSafeArea = staticCompositionLocalOf<IOSInsets> {
  * Composition local for layoutMargins of ComposeUIViewController
  */
 @InternalComposeApi
-val LocalLayoutMargins = staticCompositionLocalOf<IOSInsets> {
+val LocalLayoutMargins = staticCompositionLocalOf<PlatformInsets> {
     error("CompositionLocal LocalLayoutMargins not present")
 }
-
-/**
- * This class represents iOS Insets.
- * It contains equals and hashcode and can be used as Compose State<IOSInsets>.
- */
-@Immutable
-@InternalComposeApi
-data class IOSInsets(
-    val top: Dp = 0.dp,
-    val bottom: Dp = 0.dp,
-    val left: Dp = 0.dp,
-    val right: Dp = 0.dp,
-)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Insets.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Insets.uikit.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.uikit
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.InternalComposeApi
-import androidx.compose.runtime.State
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -27,16 +26,16 @@ import androidx.compose.ui.unit.dp
  * Composition local for SafeArea of ComposeUIViewController
  */
 @InternalComposeApi
-val LocalSafeAreaState = staticCompositionLocalOf<State<IOSInsets>> {
-    error("CompositionLocal LocalSafeAreaTopState not present")
+val LocalSafeArea = staticCompositionLocalOf<IOSInsets> {
+    error("CompositionLocal LocalSafeArea not present")
 }
 
 /**
  * Composition local for layoutMargins of ComposeUIViewController
  */
 @InternalComposeApi
-val LocalLayoutMarginsState = staticCompositionLocalOf<State<IOSInsets>> {
-    error("CompositionLocal LocalLayoutMarginsState not present")
+val LocalLayoutMargins = staticCompositionLocalOf<IOSInsets> {
+    error("CompositionLocal LocalLayoutMargins not present")
 }
 
 /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -50,7 +50,6 @@ import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.SkikoKeyboardEvent
@@ -149,8 +148,8 @@ internal actual class ComposeWindow : UIViewController {
     internal lateinit var configuration: ComposeUIViewControllerConfiguration
     private val keyboardOverlapHeightState = mutableStateOf(0f)
     private var isInsideSwiftUI = false
-    private var safeAreaState by mutableStateOf(IOSInsets())
-    private var layoutMarginsState by mutableStateOf(IOSInsets())
+    private var safeAreaState by mutableStateOf(PlatformInsets())
+    private var layoutMarginsState by mutableStateOf(PlatformInsets())
     private val interopContext = UIKitInteropContext(
         requestRedraw = {
             attachedComposeContext?.view?.needRedraw()
@@ -300,7 +299,7 @@ internal actual class ComposeWindow : UIViewController {
     fun viewSafeAreaInsetsDidChange() {
         // super.viewSafeAreaInsetsDidChange() // TODO: call super after Kotlin 1.8.20
         view.safeAreaInsets.useContents {
-            safeAreaState = IOSInsets(
+            safeAreaState = PlatformInsets(
                 top = top.dp,
                 bottom = bottom.dp,
                 left = left.dp,
@@ -308,7 +307,7 @@ internal actual class ComposeWindow : UIViewController {
             )
         }
         view.directionalLayoutMargins.useContents {
-            layoutMarginsState = IOSInsets(
+            layoutMarginsState = PlatformInsets(
                 top = top.dp,
                 bottom = bottom.dp,
                 left = leading.dp,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -19,7 +19,9 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.SystemTheme
@@ -32,7 +34,6 @@ import androidx.compose.ui.input.pointer.toCompose
 import androidx.compose.ui.interop.LocalLayerContainer
 import androidx.compose.ui.interop.LocalUIKitInteropContext
 import androidx.compose.ui.interop.LocalUIViewController
-import androidx.compose.ui.interop.UIKitInteropAction
 import androidx.compose.ui.interop.UIKitInteropContext
 import androidx.compose.ui.interop.UIKitInteropTransaction
 import androidx.compose.ui.platform.*
@@ -148,8 +149,8 @@ internal actual class ComposeWindow : UIViewController {
     internal lateinit var configuration: ComposeUIViewControllerConfiguration
     private val keyboardOverlapHeightState = mutableStateOf(0f)
     private var isInsideSwiftUI = false
-    private val safeAreaState = mutableStateOf(IOSInsets())
-    private val layoutMarginsState = mutableStateOf(IOSInsets())
+    private var safeAreaState by mutableStateOf(IOSInsets())
+    private var layoutMarginsState by mutableStateOf(IOSInsets())
     private val interopContext = UIKitInteropContext(
         requestRedraw = {
             attachedComposeContext?.view?.needRedraw()
@@ -299,7 +300,7 @@ internal actual class ComposeWindow : UIViewController {
     fun viewSafeAreaInsetsDidChange() {
         // super.viewSafeAreaInsetsDidChange() // TODO: call super after Kotlin 1.8.20
         view.safeAreaInsets.useContents {
-            safeAreaState.value = IOSInsets(
+            safeAreaState = IOSInsets(
                 top = top.dp,
                 bottom = bottom.dp,
                 left = left.dp,
@@ -307,7 +308,7 @@ internal actual class ComposeWindow : UIViewController {
             )
         }
         view.directionalLayoutMargins.useContents {
-            layoutMarginsState.value = IOSInsets(
+            layoutMarginsState = IOSInsets(
                 top = top.dp,
                 bottom = bottom.dp,
                 left = leading.dp,
@@ -665,8 +666,8 @@ internal actual class ComposeWindow : UIViewController {
                     LocalLayerContainer provides view,
                     LocalUIViewController provides this,
                     LocalKeyboardOverlapHeightState provides keyboardOverlapHeightState,
-                    LocalSafeAreaState provides safeAreaState,
-                    LocalLayoutMarginsState provides layoutMarginsState,
+                    LocalSafeArea provides safeAreaState,
+                    LocalLayoutMargins provides layoutMarginsState,
                     LocalInterfaceOrientationState provides interfaceOrientationState,
                     LocalSystemTheme provides systemTheme.value,
                     LocalUIKitInteropContext provides interopContext,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
@@ -20,9 +20,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.uikit.IOSInsets
-import androidx.compose.ui.uikit.LocalLayoutMargins
-import androidx.compose.ui.uikit.LocalSafeArea
+import androidx.compose.ui.platform.PlatformInsets
+import androidx.compose.ui.platform.LocalLayoutMargins
+import androidx.compose.ui.platform.LocalSafeArea
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 
@@ -41,14 +41,14 @@ internal actual fun platformOwnerContent(content: @Composable () -> Unit) {
     val safeArea = LocalSafeArea.current
     val layoutMargins = LocalLayoutMargins.current
     CompositionLocalProvider(
-        LocalSafeArea provides IOSInsets(),
+        LocalSafeArea provides PlatformInsets(),
         LocalLayoutMargins provides layoutMargins.exclude(safeArea),
         content = content
     )
 }
 
 @OptIn(InternalComposeApi::class)
-private fun IOSInsets.toRootLayoutPadding(density: Density) = with(density) {
+private fun PlatformInsets.toRootLayoutPadding(density: Density) = with(density) {
     RootLayoutPadding(
         left = left.roundToPx(),
         top = top.roundToPx(),
@@ -58,7 +58,7 @@ private fun IOSInsets.toRootLayoutPadding(density: Density) = with(density) {
 }
 
 @OptIn(InternalComposeApi::class)
-private fun IOSInsets.exclude(insets: IOSInsets) = IOSInsets(
+private fun PlatformInsets.exclude(insets: PlatformInsets) = PlatformInsets(
     left = (left - insets.left).coerceAtLeast(0.dp),
     top = (top - insets.top).coerceAtLeast(0.dp),
     right = (right - insets.right).coerceAtLeast(0.dp),

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
@@ -19,21 +19,16 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.LocalLayoutMargins
 import androidx.compose.ui.platform.LocalSafeArea
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.PlatformInsets
+import androidx.compose.ui.platform.exclude
 
 @OptIn(InternalComposeApi::class)
 @Composable
-internal actual fun platformPadding(): RootLayoutPadding {
-    val density = LocalDensity.current
-    val safeArea = LocalSafeArea.current
-    return safeArea.toRootLayoutPadding(density)
+internal actual fun platformInsets(): PlatformInsets {
+    return LocalSafeArea.current
 }
-
 
 @OptIn(InternalComposeApi::class)
 @Composable
@@ -46,21 +41,3 @@ internal actual fun platformOwnerContent(content: @Composable () -> Unit) {
         content = content
     )
 }
-
-@OptIn(InternalComposeApi::class)
-private fun PlatformInsets.toRootLayoutPadding(density: Density) = with(density) {
-    RootLayoutPadding(
-        left = left.roundToPx(),
-        top = top.roundToPx(),
-        right = right.roundToPx(),
-        bottom = bottom.roundToPx()
-    )
-}
-
-@OptIn(InternalComposeApi::class)
-private fun PlatformInsets.exclude(insets: PlatformInsets) = PlatformInsets(
-    left = (left - insets.left).coerceAtLeast(0.dp),
-    top = (top - insets.top).coerceAtLeast(0.dp),
-    right = (right - insets.right).coerceAtLeast(0.dp),
-    bottom = (bottom - insets.bottom).coerceAtLeast(0.dp)
-)


### PR DESCRIPTION
## Proposed Changes

- Unwrap unnecessary state for `LocalSafeArea`/`LocalLayoutMargins`
- Override  `LocalSafeArea`/`LocalLayoutMargins` for separate owners.
- Replace `IOSInsets` to `PlatformInsets` - [Don't use data classes in an API](https://kotlinlang.org/docs/jvm-api-guidelines-backward-compatibility.html#don-t-use-data-classes-in-an-api)

## Changes in API

```diff
-androidx.compose.ui.uikit.IOSInsets
+androidx.compose.ui.platform.PlatformInsets
```
```diff
-androidx.compose.ui.uikit.LocalSafeAreaState
+androidx.compose.ui.platform.LocalSafeArea
```
```diff
-androidx.compose.ui.uikit.LocalLayoutMarginsState
+androidx.compose.ui.platform.LocalLayoutMargins
```

## Testing

```kt
Box(modifier = Modifier
    .fillMaxSize()
    .windowInsetsPadding(WindowInsets.systemBars)
    .background(Color.Green)
)
Popup {
    Box(modifier = Modifier
        .fillMaxSize()
        .windowInsetsPadding(WindowInsets.systemBars)
        .background(Color.Red)
    )
}
```

Android | iOS (Before) | iOS (After)
--- | --- | ---
<img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/8fe492a6-007e-4cbf-9c8a-fa6eea9bb056" height="600"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/3168efba-0072-47aa-853a-1c44bd68e4e0" height="600"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/3845efe8-eb8e-4c71-87e2-ea44dd73a91e" height="600">

## Issues Fixed

Fixes (partially) https://github.com/JetBrains/compose-multiplatform/issues/3701