### PR TITLE
UIViewController interop

### DIFF
--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
@@ -35,7 +35,7 @@ struct NestedContentView: View {
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         SwiftHelper().getViewController { index in
-            let viewController = UIHostingController(rootView: NestedContentView(index: index))
+            let viewController = UIHostingController(rootView: NestedContentView(index: Int(index)))
             return viewController
         }
     }

--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
@@ -24,9 +24,18 @@ struct ContentView: View {
     }
 }
 
+struct NestedContentView: View {
+    var body: some View {
+        Text("Hello from SwiftUI")
+    }
+}
+
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        SwiftHelper().getViewController()
+        SwiftHelper().getViewController {
+            let viewController = UIHostingController(rootView: NestedContentView())
+            return viewController
+        }
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}

--- a/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
+++ b/compose/mpp/demo-uikit/src/iosAppMain/apple/ContentView.swift
@@ -25,15 +25,17 @@ struct ContentView: View {
 }
 
 struct NestedContentView: View {
+    let index: Int
+
     var body: some View {
-        Text("Hello from SwiftUI")
+        Text("Hello from SwiftUI #\(index)")
     }
 }
 
 struct ComposeView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        SwiftHelper().getViewController {
-            let viewController = UIHostingController(rootView: NestedContentView())
+        SwiftHelper().getViewController { index in
+            let viewController = UIHostingController(rootView: NestedContentView(index: index))
             return viewController
         }
     }

--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/SwiftHelper.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/SwiftHelper.kt
@@ -19,5 +19,5 @@ package androidx.compose.mpp.demo
 import platform.UIKit.UIViewController
 
 class SwiftHelper {
-    fun getViewController(): UIViewController = getViewControllerWithCompose()
+    fun getViewController(makeHostingViewController: () -> UIViewController): UIViewController = getViewControllerWithCompose(makeHostingViewController)
 }

--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/SwiftHelper.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/SwiftHelper.kt
@@ -19,5 +19,5 @@ package androidx.compose.mpp.demo
 import platform.UIKit.UIViewController
 
 class SwiftHelper {
-    fun getViewController(makeHostingViewController: () -> UIViewController): UIViewController = getViewControllerWithCompose(makeHostingViewController)
+    fun getViewController(makeHostingViewController: (Int) -> UIViewController): UIViewController = getViewControllerWithCompose(makeHostingViewController)
 }

--- a/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
+++ b/compose/mpp/demo-uikit/src/uikitMain/kotlin/androidx/compose/mpp/demo/getViewControllerWithCompose.kt
@@ -21,6 +21,6 @@ import platform.UIKit.UIViewController
 
 // TODO This module is just a proxy to run the demo from mpp:demo. Figure out how to get rid of it.
 //  If it is removed, there is no available configuration in IDE
-fun getViewControllerWithCompose(makeHostingViewController: () -> UIViewController) = ComposeUIViewController {
+fun getViewControllerWithCompose(makeHostingViewController: (Int) -> UIViewController) = ComposeUIViewController {
     IosDemo("", makeHostingViewController)
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/SwiftUIInteropExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/SwiftUIInteropExample.kt
@@ -36,7 +36,7 @@ fun SwiftUIInteropExample(makeViewController: (Int) -> UIViewController) = Scree
             UIKitViewController(factory = {
                 makeViewController(it)
             }, Modifier.fillMaxWidth().height(160.dp))
-            Spacer(Modifier.height(160.dp).background(Color.Green))
+            Spacer(Modifier.height(160.dp))
         }
     }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/SwiftUIInteropExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/SwiftUIInteropExample.kt
@@ -1,5 +1,12 @@
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitViewController
+import platform.UIKit.UIViewController
+
 /*
- * Copyright 2022 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +21,6 @@
  * limitations under the License.
  */
 
