### PR TITLE
Make Skia context usage a critical section on iOS.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -290,7 +290,6 @@ internal class MetalRedrawer(
     }
 
     fun dispose() = disposeLock.doLocked {
-        println("dispose")
         check(caDisplayLink != null) { "MetalRedrawer.dispose() was called more than once" }
 
         applicationStateListener.dispose()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.kt
@@ -203,6 +203,11 @@ internal class MetalRedrawer(
     private var lastRenderTimestamp: NSTimeInterval = CACurrentMediaTime()
     private val pictureRecorder = PictureRecorder()
 
+    /**
+     * Lock used to avoid skia context being disposed in the middle of rendering encoding on a separate thread.
+     */
+    private val disposeLock = NSLock()
+
     // Semaphore for preventing command buffers count more than swapchain size to be scheduled/executed at the same time
     private val inflightSemaphore =
         dispatch_semaphore_create(metalLayer.maximumDrawableCount.toLong())
@@ -284,7 +289,8 @@ internal class MetalRedrawer(
         caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
     }
 
-    fun dispose() {
+    fun dispose() = disposeLock.doLocked {
+        println("dispose")
         check(caDisplayLink != null) { "MetalRedrawer.dispose() was called more than once" }
 
         applicationStateListener.dispose()
@@ -432,7 +438,16 @@ internal class MetalRedrawer(
             } else {
                 dispatch_async(renderingDispatchQueue) {
                     autoreleasepool {
-                        encodeAndPresentBlock()
+                        disposeLock.doLocked {
+                            if (caDisplayLink == null) {
+                                // Was disposed before render encoding started
+                                picture.close()
+                                surface.close()
+                                renderTarget.close()
+                            } else {
+                                encodeAndPresentBlock()
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Proposed Changes

Since there are no reliable repros, it's a speculative fix for [the crash](https://github.com/JetBrains/compose-multiplatform/issues/3862) on iOS.
It's based on an assumption that the case for the crash is caused by render command encoding in a separate thread being performed after (or in parallel) with the context disposal on the main thread which leads to incorrect state inside Skia.

## Testing

Test: see if issues persists.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3862

## Note
Skia is supposed to handle internal resources based on reference counting and assumed scenario shouldn't lead to the crash, since the context should be indirectly retained by the moment encoding starts.
Revert if issue persists because that logic would be redundant.
