### PR TITLE
Fix outlined text view regression

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -585,11 +585,6 @@ internal fun CoreTextField(
 
     val overscrollEffect = rememberTextFieldOverscrollEffect()
 
-    fun Modifier.overscroll(): Modifier =
-        overscrollEffect?.let {
-            this then it.effectModifier
-        } ?: this
-
     // Modifiers that should be applied to the outer text field container. Usually those include
     // gesture and semantics modifiers.
     val decorationBoxModifier = modifier
@@ -613,6 +608,11 @@ internal fun CoreTextField(
 
     CoreTextFieldRootBox(decorationBoxModifier, manager) {
         decorationBox {
+            fun Modifier.overscroll(): Modifier =
+                overscrollEffect?.let {
+                    this then it.effectModifier
+                } ?: this
+
             // Modifiers applied directly to the internal input field implementation. In general,
             // these will most likely include draw, layout and IME related modifiers.
             val coreTextFieldModifier = Modifier

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -608,11 +608,6 @@ internal fun CoreTextField(
 
     CoreTextFieldRootBox(decorationBoxModifier, manager) {
         decorationBox {
-            fun Modifier.overscroll(): Modifier =
-                overscrollEffect?.let {
-                    this then it.effectModifier
-                } ?: this
-
             // Modifiers applied directly to the internal input field implementation. In general,
             // these will most likely include draw, layout and IME related modifiers.
             val coreTextFieldModifier = Modifier
@@ -624,7 +619,11 @@ internal fun CoreTextField(
                     minLines = minLines,
                     maxLines = maxLines
                 )
-                .overscroll()
+                .run {
+                    overscrollEffect?.let {
+                        this then it.effectModifier
+                    } ?: this
+                }
                 .textFieldScroll(
                     scrollerPosition,
                     value,

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -583,6 +583,13 @@ internal fun CoreTextField(
             imeAction = imeOptions.imeAction,
         )
 
+    val overscrollEffect = rememberTextFieldOverscrollEffect()
+
+    fun Modifier.overscroll(): Modifier =
+        overscrollEffect?.let {
+            this then it.effectModifier
+        } ?: this
+
     // Modifiers that should be applied to the outer text field container. Usually those include
     // gesture and semantics modifiers.
     val decorationBoxModifier = modifier
@@ -590,7 +597,7 @@ internal fun CoreTextField(
         .interceptDPadAndMoveFocus(state, focusManager)
         .previewKeyEventToDeselectOnBack(state, manager)
         .then(textKeyInputModifier)
-        .textFieldScrollable(scrollerPosition, interactionSource, enabled)
+        .textFieldScrollable(scrollerPosition, interactionSource, enabled, overscrollEffect)
         .then(pointerModifier)
         .then(semanticsModifier)
         .onGloballyPositioned {
@@ -617,6 +624,7 @@ internal fun CoreTextField(
                     minLines = minLines,
                     maxLines = maxLines
                 )
+                .overscroll()
                 .textFieldScroll(
                     scrollerPosition,
                     value,

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -608,6 +608,11 @@ internal fun CoreTextField(
 
     CoreTextFieldRootBox(decorationBoxModifier, manager) {
         decorationBox {
+            fun Modifier.overscroll(): Modifier =
+                overscrollEffect?.let {
+                    this then it.effectModifier
+                } ?: this
+
             // Modifiers applied directly to the internal input field implementation. In general,
             // these will most likely include draw, layout and IME related modifiers.
             val coreTextFieldModifier = Modifier
@@ -619,11 +624,7 @@ internal fun CoreTextField(
                     minLines = minLines,
                     maxLines = maxLines
                 )
-                .run {
-                    overscrollEffect?.let {
-                        this then it.effectModifier
-                    } ?: this
-                }
+                .overscroll()
                 .textFieldScroll(
                     scrollerPosition,
                     value,

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
@@ -64,7 +64,8 @@ internal expect fun rememberTextFieldOverscrollEffect(): OverscrollEffect?
 internal fun Modifier.textFieldScrollable(
     scrollerPosition: TextFieldScrollerPosition,
     interactionSource: MutableInteractionSource? = null,
-    enabled: Boolean = true
+    enabled: Boolean = true,
+    overscrollEffect: OverscrollEffect? = null
 ) = composed(
     inspectorInfo = debugInspectorInfo {
         name = "textFieldScrollable"
@@ -93,8 +94,6 @@ internal fun Modifier.textFieldScrollable(
         createScrollableState(scrollableState, scrollerPosition)
     }
 
-    val overscrollEffect = rememberTextFieldOverscrollEffect()
-
     val scroll = Modifier.scrollable(
         orientation = scrollerPosition.orientation,
         reverseDirection = reverseDirection,
@@ -104,11 +103,7 @@ internal fun Modifier.textFieldScrollable(
         enabled = enabled && scrollerPosition.maximum != 0f
     )
 
-    overscrollEffect?.effectModifier?.let { overscrollModifer ->
-        // Just like LazyList does, we need to apply clipScrollableContainer
-        // to avoid situation where overscroll modifier causes text to clip through the container
-        Modifier.clipScrollableContainer(scrollerPosition.orientation) then overscrollModifer then scroll
-    } ?: scroll
+    scroll
 
 }
 

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -16,19 +16,17 @@
 
 package androidx.compose.mpp.demo.textfield
 
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
@@ -59,6 +57,17 @@ val TextFields = Screen.Selection(
             FastDelete()
         }
     },
+    Screen.Example("OutlinedTextField") {
+        ClearFocusBox {
+            var text by remember { mutableStateOf("Some text") }
+            OutlinedTextField(
+                readOnly = true,
+                value = text,
+                onValueChange = { text = it },
+                label = { Text("OutlinedTextField Label") },
+            )
+        }
+    }
 )
 
 @Composable


### PR DESCRIPTION
## Proposed Changes

Construct `OverscrollEffect` outside of `textFieldScrollable` and pass it there to keep scroll behavior similar to iOS (the only platform providing text field overscroll for now)
Use the `OverscrollEffect.effectModifier` (if any) for internal text and not decoration box itself to avoid unintended clipping.

## Testing

Test: check that `OutlinedTextField` is not incorrectly clipped. `OverscrollEffect` for large text fields still works correctly.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3737