### PR TITLE
Implement temporary workaround for interop view intercepting touches for popups.

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitViewAndDropDownMenu.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitViewAndDropDownMenu.kt
@@ -49,7 +49,7 @@ val UIKitViewAndDropDownMenu = Screen.Example("UIKitViewAndDropDownMenu") {
             contentAlignment = Alignment.Center
         ) {
             UIKitView(modifier = Modifier.fillMaxSize(), factory = { MKMapView() })
-            ButtonAndDropDownMenu("Menu not over UIKitView")
+            ButtonAndDropDownMenu("Menu over UIKitView")
         }
         Divider()
         Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -530,7 +530,7 @@ class ComposeScene internal constructor(
         forEachOwner { it.clearInvalidObservations() }
     }
 
-    private var focusedOwner: SkiaBasedOwner? = null
+    internal var focusedOwner: SkiaBasedOwner? = null
     private var gestureOwner: SkiaBasedOwner? = null
     private var lastHoverOwner: SkiaBasedOwner? = null
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -551,7 +551,7 @@ class ComposeScene internal constructor(
         forEachOwner { it.clearInvalidObservations() }
     }
 
-    internal var focusedOwner: SkiaBasedOwner? = null
+    private var focusedOwner: SkiaBasedOwner? = null
     private var gestureOwner: SkiaBasedOwner? = null
     private var lastHoverOwner: SkiaBasedOwner? = null
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -513,6 +513,23 @@ class ComposeScene internal constructor(
         snapshotChanges.perform()
     }
 
+    internal fun hitTestInteropView(position: Offset): Boolean {
+        // TODO: temporary solution copying control flow from [processPress]
+        owners.fastForEachReversed { owner ->
+            if (owner.isInBounds(position)) {
+                return owner.hitInteropView(
+                    pointerPosition = position,
+                    isTouchEvent = true,
+                )
+            } else if (owner == focusedOwner) {
+                return false
+            }
+        }
+
+        // We didn't pass isInBounds check for any owner 🤷
+        return false
+    }
+
     /**
      * Render the current content on [canvas]. Passed [nanoTime] will be used to drive all
      * animations in the content (or any other code, which uses [withFrameNanos]

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -514,7 +514,11 @@ class ComposeScene internal constructor(
     }
 
     internal fun hitTestInteropView(position: Offset): Boolean {
-        // TODO: temporary solution copying control flow from [processPress]
+        // TODO:
+        //  Temporary solution copying control flow from [processPress].
+        //  A proper solution is to send touches to scene as black box
+        //  and handle only that ones that were received in interop view
+        //  instead of using [pointInside].
         owners.fastForEachReversed { owner ->
             if (owner.isInBounds(position)) {
                 return owner.hitInteropView(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -607,15 +607,32 @@ internal actual class ComposeWindow : UIViewController {
 
             override fun pointInside(point: CValue<CGPoint>, event: UIEvent?): Boolean =
                 point.useContents {
-                    val hitsInteropView = attachedComposeContext?.scene?.mainOwner?.hitInteropView(
-                        pointerPosition = Offset(
-                            (x * density.density).toFloat(),
-                            (y * density.density).toFloat()
-                        ),
-                        isTouchEvent = true,
-                    ) ?: false
+                    val position = Offset(
+                        (x * density.density).toFloat(),
+                        (y * density.density).toFloat()
+                    )
 
-                    !hitsInteropView
+                    // TODO: temporary solution copying control flow from [ComposeScene.processPress]
+                    // there is no fastReverseAny in Kotlin
+                    for (i in scene.owners.size - 1 downTo 0) {
+                        val owner = scene.owners[i]
+
+                        if (owner.isInBounds(position)) {
+                            val hitsInteropView = owner.hitInteropView(
+                                pointerPosition = position,
+                                isTouchEvent = true,
+                            )
+
+                            return@useContents !hitsInteropView
+                        } else {
+                            if (owner == scene.focusedOwner) {
+                                return@useContents true
+                            }
+                        }
+                    }
+
+                    // We didn't pass isInBounds check for any owner 🤷
+                    return@useContents true
                 }
 
             override fun onPointerEvent(event: SkikoPointerEvent) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -612,25 +612,7 @@ internal actual class ComposeWindow : UIViewController {
                         (y * density.density).toFloat()
                     )
 
-                    // TODO: temporary solution copying control flow from [ComposeScene.processPress]
-                    // there is no fastReverseAny in Kotlin
-                    for (i in scene.owners.size - 1 downTo 0) {
-                        val owner = scene.owners[i]
-
-                        if (owner.isInBounds(position)) {
-                            val hitsInteropView = owner.hitInteropView(
-                                pointerPosition = position,
-                                isTouchEvent = true,
-                            )
-
-                            return@useContents !hitsInteropView
-                        } else if (owner == scene.focusedOwner) {
-                            return@useContents true
-                        }
-                    }
-
-                    // We didn't pass isInBounds check for any owner 🤷
-                    return@useContents true
+                    !scene.hitTestInteropView(position)
                 }
 
             override fun onPointerEvent(event: SkikoPointerEvent) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -624,10 +624,8 @@ internal actual class ComposeWindow : UIViewController {
                             )
 
                             return@useContents !hitsInteropView
-                        } else {
-                            if (owner == scene.focusedOwner) {
-                                return@useContents true
-                            }
+                        } else if (owner == scene.focusedOwner) {
+                            return@useContents true
                         }
                     }
 


### PR DESCRIPTION
## Proposed Changes

Traverse owners top down and see, if the touch should be dispatched into compose instead of interop view.

## Testing

Test: check ComposeDemo IosBugs/UIKitViewAndDropDown example to work correctly.

## Issues Fixed

Fixes: interop view intercepting touches on compose popup on top of it.



https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/2637a5fc-c23e-4a48-a7b1-998ca4f87f5b

