### PR TITLE
Fix `transparency` init order

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -226,11 +226,16 @@ internal class ComposeSceneMediator(
         get() = if (useInteropBlending) 0 else 20
 
     init {
+        /*
+         * Transparency is used during redrawer creation that triggered by [addNotify], so
+         * it must be set to correct value before adding to the hierarchy to handle cases
+         * when [container] is already [isDisplayable].
+         */
+        skiaLayerComponent.transparency = useInteropBlending
+
         container.addToLayer(invisibleComponent, contentLayer)
         container.addToLayer(contentComponent, contentLayer)
         container.addContainerListener(containerListener)
-
-        skiaLayerComponent.transparency = useInteropBlending
 
         // It will be enabled dynamically. See DesktopPlatformComponent
         contentComponent.enableInputMethods(false)


### PR DESCRIPTION
## Proposed Changes

- Transparency is used during redrawer creation that triggered by `addNotify`, so it must be set to correct value before adding to the hierarchy to handle cases when `container` is already `isDisplayable`

## Testing

Test: `desktop-samples:runSwing` with `compose.interop.blending` flag on Windows (D3D)
