### PR TITLE
Font with lazy get data in skikoMain

### DIFF
--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -1345,6 +1345,7 @@ public final class androidx/compose/ui/text/platform/LoadedFont : androidx/compo
 	public static final field $stable I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()[B
+	public final fun getGetData ()Lkotlin/jvm/functions/Function0;
 	public fun getIdentity ()Ljava/lang/String;
 	public fun getLoadingStrategy-PKNRLFQ ()I
 	public fun getStyle-_-LCdwA ()I
@@ -1359,7 +1360,9 @@ public abstract class androidx/compose/ui/text/platform/PlatformFont : androidx/
 }
 
 public final class androidx/compose/ui/text/platform/PlatformFont_skikoKt {
+	public static final fun Font-wCLgNak (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/text/font/FontWeight;I)Landroidx/compose/ui/text/font/Font;
 	public static final fun Font-wCLgNak (Ljava/lang/String;[BLandroidx/compose/ui/text/font/FontWeight;I)Landroidx/compose/ui/text/font/Font;
+	public static synthetic fun Font-wCLgNak$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/text/font/FontWeight;IILjava/lang/Object;)Landroidx/compose/ui/text/font/Font;
 	public static synthetic fun Font-wCLgNak$default (Ljava/lang/String;[BLandroidx/compose/ui/text/font/FontWeight;IILjava/lang/Object;)Landroidx/compose/ui/text/font/Font;
 	public static final fun Typeface (Lorg/jetbrains/skia/Typeface;Ljava/lang/String;)Landroidx/compose/ui/text/font/Typeface;
 	public static synthetic fun Typeface$default (Lorg/jetbrains/skia/Typeface;Ljava/lang/String;ILjava/lang/Object;)Landroidx/compose/ui/text/font/Typeface;

--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -1345,7 +1345,6 @@ public final class androidx/compose/ui/text/platform/LoadedFont : androidx/compo
 	public static final field $stable I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()[B
-	public final fun getGetData ()Lkotlin/jvm/functions/Function0;
 	public fun getIdentity ()Ljava/lang/String;
 	public fun getLoadingStrategy-PKNRLFQ ()I
 	public fun getStyle-_-LCdwA ()I

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
@@ -163,7 +163,7 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
     return when (font) {
         is ResourceFont -> typefaceResource(font.name)
         is FileFont -> SkTypeface.makeFromFile(font.file.toString())
-        is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.data))
+        is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.getData()))
         is SystemFont -> SkTypeface.makeFromName(font.identity, font.skFontStyle)
     }
 }

