### PR TITLE
Make CombinedPointerMatcher.sources immutable

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
@@ -51,15 +51,15 @@ interface PointerMatcher {
 
     @ExperimentalFoundationApi
     operator fun plus(pointerMatcher: PointerMatcher): PointerMatcher {
-        return if (this is CombinedPointerMatcher) {
-            this.sources.add(pointerMatcher)
-            this
-        } else if (pointerMatcher is CombinedPointerMatcher) {
-            pointerMatcher.sources.add(this)
-            pointerMatcher
-        } else {
-            CombinedPointerMatcher(mutableListOf(this, pointerMatcher))
+        val sources = buildList {
+            for (matcher in listOf(this@PointerMatcher, pointerMatcher)) {
+                if (matcher is CombinedPointerMatcher)
+                    addAll(matcher.sources)
+                else
+                    add(matcher)
+            }
         }
+        return CombinedPointerMatcher(sources)
     }
 
     @Suppress("MemberVisibilityCanBePrivate")
@@ -128,8 +128,7 @@ interface PointerMatcher {
             override val pointerType = PointerType.Eraser
         }
 
-        private class CombinedPointerMatcher(val sources: MutableList<PointerMatcher>) : PointerMatcher {
-
+        private class CombinedPointerMatcher(val sources: List<PointerMatcher>) : PointerMatcher {
             override fun matches(event: PointerEvent): Boolean {
                 return sources.any { it.matches(event) }
             }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
@@ -143,6 +143,13 @@ interface PointerMatcher {
          * - [PointerType] is [PointerType.Eraser]
          */
         @ExperimentalFoundationApi
-        val Primary = mouse(PointerButton.Primary) + touch + stylus + eraser
+        val Primary: PointerMatcher = CombinedPointerMatcher(
+            listOf(
+                mouse(PointerButton.Primary),
+                touch,
+                stylus,
+                eraser
+            )
+        )
     }
 }


### PR DESCRIPTION
`CombinedPointerMatcher.sources` is currently a mutable list, and it's being actively modified by `PointerMatcher.plus`. This causes problems because merely executing the expression `PointerMatcher.Primary + PointerMatcher.mouse(PointerButton.Secondary)` actually modifies `PointerMatcher.Primary` and it will start detecting right-clicks too.

## Proposed Changes

Make `CombinedPointerMatcher.sources` immutable.

## Testing

Test: Tested manually the code below:

```
@OptIn(ExperimentalFoundationApi::class)
fun main() = singleWindowApplication {
    var clickCount by remember { mutableStateOf(0) }
    Column {
        Box(
            Modifier
                .fillMaxWidth()
                .weight(1f)
                .background(if (clickCount.mod(2) == 1) Color.Red else Color.Green)
                .onClick {
                    clickCount += 1
                }
        )
        Spacer(Modifier.height(100.dp))
        Box(
            modifier = Modifier
                .size(100.dp)
                .onDrag(
                    matcher = PointerMatcher.Primary + PointerMatcher.mouse(PointerButton.Secondary),
                    onDrag = {}
                )
        ) {
            Text("Drag")
        }
    }
}
```
