### PR TITLE
Add an option to disable insets in `Popup`/`Dialog`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -58,6 +58,8 @@ private val DefaultScrimColor = Color.Black.copy(alpha = DefaultScrimOpacity)
  * dialog's bounds. If true, clicking outside the dialog will call onDismissRequest.
  * @property usePlatformDefaultWidth Whether the width of the dialog's content should be limited to
  * the platform default, which is smaller than the screen width.
+ * @property usePlatformInsets Whether the width of the popup's content should be limited by
+ * platform insets.
  * @property scrimColor Color of background fill.
  */
 @Immutable
@@ -65,6 +67,7 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
     actual val dismissOnBackPress: Boolean = true,
     actual val dismissOnClickOutside: Boolean = true,
     actual val usePlatformDefaultWidth: Boolean = true,
+    val usePlatformInsets: Boolean = true,
     val scrimColor: Color = DefaultScrimColor,
 ) {
     // Constructor with all non-experimental arguments.
@@ -76,7 +79,8 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
         dismissOnBackPress = dismissOnBackPress,
         dismissOnClickOutside = dismissOnClickOutside,
         usePlatformDefaultWidth = usePlatformDefaultWidth,
-        scrimColor = DefaultScrimColor
+        usePlatformInsets = true,
+        scrimColor = DefaultScrimColor,
     )
 
     actual constructor(
@@ -97,7 +101,8 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
         dismissOnBackPress = dismissOnBackPress,
         dismissOnClickOutside = dismissOnClickOutside,
         usePlatformDefaultWidth = usePlatformDefaultWidth,
-        scrimColor = DefaultScrimColor
+        usePlatformInsets = true,
+        scrimColor = DefaultScrimColor,
     )
 
     override fun equals(other: Any?): Boolean {
@@ -107,6 +112,7 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
         if (dismissOnBackPress != other.dismissOnBackPress) return false
         if (dismissOnClickOutside != other.dismissOnClickOutside) return false
         if (usePlatformDefaultWidth != other.usePlatformDefaultWidth) return false
+        if (usePlatformInsets != other.usePlatformInsets) return false
         if (scrimColor != other.scrimColor) return false
 
         return true
@@ -116,6 +122,7 @@ actual class DialogProperties @ExperimentalComposeUiApi constructor(
         var result = dismissOnBackPress.hashCode()
         result = 31 * result + dismissOnClickOutside.hashCode()
         result = 31 * result + usePlatformDefaultWidth.hashCode()
+        result = 31 * result + usePlatformInsets.hashCode()
         result = 31 * result + scrimColor.hashCode()
         return result
     }
@@ -170,7 +177,11 @@ private fun DialogLayout(
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
-    val platformInsets = platformInsets()
+    val platformInsets = if (properties.usePlatformInsets) {
+        platformInsets()
+    } else {
+        PlatformInsets.Zero
+    }
     RootLayout(
         modifier = modifier,
         focusable = true,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -58,11 +58,13 @@ import androidx.compose.ui.unit.round
  * @property dismissOnClickOutside Whether the popup can be dismissed by clicking outside the
  * popup's bounds. If true, clicking outside the popup will call onDismissRequest.
  * @property clippingEnabled Whether to allow the popup window to extend beyond the bounds of the
- * screen. By default the window is clipped to the screen boundaries. Setting this to false will
+ * screen. By default, the window is clipped to the screen boundaries. Setting this to false will
  * allow windows to be accurately positioned.
  * The default value is true.
- * @property usePlatformDefaultWidth Whether the width of the dialog's content should be limited to
+ * @property usePlatformDefaultWidth Whether the width of the popup's content should be limited to
  * the platform default, which is smaller than the screen width.
+ * @property usePlatformInsets Whether the width of the popup's content should be limited by
+ * platform insets.
  */
 @Immutable
 actual class PopupProperties @ExperimentalComposeUiApi constructor(
@@ -71,6 +73,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
     actual val dismissOnClickOutside: Boolean = true,
     actual val clippingEnabled: Boolean = true,
     val usePlatformDefaultWidth: Boolean = false,
+    val usePlatformInsets: Boolean = true,
 ) {
     // Constructor with all non-experimental arguments.
     constructor(
@@ -84,6 +87,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
         dismissOnClickOutside = dismissOnClickOutside,
         clippingEnabled = clippingEnabled,
         usePlatformDefaultWidth = false,
+        usePlatformInsets = true,
     )
 
     actual constructor(
@@ -107,6 +111,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
         dismissOnClickOutside = dismissOnClickOutside,
         clippingEnabled = clippingEnabled,
         usePlatformDefaultWidth = false,
+        usePlatformInsets = true,
     )
 
     override fun equals(other: Any?): Boolean {
@@ -118,6 +123,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
         if (dismissOnClickOutside != other.dismissOnClickOutside) return false
         if (clippingEnabled != other.clippingEnabled) return false
         if (usePlatformDefaultWidth != other.usePlatformDefaultWidth) return false
+        if (usePlatformInsets != other.usePlatformInsets) return false
 
         return true
     }
@@ -128,6 +134,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
         result = 31 * result + dismissOnClickOutside.hashCode()
         result = 31 * result + clippingEnabled.hashCode()
         result = 31 * result + usePlatformDefaultWidth.hashCode()
+        result = 31 * result + usePlatformInsets.hashCode()
         return result
     }
 }
@@ -421,7 +428,11 @@ private fun PopupLayout(
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
-    val platformInsets = platformInsets()
+    val platformInsets = if (properties.usePlatformInsets) {
+        platformInsets()
+    } else {
+        PlatformInsets.Zero
+    }
     var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
     EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
     RootLayout(


### PR DESCRIPTION
## Proposed Changes

- Add `usePlatformInsets` to `PopupProperties` and `DialogProperties` to be able showing full screen content inside `Popup` and `Dialog` 

Default | `usePlatformInsets = false`
--- | ---
<img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/9c41f57f-d95f-4955-b51d-ff6beb0a6ef4" height="600"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/1469baf3-10c6-4b11-89de-c67b799a0e3c" height="600">


## Changes in API

```diff
+PopupProperties.usePlatformInsets
+DialogProperties.usePlatformInsets
```

## Testing

Test: Try to use `Popup` and `Dialog` with max size content on iOS with safe area. mpp demo will be update in separate PR

