### PR TITLE
iOS freeze on unavailable transaction

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -391,8 +391,6 @@ internal class MetalRedrawer(
                 if (interopTransaction.state == UIKitInteropState.ENDED) {
                     isInteropActive = false
                 }
-
-                CATransaction.commit()
             }
 
             surface.close()


### PR DESCRIPTION
## Proposed Changes

Regression fix cherry pick from https://github.com/JetBrains/compose-multiplatform-core/pull/829
Only configure synchronisation for frames, that contain actual pending UIKit changes.

## Testing

Test: check that iOSBugs/UIKitRenderSync doesn't freeze when trying to tap into TextField on 120hz devices.

## Issues Fixed

Fixes: freeze when no implicit transaction is available.