### PR TITLE
Override `RootLayout` insets only in case of `usePlatformInsets`

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/PopupExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/PopupExample.kt
@@ -101,18 +101,24 @@ fun PopupExample() {
                 onDismissRequest = { open = false },
                 properties = properties
             ) {
-                var modifier = if (fillMaxSize) {
+                val modifier = if (fillMaxSize) {
                     Modifier.fillMaxSize()
                 } else {
                     Modifier.size(400.dp, 300.dp)
                 }
-                if (windowInsets) {
-                    modifier = modifier.windowInsetsPadding(WindowInsets.systemBars)
-                }
                 Box(modifier
                     .background(Color.Yellow)
                     .clickable { open = false }
-                )
+                ) {
+                    val contentModifier = if (windowInsets) {
+                        Modifier.windowInsetsPadding(WindowInsets.systemBars)
+                    } else {
+                        Modifier
+                    }
+                    Box(contentModifier) {
+                        Text("Example Popup content. Click to close")
+                    }
+                }
             }
         }
 

--- a/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
+++ b/compose/ui/ui/src/notMobileMain/kotlin/androidx/compose/ui/window/RootLayout.notMobile.kt
@@ -26,6 +26,6 @@ internal actual fun platformInsets(): PlatformInsets =
     PlatformInsets.Zero
 
 @Composable
-internal actual fun platformOwnerContent(content: @Composable () -> Unit) {
+internal actual fun platformOwnerContent(overrideInsets: Boolean, content: @Composable () -> Unit) {
     content()
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -193,10 +193,12 @@ private fun DialogLayout(
         ) {
             owner.bounds = it
         }
-        Layout(
-            content = content,
-            measurePolicy = measurePolicy
-        )
+        platformOwnerContent(overrideInsets = properties.usePlatformInsets) {
+            Layout(
+                content = content,
+                measurePolicy = measurePolicy
+            )
+        }
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -451,10 +451,12 @@ private fun PopupLayout(
         ) {
             owner.bounds = it
         }
-        Layout(
-            content = content,
-            measurePolicy = measurePolicy
-        )
+        platformOwnerContent(overrideInsets = properties.usePlatformInsets) {
+            Layout(
+                content = content,
+                measurePolicy = measurePolicy
+            )
+        }
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootLayout.skiko.kt
@@ -73,9 +73,7 @@ internal fun RootLayout(
         )
         scene.attach(owner)
         owner to owner.setContent(parent = parentComposition) {
-            platformOwnerContent {
-                content(owner)
-            }
+            content(owner)
         }
     }
     DisposableEffect(Unit) {
@@ -164,7 +162,7 @@ internal fun MeasureScope.positionWithInsets(
 internal expect fun platformInsets(): PlatformInsets
 
 @Composable
-internal expect fun platformOwnerContent(content: @Composable () -> Unit)
+internal expect fun platformOwnerContent(overrideInsets: Boolean, content: @Composable () -> Unit)
 
 private fun Density.platformDefaultConstrains(
     constraints: Constraints

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RootLayout.uikit.kt
@@ -32,12 +32,16 @@ internal actual fun platformInsets(): PlatformInsets {
 
 @OptIn(InternalComposeApi::class)
 @Composable
-internal actual fun platformOwnerContent(content: @Composable () -> Unit) {
-    val safeArea = LocalSafeArea.current
-    val layoutMargins = LocalLayoutMargins.current
-    CompositionLocalProvider(
-        LocalSafeArea provides PlatformInsets(),
-        LocalLayoutMargins provides layoutMargins.exclude(safeArea),
-        content = content
-    )
+internal actual fun platformOwnerContent(overrideInsets: Boolean, content: @Composable () -> Unit) {
+    if (overrideInsets) {
+        val safeArea = LocalSafeArea.current
+        val layoutMargins = LocalLayoutMargins.current
+        CompositionLocalProvider(
+            LocalSafeArea provides PlatformInsets(),
+            LocalLayoutMargins provides layoutMargins.exclude(safeArea),
+            content = content
+        )
+    } else {
+        content()
+    }
 }


### PR DESCRIPTION
## Proposed Changes

- Override `RootLayout` insets only in case of `usePlatformInsets`

## Testing

Test: look at `Popup` example in mpp

```kt
Popup(properties = PopupProperties(usePlatformInsets = false)) {
    Box(Modifier.fillMaxSize().background(Color.Yellow)) {
        Box(Modifier.systemBarsPadding()) {
            Text("Example Popup content")
        }
    }
}
```

Settings | Before | After
--- | --- | ---
<img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/c01468c1-a554-48b0-96a7-2a8215f386ed" height="500"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/01bdab3d-ae1f-44d4-a2d1-0b73f1396f80" height="500"> | <img src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/8c3e0a6e-471b-4945-a8ae-a1da03e368e6" height="500">

