### PR TITLE
Use binary search in SkiaParagraph.lineMetricsForOffset

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -188,15 +188,16 @@ internal class SkiaParagraph(
     private fun lineMetricsForOffset(offset: Int): LineMetrics? {
         checkOffsetIsValid(offset)
         val metrics = lineMetrics
-        for (line in metrics) {
-            if (offset < line.endIncludingNewline) {
-                return line
-            }
-        }
         if (metrics.isEmpty()) {
             return null
         }
-        return metrics.last()
+
+        val index = metrics.asList().binarySearch {
+            if (offset >= it.endIncludingNewline) -1 else 1
+        }
+
+        // The search will always return a negative value because the comparison never returns 0
+        return metrics[(-index - 1).coerceAtMost(metrics.lastIndex)]
     }
 
     override fun getLineHeight(lineIndex: Int) =


### PR DESCRIPTION
## Proposed Changes

Use binary search in SkiaParagraph.lineMetricsForOffset. Currently the search is linear.

## Testing

Test: Ran the user-provided reproducer. Also tested manually that caret is placed correctly when clicking in a multi-line textfield.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4021
