### PR TITLE
Make OEL publication compatible with kotlin 1.9.0 and newer

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -232,7 +232,7 @@ fun enableOELPublishing(project: Project) {
  * Usage that should be added to rootSoftwareComponent to represent android-specific variants
  * It will be serialized to *.module in "variants" collection.
  */
-private class FakeAndroidUsage(
+private class CustomAndroidUsage(
     private val name: String,
     private val attributes: AttributeContainer,
     private val dependencies: Set<ModuleDependency>
@@ -302,7 +302,7 @@ private fun Project.publishAndroidxReference(target: KotlinAndroidTarget) {
 
             fun addUsageFromConfiguration(configuration: Configuration) {
                 extraUsages.add(
-                    FakeAndroidUsage(
+                    CustomAndroidUsage(
                         name = configuration.name,
                         attributes = configuration.attributes,
                         dependencies = setOf(newDependency)
@@ -359,8 +359,6 @@ private fun Project.publishAndroidxReference(target: KotlinAndroidTarget) {
                 // Use -published configuration because it would have correct attribute set
                 // required for publication.
                 val configurationName = usage.name + "-published"
-
-                //
                 configurations.matching { it.name == configurationName }.all { conf ->
                     newRootComponent.addUsageFromConfiguration(conf)
                 }
@@ -368,7 +366,3 @@ private fun Project.publishAndroidxReference(target: KotlinAndroidTarget) {
         }
     }
 }
-
-// We have few workarounds in build scripts or gradle plugins,
-// and this global val can help track them
-internal val isJBFork = true

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -21,17 +21,28 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
-import kotlin.reflect.full.memberProperties
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.internal.dependencies.DefaultMavenDependency
-import org.gradle.api.publish.maven.internal.dependencies.MavenDependencyInternal
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
 import org.gradle.api.attributes.Usage
 import org.jetbrains.kotlin.konan.target.KonanTarget
-
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencyConstraint
+import org.gradle.api.artifacts.ExcludeRule
+import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.capabilities.Capability
+import org.gradle.api.component.ComponentWithCoordinates
+import org.gradle.api.component.ComponentWithVariants
+import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.internal.component.SoftwareComponentInternal
+import org.gradle.api.internal.component.UsageContext
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.kotlin.dsl.create
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
@@ -216,26 +227,127 @@ fun enableOELPublishing(project: Project) {
     }
 }
 
-// FIXME: reflection access! Some API in Kotlin is needed
-@Suppress("unchecked_cast")
-private val KotlinTarget.kotlinComponents: Iterable<KotlinTargetComponent>
-    get() = javaClass.kotlin.memberProperties
-        .single { it.name == "kotlinComponents" }
-        .get(this) as Iterable<KotlinTargetComponent>
 
+/**
+ * Usage that should be added to rootSoftwareComponent to represent android-specific variants
+ * It will be serialized to *.module in "variants" collection.
+ */
+private class FakeAndroidUsage(
+    private val name: String,
+    private val attributes: AttributeContainer,
+    private val dependencies: Set<ModuleDependency>
+) : UsageContext {
+    override fun getName(): String = name
+    override fun getArtifacts(): Set<PublishArtifact> = emptySet()
+    override fun getAttributes(): AttributeContainer = attributes
+    override fun getCapabilities(): Set<Capability> = emptySet()
+    override fun getDependencies(): Set<ModuleDependency> = dependencies
+    override fun getDependencyConstraints(): Set<DependencyConstraint> = emptySet()
+    override fun getGlobalExcludes(): Set<ExcludeRule> = emptySet()
+    override fun getUsage(): Usage = error("Should not be accessed!")
+}
 
-@Suppress("unchecked_cast")
-private fun Project.publishAndroidxReference(target: KotlinTarget) {
+private fun Project.publishAndroidxReference(target: KotlinAndroidTarget) {
     afterEvaluate {
+        // Take root component which should contain "variants" (aka usages)
+        // this component gets published as "main/common" module
+        // that we want to add as android ones.
+        val rootComponent = target.project
+            .components
+            .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
+            .getByName("kotlin")
+
+        val composeVersion = requireNotNull(target.project.oelAndroidxVersion()) {
+            "Please specify oel.androidx.version property"
+        }
+        val material3Version =
+            requireNotNull(target.project.oelAndroidxMaterial3Version()) {
+                "Please specify oel.androidx.material3.version property"
+            }
+        val foundationVersion =
+            target.project.oelAndroidxFoundationVersion() ?: composeVersion
+        val materialVersion =
+            target.project.oelAndroidxMaterialVersion() ?: composeVersion
+
+        val groupId = target.project.group.toString()
+        val version = if (groupId.contains("org.jetbrains.compose.material3")) {
+            material3Version
+        } else if (groupId.contains("org.jetbrains.compose.foundation")) {
+            foundationVersion
+        } else if (groupId.contains("org.jetbrains.compose.material")) {
+            materialVersion
+        } else {
+            composeVersion
+        }
+        val dependencyGroup = target.project.group.toString().replace(
+            "org.jetbrains.compose",
+            "androidx.compose"
+        )
+        val newDependency = target.project.dependencies.create(dependencyGroup, name, version)
+
+
+        // We can't add more usages to rootComponent, so we must decorate it
+        val newRootComponent = object :
+            SoftwareComponentInternal,
+            ComponentWithVariants,
+            ComponentWithCoordinates {
+            override fun getName(): String = "kotlinDecoratedRootComponent"
+            override fun getVariants(): Set<SoftwareComponent> = rootComponent.variants
+            override fun getCoordinates(): ModuleVersionIdentifier =
+                rootComponent.coordinates
+
+            override fun getUsages(): Set<UsageContext> = rootComponent.usages + extraUsages
+
+            private val extraUsages = mutableSetOf<UsageContext>()
+
+            fun addUsageFromConfiguration(configuration: Configuration) {
+                extraUsages.add(
+                    FakeAndroidUsage(
+                        name = configuration.name,
+                        attributes = configuration.attributes,
+                        dependencies = setOf(newDependency)
+                    )
+                )
+            }
+        }
+
+        extensions.getByType(PublishingExtension::class.java).apply {
+            val kotlinMultiplatform = publications
+                .getByName("kotlinMultiplatform") as MavenPublication
+
+            publications.create("kotlinMultiplatformDecorated", MavenPublication::class.java) {
+                it.artifactId = kotlinMultiplatform.artifactId
+                it.groupId = kotlinMultiplatform.groupId
+                it.version = kotlinMultiplatform.version
+
+                it.from(newRootComponent)
+            }
+        }
+
+        // Disable all publication tasks that uses OLD rootSoftwareComponent: we don't want to
+        // accidentally publish two "root" components
+        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+            if (it.publication.name == "kotlinMultiplatform") it.enabled = false
+        }
+
         target.kotlinComponents.forEach { component ->
             val componentName = component.name
 
-            val multiplatformExtension =
-                extensions.findByType(KotlinMultiplatformExtension::class.java)
-                    ?: error("Expected a multiplatform project")
-
             if (component is KotlinVariant)
                 component.publishable = false
+
+            extensions.getByType(PublishingExtension::class.java)
+                .publications.withType(DefaultMavenPublication::class.java)
+                    // isAlias is needed for Gradle to ignore the fact that there's a
+                    // publication that is not referenced as an available-at variant of the root module
+                    // and has the Maven coordinates that are different from those of the root module
+                    // FIXME: internal Gradle API! We would rather not create the publications,
+                    //        but some API for that is needed in the Kotlin Gradle plugin
+                    .all { publication ->
+                        if (publication.name == componentName) {
+                            publication.isAlias = true
+                        }
+                    }
 
             val usages = when (component) {
                 is KotlinVariant -> component.usages
@@ -243,61 +355,20 @@ private fun Project.publishAndroidxReference(target: KotlinTarget) {
                 else -> emptyList()
             }
 
-            extensions.getByType(PublishingExtension::class.java)
-                .publications.withType(DefaultMavenPublication::class.java)
-                // isAlias is needed for Gradle to ignore the fact that there's a
-                // publication that is not referenced as an available-at variant of the root module
-                // and has the Maven coordinates that are different from those of the root module
-                // FIXME: internal Gradle API! We would rather not create the publications,
-                //        but some API for that is needed in the Kotlin Gradle plugin
-                .all { publication ->
-                    if (publication.name == componentName) {
-                        publication.isAlias = true
-                    }
-                }
-
-            usages.forEach {    usage ->
+            usages.forEach { usage ->
+                // Use -published configuration because it would have correct attribute set
+                // required for publication.
                 val configurationName = usage.name + "-published"
 
-                configurations.matching{it.name == configurationName}.all() { conf ->
-                    conf.artifacts.clear()
-                    conf.dependencies.clear()
-                    conf.setExtendsFrom(emptyList())
-                    val composeVersion = requireNotNull(target.project.oelAndroidxVersion()) {
-                        "Please specify oel.androidx.version property"
-                    }
-                    val material3Version = requireNotNull(target.project.oelAndroidxMaterial3Version()) {
-                        "Please specify oel.androidx.material3.version property"
-                    }
-                    val foundationVersion = target.project.oelAndroidxFoundationVersion() ?: composeVersion
-                    val materialVersion = target.project.oelAndroidxMaterialVersion() ?: composeVersion
-
-                    val groupId = target.project.group.toString()
-                    val version = if (groupId.contains("org.jetbrains.compose.material3")) {
-                        material3Version
-                    } else if (groupId.contains("org.jetbrains.compose.foundation")) {
-                        foundationVersion
-                    } else if (groupId.contains("org.jetbrains.compose.material")){
-                        materialVersion
-                    } else {
-                        composeVersion
-                    }
-                    val newDependency = target.project.group.toString().replace("org.jetbrains.compose", "androidx.compose") + ":" + name + ":" + version
-                    conf.dependencies.add(target.project.dependencies.create(newDependency))
+                //
+                configurations.matching { it.name == configurationName }.all { conf ->
+                    newRootComponent.addUsageFromConfiguration(conf)
                 }
-
-                val rootComponent : KotlinSoftwareComponent = target.project.components.withType(KotlinSoftwareComponent::class.java)
-                    .getByName("kotlin")
-
-                (rootComponent.usages as MutableSet).add(
-                    DefaultKotlinUsageContext(
-                        multiplatformExtension.metadata().compilations.getByName("main"),
-                        KotlinUsageContext.MavenScope.COMPILE,
-                        configurationName
-                    )
-                )
             }
         }
     }
 }
 
+// We have few workarounds in build scripts or gradle plugins,
+// and this global val can help track them
+internal val isJBFork = true

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
@@ -69,6 +69,7 @@ abstract class AndroidXRootImplPlugin : Plugin<Project> {
         configureKtlintCheckFile()
         tasks.register(CheckExternalDependencyLicensesTask.TASK_NAME)
 
+        val isJBFork = true
         // If we're running inside Studio, validate the Android Gradle Plugin version.
         val expectedAgpVersion = System.getenv("EXPECTED_AGP_VERSION")
         if (!isJBFork && properties.containsKey("android.injected.invoked.from.ide")) {

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
@@ -69,7 +69,6 @@ abstract class AndroidXRootImplPlugin : Plugin<Project> {
         configureKtlintCheckFile()
         tasks.register(CheckExternalDependencyLicensesTask.TASK_NAME)
 
-        val isJBFork = true
         // If we're running inside Studio, validate the Android Gradle Plugin version.
         val expectedAgpVersion = System.getenv("EXPECTED_AGP_VERSION")
         if (!isJBFork && properties.containsKey("android.injected.invoked.from.ide")) {

--- a/buildSrc/private/src/main/kotlin/androidx/build/buildInfo/CreateLibraryBuildInfoFileTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/buildInfo/CreateLibraryBuildInfoFileTask.kt
@@ -183,14 +183,12 @@ abstract class CreateLibraryBuildInfoFileTask : DefaultTask() {
             variant: VariantPublishPlan,
             shaProvider: Provider<String>
         ): TaskProvider<CreateLibraryBuildInfoFileTask> {
-            if (androidx.build.isJBFork) {
-                // We don't really use these tasks in our fork, and we may disable this completely.
-                // The reason for a duplicate is that we have a custom 'KotlinMultiplatformDecoration' publication,
-                // which leads to a task duplicate here.
-                val task = project.tasks.findByName(TASK_NAME + variant.taskSuffix)
-                if (task != null)
-                    return project.tasks.named<CreateLibraryBuildInfoFileTask>(TASK_NAME + variant.taskSuffix)
-            }
+            // We don't really use these tasks in our fork, and we may disable this completely.
+            // The reason for a duplicate is that we have a custom 'KotlinMultiplatformDecoration' publication,
+            // which leads to a task duplicate here.
+            val existingTask = project.tasks.findByName(TASK_NAME + variant.taskSuffix)
+            if (existingTask != null)
+                return project.tasks.named<CreateLibraryBuildInfoFileTask>(TASK_NAME + variant.taskSuffix)
             return project.tasks.register(
                 TASK_NAME + variant.taskSuffix,
                 CreateLibraryBuildInfoFileTask::class.java

--- a/buildSrc/private/src/main/kotlin/androidx/build/buildInfo/CreateLibraryBuildInfoFileTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/buildInfo/CreateLibraryBuildInfoFileTask.kt
@@ -51,6 +51,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.named
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
@@ -182,6 +183,14 @@ abstract class CreateLibraryBuildInfoFileTask : DefaultTask() {
             variant: VariantPublishPlan,
             shaProvider: Provider<String>
         ): TaskProvider<CreateLibraryBuildInfoFileTask> {
+            if (androidx.build.isJBFork) {
+                // We don't really use these tasks in our fork, and we may disable this completely.
+                // The reason for a duplicate is that we have a custom 'KotlinMultiplatformDecoration' publication,
+                // which leads to a task duplicate here.
+                val task = project.tasks.findByName(TASK_NAME + variant.taskSuffix)
+                if (task != null)
+                    return project.tasks.named<CreateLibraryBuildInfoFileTask>(TASK_NAME + variant.taskSuffix)
+            }
             return project.tasks.register(
                 TASK_NAME + variant.taskSuffix,
                 CreateLibraryBuildInfoFileTask::class.java

--- a/buildSrc/src/main/kotlin/AbstractComposePublishingTask.kt
+++ b/buildSrc/src/main/kotlin/AbstractComposePublishingTask.kt
@@ -36,7 +36,11 @@ abstract class AbstractComposePublishingTask : DefaultTask() {
     }
 
     fun publishMultiplatform(component: ComposeComponent) {
-        dependsOnComposeTask("${component.path}:publish${ComposePlatforms.KotlinMultiplatform.name}PublicationTo$repository")
+        // To make OEL publishing (for android artifacts) work properly with kotlin >= 1.9.0,
+        // we use decorated `KotlinMultiplatform` publication named - 'KotlinMultiplatformDecorated'.
+        // see AndroidXComposeMultiplatformExtensionImpl.publishAndroidxReference for details.
+        val kotlinCommonPublicationName = "${ComposePlatforms.KotlinMultiplatform.name}Decorated"
+        dependsOnComposeTask("${component.path}:publish${kotlinCommonPublicationName}PublicationTo$repository")
 
         for (platform in targetPlatforms) {
             if (platform !in component.supportedPlatforms) continue


### PR DESCRIPTION
Kotlin >= 1.9.0 had an implementation change which made our OEL publication crash. We were using reflection to access some APIs. 
This PR updates `publishAndroidxReference` function making it compatible with current kotlin version a newer ones. 