### PR TITLE
Fix `Popup` regression: `PopupPositionProvider` should work with local coordinates

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -481,16 +481,23 @@ private fun rememberPopupMeasurePolicy(
         platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { windowSize, contentSize ->
-        var position = positionWithInsets(platformInsets, windowSize) {
-            popupPositionProvider.calculatePosition(
-                parentBounds, it, layoutDirection, contentSize
+        val position = positionWithInsets(platformInsets, windowSize) {
+            // Position provider should work with local coordinates.
+            val localBounds = parentBounds.translate(
+                -platformInsets.left.roundToPx(),
+                -platformInsets.top.roundToPx()
             )
-        }
-        if (properties.clippingEnabled) {
-            position = IntOffset(
-                x = position.x.coerceIn(0, windowSize.width - contentSize.width),
-                y = position.y.coerceIn(0, windowSize.height - contentSize.height)
+            val position = popupPositionProvider.calculatePosition(
+                localBounds, it, layoutDirection, contentSize
             )
+            if (properties.clippingEnabled) {
+                IntOffset(
+                    x = position.x.coerceIn(0, it.width - contentSize.width),
+                    y = position.y.coerceIn(0, it.height - contentSize.height)
+                )
+            } else {
+                position
+            }
         }
         onBoundsChanged(IntRect(position, contentSize))
         position

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -487,16 +487,16 @@ private fun rememberPopupMeasurePolicy(
                 -platformInsets.left.roundToPx(),
                 -platformInsets.top.roundToPx()
             )
-            val position = popupPositionProvider.calculatePosition(
+            val localPosition = popupPositionProvider.calculatePosition(
                 localBounds, it, layoutDirection, contentSize
             )
             if (properties.clippingEnabled) {
                 IntOffset(
-                    x = position.x.coerceIn(0, it.width - contentSize.width),
-                    y = position.y.coerceIn(0, it.height - contentSize.height)
+                    x = localPosition.x.coerceIn(0, it.width - contentSize.width),
+                    y = localPosition.y.coerceIn(0, it.height - contentSize.height)
                 )
             } else {
-                position
+                localPosition
             }
         }
         onBoundsChanged(IntRect(position, contentSize))


### PR DESCRIPTION
## Issues Fixed

After #825, the position of `Popup` content based on parent bounds is incorrect:

<img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/3196158e-a554-4c07-977c-ff8adeb66fc5" height="400">

## Proposed Changes

- Use local coordinates for `PopupPositionProvider` and `clippingEnabled`

## Testing

Test: Run mpp on iOS device with safe area
