### PR TITLE
DatePicker. Fix selection of the current day

### DIFF
--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/PlatformDateFormat.darwin.kt
@@ -57,6 +57,7 @@ internal actual object PlatformDateFormat {
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
         return NSDateFormatter().apply {
+            setTimeZone(TimeZone.UTC.toNSTimeZone())
             setLocale(locale)
             setLocalizedDateFormatFromTemplate(skeleton)
         }.stringFromDate(nsDate)

--- a/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/jsWasmMain/kotlin/androidx/compose/material3/PlatformDateFormat.jsWasm.kt
@@ -55,7 +55,7 @@ internal actual object PlatformDateFormat {
 
         val date = Instant
             .fromEpochMilliseconds(utcTimeMillis)
-            .toLocalDateTime(TimeZone.currentSystemDefault())
+            .toLocalDateTime(TimeZone.UTC)
 
         val jsDate = Date(utcTimeMillis)
 

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/KotlinxDatetimeCalendarModelTest.kt
@@ -259,6 +259,45 @@ internal class KotlinxDatetimeCalendarModelTest {
     }
 
     @Test
+    fun formatDate_differentTZ() {
+
+        if (!supportsDateSkeleton)
+            return
+
+        val defaultTz = getTimeZone()
+
+        val locale = calendarLocale("en","US")
+
+        val date =
+            CalendarDate(
+                year = 2022,
+                month = 1,
+                dayOfMonth = 1,
+                utcTimeMillis = January2022Millis
+            )
+
+        val test = {
+            assertThat(model.formatWithSkeleton(date, "yMMMd", locale)).isEqualTo("Jan 1, 2022")
+            assertThat(model.formatWithSkeleton(date, "dMMMy", locale)).isEqualTo("Jan 1, 2022")
+            assertThat(model.formatWithSkeleton(date, "yMMMMEEEEd", locale))
+                .isEqualTo("Saturday, January 1, 2022")
+            // Check that the direct formatting is equal to the one the model does.
+            assertThat(model.formatWithSkeleton(date, "yMMMd", locale))
+                .isEqualTo(date.format(model, "yMMMd", locale))
+        }
+
+        setTimeZone("GMT-5")
+
+        test()
+
+        setTimeZone("GMT+5")
+
+        test()
+
+        setTimeZone(defaultTz)
+    }
+
+    @Test
     fun formatMonth() {
 
         if (!supportsDateSkeleton)
@@ -271,6 +310,36 @@ internal class KotlinxDatetimeCalendarModelTest {
         // Check that the direct formatting is equal to the one the model does.
         assertThat(model.formatWithSkeleton(month, "yMMMM", locale))
             .isEqualTo(month.format(model, "yMMMM", locale))
+    }
+
+    @Test
+    fun formatMonth_differentTz() {
+
+        if (!supportsDateSkeleton)
+            return
+        val defaultTz = getTimeZone()
+
+
+        val locale = calendarLocale("en", "US")
+        val month = model.getMonth(year = 2022, month = 3)
+
+        val test = {
+            assertThat(model.formatWithSkeleton(month, "yMMMM", locale)).isEqualTo("March 2022")
+            assertThat(model.formatWithSkeleton(month, "MMMMy", locale)).isEqualTo("March 2022")
+            // Check that the direct formatting is equal to the one the model does.
+            assertThat(model.formatWithSkeleton(month, "yMMMM", locale))
+                .isEqualTo(month.format(model, "yMMMM", locale))
+        }
+
+        setTimeZone("GMT-5")
+
+        test()
+
+        setTimeZone("GMT+5")
+
+        test()
+
+        setTimeZone(defaultTz)
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

Fixed  https://kotlinlang.slack.com/archives/CJLTWPH7S/p1697506072139909

Draft because I can't build compose with xcode 15 even with `-ld64` workaround.
 Can you please run tests for uikit and check datepicker on device with
`NSTimeZone.setDefaultTimeZone(NSTimeZone.timeZoneWithName("GMT-5")!!)`

## Testing

Test: new unit tests

