### PR TITLE
cfw: inhibit focus outline for Compose-managed canvas elements

### DIFF
--- a/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
+++ b/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
@@ -3,12 +3,7 @@ package androidx.compose.mpp.demo
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.CanvasBasedWindow
-import androidx.compose.ui.window.Window
-import kotlinx.browser.document
-import org.jetbrains.skiko.GenericSkikoView
-import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.wasm.onWasmReady
-import org.w3c.dom.HTMLCanvasElement
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {

--- a/compose/mpp/demo/src/jsMain/resources/styles.css
+++ b/compose/mpp/demo/src/jsMain/resources/styles.css
@@ -1,4 +1,0 @@
-canvas {
-    border: 1px solid black;
-}
-

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -35,11 +35,11 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.browser.document
 import kotlinx.browser.window
-import kotlinx.coroutines.isActive
-import org.w3c.dom.HTMLCanvasElement
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.HTMLTitleElement
 
@@ -164,7 +164,11 @@ fun CanvasBasedWindow(
         document.head!!.appendChild(
             (document.createElement("style") as HTMLStyleElement).apply {
                 type = "text/css"
-                appendChild(document.createTextNode("body { margin: 0; overflow: hidden; }"))
+                appendChild(
+                    document.createTextNode(
+                        "body { margin: 0; overflow: hidden; } #$canvasElementId { outline: none; }"
+                    )
+                )
             }
         )
     }


### PR DESCRIPTION
User agents may [add a CSS outline to focused elements](https://chromium.googlesource.com/chromium/blink/+/master/Source/core/css/html.css#970). This is not useful for canvas elements managed by CanvasBasedWindow, where Compose uses its own focus indicators inside.

This change also removes the CSS file adding a canvas border in the mpp/demo example, so that all canvas styling will be Compose-controlled.

## Proposed Changes

  - add outline-inhibiting style in CanvasBasedWindow
  - remove styles.css
  - optimize imports

## Testing

Test: Visual checking of `mpp/demo` rendering.