### PR TITLE
Fix material icons API verification on windows

### DIFF
--- a/compose/material/material/icons/generator/api/.gitattributes
+++ b/compose/material/material/icons/generator/api/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf


### PR DESCRIPTION
## Proposed Changes

Fixes git line endings to fix API check of material icons on windows.
```
Found differences when comparing API files!
Please check the difference and copy over the changes if intended.
expected file: compose\material\material\icons\generator\api\icons.txt
generated file: out\androidx\compose\material\material-icons-core\build\generatedIcons\allVariants\api\icons.txt
Please manually un-ignore and run ExtendedIconComparisonTest locally before uploading.
```

## Testing

Test: try to run mpp from windows