### PR TITLE
[Tests] Use `ComposeRootRegistry` instead of scene tree

### DIFF
--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/ComposeRootRegistry.skiko.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/ComposeRootRegistry.skiko.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test.junit4
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.platform.SkiaRootForTest
+
+/**
+ * Registry where all views implementing [SkiaRootForTest] should be registered while they
+ * are attached to the window. This registry is used by the testing library to query the roots'
+ * state.
+ */
+@OptIn(InternalComposeUiApi::class)
+internal class ComposeRootRegistry {
+    private val lock = Any()
+    private val roots = mutableSetOf<SkiaRootForTest>()
+
+    /**
+     * Returns if the registry is setup to receive registrations from [SkiaRootForTest]s
+     */
+    val isSetUp: Boolean
+        get() = SkiaRootForTest.onRootCreatedCallback == ::onRootCreated
+
+    /**
+     * Sets up this registry to be notified of any [SkiaRootForTest] created
+     */
+    private fun setupRegistry() {
+        SkiaRootForTest.onRootCreatedCallback = ::onRootCreated
+        SkiaRootForTest.onRootDisposedCallback = ::onRootDisposed
+    }
+
+    /**
+     * Cleans up the changes made by [setupRegistry]. Call this after your test has run.
+     */
+    @VisibleForTesting
+    internal fun tearDownRegistry() {
+        // Stop accepting new roots
+        SkiaRootForTest.onRootCreatedCallback = null
+        SkiaRootForTest.onRootDisposedCallback = null
+        synchronized(lock) {
+            // Clear all references
+            roots.clear()
+        }
+    }
+
+    private fun onRootCreated(root: SkiaRootForTest) {
+        synchronized(lock) {
+            if (isSetUp) {
+                roots.add(root)
+            }
+        }
+    }
+
+    private fun onRootDisposed(root: SkiaRootForTest) {
+        synchronized(lock) {
+            if (isSetUp) {
+                roots.remove(root)
+            }
+        }
+    }
+
+    /**
+     * Returns a copy of the set of all registered [SkiaRootForTest]s that can be interacted with.
+     */
+    fun getComposeRoots(): Set<SkiaRootForTest> {
+        return synchronized(lock) { roots.toSet() }
+    }
+
+    fun <R> withRegistry(block: () -> R): R {
+        try {
+            setupRegistry()
+            return block()
+        } finally {
+            tearDownRegistry()
+        }
+    }
+}

--- a/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/ComposeRootRegistry.skiko.kt
+++ b/compose/ui/ui-test-junit4/src/skikoMain/kotlin/androidx/compose/ui/test/junit4/ComposeRootRegistry.skiko.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.test.junit4
 
-import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.SkiaRootForTest
 
