### PR TITLE
Avoid unnecessary composition recreation in `Dialog`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.platform.InsetsConfig
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.ZeroInsetsConfig
+import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
@@ -176,7 +177,7 @@ private fun DialogLayout(
     layer.scrimColor = properties.scrimColor
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
-    layer.setContent {
+    rememberLayerContent(layer) {
         val measurePolicy = rememberDialogMeasurePolicy(
             properties = properties,
             platformInsets = platformInsets
@@ -190,6 +191,13 @@ private fun DialogLayout(
                 measurePolicy = measurePolicy
             )
         }
+    }
+}
+
+@Composable
+private fun rememberLayerContent(layer: ComposeSceneLayer, content: @Composable () -> Unit) {
+    remember(layer, content) {
+        layer.setContent(content)
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.ZeroInsetsConfig
+import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
@@ -433,8 +434,8 @@ private fun PopupLayout(
     )
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
-    layer.setContent {
-        val parentBounds = layoutParentBoundsInWindow ?: return@setContent
+    rememberLayerContent(layer) {
+        val parentBounds = layoutParentBoundsInWindow ?: return@rememberLayerContent
         val layoutDirection = LocalLayoutDirection.current
         val measurePolicy = rememberPopupMeasurePolicy(
             popupPositionProvider = popupPositionProvider,
@@ -452,6 +453,13 @@ private fun PopupLayout(
                 measurePolicy = measurePolicy
             )
         }
+    }
+}
+
+@Composable
+private fun rememberLayerContent(layer: ComposeSceneLayer, content: @Composable () -> Unit) {
+    remember(layer, content) {
+        layer.setContent(content)
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

- Fixes regression after #908
- Repeated call of `setContent` recreates recomposition that breaks the state.

## Testing

```kt
fun main() = singleWindowApplication {
    var text by remember { mutableStateOf("") }
    Dialog(
        onDismissRequest = {  },
    ) {
        Box(modifier = Modifier.background(Color.White).size(400.dp, 300.dp)) {
            OutlinedTextField(
                value = text,
                onValueChange = { text = it },
                modifier = Modifier.padding(32.dp)
            )
        }
    }
}
```

