### PR TITLE
Fix focus in Cupertino textfield

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -522,7 +522,7 @@ internal fun CoreTextField(
         onClick {
             // according to the documentation, we still need to provide proper semantics actions
             // even if the state is 'disabled'
-            tapTextFieldToFocus(state, focusRequester, !readOnly)
+            requestFocusAndShowKeyboardIfNeeded(state, focusRequester, !readOnly)
             true
         }
         onLongClick {
@@ -947,7 +947,7 @@ internal class TextFieldState(
 /**
  * Request focus on tap. If already focused, makes sure the keyboard is requested.
  */
-internal fun tapTextFieldToFocus(
+internal fun requestFocusAndShowKeyboardIfNeeded(
     state: TextFieldState,
     focusRequester: FocusRequester,
     allowKeyboard: Boolean

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldPointerModifier.common.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldPointerModifier.common.kt
@@ -50,7 +50,7 @@ internal fun Modifier.defaultTextFieldPointer(
         Modifier.longPressDragGestureFilter(manager.touchSelectionObserver, enabled)
     this
         .tapPressTextFieldModifier(interactionSource, enabled) { offset ->
-            tapTextFieldToFocus(state, focusRequester, !readOnly)
+            requestFocusAndShowKeyboardIfNeeded(state, focusRequester, !readOnly)
             if (state.hasFocus) {
                 if (state.handleState != HandleState.Selection) {
                     state.layoutResult?.let { layoutResult ->

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -99,7 +99,7 @@ private fun getTapHandlerModifier(
             onTap = { touchPointOffset ->
                 if (currentState.hasFocus) {
                     // To show keyboard if it was hidden. Even in selection mode (like native)
-                    tapTextFieldToFocus(
+                    requestFocusAndShowKeyboardIfNeeded(
                         currentState,
                         currentFocusRequester,
                         !currentReadOnly
@@ -119,7 +119,7 @@ private fun getTapHandlerModifier(
                         currentManager.deselect(touchPointOffset)
                     }
                 } else {
-                    tapTextFieldToFocus(
+                    requestFocusAndShowKeyboardIfNeeded(
                         currentState,
                         currentFocusRequester,
                         !currentReadOnly

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -98,6 +98,12 @@ private fun getTapHandlerModifier(
         detectRepeatingTapGestures(
             onTap = { touchPointOffset ->
                 if (currentState.hasFocus) {
+                    // To show keyboard if it was hidden. Even in selection mode (like native)
+                    tapTextFieldToFocus(
+                        currentState,
+                        currentFocusRequester,
+                        !currentReadOnly
+                    )
                     if (currentState.handleState != HandleState.Selection) {
                         currentState.layoutResult?.let { layoutResult ->
                             TextFieldDelegate.cupertinoSetCursorOffsetFocused(


### PR DESCRIPTION
## Proposed Changes

added explicit showing keyboard method in focused textfield (like it is in android)

## Testing

Test: open app, go to Application layouts, toggle "Insets" switch, then try to click on 'show keyboard' textfield and 'hide keyboard' button repetitively.

## Issues Fixed

https://youtrack.jetbrains.com/issue/COMPOSE-667/fix-Regression-with-TextField-and-Keyboard

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
