### PR TITLE
Fix tooltip regression

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -502,7 +502,13 @@ private class MultiLayerComposeSceneImpl(
 
         override var density: Density by owner::density
         override var layoutDirection: LayoutDirection by owner::layoutDirection
-        override var boundsInWindow: IntRect by mutableStateOf(owner.bounds ?: IntRect.Zero)
+
+        /*
+         * We cannot set [owner.bounds] as default value because real bounds will be available
+         * not immediately, so it will change [lastHoverOwner] for a few frames.
+         * This scenario is important when user code relies on hover events to show tooltips.
+         */
+        override var boundsInWindow: IntRect by mutableStateOf(IntRect.Zero)
         override var scrimColor: Color? by mutableStateOf(null)
         override var focusable: Boolean = focusable
             set(value) {


### PR DESCRIPTION
## Proposed Changes

- Reverts default bounds value of new layer that used before calculation of real bounds.

## Testing

Test: run code from the issue.

TODO: add unit test for this case

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4067
