### PR TITLE
Fix Accessibility. Crash on text hover on Windows

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/TextStringSimpleNode.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/modifiers/TextStringSimpleNode.kt
@@ -199,7 +199,6 @@ internal class TextStringSimpleNode(
                     textLayoutResult.add(it)
                 }
                 layout != null
-                false
             }
             semanticsTextLayoutResult = localSemanticsTextLayoutResult
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -16,17 +16,11 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.height
 import androidx.compose.material.Button
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.isEqualTo
@@ -36,7 +30,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.unit.dp
+import java.awt.Point
 import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleText
 import kotlin.test.fail
@@ -74,6 +68,9 @@ class AccessibilityTest {
         assertEquals("d", accessibleText.getBeforeIndex(AccessibleText.CHARACTER, 21))
         assertEquals("world", accessibleText.getBeforeIndex(AccessibleText.WORD, 21))
         assertEquals("Hi world", accessibleText.getBeforeIndex(AccessibleText.SENTENCE, 21))
+
+        assertEquals(0, accessibleText.getIndexAtPoint(Point(0, 0)))
+        assertEquals("Hello world. Hi world.".length, accessibleText.getIndexAtPoint(Point(10000, 10000)))
     }
 
     @Test


### PR DESCRIPTION
Fix Accessibility. Crash on text hover on Windows

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3742

The fix is cherry-picked from https://github.com/androidx/androidx/commit/7a7f57c49041d64f4c88b28686979f325cc6fd7c to jb-main
(it contains other fix as well)

Because we always return `false`, we [have textLayoutResult = null](https://github.com/JetBrains/compose-multiplatform-core/blob/7f72ab8719252acaafc753a9aa28d2940ea995df/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt#L116)

It isn't reproducible on macOs because it doesn't call `ComposeAccessibleText.getCharacterBounds`

# Test
1. Modified AccessibilityTest (it fails before the fix on Windows/macOs)
2. VoiceOver pronounces the hovered Text on macOs, Windows