### PR TITLE
Fix root window size in `Popup`/`Dialog`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.input.pointer.PointerInputModifier
 import androidx.compose.ui.input.pointer.changedToDownIgnoreConsumed
 import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
@@ -98,7 +99,7 @@ public fun <T : Component> SwingPanel(
 
     Box(
         modifier = modifier.onGloballyPositioned { coordinates ->
-            val bounds = coordinates.boundsInWindow().round(density)
+            val bounds = coordinates.boundsInRoot().round(density)
             componentInfo.container.setBounds(bounds.left, bounds.top, bounds.width, bounds.height)
             componentInfo.container.validate()
             componentInfo.container.repaint()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -44,6 +44,8 @@ import java.awt.event.KeyEvent
 import java.awt.im.InputMethodRequests
 import javax.accessibility.Accessible
 import javax.swing.JLayeredPane
+import javax.swing.RootPaneContainer
+import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.*
@@ -410,8 +412,18 @@ internal class ComposeSceneMediator(
     fun onChangeComponentSize() = catchExceptions {
         if (!container.isDisplayable) return
 
-        // TODO: Recalculate it to window related coordinates
-        val boundsInWindow = IntRect(IntOffset.Zero, container.sizeInPx)
+        val scale = container.density.density
+        val window = SwingUtilities.getWindowAncestor(container)
+        val windowContainer = (window as? RootPaneContainer)?.contentPane ?: window
+        val pointInWindow = SwingUtilities.convertPoint(container, Point(0, 0), windowContainer)
+        val offsetInWindow = IntOffset(
+            x = (pointInWindow.x * scale).toInt(),
+            y = (pointInWindow.y * scale).toInt()
+        )
+        val boundsInWindow = IntRect(
+            offset = offsetInWindow,
+            size = container.sizeInPx
+        )
         if (scene.boundsInWindow != boundsInWindow) {
             scene.boundsInWindow = boundsInWindow
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.InsetsConfig
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.ZeroInsetsConfig
@@ -37,6 +38,7 @@ import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.center
 
 /**
@@ -178,9 +180,11 @@ private fun DialogLayout(
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     rememberLayerContent(layer) {
+        val containerSize = LocalWindowInfo.current.containerSize
         val measurePolicy = rememberDialogMeasurePolicy(
             layer = layer,
             properties = properties,
+            containerSize = containerSize,
             platformInsets = platformInsets
         )
         properties.insetsConfig.excludeSafeInsets {
@@ -207,13 +211,14 @@ private val DialogProperties.insetsConfig: InsetsConfig
 private fun rememberDialogMeasurePolicy(
     layer: ComposeSceneLayer,
     properties: DialogProperties,
+    containerSize: IntSize,
     platformInsets: PlatformInsets
-) = remember(layer, properties, platformInsets) {
+) = remember(layer, properties, containerSize, platformInsets) {
     RootMeasurePolicy(
         platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
-    ) { windowSize, contentSize ->
-        val positionWithInsets = positionWithInsets(platformInsets, windowSize) { sizeWithoutInsets ->
+    ) { contentSize ->
+        val positionWithInsets = positionWithInsets(platformInsets, containerSize) { sizeWithoutInsets ->
             sizeWithoutInsets.center - contentSize.center
         }
         layer.boundsInWindow = IntRect(positionWithInsets, contentSize)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.InsetsConfig
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.ZeroInsetsConfig
@@ -44,6 +45,7 @@ import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.round
 
@@ -436,11 +438,13 @@ private fun PopupLayout(
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     rememberLayerContent(layer) {
         val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@rememberLayerContent
+        val containerSize = LocalWindowInfo.current.containerSize
         val layoutDirection = LocalLayoutDirection.current
         val measurePolicy = rememberPopupMeasurePolicy(
             layer = layer,
             popupPositionProvider = popupPositionProvider,
             properties = properties,
+            containerSize = containerSize,
             platformInsets = platformInsets,
             layoutDirection = layoutDirection,
             parentBoundsInWindow = parentBoundsInWindow
@@ -489,15 +493,16 @@ private fun rememberPopupMeasurePolicy(
     layer: ComposeSceneLayer,
     popupPositionProvider: PopupPositionProvider,
     properties: PopupProperties,
+    containerSize: IntSize,
     platformInsets: PlatformInsets,
     layoutDirection: LayoutDirection,
     parentBoundsInWindow: IntRect,
-) = remember(layer, popupPositionProvider, properties, platformInsets, layoutDirection, parentBoundsInWindow) {
+) = remember(layer, popupPositionProvider, properties, containerSize, platformInsets, layoutDirection, parentBoundsInWindow) {
     RootMeasurePolicy(
         platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
-    ) { windowSize, contentSize ->
-        val positionWithInsets = positionWithInsets(platformInsets, windowSize) { sizeWithoutInsets ->
+    ) { contentSize ->
+        val positionWithInsets = positionWithInsets(platformInsets, containerSize) { sizeWithoutInsets ->
             // Position provider works in coordinates without insets.
             val boundsWithoutInsets = parentBoundsInWindow.translate(
                 -platformInsets.left.roundToPx(),

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
@@ -34,19 +34,18 @@ import kotlin.math.min
 internal fun RootMeasurePolicy(
     platformInsets: PlatformInsets,
     usePlatformDefaultWidth: Boolean,
-    calculatePosition: MeasureScope.(windowSize: IntSize, contentSize: IntSize) -> IntOffset,
+    calculatePosition: MeasureScope.(contentSize: IntSize) -> IntOffset,
 ) = MeasurePolicy {measurables, constraints ->
     val platformConstraints = applyPlatformConstrains(
         constraints, platformInsets, usePlatformDefaultWidth
     )
     val placeables = measurables.fastMap { it.measure(platformConstraints) }
-    val windowSize = IntSize(constraints.maxWidth, constraints.maxHeight)
     val contentSize = IntSize(
         width = placeables.fastMaxBy { it.width }?.width ?: constraints.minWidth,
         height = placeables.fastMaxBy { it.height }?.height ?: constraints.minHeight
     )
-    val position = calculatePosition(windowSize, contentSize)
-    layout(windowSize.width, windowSize.height) {
+    val position = calculatePosition(contentSize)
+    layout(constraints.maxWidth, constraints.maxHeight) {
         placeables.fastForEach {
             it.place(position.x, position.y)
         }


### PR DESCRIPTION
## Proposed Changes

- Address TODO from #956
- Use `WindowInfo.contentSize` instead of local constraints in `Popup`/`Dialog`
- Pass real scene offset relative to the window.
