### PR TITLE
Publish ui-test module for all supported platforms.

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -40,7 +40,7 @@ val mainComponents =
         ComposeComponent(":compose:ui:ui"),
         ComposeComponent(":compose:ui:ui-geometry"),
         ComposeComponent(":compose:ui:ui-graphics"),
-        ComposeComponent(":compose:ui:ui-test", supportedPlatforms = ComposePlatforms.JVM_BASED),
+        ComposeComponent(":compose:ui:ui-test"),
         ComposeComponent(
             ":compose:ui:ui-test-junit4",
             supportedPlatforms = ComposePlatforms.JVM_BASED


### PR DESCRIPTION
Now that the Compose Test API no longer depends on JUnit, we can publish `ui-test` for all supported platforms.

## Testing

Test: Ran tests manually on iOS and wasmJs.