### PR TITLE
iOS: Fix first screen is recomposed twice

### DIFF
--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -21,5 +21,5 @@ import androidx.compose.ui.window.ComposeUIViewController
 // TODO This module is just a proxy to run the demo from mpp:demo. Figure out how to get rid of it.
 //  If it is removed, there is no available configuration in IDE
 fun getViewControllerWithCompose() = ComposeUIViewController {
-    IosDemo()
+    IosDemo("")
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -6,16 +6,18 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.main.defaultUIKitMain
 import androidx.compose.ui.window.ComposeUIViewController
 import bugs.IosBugs
+import bugs.StartRecompositionCheck
 
 
-fun main() {
+fun main(vararg args: String) {
+    val arg = args.firstOrNull() ?: ""
     defaultUIKitMain("ComposeDemo", ComposeUIViewController {
-        IosDemo()
+        IosDemo(arg)
     })
 }
 
 @Composable
-fun IosDemo() {
+fun IosDemo(arg: String) {
     val app = remember {
         App(
             extraScreens = listOf(
@@ -24,5 +26,10 @@ fun IosDemo() {
             )
         )
     }
-    app.Content()
+    when (arg) {
+        "demo=StartRecompositionCheck" ->
+            // The issue tested by this demo can be properly reproduced/tested only right after app start
+            StartRecompositionCheck.content()
+        else -> app.Content()
+    }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/RedundantRecompositionOnStart.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/RedundantRecompositionOnStart.kt
@@ -17,19 +17,19 @@
 package bugs
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.Text
 import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 
 private var counter = 0
 
 // https://github.com/JetBrains/compose-multiplatform/issues/3778
 val StartRecompositionCheck = Screen.Example("Start Recomposition Check") {
-    remember {
-        counter = 0
-    }
-
     val value = remember(LocalDensity.current) {
         (1..100).random()
     }
@@ -37,6 +37,8 @@ val StartRecompositionCheck = Screen.Example("Start Recomposition Check") {
     println("value is $value")
 
     Column {
+        Spacer(Modifier.height(64.dp))
+        Text("This demo should be launched using app arguments: `demo=StartRecompositionCheck`\n")
         Text("Recompositions count = ${++counter} (should be 1)")
         Text("Density = ${LocalDensity.current}")
     }

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/RedundantRecompositionOnStart.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/RedundantRecompositionOnStart.kt
@@ -16,18 +16,28 @@
 
 package bugs
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material.Text
 import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
 
+private var counter = 0
+
 // https://github.com/JetBrains/compose-multiplatform/issues/3778
 val StartRecompositionCheck = Screen.Example("Start Recomposition Check") {
-    Text("See logs. Density should be printed only once")
+    remember {
+        counter = 0
+    }
 
     val value = remember(LocalDensity.current) {
         (1..100).random()
     }
     println("Density: ${LocalDensity.current}")
     println("value is $value")
+
+    Column {
+        Text("Recompositions count = ${++counter} (should be 1)")
+        Text("Density = ${LocalDensity.current}")
+    }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/RedundantRecompositionOnStart.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/RedundantRecompositionOnStart.kt
@@ -16,14 +16,18 @@
 
 package bugs
 
+import androidx.compose.material.Text
 import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
 
-val IosBugs = Screen.Selection(
-    "IosBugs",
-    UIKitViewAndDropDownMenu,
-    KeyboardEmptyWhiteSpace,
-    KeyboardPasswordType,
-    UIKitRenderSync,
-    DispatchersMainDelayCheck,
-    StartRecompositionCheck
-)
+// https://github.com/JetBrains/compose-multiplatform/issues/3778
+val StartRecompositionCheck = Screen.Example("Start Recomposition Check") {
+    Text("See logs. Density should be printed only once")
+
+    val value = remember(LocalDensity.current) {
+        (1..100).random()
+    }
+    println("Density: ${LocalDensity.current}")
+    println("value is $value")
+}

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/StartRecompositionCheck.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/StartRecompositionCheck.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 private var counter = 0
 
 // https://github.com/JetBrains/compose-multiplatform/issues/3778
+//TODO: We should write autotest to check this sample: https://youtrack.jetbrains.com/issue/COMPOSE-488/iOS-test-on-CI-to-check-recompositions-count
 val StartRecompositionCheck = Screen.Example("Start Recomposition Check") {
     val value = remember(LocalDensity.current) {
         (1..100).random()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -679,9 +679,8 @@ internal actual class ComposeWindow : UIViewController {
                         LocalInterfaceOrientationState provides interfaceOrientationState,
                         LocalSystemTheme provides systemTheme.value,
                         LocalUIKitInteropContext provides interopContext,
-                    ) {
-                        content()
-                    }
+                        content = content
+                    )
                 },
             )
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -605,6 +605,7 @@ internal actual class ComposeWindow : UIViewController {
             density = density,
             invalidate = skikoUIView::needRedraw,
         )
+        val isReadyToShowContent = mutableStateOf(false)
 
         skikoUIView.input = inputServices.skikoInput
         skikoUIView.inputTraits = inputTraits
@@ -663,9 +664,12 @@ internal actual class ComposeWindow : UIViewController {
 
                 scene.render(canvas, nanos)
             }
-        }
 
-        val isReadyToShowContent = mutableStateOf(false)
+            override fun onAttachedToWindow() {
+                attachedComposeContext!!.scene.density = density
+                isReadyToShowContent.value = true
+            }
+        }
 
         scene.setContent(
             onPreviewKeyEvent = inputServices::onPreviewKeyEvent,
@@ -691,11 +695,6 @@ internal actual class ComposeWindow : UIViewController {
                 it.setConstraintsToFillView(view)
                 updateLayout(it)
             }
-
-        skikoUIView.onAttachedToWindow = {
-            attachedComposeContext!!.scene.density = density
-            isReadyToShowContent.value = true
-        }
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -665,31 +665,35 @@ internal actual class ComposeWindow : UIViewController {
             }
         }
 
-        scene.setContent(
-            onPreviewKeyEvent = inputServices::onPreviewKeyEvent,
-            onKeyEvent = { false },
-            content = {
-                CompositionLocalProvider(
-                    LocalLayerContainer provides view,
-                    LocalUIViewController provides this,
-                    LocalKeyboardOverlapHeightState provides keyboardOverlapHeightState,
-                    LocalSafeArea provides safeAreaState,
-                    LocalLayoutMargins provides layoutMarginsState,
-                    LocalInterfaceOrientationState provides interfaceOrientationState,
-                    LocalSystemTheme provides systemTheme.value,
-                    LocalUIKitInteropContext provides interopContext,
-                ) {
-                    content()
+        fun onReadyToSetContent() {
+            scene.setContent(
+                onPreviewKeyEvent = inputServices::onPreviewKeyEvent,
+                onKeyEvent = { false },
+                content = {
+                    CompositionLocalProvider(
+                        LocalLayerContainer provides view,
+                        LocalUIViewController provides this,
+                        LocalKeyboardOverlapHeightState provides keyboardOverlapHeightState,
+                        LocalSafeArea provides safeAreaState,
+                        LocalLayoutMargins provides layoutMarginsState,
+                        LocalInterfaceOrientationState provides interfaceOrientationState,
+                        LocalSystemTheme provides systemTheme.value,
+                        LocalUIKitInteropContext provides interopContext,
+                    ) {
+                        content()
+                    }
+                },
+            )
+        }
+
+        skikoUIView.onAttachedToWindow = {
+            attachedComposeContext =
+                AttachedComposeContext(scene, skikoUIView, interopContext).also {
+                    it.setConstraintsToFillView(view)
+                    updateLayout(it)
                 }
-            },
-        )
-
-
-        attachedComposeContext =
-            AttachedComposeContext(scene, skikoUIView, interopContext).also {
-                it.setConstraintsToFillView(view)
-                updateLayout(it)
-            }
+            onReadyToSetContent()
+        }
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -107,6 +107,11 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             _redrawer.needsProactiveDisplayLink = needHighFrequencyPolling
         }
 
+    /**
+     * A callback to let ComposeWindow listen to [didMoveToWindow]
+     */
+    internal lateinit var onAttachedToWindow: () -> Unit
+
     constructor() : super(frame = CGRectZero.readValue())
 
     init {
@@ -196,6 +201,9 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
         window?.screen?.let {
             contentScaleFactor = it.scale
             _redrawer.maximumFramesPerSecond = it.maximumFramesPerSecond
+        }
+        if (window != null) {
+            onAttachedToWindow()
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -53,6 +53,11 @@ internal interface SkikoUIViewDelegate {
     fun retrieveInteropTransaction(): UIKitInteropTransaction
 
     fun render(canvas: Canvas, targetTimestamp: NSTimeInterval)
+
+    /**
+     * A callback invoked when [UIView.didMoveToWindow] receives non null window
+     */
+    fun onAttachedToWindow() {}
 }
 
 internal enum class UITouchesEventPhase {
@@ -106,11 +111,6 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
             _redrawer.needsProactiveDisplayLink = needHighFrequencyPolling
         }
-
-    /**
-     * A callback to let ComposeWindow listen to [didMoveToWindow]
-     */
-    internal lateinit var onAttachedToWindow: () -> Unit
 
     constructor() : super(frame = CGRectZero.readValue())
 
@@ -203,7 +203,7 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             _redrawer.maximumFramesPerSecond = it.maximumFramesPerSecond
         }
         if (window != null) {
-            onAttachedToWindow()
+            delegate?.onAttachedToWindow()
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3778

Implemented according to what @elijah-semyonov suggested:

> We need to defer the first recomposition until `didMoveToWindow` was called with non-nil window. That's when a correct density scale is available.