### PR TITLE
iOS UIKit interop regression fix

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
@@ -3,6 +3,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.mpp.demo.Screen
@@ -11,9 +14,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.interop.LocalUIViewController
+import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
+import platform.UIKit.UILabel
 import platform.UIKit.UINavigationController
 import platform.UIKit.navigationController
+import platform.UIKit.UIColor
 
 /*
  * Copyright 2023 The Android Open Source Project
@@ -63,6 +70,18 @@ private fun NativeNavigationPage() {
             )
         }) {
             Text("Push")
+        }
+
+        LazyVerticalGrid(GridCells.Fixed(2)) {
+            items(10) { index ->
+                UIKitView(factory = {
+                    val label = UILabel()
+                    label.text = "Lorem ipsum $index"
+                    label.backgroundColor = UIColor.whiteColor
+                    label.textColor = UIColor.blackColor
+                    label
+                }, Modifier.height(80.dp))
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Bind `UIKitInteropContext` to `AttachedComposeContext` lifetime, flush all pending `UIKitInteropActions` when `AttachedComposeContext` is closed.

## Testing

Test: check that there are no black screens for interop `UIImageView`s in Demo/NativeModalWithNavigation

## Issues Fixed

Fixes: [invalid UIKit view hierarchy when scene is disposed after navigating from ComposeUIViewController sourcing it](https://github.com/JetBrains/compose-multiplatform/issues/3749).

https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/f76dcfb4-9571-4257-a7be-d1d2fa837ad5