### PR TITLE
Use LayoutCoordinates.positionInWindow() instead of LayoutCoordinates.localToWindow(Offset.Zero)

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.round
@@ -81,7 +82,7 @@ public fun <T : Component> SwingPanel(
 
     Box(
         modifier = modifier.onGloballyPositioned { coordinates ->
-            val location = coordinates.localToWindow(Offset.Zero).round()
+            val location = coordinates.positionInWindow().round()
             val size = coordinates.size
             componentInfo.container.setBounds(
                 (location.x / density).toInt(),

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
@@ -96,7 +97,7 @@ fun <T : UIView> UIKitView(
 
     Place(
         modifier.onGloballyPositioned { coordinates ->
-            localToWindowOffset = coordinates.localToWindow(Offset.Zero).round()
+            localToWindowOffset = coordinates.positionInWindow().round()
             val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
             if (rectInPixels != newRectInPixels) {
                 val rect = newRectInPixels / density
@@ -195,7 +196,7 @@ fun <T : UIViewController> UIKitViewController(
 
     Place(
         modifier.onGloballyPositioned { coordinates ->
-            localToWindowOffset = coordinates.localToWindow(Offset.Zero).round()
+            localToWindowOffset = coordinates.positionInWindow().round()
             val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
             if (rectInPixels != newRectInPixels) {
                 val rect = newRectInPixels / density


### PR DESCRIPTION
Just a tiny improvement: use an existing `LayoutCoordinates.positionInWindow()` function instead of reimplementing it inline.

## Testing

Test: No testing
