### PR TITLE
Report semantic `ProgressBarRangeInfo` changes.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.node.LayoutNode
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -118,6 +119,15 @@ internal class AccessibilityControllerImpl(
                                     AccessibleState.CHECKED, null
                                 )
                         }
+                    }
+
+                    SemanticsProperties.ProgressBarRangeInfo -> {
+                        val value = entry.value as ProgressBarRangeInfo
+                        component.composeAccessibleContext.firePropertyChange(
+                            ACCESSIBLE_VALUE_PROPERTY,
+                            prev,
+                            value.current
+                        )
                     }
                 }
             }


### PR DESCRIPTION
Currently, we don't report progress bar value changes to the accessibility system.

## Proposed Changes

Fire a property change event when the ProgressBarRangeInfo value changes. This is what Swing's JProgressBar does.


## Testing

Test: Ran this with VoiceOver on:

```
fun main() = singleWindowApplication {
    Column {
        var progress by remember { mutableStateOf(0.0f) }

        LinearProgressIndicator(
            progress,
            modifier = Modifier.focusable().height(16.dp)
        )

        LaunchedEffect(progress) {
            if (progress < 1f) {
                delay(2000)
                progress += 0.1f
            }
        }
    }
}
```
