### PR TITLE
Clean up all dependencies of InteractionUIView to prevent retain cycles

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -389,6 +389,7 @@ internal class ComposeSceneMediator(
         focusStack?.popUntilNext(renderingView)
         renderingView.dispose()
         renderingView.removeFromSuperview()
+        interactionView.dispose()
         interactionView.removeFromSuperview()
         scene.close()
         // After scene is disposed all UIKit interop actions can't be deferred to be synchronized with rendering


### PR DESCRIPTION
The fix breaks the dependency cycle that occurs when the native UIEvent implicitly captures InteractiveUIView at the same time it is captured by Compose scene.