### PR TITLE
Make `ComposePanel.windowContainer` public

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -471,9 +471,9 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public final fun dispose ()V
 	public final fun getExceptionHandler ()Landroidx/compose/ui/window/WindowExceptionHandler;
 	public fun getFocusTraversalKeysEnabled ()Z
-	public final fun getLayersContainer ()Ljavax/swing/JLayeredPane;
 	public fun getPreferredSize ()Ljava/awt/Dimension;
 	public final fun getRenderApi ()Lorg/jetbrains/skiko/GraphicsApi;
+	public final fun getWindowContainer ()Ljavax/swing/JLayeredPane;
 	public fun hasFocus ()Z
 	public final fun isDisposeOnRemove ()Z
 	public fun isFocusOwner ()Z
@@ -494,9 +494,9 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public final fun setExceptionHandler (Landroidx/compose/ui/window/WindowExceptionHandler;)V
 	public fun setFocusTraversalKeysEnabled (Z)V
 	public fun setFocusable (Z)V
-	public final fun setLayersContainer (Ljavax/swing/JLayeredPane;)V
 	public fun setLocale (Ljava/util/Locale;)V
 	public fun setRequestFocusEnabled (Z)V
+	public final fun setWindowContainer (Ljavax/swing/JLayeredPane;)V
 }
 
 public final class androidx/compose/ui/awt/ComposeWindow : javax/swing/JFrame {

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -471,6 +471,7 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public final fun dispose ()V
 	public final fun getExceptionHandler ()Landroidx/compose/ui/window/WindowExceptionHandler;
 	public fun getFocusTraversalKeysEnabled ()Z
+	public final fun getLayersContainer ()Ljavax/swing/JLayeredPane;
 	public fun getPreferredSize ()Ljava/awt/Dimension;
 	public final fun getRenderApi ()Lorg/jetbrains/skiko/GraphicsApi;
 	public fun hasFocus ()Z
@@ -493,6 +494,7 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public final fun setExceptionHandler (Landroidx/compose/ui/window/WindowExceptionHandler;)V
 	public fun setFocusTraversalKeysEnabled (Z)V
 	public fun setFocusable (Z)V
+	public final fun setLayersContainer (Ljavax/swing/JLayeredPane;)V
 	public fun setLocale (Ljava/util/Locale;)V
 	public fun setRequestFocusEnabled (Z)V
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -158,7 +158,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         }
 
     /**
-     * A container used for additional layers. It's used with [LayerType.OnComponent]
+     * A container used for additional layers and as reference for window coordinate space.
+     * It might be customized only with [LayerType.OnComponent].
      *
      * See [ComposeFeatureFlags.layerType]
      */

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -163,10 +163,10 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * See [ComposeFeatureFlags.layerType]
      */
     @ExperimentalComposeUiApi
