### PR TITLE
Fix `LayoutCoordinates.localToWindow` coordinates conversion for non-full Compose components

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toIntRect
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
@@ -179,7 +180,7 @@ class SkikoComposeUiTest(
         composeSceneContext = TestComposeSceneContext(),
         invalidate = { }
     ).also {
-        it.size = size
+        it.boundsInWindow = size.toIntRect()
     }
 
     private fun shouldPumpTime(): Boolean {

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3299,11 +3299,11 @@ public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public abstract fun calculateContentSize-YbymL2g ()J
 	public abstract fun close ()V
 	public abstract fun createLayer (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;ZLandroidx/compose/runtime/CompositionContext;)Landroidx/compose/ui/scene/ComposeSceneLayer;
+	public abstract fun getBoundsInWindow ()Landroidx/compose/ui/unit/IntRect;
 	public abstract fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
 	public abstract fun getFocusManager ()Landroidx/compose/ui/scene/ComposeSceneFocusManager;
 	public abstract fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
-	public abstract fun getSize-bOM6tXw ()Landroidx/compose/ui/unit/IntSize;
 	public abstract fun hasInvalidations ()Z
 	public abstract fun hitTestInteropView-k-4lQ0M (J)Z
 	public abstract fun render (Landroidx/compose/ui/graphics/Canvas;J)V
@@ -3312,11 +3312,11 @@ public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public static synthetic fun sendPointerEvent-BGSDPeU$default (Landroidx/compose/ui/scene/ComposeScene;IJJJILandroidx/compose/ui/input/pointer/PointerButtons;Landroidx/compose/ui/input/pointer/PointerKeyboardModifiers;Ljava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;ILjava/lang/Object;)V
 	public abstract fun sendPointerEvent-WlEVilQ (ILjava/util/List;IIJJLjava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;)V
 	public static synthetic fun sendPointerEvent-WlEVilQ$default (Landroidx/compose/ui/scene/ComposeScene;ILjava/util/List;IIJJLjava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;ILjava/lang/Object;)V
+	public abstract fun setBoundsInWindow (Landroidx/compose/ui/unit/IntRect;)V
 	public abstract fun setCompositionLocalContext (Landroidx/compose/runtime/CompositionLocalContext;)V
 	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun setDensity (Landroidx/compose/ui/unit/Density;)V
 	public abstract fun setLayoutDirection (Landroidx/compose/ui/unit/LayoutDirection;)V
-	public abstract fun setSize-fhxjrPA (Landroidx/compose/ui/unit/IntSize;)V
 }
 
 public abstract interface class androidx/compose/ui/scene/ComposeSceneContext {
@@ -3336,13 +3336,14 @@ public abstract interface class androidx/compose/ui/scene/ComposeSceneFocusManag
 }
 
 public abstract interface class androidx/compose/ui/scene/ComposeSceneLayer {
+	public abstract fun calculateLocalPosition-qkQi6aY (J)J
 	public abstract fun close ()V
-	public abstract fun getBounds ()Landroidx/compose/ui/unit/IntRect;
+	public abstract fun getBoundsInWindow ()Landroidx/compose/ui/unit/IntRect;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
 	public abstract fun getFocusable ()Z
 	public abstract fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
 	public abstract fun getScrimColor-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
-	public abstract fun setBounds (Landroidx/compose/ui/unit/IntRect;)V
+	public abstract fun setBoundsInWindow (Landroidx/compose/ui/unit/IntRect;)V
 	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun setDensity (Landroidx/compose/ui/unit/Density;)V
 	public abstract fun setFocusable (Z)V
@@ -3370,13 +3371,13 @@ public final class androidx/compose/ui/scene/ComposeScenePointer {
 }
 
 public final class androidx/compose/ui/scene/MultiLayerComposeScene_skikoKt {
-	public static final fun MultiLayerComposeScene-3tKcejY (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
-	public static synthetic fun MultiLayerComposeScene-3tKcejY$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
+	public static final fun MultiLayerComposeScene (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntRect;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
+	public static synthetic fun MultiLayerComposeScene$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntRect;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
 }
 
 public final class androidx/compose/ui/scene/SingleLayerComposeScene_skikoKt {
-	public static final fun SingleLayerComposeScene-3tKcejY (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
-	public static synthetic fun SingleLayerComposeScene-3tKcejY$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
+	public static final fun SingleLayerComposeScene (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntRect;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
+	public static synthetic fun SingleLayerComposeScene$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntRect;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
 }
 
 public final class androidx/compose/ui/semantics/AccessibilityAction {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toIntRect
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
 import java.awt.*
@@ -383,16 +384,21 @@ internal class ComposeBridge(
     }
 
     fun updateSceneSize() {
+        // Convert AWT scaled size to real pixels.
         val scale = contentComponent.density.density
-        val size = IntSize(
+        val sizeInPx = IntSize(
             width = (contentComponent.width * scale).toInt(),
             height = (contentComponent.height * scale).toInt()
         )
-        windowContext.setContainerSize(size)
+        windowContext.setContainerSize(sizeInPx)
 
         // Zero size will literally limit scene's content size to zero,
         // so it case of late initialization skip this to avoid extra layout run.
-        scene.size = size.takeIf { size != IntSize.Zero }
+        scene.boundsInWindow = if (sizeInPx != IntSize.Zero) {
+            sizeInPx.toIntRect()
+        } else {
+            null
+        }
     }
 
     fun resetSceneDensity() {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.WindowExceptionHandler
@@ -383,12 +384,6 @@ internal class ComposeBridge(
     }
 
     fun updateSceneSize() {
-        // Zero size will literally limit scene's content size to zero,
-        // so it case of late initialization skip this to avoid extra layout run.
-        if (contentComponent.width == 0 && contentComponent.height == 0) {
-            return
-        }
-
         // Convert AWT scaled size to real pixels.
         val scale = contentComponent.density.density
 
@@ -403,7 +398,9 @@ internal class ComposeBridge(
         // TODO: It should be window content area size
         windowContext.setContainerSize(boundsInWindow.size)
 
-        scene.boundsInWindow = boundsInWindow
+        // Zero size will literally limit scene's content size to zero,
+        // so it case of late initialization skip this to avoid extra layout run.
+        scene.boundsInWindow = boundsInWindow.takeIf { boundsInWindow.size != IntSize.Zero }
     }
 
     fun resetSceneDensity() {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeBridge.desktop.kt
@@ -32,10 +32,9 @@ import androidx.compose.ui.scene.toPointerKeyboardModifiers
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toIntRect
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
 import java.awt.*
@@ -384,21 +383,27 @@ internal class ComposeBridge(
     }
 
     fun updateSceneSize() {
-        // Convert AWT scaled size to real pixels.
-        val scale = contentComponent.density.density
-        val sizeInPx = IntSize(
-            width = (contentComponent.width * scale).toInt(),
-            height = (contentComponent.height * scale).toInt()
-        )
-        windowContext.setContainerSize(sizeInPx)
-
         // Zero size will literally limit scene's content size to zero,
         // so it case of late initialization skip this to avoid extra layout run.
-        scene.boundsInWindow = if (sizeInPx != IntSize.Zero) {
-            sizeInPx.toIntRect()
-        } else {
-            null
+        if (contentComponent.width == 0 && contentComponent.height == 0) {
+            return
         }
+
+        // Convert AWT scaled size to real pixels.
+        val scale = contentComponent.density.density
+
+        // TODO: Recalculate it to window related coordinates
+        val boundsInWindow = IntRect(
+            top = 0,
+            left = 0,
+            right = (contentComponent.width * scale).toInt(),
+            bottom = (contentComponent.height * scale).toInt()
+        )
+
+        // TODO: It should be window content area size
+        windowContext.setContainerSize(boundsInWindow.size)
+
+        scene.boundsInWindow = boundsInWindow
     }
 
     fun resetSceneDensity() {

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.scene.MultiLayerComposeScene
 import androidx.compose.ui.scene.ComposeSceneContext
 import androidx.compose.ui.scene.ComposeScenePointer
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.IntRect
 import kotlinx.coroutines.Dispatchers
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SkiaLayer
@@ -139,7 +139,7 @@ internal class ComposeLayer(
     }
 
     fun setSize(width: Int, height: Int) {
-        scene.size = IntSize(width, height)
+        scene.boundsInWindow = IntRect(0, 0, width, height)
 
         layer.needRedraw()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -193,8 +193,8 @@ class ComposeScene internal constructor(
      * Constraints used to measure and layout content.
      */
     var constraints: Constraints
-        get() = replacement.size?.toConstraints() ?: Constraints()
-        set(value) { replacement.size = value.toSize() }
+        get() = replacement.boundsInWindow?.size?.toConstraints() ?: Constraints()
+        set(value) { replacement.boundsInWindow = value.toSize()?.toIntRect() }
 
     /**
      * Returns the current content size

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -33,9 +33,11 @@ import androidx.compose.ui.scene.MultiLayerComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toIntRect
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.DurationUnit.NANOSECONDS
@@ -137,7 +139,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
         layoutDirection = layoutDirection,
         coroutineContext = coroutineContext,
     ).also {
-        it.size = IntSize(width, height)
+        it.boundsInWindow = IntRect(0, 0, width, height)
         it.setContent(content = content)
     }
 
@@ -170,8 +172,8 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      * Constraints used to measure and layout content.
      */
     var constraints: Constraints
-        get() = scene.size?.toConstraints() ?: Constraints()
-        set(value) { scene.size = value.toSize() }
+        get() = scene.boundsInWindow?.size?.toConstraints() ?: Constraints()
+        set(value) { scene.boundsInWindow = value.toSize()?.toIntRect() }
 
     /**
      * Returns true if there are pending recompositions, renders or dispatched tasks.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.round
+import androidx.compose.ui.unit.toOffset
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -114,6 +115,10 @@ internal class RootNodeOwner(
         }
     val owner: Owner = OwnerImpl(layoutDirection, coroutineContext)
     val semanticsOwner = SemanticsOwner(owner.root)
+
+    /**
+     * Bounds of [Owner] in window coordinates.
+     */
     var bounds by mutableStateOf(bounds)
     var density: Density by mutableStateOf(density)
 
@@ -357,9 +362,15 @@ internal class RootNodeOwner(
             }
         }
 
-        override fun calculatePositionInWindow(localPosition: Offset): Offset = localPosition
+        override fun calculatePositionInWindow(localPosition: Offset): Offset {
+            val offset = bounds?.topLeft?.toOffset() ?: Offset.Zero
+            return localPosition + offset
+        }
 
-        override fun calculateLocalPosition(positionInWindow: Offset): Offset = positionInWindow
+        override fun calculateLocalPosition(positionInWindow: Offset): Offset {
+            val offset = bounds?.topLeft?.toOffset() ?: Offset.Zero
+            return positionInWindow - offset
+        }
 
         private val endApplyChangesListeners = mutableVectorOf<(() -> Unit)?>()
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Dialog
@@ -85,12 +86,15 @@ interface ComposeScene {
     var layoutDirection: LayoutDirection
 
     /**
-     * Represents the scene size in scaled pixels ([Dp]).
-     * This is used to impose constraints on the content. If the size is undefined, it can be
+     * Represents the scene bounds relatively to window in pixels.
+     *
+     * The position is used to convert local coordinates to window ones.
+     *
+     * The size is used to impose constraints on the content. If the size is undefined, it can be
      * set to `null`. In such a case, the content will be laid out without any restrictions and
      * the window size will be utilized to bounds verification.
      */
-    var size: IntSize?
+    var boundsInWindow: IntRect?
 
     /**
      * Top-level composition locals, which will be provided for the Composable content, which is set by [setContent].

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.Dialog
@@ -62,7 +63,7 @@ interface ComposeSceneLayer {
      * The implementation should be ready to react on the changes in size/position that can
      * happen during recompositions.
      */
-    var bounds: IntRect
+    var boundsInWindow: IntRect
 
     /**
      * The color of the background fill. It can be set to null if no background drawing is necessary.
@@ -123,18 +124,24 @@ interface ComposeSceneLayer {
 
     /**
      * Establishes a callback function that is triggered when a pointer event occurs outside
-     * of [bounds]. It's important to note that any gestures initiated within the [bounds] should
-     * be entirely handled by this layer, without activating this event.
+     * of [boundsInWindow]. It's important to note that any gestures initiated within
+     * the [boundsInWindow] should be entirely handled by this layer, without activating this event.
      *
      * @param onOutsidePointerEvent The callback function that is invoked when a pointer event
      * occurs outside. It accepts a boolean parameter to denote if the event is intended to close
      * this layer. When the parameter is true, it typically signifies that it's the primary (left)
      * mouse button or single pointer that executed a full click (press and release) outside
-     * of [bounds], and false in all other cases.
+     * of [boundsInWindow], and false in all other cases.
      */
     fun setOutsidePointerEventListener(
         onOutsidePointerEvent: ((dismissRequest: Boolean) -> Unit)? = null,
     )
+
+    /**
+     * Returns the position relative to the [ComposeScene] of the [positionInWindow],
+     * the position relative to the window.
+     */
+    fun calculateLocalPosition(positionInWindow: IntOffset): IntOffset
 }
 
 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -51,7 +51,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.toIntRect
+import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
@@ -69,8 +69,8 @@ import kotlinx.coroutines.Dispatchers
  *
  * @param density Initial density of the content which will be used to convert [Dp] units.
  * @param layoutDirection Initial layout direction of the content.
- * @param size The size of the ComposeScene. Default value is `null`, which means the size will be
- * determined by the contents.
+ * @param bounds The bounds of the ComposeScene. Default value is `null`, which means the size will
+ * be determined by the content.
  * @param coroutineContext Context which will be used to launch effects ([LaunchedEffect],
  * [rememberCoroutineScope]) and run recompositions.
  * @param composeSceneContext The context to share resources between multiple scenes and provide
@@ -87,14 +87,14 @@ import kotlinx.coroutines.Dispatchers
 fun MultiLayerComposeScene(
     density: Density = Density(1f),
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
-    size: IntSize? = null,
+    bounds: IntRect? = null,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
     invalidate: () -> Unit = {},
 ): ComposeScene = MultiLayerComposeSceneImpl(
     density = density,
     layoutDirection = layoutDirection,
-    size = size,
+    bounds = bounds,
     coroutineContext = coroutineContext,
     composeSceneContext = composeSceneContext,
     invalidate = invalidate
@@ -103,7 +103,7 @@ fun MultiLayerComposeScene(
 private class MultiLayerComposeSceneImpl(
     density: Density,
     layoutDirection: LayoutDirection,
-    size: IntSize?,
+    bounds: IntRect?,
     coroutineContext: CoroutineContext,
     composeSceneContext: ComposeSceneContext,
     invalidate: () -> Unit = {},
@@ -115,7 +115,7 @@ private class MultiLayerComposeSceneImpl(
     private val mainOwner = RootNodeOwner(
         density = density,
         layoutDirection = layoutDirection,
-        bounds = size?.toIntRect(),
+        bounds = bounds,
         coroutineContext = compositionContext.effectCoroutineContext,
         platformContext = composeSceneContext.platformContext,
         snapshotInvalidationTracker = snapshotInvalidationTracker,
@@ -136,12 +136,12 @@ private class MultiLayerComposeSceneImpl(
             mainOwner.layoutDirection = value
         }
 
-    override var size: IntSize? = size
+    override var boundsInWindow: IntRect? = bounds
         set(value) {
             check(!isClosed) { "ComposeScene is closed" }
             field = value
-            mainOwner.bounds = value?.toIntRect()
-            forEachLayer { it.size = value }
+            mainOwner.bounds = value
+            forEachLayer { it.owner.bounds = value }
         }
 
     private val _focusManager = ComposeSceneFocusManagerImpl()
@@ -289,6 +289,8 @@ private class MultiLayerComposeSceneImpl(
 
             // If the position of in bounds of the owner - send event to it and stop processing
             if (layer.isInBounds(position)) {
+                // Layer don't have any offset from [mainOwner], so we don't need to
+                // convert event coordinates here.
                 layer.owner.onPointerInput(event)
                 gestureOwner = layer.owner
                 return
@@ -386,7 +388,7 @@ private class MultiLayerComposeSceneImpl(
     ): ComposeSceneLayer = AttachedComposeSceneLayer(
         density = density,
         layoutDirection = layoutDirection,
-        size = size,
+        bounds = boundsInWindow,
         focusable = focusable,
         compositionContext = compositionContext,
     )
@@ -472,7 +474,7 @@ private class MultiLayerComposeSceneImpl(
     private inner class AttachedComposeSceneLayer(
         density: Density,
         layoutDirection: LayoutDirection,
-        size: IntSize?,
+        bounds: IntRect?,
         focusable: Boolean,
         private val compositionContext: CompositionContext,
     ) : ComposeSceneLayer {
@@ -480,7 +482,7 @@ private class MultiLayerComposeSceneImpl(
             density = density,
             layoutDirection = layoutDirection,
             coroutineContext = compositionContext.effectCoroutineContext,
-            bounds = size?.toIntRect(),
+            bounds = bounds,
             platformContext = object : PlatformContext by composeSceneContext.platformContext {
 
                 /**
@@ -499,15 +501,9 @@ private class MultiLayerComposeSceneImpl(
         private var callback: ((Boolean) -> Unit)? = null
         private var isClosed = false
 
-        var size: IntSize? = size
-            set(value) {
-                field = value
-                owner.bounds = value?.toIntRect()
-            }
-
         override var density: Density by owner::density
         override var layoutDirection: LayoutDirection by owner::layoutDirection
-        override var bounds: IntRect by mutableStateOf(owner.bounds ?: IntRect.Zero)
+        override var boundsInWindow: IntRect by mutableStateOf(owner.bounds ?: IntRect.Zero)
         override var scrimColor: Color? by mutableStateOf(null)
         override var focusable: Boolean = focusable
             set(value) {
@@ -582,9 +578,15 @@ private class MultiLayerComposeSceneImpl(
             }
         }
 
-        fun isInBounds(point: Offset): Boolean {
-            val intOffset = IntOffset(point.x.toInt(), point.y.toInt())
-            return bounds.contains(intOffset)
+        override fun calculateLocalPosition(positionInWindow: IntOffset): IntOffset {
+            val offset = owner.bounds?.topLeft ?: IntOffset.Zero
+            return positionInWindow - offset
+        }
+
+        fun isInBounds(position: Offset): Boolean {
+            val offset = owner.bounds?.topLeft ?: IntOffset.Zero
+            val positionInWindow = IntOffset(position.x.toInt(), position.y.toInt()) + offset
+            return boundsInWindow.contains(positionInWindow)
         }
 
         fun onOutsidePointerEvent(event: PointerInputEvent) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -289,7 +289,7 @@ private class MultiLayerComposeSceneImpl(
 
             // If the position of in bounds of the owner - send event to it and stop processing
             if (layer.isInBounds(position)) {
-                // Layer don't have any offset from [mainOwner], so we don't need to
+                // The layer doesn't have any offset from [mainOwner], so we don't need to
                 // convert event coordinates here.
                 layer.owner.onPointerInput(event)
                 gestureOwner = layer.owner

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toIntRect
@@ -65,14 +66,14 @@ import kotlinx.coroutines.Dispatchers
 fun SingleLayerComposeScene(
     density: Density = Density(1f),
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
-    size: IntSize? = null,
+    bounds: IntRect? = null,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
     invalidate: () -> Unit = {},
 ): ComposeScene = SingleLayerComposeSceneImpl(
     density = density,
     layoutDirection = layoutDirection,
-    size = size,
+    bounds = bounds,
     coroutineContext = coroutineContext,
     composeSceneContext = composeSceneContext,
     invalidate = invalidate
@@ -81,7 +82,7 @@ fun SingleLayerComposeScene(
 private class SingleLayerComposeSceneImpl(
     density: Density,
     layoutDirection: LayoutDirection,
-    size: IntSize?,
+    bounds: IntRect?,
     coroutineContext: CoroutineContext,
     composeSceneContext: ComposeSceneContext,
     invalidate: () -> Unit = {},
@@ -95,7 +96,7 @@ private class SingleLayerComposeSceneImpl(
             density = density,
             layoutDirection = layoutDirection,
             coroutineContext = compositionContext.effectCoroutineContext,
-            bounds = size?.toIntRect(),
+            bounds = bounds,
             platformContext = composeSceneContext.platformContext,
             snapshotInvalidationTracker = snapshotInvalidationTracker,
             inputHandler = inputHandler,
@@ -116,11 +117,11 @@ private class SingleLayerComposeSceneImpl(
             mainOwner.layoutDirection = value
         }
 
-    override var size: IntSize? = size
+    override var boundsInWindow: IntRect? = bounds
         set(value) {
             check(!isClosed) { "ComposeScene is closed" }
             field = value
-            mainOwner.bounds = value?.toIntRect()
+            mainOwner.bounds = value
         }
 
     override val focusManager: ComposeSceneFocusManager =

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -179,11 +179,10 @@ private fun DialogLayout(
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     rememberLayerContent(layer) {
         val measurePolicy = rememberDialogMeasurePolicy(
+            layer = layer,
             properties = properties,
             platformInsets = platformInsets
-        ) {
-            layer.bounds = it
-        }
+        )
         properties.insetsConfig.excludeSafeInsets {
             Layout(
                 content = content,
@@ -206,19 +205,19 @@ private val DialogProperties.insetsConfig: InsetsConfig
 
 @Composable
 private fun rememberDialogMeasurePolicy(
+    layer: ComposeSceneLayer,
     properties: DialogProperties,
-    platformInsets: PlatformInsets,
-    onBoundsChanged: (IntRect) -> Unit
-) = remember(properties, platformInsets, onBoundsChanged) {
+    platformInsets: PlatformInsets
+) = remember(layer, properties, platformInsets) {
     RootMeasurePolicy(
         platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { windowSize, contentSize ->
-        val position = positionWithInsets(platformInsets, windowSize) {
-            it.center - contentSize.center
+        val positionWithInsets = positionWithInsets(platformInsets, windowSize) { sizeWithoutInsets ->
+            sizeWithoutInsets.center - contentSize.center
         }
-        onBoundsChanged(IntRect(position, contentSize))
-        position
+        layer.boundsInWindow = IntRect(positionWithInsets, contentSize)
+        layer.calculateLocalPosition(positionWithInsets)
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
@@ -73,15 +73,15 @@ private fun Density.applyPlatformConstrains(
 internal fun MeasureScope.positionWithInsets(
     insets: PlatformInsets,
     size: IntSize,
-    calculatePosition: (size: IntSize) -> IntOffset,
+    calculatePosition: (sizeWithoutInsets: IntSize) -> IntOffset,
 ): IntOffset {
     val horizontal = insets.left.roundToPx() + insets.right.roundToPx()
     val vertical = insets.top.roundToPx() + insets.bottom.roundToPx()
-    val sizeWithPadding = IntSize(
+    val sizeWithoutInsets = IntSize(
         width = size.width - horizontal,
         height = size.height - vertical
     )
-    val position = calculatePosition(sizeWithPadding)
+    val position = calculatePosition(sizeWithoutInsets)
     val offset = IntOffset(
         x = insets.left.roundToPx(),
         y = insets.top.roundToPx()

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -99,7 +99,7 @@ class PointerIconTest {
         )
 
         try {
-            scene.size = IntSize(surface.width, surface.height)
+            scene.boundsInWindow = IntRect(0, 0, surface.width, surface.height)
             scene.setContent {
                 Box(
                     modifier = Modifier
@@ -129,7 +129,7 @@ class PointerIconTest {
         )
 
         try {
-            scene.size = IntSize(surface.width, surface.height)
+            scene.boundsInWindow = IntRect(0, 0, surface.width, surface.height)
             scene.setContent {
                 Box(
                     modifier = Modifier
@@ -234,7 +234,7 @@ class PointerIconTest {
         val recomposeChannel = Channel<Int>(Channel.CONFLATED) // helps with waiting for recomposition
         var count = 0
         try {
-            scene.size = IntSize(surface.width, surface.height)
+            scene.boundsInWindow = IntRect(0, 0, surface.width, surface.height)
             scene.setContent {
                 Box(
                     modifier = Modifier.pointerHoverIcon(iconState.value).size(30.dp, 30.dp)
@@ -278,7 +278,7 @@ class PointerIconTest {
         val recomposeChannel = Channel<Int>(Channel.CONFLATED) // helps with waiting for recomposition
         var count = 0
         try {
-            scene.size = IntSize(surface.width, surface.height)
+            scene.boundsInWindow = IntRect(0, 0, surface.width, surface.height)
             scene.setContent {
                 Box(
                     modifier = Modifier.size(100.dp, 100.dp).pointerHoverIcon(PointerIcon.Default)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -48,11 +48,9 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.roundToIntRect
-import androidx.compose.ui.unit.toIntRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.FocusStack
 import androidx.compose.ui.window.InteractionUIView
@@ -63,7 +61,6 @@ import androidx.compose.ui.window.UITouchesEventPhase
 import androidx.compose.ui.window.uiContentSizeCategoryToFontScaleMap
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.floor
-import kotlin.math.roundToInt
 import kotlin.math.roundToLong
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ObjCAction
@@ -439,17 +436,19 @@ internal class ComposeSceneMediator(
 
     fun viewWillLayoutSubviews() {
         val density = getSystemDensity()
-        val scale = density.density
         //TODO: Current code updates layout based on rootViewController size.
         // Maybe we need to rewrite it for SingleLayerComposeScene.
-        val size = container.frame.useContents {
-            IntSize(
-                width = (size.width * scale).roundToInt(),
-                height = (size.height * scale).roundToInt()
-            )
+
+        val boundsInWindow = container.convertRect(
+            rect = container.bounds,
+            toView = null
+        ).useContents {
+            with(density) {
+                toDpRect().toRect().roundToIntRect()
+            }
         }
         scene.density = density // TODO: Maybe it is wrong to set density to scene here?
-        scene.boundsInWindow = size.toIntRect() // TODO: Pass offset if it's not full-screen
+        scene.boundsInWindow = boundsInWindow
         onComposeSceneInvalidate()
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.roundToIntRect
+import androidx.compose.ui.unit.toIntRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.FocusStack
 import androidx.compose.ui.window.InteractionUIView
@@ -448,7 +449,7 @@ internal class ComposeSceneMediator(
             )
         }
         scene.density = density // TODO: Maybe it is wrong to set density to scene here?
-        scene.size = size
+        scene.boundsInWindow = size.toIntRect() // TODO: Pass offset if it's not full-screen
         onComposeSceneInvalidate()
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -117,7 +117,7 @@ internal class UIViewComposeSceneLayer(
     override var density by mediator::density
     override var layoutDirection by mediator::layoutDirection
 
-    override var bounds: IntRect
+    override var boundsInWindow: IntRect
         get() = mediator.getBoundsInPx()
         set(value) {
             mediator.setLayout(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.window.ComposeContainer
@@ -156,6 +157,10 @@ internal class UIViewComposeSceneLayer(
         onOutsidePointerEvent: ((dismissRequest: Boolean) -> Unit)?
     ) {
         this.onOutsidePointerEvent = onOutsidePointerEvent
+    }
+
+    override fun calculateLocalPosition(positionInWindow: IntOffset): IntOffset {
+        return positionInWindow
     }
 
     fun viewDidAppear(animated: Boolean) {


### PR DESCRIPTION
## Proposed Changes

- Replace `size` to `boundsInWindow` in `ComposeScene`
- Provide implementation for `calculatePositionInWindow` in `Owner`
- Fix layer position if the main scene is placed with offset