### PR TITLE
Apply GlobalSnapshotManager optimization from upstream

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.desktop.kt
@@ -16,40 +16,7 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.snapshots.Snapshot
-import androidx.compose.ui.platform.GlobalSnapshotManager.ensureStarted
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.consumeEach
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineDispatcher
 import org.jetbrains.skiko.MainUIDispatcher
-import java.util.concurrent.atomic.AtomicBoolean
 
-/**
- * Platform-specific mechanism for starting a monitor of global snapshot state writes
- * in order to schedule the periodic dispatch of snapshot apply notifications.
- * This process should remain platform-specific; it is tied to the threading and update model of
- * a particular platform and framework target.
- *
- * Composition bootstrapping mechanisms for a particular platform/framework should call
- * [ensureStarted] during setup to initialize periodic global snapshot notifications.
- * For desktop, these notifications are always sent on [MainUIDispatcher]. Other platforms
- * may establish different policies for these notifications.
- */
-internal actual object GlobalSnapshotManager {
-    private val started = AtomicBoolean(false)
-
-    actual fun ensureStarted() {
-        if (started.compareAndSet(false, true)) {
-            val channel = Channel<Unit>(Channel.CONFLATED)
-            CoroutineScope(MainUIDispatcher).launch {
-                channel.consumeEach {
-                    Snapshot.sendApplyNotifications()
-                }
-            }
-            Snapshot.registerGlobalWriteObserver {
-                channel.trySend(Unit)
-            }
-        }
-    }
-}
+internal actual val GlobalSnapshotManagerDispatcher: CoroutineDispatcher = MainUIDispatcher

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.js.kt
@@ -16,39 +16,7 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.snapshots.Snapshot
-import androidx.compose.ui.platform.GlobalSnapshotManager.ensureStarted
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.consumeEach
-import kotlinx.coroutines.launch
 
-/**
- * Platform-specific mechanism for starting a monitor of global snapshot state writes
- * in order to schedule the periodic dispatch of snapshot apply notifications.
- * This process should remain platform-specific; it is tied to the threading and update model of
- * a particular platform and framework target.
- *
- * Composition bootstrapping mechanisms for a particular platform/framework should call
- * [ensureStarted] during setup to initialize periodic global snapshot notifications.
- * For desktop, these notifications are always sent on [Dispatchers.Swing]. Other platforms
- * may establish different policies for these notifications.
- */
-internal actual object GlobalSnapshotManager {
-    private val started = AtomicInt(0)
-
-    actual fun ensureStarted() {
-        if (started.compareAndSet(0, 1)) {
-            val channel = Channel<Unit>(Channel.CONFLATED)
-            CoroutineScope(Dispatchers.Main).launch {
-                channel.consumeEach {
-                    Snapshot.sendApplyNotifications()
-                }
-            }
-            Snapshot.registerGlobalWriteObserver {
-                channel.trySend(Unit)
-            }
-        }
-    }
-}
+internal actual val GlobalSnapshotManagerDispatcher: CoroutineDispatcher = Dispatchers.Main


### PR DESCRIPTION
The same as in https://github.com/androidx/androidx/commit/f468727e328aad5c5baef9b5b3548c53e19fed2d

This optimization is valuable for some cases. it isn't visible in our current benchmarks, but was visible in some androidx benchmarks for Android (LazyList scrolling)

## Testing
- Run existing tests
- ./gradlew run1