-    var layersContainer: JLayeredPane? = null
+    var windowContainer: JLayeredPane? = null
         set(value) {
             field = value
-            _composeContainer?.layersContainer = value
+            _composeContainer?.windowContainer = value
         }
 
     override fun add(component: Component): Component {
@@ -200,7 +200,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             contentComponent.isFocusable = _isFocusable
             contentComponent.isRequestFocusEnabled = _isRequestFocusEnabled
             exceptionHandler = this@ComposePanel.exceptionHandler
-            layersContainer = this@ComposePanel.layersContainer
+            windowContainer = this@ComposePanel.windowContainer
 
             _focusListeners.forEach(contentComponent::addFocusListener)
             contentComponent.addFocusListener(object : FocusListener {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -163,7 +163,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * See [ComposeFeatureFlags.layerType]
      */
     @ExperimentalComposeUiApi
-    var windowContainer: JLayeredPane? = null
+    var windowContainer: JLayeredPane = this
         set(value) {
             field = value
             _composeContainer?.windowContainer = value
@@ -194,13 +194,16 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     }
 
     private fun createComposeContainer(): ComposeContainer {
-        return ComposeContainer(this, skiaLayerAnalytics).apply {
+        return ComposeContainer(
+            container = this,
+            skiaLayerAnalytics = skiaLayerAnalytics,
+            windowContainer = windowContainer
+        ).apply {
             focusManager.releaseFocus()
             setBounds(0, 0, width, height)
             contentComponent.isFocusable = _isFocusable
             contentComponent.isRequestFocusEnabled = _isRequestFocusEnabled
             exceptionHandler = this@ComposePanel.exceptionHandler
-            windowContainer = this@ComposePanel.windowContainer
 
             _focusListeners.forEach(contentComponent::addFocusListener)
             contentComponent.addFocusListener(object : FocusListener {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -121,8 +121,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     }
 
     override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
-        _composeContainer?.setBounds(0, 0, width, height)
         super.setBounds(x, y, width, height)
+        _composeContainer?.setBounds(0, 0, width, height)
     }
 
     override fun getPreferredSize(): Dimension? = if (isPreferredSizeSet) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -161,9 +161,9 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * A container used for additional layers. It's used with [LayerType.OnComponent]
      *
      * See [ComposeFeatureFlags.layerType]
-     * TODO: Make it public with @ExperimentalComposeUiApi
      */
-    internal var layersContainer: JLayeredPane? = null
+    @ExperimentalComposeUiApi
+    var layersContainer: JLayeredPane? = null
         set(value) {
             field = value
             _composeContainer?.layersContainer = value

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -128,8 +128,8 @@ internal class ComposeWindowPanel(
     }
 
     override fun setBounds(x: Int, y: Int, width: Int, height: Int) {
-        composeContainer.setBounds(0, 0, width, height)
         super.setBounds(x, y, width, height)
+        composeContainer.setBounds(0, 0, width, height)
     }
 
     override fun add(component: Component): Component {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -20,9 +20,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.density
+import java.awt.Component
 import java.awt.Container
+import java.awt.Point
+import javax.swing.SwingUtilities
 
 /**
  * Tracking a state of window.
@@ -33,7 +38,7 @@ internal class PlatformWindowContext {
     private val _windowInfo = WindowInfoImpl()
     val windowInfo: WindowInfo get() = _windowInfo
 
-    var windowContainer: Container? = null
+    private var _windowContainer: Container? = null
 
     /**
      * Indicates whether the window is transparent or not.
@@ -49,9 +54,26 @@ internal class PlatformWindowContext {
         _windowInfo.isWindowFocused = focused
     }
 
+    fun setWindowContainer(windowContainer: Container) {
+        _windowContainer = windowContainer
+    }
+
     fun setContainerSize(size: IntSize) {
         if (_windowInfo.containerSize != size) {
             _windowInfo.containerSize = size
         }
+    }
+
+    fun offsetInWindow(container: Component): IntOffset {
+        val scale = container.density.density
+        val pointInWindow = if (_windowContainer != null) {
+            SwingUtilities.convertPoint(container, Point(0, 0), _windowContainer)
+        } else {
+            Point(0, 0)
+        }
+        return IntOffset(
+            x = (pointInWindow.x * scale).toInt(),
+            y = (pointInWindow.y * scale).toInt()
+        )
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.window.Dialog
+import java.awt.Container
 
 /**
  * Tracking a state of window.
@@ -31,6 +32,8 @@ import androidx.compose.ui.window.Dialog
 internal class PlatformWindowContext {
     private val _windowInfo = WindowInfoImpl()
     val windowInfo: WindowInfo get() = _windowInfo
+
+    var windowContainer: Container? = null
 
     /**
      * Indicates whether the window is transparent or not.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -64,6 +64,13 @@ internal class PlatformWindowContext {
         }
     }
 
+    /**
+     * Calculates the offset of the given [container] within the window.
+     * It uses [_windowContainer] as a reference for window coordinate space.
+     *
+     * @param container The container component whose offset needs to be calculated.
+     * @return The offset of the container within the window as an [IntOffset] object.
+     */
     fun offsetInWindow(container: Component): IntOffset {
         val scale = container.density.density
         val pointInWindow = if (_windowContainer != null) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -55,7 +55,14 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * Internal entry point to Compose.
  *
  * It binds Skia canvas and [ComposeScene] to [container].
- * It also configures compose based on [ComposeFeatureFlags].
+ *
+ * @property container A container for the [ComposeScene].
+ * @property skiaLayerAnalytics The analytics for the Skia layer.
+ * @property window The window ancestor of the [container].
+ * @property windowContainer A container used for additional layers and as reference
+ *  for window coordinate space.
+ * @property useSwingGraphics Flag indicating if offscreen rendering to Swing graphics is used.
+ * @property layerType The type of layer used for Popup/Dialog.
  */
 internal class ComposeContainer(
     val container: JLayeredPane,
@@ -78,9 +85,6 @@ internal class ComposeContainer(
      */
     private val layers = mutableListOf<DesktopComposeSceneLayer>()
 
-    /**
-     * A container used for additional layers.
-     */
     private var _windowContainer: JLayeredPane? = null
     var windowContainer: JLayeredPane
         get() = requireNotNull(_windowContainer)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -161,6 +161,8 @@ internal class ComposeContainer(
     }
 
     private fun onChangeWindowBounds() {
+        if (!container.isDisplayable) return
+
         windowContext.setContainerSize(windowContainer.sizeInPx)
         layers.fastForEach(DesktopComposeSceneLayer::onChangeWindowBounds)
     }
@@ -183,6 +185,9 @@ internal class ComposeContainer(
     fun addNotify() {
         mediator.onComponentAttached()
         setWindow(SwingUtilities.getWindowAncestor(container))
+
+        // Re-checking the actual size if it wasn't available during init.
+        onChangeWindowBounds()
     }
 
     fun removeNotify() {
@@ -207,7 +212,7 @@ internal class ComposeContainer(
         }
 
         this.window?.removeWindowFocusListener(this)
-        window?.addComponentListener(this)
+        window?.addWindowFocusListener(this)
         this.window = window
 
         onChangeWindowFocus()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -436,9 +436,12 @@ internal class ComposeSceneMediator(
         if (!container.isDisplayable) return
 
         val scale = container.density.density
-        val window = SwingUtilities.getWindowAncestor(container)
-        val windowContainer = (window as? RootPaneContainer)?.contentPane ?: window
-        val pointInWindow = SwingUtilities.convertPoint(container, Point(0, 0), windowContainer)
+        val windowContainer = windowContext.windowContainer
+        val pointInWindow = if (windowContainer != null) {
+            SwingUtilities.convertPoint(container, Point(0, 0), windowContainer)
+        } else {
+            Point(0, 0)
+        }
         val offsetInWindow = IntOffset(
             x = (pointInWindow.x * scale).toInt(),
             y = (pointInWindow.y * scale).toInt()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -435,17 +435,7 @@ internal class ComposeSceneMediator(
     fun onChangeComponentSize() = catchExceptions {
         if (!container.isDisplayable) return
 
-        val scale = container.density.density
-        val windowContainer = windowContext.windowContainer
-        val pointInWindow = if (windowContainer != null) {
-            SwingUtilities.convertPoint(container, Point(0, 0), windowContainer)
-        } else {
-            Point(0, 0)
-        }
-        val offsetInWindow = IntOffset(
-            x = (pointInWindow.x * scale).toInt(),
-            y = (pointInWindow.y * scale).toInt()
-        )
+        val offsetInWindow = windowContext.offsetInWindow(container)
         val size = sceneBoundsInPx?.size ?: container.sizeInPx
         val boundsInWindow = IntRect(
             offset = offsetInWindow,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -49,7 +49,7 @@ internal class SwingComposeSceneLayer(
     focusable: Boolean,
     compositionContext: CompositionContext
 ) : DesktopComposeSceneLayer(), MouseListener {
-    private val windowContainer get() = composeContainer.windowContainer ?: composeContainer.container
+    private val windowContainer get() = composeContainer.windowContainer
     private val container = object : JLayeredPane() {
         override fun addNotify() {
             super.addNotify()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -35,6 +35,8 @@ import java.awt.Rectangle
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import javax.swing.JLayeredPane
+import javax.swing.RootPaneContainer
+import javax.swing.SwingUtilities
 import kotlin.math.ceil
 import kotlin.math.floor
 import org.jetbrains.skiko.SkiaLayerAnalytics
@@ -47,12 +49,14 @@ internal class SwingComposeSceneLayer(
     focusable: Boolean,
     compositionContext: CompositionContext
 ) : DesktopComposeSceneLayer(), MouseListener {
-    private val layersContainer get() = composeContainer.layersContainer ?: composeContainer.container
+    private val windowContainer get() = composeContainer.windowContainer ?: composeContainer.container
     private val container = object : JLayeredPane() {
         override fun addNotify() {
             super.addNotify()
             _mediator?.onComponentAttached()
-            _mediator?.contentComponent?.bounds = this@SwingComposeSceneLayer.boundsInWindow.toAwtRectangle(density)
+            _boundsInWindow?.let {
+                _mediator?.contentComponent?.bounds = it.toAwtRectangle(density)
+            }
         }
 
         override fun paint(g: Graphics) {
@@ -66,18 +70,21 @@ internal class SwingComposeSceneLayer(
         it.layout = null
         it.isOpaque = false
         it.background = Color.Transparent.toAwtColor()
-        it.size = Dimension(layersContainer.width, layersContainer.height)
+        it.size = Dimension(windowContainer.width, windowContainer.height)
         it.addMouseListener(this)
 
         // TODO: Currently it works only with offscreen rendering
         // TODO: Do not clip this from main scene if layersContainer == main container
-        layersContainer.add(it, JLayeredPane.POPUP_LAYER, 0)
+        windowContainer.add(it, JLayeredPane.POPUP_LAYER, 0)
     }
     private var containerSize = IntSize.Zero
         set(value) {
             if (field.width != value.width || field.height != value.height) {
                 field = value
                 container.setBounds(0, 0, value.width, value.height)
+                if (_boundsInWindow == null) {
+                    _mediator?.contentComponent?.size = container.size
+                }
                 _mediator?.onChangeComponentSize()
             }
         }
@@ -103,10 +110,16 @@ internal class SwingComposeSceneLayer(
             // TODO: Pass it to mediator/scene
         }
 
-    override var boundsInWindow: IntRect = IntRect.Zero
+    private var _boundsInWindow: IntRect? = null
+    override var boundsInWindow: IntRect
+        get() = _boundsInWindow ?: IntRect.Zero
         set(value) {
-            field = value
-            _mediator?.contentComponent?.bounds = value.toAwtRectangle(container.density)
+            _boundsInWindow = value
+            val localBounds = SwingUtilities.convertRectangle(
+                /* source = */ windowContainer,
+                /* aRectangle = */ value.toAwtRectangle(container.density),
+                /* destination = */ container)
+            _mediator?.contentComponent?.bounds = localBounds
         }
 
     override var scrimColor: Color? = null
@@ -117,7 +130,6 @@ internal class SwingComposeSceneLayer(
         }
 
     init {
-        boundsInWindow = IntRect(0, 0, layersContainer.width, layersContainer.height)
         _mediator = ComposeSceneMediator(
             container = container,
             windowContext = composeContainer.windowContext,
@@ -129,7 +141,7 @@ internal class SwingComposeSceneLayer(
             composeSceneFactory = ::createComposeScene,
         ).also {
             it.onChangeWindowTransparency(true)
-            it.contentComponent.bounds = boundsInWindow.toAwtRectangle(density)
+            it.contentComponent.size = container.size
         }
         composeContainer.attachLayer(this)
     }
@@ -139,9 +151,9 @@ internal class SwingComposeSceneLayer(
         _mediator?.dispose()
         _mediator = null
 
-        layersContainer.remove(container)
-        layersContainer.invalidate()
-        layersContainer.repaint()
+        windowContainer.remove(container)
+        windowContainer.invalidate()
+        windowContainer.repaint()
     }
 
     override fun setContent(content: @Composable () -> Unit) {
@@ -186,7 +198,7 @@ internal class SwingComposeSceneLayer(
     }
 
     override fun onChangeWindowBounds() {
-        containerSize = IntSize(layersContainer.width, layersContainer.height)
+        containerSize = IntSize(windowContainer.width, windowContainer.height)
     }
 
     // region MouseListener

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -49,7 +49,7 @@ internal class WindowComposeSceneLayer(
     compositionContext: CompositionContext
 ) : DesktopComposeSceneLayer() {
     private val window get() = requireNotNull(composeContainer.window)
-    private val windowContainer get() = requireNotNull(composeContainer.windowContainer)
+    private val windowContainer get() = composeContainer.windowContainer ?: composeContainer.container
     private val windowContext = PlatformWindowContext().also {
         it.isWindowTransparent = true
         it.setContainerSize(windowContainer.sizeInPx)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -49,7 +49,7 @@ internal class WindowComposeSceneLayer(
     compositionContext: CompositionContext
 ) : DesktopComposeSceneLayer() {
     private val window get() = requireNotNull(composeContainer.window)
-    private val windowContainer get() = composeContainer.windowContainer ?: composeContainer.container
+    private val windowContainer get() = composeContainer.windowContainer
     private val windowContext = PlatformWindowContext().also {
         it.isWindowTransparent = true
         it.setContainerSize(windowContainer.sizeInPx)


### PR DESCRIPTION
## Proposed Changes

- Resolve TODO from #962
- Expose `ComposePanel.windowContainer` to customize behavior of additional layers (Popup/Dialog)
- Fixes inconsistency with window coordinates

## Testing

Test: try to use this API with `compose.layers.type=COMPONENT`

```kt
@OptIn(ExperimentalComposeUiApi::class)
fun main() = SwingUtilities.invokeLater {
    System.setProperty("compose.swing.render.on.graphics", "true")
    System.setProperty("compose.layers.type", "COMPONENT")

    val window = JFrame()
    window.defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE

    val contentPane = JLayeredPane()
    contentPane.layout = null

    val composePanel = ComposePanel()
    composePanel.setBounds(200, 200, 200, 200)
    composePanel.setContent {
        ComposeContent()
    }
    composePanel.windowContainer = contentPane  // Use the full window for dialogs
    contentPane.add(composePanel)
    
    window.contentPane.add(contentPane)
    window.setSize(800, 600)
    window.isVisible = true
}

@Composable
fun ComposeContent() {
    Box(Modifier.fillMaxSize().background(Color.Green)) {
        Dialog(onDismissRequest = {}) {
            Box(Modifier.size(100.dp).background(Color.Yellow))
        }
    }
}
```

Default `windowContainer` | Full-size `windowContainer`
--- | ---
<img width="912" alt="Screenshot 2024-01-17 at 17 35 26" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/3de680a2-d497-460f-bc8a-a18f5fd1689a"> | <img width="912" alt="Screenshot 2024-01-17 at 17 35 41" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/dcc4f0c8-d870-4e61-ad0d-bf6545a0218d">
