### PR TITLE
Fix late snapshot state observer dispatch

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Expect.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/Expect.kt
@@ -46,3 +46,5 @@ internal expect fun InspectorInfo.tryPopulateReflectively(
 internal expect abstract class PlatformOptimizedCancellationException(
     message: String? = null
 ) : CancellationException
+
+internal expect fun getCurrentThreadId(): Long

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
@@ -45,9 +45,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusState
 import androidx.compose.ui.focus.focusProperties
@@ -68,6 +70,8 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.RootMeasurePolicy.measure
 import androidx.compose.ui.platform.renderingTest
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
@@ -77,6 +81,8 @@ import androidx.compose.ui.test.performKeyPress
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import java.awt.event.KeyEvent
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
@@ -170,6 +176,54 @@ class ComposeSceneTest {
         awaitNextRender()
         val after = surface.makeImageSnapshot().toComposeImageBitmap().toPixelMap().buffer
         assertThat(after).isNotEqualTo(before)
+    }
+
+    // Verify that when snapshot state changes in one of the render phases, the change is applied
+    // before the next phase, and is visible there.
+    // Note that it tests the same thing as `rendering of Text state change` is trying to, but at a
+    // lower-level, and without depending on the implementation of Text.
+    @Suppress("UNUSED_EXPRESSION")
+    @Test
+    fun stateChangesAppliedBetweenRenderPhases() = renderingTest(width = 400, height = 200) {
+        var value by mutableStateOf(0)
+        var compositionCount = 0
+        var layoutCount = 0
+        var drawCount = 0
+
+        var layoutScopeInvalidation by mutableStateOf(Unit, neverEqualPolicy())
+        var drawScopeInvalidation by mutableStateOf(Unit, neverEqualPolicy())
+
+        setContent {
+            value
+            compositionCount += 1
+            layoutScopeInvalidation = Unit
+            Layout(
+                modifier = remember {
+                    Modifier.graphicsLayer().drawBehind {
+                        drawScopeInvalidation
+                        drawCount += 1
+                    }
+                },
+                measurePolicy = remember {
+                    MeasurePolicy { measurables, constraints ->
+                        layoutScopeInvalidation
+                        drawScopeInvalidation = Unit
+                        layoutCount += 1
+                        measure(measurables, constraints)
+                    }
+                }
+            )
+        }
+
+        awaitNextRender()
+        assertEquals(compositionCount, layoutCount)
+        assertEquals(layoutCount, drawCount)
+
+        value = 1
+        awaitNextRender()
+        assertTrue(compositionCount >= 2)
+        assertTrue(layoutCount >= compositionCount, "Layout was performed less times than composition")
+        assertTrue(drawCount >= layoutCount, "Draw was performed less times than layout")
     }
 
     @Test(timeout = 5000)

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/Actuals.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/Actuals.js.kt
@@ -21,3 +21,5 @@ internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
         "Object.getPrototypeOf(a).constructor == Object.getPrototypeOf(b).constructor"
     )) as Boolean
 }
+
+internal actual fun getCurrentThreadId(): Long = 0

--- a/compose/ui/ui/src/jvmMain/kotlin/androidx/compose/ui/Actual.kt
+++ b/compose/ui/ui/src/jvmMain/kotlin/androidx/compose/ui/Actual.kt
@@ -60,3 +60,5 @@ internal actual abstract class PlatformOptimizedCancellationException actual con
     }
 
 }
+
+internal actual fun getCurrentThreadId(): Long = Thread.currentThread().id

--- a/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.nativeMain.kt
+++ b/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.nativeMain.kt
@@ -19,3 +19,11 @@ package androidx.compose.ui
 internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a::class == b::class
 }
+
+private val threadCounter = kotlin.native.concurrent.AtomicLong(0)
+
+@kotlin.native.concurrent.ThreadLocal
+private var threadId: Long = threadCounter.addAndGet(1)
+
+internal actual fun getCurrentThreadId(): Long = threadId
+

--- a/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.nativeMain.kt
+++ b/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.nativeMain.kt
@@ -16,11 +16,13 @@
 
 package androidx.compose.ui
 
+import kotlinx.atomicfu.atomic
+
 internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a::class == b::class
 }
 
