### PR TITLE
Fix enter/exit event order after reverting 1b9c0419

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/HitPathTracker.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.node.InternalCoreApi
 import androidx.compose.ui.node.Nodes
 import androidx.compose.ui.node.dispatchForKind
+import androidx.compose.ui.node.has
 import androidx.compose.ui.node.layoutCoordinates
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastForEach
@@ -175,6 +176,7 @@ internal open class NodeParent {
             dispatched = it.dispatchFinalEventPass(internalPointerEvent) || dispatched
         }
         cleanUpHits(internalPointerEvent)
+        cleanUpHover()
         return dispatched
     }
 
@@ -217,6 +219,12 @@ internal open class NodeParent {
             }
         }
     }
+
+    open fun cleanUpHover() {
+        children.forEach {
+            it.cleanUpHover()
+        }
+    }
 }
 
 /**
@@ -235,6 +243,9 @@ internal class Node(val modifierNode: Modifier.Node) : NodeParent() {
     // set.
     val pointerIds: MutableVector<PointerId> = mutableVectorOf()
 
+    private var isIn = true
+    private var hasEntered = false
+
     /**
      * Cached properties that will be set before the main event pass, and reset after the final
      * pass. Since we know that these won't change within the entire pass, we don't need to
@@ -246,8 +257,6 @@ internal class Node(val modifierNode: Modifier.Node) : NodeParent() {
     private val relevantChanges: MutableMap<PointerId, PointerInputChange> = mutableMapOf()
     private var coordinates: LayoutCoordinates? = null
     private var pointerEvent: PointerEvent? = null
-    private var isIn = true
-    private var hasEntered = false
 
     override fun dispatchMainEventPass(
         changes: Map<PointerId, PointerInputChange>,
@@ -488,7 +497,10 @@ internal class Node(val modifierNode: Modifier.Node) : NodeParent() {
                 pointerIds.remove(change.id)
             }
         }
+    }
 
+    override fun cleanUpHover() {
+        super.cleanUpHover()
         isIn = false
     }
 


### PR DESCRIPTION
After reverting 1b9c0419 in [this PR](https://github.com/JetBrains/compose-multiplatform-core/pull/752), enter/exit events don't have a proper order - we can have an enter without exiting another component first. The tests are written in that PR.

1. In the past we made some fixes in HitPathTracker for hover without upstreaming (`isIn`, `hasEntered` are involved)
2. In the upstream there was an optimization that filter Move's with the same position.
3. Because it breaks some cases, we reverted it in 1b9c0419, but this adds unneccesary moves, and breaks touch handling
4. We'll revert it back in https://github.com/JetBrains/compose-multiplatform-core/pull/752
5. After we enable the optimization again, we still have an issue with hover (Enter/Exit aren't symmetric). This PR prepares the fix.
6. It doesn't work properly, because `isIn` is cached and don't reset to `false` after we return from `dispatchChanges` eagerly. It leads that the old hit nodes won't receive Exit after the new hit test.
7. To solve this, we always reset it to `false` as it was before the optimization (we extracted `cleanUpHover`)

The order of calling after [the PR](https://github.com/JetBrains/compose-multiplatform-core/pull/752):
```
addHitPath
  [for new hit nodes] create node with `isIn  = true`
  [for old hit nodes] markIsIn: `isIn  = true`
dispatchChanges
  buildCache
    determine if it is enter/exit/move by `isIn`
  [if position is changed] send it to Compose
  [if position is changed] cleanUpHits
  cleanUpHover: `isIn  = false`
```

The bugs with hover probably exist in the upstream as well, we will upstream fixes later.

# Test
1. Run MouseMoveTest in [this PR](https://github.com/JetBrains/compose-multiplatform-core/pull/752) - it succeed
2. Revert this fix, run tests again - some will fail. The test for the case fixed in this PR is "move between two overlapped components"