### PR TITLE
Unify runtime-saveable's targets with the runtime

### DIFF
--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -73,6 +73,21 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     }
 
     kotlin {
+        // Not all modules can have these targets, so declare them here instead of androidXComposeMultiplatform.
+        // We can support the kotlin-native targets supported by kotlin coroutines:
+        // https://github.com/Kotlin/kotlinx.coroutines/blob/master/gradle/compile-native-multiplatform.gradle
+        // NOTE: Keep this list in sync with runtime's targets.
+        watchosArm64()
+        watchosArm32()
+        watchosX86()
+        watchosX64()
+        watchosSimulatorArm64()
+        tvosArm64()
+        tvosX64()
+        tvosSimulatorArm64()
+        mingwX64()
+        linuxX64()
+
         /* When updating dependencies, make sure to make the an an analogous update in the
             corresponding block above */
         sourceSets {

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -72,6 +72,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         // Not all modules can have these targets, so declare them here instead of androidXComposeMultiplatform.
         // We can support the kotlin-native targets supported by kotlin coroutines:
         // https://github.com/Kotlin/kotlinx.coroutines/blob/master/gradle/compile-native-multiplatform.gradle
+        // NOTE: Keep this list in sync with runtime-saveable's targets.
         watchosArm64()
         watchosArm32()
         watchosX86()

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -36,7 +36,7 @@ val mainComponents =
         ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
         ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),
-        ComposeComponent(":compose:runtime:runtime-saveable"),
+        ComposeComponent(":compose:runtime:runtime-saveable", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":compose:ui:ui"),
         ComposeComponent(":compose:ui:ui-geometry"),
         ComposeComponent(":compose:ui:ui-graphics"),


### PR DESCRIPTION
It supports more targets than the general compose multiplatform libraries, and the two should be unified.

Test: gw :compose:runtime:runtime-saveable:watchosArm64Binaries :compose:runtime:runtime-saveable:watchosArm32Binaries :compose:runtime:runtime-saveable:watchosX86Binaries :compose:runtime:runtime-saveable:watchosX64Binaries :compose:runtime:runtime-saveable:watchosSimulatorArm64Binaries :compose:runtime:runtime-saveable:tvosArm64Binaries :compose:runtime:runtime-saveable:tvosX64Binaries :compose:runtime:runtime-saveable:tvosSimulatorArm64Binaries :compose:runtime:runtime-saveable:mingwX64Binaries :compose:runtime:runtime-saveable:linuxX64Binaries

Closes https://github.com/JetBrains/compose-multiplatform/issues/3899