### PR TITLE
`ComposeScene`/`Owner` refactor (Part 1)

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -66,11 +66,6 @@ internal abstract class ComposeBridge(
 ) {
     private var isDisposed = false
 
-    val sceneAccessible = ComposeSceneAccessible(
-        ownersProvider = { scene.owners.asReversed() },
-        mainOwnerProvider = { scene.mainOwner }
-    )
-
     private val _invisibleComponent = InvisibleComponent()
 
     abstract val component: JComponent
@@ -164,6 +159,8 @@ internal abstract class ComposeBridge(
             onComposeInvalidation()
         },
     )
+
+    val sceneAccessible = ComposeSceneAccessible(scene)
 
     var compositionLocalContext: CompositionLocalContext? by scene::compositionLocalContext
 

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -143,12 +143,6 @@ internal class ComposeLayer(
         return focusRect.toDpRect(density)
     }
 
-    fun hitInteropView(point: Point, isTouchEvent: Boolean): Boolean =
-        scene.mainOwner?.hitInteropView(
-            pointerPosition = Offset(point.x * density.density, point.y * density.density),
-            isTouchEvent = isTouchEvent,
-        ) ?: false
-
     fun setContent(
         onPreviewKeyEvent: (ComposeKeyEvent) -> Boolean = { false },
         onKeyEvent: (ComposeKeyEvent) -> Boolean = { false },

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyInputElement
 import androidx.compose.ui.input.key.NativeKeyEvent
@@ -476,7 +477,7 @@ class ComposeScene internal constructor(
         syntheticEventSender.updatePointerPosition()
         sendAndPerformSnapshotChanges()  // Apply changes from layout phase to draw phase
         needDraw = false
-        mainOwner?.draw(canvas)
+        mainOwner?.draw(canvas.asComposeCanvas())
         mainOwner?.clearInvalidObservations()
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -392,6 +392,9 @@ class ComposeScene internal constructor(
             KeyInputElement(onKeyEvent = onKeyEvent, onPreKeyEvent = onPreviewKeyEvent)
         )
 
+        this.mainOwner = mainOwner
+
+        // setContent might spawn more owners, so this.mainOwner should be set before that.
         composition = mainOwner.setContent(
             parentComposition ?: recomposer,
             { compositionLocalContext }
@@ -401,7 +404,6 @@ class ComposeScene internal constructor(
                 content = content
             )
         }
-        this.mainOwner = mainOwner
 
         // to perform all pending work synchronously
         recomposeDispatcher.flush()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Platform.skiko.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.platform
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Rect

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Wrapper.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/Wrapper.skiko.kt
@@ -24,9 +24,10 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.node.LayoutNode
+import androidx.compose.ui.window.RootNodeOwner
 
 /**
- * Composes the given composable into [SkiaBasedOwner]
+ * Composes the given composable into [RootNodeOwner]
  *
  * @param parent The parent composition reference to coordinate scheduling of composition updates
  *        If null then default root composition will be used.
@@ -35,7 +36,7 @@ import androidx.compose.ui.node.LayoutNode
  * @param content A `@Composable` function declaring the UI contents
  */
 @OptIn(ExperimentalComposeUiApi::class)
-internal fun SkiaBasedOwner.setContent(
+internal fun RootNodeOwner.setContent(
     parent: CompositionContext,
     getCompositionLocalContext: () -> CompositionLocalContext? = { null },
     content: @Composable () -> Unit

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
@@ -67,7 +67,7 @@ internal class CombinedRootNodeOwner(
         set(value) {
             field = value
             forEachAttachedOwner { it.constraints = value }
-            bounds = constraints.maxSize.toIntRect()
+            bounds = value.maxSize.toIntRect()
         }
 
     override val accessibilityControllers

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusOwner
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputEvent
@@ -324,7 +325,7 @@ internal class CombinedRootNodeOwner(
         forEachAttachedOwner { it.measureAndLayout(sendPointerUpdate) }
     }
 
-    override fun draw(canvas: org.jetbrains.skia.Canvas) {
+    override fun draw(canvas: Canvas) {
         super.draw(canvas)
         forEachAttachedOwner { it.draw(canvas) }
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
@@ -65,6 +65,7 @@ internal class CombinedRootNodeOwner(
     override var constraints = constraints
         set(value) {
             field = value
+            forEachAttachedOwner { it.constraints = value }
             bounds = constraints.maxSize.toIntRect()
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.node.LayoutNode
+import androidx.compose.ui.node.Owner
 import androidx.compose.ui.platform.Platform
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
@@ -323,6 +325,11 @@ internal class CombinedRootNodeOwner(
     override fun measureAndLayout(sendPointerUpdate: Boolean) {
         super.measureAndLayout(sendPointerUpdate)
         forEachAttachedOwner { it.measureAndLayout(sendPointerUpdate) }
+    }
+
+    override fun measureAndLayout(layoutNode: LayoutNode, constraints: Constraints) {
+        super.measureAndLayout(layoutNode, constraints)
+        forEachAttachedOwner { it.measureAndLayout(layoutNode, constraints) }
     }
 
     override fun draw(canvas: Canvas) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/CombinedRootNodeOwner.skiko.kt
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.ComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusOwner
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputEvent
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.Platform
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.toIntRect
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastForEachReversed
+import kotlin.coroutines.CoroutineContext
+
+internal class CombinedRootNodeOwner(
+    scene: ComposeScene,
+    platform: Platform,
+    initDensity: Density,
+    coroutineContext: CoroutineContext,
+    initLayoutDirection: LayoutDirection,
+    constraints: Constraints,
+    onPointerUpdate: () -> Unit,
+    modifier: Modifier = Modifier,
+) : RootNodeOwner(
+    scene = scene,
+    platform = platform,
+    initDensity = initDensity,
+    coroutineContext = coroutineContext,
+    initLayoutDirection = initLayoutDirection,
+    constraints = constraints,
+    focusable = true,
+    onOutsidePointerEvent = null,
+    onPointerUpdate = onPointerUpdate,
+    modifier = modifier
+) {
+    /**
+     * Contains attached registered [RootNodeOwner] in order of attachment.
+     * This logic is used by accessibility.
+     */
+    internal val attachedOwners = mutableListOf<RootNodeOwner>()
+    private val listCopy = mutableListOf<RootNodeOwner>()
+
+    override var constraints = constraints
+        set(value) {
+            field = value
+            bounds = constraints.maxSize.toIntRect()
+        }
+
+    override val accessibilityControllers
+        get() = attachedOwners.asReversed()
+            .map { it.accessibilityController } + super.accessibilityControllers
+
+    private var focusedOwner: RootNodeOwner = this
+    private var gestureOwner: RootNodeOwner? = null
+    private var lastHoverOwner: RootNodeOwner? = null
+
+    private val _focusOwner = createFocusOwner(platform.focusManager)
+    override val focusOwner = object : FocusOwner by _focusOwner {
+        override fun takeFocus() {
+            val focusOwner = attachedOwners.findLast { it.focusable }?.focusOwner ?: _focusOwner
+            focusOwner.takeFocus()
+        }
+
+        override fun releaseFocus() {
+            _focusOwner.releaseFocus()
+            forEachAttachedOwner { it.focusOwner.releaseFocus() }
+        }
+
+        override fun moveFocus(focusDirection: FocusDirection): Boolean {
+            val focusOwner = attachedOwners.lastOrNull()?.focusOwner ?: _focusOwner
+            return focusOwner.moveFocus(focusDirection) ?: false
+        }
+    }
+
+    /**
+     * Find hovered owner for position of first pointer.
+     */
+    private fun hoveredOwner(event: PointerInputEvent): RootNodeOwner {
+        val position = event.pointers.first().position
+        return attachedOwners.lastOrNull { it.isInBounds(position) } ?: this
+    }
+
+    /**
+     * Check if [focusedOwner] blocks input for this owner.
+     */
+    private fun isInteractive(owner: RootNodeOwner?) =
+        when (owner) {
+            null -> true
+            this -> focusedOwner == this
+            else -> attachedOwners.indexOf(focusedOwner) <= attachedOwners.indexOf(owner)
+        }
+
+    private inline fun forEachAttachedOwner(action: (RootNodeOwner) -> Unit) {
+        listCopy.addAll(attachedOwners)
+        try {
+            listCopy.fastForEach(action)
+        } finally {
+            listCopy.clear()
+        }
+    }
+
+    private inline fun forEachOwnerReversed(action: (RootNodeOwner) -> Unit) {
+        listCopy.add(this)
+        listCopy.addAll(attachedOwners)
+        try {
+            listCopy.fastForEachReversed(action)
+        } finally {
+            listCopy.clear()
+        }
+    }
+
+    internal fun attach(owner: RootNodeOwner) {
+        attachedOwners.add(owner)
+        owner.requestLayout = this.requestLayout
+        owner.requestDraw = this.requestDraw
+        owner.dispatchSnapshotChanges = this.dispatchSnapshotChanges
+        owner.constraints = this.constraints
+        if (owner.focusable) {
+            focusedOwner = owner
+
+            // Exit event to lastHoverOwner will be sent via synthetic event on next frame
+        }
+    }
+
+    internal fun detach(owner: RootNodeOwner) {
+        attachedOwners.remove(owner)
+        owner.dispatchSnapshotChanges = null
+        owner.requestDraw = null
+        owner.requestLayout = null
+        if (owner == focusedOwner) {
+            focusedOwner = attachedOwners.lastOrNull { it.focusable } ?: this
+
+            // Enter event to new focusedOwner will be sent via synthetic event on next frame
+        }
+        if (owner == lastHoverOwner) {
+            lastHoverOwner = null
+        }
+        if (owner == gestureOwner) {
+            gestureOwner = null
+        }
+    }
+
+    override fun hitTestInteropView(position: Offset): Boolean {
+        // TODO:
+        //  Temporary solution copying control flow from [processPress].
+        //  A proper solution is to send touches to scene as black box
+        //  and handle only that ones that were received in interop view
+        //  instead of using [pointInside].
+        attachedOwners.fastForEachReversed { owner ->
+            if (owner.isInBounds(position)) {
+                return owner.hitTestInteropView(position)
+            } else if (owner == focusedOwner) {
+                return false
+            }
+        }
+        return super.hitTestInteropView(position)
+    }
+
+    override fun sendKeyEvent(keyEvent: KeyEvent): Boolean {
+        return if (focusedOwner == this) {
+            super.sendKeyEvent(keyEvent)
+        } else {
+            focusedOwner.sendKeyEvent(keyEvent)
+        }
+    }
+
+    private fun forwardPointerInput(owner: RootNodeOwner?, event: PointerInputEvent) {
+        if (owner == this) {
+            super.processPointerInput(event)
+        } else {
+            owner?.processPointerInput(event)
+        }
+    }
+
+    override fun processPointerInput(event: PointerInputEvent) {
+        when (event.eventType) {
+            PointerEventType.Press -> processPress(event)
+            PointerEventType.Release -> processRelease(event)
+            PointerEventType.Move -> processMove(event)
+            PointerEventType.Enter -> processMove(event)
+            PointerEventType.Exit -> processMove(event)
+            PointerEventType.Scroll -> processScroll(event)
+        }
+
+        // Clean gestureOwner when there is no pressed pointers/buttons
+        if (!event.isGestureInProgress) {
+            gestureOwner = null
+        }
+    }
+
+    private fun processPress(event: PointerInputEvent) {
+        val currentGestureOwner = gestureOwner
+        if (currentGestureOwner != null) {
+            forwardPointerInput(currentGestureOwner, event)
+            return
+        }
+        val position = event.pointers.first().position
+        forEachOwnerReversed { owner ->
+
+            // If the position of in bounds of the owner - send event to it and stop processing
+            if (owner.isInBounds(position)) {
+                forwardPointerInput(owner, event)
+                gestureOwner = owner
+                return
+            }
+
+            // Input event is out of bounds - send click outside notification
+            owner.onOutsidePointerEvent?.invoke(event)
+
+            // if the owner is in focus, do not pass the event to underlying owners
+            if (owner == focusedOwner) {
+                return
+            }
+        }
+    }
+
+    private fun processRelease(event: PointerInputEvent) {
+        // Send Release to gestureOwner even if is not hovered or under focusedOwner
+        forwardPointerInput(gestureOwner, event)
+        if (!event.isGestureInProgress) {
+            val owner = hoveredOwner(event)
+            if (isInteractive(owner)) {
+                processHover(event, owner)
+            } else if (gestureOwner == null) {
+                // If hovered owner is not interactive, then it means that
+                // - It's not focusedOwner
+                // - It placed under focusedOwner or not exist at all
+                // In all these cases the even happened outside focused owner bounds
+                focusedOwner.onOutsidePointerEvent?.invoke(event)
+            }
+        }
+    }
+
+    private fun processMove(event: PointerInputEvent) {
+        var owner = when {
+            // All touch events or mouse with pressed button(s)
+            event.isGestureInProgress -> gestureOwner
+
+            // Do not generate Enter and Move
+            event.eventType == PointerEventType.Exit -> null
+
+            // Find owner under mouse position
+            else -> hoveredOwner(event)
+        }
+
+        // Even if the owner is not interactive, hover state still need to be updated
+        if (!isInteractive(owner)) {
+            owner = null
+        }
+        if (processHover(event, owner)) {
+            return
+        }
+        forwardPointerInput(owner, event.copy(eventType = PointerEventType.Move))
+    }
+
+    /**
+     * Updates hover state and generates [PointerEventType.Enter] and [PointerEventType.Exit]
+     * events. Returns true if [event] is consumed.
+     */
+    private fun processHover(event: PointerInputEvent, owner: RootNodeOwner?): Boolean {
+        if (event.pointers.fastAny { it.type != PointerType.Mouse }) {
+            // Track hover only for mouse
+            return false
+        }
+        // Cases:
+        // - move from outside to the window (owner != null, lastMoveOwner == null): Enter
+        // - move from the window to outside (owner == null, lastMoveOwner != null): Exit
+        // - move from one point of the window to another (owner == lastMoveOwner): Move
+        // - move from one popup to another (owner != lastMoveOwner): [Popup 1] Exit, [Popup 2] Enter
+        if (owner == lastHoverOwner) {
+            // Owner wasn't changed
+            return false
+        }
+        forwardPointerInput(lastHoverOwner, event.copy(eventType = PointerEventType.Exit))
+        forwardPointerInput(owner, event.copy(eventType = PointerEventType.Enter))
+        lastHoverOwner = owner
+
+        // Changing hovering state replaces Move event, so treat it as consumed
+        return true
+    }
+
+    private fun processScroll(event: PointerInputEvent) {
+        val owner = hoveredOwner(event)
+        if (isInteractive(owner)) {
+            forwardPointerInput(owner, event)
+        }
+    }
+
+    override fun measureAndLayout(sendPointerUpdate: Boolean) {
+        super.measureAndLayout(sendPointerUpdate)
+        forEachAttachedOwner { it.measureAndLayout(sendPointerUpdate) }
+    }
+
+    override fun draw(canvas: org.jetbrains.skia.Canvas) {
+        super.draw(canvas)
+        forEachAttachedOwner { it.draw(canvas) }
+    }
+
+    override fun clearInvalidObservations() {
+        super.clearInvalidObservations()
+        forEachAttachedOwner { it.clearInvalidObservations() }
+    }
+}
+
+private val PointerInputEvent.isGestureInProgress get() = pointers.fastAny { it.down }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootLayout.skiko.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformInsets
-import androidx.compose.ui.platform.SkiaBasedOwner
 import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.requireCurrent
 import androidx.compose.ui.unit.Constraints
@@ -53,24 +52,26 @@ internal fun RootLayout(
     modifier: Modifier,
     focusable: Boolean,
     onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
-    content: @Composable (SkiaBasedOwner) -> Unit
+    content: @Composable (RootNodeOwner) -> Unit
 ) {
     val scene = LocalComposeScene.requireCurrent()
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val parentComposition = rememberCompositionContext()
     val (owner, composition) = remember {
-        val owner = SkiaBasedOwner(
+        val owner = RootNodeOwner(
             scene = scene,
             platform = scene.platform,
             coroutineContext = parentComposition.effectCoroutineContext,
             initDensity = density,
             initLayoutDirection = layoutDirection,
+            constraints = scene.constraints,
             focusable = focusable,
             onOutsidePointerEvent = onOutsidePointerEvent,
             onPointerUpdate = scene::onPointerUpdate,
             modifier = modifier
         )
+        owner.initialize()
         scene.attach(owner)
         owner to owner.setContent(parent = parentComposition) {
             content(owner)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootNodeOwner.skiko.kt
@@ -87,7 +87,7 @@ internal open class RootNodeOwner(
     initDensity: Density = Density(1f, 1f),
     override val coroutineContext: CoroutineContext,
     initLayoutDirection: LayoutDirection,
-    open var constraints: Constraints,
+    constraints: Constraints,
     val focusable: Boolean = true,
     val onOutsidePointerEvent: ((PointerInputEvent) -> Unit)? = null,
     private val onPointerUpdate: () -> Unit = {},
@@ -101,9 +101,11 @@ internal open class RootNodeOwner(
         return bounds.contains(intOffset)
     }
 
-    var bounds by mutableStateOf(
-        constraints.maxSize.toIntRect()
-    )
+    // Cannot be constructor property because of need raw parameter access in other initializers.
+    @Suppress("CanBePrimaryConstructorProperty")
+    open var constraints: Constraints = constraints
+
+    var bounds by mutableStateOf(constraints.maxSize.toIntRect())
 
     override var density by mutableStateOf(initDensity)
 
@@ -135,7 +137,7 @@ internal open class RootNodeOwner(
     override val inputModeManager: InputModeManager
         get() = platform.inputModeManager
 
-    override val modifierLocalManager: ModifierLocalManager = ModifierLocalManager(this)
+    override val modifierLocalManager by lazy { ModifierLocalManager(this) }
 
     // TODO(b/177931787) : Consider creating a KeyInputManager like we have for FocusManager so
     //  that this common logic can be used by all owners.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootNodeOwner.skiko.kt
@@ -287,6 +287,10 @@ internal open class RootNodeOwner(
         contentSize = computeContentSize()
     }
 
+    override fun measureAndLayoutForTest() {
+        measureAndLayout()
+    }
+
     // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
     private fun computeContentSize() = IntSize(
         root.children.maxOfOrNull { it.outerCoordinator.measuredWidth } ?: 0,
@@ -321,13 +325,7 @@ internal open class RootNodeOwner(
         affectsLookahead: Boolean,
         forceRequest: Boolean
     ) {
-        if (affectsLookahead) {
-            if (measureAndLayoutDelegate.requestLookaheadRelayout(layoutNode, forceRequest)) {
-                requestLayout?.invoke()
-            }
-        } else if (measureAndLayoutDelegate.requestRelayout(layoutNode, forceRequest)) {
-            requestLayout?.invoke()
-        }
+        this.onRequestMeasure(layoutNode, affectsLookahead, forceRequest, scheduleMeasureAndLayout = true)
     }
 
     override fun requestOnPositionedCallback(layoutNode: LayoutNode) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootNodeOwner.skiko.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.focus.FocusDirection.Companion.Out
 import androidx.compose.ui.focus.FocusDirection.Companion.Previous
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
-import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.InputMode.Companion.Keyboard
 import androidx.compose.ui.input.InputMode.Companion.Touch
 import androidx.compose.ui.input.InputModeManager
@@ -372,8 +371,8 @@ internal open class RootNodeOwner(
 
     override fun screenToLocal(positionOnScreen: Offset): Offset = positionOnScreen
 
-    open fun draw(canvas: org.jetbrains.skia.Canvas) {
-        root.draw(canvas.asComposeCanvas())
+    open fun draw(canvas: Canvas) {
+        root.draw(canvas)
     }
 
     open fun processPointerInput(event: PointerInputEvent) {


### PR DESCRIPTION
## Proposed Changes

- Rename `SkiaBasedOwner` to `RootNodeOwner`
- Remove `owners` list from `ComposeScene` class
- Add `CombinedRootNodeOwner` to allow adding multiple root nodes to the same canvas/`ComposeScene`
- `ComposeSceneAccessible` now uses the new `accessibilityControllers` owner property

## Testing

Test: CI should pass, everything should work as before
