### PR TITLE
Fix negative scene size

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -442,6 +442,7 @@ internal class ComposeSceneMediator(
         val boundsInWindow = IntRect(
             offset = offsetInWindow,
             size = IntSize(
+                // container.sizeInPx can be negative
                 width = size.width.coerceAtLeast(0),
                 height = size.height.coerceAtLeast(0)
             )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.platform.*
@@ -32,6 +33,7 @@ import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toOffset
@@ -439,7 +441,10 @@ internal class ComposeSceneMediator(
         val size = sceneBoundsInPx?.size ?: container.sizeInPx
         val boundsInWindow = IntRect(
             offset = offsetInWindow,
-            size = size
+            size = IntSize(
+                width = size.width.coerceAtLeast(0),
+                height = size.height.coerceAtLeast(0)
+            )
         )
         if (scene.boundsInWindow != boundsInWindow) {
             scene.boundsInWindow = boundsInWindow


### PR DESCRIPTION
## Proposed Changes

Fixes negative constraints exception:

```kt
Exception in thread "AWT-EventQueue-0" java.lang.IllegalArgumentException: maxHeight(-8) must be >= than minHeight(0)
	at androidx.compose.ui.unit.ConstraintsKt.Constraints(Constraints.kt:427)
	at androidx.compose.ui.unit.ConstraintsKt.Constraints$default(Constraints.kt:418)
	at androidx.compose.ui.node.RootNodeOwner_skikoKt.toConstraints(RootNodeOwner.skiko.kt:491)
	at androidx.compose.ui.node.RootNodeOwner_skikoKt.access$toConstraints(RootNodeOwner.skiko.kt:1)
	at androidx.compose.ui.node.RootNodeOwner$OwnerImpl.measureAndLayout(RootNodeOwner.skiko.kt:281)
	at androidx.compose.ui.node.RootNodeOwner.measureAndLayout(RootNodeOwner.skiko.kt:184)
	at androidx.compose.ui.scene.MultiLayerComposeSceneImpl.measureAndLayout(MultiLayerComposeScene.skiko.kt:244)
	at androidx.compose.ui.scene.BaseComposeScene.doLayout(BaseComposeScene.skiko.kt:211)
	at androidx.compose.ui.scene.BaseComposeScene.access$doLayout(BaseComposeScene.skiko.kt:51)
	at androidx.compose.ui.scene.BaseComposeScene.render(BaseComposeScene.skiko.kt:152)
	at androidx.compose.ui.scene.ComposeSceneMediator$DesktopSkikoView.onRender(ComposeSceneMediator.desktop.kt:486)
	at org.jetbrains.skiko.SkiaLayer.update$skiko(SkiaLayer.awt.kt:548)
	at org.jetbrains.skiko.redrawer.AWTRedrawer.update(AWTRedrawer.kt:54)
	at org.jetbrains.skiko.redrawer.Direct3DRedrawer$frameDispatcher$1.invokeSuspend(Direct3DRedrawer.kt:48)
	at org.jetbrains.skiko.redrawer.Direct3DRedrawer$frameDispatcher$1.invoke(Direct3DRedrawer.kt)
	at org.jetbrains.skiko.redrawer.Direct3DRedrawer$frameDispatcher$1.invoke(Direct3DRedrawer.kt)
	at org.jetbrains.skiko.FrameDispatcher$job$1.invokeSuspend(FrameDispatcher.kt:33)
```

## Testing

Test: `desktop-samples:runSwing`, try to resize the window more than allowing a compose panel to be visible.
