### PR TITLE
Add support `LineHeightStyle.Trim`

### DIFF
--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphIntegrationLineHeightStyleTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphIntegrationLineHeightStyleTest.kt
@@ -1,0 +1,1009 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.text.platform.Font
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.text.style.LineHeightStyle.Alignment
+import androidx.compose.ui.text.style.LineHeightStyle.Trim
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.sp
+import com.google.common.truth.Truth.assertThat
+import kotlin.math.abs
+import kotlin.math.ceil
+import kotlin.math.roundToInt
+import org.jetbrains.skia.FontMetrics
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+
+@RunWith(JUnit4::class)
+class DesktopParagraphIntegrationLineHeightStyleTest {
+    private val fontFamilyResolver = createFontFamilyResolver()
+    private val fontFamilyMeasureFont =
+        FontFamily(
+            Font(
+                "font/sample_font.ttf",
+                weight = FontWeight.Normal,
+                style = FontStyle.Normal
+            )
+        )
+    private val defaultDensity = Density(density = 1f)
+    private val fontSize = 10.sp
+    private val lineHeight = 20.sp
+    private val fontSizeInPx = with(defaultDensity) { fontSize.toPx() }
+    private val lineHeightInPx = with(defaultDensity) { lineHeight.toPx().roundToInt() }
+
+    /* single line even */
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_even_trim_None() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_even_trim_LastLineBottom() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_even_trim_FirstLineTop() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    fun singleLine_even_trim_Both() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(defaultFontMetrics.lineHeight())
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    /* single line top */
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_top_trim_None() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_top_trim_LastLineBottom() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(defaultFontMetrics.descent)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_top_trim_FirstLineTop() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    fun singleLine_top_trim_Both() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(defaultFontMetrics.lineHeight())
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    /* single line bottom */
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_bottom_trim_None() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_bottom_trim_LastLineBottom() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent - diff)
+            assertThat(getLineDescent(0)).isEqualTo(defaultFontMetrics.descent)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun singleLine_bottom_trim_FirstLineTop() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    fun singleLine_bottom_trim_Both() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(defaultFontMetrics.lineHeight())
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    /* single line proportional */
+
+    @Test
+    fun singleLine_proportional_trim_None() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent - ascentDiff
+        val expectedDescent = defaultFontMetrics.descent + descentDiff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    fun singleLine_proportional_trim_LastLineBottom() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent - ascentDiff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - descentDiff)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    fun singleLine_proportional_trim_FirstLineTop() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + descentDiff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - ascentDiff)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    @Test
+    fun singleLine_proportional_trim_Both() {
+        val paragraph = singleLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(defaultFontMetrics.lineHeight())
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+        }
+    }
+
+    /* multi line even */
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_even_trim_None() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            for (line in 0 until lineCount) {
+                assertThat(getLineHeight(line)).isEqualTo(lineHeightInPx)
+                assertThat(getLineAscent(line)).isEqualTo(expectedAscent)
+                assertThat(getLineDescent(line)).isEqualTo(expectedDescent)
+            }
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_even_trim_LastLineBottom() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_even_trim_FirstLineTop() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Center is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_even_trim_Both() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Center
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = (lineHeightInPx - defaultFontMetrics.lineHeight()) / 2
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    /* multi line top */
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_top_trim_None() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_top_trim_LastLineBottom() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_top_trim_FirstLineTop() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Top is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_top_trim_Both() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Top
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent
+        val expectedDescent = defaultFontMetrics.descent + diff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    /* multi line bottom */
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_bottom_trim_None() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_bottom_trim_LastLineBottom() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_bottom_trim_FirstLineTop() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    @Ignore("Alignment.Bottom is not supported") // TODO: Support non-proportional alignment
+    fun multiLine_bottom_trim_Both() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Bottom
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val diff = lineHeightInPx - defaultFontMetrics.lineHeight()
+        val expectedAscent = defaultFontMetrics.ascent - diff
+        val expectedDescent = defaultFontMetrics.descent
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - diff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    /* multi line proportional */
+
+    @Test
+    fun multiLine_proportional_trim_None() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.None,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent - ascentDiff
+        val expectedDescent = defaultFontMetrics.descent + descentDiff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    fun multiLine_proportional_trim_LastLineBottom() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.LastLineBottom,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent - ascentDiff
+        val expectedDescent = defaultFontMetrics.descent + descentDiff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(0)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx - descentDiff)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    fun multiLine_proportional_trim_FirstLineTop() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.FirstLineTop,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent - ascentDiff
+        val expectedDescent = defaultFontMetrics.descent + descentDiff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - ascentDiff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(expectedDescent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    fun multiLine_proportional_trim_Both() {
+        val paragraph = multiLineParagraph(
+            lineHeightTrim = Trim.Both,
+            lineHeightAlignment = Alignment.Proportional
+        )
+
+        val defaultFontMetrics = defaultFontMetrics()
+        val descentDiff = proportionalDescentDiff(defaultFontMetrics)
+        val ascentDiff = defaultFontMetrics.lineHeight() - descentDiff
+        val expectedAscent = defaultFontMetrics.ascent - ascentDiff
+        val expectedDescent = defaultFontMetrics.descent + descentDiff
+
+        with(paragraph) {
+            assertThat(getLineHeight(0)).isEqualTo(lineHeightInPx - ascentDiff)
+            assertThat(getLineAscent(0)).isEqualTo(defaultFontMetrics.ascent)
+            assertThat(getLineDescent(0)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(1)).isEqualTo(lineHeightInPx)
+            assertThat(getLineAscent(1)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(1)).isEqualTo(expectedDescent)
+
+            assertThat(getLineHeight(2)).isEqualTo(lineHeightInPx - descentDiff)
+            assertThat(getLineAscent(2)).isEqualTo(expectedAscent)
+            assertThat(getLineDescent(2)).isEqualTo(defaultFontMetrics.descent)
+
+            assertThat(getLineBaseline(1) - getLineBaseline(0)).isEqualTo(lineHeightInPx)
+            assertThat(getLineBaseline(2) - getLineBaseline(1)).isEqualTo(lineHeightInPx)
+        }
+    }
+
+    @Test
+    fun lastLineEmptyTextHasSameLineHeightAsNonEmptyText() {
+        assertEmptyLineMetrics("", "a")
+        assertEmptyLineMetrics("\n", "a\na")
+        assertEmptyLineMetrics("a\n", "a\na")
+        assertEmptyLineMetrics("\na", "a\na")
+        assertEmptyLineMetrics("\na\na", "a\na\na")
+        assertEmptyLineMetrics("a\na\n", "a\na\na")
+    }
+
+    private fun assertEmptyLineMetrics(textWithEmptyLine: String, textWithoutEmptyLine: String) {
+        val textStyle = TextStyle(
+            lineHeightStyle = LineHeightStyle(
+                trim = Trim.None,
+                alignment = Alignment.Proportional
+            ),
+        )
+
+        val paragraphWithEmptyLastLine = simpleParagraph(
+            text = textWithEmptyLine,
+            style = textStyle
+        ) as SkiaParagraph
+
+        val otherParagraph = simpleParagraph(
+            text = textWithoutEmptyLine,
+            style = textStyle
+        ) as SkiaParagraph
+
+        with(paragraphWithEmptyLastLine) {
+            for (line in 0 until lineCount) {
+                assertThat(height).isEqualTo(otherParagraph.height)
+                assertThat(getLineTop(line)).isEqualTo(otherParagraph.getLineTop(line))
+                assertThat(getLineBottom(line)).isEqualTo(otherParagraph.getLineBottom(line))
+                assertThat(getLineHeight(line)).isEqualTo(otherParagraph.getLineHeight(line))
+                assertThat(getLineAscent(line)).isEqualTo(otherParagraph.getLineAscent(line))
+                assertThat(getLineDescent(line)).isEqualTo(otherParagraph.getLineDescent(line))
+                assertThat(getLineBaseline(line)).isEqualTo(otherParagraph.getLineBaseline(line))
+            }
+        }
+    }
+
+    private fun singleLineParagraph(
+        lineHeightTrim: Trim,
+        lineHeightAlignment: Alignment,
+        text: String = "AAA"
+    ): SkiaParagraph {
+        val textStyle = TextStyle(
+            lineHeightStyle = LineHeightStyle(
+                trim = lineHeightTrim,
+                alignment = lineHeightAlignment
+            )
+        )
+
+        val paragraph = simpleParagraph(
+            text = text,
+            style = textStyle,
+            width = text.length * fontSizeInPx
+        ) as SkiaParagraph
+
+        assertThat(paragraph.lineCount).isEqualTo(1)
+
+        return paragraph
+    }
+
+    @Suppress("DEPRECATION")
+    private fun multiLineParagraph(
+        lineHeightTrim: Trim,
+        lineHeightAlignment: Alignment,
+    ): SkiaParagraph {
+        val lineCount = 3
+        val word = "AAA"
+        val text = "AAA".repeat(lineCount)
+
+        val textStyle = TextStyle(
+            lineHeightStyle = LineHeightStyle(
+                trim = lineHeightTrim,
+                alignment = lineHeightAlignment
+            )
+        )
+
+        val paragraph = simpleParagraph(
+            text = text,
+            style = textStyle,
+            width = word.length * fontSizeInPx
+        ) as SkiaParagraph
+
+        assertThat(paragraph.lineCount).isEqualTo(lineCount)
+
+        return paragraph
+    }
+
+    private fun simpleParagraph(
+        text: String = "",
+        style: TextStyle? = null,
+        maxLines: Int = Int.MAX_VALUE,
+        ellipsis: Boolean = false,
+        spanStyles: List<AnnotatedString.Range<SpanStyle>> = listOf(),
+        width: Float = Float.MAX_VALUE
+    ): Paragraph {
+        return Paragraph(
+            text = text,
+            spanStyles = spanStyles,
+            style = TextStyle(
+                fontFamily = fontFamilyMeasureFont,
+                fontSize = fontSize,
+                lineHeight = lineHeight,
+            ).merge(style),
+            maxLines = maxLines,
+            ellipsis = ellipsis,
+            constraints = Constraints(maxWidth = width.ceilToInt()),
+            density = defaultDensity,
+            fontFamilyResolver = fontFamilyResolver
+        )
+    }
+
+    private fun defaultFontMetrics(): FontMetricsInt {
+        val defaultFont = (simpleParagraph() as SkiaParagraph).defaultFont
+        return FontMetricsInt(defaultFont.metrics)
+    }
+
+    private fun proportionalDescentDiff(fontMetrics: FontMetricsInt): Int {
+        val ascent = abs(fontMetrics.ascent.toFloat())
+        val ascentRatio = ascent / fontMetrics.lineHeight()
+        return ceil(fontMetrics.lineHeight() * (1f - ascentRatio)).toInt()
+    }
+}
+
+private data class FontMetricsInt(
+    var ascent: Int,
+    var descent: Int
+) {
+    constructor(fontMetrics: FontMetrics) : this(
+        ascent = fontMetrics.ascent.roundToInt(),
+        descent = fontMetrics.descent.roundToInt(),
+    )
+
+    fun lineHeight(): Int = descent - ascent
+}

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -76,6 +76,7 @@ internal class ParagraphLayouter(
     private var width: Float = Float.NaN
 
     val defaultFont get() = builder.defaultFont
+    val textStyle get() = builder.textStyle
 
     internal fun emptyLineMetrics(paragraph: Paragraph): Array<LineMetrics> =
         builder.emptyLineMetrics(paragraph)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -26,11 +26,13 @@ import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Density
 import kotlin.math.abs
 import org.jetbrains.skia.Paint
+import org.jetbrains.skia.paragraph.LineMetrics
 import org.jetbrains.skia.paragraph.Paragraph
 
 /**
@@ -74,7 +76,9 @@ internal class ParagraphLayouter(
     private var width: Float = Float.NaN
 
     val defaultFont get() = builder.defaultFont
-    val paragraphStyle get() = builder.paragraphStyle
+
+    internal fun emptyLineMetrics(paragraph: Paragraph): Array<LineMetrics> =
+        builder.emptyLineMetrics(paragraph)
 
     fun setParagraphStyle(
         maxLines: Int,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -498,8 +498,24 @@ internal class ParagraphBuilder(
             pStyle.alignment = it.toSkAlignment()
         }
 
-        val lineHeightStyle = style.lineHeightStyle ?: LineHeightStyle.Default
-        pStyle.heightMode = lineHeightStyle.trim.toHeightMode()
+        val lineHeight = computedStyle.lineHeight
+        if (lineHeight != null && lineHeight > computedStyle.fontSize) {
+            val lineHeightStyle = style.lineHeightStyle ?: LineHeightStyle.Default
+            pStyle.heightMode = lineHeightStyle.trim.toHeightMode()
+        } else {
+            /*
+             * "DISABLE_ALL" replaces calculated from lineHeight
+             * ascent for the first line and descent for the last line
+             * to default font's values.
+             *
+             * To match android behavior, set it without taking into account trim value
+             * in case when lineHeight < fontSize. This keeps the single line height NOT less
+             * than defined in font. Note that it just ensures of minimal external paddings,
+             * internal (between lines in multiline text) calculated as-is.
+             */
+            pStyle.heightMode = HeightMode.DISABLE_ALL
+        }
+
         // TODO: Support lineHeightStyle.alignment. Currently it's not exposed in skia
 
         pStyle.direction = textDirection.toSkDirection()

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.text.style.*
 import androidx.compose.ui.unit.*
 import org.jetbrains.skia.FontFeature
