### PR TITLE
Provide a way to calculate ComposeScene preferredSize that is needed for Swing

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -132,8 +132,8 @@ public final class androidx/compose/ui/ComposeScene {
 	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun calculateContentSize-YbymL2g ()J
 	public final fun close ()V
-	public final fun contentSizeInConstraints-ToXhtMw (J)J
 	public final fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public final fun getConstraints-msEJaDk ()J
 	public final fun getContentSize-YbymL2g ()J
@@ -229,6 +229,7 @@ public final class androidx/compose/ui/ImageComposeScene {
 	public synthetic fun <init> (IILandroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (IILandroidx/compose/ui/unit/Density;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (IILandroidx/compose/ui/unit/Density;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun calculateContentSize-YbymL2g ()J
 	public final fun close ()V
 	public final fun getConstraints-msEJaDk ()J
 	public final fun getContentSize-YbymL2g ()J

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -133,6 +133,7 @@ public final class androidx/compose/ui/ComposeScene {
 	public fun <init> (Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close ()V
+	public final fun contentSizeInConstraints-ToXhtMw (J)J
 	public final fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public final fun getConstraints-msEJaDk ()J
 	public final fun getContentSize-YbymL2g ()J

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -181,28 +181,7 @@ internal abstract class ComposeBridge(
     }
 
     /**
-     * Provides the maximum constraints where ComposeScene can be rendered.
-     * Dimensions' max dimension of all displays is used for that.
-     * Since we cannot show more than on all the screens.
-     *
-     * See [scenePreferredSize]
-     */
-    private fun getMaxConstraints(): Constraints {
-        val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
-        val deviceBounds = ge.screenDevices.map { it.defaultConfiguration.bounds }
-
-        val totalWidth = deviceBounds.maxOfOrNull { it.width } ?: 0
-        val totalHeight = deviceBounds.maxOfOrNull { it.height } ?: 0
-
-        val density = component.density.density
-        return Constraints(
-            maxWidth = (totalWidth * density).toInt(),
-            maxHeight = (totalHeight * density).toInt()
-        )
-    }
-
-    /**
-     * Provides the size of ComposeScene content inside max possible constraints
+     * Provides the size of ComposeScene content inside infinity constraints
      *
      * This is needed for the bridge between Compose and Swing since
      * in some cases, Swing's LayoutManagers need
@@ -217,7 +196,7 @@ internal abstract class ComposeBridge(
     protected val scenePreferredSize: Dimension
         get() {
             val contentSize =
-                scene.contentSizeInConstraints(getMaxConstraints())
+                scene.contentSizeInConstraints(Constraints())
             return Dimension(
                 (contentSize.width / component.density.density).toInt(),
                 (contentSize.height / component.density.density).toInt()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -195,8 +195,7 @@ internal abstract class ComposeBridge(
      */
     protected val scenePreferredSize: Dimension
         get() {
-            val contentSize =
-                scene.contentSizeInConstraints(Constraints())
+            val contentSize = scene.calculateContentSize()
             return Dimension(
                 (contentSize.width / component.density.density).toInt(),
                 (contentSize.height / component.density.density).toInt()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -180,11 +180,49 @@ internal abstract class ComposeBridge(
         }
     }
 
-    protected val sceneDimension: Dimension
-        get() = Dimension(
-            (scene.contentSize.width / component.density.density).toInt(),
-            (scene.contentSize.height / component.density.density).toInt()
+    /**
+     * Provides the maximum constraints where ComposeScene can be rendered.
+     * Dimensions' sum of all displays is used for that.
+     * Since we cannot show more than on all the screens.
+     *
+     * See [scenePreferredSize]
+     */
+    private fun getMaxConstraints(): Constraints {
+        val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
+        val deviceBounds = ge.screenDevices.map { it.defaultConfiguration.bounds }
+
+        val totalWidth = deviceBounds.sumOf { it.width }
+        val totalHeight = deviceBounds.sumOf { it.height }
+
+        val density = component.density.density
+        return Constraints(
+            maxWidth = (totalWidth * density).toInt(),
+            maxHeight = (totalHeight * density).toInt()
         )
+    }
+
+    /**
+     * Provides the size of ComposeScene content inside max possible constraints
+     *
+     * This is needed for the bridge between Compose and Swing since
+     * in some cases, Swing's LayoutManagers need
+     * to calculate the preferred size of the content without max/min constraints
+     * to properly lay it out.
+     *
+     * Example: Compose content inside Popup without a preferred size.
+     * Swing will calculate the preferred size of the Compose content and set Popup's side for that.
+     *
+     * See [androidx.compose.ui.awt.ComposePanelTest] test `initial panel size of LazyColumn with border layout`
+     */
+    protected val scenePreferredSize: Dimension
+        get() {
+            val contentSize =
+                scene.contentSizeInConstraints(getMaxConstraints())
+            return Dimension(
+                (contentSize.width / component.density.density).toInt(),
+                (contentSize.height / component.density.density).toInt()
+            )
+        }
 
     private val density get() = platformComponent.density.density
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -182,7 +182,7 @@ internal abstract class ComposeBridge(
 
     /**
      * Provides the maximum constraints where ComposeScene can be rendered.
-     * Dimensions' sum of all displays is used for that.
+     * Dimensions' max dimension of all displays is used for that.
      * Since we cannot show more than on all the screens.
      *
      * See [scenePreferredSize]
@@ -191,8 +191,8 @@ internal abstract class ComposeBridge(
         val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
         val deviceBounds = ge.screenDevices.map { it.defaultConfiguration.bounds }
 
-        val totalWidth = deviceBounds.sumOf { it.width }
-        val totalHeight = deviceBounds.sumOf { it.height }
+        val totalWidth = deviceBounds.maxOfOrNull { it.width } ?: 0
+        val totalHeight = deviceBounds.maxOfOrNull { it.height } ?: 0
 
         val density = component.density.density
         return Constraints(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeSwingLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeSwingLayer.desktop.kt
@@ -76,7 +76,7 @@ internal class SwingComposeBridge(
             }
 
             override fun getPreferredSize(): Dimension {
-                return if (isPreferredSizeSet) super.getPreferredSize() else sceneDimension
+                return if (isPreferredSizeSet) super.getPreferredSize() else scenePreferredSize
             }
 
             override fun getAccessibleContext(): AccessibleContext? {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowComposeBridge.desktop.kt
@@ -70,7 +70,7 @@ internal class WindowComposeBridge(
         }
 
         override fun getPreferredSize(): Dimension {
-            return if (isPreferredSizeSet) super.getPreferredSize() else sceneDimension
+            return if (isPreferredSizeSet) super.getPreferredSize() else scenePreferredSize
         }
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -18,7 +18,13 @@ package androidx.compose.ui.awt
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.runtime.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
@@ -26,21 +32,26 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.density
 import com.google.common.truth.Truth.assertThat
+import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import javax.swing.JFrame
+import javax.swing.JPanel
+import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import org.jetbrains.skiko.*
+import org.jetbrains.skiko.ExperimentalSkikoApi
+import org.jetbrains.skiko.GraphicsApi
+import org.jetbrains.skiko.MainUIDispatcher
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.junit.Assume.assumeFalse
 import org.junit.Test
 
 class ComposePanelTest {
     @Test
     fun `don't override user preferred size`() {
-        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
-
         runBlocking(MainUIDispatcher) {
             val composePanel = ComposePanel()
             composePanel.preferredSize = Dimension(234, 345)
@@ -244,6 +255,103 @@ class ComposePanelTest {
                 frame.contentPane.add(composePanel)
                 delay(1000)
                 assertEquals(2, initialStateCounter)
+            } finally {
+                frame.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun `initial panel size with border layout`() {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        runBlocking(MainUIDispatcher) {
+            val composePanel = ComposePanel()
+            composePanel.setContent {
+                Text("Content")
+            }
+
+            val frame = JFrame()
+            try {
+                val content = JPanel(BorderLayout()).apply {
+                    add(composePanel, BorderLayout.CENTER)
+                }
+                frame.contentPane.add(content)
+                frame.pack()
+
+                frame.isVisible = true
+                delay(1000)
+                assertTrue(content.size.height > 2)
+                assertTrue(content.size.width > 2)
+            } finally {
+                frame.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun `initial panel size of LazyColumn with border layout`() {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        runBlocking(MainUIDispatcher) {
+            val composePanel = ComposePanel()
+            composePanel.setContent {
+                LazyColumn {
+                    repeat(100_000) {
+                        item {
+                            Text("Text $it")
+                        }
+                    }
+                }
+            }
+
+            val frame = JFrame()
+            try {
+                val content = JPanel(BorderLayout()).apply {
+                    add(composePanel, BorderLayout.CENTER)
+                }
+                frame.contentPane.add(content)
+                frame.pack()
+
+                frame.isVisible = true
+                delay(1000)
+                assertTrue(content.size.width > 2)
+                assertTrue(content.size.height > 2)
+            } finally {
+                frame.dispose()
+            }
+        }
+    }
+
+    @Test
+    fun `initial panel size of LazyColumn with border layout and preferred frame size`() {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        runBlocking(MainUIDispatcher) {
+            val composePanel = ComposePanel()
+            composePanel.setContent {
+                LazyColumn {
+                    repeat(100_000) {
+                        item {
+                            Text("Text $it")
+                        }
+                    }
+                }
+            }
+
+            val frame = JFrame()
+            try {
+                val content = JPanel(BorderLayout()).apply {
+                    add(composePanel, BorderLayout.CENTER)
+                }
+                frame.contentPane.add(content)
+                frame.contentPane.preferredSize = Dimension(200, 300)
+                frame.pack()
+
+                frame.isVisible = true
+                delay(1000)
+                assertEquals(200, content.size.width)
+                assertEquals(300, content.size.height)
             } finally {
                 frame.dispose()
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -53,6 +53,8 @@ import org.junit.Test
 class ComposePanelTest {
     @Test
     fun `don't override user preferred size`() {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
         runBlocking(MainUIDispatcher) {
             val composePanel = ComposePanel()
             composePanel.preferredSize = Dimension(234, 345)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.awt
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Text
 import androidx.compose.runtime.LaunchedEffect
@@ -296,7 +297,7 @@ class ComposePanelTest {
         runBlocking(MainUIDispatcher) {
             val composePanel = ComposePanel()
             composePanel.setContent {
-                LazyColumn {
+                LazyColumn(modifier = Modifier.sizeIn(maxHeight = 500.dp)) {
                     repeat(100_000) {
                         item {
                             Text("Text $it")
@@ -316,7 +317,7 @@ class ComposePanelTest {
                 frame.isVisible = true
                 delay(1000)
                 assertTrue(content.size.width > 2)
-                assertTrue(content.size.height > 2)
+                assertEquals(500, content.size.height)
             } finally {
                 frame.dispose()
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -477,6 +477,7 @@ class ComposeScene internal constructor(
     /**
      * Returns the current content size
      */
+    @Deprecated("Will be removed in 1.7", replaceWith = ReplaceWith("calculateContentSize()"))
     val contentSize: IntSize
         get() {
             val mainOwner = mainOwner ?: return IntSize.Zero
@@ -484,12 +485,21 @@ class ComposeScene internal constructor(
         }
 
     /**
+     * Returns the current content size in infinity constraints.
+     *
+     * @throws IllegalStateException when [ComposeScene] content has lazy layouts without maximum size bounds
+     * (e.g. LazyColumn without maximum height).
+     */
+    fun calculateContentSize(): IntSize {
+        return contentSizeInConstraints(Constraints())
+    }
+
+    /**
      * Provides [ComposeScene] content size in given [constraints]
      *
      * This function doesn't change current [ComposeScene] scene constraints.
      */
-    @ExperimentalComposeUiApi
-    fun contentSizeInConstraints(constraints: Constraints): IntSize {
+    private fun contentSizeInConstraints(constraints: Constraints): IntSize {
         check(!isClosed) { "ComposeScene is closed" }
         return mainOwner?.measureInConstraints(constraints) ?: IntSize.Zero
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -477,7 +477,8 @@ class ComposeScene internal constructor(
     /**
      * Returns the current content size
      */
-    @Deprecated("Use calculateContentSize() instead", replaceWith = ReplaceWith("calculateContentSize()"))
+    // TODO: make calculateContentSize stable in 1.7 and mark it as
+    //  @Deprecated("Use calculateContentSize() instead", replaceWith = ReplaceWith("calculateContentSize()"))
     val contentSize: IntSize
         get() {
             val mainOwner = mainOwner ?: return IntSize.Zero
@@ -490,6 +491,8 @@ class ComposeScene internal constructor(
      * @throws IllegalStateException when [ComposeScene] content has lazy layouts without maximum size bounds
      * (e.g. LazyColumn without maximum height).
      */
+    // TODO: make stable and deprecate contentSize in 1.7
+    @ExperimentalComposeUiApi
     fun calculateContentSize(): IntSize {
         return contentSizeInConstraints(Constraints())
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -479,11 +479,14 @@ class ComposeScene internal constructor(
      */
     val contentSize: IntSize
         get() {
-            check(!isClosed) { "ComposeScene is closed" }
             val mainOwner = mainOwner ?: return IntSize.Zero
-            mainOwner.measureAndLayout()
-            return mainOwner.contentSize
+            return contentSizeInConstraints(mainOwner.constraints)
         }
+
+    internal fun contentSizeInConstraints(constraints: Constraints): IntSize {
+        check(!isClosed) { "ComposeScene is closed" }
+        return mainOwner?.measureInConstraints(constraints) ?: IntSize.Zero
+    }
 
     /**
      * Sends any pending apply notifications and performs the changes they cause.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -477,7 +477,7 @@ class ComposeScene internal constructor(
     /**
      * Returns the current content size
      */
-    @Deprecated("Will be removed in 1.7", replaceWith = ReplaceWith("calculateContentSize()"))
+    @Deprecated("Use calculateContentSize() instead", replaceWith = ReplaceWith("calculateContentSize()"))
     val contentSize: IntSize
         get() {
             val mainOwner = mainOwner ?: return IntSize.Zero

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -483,7 +483,13 @@ class ComposeScene internal constructor(
             return contentSizeInConstraints(mainOwner.constraints)
         }
 
-    internal fun contentSizeInConstraints(constraints: Constraints): IntSize {
+    /**
+     * Provides [ComposeScene] content size in given [constraints]
+     *
+     * This function doesn't change current [ComposeScene] scene constraints.
+     */
+    @ExperimentalComposeUiApi
+    fun contentSizeInConstraints(constraints: Constraints): IntSize {
         check(!isClosed) { "ComposeScene is closed" }
         return mainOwner?.measureInConstraints(constraints) ?: IntSize.Zero
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -193,7 +193,18 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     /**
      * Returns the current content size
      */
+    @Deprecated("Will be removed in 1.7", replaceWith = ReplaceWith("calculateContentSize()"))
     val contentSize: IntSize get() = scene.contentSize
+
+    /**
+     * Returns the current content size in infinity constraints.
+     *
+     * @throws IllegalStateException when [ComposeScene] content has lazy layouts without maximum size bounds
+     * (e.g. LazyColumn without maximum height).
+     */
+    fun calculateContentSize(): IntSize {
+        return scene.calculateContentSize()
+    }
 
     /**
      * Render the current content into an image. [nanoTime] will be used to drive all

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -249,7 +249,8 @@ internal class SkiaBasedOwner(
      * Provides a way to measure Owner's content in given [constraints]
      * Draw/pointer and other callbacks won't be called here like in [measureAndLayout] functions
      */
-    internal fun measureInConstraints(constraints: Constraints): IntSize {
+    @ExperimentalComposeUiApi
+    fun measureInConstraints(constraints: Constraints): IntSize {
         val oldConstraints = this.constraints
         try {
             // TODO: is it possible to measure without reassigning root constraints?

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -245,8 +245,26 @@ internal class SkiaBasedOwner(
         }
     }
 
-    var contentSize = IntSize.Zero
-        private set
+    /**
+     * Provides a way to measure Owner's content in given [constraints]
+     * Draw/pointer and other callbacks won't be called here like in [measureAndLayout] functions
+     */
+    internal fun measureInConstraints(constraints: Constraints): IntSize {
+        val oldConstraints = this.constraints
+        try {
+            // TODO: is it possible to measure without reassigning root constraints?
+            measureAndLayoutDelegate.updateRootConstraints(constraints)
+            measureAndLayoutDelegate.measureAndLayout()
+
+            // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
+            return IntSize(
+                root.children.maxOfOrNull { it.outerCoordinator.measuredWidth } ?: 0,
+                root.children.maxOfOrNull { it.outerCoordinator.measuredHeight } ?: 0,
+            )
+        } finally {
+            measureAndLayoutDelegate.updateRootConstraints(oldConstraints)
+        }
+    }
 
     override fun measureAndLayout(sendPointerUpdate: Boolean) {
         measureAndLayoutDelegate.updateRootConstraints(constraints)
@@ -260,21 +278,13 @@ internal class SkiaBasedOwner(
             requestDraw?.invoke()
         }
         measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
-        contentSize = computeContentSize()
     }
 
     override fun measureAndLayout(layoutNode: LayoutNode, constraints: Constraints) {
         measureAndLayoutDelegate.measureAndLayout(layoutNode, constraints)
         onPointerUpdate()
         measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
-        contentSize = computeContentSize()
     }
-
-    // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
-    private fun computeContentSize() = IntSize(
-        root.children.maxOfOrNull { it.outerCoordinator.measuredWidth } ?: 0,
-        root.children.maxOfOrNull { it.outerCoordinator.measuredHeight } ?: 0,
-    )
 
     override fun forceMeasureTheSubtree(layoutNode: LayoutNode, affectsLookahead: Boolean) {
         measureAndLayoutDelegate.forceMeasureTheSubtree(layoutNode, affectsLookahead)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -249,8 +249,7 @@ internal class SkiaBasedOwner(
      * Provides a way to measure Owner's content in given [constraints]
      * Draw/pointer and other callbacks won't be called here like in [measureAndLayout] functions
      */
-    @ExperimentalComposeUiApi
-    fun measureInConstraints(constraints: Constraints): IntSize {
+    internal fun measureInConstraints(constraints: Constraints): IntSize {
         val oldConstraints = this.constraints
         try {
             // TODO: is it possible to measure without reassigning root constraints?

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaBasedOwner.skiko.kt
@@ -254,7 +254,7 @@ internal class SkiaBasedOwner(
         try {
             // TODO: is it possible to measure without reassigning root constraints?
             measureAndLayoutDelegate.updateRootConstraints(constraints)
-            measureAndLayoutDelegate.measureAndLayout()
+            measureAndLayoutDelegate.measureOnly()
 
             // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
             return IntSize(


### PR DESCRIPTION
## Proposed Changes

Previous solution with preferred size didn't work well because constraints with maxSize taken from component.size were used, but component.size is not set (0 by default).

See issue: https://github.com/JetBrains/compose-multiplatform/issues/3834

By Swing design preferred size should be calculated without incoming constraints. It is not possible in Compose, so I artificially set max constraints taking sum of displays dimensions here. Not the best solution, but I couldn't imagine better one..

## Testing

Test: run ComposePanelTest.kt

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3834
