### PR TITLE
Support Windows ARM64

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -75,7 +75,8 @@ fun ComposePublishingTask.mainPublications() {
             "Jvmlinux-arm64",
             "Jvmmacos-x64",
             "Jvmmacos-arm64",
-            "Jvmwindows-x64"
+            "Jvmwindows-x64",
+            "Jvmwindows-arm64",
         )
     )
 


### PR DESCRIPTION
Everything is already configured but we didn't publish desktop-windows-arm64 "helper" dependency for another users that use "compose.desktop.currentOs" DSL.

The publication was configured in https://github.com/JetBrains/compose-multiplatform-core/pull/322 and in https://github.com/JetBrains/skiko/pull/610

Resolves https://youtrack.jetbrains.com/issue/COMPOSE-223/Finish-Windows-ARM-64-support

plugin PR: https://github.com/JetBrains/compose-multiplatform/pull/3743

TODO: Test Compose on a real Windows ARM64 machine