### PR TITLE
Return `null` from ComposeAccessible.getAccessibleContext when the node has been removed

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/Accessibility.desktop.kt
@@ -55,12 +55,13 @@ internal class AccessibilityControllerImpl(
         }
 
     @Suppress("UNUSED_PARAMETER")
-    fun fireNewNodeEvent(accessible: ComposeAccessible) {}
+    private fun onNodeAdded(accessible: ComposeAccessible) {}
 
-    @Suppress("UNUSED_PARAMETER")
-    fun fireRemovedNodeEvent(accessible: ComposeAccessible) {}
+    private fun onNodeRemoved(accessible: ComposeAccessible) {
+        accessible.removed = true
+    }
 
-    fun fireChangedNodeEvent(
+    private fun onNodeChanged(
         component: ComposeAccessible,
         previousSemanticsNode: SemanticsNode,
         newSemanticsNode: SemanticsNode
@@ -160,10 +161,10 @@ internal class AccessibilityControllerImpl(
             nodes[currentNode.id] = previous[currentNode.id]?.let {
                 val prevSemanticsNode = it.semanticsNode
                 it.semanticsNode = currentNode
-                fireChangedNodeEvent(it, prevSemanticsNode, currentNode)
+                onNodeChanged(it, prevSemanticsNode, currentNode)
                 it
             } ?: ComposeAccessible(currentNode, this).also {
-                fireNewNodeEvent(it)
+                onNodeAdded(it)
             }
 
             // TODO fake nodes?
@@ -178,7 +179,7 @@ internal class AccessibilityControllerImpl(
         findAllSemanticNodesRecursive(rootSemanticNode)
         for ((id, prevNode) in previous.entries) {
             if (nodes[id] == null) {
-                fireRemovedNodeEvent(prevNode)
+                onNodeRemoved(prevNode)
             }
         }
         _currentNodes = nodes

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
@@ -91,7 +91,15 @@ internal class ComposeAccessible(
 
     val composeAccessibleContext: ComposeAccessibleComponent by lazy { ComposeAccessibleComponent() }
 
-    override fun getAccessibleContext(): AccessibleContext {
+    var removed = false
+
+    override fun getAccessibleContext(): AccessibleContext? {
+        if (removed) {
+            // The accessibility system keeps calling functions on the context even after the node
+            // has been removed. We return null so it doesn't do that.
+            return null
+        }
+
         // see doc for [nativeInitializeAccessible] for details, why this initialization is needed
         if (isNativelyInitialized.compareAndSet(false, true)) {
             nativeInitializeAccessible(this)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -53,7 +53,7 @@ class AccessibilityTest {
         }
 
         val node = rule.onNodeWithTag("text").fetchSemanticsNode()
-        val accessibleContext = ComposeAccessible(node).accessibleContext
+        val accessibleContext = ComposeAccessible(node).accessibleContext!!
         val accessibleText = accessibleContext.accessibleText!!
         assertEquals(22, accessibleText.charCount)
 
@@ -115,7 +115,7 @@ class AccessibilityTest {
         }
 
         rule.onNodeWithTag("progressbar").apply {
-            val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext
+            val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
             val value = context.accessibleValue
                 ?: fail("No accessibleValue on LinearProgressIndicator")
 
@@ -124,11 +124,10 @@ class AccessibilityTest {
             assertThat(value.maximumAccessibleValue).isEqualTo(1f)
             assertThat(value.currentAccessibleValue).isEqualTo(0.2f)
         }
-
     }
 
     private fun SemanticsNodeInteraction.assertHasAccessibleRole(role: AccessibleRole) {
-        val accessibleContext = ComposeAccessible(fetchSemanticsNode()).accessibleContext
+        val accessibleContext = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
         assertThat(accessibleContext.accessibleRole).isEqualTo(role)
     }
 


### PR DESCRIPTION
The long story of this PR is this:

I reproduced the printed exception in https://github.com/JetBrains/compose-multiplatform/issues/3728 and noticed that we don't report to the accessibility system anywhere when a node has been removed. So I thought it wasn't surprising that it would continue calling functions on it, which would then throw that exception.

So I set out to report node addition/removal by correctly firing `AccessibleContext.ACCESSIBLE_CHILD_PROPERTY` property change events. When that didn't do anything, I realized that `ComposeAccessibleComponent` doesn't have the child/parent hierarchy set up correctly, and thought that perhaps this is confusing the system.

Specifically `rootAccessible` in `AccessibilityControllerImpl` (which is only the root for a single `SemanticsOwner`, so it's not really the root) doesn't report having a parent, even though `ComposeSceneAccessibleContext` returns it from `getAccessibleChild`. So I fixed that. But unfortunately that didn't help either.

Then I decided to see what exactly the system does when it receives an `ACCESSIBLE_CHILD_PROPERTY` property change event. Turns out that `AXChangeNotifier` (the accessible listener on macOS) doesn't even listen to that event, and its (native) `ptr` is `null` altogether for some reason.

So then I just gave up and implemented this PR. It simply marks `ComposeAccessible`s as removed when they are removed, and their `getAccessibleContext` then returns `null`. In `CAccessibility.java`, all the getter functions check the return value of `getAccessibleContext` and return `null` if it returns `null`.

If we want to properly report `ACCESSIBLE_CHILD_PROPERTY` events and have the parents set up correctly, I can submit a separate PR, or just keep it stashed for now.

## Proposed Changes

 When the semantics node of a `ComposeAccessible` is removed, mark it as removed, and have it return `null` from `getAccessibleContext`.


Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3728
