### PR TITLE
Fix NPE for getComponentAfter/Before in ComposePanel

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -57,13 +57,19 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         background = Color.white
         layout = null
         focusTraversalPolicy = object : FocusTraversalPolicy() {
-            override fun getComponentAfter(aContainer: Container?, aComponent: Component?): Component {
+            override fun getComponentAfter(
+                aContainer: Container?,
+                aComponent: Component?
+            ): Component? {
                 val ancestor = focusCycleRootAncestor
                 val policy = ancestor.focusTraversalPolicy
                 return policy.getComponentAfter(ancestor, this@ComposePanel)
             }
 
-            override fun getComponentBefore(aContainer: Container?, aComponent: Component?): Component {
+            override fun getComponentBefore(
+                aContainer: Container?,
+                aComponent: Component?
+            ): Component? {
                 val ancestor = focusCycleRootAncestor
                 val policy = ancestor.focusTraversalPolicy
                 return policy.getComponentBefore(ancestor, this@ComposePanel)


### PR DESCRIPTION
## Proposed Changes

- Make return type of getComponentAfter/Before nullable in ComposePanel

These methods are called on remove(ComposePanel.desktop.kt:121), and since NPE can be thrown bridge property doesn't become null (ComposePanel.desktop.kt:122)

Related issue: https://github.com/JetBrains/jewel/issues/182