### PR TITLE
Fix accessibility not reporting changes

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
@@ -70,21 +70,21 @@ internal class AccessibilityControllerImpl(
             if (entry.value != prev) {
                 when (entry.key) {
                     SemanticsProperties.Text -> {
-                        component.accessibleContext.firePropertyChange(
+                        component.composeAccessibleContext.firePropertyChange(
                             ACCESSIBLE_TEXT_PROPERTY,
                             prev, entry.value
                         )
                     }
 
                     SemanticsProperties.EditableText -> {
-                        component.accessibleContext.firePropertyChange(
+                        component.composeAccessibleContext.firePropertyChange(
                             ACCESSIBLE_TEXT_PROPERTY,
                             prev, entry.value
                         )
                     }
 
                     SemanticsProperties.TextSelectionRange -> {
-                        component.accessibleContext.firePropertyChange(
+                        component.composeAccessibleContext.firePropertyChange(
                             ACCESSIBLE_CARET_PROPERTY,
                             prev, (entry.value as TextRange).start
                         )
@@ -92,13 +92,13 @@ internal class AccessibilityControllerImpl(
 
                     SemanticsProperties.Focused ->
                         if (entry.value as Boolean) {
-                            component.accessibleContext.firePropertyChange(
+                            component.composeAccessibleContext.firePropertyChange(
                                 ACCESSIBLE_STATE_PROPERTY,
                                 null, AccessibleState.FOCUSED
                             )
                             onFocusReceived(component)
                         } else {
-                            component.accessibleContext.firePropertyChange(
+                            component.composeAccessibleContext.firePropertyChange(
                                 ACCESSIBLE_STATE_PROPERTY,
                                 AccessibleState.FOCUSED, null
                             )
@@ -107,13 +107,13 @@ internal class AccessibilityControllerImpl(
                     SemanticsProperties.ToggleableState -> {
                         when (entry.value as ToggleableState) {
                             ToggleableState.On ->
-                                component.accessibleContext.firePropertyChange(
+                                component.composeAccessibleContext.firePropertyChange(
                                     ACCESSIBLE_STATE_PROPERTY,
                                     null, AccessibleState.CHECKED
                                 )
 
                             ToggleableState.Off, ToggleableState.Indeterminate ->
-                                component.accessibleContext.firePropertyChange(
+                                component.composeAccessibleContext.firePropertyChange(
                                     ACCESSIBLE_STATE_PROPERTY,
                                     AccessibleState.CHECKED, null
                                 )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeSceneAccessible.kt
@@ -85,9 +85,7 @@ internal class ComposeSceneAccessible(
                 val controller = owner.accessibilityController as? AccessibilityControllerImpl
                     ?: continue
                 val rootAccessible = controller.rootAccessible
-                val context =
-                    rootAccessible.getAccessibleContext() as? AccessibleComponent
-                        ?: continue
+                val context = rootAccessible.composeAccessibleContext
                 val accessibleOnPoint = context.getAccessibleAt(p) ?: continue
                 if (accessibleOnPoint != rootAccessible) {
                     // TODO: ^ this check produce weird behavior
@@ -117,19 +115,19 @@ internal class ComposeSceneAccessible(
         }
 
         override fun getSize(): Dimension? {
-            return getMainOwnerAccessibleRoot()?.accessibleContext?.size
+            return getMainOwnerAccessibleRoot()?.composeAccessibleContext?.size
         }
 
         override fun getLocationOnScreen(): Point? {
-            return getMainOwnerAccessibleRoot()?.accessibleContext?.locationOnScreen
+            return getMainOwnerAccessibleRoot()?.composeAccessibleContext?.locationOnScreen
         }
 
         override fun getLocation(): Point? {
-            return getMainOwnerAccessibleRoot()?.accessibleContext?.location
+            return getMainOwnerAccessibleRoot()?.composeAccessibleContext?.location
         }
 
         override fun getBounds(): Rectangle? {
-            return getMainOwnerAccessibleRoot()?.accessibleContext?.bounds
+            return getMainOwnerAccessibleRoot()?.composeAccessibleContext?.bounds
         }
 
         override fun isShowing(): Boolean = true

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -53,8 +53,8 @@ class AccessibilityTest {
         }
 
         val node = rule.onNodeWithTag("text").fetchSemanticsNode()
-        val accessibleNode = ComposeAccessible(node)
-        val accessibleText = accessibleNode.accessibleContext.accessibleText!!
+        val accessibleContext = ComposeAccessible(node).accessibleContext
+        val accessibleText = accessibleContext.accessibleText!!
         assertEquals(22, accessibleText.charCount)
 
         assertEquals("H", accessibleText.getAtIndex(AccessibleText.CHARACTER, 0))
@@ -128,8 +128,8 @@ class AccessibilityTest {
     }
 
     private fun SemanticsNodeInteraction.assertHasAccessibleRole(role: AccessibleRole) {
-        val accessible = ComposeAccessible(fetchSemanticsNode())
-        assertThat(accessible.accessibleContext.accessibleRole).isEqualTo(role)
+        val accessibleContext = ComposeAccessible(fetchSemanticsNode()).accessibleContext
+        assertThat(accessibleContext.accessibleRole).isEqualTo(role)
     }
 
 }


### PR DESCRIPTION
`sun.lwawt.macosx.CAccessible` does this weird thing:

```
    private CAccessible(final Accessible accessible) {
        ...
        if (accessible instanceof Component) {
            addNotificationListeners((Component)accessible);
        }
    }

    public void addNotificationListeners(Component c) {
        if (c instanceof Accessible) {
            AccessibleContext ac = ((Accessible)c).getAccessibleContext();
            ac.addPropertyChangeListener(new AXChangeNotifier());
        }
    }
```

So unless the `Accessible` is an instance of `java.awt.Component`, it will not register its property change listener with its accessible context. This prevents us from notifying it when a value changes (a progress bar updates for example).


## Proposed Changes

Make `ComposeAccessible` a subclass of `java.awt.Component`.

This also requires renaming its `accessibleContext` property, because `java.awt.Component` already has a protected field with the same name.

## Testing

Test: Can't test this without exposing something about the amount of property change listeners registered with `ComposeAccessibleComponent`. Tested manually with a progress bar (needs a bit of additional code, which I'll add in the next PR).
