### PR TITLE
Andrei.salavei/decrease maven local priority

### DIFF
--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -59,8 +59,8 @@ def addMavenRepositories(RepositoryHandler handler) {
     }
     def isJBFork = true
     if (isJBFork) {
-        handler.mavenLocal()
         handler.mavenCentral()
+        handler.mavenLocal()
         handler.google()
         handler.gradlePluginPortal()
         handler.maven {

--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -60,7 +60,6 @@ def addMavenRepositories(RepositoryHandler handler) {
     def isJBFork = true
     if (isJBFork) {
         handler.mavenCentral()
-        handler.mavenLocal()
         handler.google()
         handler.gradlePluginPortal()
         handler.maven {
@@ -76,6 +75,7 @@ def addMavenRepositories(RepositoryHandler handler) {
                 includeModule("com.android.tools", "r8")
             }
         }
+        handler.mavenLocal()
     }
     // Ordering appears to be important: b/229733266
     def androidPluginRepoOverride = System.getenv("GRADLE_PLUGIN_REPO")

--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -60,6 +60,8 @@ def addMavenRepositories(RepositoryHandler handler) {
     def isJBFork = true
     if (isJBFork) {
         handler.mavenCentral()
+        // Keep mavenLocal() repository below mavenCentral to avoid issues with stdlib imports
+        handler.mavenLocal()
         handler.google()
         handler.gradlePluginPortal()
         handler.maven {
@@ -75,7 +77,6 @@ def addMavenRepositories(RepositoryHandler handler) {
                 includeModule("com.android.tools", "r8")
             }
         }
-        handler.mavenLocal()
     }
     // Ordering appears to be important: b/229733266
     def androidPluginRepoOverride = System.getenv("GRADLE_PLUGIN_REPO")


### PR DESCRIPTION
Currently we're experiencing issues with CI builds accessing some stdlib symbols like [this](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Publish_2_Subtasks_1ComposePublishNativeOptional/4413074?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildProblemsSection=true&expandBuildDeploymentsSection=false). 

It's [recommended](https://kotlinlang.org/docs/gradle-configure-project.html#declare-repositories) to use `mavenLocal()` as a last repository.