### PR TITLE
Add Arial and Consolas as backup fonts on Linux and mention font name when one fails to load

### DIFF
--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/font/FontFamilyResolver.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/font/FontFamilyResolver.kt
@@ -66,7 +66,7 @@ internal class FontFamilyResolverImpl(
                 platformFontLoader = platformFontLoader,
                 onAsyncCompletion = { /* nothing */ },
                 createDefaultTypeface = createDefaultTypeface
-            ) ?: throw IllegalStateException("Could not load font")
+            ) ?: throw FontLoadFailedException(typeRequest.fontFamily)
         }
     }
 
@@ -100,7 +100,7 @@ internal class FontFamilyResolverImpl(
                 platformFontLoader,
                 onAsyncCompletion,
                 createDefaultTypeface
-            ) ?: throw IllegalStateException("Could not load font")
+            ) ?: throw FontLoadFailedException(typefaceRequest.fontFamily)
         }
         return result
     }
@@ -204,7 +204,7 @@ internal class TypefaceRequestCache {
                 }
             }
         } catch (cause: Exception) {
-            throw IllegalStateException("Could not load font", cause)
+            throw FontLoadFailedException(typefaceRequest.fontFamily, cause)
         }
         synchronized(lock) {
             // async result may have completed prior to this block entering, do not overwrite
@@ -229,7 +229,7 @@ internal class TypefaceRequestCache {
             val next = try {
                 resolveTypeface(typeRequest)
             } catch (cause: Exception) {
-                throw IllegalStateException("Could not load font", cause)
+                throw FontLoadFailedException(typeRequest.fontFamily, cause)
             }
 
             // only cache immutable, should not reach as FontListFontFamilyTypefaceAdapter already
@@ -253,3 +253,11 @@ internal class TypefaceRequestCache {
             resultCache.size
         }
 }
+
+internal class FontLoadFailedException(
+    fontFamily: FontFamily?,
+    cause: Throwable? = null,
+) : IllegalStateException(
+    message = "Failed to load font $fontFamily. Is it installed on the system?",
+    cause = cause,
+)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -278,9 +278,9 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
     when (currentPlatform()) {
         Platform.Linux ->
             mapOf(
-                FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans"),
+                FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans", "Arial"),
                 FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
-                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono"),
+                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono", "Consolas"),
                 // better alternative?
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )


### PR DESCRIPTION
## Proposed Changes
One of the users of my Compose Multiplatform app [ran into an issue](https://github.com/zacharee/SamloaderKotlin/issues/123) where the app immediately crashed on Arch saying "could not load font". I couldn't reproduce it, but when they asked for the fonts Compose is looking for and I started looking into it, I realized they might not have the right fonts installed. After they installed DejaVu Sans, the app opened as normal.

This PR does a few things:
- Adds "Arial" as a backup font for SansSerif.
- Adds "Consolas" as a backup font for Monospace.
- Expands on the "could not load font" error a bit to mention the font family and also indicate that the font might be missing from the system.

## Testing

Test: Get a Linux GUI up and running without Noto Sans or DejaVu Sans installed, but with Arial installed. Build a Compose sample app and it should run using Arial. Remove Arial and the error thrown should now be more descriptive.

## Issues Fixed
N/A

## Google CLA
Signed