### PR TITLE
Use larger icon size for Window's IconImage

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -171,10 +171,8 @@ internal fun Dialog.setUndecoratedSafely(value: Boolean) {
     }
 }
 
-// In fact, this size doesn't affect anything on Windows/Linux, and isn't used by macOS (macOS
-// doesn't have separate Window icons). We specify it to support Painter's with
-// Unspecified intrinsicSize
-private val iconSize = Size(32f, 32f)
+// We specify this to support Painter's with unspecified intrinsicSize
+private val iconSize = Size(192f, 192f)
 
 internal fun Window.setIcon(painter: Painter?) {
     setIconImage(painter?.toAwtImage(density, layoutDirectionFor(this), iconSize))


### PR DESCRIPTION
This avoids blurry icons on window switchers (Alt+Tab) on Windows and Linux.

## Proposed Changes

  - change icon image size for windows to a larger base image 192px instead of 32px, otherwise we end up with blurry icons (see https://github.com/JetBrains/compose-multiplatform/issues/1838)

## Testing

Test: I have not tested this change directly, but am using this size on other apps to set the size and this seems to work well on the systems I tried on.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/1838

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
