### PR TITLE
Ignore AWT mouse events during window resize

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -38,7 +38,6 @@ import java.awt.image.MultiResolutionImage
 import java.text.AttributedString
 import javax.swing.Icon
 import javax.swing.ImageIcon
-import kotlin.math.floor
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
 import org.jetbrains.skiko.MainUIDispatcher
@@ -115,11 +114,46 @@ fun Window.sendInputEvent(
     return event.isConsumed
 }
 
+fun Container.sendMousePress(
+    button: Int = MouseEvent.BUTTON1,
+    x: Int,
+    y: Int
+): Boolean {
+    val modifiers = when (button) {
+        MouseEvent.BUTTON1 -> MouseEvent.BUTTON1_DOWN_MASK
+        MouseEvent.BUTTON2 -> MouseEvent.BUTTON2_DOWN_MASK
+        MouseEvent.BUTTON3 -> MouseEvent.BUTTON3_DOWN_MASK
+        else -> 0
+    }
+    return sendMouseEvent(
+        id = MouseEvent.MOUSE_PRESSED,
+        x = x,
+        y = y,
+        modifiers = modifiers,
+        button = button
+    )
+}
+
+fun Container.sendMouseRelease(
+    button: Int = MouseEvent.BUTTON1,
+    x: Int,
+    y: Int,
+): Boolean {
+    return sendMouseEvent(
+        id = MouseEvent.MOUSE_RELEASED,
+        x = x,
+        y = y,
+        modifiers = 0,
+        button = button
+    )
+}
+
 fun Container.sendMouseEvent(
     id: Int,
     x: Int,
     y: Int,
-    modifiers: Int = 0
+    modifiers: Int = 0,
+    button: Int = MouseEvent.NOBUTTON,
 ): Boolean {
     // we use width and height instead of x and y because we can send (-1, -1), but still need
     // the component inside window
@@ -132,7 +166,8 @@ fun Container.sendMouseEvent(
         x,
         y,
         1,
-        false
+        false,
+        button
     )
     component.dispatchEvent(event)
     return event.isConsumed

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeDialogTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeDialogTest.kt
@@ -28,6 +28,8 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.sendMouseEvent
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
@@ -36,11 +38,9 @@ import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
-import java.awt.event.MouseEvent.BUTTON1_DOWN_MASK
+import java.awt.event.MouseEvent.BUTTON1
 import java.awt.event.MouseEvent.MOUSE_ENTERED
 import java.awt.event.MouseEvent.MOUSE_MOVED
-import java.awt.event.MouseEvent.MOUSE_PRESSED
-import java.awt.event.MouseEvent.MOUSE_RELEASED
 import java.awt.event.WindowEvent
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.ExperimentalSkikoApi
@@ -132,7 +132,7 @@ class ComposeDialogTest {
 
             window.isVisible = true
             awaitIdle()
-            window.sendMouseEvent(MOUSE_PRESSED, x = 100, y = 50)
+            window.sendMousePress(BUTTON1, x = 100, y = 50)
             awaitIdle()
             assertThat(caughtExceptions.size).isEqualTo(1)
             assertThat(caughtExceptions.last()).isInstanceOf(TestException::class.java)
@@ -236,9 +236,9 @@ class ComposeDialogTest {
             awaitIdle()
             window.sendMouseEvent(MOUSE_MOVED, 100, 50)
             awaitIdle()
-            window.sendMouseEvent(MOUSE_PRESSED, 100, 50, modifiers = BUTTON1_DOWN_MASK)
+            window.sendMousePress(BUTTON1, 100, 50)
             awaitIdle()
-            window.sendMouseEvent(MOUSE_RELEASED, 100, 50)
+            window.sendMouseRelease(BUTTON1, 100, 50)
             awaitIdle()
             assertThat(isClickHappened).isTrue()
         } finally {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.BaseComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.sendMouseEvent
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntSize
@@ -40,11 +42,9 @@ import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
-import java.awt.event.MouseEvent.BUTTON1_DOWN_MASK
+import java.awt.event.MouseEvent.BUTTON1
 import java.awt.event.MouseEvent.MOUSE_ENTERED
 import java.awt.event.MouseEvent.MOUSE_MOVED
-import java.awt.event.MouseEvent.MOUSE_PRESSED
-import java.awt.event.MouseEvent.MOUSE_RELEASED
 import java.awt.event.WindowEvent
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.ExperimentalSkikoApi
@@ -134,7 +134,7 @@ class ComposeWindowTest {
 
             window.isVisible = true
             awaitIdle()
-            window.sendMouseEvent(MOUSE_PRESSED, x = 100, y = 50)
+            window.sendMousePress(BUTTON1, x = 100, y = 50)
             awaitIdle()
             assertThat(caughtExceptions.size).isEqualTo(1)
             assertThat(caughtExceptions.last()).isInstanceOf(TestException::class.java)
@@ -256,9 +256,9 @@ class ComposeWindowTest {
             awaitIdle()
             window.sendMouseEvent(MOUSE_MOVED, 100, 50)
             awaitIdle()
-            window.sendMouseEvent(MOUSE_PRESSED, 100, 50, modifiers = BUTTON1_DOWN_MASK)
+            window.sendMousePress(BUTTON1, 100, 50)
             awaitIdle()
-            window.sendMouseEvent(MOUSE_RELEASED, 100, 50)
+            window.sendMouseRelease(BUTTON1, 100, 50)
             awaitIdle()
             assertThat(isClickHappened).isTrue()
         } finally {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -48,6 +48,7 @@ import java.awt.Dimension
 import java.awt.Toolkit
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
+import java.awt.event.MouseEvent.BUTTON1
 import java.awt.event.MouseEvent.BUTTON1_DOWN_MASK
 import java.awt.event.MouseEvent.BUTTON3_DOWN_MASK
 import java.awt.event.MouseEvent.CTRL_DOWN_MASK
@@ -329,7 +330,7 @@ class WindowInputEventTest {
         assertThat(events.last().pressed).isEqualTo(false)
         assertThat(events.last().position).isEqualTo(Offset(100 * density, 50 * density))
 
-        window.sendMouseEvent(MOUSE_PRESSED, 100, 50, modifiers = BUTTON1_DOWN_MASK)
+        window.sendMousePress(BUTTON1, 100, 50)
         awaitIdle()
         assertThat(events.size).isEqualTo(2)
         assertThat(events.last().pressed).isEqualTo(true)
@@ -341,7 +342,7 @@ class WindowInputEventTest {
         assertThat(events.last().pressed).isEqualTo(true)
         assertThat(events.last().position).isEqualTo(Offset(90 * density, 40 * density))
 
-        window.sendMouseEvent(MOUSE_RELEASED, 80, 30)
+        window.sendMouseRelease(BUTTON1, 80, 30)
         awaitIdle()
         // Synthetic move, because position of the Release isn't the same as in the previous event
         assertThat(events.size).isEqualTo(5)
@@ -399,9 +400,9 @@ class WindowInputEventTest {
         assertThat(onEnters).isEqualTo(1)
         assertThat(onExits).isEqualTo(0)
 
-        window.sendMouseEvent(MOUSE_PRESSED, x = 90, y = 50, modifiers = BUTTON1_DOWN_MASK)
+        window.sendMousePress(BUTTON1, x = 90, y = 50)
         window.sendMouseEvent(MOUSE_DRAGGED, x = 80, y = 50, modifiers = BUTTON1_DOWN_MASK)
-        window.sendMouseEvent(MOUSE_RELEASED, x = 80, y = 50)
+        window.sendMouseRelease(BUTTON1, x = 80, y = 50)
         awaitIdle()
         assertThat(onMoves.size).isEqualTo(2)
         assertThat(onMoves.last()).isEqualTo(Offset(80 * density, 50 * density))
@@ -557,11 +558,12 @@ class WindowInputEventTest {
         awaitIdle()
 
         window.sendMouseEvent(
-            MOUSE_PRESSED,
+            id = MOUSE_PRESSED,
             x = 100,
             y = 50,
             modifiers = SHIFT_DOWN_MASK or CTRL_DOWN_MASK or
-                BUTTON1_DOWN_MASK or BUTTON3_DOWN_MASK
+                BUTTON1_DOWN_MASK or BUTTON3_DOWN_MASK,
+            button = BUTTON1
         )
 
         awaitIdle()
@@ -681,8 +683,8 @@ class WindowInputEventTest {
         }
         awaitIdle()
 
-        window.sendMouseEvent(id = MOUSE_PRESSED, x = 1, y = 1, modifiers = BUTTON1_DOWN_MASK)
-        window.sendMouseEvent(id = MOUSE_RELEASED, x = 21, y = 1)
+        window.sendMousePress(BUTTON1, x = 1, y = 1)
+        window.sendMouseRelease(BUTTON1, x = 21, y = 1)
 
         assertThat(box1ReleaseCount).isEqualTo(1)
         assertThat(box2ReleaseCount).isEqualTo(0)


### PR DESCRIPTION
While resizing the window by dragging it by its edge, AWT (at least on macOS) sends mouse enter/exit events that report the primary button as pressed. This causes `PointerInputScope.detectTapAndPress` to falsely detect a tap.

## Proposed Changes

Ignore mouse events that signal a change in the pressed state of the primary mouse button, but aren't mouse press/release events.

## Testing

Test: tested manually that resizing the window no longer triggers `PointerInputScope.detectTapAndPress`.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/2850
