### PR TITLE
Fix crash when DesktopInputService.methodRequestForInput() -> getTextLocation() is called

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -177,7 +177,7 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
                 return AttributedString(str).iterator
             }
 
-            override fun getTextLocation(offset: TextHitInfo): Rectangle? {
+            override fun getTextLocation(offset: TextHitInfo?): Rectangle? {
                 return input.focusedRect?.let {
                     val x = (it.right / component.density.density).toInt() +
                         component.locationOnScreen.x


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4115

The documentation of `InputMethodRequests.getTextLocation` says the `offset` argument can be `null`, but in our implementation of the interface it's marked as non-null. This causes the app to crash when actually called with `null`:

```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Parameter specified as non-null is null: method 
androidx.compose.ui.platform.PlatformInput$methodRequestsForInput$1.getTextLocation, parameter offset
```

## Proposed Changes
Mark the argument as nullable

## Testing

Test: Nothing to test
