### PR TITLE
Desktop. Fix input methods on JBR, disable input methods when we lose focus

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -113,6 +113,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         if (bridge != null) {
             bridge!!.dispose()
             super.remove(bridge!!.component)
+            super.remove(bridge!!.invisibleComponent)
             bridge = null
         }
     }
@@ -187,6 +188,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         if (bridge == null) {
             bridge = createComposeBridge()
             initContent()
+            super.add(bridge!!.invisibleComponent, Integer.valueOf(1))
             super.add(bridge!!.component, Integer.valueOf(1))
         }
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt
@@ -93,11 +93,13 @@ internal class ComposeWindowDelegate(
 
         init {
             layout = null
+            super.add(bridge.invisibleComponent, 1)
             super.add(bridge.component, 1)
         }
 
         fun dispose() {
             super.remove(bridge.component)
+            super.remove(bridge.invisibleComponent)
         }
     }
 


### PR DESCRIPTION
### Rerequest focus on main component when we need to type using input methods
Fixes https://github.com/JetBrains/compose-multiplatform/issues/2628

The issue was because of 2 things:
  - we used a hack to force a focused event (`component.inputContext.dispatchEvent(focusGainedEvent)`
  - JBR added optimization to ignore focus on the same element (thanks @AiHMin for investigation [here](https://github.com/JetBrains/compose-multiplatform/issues/2628#issuecomment-1704562796)). In Compose we have only one element. 
Because optimization is correct, and the hack depends on the internals, it isn't right to fix it in JBR, we should fix it in Compose. Furthermore, even without JBR changes, this hack didn't complete work - we can't for example use it for disabling input methods (see the next point).

In this PR we also use a hack unfortenutely - we refocus the root component, focusing on invisible component first. That leads to another issue with acccessibility, but we fix it [here](https://github.com/JetBrains/compose-multiplatform-core/pull/885)).

A proper fix should be switching to native code, or making an API in JBR (but other vendors still be unsupported).

### Don't show input methods popup if there is no focused TextField 

Previously we showed a popup, even if there are no focused textfield:
![image](https://github.com/JetBrains/compose-multiplatform-core/assets/5963351/82e3543f-11f4-4013-8da5-d782b824ed2c)
Now we don't show it if we isn't in a textfield.
P.S. only on Windows/Linux for now, on macOs Swing seems has [a bug](https://github.com/JetBrains/compose-multiplatform/issues/3839)

## Testing
Tested manually on:
1. Windows, Chinese/Korean/Japanese, OpenJDK/JBR 17, Accessibility enabled/disabled, ComposeWindow/ComposePanel
2. macOs, Chinese, OpenJDK/JBR 17, Accessibility enabled/disabled
4. Linux, Chinese layout, OpenJDK 17