### PR TITLE
Remove @ExportObjCClass from SkikoUIView

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SkikoUIView.kt
@@ -65,7 +65,6 @@ internal enum class UITouchesEventPhase {
 }
 
 @Suppress("CONFLICTING_OVERLOADS")
-@ExportObjCClass
 internal class SkikoUIView : UIView, UIKeyInputProtocol, UITextInputProtocol {
     companion object : UIViewMeta() {
         override fun layerClass() = CAMetalLayer


### PR DESCRIPTION
We don't use this class from ObjC. There the annotation is redundant

This change also fixes the warning "Class SkikoUIView has multiple implementations. Which one will be used is undefined."

