### PR TITLE
Fix owner's `isInBounds` check

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -367,8 +367,9 @@ class ComposePanelTest {
         }
     }
 
+    // Issue: https://github.com/JetBrains/compose-multiplatform/issues/4123
     @Test
-    fun `hover events in panel`() = runApplicationTest {
+    fun `hover events in panel with offset`() = runApplicationTest {
         var enterEvents = 0
         var exitEvents = 0
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.awt
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Text
@@ -28,14 +29,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.layout
+import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.density
+import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
+import java.awt.event.MouseEvent
 import javax.swing.JFrame
 import javax.swing.JPanel
 import junit.framework.TestCase.assertTrue
@@ -358,6 +364,48 @@ class ComposePanelTest {
             } finally {
                 frame.dispose()
             }
+        }
+    }
+
+    @Test
+    fun `hover events in panel`() = runApplicationTest {
+        var enterEvents = 0
+        var exitEvents = 0
+
+        val composePanel = ComposePanel()
+        composePanel.setBounds(25, 25, 50, 50)
+        composePanel.setContent {
+            Box(Modifier.size(50.dp)
+                .onPointerEvent(PointerEventType.Enter) { enterEvents++ }
+                .onPointerEvent(PointerEventType.Exit) { exitEvents++ }
+            )
+        }
+
+        val window = JFrame()
+        window.size = Dimension(200, 200)
+        try {
+            val content = JPanel(BorderLayout()).apply {
+                layout = null
+                add(composePanel, BorderLayout.CENTER)
+            }
+            window.contentPane.add(content)
+            window.isVisible = true
+
+            composePanel.sendMouseEvent(MouseEvent.MOUSE_ENTERED, 20, 20)
+            awaitIdle()
+            composePanel.sendMouseEvent(MouseEvent.MOUSE_MOVED, 20, 20)
+            awaitIdle()
+
+            assertEquals(1, enterEvents)
+            assertEquals(0, exitEvents)
+
+            composePanel.sendMouseEvent(MouseEvent.MOUSE_MOVED, 50, 50)
+            awaitIdle()
+
+            assertEquals(1, enterEvents)
+            assertEquals(1, exitEvents)
+        } finally {
+            window.dispose()
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -199,7 +199,8 @@ internal class RootNodeOwner(
             platformContext.inputModeManager.requestInputMode(InputMode.Touch)
         }
         val isInBounds = event.eventType != PointerEventType.Exit && event.pointers.all {
-            bounds?.contains(it.position.round()) ?: true
+            val positionInWindow = owner.calculatePositionInWindow(it.position)
+            bounds?.contains(positionInWindow.round()) ?: true
         }
         pointerInputEventProcessor.process(
             event,


### PR DESCRIPTION
## Proposed Changes

- Use window coordinates to check if it's in bounds - it's different after #956

## Testing

Test: run added unit test or the next sample:
```kt
fun main() = SwingUtilities.invokeLater {
    SwingComposeWindow()
}

fun SwingComposeWindow() {
    val window = JFrame()
    window.defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE

    val panel = JPanel()
    panel.layout = GridLayout(2, 1)
    panel.add(JPanel())
    panel.add(ComposePanel().apply {
        setContent {
            ComposeContent(background = Color.Green)
        }
    })
    window.contentPane.add(panel, BorderLayout.CENTER)

    window.setSize(800, 600)
    window.isVisible = true
}

@OptIn(ExperimentalFoundationApi::class)
@Composable
fun ComposeContent(background: Color) {
    Box(
        modifier = Modifier.fillMaxSize().background(color = background),
        contentAlignment = Alignment.Center
    ) {

        TooltipArea({ BasicText("Tooltip", Modifier.background(Color.Magenta).padding(8.dp)) }) {
            BasicText("Hover here", Modifier.background(Color.Gray).padding(8.dp))
        }
    }
}
```

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4123