### PR TITLE
Ignore specific common tests in foundation/foundation in wasm

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/test/IgnoreTargetsActuals.desktop.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/test/IgnoreTargetsActuals.desktop.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.test
+
+actual typealias IgnoreWasmTarget = DoNothing

--- a/compose/foundation/foundation/src/jsTest/kotlin/test/IgnoreTargetsActuals.js.kt
+++ b/compose/foundation/foundation/src/jsTest/kotlin/test/IgnoreTargetsActuals.js.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.test
+
+actual typealias IgnoreWasmTarget = kotlin.test.Ignore

--- a/compose/foundation/foundation/src/nativeTest/kotlin/test/IgnoreTargetsActuals.native.kt
+++ b/compose/foundation/foundation/src/nativeTest/kotlin/test/IgnoreTargetsActuals.native.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.test
+
+actual typealias IgnoreWasmTarget = DoNothing

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.test.IgnoreWasmTarget
 
 @OptIn(ExperimentalTestApi::class)
 class ScrollableTest {
@@ -2153,6 +2154,8 @@ class ScrollableTest {
 
     @OptIn(ExperimentalFoundationApi::class)
     @Test
+    @IgnoreWasmTarget
+    // TODO(shabunc): https://youtrack.jetbrains.com/issue/COMPOSE-805/Fix-producingEqualMaterializedModifierAfterRecomposition-test-om-wasm-target
     fun producingEqualMaterializedModifierAfterRecomposition() = runSkikoComposeUiTest {
         val state = ScrollableState { it }
         val counter = mutableStateOf(0)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldCursorTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldCursorTest.kt
@@ -59,6 +59,7 @@ import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlinx.test.IgnoreWasmTarget
 
 @OptIn(ExperimentalTestApi::class)
 class TextFieldCursorTest {
@@ -305,6 +306,7 @@ class TextFieldCursorTest {
     }
 
     @Test
+    @IgnoreWasmTarget
     fun selectionChanges_cursorNotBlinking() = runSkikoComposeUiTest {
         mainClock.autoAdvance = false
         val textValue = mutableStateOf(TextFieldValue("test", selection = TextRange(2)))

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.test.IgnoreWasmTarget
 
 class CupertinoTextFieldDelegateTest {
     private val sampleText =
@@ -122,6 +123,7 @@ class CupertinoTextFieldDelegateTest {
     }
 
     @Test
+    @IgnoreWasmTarget
     fun determineCursorDesiredOffset_tap_on_the_right_edge_empty_line() {
         // Tap was on the last line in the given example string
         val givenOffset = 231
@@ -150,6 +152,7 @@ class CupertinoTextFieldDelegateTest {
     }
 
     @Test
+    @IgnoreWasmTarget
     fun determineCursorDesiredOffset_tap_on_the_left_edge_empty_line() {
         // Tap was on the last line in the given example string
         val givenOffset = 231

--- a/compose/foundation/foundation/src/skikoTest/kotlin/test/IgnoreTargets.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/test/IgnoreTargets.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.test
+
+annotation class DoNothing
+
+expect annotation class IgnoreWasmTarget

--- a/compose/foundation/foundation/src/wasmJsTest/kotlin/test/IgnoreTargetsActuals.wasmJs.kt
+++ b/compose/foundation/foundation/src/wasmJsTest/kotlin/test/IgnoreTargetsActuals.wasmJs.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotlinx.test
+
+actual typealias IgnoreWasmTarget = kotlin.test.Ignore


### PR DESCRIPTION
All off them except one are already fixed in newer skiko and will be enabled later on, as soon as we'll update skiko dependency in compose