### PR TITLE
[mpp test app] Check nav stack size to avoid crash on double click

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -100,7 +100,11 @@ class App(
             }
 
             is Screen.FullscreenExample -> {
-                screen.content { navigationStack.removeLast() }
+                screen.content {
+                    if (navigationStack.size > 1) {
+                        navigationStack.removeLast()
+                    }
+                }
             }
         }
     }
@@ -127,7 +131,7 @@ class App(
                         Icon(
                             Icons.Filled.ArrowBack,
                             contentDescription = "Back",
-                            modifier = Modifier.clickable { navigationStack.removeLast() }
+                            modifier = Modifier.backButton()
                         )
                     }
                 )
@@ -169,7 +173,7 @@ class App(
                                     Icon(
                                         Icons.Filled.ArrowBack,
                                         contentDescription = "Back",
-                                        modifier = Modifier.clickable { navigationStack.removeLast() }
+                                        modifier = Modifier.backButton()
                                     )
                                     Spacer(Modifier.width(16.dp))
                                 }
@@ -194,6 +198,12 @@ class App(
             ) {
                 content()
             }
+        }
+    }
+
+    private fun Modifier.backButton() = clickable {
+        if (navigationStack.size > 1) {
+            navigationStack.removeLast()
         }
     }
 }


### PR DESCRIPTION
```kt
Uncaught Kotlin exception: kotlin.NoSuchElementException: List is empty.
    at 0   ComposeDemo                         0x10047954b        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 123 
    at 1   ComposeDemo                         0x100471bcf        kfun:kotlin.Exception#<init>(kotlin.String?){} + 119 
    at 2   ComposeDemo                         0x100472013        kfun:kotlin.RuntimeException#<init>(kotlin.String?){} + 119 
    at 3   ComposeDemo                         0x100471e9b        kfun:kotlin.NoSuchElementException#<init>(kotlin.String?){} + 119 
    at 4   ComposeDemo                         0x1004be99f        kfun:kotlin.collections#last__at__kotlin.collections.List<0:0>(){0§<kotlin.Any?>}0:0 + 335 
    at 5   ComposeDemo                         0x10166590b        kfun:androidx.compose.mpp.demo.App#Content(androidx.compose.runtime.Composer?;kotlin.Int){} + 1587 
    at 6   ComposeDemo                         0x1018afa17        kfun:androidx.compose.mpp.demo#IosDemo(kotlin.String;androidx.compose.runtime.Composer?;kotlin.Int){} + 3455 
    at 7   ComposeDemo                         0x1018b0277        kfun:androidx.compose.mpp.demo.main$lambda$0#internal + 615 
    at 8   ComposeDemo                         0x1018b04c7        kfun:androidx.compose.mpp.demo.$main$lambda$0$FUNCTION_REFERENCE$0.invoke#internal + 139 
    at 9   ComposeDemo                         0x1018b0633        kfun:androidx.compose.mpp.demo.$main$lambda$0$FUNCTION_REFERENCE$0.$<bridge-UNNNB>invoke(androidx.compose.runtime.Composer;kotlin.Int){}#internal + 183 
    at 10  ComposeDemo                         0x1007bb39b        kfun:androidx.compose.runtime.internal.ComposableLambdaImpl#invoke(androidx.compose.runtime.Composer;kotlin.Int){}kotlin.Any? + 875
```
