### PR TITLE
Add support for text decoration line styles via PlatformTextStyle

### DIFF
--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -1425,7 +1425,7 @@ public final class androidx/compose/ui/text/platform/ResourceFont : androidx/com
 }
 
 public final class androidx/compose/ui/text/platform/SkiaParagraph_skikoKt {
-	public static final fun toSkDecorationStyle-zoh9Kos (Landroidx/compose/ui/text/style/TextDecoration;JLandroidx/compose/ui/text/TextDecorationLineStyle;)Lorg/jetbrains/skia/paragraph/DecorationStyle;
+	public static final synthetic fun toSkDecorationStyle-4WTKRHQ (Landroidx/compose/ui/text/style/TextDecoration;J)Lorg/jetbrains/skia/paragraph/DecorationStyle;
 	public static final fun toSkFontStyle-nzbMABs (I)Lorg/jetbrains/skia/FontStyle;
 	public static final fun toSkPlaceholderAlignment-do9X-Gg (I)Lorg/jetbrains/skia/paragraph/PlaceholderAlignment;
 }

--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -334,7 +334,9 @@ public final class androidx/compose/ui/text/PlatformSpanStyle {
 	public static final field $stable I
 	public static final field Companion Landroidx/compose/ui/text/PlatformSpanStyle$Companion;
 	public fun <init> ()V
+	public synthetic fun <init> (Landroidx/compose/ui/text/TextDecorationLineStyle;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTextDecorationLineStyle-Gch4ia8 ()Landroidx/compose/ui/text/TextDecorationLineStyle;
 	public fun hashCode ()I
 	public final fun merge (Landroidx/compose/ui/text/PlatformSpanStyle;)Landroidx/compose/ui/text/PlatformSpanStyle;
 }
@@ -346,6 +348,7 @@ public final class androidx/compose/ui/text/PlatformSpanStyle$Companion {
 public final class androidx/compose/ui/text/PlatformTextStyle {
 	public static final field $stable I
 	public fun <init> (Landroidx/compose/ui/text/PlatformSpanStyle;Landroidx/compose/ui/text/PlatformParagraphStyle;)V
+	public synthetic fun <init> (Landroidx/compose/ui/text/TextDecorationLineStyle;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getParagraphStyle ()Landroidx/compose/ui/text/PlatformParagraphStyle;
 	public final fun getSpanStyle ()Landroidx/compose/ui/text/PlatformSpanStyle;
@@ -414,6 +417,28 @@ public final class androidx/compose/ui/text/StringKt {
 
 public final class androidx/compose/ui/text/SynchronizationKt {
 	public static final fun synchronized (Landroidx/compose/ui/text/SynchronizedObject;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class androidx/compose/ui/text/TextDecorationLineStyle {
+	public static final field Companion Landroidx/compose/ui/text/TextDecorationLineStyle$Companion;
+	public static final synthetic fun box-impl (I)Landroidx/compose/ui/text/TextDecorationLineStyle;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class androidx/compose/ui/text/TextDecorationLineStyle$Companion {
+	public final fun getDashed-671RMmY ()I
+	public final fun getDotted-671RMmY ()I
+	public final fun getDouble-671RMmY ()I
+	public final fun getSolid-671RMmY ()I
+	public final fun getWavy-671RMmY ()I
 }
 
 public final class androidx/compose/ui/text/TextLayoutInput {
@@ -1400,7 +1425,7 @@ public final class androidx/compose/ui/text/platform/ResourceFont : androidx/com
 }
 
 public final class androidx/compose/ui/text/platform/SkiaParagraph_skikoKt {
-	public static final fun toSkDecorationStyle-4WTKRHQ (Landroidx/compose/ui/text/style/TextDecoration;J)Lorg/jetbrains/skia/paragraph/DecorationStyle;
+	public static final fun toSkDecorationStyle-zoh9Kos (Landroidx/compose/ui/text/style/TextDecoration;JLandroidx/compose/ui/text/TextDecorationLineStyle;)Lorg/jetbrains/skia/paragraph/DecorationStyle;
 	public static final fun toSkFontStyle-nzbMABs (I)Lorg/jetbrains/skia/FontStyle;
 	public static final fun toSkPlaceholderAlignment-do9X-Gg (I)Lorg/jetbrains/skia/paragraph/PlaceholderAlignment;
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextDecorationLineStyle.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextDecorationLineStyle.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import kotlin.jvm.JvmInline
+
+/**
+ * Defines the style of the text decoration line (e.g. underline).
+ *
+ * The decoration itself is determined via [androidx.compose.ui.text.style.TextDecoration].
+ */
+@ExperimentalTextApi
+@JvmInline
+value class TextDecorationLineStyle internal constructor(val value: Int) {
+
+    override fun toString(): String {
+        return when (this) {
+            Solid -> "Solid"
+            Double -> "Double"
+            Dotted -> "Dotted"
+            Dashed -> "Dashed"
+            Wavy -> "Wavy"
+            else -> "Invalid"
+        }
+    }
+
+    companion object {
+        /**
+         * Solid line.
+         */
+        val Solid = TextDecorationLineStyle(1)
+
+        /**
+         * Double line.
+         */
+        val Double = TextDecorationLineStyle(2)
+
+        /**
+         * Dotted line.
+         */
+        val Dotted = TextDecorationLineStyle(3)
+
+        /**
+         * Dashed line.
+         */
+        val Dashed = TextDecorationLineStyle(4)
+
+        /**
+         * Wavy line.
+         */
+        val Wavy = TextDecorationLineStyle(5)
+    }
+
+}

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -37,6 +37,9 @@ actual class PlatformTextStyle {
 
     /**
      * Allows specifying the style of the decoration line for the text.
+     *
+     * This parameter is relevant only if `textDecoration` is specified, for example in
+     * `TextStyle(textDecoration = )` or in `SpanStyle(textDecoration = )`
      */
     @ExperimentalTextApi
     constructor(
@@ -94,9 +97,11 @@ actual class PlatformParagraphStyle {
 /**
  * Provides configuration options for behavior compatibility for SpanStyle.
  *
- * @param textDecorationLineStyle The style of the text decoration line.
+ * @param textDecorationLineStyle The style of the text decoration line. Note that this parameter is
+ * relevant only if `textDecoration` is specified, for example in `TextStyle(textDecoration = )` or
+ * in `SpanStyle(textDecoration = )`.
  */
-actual class PlatformSpanStyle(
+actual class PlatformSpanStyle @ExperimentalTextApi constructor(
     val textDecorationLineStyle: TextDecorationLineStyle?
 ) {
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:JvmName("DesktopTextStyleKt")
+@file:JvmName("DesktopTextStyle_skikoKt")
 
 package androidx.compose.ui.text
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
+@file:JvmName("DesktopTextStyleKt")
+
 package androidx.compose.ui.text
+
+import kotlin.jvm.JvmName
 
 /**
  * Provides configuration options for behavior compatibility for TextStyle.
@@ -30,6 +34,17 @@ actual class PlatformTextStyle {
         this.spanStyle = spanStyle
         this.paragraphStyle = paragraphStyle
     }
+
+    /**
+     * Allows specifying the style of the decoration line for the text.
+     */
+    @ExperimentalTextApi
+    constructor(
+        textDecorationLineStyle: TextDecorationLineStyle?
+    ) : this (
+        spanStyle = PlatformSpanStyle(textDecorationLineStyle),
+        paragraphStyle = null
+    )
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -78,8 +93,16 @@ actual class PlatformParagraphStyle {
 
 /**
  * Provides configuration options for behavior compatibility for SpanStyle.
+ *
+ * @param textDecorationLineStyle The style of the text decoration line.
  */
-actual class PlatformSpanStyle {
+actual class PlatformSpanStyle(
+    val textDecorationLineStyle: TextDecorationLineStyle?
+) {
+
+    constructor() : this(textDecorationLineStyle = null)
+
+
     actual companion object {
         actual val Default: PlatformSpanStyle = PlatformSpanStyle()
     }
@@ -91,12 +114,12 @@ actual class PlatformSpanStyle {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is PlatformSpanStyle) return false
+        if (textDecorationLineStyle != other.textDecorationLineStyle) return false
         return true
     }
 
-    @Suppress("RedundantOverride")
     override fun hashCode(): Int {
-        return super.hashCode()
+        return textDecorationLineStyle.hashCode()
     }
 }
 
@@ -139,5 +162,13 @@ actual fun lerp(
     stop: PlatformSpanStyle,
     fraction: Float
 ): PlatformSpanStyle {
-    return start
+    if (start.textDecorationLineStyle == stop.textDecorationLineStyle) return start
+
+    return PlatformSpanStyle(
+        textDecorationLineStyle = lerpDiscrete(
+            start.textDecorationLineStyle,
+            stop.textDecorationLineStyle,
+            fraction
+        )
+    )
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -435,8 +435,8 @@ internal class ParagraphBuilder(
         cuts.sortBy { it.position }
         val activeStyles = mutableListOf(initialStyle)
         for (cut in cuts) {
-            when {
-                cut is Cut.StyleAdd -> {
+            when (cut) {
+                is Cut.StyleAdd -> {
                     activeStyles.add(cut.style)
                     val prev = previousStyleAddAtTheSamePosition(cut.position, ops)
                     if (prev == null) {
@@ -450,11 +450,11 @@ internal class ParagraphBuilder(
                         prev.style.merge(density, cut.style)
                     }
                 }
-                cut is Cut.StyleRemove -> {
+                is Cut.StyleRemove -> {
                     activeStyles.remove(cut.style)
                     ops.add(Op.StyleAdd(cut.position, mergeStyles(activeStyles)))
                 }
-                cut is Cut.PutPlaceholder -> {
+                is Cut.PutPlaceholder -> {
                     val currentStyle = mergeStyles(activeStyles)
                     val op = Op.PutPlaceholder(
                         cut = cut,
@@ -469,8 +469,7 @@ internal class ParagraphBuilder(
                     )
                     ops.add(op)
                 }
-                cut is Cut.EndPlaceholder ->
-                    ops.add(Op.EndPlaceholder(cut))
+                is Cut.EndPlaceholder -> ops.add(Op.EndPlaceholder(cut))
             }
         }
         return ops
@@ -629,8 +628,16 @@ fun FontStyle.toSkFontStyle(): SkFontStyle {
     }
 }
 
-// TODO: Remove from public
-fun TextDecoration.toSkDecorationStyle(
+@Suppress("unused")
+@Deprecated(
+    message = "This method was not intended to be public",
+    level = DeprecationLevel.HIDDEN
+)
+fun TextDecoration.toSkDecorationStyle(color: Color): SkDecorationStyle {
+    return toSkDecorationStyle(color, null)
+}
+
+private fun TextDecoration.toSkDecorationStyle(
     color: Color,
     textDecorationLineStyle: TextDecorationLineStyle?
 ): SkDecorationStyle {


### PR DESCRIPTION
## Proposed Changes

Skia already supports different text decoration (e.g. underline) styles (e.g. solid, dashed, dotted etc.), but we don't expose this.

This PR exposes it via `PlatformTextStyle`.

<img width="198" alt="image" src="https://github.com/JetBrains/compose-multiplatform-core/assets/5230206/175e89de-fb02-4446-bfad-9248a8cf13c9">

```
import androidx.compose.material.Text
import androidx.compose.ui.text.ExperimentalTextApi
import androidx.compose.ui.text.PlatformTextStyle
import androidx.compose.ui.text.TextDecorationLineStyle
import androidx.compose.ui.text.TextStyle
import androidx.compose.ui.text.style.TextDecoration
import androidx.compose.ui.window.singleWindowApplication

@OptIn(ExperimentalTextApi::class)
fun main() = singleWindowApplication {
    Text(
        "Hello, Compose",
        style = TextStyle(
            textDecoration = TextDecoration.Underline,
            platformStyle = PlatformTextStyle(
                textDecorationLineStyle = TextDecorationLineStyle.Dotted
            )
        )
    )
}
```
Note that this isn't supported on Android.

## Testing

Test: Manually.

