### PR TITLE
Fix coping of `MouseEvent` for `SwingPanel` interop

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -55,6 +55,7 @@ import java.awt.Point
 import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
 import java.awt.event.MouseEvent
+import java.awt.event.MouseWheelEvent
 import javax.swing.JPanel
 import javax.swing.LayoutFocusTraversalPolicy
 import javax.swing.SwingUtilities
@@ -366,14 +367,32 @@ private class InteropPointerInputModifier<T : Component>(
 private fun MouseEvent.copy(
     component: Component,
     point: Point
-) = MouseEvent(
-    /* source = */ component,
-    /* id = */ id,
-    /* when = */ `when`,
-    /* modifiers = */ modifiersEx,
-    /* x = */ point.x,
-    /* y = */ point.y,
-    /* clickCount = */ clickCount,
-    /* popupTrigger = */ isPopupTrigger,
-    /* button = */ button
-)
+) = when(this) {
+    is MouseWheelEvent -> MouseWheelEvent(
+        /* source = */ component,
+        /* id = */ id,
+        /* when = */ `when`,
+        /* modifiers = */ modifiersEx,
+        /* x = */ point.x,
+        /* y = */ point.y,
+        /* xAbs = */ xOnScreen,
+        /* yAbs = */ yOnScreen,
+        /* clickCount = */ clickCount,
+        /* popupTrigger = */ isPopupTrigger,
+        /* scrollType = */ scrollType,
+        /* scrollAmount = */ scrollAmount,
+        /* wheelRotation = */ wheelRotation,
+        /* preciseWheelRotation = */ preciseWheelRotation
+    )
+    else -> MouseEvent(
+        /* source = */ component,
+        /* id = */ id,
+        /* when = */ `when`,
+        /* modifiers = */ modifiersEx,
+        /* x = */ point.x,
+        /* y = */ point.y,
+        /* clickCount = */ clickCount,
+        /* popupTrigger = */ isPopupTrigger,
+        /* button = */ button
+    )
+}


### PR DESCRIPTION
## Proposed Changes

- Native event might be with `MouseWheelEvent` type, so we should construct the same type during copying

```kt
java.lang.ClassCastException: class java.awt.event.MouseEvent cannot be cast to class java.awt.event.MouseWheelEvent (java.awt.event.MouseEvent and java.awt.event.MouseWheelEvent are in module java.desktop of loader 'bootstrap')
    at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4930)
    at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
    at java.desktop/java.awt.Component.dispatchEvent(Component.java:4866)
    at androidx.compose.ui.awt.InteropPointerInputModifier.dispatchToView(SwingPanel.desktop.kt:367)
    at androidx.compose.ui.awt.InteropPointerInputModifier.onPointerEvent-H0pRuoY(SwingPanel.desktop.kt:350)
    at androidx.compose.ui.node.BackwardsCompatNode.onPointerEvent-H0pRuoY(BackwardsCompatNode.kt:365)
    at androidx.compose.ui.input.pointer.Node.dispatchFinalEventPass(HitPathTracker.kt:344)
    at androidx.compose.ui.input.pointer.Node.dispatchFinalEventPass(HitPathTracker.kt:349)
    at androidx.compose.ui.input.pointer.Node.dispatchFinalEventPass(HitPathTracker.kt:349)
    at androidx.compose.ui.input.pointer.NodeParent.dispatchFinalEventPass(HitPathTracker.kt:204)
    at androidx.compose.ui.input.pointer.HitPathTracker.dispatchChanges(HitPathTracker.kt:110)
    at androidx.compose.ui.input.pointer.PointerInputEventProcessor.process-BIzXfog(PointerInputEventProcessor.kt:97)
    at androidx.compose.ui.node.RootNodeOwner.onPointerInput(RootNodeOwner.skiko.kt:199)
    at androidx.compose.ui.scene.MultiLayerComposeSceneImpl.processScroll(MultiLayerComposeScene.skiko.kt:377)
    at androidx.compose.ui.scene.MultiLayerComposeSceneImpl.processPointerInputEvent(MultiLayerComposeScene.skiko.kt:232)
    at androidx.compose.ui.scene.BaseComposeScene$inputHandler$2.invoke(BaseComposeScene.skiko.kt:61)
    at androidx.compose.ui.scene.BaseComposeScene$inputHandler$2.invoke(BaseComposeScene.skiko.kt:61)
    at androidx.compose.ui.input.pointer.SyntheticEventSender.sendInternal(SyntheticEventSender.skiko.kt:175)
    at androidx.compose.ui.input.pointer.SyntheticEventSender.send(SyntheticEventSender.skiko.kt:79)
    at androidx.compose.ui.scene.ComposeSceneInputHandler.onPointerEvent-WlEVilQ(ComposeSceneInputHandler.skiko.kt:117)
    at androidx.compose.ui.scene.ComposeSceneInputHandler.onPointerEvent-BGSDPeU(ComposeSceneInputHandler.skiko.kt:84)
    at androidx.compose.ui.scene.BaseComposeScene.sendPointerEvent-BGSDPeU(BaseComposeScene.skiko.kt:167)
    at androidx.compose.ui.scene.ComposeScene.sendPointerEvent-BGSDPeU$default(ComposeScene.skiko.kt:174)
    at androidx.compose.ui.awt.ComposeBridge_desktopKt.onMouseWheelEvent(ComposeBridge.desktop.kt:546)
    at androidx.compose.ui.awt.ComposeBridge_desktopKt.access$onMouseWheelEvent(ComposeBridge.desktop.kt:1)
    at androidx.compose.ui.awt.ComposeBridge.onMouseWheelEvent(ComposeBridge.desktop.kt:291)
    at androidx.compose.ui.awt.ComposeBridge._init_$lambda$0(ComposeBridge.desktop.kt:269)
    at java.desktop/java.awt.Component.processMouseWheelEvent(Component.java:6756)
    at java.desktop/java.awt.Component.processEvent(Component.java:6440)
    at java.desktop/java.awt.Container.processEvent(Container.java:2266)
    at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5038)
    at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
    at java.desktop/java.awt.Component.dispatchEvent(Component.java:4866)
    at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4969)
    at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4612)
    at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4524)
    at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
    at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2809)
    at java.desktop/java.awt.Component.dispatchEvent(Component.java:4866)
```

## Testing

Test: Use `desktop-samples:runSwing` with `compose.interop.blending` flag on Windows (D3D), try to send mouse wheel event to `SwingPanel` interop view.