+import org.jetbrains.skia.FontMetrics
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.paragraph.*
 import org.jetbrains.skia.paragraph.ParagraphStyle
@@ -524,19 +525,12 @@ internal class ParagraphBuilder(
     // workaround for https://bugs.chromium.org/p/skia/issues/detail?id=11321 :(
     internal fun emptyLineMetrics(paragraph: SkParagraph): Array<LineMetrics> {
         val metrics = defaultFont.metrics
-        var ascent = metrics.ascent.toDouble()
-        var descent = metrics.descent.toDouble()
-        val baseline = paragraph.alphabeticBaseline.toDouble()
-        val lineHeightStyle = textStyle.lineHeightStyle ?: LineHeightStyle.Default
         val heightMultiplier = defaultStyle.lineHeight?.let {
-            it / defaultStyle.fontSize
-        } ?: 1f
-        if (!lineHeightStyle.trim.isTrimFirstLineTop()) {
-            ascent *= heightMultiplier // TODO: Support non-proportional alignment
-        }
-        if (!lineHeightStyle.trim.isTrimLastLineBottom()) {
-            descent *= heightMultiplier // TODO: Support non-proportional alignment
-        }
+            it / defaultStyle.fontSize.toDouble()
+        } ?: 1.0
+        val ascent = metrics.ascent * heightMultiplier // TODO: Support non-proportional alignment
+        val descent = metrics.descent * heightMultiplier // TODO: Support non-proportional alignment
+        val baseline = paragraph.alphabeticBaseline.toDouble()
         val height = descent - ascent
         return arrayOf(
             LineMetrics(
@@ -545,7 +539,7 @@ internal class ParagraphBuilder(
                 endExcludingWhitespaces = 0,
                 endIncludingNewline = 0,
                 isHardBreak = true,
-                ascent = ascent,
+                ascent = -ascent,
                 descent = descent,
                 unscaledAscent = ascent,
                 height = height,
@@ -606,6 +600,7 @@ private fun SpanStyle.copyWithDefaultFontSize(drawStyle: DrawStyle? = null): Spa
     )
 }
 
+// TODO: Remove from public
 fun FontStyle.toSkFontStyle(): SkFontStyle {
     return when (this) {
         FontStyle.Italic -> org.jetbrains.skia.FontStyle.ITALIC
@@ -613,6 +608,7 @@ fun FontStyle.toSkFontStyle(): SkFontStyle {
     }
 }
 
+// TODO: Remove from public
 fun TextDecoration.toSkDecorationStyle(color: Color): SkDecorationStyle {
     val underline = contains(TextDecoration.Underline)
     val overline = false
@@ -631,6 +627,7 @@ fun TextDecoration.toSkDecorationStyle(color: Color): SkDecorationStyle {
     )
 }
 
+// TODO: Remove from public
 fun PlaceholderVerticalAlign.toSkPlaceholderAlignment(): PlaceholderAlignment {
     return when (this) {
         PlaceholderVerticalAlign.AboveBaseline -> PlaceholderAlignment.ABOVE_BASELINE


### PR DESCRIPTION
## Proposed Changes

- Set `ParagraphStyle.heightMode` based on `LineHeightStyle.Trim` value
- Align default behavior with Android
- Avoid using `StrutStyle` - it doesn't allow the line height trimming. Set `height` via `TextStyle` instead
- Cache and post-process `lineMetrics`
- Port tests from an Android source set

## Behaviour change

In case of larger `lineHeight`, both paddings are trimmed by default to match the Android behaviour.

## Testing

Test: run tests from `DesktopParagraphIntegrationLineHeightStyleTest`

```kt
Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
    for (lineHeightStyle in listOf(
        null,
        LineHeightStyle(LineHeightStyle.Alignment.Proportional, LineHeightStyle.Trim.Both),
        LineHeightStyle(LineHeightStyle.Alignment.Proportional, LineHeightStyle.Trim.FirstLineTop),
        LineHeightStyle(LineHeightStyle.Alignment.Proportional, LineHeightStyle.Trim.LastLineBottom),
        LineHeightStyle(LineHeightStyle.Alignment.Proportional, LineHeightStyle.Trim.None),
    )) {
        Text("Line 1\nLine 2",
            modifier = Modifier.background(Color.Gray),
            style = TextStyle(
                fontSize = 18.sp,
                lineHeight = 50.sp,
                lineHeightStyle = lineHeightStyle
            )
        )
    }
}
```

Before | After
--- | ---
<img width="285" alt="Screenshot 2023-11-08 at 13 38 08" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/2c7fbddc-dac9-408e-ad53-cedc361fe777"> | <img width="285" alt="Screenshot 2023-11-08 at 13 37 45" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/4fe4d7c9-a414-4338-885f-6701e6daecf1">



## Issues Fixed

Fixes (partially) https://github.com/JetBrains/compose-multiplatform/issues/2602
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3866