### PR TITLE
Remove unnecessary state from composition local

### DIFF
--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -64,7 +64,7 @@ actual val WindowInsets.Companion.captionBar: WindowInsets
 actual val WindowInsets.Companion.displayCutout: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class)
-    get() = when (LocalInterfaceOrientationState.current.value) {
+    get() = when (LocalInterfaceOrientation.current) {
         InterfaceOrientation.Portrait -> iosSafeArea.only(WindowInsetsSides.Top)
         InterfaceOrientation.PortraitUpsideDown -> iosSafeArea.only(WindowInsetsSides.Bottom)
         InterfaceOrientation.LandscapeLeft -> iosSafeArea.only(WindowInsetsSides.Right)
@@ -80,7 +80,7 @@ actual val WindowInsets.Companion.displayCutout: WindowInsets
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class)
-    get() = WindowInsets(bottom = LocalKeyboardOverlapHeightState.current.value.dp)
+    get() = WindowInsets(bottom = LocalKeyboardOverlapHeight.current.dp)
 
 /**
  * These insets represent the space where system gestures have priority over application gestures.
@@ -103,7 +103,7 @@ actual val WindowInsets.Companion.navigationBars: WindowInsets
 actual val WindowInsets.Companion.statusBars: WindowInsets
     @Composable
     @OptIn(InternalComposeApi::class)
-    get() = when (LocalInterfaceOrientationState.current.value) {
+    get() = when (LocalInterfaceOrientation.current) {
         InterfaceOrientation.Portrait -> iosSafeArea.only(WindowInsetsSides.Top)
         else -> ZeroInsets
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
@@ -46,6 +46,6 @@ enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
  * Composition local for [InterfaceOrientation]
  */
 @InternalComposeApi
-val LocalInterfaceOrientationState = staticCompositionLocalOf<State<InterfaceOrientation>> {
-    error("CompositionLocal LocalInterfaceOrientationState not present")
+val LocalInterfaceOrientation = staticCompositionLocalOf<InterfaceOrientation> {
+    error("CompositionLocal LocalInterfaceOrientation not present")
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/KeyboardOverlapHeight.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/KeyboardOverlapHeight.uikit.kt
@@ -16,12 +16,14 @@
 
 package androidx.compose.ui.uikit
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.staticCompositionLocalOf
+
 
 /**
  * Composition local for height that is overlapped with keyboard over Compose view.
  */
 @InternalComposeApi
-val LocalKeyboardOverlapHeightState = staticCompositionLocalOf<State<Float>> {
-    error("CompositionLocal LocalKeyboardOverlapHeightState not present")
+val LocalKeyboardOverlapHeight = staticCompositionLocalOf<Float> {
+    error("CompositionLocal LocalKeyboardOverlapHeight not present")
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -157,16 +157,16 @@ private class AttachedComposeContext(
 internal actual class ComposeWindow : UIViewController {
 
     internal lateinit var configuration: ComposeUIViewControllerConfiguration
-    private val keyboardOverlapHeightState = mutableStateOf(0f)
+    private var keyboardOverlapHeightState by mutableStateOf(0f)
     private var isInsideSwiftUI = false
     private var safeAreaState by mutableStateOf(PlatformInsets())
     private var layoutMarginsState by mutableStateOf(PlatformInsets())
 
     /*
-     * Initial value is arbitarily chosen to avoid propagating invalid value logic
+     * Initial value is arbitrarily chosen to avoid propagating invalid value logic
      * It's never the case in real usage scenario to reflect that in type system
      */
-    private val interfaceOrientationState = mutableStateOf(
+    private var interfaceOrientationState by mutableStateOf(
         InterfaceOrientation.Portrait
     )
 
@@ -236,7 +236,7 @@ internal actual class ComposeWindow : UIViewController {
             val bottomIndent = screenHeight - composeViewBottomY
 
             if (bottomIndent < keyboardHeight) {
-                keyboardOverlapHeightState.value = (keyboardHeight - bottomIndent).toFloat()
+                keyboardOverlapHeightState = (keyboardHeight - bottomIndent).toFloat()
             }
 
             val scene = attachedComposeContext?.scene ?: return
@@ -255,7 +255,7 @@ internal actual class ComposeWindow : UIViewController {
         @Suppress("unused")
         @ObjCAction
         fun keyboardWillHide(arg: NSNotification) {
-            keyboardOverlapHeightState.value = 0f
+            keyboardOverlapHeightState = 0f
             if (configuration.onFocusBehavior == OnFocusBehavior.FocusableAboveKeyboard) {
                 updateViewBounds(offsetY = 0.0)
             }
@@ -348,7 +348,7 @@ internal actual class ComposeWindow : UIViewController {
 
         // UIKit possesses all required info for layout at this point
         currentInterfaceOrientation?.let {
-            interfaceOrientationState.value = it
+            interfaceOrientationState = it
         }
 
         attachedComposeContext?.let {
@@ -679,10 +679,10 @@ internal actual class ComposeWindow : UIViewController {
                 CompositionLocalProvider(
                     LocalLayerContainer provides view,
                     LocalUIViewController provides this,
-                    LocalKeyboardOverlapHeightState provides keyboardOverlapHeightState,
+                    LocalKeyboardOverlapHeight provides keyboardOverlapHeightState,
                     LocalSafeArea provides safeAreaState,
                     LocalLayoutMargins provides layoutMarginsState,
-                    LocalInterfaceOrientationState provides interfaceOrientationState,
+                    LocalInterfaceOrientation provides interfaceOrientationState,
                     LocalSystemTheme provides systemTheme.value,
                     LocalUIKitInteropContext provides interopContext,
                     content = content

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeWindow.uikit.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.input.pointer.HistoricalChange
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.input.pointer.toCompose
 import androidx.compose.ui.interop.LocalLayerContainer
 import androidx.compose.ui.interop.LocalUIKitInteropContext
 import androidx.compose.ui.interop.LocalUIViewController
@@ -43,15 +42,12 @@ import androidx.compose.ui.platform.*
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.uikit.*
 import androidx.compose.ui.unit.*
-import androidx.compose.ui.util.fastMap
 import kotlin.math.floor
 import kotlin.math.roundToInt
-import kotlin.math.roundToLong
 import kotlin.math.roundToLong
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.ObjCAction
-import kotlinx.cinterop.objcPtr
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.Dispatchers
@@ -59,8 +55,6 @@ import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.SkikoKeyboardEvent
-import org.jetbrains.skiko.SkikoPointerEvent
-import org.jetbrains.skiko.currentNanoTime
 import platform.CoreGraphics.CGPoint
 import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGAffineTransformIdentity
@@ -157,16 +151,16 @@ private class AttachedComposeContext(
 internal actual class ComposeWindow : UIViewController {
 
     internal lateinit var configuration: ComposeUIViewControllerConfiguration
-    private var keyboardOverlapHeightState by mutableStateOf(0f)
+    private var keyboardOverlapHeight by mutableStateOf(0f)
     private var isInsideSwiftUI = false
-    private var safeAreaState by mutableStateOf(PlatformInsets())
-    private var layoutMarginsState by mutableStateOf(PlatformInsets())
+    private var safeArea by mutableStateOf(PlatformInsets())
+    private var layoutMargins by mutableStateOf(PlatformInsets())
 
     /*
      * Initial value is arbitrarily chosen to avoid propagating invalid value logic
      * It's never the case in real usage scenario to reflect that in type system
      */
-    private var interfaceOrientationState by mutableStateOf(
+    private var interfaceOrientation by mutableStateOf(
         InterfaceOrientation.Portrait
     )
 
@@ -236,7 +230,7 @@ internal actual class ComposeWindow : UIViewController {
             val bottomIndent = screenHeight - composeViewBottomY
 
             if (bottomIndent < keyboardHeight) {
-                keyboardOverlapHeightState = (keyboardHeight - bottomIndent).toFloat()
+                keyboardOverlapHeight = (keyboardHeight - bottomIndent).toFloat()
             }
 
             val scene = attachedComposeContext?.scene ?: return
@@ -255,7 +249,7 @@ internal actual class ComposeWindow : UIViewController {
         @Suppress("unused")
         @ObjCAction
         fun keyboardWillHide(arg: NSNotification) {
-            keyboardOverlapHeightState = 0f
+            keyboardOverlapHeight = 0f
             if (configuration.onFocusBehavior == OnFocusBehavior.FocusableAboveKeyboard) {
                 updateViewBounds(offsetY = 0.0)
             }
@@ -305,7 +299,7 @@ internal actual class ComposeWindow : UIViewController {
     fun viewSafeAreaInsetsDidChange() {
         // super.viewSafeAreaInsetsDidChange() // TODO: call super after Kotlin 1.8.20
         view.safeAreaInsets.useContents {
-            safeAreaState = PlatformInsets(
+            safeArea = PlatformInsets(
                 left = left.dp,
                 top = top.dp,
                 right = right.dp,
@@ -313,7 +307,7 @@ internal actual class ComposeWindow : UIViewController {
             )
         }
         view.directionalLayoutMargins.useContents {
-            layoutMarginsState = PlatformInsets(
+            layoutMargins = PlatformInsets(
                 left = leading.dp, // TODO: Check RTL support
                 top = top.dp,
                 right = trailing.dp, // TODO: Check RTL support
@@ -348,7 +342,7 @@ internal actual class ComposeWindow : UIViewController {
 
         // UIKit possesses all required info for layout at this point
         currentInterfaceOrientation?.let {
-            interfaceOrientationState = it
+            interfaceOrientation = it
         }
 
         attachedComposeContext?.let {
@@ -679,10 +673,10 @@ internal actual class ComposeWindow : UIViewController {
                 CompositionLocalProvider(
                     LocalLayerContainer provides view,
                     LocalUIViewController provides this,
-                    LocalKeyboardOverlapHeight provides keyboardOverlapHeightState,
-                    LocalSafeArea provides safeAreaState,
-                    LocalLayoutMargins provides layoutMarginsState,
-                    LocalInterfaceOrientation provides interfaceOrientationState,
+                    LocalKeyboardOverlapHeight provides keyboardOverlapHeight,
+                    LocalSafeArea provides safeArea,
+                    LocalLayoutMargins provides layoutMargins,
+                    LocalInterfaceOrientation provides interfaceOrientation,
                     LocalSystemTheme provides systemTheme.value,
                     LocalUIKitInteropContext provides interopContext,
                     content = content


### PR DESCRIPTION
## Proposed Changes

Changing API marked as internal (`@InternalComposeApi`)

```diff
-androidx.compose.ui.uikit.LocalInterfaceOrientationState
+androidx.compose.ui.uikit.LocalInterfaceOrientation
```
```diff
-androidx.compose.ui.uikit.LocalKeyboardOverlapHeightState
+androidx.compose.ui.uikit.LocalKeyboardOverlapHeight
```


## Testing

Test: run test app on iOS
