### PR TITLE
COMPOSE-499 Fix crash with Asian languages in TextField.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.kt
@@ -125,6 +125,35 @@ internal interface IOSSkikoInput {
      */
     fun rangeEnclosingPosition(position: Int, withGranularity: UITextGranularity, inDirection: UITextDirection): IntRange?
 
+    /**
+     * Return whether a text position is at a boundary of a text unit of a specified granularity in a specified direction.
+     * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614553-isposition?language=objc
+     * @param position
+     * A text-position object that represents a location in a document.
+     * @param granularity
+     * A constant that indicates a certain granularity of text unit.
+     * @param direction
+     * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+     * @return
+     * TRUE if the text position is at the given text-unit boundary in the given direction; FALSE if it is not at the boundary.
+     */
+    fun isPositionAtBoundary(position: Int, atBoundary: UITextGranularity, inDirection: UITextDirection): Boolean
+
+    /**
+     * Return whether a text position is within a text unit of a specified granularity in a specified direction.
+     * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition?language=objc
+     * @param position
+     * A text-position object that represents a location in a document.
+     * @param granularity
+     * A constant that indicates a certain granularity of text unit.
+     * @param direction
+     * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+     * @return
+     * TRUE if the text position is within a text unit of the specified granularity in the specified direction; otherwise, return FALSE.
+     * If the text position is at a boundary, return TRUE only if the boundary is part of the text unit in the given direction.
+     */
+    fun isPositionWithingTextUnit(position: Int, withinTextUnit: UITextGranularity, inDirection: UITextDirection): Boolean
+
     object Empty : IOSSkikoInput {
         override fun hasText(): Boolean = false
         override fun insertText(text: String) = Unit
@@ -144,5 +173,17 @@ internal interface IOSSkikoInput {
             withGranularity: UITextGranularity,
             inDirection: UITextDirection
         ): IntRange? = null
+
+        override fun isPositionAtBoundary(
+            position: Int,
+            atBoundary: UITextGranularity,
+            inDirection: UITextDirection
+        ): Boolean = false
+
+        override fun isPositionWithingTextUnit(
+            position: Int,
+            withinTextUnit: UITextGranularity,
+            inDirection: UITextDirection
+        ): Boolean = false
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -361,16 +361,7 @@ internal class UIKitTextInputService(
                 }
             }
 
-            val iterator: BreakIterator =
-                when (withGranularity) {
-                    UITextGranularity.UITextGranularitySentence -> BreakIterator.makeSentenceInstance()
-                    UITextGranularity.UITextGranularityLine -> BreakIterator.makeLineInstance()
-                    UITextGranularity.UITextGranularityWord -> BreakIterator.makeWordInstance()
-                    UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
-                    UITextGranularity.UITextGranularityParagraph -> TODO("UITextGranularityParagraph iterator")
-                    UITextGranularity.UITextGranularityDocument -> TODO("UITextGranularityDocument iterator")
-                    else -> error("Unknown granularity")
-                }
+            val iterator: BreakIterator = withGranularity.toTextIterator()
             iterator.setText(text)
 
             if (inDirection == UITextStorageDirectionForward) {
@@ -398,6 +389,63 @@ internal class UIKitTextInputService(
             } else {
                 error("Unknown inDirection: $inDirection")
             }
+        }
+
+        /**
+         * Return whether a text position is at a boundary of a text unit of a specified granularity in a specified direction.
+         * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614553-isposition?language=objc
+         * @param position
+         * A text-position object that represents a location in a document.
+         * @param granularity
+         * A constant that indicates a certain granularity of text unit.
+         * @param direction
+         * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+         * @return
+         * TRUE if the text position is at the given text-unit boundary in the given direction; FALSE if it is not at the boundary.
+         */
+        override fun isPositionAtBoundary(
+            position: Int,
+            atBoundary: UITextGranularity,
+            inDirection: UITextDirection
+        ): Boolean {
+            val text = getState()?.text ?: return false
+            assert(position >= 0) { "isPositionAtBoundary position >= 0" }
+
+            val iterator = atBoundary.toTextIterator()
+            iterator.setText(text)
+            return iterator.isBoundary(position)
+        }
+
+        /**
+         * Return whether a text position is within a text unit of a specified granularity in a specified direction.
+         * https://developer.apple.com/documentation/uikit/uitextinputtokenizer/1614491-isposition?language=objc
+         * @param position
+         * A text-position object that represents a location in a document.
+         * @param granularity
+         * A constant that indicates a certain granularity of text unit.
+         * @param direction
+         * A constant that indicates a direction relative to position. The constant can be of type UITextStorageDirection or UITextLayoutDirection.
+         * @return
+         * TRUE if the text position is within a text unit of the specified granularity in the specified direction; otherwise, return FALSE.
+         * If the text position is at a boundary, return TRUE only if the boundary is part of the text unit in the given direction.
+         */
+        override fun isPositionWithingTextUnit(
+            position: Int,
+            withinTextUnit: UITextGranularity,
+            inDirection: UITextDirection
+        ): Boolean {
+            val text = getState()?.text ?: return false
+            assert(position >= 0) { "isPositionWithingTextUnit position >= 0" }
+
+            val iterator = withinTextUnit.toTextIterator()
+            iterator.setText(text)
+
+            if (inDirection == UITextStorageDirectionForward) {
+
+            } else if (inDirection == UITextStorageDirectionBackward) {
+
+            }
+            return false // TODO: Write implementation
         }
     }
 
@@ -557,3 +605,14 @@ internal class UIKitTextInputService(
     private fun getState(): TextFieldValue? = currentInput?.value
 
 }
