### PR TITLE
New line on `NumPadEnter`

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyMapping.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyMapping.kt
@@ -53,6 +53,7 @@ internal expect object MappedKeys {
     val MoveEnd: Key
     val Insert: Key
     val Enter: Key
+    val NumPadEnter: Key
     val Backspace: Key
     val Delete: Key
     val Paste: Key
@@ -107,7 +108,7 @@ internal fun commonKeyMapping(
                         MappedKeys.PageDown -> KeyCommand.PAGE_DOWN
                         MappedKeys.MoveHome -> KeyCommand.LINE_START
                         MappedKeys.MoveEnd -> KeyCommand.LINE_END
-                        MappedKeys.Enter -> KeyCommand.NEW_LINE
+                        MappedKeys.Enter, MappedKeys.NumPadEnter -> KeyCommand.NEW_LINE
                         MappedKeys.Backspace -> KeyCommand.DELETE_PREV_CHAR
                         MappedKeys.Delete -> KeyCommand.DELETE_NEXT_CHAR
                         MappedKeys.Paste -> KeyCommand.PASTE

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.foundation.text
 import java.awt.event.KeyEvent as AwtKeyEvent
 import androidx.compose.foundation.DesktopPlatform
 import androidx.compose.ui.input.key.Key
+import java.awt.event.KeyEvent
 
 internal actual val platformDefaultKeyMapping: KeyMapping
     get() = overriddenDefaultKeyMapping ?: _platformDefaultKeyMapping
@@ -56,6 +57,7 @@ internal actual object MappedKeys {
     actual val MoveEnd: Key = Key(AwtKeyEvent.VK_END)
     actual val Insert: Key = Key(AwtKeyEvent.VK_INSERT)
     actual val Enter: Key = Key(AwtKeyEvent.VK_ENTER)
+    actual val NumPadEnter = Key(KeyEvent.VK_ENTER, KeyEvent.KEY_LOCATION_NUMPAD)
     actual val Backspace: Key = Key(AwtKeyEvent.VK_BACK_SPACE)
     actual val Delete: Key = Key(AwtKeyEvent.VK_DELETE)
     actual val Paste: Key = Key(AwtKeyEvent.VK_PASTE)

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
@@ -19,7 +19,6 @@ package androidx.compose.foundation.text
 import java.awt.event.KeyEvent as AwtKeyEvent
 import androidx.compose.foundation.DesktopPlatform
 import androidx.compose.ui.input.key.Key
-import java.awt.event.KeyEvent
 
 internal actual val platformDefaultKeyMapping: KeyMapping
     get() = overriddenDefaultKeyMapping ?: _platformDefaultKeyMapping
@@ -57,7 +56,7 @@ internal actual object MappedKeys {
     actual val MoveEnd: Key = Key(AwtKeyEvent.VK_END)
     actual val Insert: Key = Key(AwtKeyEvent.VK_INSERT)
     actual val Enter: Key = Key(AwtKeyEvent.VK_ENTER)
-    actual val NumPadEnter = Key(KeyEvent.VK_ENTER, KeyEvent.KEY_LOCATION_NUMPAD)
+    actual val NumPadEnter = Key(AwtKeyEvent.VK_ENTER, AwtKeyEvent.KEY_LOCATION_NUMPAD)
     actual val Backspace: Key = Key(AwtKeyEvent.VK_BACK_SPACE)
     actual val Delete: Key = Key(AwtKeyEvent.VK_DELETE)
     actual val Paste: Key = Key(AwtKeyEvent.VK_PASTE)

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/KeyMapping.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/KeyMapping.jsNative.kt
@@ -41,6 +41,7 @@ internal actual object MappedKeys {
     actual val MoveEnd: Key = Key(Key.MoveEnd.keyCode)
     actual val Insert: Key = Key(Key.Insert.keyCode)
     actual val Enter: Key = Key(Key.Enter.keyCode)
+    actual val NumPadEnter: Key = Key(Key.NumPadEnter.keyCode)
     actual val Backspace: Key = Key(Key.Backspace.keyCode)
     actual val Delete: Key = Key(Key.Delete.keyCode)
     actual val Paste: Key = Key(Key.Paste.keyCode)


### PR DESCRIPTION
## Proposed Changes

- Handle `NumPadEnter` as new line in text fields

## Testing

Test: use reproducer from the issue 

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4109
