### PR TITLE
Fix text style in mpp demo

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontFamilies.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontFamilies.kt
@@ -62,13 +62,13 @@ fun FontFamilyShowcase(fontFamily: FontFamily) {
         )
         Text(
             text = "The quick brown fox jumps over the lazy dog.",
-            fontSize = 48.sp,
-            fontFamily = fontFamily
+            fontFamily = fontFamily,
+            style = MaterialTheme.typography.h3
         )
         Text(
             text = "1234567890",
-            fontSize = 48.sp,
-            fontFamily = fontFamily
+            fontFamily = fontFamily,
+            style = MaterialTheme.typography.h3
         )
     }
 }


### PR DESCRIPTION
## Proposed Changes

After https://github.com/JetBrains/compose-multiplatform-core/commit/b4443bdb5e16dd90082451add9856171bc964888 (1.6.0 merge) `lineHeight` is explicitly specified in `MaterialTheme`. It makes incorrect usage of `fontSize` parameter alone. This behavior already exists in material3, so it's by design.
This PR fixes the incorrect usage in our demo app.

## Testing

Test: run mpp > "FontFamilies" page

![image](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/8947e06d-9eff-4139-bc7c-c81b30bef72c)
