### PR TITLE
Add test to verify that a modal DialogWindow doesn't block rendering in the parent window.

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.sendKeyEvent
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.toInt
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -605,5 +607,37 @@ class DialogWindowTest {
         layoutDirection = LayoutDirection.Ltr
         awaitIdle()
         assertThat(localLayoutDirection).isEqualTo(LayoutDirection.Ltr)
+    }
+
+    @Test
+    fun `modal DialogWindow does not block parent window rendering`() = runApplicationTest {
+        var text by mutableStateOf("1")
+        var renderedText: String? = null
+        lateinit var dialog: ComposeDialog
+
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                val textMeasurer = rememberTextMeasurer()
+                Canvas(Modifier.size(200.dp)) {
+                    renderedText = text
+                    drawText(
+                        textMeasurer = textMeasurer,
+                        text = text
+                    )
+                }
+
+                DialogWindow(onCloseRequest = {}) {
+                    dialog = window
+                }
+            }
+        }
+
+        awaitIdle()
+        assertThat(dialog.isModal).isTrue()
+        assertThat(renderedText).isEqualTo("1")
+
+        text = "2"
+        awaitIdle()
+        assertThat(renderedText).isEqualTo("2")
     }
 }


### PR DESCRIPTION
This PR is not meant to be merged. I just want to see whether the test fails in the CI before the changes in https://github.com/JetBrains/compose-multiplatform-core/pull/863

## Testing

Test: Added a unit test