--- a/compose/ui/ui-text/src/jsWasmMain/kotlin/androidx/compose/ui/text/platform/JsFont.js.kt
+++ b/compose/ui/ui-text/src/jsWasmMain/kotlin/androidx/compose/ui/text/platform/JsFont.js.kt
@@ -30,7 +30,7 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
         throw IllegalArgumentException("Unsupported font type: $font")
     }
     return when (font) {
-        is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.data))
+        is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.getData()))
         is SystemFont -> SkTypeface.makeFromName(font.identity, font.skFontStyle)
     }
 }

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeFont.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeFont.native.kt
@@ -26,7 +26,7 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
     }
     @Suppress("REDUNDANT_ELSE_IN_WHEN")
     return when (font) {
-        is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.data))
+        is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.getData()))
         // TODO: compilation fails without `else` see https://youtrack.jetbrains.com/issue/KT-43875
         else -> throw IllegalArgumentException("Unsupported font type: $font")
     }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -73,6 +73,7 @@ class LoadedFont internal constructor(
 ) : PlatformFont() {
     @ExperimentalTextApi
     override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking
+    val data: ByteArray by lazy { getData() }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -281,7 +281,6 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 // better alternative?
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-
         Platform.Windows ->
             mapOf(
                 // Segoe UI is the Windows system font, so try it first.
@@ -291,7 +290,6 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Consolas"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-
         Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS ->
             mapOf(
                 // .AppleSystem* aliases is the only legal way to get default SF and NY fonts.
@@ -301,7 +299,6 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 // Safari "font-family: cursive" real font names from macOS and iOS.
                 FontFamily.Cursive.name to listOf("Apple Chancery", "Snell Roundhand")
             )
-
         Platform.Android -> // https://m3.material.io/styles/typography/fonts
             mapOf(
                 FontFamily.SansSerif.name to listOf("Roboto", "Noto Sans"),
@@ -309,7 +306,6 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Roboto Mono", "Noto Sans Mono"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-
         Platform.Unknown ->
             mapOf(
                 FontFamily.SansSerif.name to listOf("Arial"),

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -73,7 +73,12 @@ class LoadedFont internal constructor(
 ) : PlatformFont() {
     @ExperimentalTextApi
     override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking
-    val data: ByteArray by lazy { getData() }
+
+    @Deprecated(
+        message = "Use getData() instead",
+        replaceWith = ReplaceWith(expression = "this.getData()")
+    )
+    val data: ByteArray get() = getData()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -134,7 +134,7 @@ private class SkiaBackedTypeface(
  * @see FontFamily
  */
 @Deprecated(
-    "Use Font with lazy getData argument instead",
+    message = "Use Font with lazy getData argument instead",
     replaceWith = ReplaceWith(
         "Font(identity, getData = { data }, weight, style)",
         "androidx.compose.ui.text.platform.Font"

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -98,7 +98,7 @@ class LoadedFont internal constructor(
  * Creates a Font using byte array with loaded font data.
  *
  * @param identity Unique identity for a font. Used internally to distinguish fonts.
- * @param getData this functions should return Byte array with loaded font data.
+ * @param getData should return Byte array with loaded font data.
  * @param weight The weight of the font. The system uses this to match a font to a font request
  * that is given in a [androidx.compose.ui.text.SpanStyle].
  * @param style The style of the font, normal or italic. The system uses this to match a font to a

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -74,7 +74,7 @@ class LoadedFont internal constructor(
     @ExperimentalTextApi
     override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking
 
-    val data: ByteArray by lazy { getData() }
+    val data: ByteArray get() = getData()
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -67,17 +67,13 @@ class SystemFont(
  */
 class LoadedFont internal constructor(
     override val identity: String,
-    val getData: () -> ByteArray,
+    internal val getData: () -> ByteArray,
     override val weight: FontWeight,
     override val style: FontStyle
 ) : PlatformFont() {
     @ExperimentalTextApi
     override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking
 
-    @Deprecated(
-        message = "Use getData() instead",
-        replaceWith = ReplaceWith(expression = "this.getData()")
-    )
     val data: ByteArray get() = getData()
 
     override fun equals(other: Any?): Boolean {
@@ -139,13 +135,6 @@ private class SkiaBackedTypeface(
  *
  * @see FontFamily
  */
-@Deprecated(
-    message = "Use Font with lazy getData argument instead",
-    replaceWith = ReplaceWith(
-        "Font(identity, getData = { data }, weight, style)",
-        "androidx.compose.ui.text.platform.Font"
-    )
-)
 fun Font(
     identity: String,
     data: ByteArray,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -74,7 +74,7 @@ class LoadedFont internal constructor(
     @ExperimentalTextApi
     override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking
 
-    val data: ByteArray get() = getData()
+    val data: ByteArray by lazy { getData() }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true


### PR DESCRIPTION
We just added new function Font with lazy getData lambda.
We don't need changes in Skiko library.

@MatkovIvan Where are no good primitives for stream of bytes in Kotlin stdlib (This one declared in ktor.io framework https://api.ktor.io/ktor-io/io.ktor.utils.io/-byte-read-channel/index.html).
Anyway - fonts is not big enought, so be can fully handle it in memory.