@@ -47,8 +46,7 @@ internal class ComposeRootRegistry {
     /**
      * Cleans up the changes made by [setupRegistry]. Call this after your test has run.
      */
-    @VisibleForTesting
-    internal fun tearDownRegistry() {
+    private fun tearDownRegistry() {
         // Stop accepting new roots
         SkiaRootForTest.onRootCreatedCallback = null
         SkiaRootForTest.onRootDisposedCallback = null

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/Assertions.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/Assertions.skikoMain.kt
@@ -55,8 +55,7 @@ internal actual fun SemanticsNode.clippedNodeBoundsInWindow(): Rect {
 
 @OptIn(InternalComposeUiApi::class)
 internal actual fun SemanticsNode.isInScreenBounds(): Boolean {
-    // TODO: Replace _content_ size to view bounds.
-    val composeView = (root as SkiaRootForTest).scene
+    val containerSize = (root as SkiaRootForTest).containerSize
 
     // Window relative bounds of our node
     val nodeBoundsInWindow = clippedNodeBoundsInWindow()
@@ -67,8 +66,8 @@ internal actual fun SemanticsNode.isInScreenBounds(): Boolean {
     // Window relative bounds of our compose root view that are visible on the screen
     return nodeBoundsInWindow.top >= 0 &&
         nodeBoundsInWindow.left >= 0 &&
-        nodeBoundsInWindow.right <= composeView.contentSize.width &&
-        nodeBoundsInWindow.bottom <= composeView.contentSize.height
+        nodeBoundsInWindow.right <= containerSize.width &&
+        nodeBoundsInWindow.bottom <= containerSize.height
 }
 
 /**

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3150,8 +3150,17 @@ public final class androidx/compose/ui/platform/PlatformLocalization_desktopKt {
 }
 
 public abstract interface class androidx/compose/ui/platform/SkiaRootForTest : androidx/compose/ui/node/RootForTest {
+	public static final field Companion Landroidx/compose/ui/platform/SkiaRootForTest$Companion;
+	public abstract fun getContainerSize-YbymL2g ()J
 	public abstract fun getHasPendingMeasureOrLayout ()Z
 	public fun getScene ()Landroidx/compose/ui/ComposeScene;
+}
+
+public final class androidx/compose/ui/platform/SkiaRootForTest$Companion {
+	public final fun getOnRootCreatedCallback ()Lkotlin/jvm/functions/Function1;
+	public final fun getOnRootDisposedCallback ()Lkotlin/jvm/functions/Function1;
+	public final fun setOnRootCreatedCallback (Lkotlin/jvm/functions/Function1;)V
+	public final fun setOnRootDisposedCallback (Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class androidx/compose/ui/platform/SoftwareKeyboardController {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -340,20 +340,17 @@ fun DialogWindow(
     val windowExceptionHandlerFactory by rememberUpdatedState(
         LocalWindowExceptionHandlerFactory.current
     )
-    val parentScene = LocalComposeScene.current
     val layoutDirection = LocalLayoutDirection.current
     AwtWindow(
         visible = visible,
         create = {
             create().apply {
-                parentScene?.addChildScene(scene)
                 this.compositionLocalContext = compositionLocalContext
                 this.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(this)
                 setContent(onPreviewKeyEvent, onKeyEvent, content)
             }
         },
         dispose = {
-            parentScene?.removeChildScene(it.scene)
             dispose(it)
         },
         update = {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -399,20 +399,17 @@ fun Window(
     val windowExceptionHandlerFactory by rememberUpdatedState(
         LocalWindowExceptionHandlerFactory.current
     )
-    val parentScene = LocalComposeScene.current
     val layoutDirection = LocalLayoutDirection.current
     AwtWindow(
         visible = visible,
         create = {
             create().apply {
-                parentScene?.addChildScene(scene)
                 this.compositionLocalContext = compositionLocalContext
                 this.exceptionHandler = windowExceptionHandlerFactory.exceptionHandler(this)
                 setContent(onPreviewKeyEvent, onKeyEvent, content)
             }
         },
         dispose = {
-            parentScene?.removeChildScene(it.scene)
             dispose(it)
         },
         update = {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -247,43 +247,13 @@ class ComposeScene internal constructor(
         }
     }
 
-    private val childScenes = mutableSetOf<ComposeScene>()
-
-    /**
-     * Adds a child [ComposeScene], so that nodes in it can be found in tests.
-     */
-    internal fun addChildScene(scene: ComposeScene) {
-        check(!isClosed) { "ComposeScene is closed" }
-        childScenes.add(scene)
-    }
-
-    /**
-     * Removes a child [ComposeScene].
-     */
-    internal fun removeChildScene(scene: ComposeScene) {
-        check(!isClosed) { "ComposeScene is closed" }
-        childScenes.remove(scene)
-    }
-
-    /**
-     * Adds this scene's [RootForTest]s, including any of its child scenes, into the given set.
-     */
-    private fun addRootsForTestTo(target: MutableSet<RootForTest>) {
-        target.addAll(owners)
-        for (child in childScenes) {
-            child.addRootsForTestTo(target)
-        }
-    }
-
-    /**
-     * All currently registered [RootForTest]s. After calling [setContent] the first root
-     * will be added. If there is an any [Popup] is present in the content, it will be added as
-     * another [RootForTest]
-     */
+    @Deprecated(
+        message = "The scene isn't tracking list of roots anymore",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("SkiaRootForTest.onRootCreatedCallback")
+    )
     val roots: Set<RootForTest>
-        get() = buildSet(owners.size) {
-            addRootsForTestTo(this)
-        }
+        get() = throw NotImplementedError()
 
     private val defaultPointerStateTracker = DefaultPointerStateTracker()
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -155,12 +155,13 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      */
     fun close(): Unit = scene.close()
 
-    /**
-     * All currently registered [RootForTest]s. After calling [setContent] the first root
-     * will be added. If there is an any [Popup] is present in the content, it will be added as
-     * another [RootForTest]
-     */
-    val roots: Set<RootForTest> get() = scene.roots
+    @Deprecated(
+        message = "The scene isn't tracking list of roots anymore",
+        level = DeprecationLevel.ERROR,
+        replaceWith = ReplaceWith("SkiaRootForTest.onRootCreatedCallback")
+    )
+    val roots: Set<RootForTest>
+        get() = throw NotImplementedError()
 
     /**
      * Constraints used to measure and layout content.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
@@ -18,9 +18,8 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.input.pointer.TestPointerInputEventData
-import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootForTest
+import androidx.compose.ui.unit.IntSize
 
 /**
  * The marker interface to be implemented by the desktop root backing the composition.
@@ -29,9 +28,15 @@ import androidx.compose.ui.node.RootForTest
 @InternalComposeUiApi
 interface SkiaRootForTest : RootForTest {
     /**
-     * The [ComposeScene] which contains this root
+     * See [WindowInfo.containerSize]
+     */
+    val containerSize: IntSize
+
+    /**
+     * The [ComposeScene] which contains this root.
+     * Required only for dispatching input events.
      *
-     * TODO: Remove this reference.
+     * TODO: Extract separate interface only for pointer input.
      */
     val scene: ComposeScene get() = throw UnsupportedOperationException("SkiaRootForTest.scene is not implemented")
 
@@ -39,4 +44,17 @@ interface SkiaRootForTest : RootForTest {
      * Whether the Owner has pending layout work.
      */
     val hasPendingMeasureOrLayout: Boolean
+
+    companion object {
+        /**
+         * Called after an owner implementing [SkiaRootForTest] is created. Used by
+         * SkikoComposeUiTest to keep track of all attached roots. Not to be
+         * set or used by any other component.
+         */
+        @InternalComposeUiApi
+        var onRootCreatedCallback: ((SkiaRootForTest) -> Unit)? = null
+
+        @InternalComposeUiApi
+        var onRootDisposedCallback: ((SkiaRootForTest) -> Unit)? = null
+    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/SkiaRootForTest.skiko.kt
@@ -51,9 +51,11 @@ interface SkiaRootForTest : RootForTest {
          * SkikoComposeUiTest to keep track of all attached roots. Not to be
          * set or used by any other component.
          */
+        // TODO: Move to "Shared Context" (aka Platform now)
         @InternalComposeUiApi
         var onRootCreatedCallback: ((SkiaRootForTest) -> Unit)? = null
 
+        // TODO: Move to "Shared Context" (aka Platform now)
         @InternalComposeUiApi
         var onRootDisposedCallback: ((SkiaRootForTest) -> Unit)? = null
     }


### PR DESCRIPTION
## Proposed Changes

It's a part of #891

- Add callbacks to `SkiaRootForTest` to collect references in `ComposeRootRegistry` (original Google's approach like in the Android source set)
- Remove "child" scenes introduced in #697. Currently it's handled in `ComposeRootRegistry` (tests-only)
- Deprecate `ComposeScene.roots` that was never intended to be public
- Address TODO in `isInScreenBounds()`:  `contentSize` instead of `containerSize` where used

## Testing

Test: CI should pass, everything should work as before