-private val threadCounter = kotlin.native.concurrent.AtomicLong(0)
+private val threadCounter = atomic(0L)
 
 @kotlin.native.concurrent.ThreadLocal
 private var threadId: Long = threadCounter.addAndGet(1)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
@@ -40,7 +40,7 @@ internal class SnapshotInvalidationTracker(
      *
      * Note that it's not valid to have more than one thread calling it at the same time.
      */
-    private val renderingThreadId = atomic<Long?>(null)
+    private var renderingThreadId: Long? by atomic(null)
 
     val hasInvalidations: Boolean
         get() = needLayout || needDraw || snapshotChanges.hasCommands
@@ -69,7 +69,7 @@ internal class SnapshotInvalidationTracker(
      * @return the observer for monitoring snapshot changes
      */
     fun snapshotObserver() = OwnerSnapshotObserver { command ->
-        if (renderingThreadId.value == getCurrentThreadId())
+        if (renderingThreadId == getCurrentThreadId())
             command()
         else
             snapshotChanges.add(command)
@@ -90,10 +90,10 @@ internal class SnapshotInvalidationTracker(
      */
     inline fun <T> performSnapshotChangesSynchronously(block: () -> T): T {
         return try {
-            renderingThreadId.value = getCurrentThreadId()
+            renderingThreadId = getCurrentThreadId()
             block()
         } finally {
-            renderingThreadId.value = null
+            renderingThreadId = null
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
@@ -51,9 +51,6 @@ internal class SnapshotInvalidationTracker(
     }
 
     fun onLayout() {
-        // Apply changes from recomposition phase to layout phase
-        sendAndPerformSnapshotChanges()
-
         needLayout = false
     }
 
@@ -63,9 +60,6 @@ internal class SnapshotInvalidationTracker(
     }
 
     fun onDraw() {
-        // Apply changes from layout phase to draw phase
-        sendAndPerformSnapshotChanges()
-
         needDraw = false
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
@@ -36,7 +36,7 @@ internal class SnapshotInvalidationTracker(
     private var needDraw = true
 
     /**
-     * The id of the thread currently inside [rendering].
+     * The id of the thread currently inside [performSnapshotChangesSynchronously].
      *
      * Note that it's not valid to have more than one thread calling it at the same time.
      */
@@ -84,13 +84,12 @@ internal class SnapshotInvalidationTracker(
     }
 
     /**
-     * [ComposeScene.render] should wrap itself in this; makes sure that inside `render`, the calls
-     * to [OwnerSnapshotObserver] are performed synchronously.
+     * Runs [block], performing any snapshot changes it generates synchronously.
      *
      * See [OwnerSnapshotObserverTest.observeReadsChangedBeforeDisposeEffect] for more details.
      */
-    inline fun rendering(crossinline block: () -> Unit) {
-        try {
+    inline fun <T> performSnapshotChangesSynchronously(block: () -> T): T {
+        return try {
             renderingThreadId.value = getCurrentThreadId()
             block()
         } finally {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -146,12 +146,14 @@ internal abstract class BaseComposeScene(
     }
 
     override fun render(canvas: Canvas, nanoTime: Long) = postponeInvalidation {
-        recomposer.performScheduledTasks()
-        frameClock.sendFrame(nanoTime) // Recomposition
+        snapshotInvalidationTracker.rendering {
+            recomposer.performScheduledTasks()
+            frameClock.sendFrame(nanoTime) // Recomposition
 
-        doLayout()
-        snapshotInvalidationTracker.onDraw()
-        draw(canvas)
+            doLayout()
+            snapshotInvalidationTracker.onDraw()
+            draw(canvas)
+        }
     }
 
     override fun sendPointerEvent(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/OwnerSnapshotObserverTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/OwnerSnapshotObserverTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.node
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+
+/**
+ * Tests related to [OwnerSnapshotObserver].
+ */
+@OptIn(ExperimentalTestApi::class)
+class OwnerSnapshotObserverTest {
+
+    /**
+     * Verifies that [ObserverModifierNode.onObservedReadsChanged] is called before `onDispose` of
+     * a [DisposableEffect] when the read change and the disposal of the effect happen in the same
+     * recomposition.
+     *
+     * This behavior is relied upon by [LazyLayoutPinnableItem] and possibly others.
+     *
+     * [The issue where the bug was originally discovered](https://youtrack.jetbrains.com/issue/COMPOSE-595).
+     * Also see [Slack discussion](https://kotlinlang.slack.com/archives/G010KHY484C/p1700136697942499).
+     */
+    @Test
+    fun onObserveReadsChangedCalledBeforeOnDispose() = runComposeUiTest {
+        var value by mutableIntStateOf(0)
+        var observedReadsChanged = false
+        var onDisposeCalled: Boolean
+        setContent {
+            // Use a local state so that the "change" we expect to be notified about in
+            // observedReadsChanged happens during recomposition and not before.
+            val localValue by rememberUpdatedState(value)
+            Box(
+                Modifier.then(
+                    ObserverTestElement(
+                        readValues = { localValue },
+                        observedReadsChanged = { observedReadsChanged = true }
+                    )
+                )
+            )
+            DisposableEffect(localValue) {
+                onDispose {
+                    assertTrue(
+                        actual = observedReadsChanged,
+                        message = "onDispose called before onObservedReadsChanged"
+                    )
+                    onDisposeCalled = true
+                }
+            }
+        }
+
+        observedReadsChanged = false
+        onDisposeCalled = false
+        value = 1
+        waitForIdle()
+        assertTrue(observedReadsChanged, "onObservedReadsChanged not called")
+        assertTrue(onDisposeCalled, "onDispose not called")
+    }
+
+
+    private class ObserverTestElement(
+        private var readValues: () -> Int,
+        private val observedReadsChanged: () -> Unit
+    ) : ModifierNodeElement<ObserverTestNode>() {
+        override fun create(): ObserverTestNode =
+            ObserverTestNode(readValues, observedReadsChanged)
+
+        override fun update(node: ObserverTestNode) {
+            node.update(readValues, observedReadsChanged)
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is ObserverTestElement) return false
+
+            if (readValues != other.readValues) return false
+            if (observedReadsChanged != other.observedReadsChanged) return false
+            return true
+        }
+
+        override fun hashCode(): Int {
+            return readValues.hashCode()*31 + observedReadsChanged.hashCode()
+        }
+    }
+
+    private class ObserverTestNode(
+        var readValues: () -> Int,
+        var observedReadsChanged: () -> Unit
+    ) : Modifier.Node(), ObserverModifierNode {
+        override fun onAttach() {
+            observeReads {
+                readValues()
+            }
+        }
+
+        fun update(readValues: () -> Int, observedReadsChanged: () -> Unit) {
+            this.readValues = readValues
+            this.observedReadsChanged = observedReadsChanged
+
+            observeReads {
+                readValues()
+            }
+        }
+
+        override fun onObservedReadsChanged() {
+            observedReadsChanged()
+        }
+    }
+
+}

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/Actuals.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/Actuals.wasm.kt
@@ -26,3 +26,5 @@ private external fun areObjectsOfSameTypeJsImpl(a: JsAny, b: JsAny): Boolean
 internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a === b || a::class == b::class
 }
+
+internal actual fun getCurrentThreadId(): Long = 0


### PR DESCRIPTION
While investigating https://youtrack.jetbrains.com/issue/COMPOSE-595 it was discovered that Compose Multiplatform can reorder `OwnerSnapshotObserver` commands and `Composition.applyChanges`. This happens because `Composition.applyChanges` happens synchronously, but `OwnerSnapshotObserver` commands are put in a `CommandList` and are executed slightly later.

On Android, the executor that schedules `OwnerSnapshotObserver` commands runs them synchronously if the scheduler is called on the main thread (which is true when rendering).

After discussing the issue with @igordmn, it was decided to have the `OwnerSnapshotObserver` executor run the commands synchronously if the call happens inside `ComposeScene.render`.

## Proposed Changes
  - Add `SnapshotInvalidationTracker.rendering` which should be called to wrap `render` calls.
  - Store the id of the calling thread.
  - When scheduling `OwnerSnapshotObserver` calls, if the id of the current thread matches the id of the thread recorded in `rendering`, execute the command immediately.
  - Remove the explicit calls to `sendAndPerformSnapshotChanges()` between render phases, as they should be applied implicitly.

## Testing

Test: Added a unit test.

## Issues Fixed

Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-595

