### PR TITLE
Remove `kotlin.native.cacheKind=none` from mpp demo config

### DIFF
--- a/compose/mpp/demo/gradle.properties
+++ b/compose/mpp/demo/gradle.properties
@@ -1,5 +1,3 @@
 # Enable kotlin/native experimental memory model
 kotlin.native.binary.memoryModel=experimental
-# Caching plays bad with skiko libraries
-kotlin.native.cacheKind=none
 kotlin.incremental.js.ir=false


### PR DESCRIPTION
## Proposed Changes

- `kotlin.native.cacheKind=none` is no longer needed after 1.9.0 
