### PR TITLE
Desktop. Don't use AccessibleRole.PANEL for root/unknown nodes (fixes issues on Windows)

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
@@ -171,6 +171,9 @@ internal class ComposeAccessible(
         val progressBarRangeInfo
             get() = semanticsNode.config.getOrNull(SemanticsProperties.ProgressBarRangeInfo)
 
+        val isTraversalGroup
+            get() = semanticsNode.config.getOrNull(SemanticsProperties.IsTraversalGroup)
+
         private fun makeScrollbarChild(
             vertical: Boolean
         ): Accessible {
@@ -402,6 +405,7 @@ internal class ComposeAccessible(
                 setText != null -> AccessibleRole.TEXT
                 text != null -> AccessibleRole.LABEL
                 progressBarRangeInfo != null -> AccessibleRole.PROGRESS_BAR
+                isTraversalGroup != null -> AccessibleRole.GROUP_BOX
                 else -> AccessibleRole.UNKNOWN
             }
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
@@ -171,6 +171,10 @@ internal class ComposeAccessible(
         val progressBarRangeInfo
             get() = semanticsNode.config.getOrNull(SemanticsProperties.ProgressBarRangeInfo)
 
+        val isContainer
+            @Suppress("DEPRECATION")
+            get() = semanticsNode.config.getOrNull(SemanticsProperties.IsContainer)
+
         val isTraversalGroup
             get() = semanticsNode.config.getOrNull(SemanticsProperties.IsTraversalGroup)
 
@@ -405,6 +409,7 @@ internal class ComposeAccessible(
                 setText != null -> AccessibleRole.TEXT
                 text != null -> AccessibleRole.LABEL
                 progressBarRangeInfo != null -> AccessibleRole.PROGRESS_BAR
+                isContainer != null -> AccessibleRole.GROUP_BOX
                 isTraversalGroup != null -> AccessibleRole.GROUP_BOX
                 else -> AccessibleRole.UNKNOWN
             }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeAccessible.kt
@@ -402,7 +402,7 @@ internal class ComposeAccessible(
                 setText != null -> AccessibleRole.TEXT
                 text != null -> AccessibleRole.LABEL
                 progressBarRangeInfo != null -> AccessibleRole.PROGRESS_BAR
-                else -> AccessibleRole.PANEL
+                else -> AccessibleRole.UNKNOWN
             }
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/ComposeSceneAccessible.kt
@@ -153,7 +153,7 @@ internal class ComposeSceneAccessible(
         }
 
         override fun getAccessibleRole(): AccessibleRole {
-            return AccessibleRole.PANEL
+            return AccessibleRole.UNKNOWN
         }
 
         override fun getAccessibleStateSet(): AccessibleStateSet {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.isContainer
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
@@ -137,6 +138,21 @@ class AccessibilityTest {
         rule.onNodeWithTag("box").apply {
             val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
             assertThat(context.accessibleRole).isEqualTo(AccessibleRole.UNKNOWN)
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun containerHasGroupRole() {
+        rule.setContent {
+            Box(Modifier.testTag("box").semantics {
+                isContainer = true
+            })
+        }
+
+        rule.onNodeWithTag("box").apply {
+            val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
+            assertThat(context.accessibleRole).isEqualTo(AccessibleRole.GROUP_BOX)
         }
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.material.Button
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Tab
@@ -126,9 +127,20 @@ class AccessibilityTest {
         }
     }
 
+    @Test
+    fun boxHasUnknownRole() {
+        rule.setContent {
+            Box(Modifier.testTag("box"))
+        }
+
+        rule.onNodeWithTag("box").apply {
+            val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
+            assertThat(context.accessibleRole).isEqualTo(AccessibleRole.UNKNOWN)
+        }
+    }
+
     private fun SemanticsNodeInteraction.assertHasAccessibleRole(role: AccessibleRole) {
         val accessibleContext = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
         assertThat(accessibleContext.accessibleRole).isEqualTo(role)
     }
-
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.test.SemanticsNodeInteraction
@@ -136,6 +137,20 @@ class AccessibilityTest {
         rule.onNodeWithTag("box").apply {
             val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
             assertThat(context.accessibleRole).isEqualTo(AccessibleRole.UNKNOWN)
+        }
+    }
+
+    @Test
+    fun traversalGroupHasGroupRole() {
+        rule.setContent {
+            Box(Modifier.testTag("box").semantics {
+                isTraversalGroup = true
+            })
+        }
+
+        rule.onNodeWithTag("box").apply {
+            val context = ComposeAccessible(fetchSemanticsNode()).accessibleContext!!
+            assertThat(context.accessibleRole).isEqualTo(AccessibleRole.GROUP_BOX)
         }
     }
 


### PR DESCRIPTION
This fixes issues on Windows:

1. Windows pronounced "Panel unavailable" at start
2. When we focus on Switch or Box(Modifier.clickable), there was "Panel0" pronounced. Now it says nothing.
3. After merging https://github.com/JetBrains/compose-multiplatform-core/pull/881, we refocus the main component. This leads to pronouncing the window title, now it says nothing, as the accessible root node is unknown

on macOs it changes one thing:
1. When we focus on Switch or Box(Modifier.clickable), now it prounonces that we in scroll area (if we in scroll area). It also pronounces it for other compnents like Button/Text

## Testing
Manually with accessibility enabled in run1 (Windows, macOs)