### PR TITLE
Fix positioning of interop views.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -80,8 +80,7 @@ public fun <T : Component> SwingPanel(
     val focusSwitcher = remember { FocusSwitcher(componentInfo, focusManager) }
 
     Box(
-        modifier = modifier.onGloballyPositioned { childCoordinates ->
-            val coordinates = childCoordinates.parentCoordinates!!
+        modifier = modifier.onGloballyPositioned { coordinates ->
             val location = coordinates.localToWindow(Offset.Zero).round()
             val size = coordinates.size
             componentInfo.container.setBounds(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.awt
+
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.runApplicationTest
+import java.awt.Point
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwingPanelTest {
+    /**
+     * Test the positioning of a [SwingPanel] with offset.
+     * See https://github.com/JetBrains/compose-multiplatform/issues/4005
+     */
+    @Test
+    fun swingPanelWithOffset() = runApplicationTest {
+        lateinit var panel: JPanel
+        launchTestApplication {
+            Window(
+                onCloseRequest = {}
+            ) {
+                SwingPanel(
+                    modifier = Modifier.size(100.dp).offset(50.dp, 50.dp),
+                    factory = {
+                        JPanel().also {
+                            panel = it
+                        }
+                    }
+                )
+            }
+        }
+        awaitIdle()
+
+        val locationInRootPane =
+            SwingUtilities.convertPoint(panel, Point(0, 0), SwingUtilities.getRootPane(panel))
+        assertEquals(expected = Point(50, 50), locationInRootPane)
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -95,8 +95,7 @@ fun <T : UIView> UIKitView(
     val interopContext = LocalUIKitInteropContext.current
 
     Place(
-        modifier.onGloballyPositioned { childCoordinates ->
-            val coordinates = childCoordinates.parentCoordinates!!
+        modifier.onGloballyPositioned { coordinates ->
             localToWindowOffset = coordinates.localToWindow(Offset.Zero).round()
             val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
             if (rectInPixels != newRectInPixels) {
@@ -195,8 +194,7 @@ fun <T : UIViewController> UIKitViewController(
     val interopContext = LocalUIKitInteropContext.current
 
     Place(
-        modifier.onGloballyPositioned { childCoordinates ->
-            val coordinates = childCoordinates.parentCoordinates!!
+        modifier.onGloballyPositioned { coordinates ->
             localToWindowOffset = coordinates.localToWindow(Offset.Zero).round()
             val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
             if (rectInPixels != newRectInPixels) {


### PR DESCRIPTION
## Proposed Changes

`SwingPanel` and `UIKitView` used the "parent" coordinates, which ignores the last positioning modifier in the chain. Instead, just use the position of the current node.

## Testing

Test: Added a unit test

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4005 and also the same problem with `UIKitView`
