### PR TITLE
Add `ComposeScene.semanticsOwner`

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -139,6 +139,7 @@ public final class androidx/compose/ui/ComposeScene {
 	public final fun getDensity ()Landroidx/compose/ui/unit/Density;
 	public final fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
 	public final fun getRoots ()Ljava/util/Set;
+	public final fun getSemanticsOwner ()Landroidx/compose/ui/semantics/SemanticsOwner;
 	public final fun hasInvalidations ()Z
 	public final fun moveFocus-3ESFkO8 (I)Z
 	public final fun releaseFocus ()V

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.platform.*
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.util.fastAny
@@ -284,6 +286,14 @@ class ComposeScene internal constructor(
         get() = buildSet(owners.size) {
             addRootsForTestTo(this)
         }
+
+    /**
+     * Semantics owner that owns [SemanticsNode] objects and notifies listeners of changes to the
+     * semantics tree.
+     */
+    @ExperimentalComposeUiApi
+    val semanticsOwner: SemanticsOwner
+        get() = requireNotNull(mainOwner).semanticsOwner
 
     private val defaultPointerStateTracker = DefaultPointerStateTracker()
 


### PR DESCRIPTION
## Proposed Changes

```diff
+ComposeScene.semanticsOwner
```

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform-core/pull/893#discussion_r1388706236
