### PR TITLE
Don't restart the drag gesture when the matcher changes.

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.util.fastAll
  */
 @ExperimentalFoundationApi
 @OptIn(ExperimentalComposeUiApi::class)
-interface PointerMatcher {
+fun interface PointerMatcher {
 
     @ExperimentalFoundationApi
     fun matches(event: PointerEvent): Boolean

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/DragGesture.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/DragGesture.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.foundation.gestures
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.PointerMatcher
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
@@ -153,18 +154,19 @@ fun Modifier.onDrag(
     factory = {
         if (!enabled) return@composed Modifier
 
-        val onDragState = rememberUpdatedState(onDrag)
-        val onDragStartState = rememberUpdatedState(onDragStart)
-        val onDragEndState = rememberUpdatedState(onDragEnd)
-        val onDragCancelState = rememberUpdatedState(onDragCancel)
+        val matcherState by rememberUpdatedState(matcher)
+        val onDragState by rememberUpdatedState(onDrag)
+        val onDragStartState by rememberUpdatedState(onDragStart)
+        val onDragEndState by rememberUpdatedState(onDragEnd)
+        val onDragCancelState by rememberUpdatedState(onDragCancel)
 
-        Modifier.pointerInput(matcher) {
+        Modifier.pointerInput(Unit) {
             detectDragGestures(
-                matcher = matcher,
-                onDragStart = { onDragStartState.value(it) },
-                onDrag = { onDragState.value(it) },
-                onDragEnd = { onDragEndState.value() },
-                onDragCancel = { onDragCancelState.value() }
+                matcher = { matcherState.matches(it) },
+                onDragStart = { onDragStartState(it) },
+                onDrag = { onDragState(it) },
+                onDragEnd = { onDragEndState() },
+                onDragCancel = { onDragCancelState() }
             )
         }
     }


### PR DESCRIPTION
We currenty restart the drag gesture detector when the pointer matcher changes:
```
        Modifier.pointerInput(matcher) {
            detectDragGestures(
                matcher = matcher,
                onDragStart = { onDragStartState.value(it) },
                onDrag = { onDragState.value(it) },
                onDragEnd = { onDragEndState.value() },
                onDragCancel = { onDragCancelState.value() }
            )
        }
```

This means that, for example, 
```
@OptIn(ExperimentalFoundationApi::class)
fun main() = singleWindowApplication {
    var n by remember { mutableStateOf(0) }
    Box(
        modifier = Modifier
            .fillMaxSize()
            .background(Color.LightGray)
            .onDrag(matcher = PointerMatcher.mouse(PointerButton.Primary)) {
                println("Dragged: $it")
                n += 1
            }
    ) {
        Text(n.toString())
    }
}
```
will not work.

## Proposed Changes

- Make `PointerMatcher` a `fun interface` (because it's fun!!)
- Remember the updated matcher and use it instead of restarting the pointer input scope.
 
## Testing

Test: Added a unit test.