+
+private fun UITextGranularity.toTextIterator() =
+    when (this) {
+        UITextGranularity.UITextGranularitySentence -> BreakIterator.makeSentenceInstance()
+        UITextGranularity.UITextGranularityLine -> BreakIterator.makeLineInstance()
+        UITextGranularity.UITextGranularityWord -> BreakIterator.makeWordInstance()
+        UITextGranularity.UITextGranularityCharacter -> BreakIterator.makeCharacterInstance()
+        UITextGranularity.UITextGranularityParagraph -> TODO("UITextGranularityParagraph iterator")
+        UITextGranularity.UITextGranularityDocument -> TODO("UITextGranularityDocument iterator")
+        else -> error("Unknown granularity")
+    }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -495,9 +495,13 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
     }
 
     override fun offsetFromPosition(from: UITextPosition, toPosition: UITextPosition): NSInteger {
-        val fromPosition = from as IntermediateTextPosition
-        val to = toPosition as IntermediateTextPosition
-        return to.position - fromPosition.position
+        if (from !is IntermediateTextPosition) {
+            error("from !is IntermediateTextPosition")
+        }
+        if (toPosition !is IntermediateTextPosition) {
+            error("toPosition !is IntermediateTextPosition")
+        }
+        return toPosition.position - from.position
     }
 
     override fun tokenizer(): UITextInputTokenizerProtocol = @Suppress("CONFLICTING_OVERLOADS") object : UITextInputStringTokenizer() {
@@ -515,10 +519,19 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
          * TRUE if the text position is at the given text-unit boundary in the given direction; FALSE if it is not at the boundary.
          */
         override fun isPosition(
-            position: UITextPosition,
+            position: UITextPosition, // Attention! position may be null.
             atBoundary: UITextGranularity,
             inDirection: UITextDirection
-        ): Boolean = TODO("implement isPosition")
+        ): Boolean {
+            if (position !is IntermediateTextPosition) {
+                return false
+            }
+            return input?.isPositionAtBoundary(
+                position = position.position.toInt(),
+                atBoundary = atBoundary,
+                inDirection = inDirection,
+            ) ?: false
+        }
 
         /**
          * Return whether a text position is within a text unit of a specified granularity in a specified direction.
@@ -534,10 +547,19 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
          * If the text position is at a boundary, return TRUE only if the boundary is part of the text unit in the given direction.
          */
         override fun isPosition(
-            position: UITextPosition,
+            position: UITextPosition, // Attention! position may be null.
             withinTextUnit: UITextGranularity,
             inDirection: UITextDirection
-        ): Boolean = TODO("implement isPosition")
+        ): Boolean {
+            if (position !is IntermediateTextPosition) {
+                return false
+            }
+            return input?.isPositionWithingTextUnit(
+                position = position.position.toInt(),
+                withinTextUnit = withinTextUnit,
+                inDirection = inDirection,
+            ) ?: false
+        }
 
         /**
          * Return the next text position at a boundary of a text unit of the given granularity in a given direction.
@@ -555,7 +577,12 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             position: UITextPosition,
             toBoundary: UITextGranularity,
             inDirection: UITextDirection
-        ): UITextPosition? = null
+        ): UITextPosition? {
+            return null
+            if (position !is IntermediateTextPosition) {
+                error("position !is IntermediateTextPosition")
+            }
+        }
 
         /**
          * Return the range for the text enclosing a text position in a text unit of a given granularity in a given direction.
@@ -575,7 +602,9 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             withGranularity: UITextGranularity,
             inDirection: UITextDirection
         ): UITextRange? {
-            position as IntermediateTextPosition
+            if (position !is IntermediateTextPosition) {
+                error("position !is IntermediateTextPosition")
+            }
             return input?.rangeEnclosingPosition(
                 position = position.position.toInt(),
                 withGranularity = withGranularity,
@@ -595,6 +624,9 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
         position: UITextPosition,
         inDirection: UITextLayoutDirection
     ): UITextRange? {
+        if (position !is IntermediateTextPosition) {
+            error("position !is IntermediateTextPosition")
+        }
         TODO("characterRangeByExtendingPosition, inDirection: ${inDirection.directionToStr()}")
     }
 
@@ -603,6 +635,9 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
         inDirection: UITextStorageDirection
     ): NSWritingDirection {
         return NSWritingDirectionLeftToRight // TODO support RTL text direction
+        if (position !is IntermediateTextPosition) {
+            error("position !is IntermediateTextPosition")
+        }
     }
 
     override fun setBaseWritingDirection(writingDirection: NSWritingDirection, forRange: UITextRange) {
@@ -618,6 +653,9 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
             Ideally, here should be correct rect for caret from Compose.
          */
         return CGRectMake(x = 1.0, y = 1.0, width = 1.0, height = 1.0)
+        if (position !is IntermediateTextPosition) {
+            error("position !is IntermediateTextPosition")
+        }
     }
 
     override fun selectionRectsForRange(range: UITextRange): List<*> = listOf<UITextSelectionRect>()
@@ -627,9 +665,15 @@ internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
 
     override fun textStylingAtPosition(position: UITextPosition, inDirection: UITextStorageDirection): Map<Any?, *>? {
         return NSDictionary.dictionary()
+        if (position !is IntermediateTextPosition) {
+            error("position !is IntermediateTextPosition")
+        }
     }
 
     override fun characterOffsetOfPosition(position: UITextPosition, withinRange: UITextRange): NSInteger {
+        if (position !is IntermediateTextPosition) {
+            error("position !is IntermediateTextPosition")
+        }
         TODO("characterOffsetOfPosition")
     }
 


### PR DESCRIPTION
https://github.com/JetBrains/compose-multiplatform/issues/3811 
 - Added basic implementations instead of TODOs.
 - Add additional checks to position argument, because it may be nullable in some methods.

