### PR TITLE
Move the call to scene.render in tests into the UI thread

### DIFF
--- a/compose/ui/ui-test-junit4/src/commonMain/kotlin/androidx/compose/ui/test/junit4/AbstractMainTestClock.kt
+++ b/compose/ui/ui-test-junit4/src/commonMain/kotlin/androidx/compose/ui/test/junit4/AbstractMainTestClock.kt
@@ -73,8 +73,8 @@ internal abstract class AbstractMainTestClock(
             // `currentTime + delayTimeMillis`. See `advanceTimeBy`.
             // Therefore we also call `runCurrent` as it's done in TestCoroutineDispatcher
             testScheduler.runCurrent()
-        }
 
-        onTimeAdvanced?.invoke(currentTime)
+            onTimeAdvanced?.invoke(currentTime)
+        }
     }
 }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
@@ -16,11 +16,17 @@
 
 package androidx.compose.ui.test
 
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.google.common.truth.Truth.assertThat
 import kotlin.coroutines.CoroutineContext
+import kotlin.test.fail
 import kotlinx.coroutines.CoroutineScope
 import org.junit.Ignore
 import org.junit.Rule
@@ -122,6 +128,32 @@ class ComposeUiTestTest {
 
             runOnIdle {
                 assertThat(lastRecordedMotionDurationScale).isEqualTo(0f)
+            }
+        }
+    }
+
+    @Test
+    fun rendererDropdownShouldWork() {
+        runComposeUiTest {
+            var runEffect by mutableStateOf(false)
+
+            setContent {
+                if (runEffect) {
+                    LaunchedEffect(Unit) {
+                        repeat(5) {
+                            withFrameMillis {}
+                        }
+                        runEffect = false
+                        withFrameMillis {
+                            fail("Effect should have stopped running")
+                        }
+                    }
+                }
+            }
+
+            repeat(2000) {
+                runEffect = true
+                waitForIdle()
             }
         }
     }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/ComposeUiTestTest.kt
@@ -133,7 +133,7 @@ class ComposeUiTestTest {
     }
 
     @Test
-    fun rendererDropdownShouldWork() {
+    fun effectShouldBeCancelledImmediately() {
         runComposeUiTest {
             var runEffect by mutableStateOf(false)
 


### PR DESCRIPTION
To avoid race conditions with GlobalSnapshotManager and effects dispatcher, move the call to scene.render in tests into the UI thread.

## Testing

Test: Added a unit test.

## Issues Fixed

Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-606
