### PR TITLE
Support a11y navigation for Swing interop

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeSwingLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeSwingLayer.desktop.kt
@@ -94,7 +94,7 @@ internal class SwingComposeBridge(
         get() = component
 
     override fun requestNativeFocusOnAccessible(accessible: Accessible) {
-        // TODO: support a11y
+        component.requestNativeFocusOnAccessible(accessible)
     }
 
     override fun onComposeInvalidation() {


### PR DESCRIPTION
## Proposed Changes

Enable a11y navigation, so focus change inside Compose component will be properly handled by a11y support