### PR TITLE
Fix iOS interop position conversion

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
@@ -23,6 +23,7 @@ import androidx.compose.mpp.demo.bug.DropdownMenuIssue
 val IosBugs = Screen.Selection(
     "IosBugs",
     UIKitViewAndDropDownMenu,
+    UIKitViewMatryoshka,
     KeyboardEmptyWhiteSpace,
     KeyboardPasswordType,
     UIKitRenderSync,

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitViewMatryoshka.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/UIKitViewMatryoshka.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bugs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.interop.UIKitViewController
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.ComposeUIViewController
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExportObjCClass
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSCoder
+import platform.MapKit.MKMapView
+import platform.UIKit.UIColor
+import platform.UIKit.UIViewController
+import platform.UIKit.addChildViewController
+import platform.UIKit.didMoveToParentViewController
+
+val UIKitViewMatryoshka = Screen.Example("UIKitViewMatryoshka") {
+    // Issue: https://github.com/JetBrains/compose-multiplatform/issues/4095
+    Box(Modifier.fillMaxSize().background(Color.White).padding(50.dp)) {
+        UIKitViewController(
+            factory = { InnerUIKitViewController() },
+            modifier = Modifier.size(600.dp, 600.dp)
+        )
+    }
+}
+
+@ExportObjCClass
+class InnerUIKitViewController: UIViewController(nibName = null, bundle = null) {
+
+    override fun viewDidLoad() {
+        super.viewDidLoad()
+        view.setBackgroundColor(UIColor.grayColor)
+
+        val innerCompose = InnerComposeViewController()
+        addChildViewController(innerCompose)
+        view.addSubview(innerCompose.view)
+        innerCompose.view.setFrame(CGRectMake(50.0, 50.0, 500.0, 500.0))
+        innerCompose.didMoveToParentViewController(this)
+    }
+}
+
+
+private fun InnerComposeViewController() = ComposeUIViewController {
+    Box(Modifier.fillMaxSize().background(Color.Green).padding(50.dp)) {
+        UIKitView(
+            factory = { MKMapView() },
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
@@ -97,7 +97,7 @@ fun <T : UIView> UIKitView(
 
     Place(
         modifier.onGloballyPositioned { coordinates ->
-            localToWindowOffset = coordinates.positionInWindow().round()
+            localToWindowOffset = coordinates.positionInRoot().round()
             val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
             if (rectInPixels != newRectInPixels) {
                 val rect = newRectInPixels / density
@@ -196,7 +196,7 @@ fun <T : UIViewController> UIKitViewController(
 
     Place(
         modifier.onGloballyPositioned { coordinates ->
-            localToWindowOffset = coordinates.positionInWindow().round()
+            localToWindowOffset = coordinates.positionInRoot().round()
             val newRectInPixels = IntRect(localToWindowOffset, coordinates.size)
             if (rectInPixels != newRectInPixels) {
                 val rect = newRectInPixels / density


### PR DESCRIPTION
## Proposed Changes

- Use root coordinates for interop instead of window ones - it's different after #956

## Testing

Test: run app from the issue or open "UIKitViewMatryoshka" in mpp

Before | After
---|---
![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 13 00 20](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/0035c206-1f1c-40d6-a59a-f6f3c9d01617) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-11 at 13 06 04](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/cf679f2a-0c35-41c2-ac1a-66c18feced8c)



## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4095