-package androidx.compose.mpp.demo
-
-import androidx.compose.ui.window.ComposeUIViewController
-import platform.UIKit.UIViewController
-
-// TODO This module is just a proxy to run the demo from mpp:demo. Figure out how to get rid of it.
-//  If it is removed, there is no available configuration in IDE
-fun getViewControllerWithCompose(makeHostingViewController: () -> UIViewController) = ComposeUIViewController {
-    IosDemo("", makeHostingViewController)
+fun SwiftUIInteropExample(makeViewController: () -> UIViewController) = Screen.Example("SwiftUI interop example") {
+    UIKitViewController(makeViewController, Modifier.fillMaxSize())
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/SwiftUIInteropExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/SwiftUIInteropExample.kt
@@ -1,8 +1,17 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.interop.UIKitViewController
+import androidx.compose.ui.unit.dp
 import platform.UIKit.UIViewController
 
 /*
@@ -21,6 +30,13 @@ import platform.UIKit.UIViewController
  * limitations under the License.
  */
 
-fun SwiftUIInteropExample(makeViewController: () -> UIViewController) = Screen.Example("SwiftUI interop example") {
-    UIKitViewController(makeViewController, Modifier.fillMaxSize())
+fun SwiftUIInteropExample(makeViewController: (Int) -> UIViewController) = Screen.Example("SwiftUI interop example") {
+    LazyColumn(Modifier.fillMaxSize()) {
+        items(20) {
+            UIKitViewController(factory = {
+                makeViewController(it)
+            }, Modifier.fillMaxWidth().height(160.dp))
+            Spacer(Modifier.height(160.dp).background(Color.Green))
+        }
+    }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -2,11 +2,13 @@
 package androidx.compose.mpp.demo
 
 import NativeModalWithNaviationExample
+import SwiftUIInteropExample
 import androidx.compose.runtime.*
 import androidx.compose.ui.main.defaultUIKitMain
 import androidx.compose.ui.window.ComposeUIViewController
 import bugs.IosBugs
 import bugs.StartRecompositionCheck
+import platform.UIKit.UIViewController
 
 
 fun main(vararg args: String) {
@@ -17,13 +19,17 @@ fun main(vararg args: String) {
 }
 
 @Composable
-fun IosDemo(arg: String) {
+fun IosDemo(arg: String, makeHostingController: (() -> UIViewController)? = null) {
     val app = remember {
         App(
             extraScreens = listOf(
                 IosBugs,
                 NativeModalWithNaviationExample,
-            )
+            ) + listOf(makeHostingController).mapNotNull {
+                it?.let {
+                    SwiftUIInteropExample(it)
+                }
+            }
         )
     }
     when (arg) {

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -19,7 +19,7 @@ fun main(vararg args: String) {
 }
 
 @Composable
-fun IosDemo(arg: String, makeHostingController: (() -> UIViewController)? = null) {
+fun IosDemo(arg: String, makeHostingController: ((Int) -> UIViewController)? = null) {
     val app = remember {
         App(
             extraScreens = listOf(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -43,25 +43,27 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.round
 import kotlinx.atomicfu.atomic
 import kotlinx.cinterop.CValue
-import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectMake
 import platform.Foundation.NSThread
-import platform.UIKit.NSStringFromCGRect
 import platform.UIKit.UIColor
 import platform.UIKit.UIView
+import platform.UIKit.UIViewController
+import platform.UIKit.addChildViewController
+import platform.UIKit.didMoveToParentViewController
+import platform.UIKit.removeFromParentViewController
+import platform.UIKit.willMoveToParentViewController
 
 private val STUB_CALLBACK_WITH_RECEIVER: Any.() -> Unit = {}
-private val NoOpUpdate: UIView.() -> Unit = STUB_CALLBACK_WITH_RECEIVER
-private val NoOpDispose: UIView.() -> Unit = STUB_CALLBACK_WITH_RECEIVER
-private val DefaultResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setFrame(rect) }
+private val DefaultViewResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setFrame(rect) }
+private val DefaultViewControllerResize: UIViewController.(CValue<CGRect>) -> Unit = { rect -> this.view.setFrame(rect) }
 
 /**
  * @param factory The block creating the [UIView] to be composed.
  * @param modifier The modifier to be applied to the layout. Size should be specified in modifier.
  * Modifier may contains crop() modifier with different shapes.
  * @param update A callback to be invoked after the layout is inflated.
- * @param background A color of UIView background.
+ * @param background A color of [UIView] background wrapping the view created by [factory].
  * @param onRelease A callback invoked as a signal that this view instance has exited the
  * composition hierarchy entirely and will not be reused again. Any additional resources used by the
  * View should be freed at this time.
@@ -72,16 +74,20 @@ private val DefaultResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setF
 fun <T : UIView> UIKitView(
     factory: () -> T,
     modifier: Modifier,
-    update: (T) -> Unit = NoOpUpdate,
+    update: (T) -> Unit = STUB_CALLBACK_WITH_RECEIVER,
     background: Color = Color.Unspecified,
-    onRelease: (T) -> Unit = NoOpDispose,
-    onResize: (view: T, rect: CValue<CGRect>) -> Unit = DefaultResize,
+    onRelease: (T) -> Unit = STUB_CALLBACK_WITH_RECEIVER,
+    onResize: (view: T, rect: CValue<CGRect>) -> Unit = DefaultViewResize,
     interactive: Boolean = true,
 ) {
     // TODO: adapt UIKitView to reuse inside LazyColumn like in AndroidView:
     //  https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1)
-    val componentInfo = remember { ComponentInfo<T>() }
-    val root = LocalLayerContainer.current
+    val embeddedInteropComponent = remember {
+        EmbeddedInteropView(
+            rootView = LocalLayerContainer.current,
+            onRelease
+        )
+    }
     val density = LocalDensity.current.density
     var rectInPixels by remember { mutableStateOf(IntRect(0, 0, 0, 0)) }
     var localToWindowOffset: IntOffset by remember { mutableStateOf(IntOffset.Zero) }
@@ -96,13 +102,13 @@ fun <T : UIView> UIKitView(
                 val rect = newRectInPixels / density
 
                 interopContext.deferAction {
-                    componentInfo.container.setFrame(rect.toCGRect())
+                    embeddedInteropComponent.wrappingView.setFrame(rect.toCGRect())
                 }
 
                 if (rectInPixels.width != newRectInPixels.width || rectInPixels.height != newRectInPixels.height) {
                     interopContext.deferAction {
                         onResize(
-                            componentInfo.component,
+                            embeddedInteropComponent.component,
                             CGRectMake(0.0, 0.0, rect.width.toDouble(), rect.height.toDouble()),
                         )
                     }
@@ -121,39 +127,128 @@ fun <T : UIView> UIKitView(
     )
 
     DisposableEffect(Unit) {
-        componentInfo.component = factory()
-        componentInfo.updater = Updater(componentInfo.component, update) {
+        embeddedInteropComponent.component = factory()
+        embeddedInteropComponent.updater = Updater(embeddedInteropComponent.component, update) {
             interopContext.deferAction(action = it)
         }
 
         interopContext.deferAction(UIKitInteropViewHierarchyChange.VIEW_ADDED) {
-            componentInfo.container = UIView().apply {
-                addSubview(componentInfo.component)
-            }
-            root.insertSubview(componentInfo.container, 0)
+            embeddedInteropComponent.addToHierarchy()
         }
 
         onDispose {
             interopContext.deferAction(UIKitInteropViewHierarchyChange.VIEW_REMOVED) {
-                componentInfo.container.removeFromSuperview()
-                componentInfo.updater.dispose()
-                onRelease(componentInfo.component)
+                embeddedInteropComponent.removeFromHierarchy()
             }
         }
     }
 
     LaunchedEffect(background) {
         interopContext.deferAction {
-            if (background == Color.Unspecified) {
-                componentInfo.container.backgroundColor = root.backgroundColor
-            } else {
-                componentInfo.container.backgroundColor = parseColor(background)
-            }
+            embeddedInteropComponent.setBackgroundColor(background)
         }
     }
 
     SideEffect {
-        componentInfo.updater.update = update
+        embeddedInteropComponent.updater.update = update
+    }
+}
+
+/**
+ * @param factory The block creating the [UIViewController] to be composed.
+ * @param modifier The modifier to be applied to the layout. Size should be specified in modifier.
+ * Modifier may contains crop() modifier with different shapes.
+ * @param update A callback to be invoked after the layout is inflated.
+ * @param background A color of [UIView] background wrapping the [UIViewController] view created by [factory].
+ * @param onRelease A callback invoked as a signal that this view controller instance has exited the
+ * composition hierarchy entirely and will not be reused again. Any additional resources used by the
+ * view controller should be freed at this time.
+ * @param onResize May be used to custom resize logic.
+ * @param interactive If true, then user touches will be passed to this UIViewController
+ */
+@Composable
+fun <T : UIViewController> UIKitViewController(
+    factory: () -> T,
+    modifier: Modifier,
+    update: (T) -> Unit = STUB_CALLBACK_WITH_RECEIVER,
+    background: Color = Color.Unspecified,
+    onRelease: (T) -> Unit = STUB_CALLBACK_WITH_RECEIVER,
+    onResize: (viewController: T, rect: CValue<CGRect>) -> Unit = DefaultViewControllerResize,
+    interactive: Boolean = true,
+) {
+    // TODO: adapt UIKitViewController to reuse inside LazyColumn like in AndroidView:
+    //  https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1)
+    val embeddedInteropComponent = remember {
+        EmbeddedInteropViewController(
+            rootView = LocalLayerContainer.current,
+            rootViewController = LocalUIViewController.current,
+            onRelease
+        )
+    }
+
+    val density = LocalDensity.current.density
+    var rectInPixels by remember { mutableStateOf(IntRect(0, 0, 0, 0)) }
+    var localToWindowOffset: IntOffset by remember { mutableStateOf(IntOffset.Zero) }
+    val interopContext = LocalUIKitInteropContext.current
+
+    Place(
+        modifier.onGloballyPositioned { childCoordinates ->
+            val coordinates = childCoordinates.parentCoordinates!!
+            localToWindowOffset = coordinates.localToWindow(Offset.Zero).round()
+            val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
+            if (rectInPixels != newRectInPixels) {
+                val rect = newRectInPixels / density
+
+                interopContext.deferAction {
+                    embeddedInteropComponent.wrappingView.setFrame(rect.toCGRect())
+                }
+
+                if (rectInPixels.width != newRectInPixels.width || rectInPixels.height != newRectInPixels.height) {
+                    interopContext.deferAction {
+                        onResize(
+                            embeddedInteropComponent.component,
+                            CGRectMake(0.0, 0.0, rect.width.toDouble(), rect.height.toDouble()),
+                        )
+                    }
+                }
+                rectInPixels = newRectInPixels
+            }
+        }.drawBehind {
+            drawRect(Color.Transparent, blendMode = BlendMode.DstAtop) // draw transparent hole
+        }.let {
+            if (interactive) {
+                it.then(InteropViewCatchPointerModifier())
+            } else {
+                it
+            }
+        }
+    )
+
+    DisposableEffect(Unit) {
+        embeddedInteropComponent.component = factory()
+        embeddedInteropComponent.updater = Updater(embeddedInteropComponent.component, update) {
+            interopContext.deferAction(action = it)
+        }
+
+        interopContext.deferAction(UIKitInteropViewHierarchyChange.VIEW_ADDED) {
+            embeddedInteropComponent.addToHierarchy()
+        }
+
+        onDispose {
+            interopContext.deferAction(UIKitInteropViewHierarchyChange.VIEW_REMOVED) {
+                embeddedInteropComponent.removeFromHierarchy()
+            }
+        }
+    }
+
+    LaunchedEffect(background) {
+        interopContext.deferAction {
+            embeddedInteropComponent.setBackgroundColor(background)
+        }
+    }
+
+    SideEffect {
+        embeddedInteropComponent.updater.update = update
     }
 }
 
@@ -176,13 +271,71 @@ private fun parseColor(color: Color): UIColor {
     )
 }
 
-private class ComponentInfo<T : UIView> {
-    lateinit var container: UIView
+private abstract class EmbeddedInteropComponent<T : Any>(
+    val rootView: UIView,
+    val onRelease: (T) -> Unit
+) {
+    lateinit var wrappingView: UIView
     lateinit var component: T
     lateinit var updater: Updater<T>
+
+    fun setBackgroundColor(color: Color) {
+        if (color == Color.Unspecified) {
+            wrappingView.backgroundColor = rootView.backgroundColor
+        } else {
+            wrappingView.backgroundColor = parseColor(color)
+        }
+    }
+
+    abstract fun addToHierarchy()
+    abstract fun removeFromHierarchy()
+
+    protected fun addViewToHierarchy(view: UIView) {
+        wrappingView = UIView().apply {
+            addSubview(view)
+        }
+        rootView.insertSubview(wrappingView, 0)
+    }
+
+    protected fun removeViewFromHierarchy(view: UIView) {
+        wrappingView.removeFromSuperview()
+        updater.dispose()
+        onRelease(component)
+    }
 }
 
-private class Updater<T : UIView>(
+private class EmbeddedInteropView<T : UIView>(
+    rootView: UIView,
+    onRelease: (T) -> Unit
+) : EmbeddedInteropComponent<T>(rootView, onRelease) {
+    override fun addToHierarchy() {
+        addViewToHierarchy(component)
+    }
+
+    override fun removeFromHierarchy() {
+        removeViewFromHierarchy(component)
+    }
+}
+
+private class EmbeddedInteropViewController<T : UIViewController>(
+    rootView: UIView,
+    private val rootViewController: UIViewController,
+    onRelease: (T) -> Unit
+) : EmbeddedInteropComponent<T>(rootView, onRelease) {
+    override fun addToHierarchy() {
+        rootViewController.addChildViewController(component)
+        addViewToHierarchy(component.view)
+        component.didMoveToParentViewController(rootViewController)
+    }
+
+    override fun removeFromHierarchy() {
+        component.willMoveToParentViewController(null)
+        removeViewFromHierarchy(component.view)
+        component.removeFromParentViewController()
+    }
+}
+
+private class Updater<T : Any>(
     private val component: T,
     update: (T) -> Unit,
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -159,7 +159,7 @@ fun <T : UIView> UIKitView(
  * @param modifier The modifier to be applied to the layout. Size should be specified in modifier.
  * Modifier may contains crop() modifier with different shapes.
  * @param update A callback to be invoked after the layout is inflated.
- * @param background A color of [UIView] background wrapping the [UIViewController] view created by [factory].
+ * @param background A color of [UIView] background wrapping the view of [UIViewController] created by [factory].
  * @param onRelease A callback invoked as a signal that this view controller instance has exited the
  * composition hierarchy entirely and will not be reused again. Any additional resources used by the
  * view controller should be freed at this time.

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -82,9 +82,10 @@ fun <T : UIView> UIKitView(
 ) {
     // TODO: adapt UIKitView to reuse inside LazyColumn like in AndroidView:
     //  https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1)
+    val rootView = LocalLayerContainer.current
     val embeddedInteropComponent = remember {
         EmbeddedInteropView(
-            rootView = LocalLayerContainer.current,
+            rootView = rootView,
             onRelease
         )
     }
@@ -178,10 +179,12 @@ fun <T : UIViewController> UIKitViewController(
 ) {
     // TODO: adapt UIKitViewController to reuse inside LazyColumn like in AndroidView:
     //  https://developer.android.com/reference/kotlin/androidx/compose/ui/viewinterop/package-summary#AndroidView(kotlin.Function1,kotlin.Function1,androidx.compose.ui.Modifier,kotlin.Function1,kotlin.Function1)
+    val rootView = LocalLayerContainer.current
+    val rootViewController = LocalUIViewController.current
     val embeddedInteropComponent = remember {
         EmbeddedInteropViewController(
-            rootView = LocalLayerContainer.current,
-            rootViewController = LocalUIViewController.current,
+            rootView,
+            rootViewController,
             onRelease
         )
     }


### PR DESCRIPTION
## Proposed Changes

Add API for embedding UIViewControllers for cases, where UIView-based API is not available (like SwiftUI integration via UIHostingController, UITabBarController, UINavigationController, etc.).

## Testing

Test: check "SwiftUI interop example" in Demo.

<img width="424" alt="Screenshot 2023-10-19 at 15 18 16" src="https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/0e7e23b5-687f-40a0-a574-cff48e951acb">

## API Changes

New iOS source set function `UIKitViewController` for embedding native UIViewController's similar to `UIKitView`