### PR TITLE
Fix crash on startup

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -35,6 +35,7 @@ import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.darwin.*
 import org.jetbrains.skia.Rect
 import platform.Foundation.NSLock
+import platform.Foundation.NSRunLoopCommonModes
 import platform.Foundation.NSTimeInterval
 import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationState
@@ -281,7 +282,7 @@ internal class MetalRedrawer(
         displayLinkConditions.isApplicationActive =
             UIApplication.sharedApplication.applicationState != UIApplicationState.UIApplicationStateBackground
 
-        caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoop.mainRunLoop.currentMode)
+        caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoopCommonModes)
     }
 
     fun dispose() {


### PR DESCRIPTION
## Proposed Changes

Explicitly supply `NSRunLoopCommonModes` as parameter when scheduling `CADisplayLink`.
`mainRunLoop.currentMode` appears to be nil when the crashing function is invoked after the refactoring.
`addToRunLoop` is explicitly marked to accept `nonnull NSRunLoopMode *`.

## Testing

Test: N/A

## Issues Fixed

Fixes: null pointer crash.