### PR TITLE
Prepare foundation/foundation SelectionTests for using on all platforms 

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/DesktopSelectionTests.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/DesktopSelectionTests.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.foundation.text.KeyMapping
+import androidx.compose.foundation.text.createMacosDefaultKeyMapping
+import androidx.compose.foundation.text.defaultSkikoKeyMapping
+import androidx.compose.foundation.text.overriddenDefaultKeyMapping
+import kotlin.test.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class DesktopSelectionTests(keyboardActions: KeyboardActions, keyMapping: KeyMapping) :
+    CommonSelectionTests(
+        DefaultKeyboardActions, defaultSkikoKeyMapping
+    ) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "with {0}")
+        fun initParameters() = arrayOf(
+            arrayOf(DefaultKeyboardActions, defaultSkikoKeyMapping),
+            arrayOf(MacosKeyboardActions, createMacosDefaultKeyMapping())
+        )
+    }
+
+    override fun setPlatformDefaultKeyMapping(value: KeyMapping) {
+        overriddenDefaultKeyMapping = value
+    }
+
+    @Test
+    override fun selectLineStartTest() {
+        selectLineStart()
+    }
+
+    @Test
+    override fun selectTextStartTest() {
+        selectTextStart()
+    }
+
+    @Test
+    override fun selectTextEndTest() {
+        selectTextEnd()
+    }
+
+    @Test
+    override fun selectLineEndTest() {
+        selectLineEnd()
+    }
+
+    @Test
+    override fun deleteAllTest() {
+        deleteAll()
+    }
+
+    @Test
+    override fun selectAllTest() {
+        selectAll()
+    }
+}

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/DesktopSelectionTests.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/DesktopSelectionTests.kt
@@ -27,7 +27,7 @@ import org.junit.runners.Parameterized
 @RunWith(Parameterized::class)
 internal class DesktopSelectionTests(keyboardActions: KeyboardActions, keyMapping: KeyMapping) :
     CommonSelectionTests(
-        DefaultKeyboardActions, defaultSkikoKeyMapping
+        keyboardActions, keyMapping
     ) {
 
     companion object {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/config/KeyboardActions.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/config/KeyboardActions.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection.config
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.KeyInjectionScope
+import androidx.compose.ui.test.pressKey
+
+interface KeyboardActions {
+    fun KeyInjectionScope.selectAll()
+    fun KeyInjectionScope.selectLineStart()
+    fun KeyInjectionScope.selectTextStart()
+    fun KeyInjectionScope.selectLineEnd()
+    fun KeyInjectionScope.selectTextEnd()
+    fun KeyInjectionScope.deleteAll()
+}
+
+object DefaultKeyboardActions : KeyboardActions {
+    override fun KeyInjectionScope.selectAll() {
+        keyDown(Key.CtrlLeft)
+        pressKey(Key.A)
+        keyUp(Key.CtrlLeft)
+    }
+
+    override fun KeyInjectionScope.selectLineStart() {
+        keyDown(Key.ShiftLeft)
+        pressKey(Key.MoveHome)
+        keyUp(Key.ShiftLeft)
+    }
+
+    override fun KeyInjectionScope.selectTextStart() {
+        keyDown(Key.CtrlLeft)
+        keyDown(Key.ShiftLeft)
+        pressKey(Key.MoveHome)
+        keyUp(Key.ShiftLeft)
+        keyUp(Key.CtrlLeft)
+    }
+
+    override fun KeyInjectionScope.selectLineEnd() {
+        keyDown(Key.ShiftLeft)
+        pressKey(Key.MoveEnd)
+        keyUp(Key.ShiftLeft)
+    }
+
+    override fun KeyInjectionScope.selectTextEnd() {
+        keyDown(Key.CtrlLeft)
+        keyDown(Key.ShiftLeft)
+        pressKey(Key.MoveEnd)
+        keyUp(Key.ShiftLeft)
+        keyUp(Key.CtrlLeft)
+    }
+
+    override fun KeyInjectionScope.deleteAll() {
+        keyDown(Key.CtrlLeft)
+        keyDown(Key.Backspace)
+    }
+
+    override fun toString() = "Win"
+}
+
+object MacosKeyboardActions : KeyboardActions {
+    override fun KeyInjectionScope.selectAll() {
+        keyDown(Key.MetaLeft)
+        pressKey(Key.A)
+        keyUp(Key.MetaLeft)
+    }
+
+    override fun KeyInjectionScope.selectLineStart() {
+        keyDown(Key.ShiftLeft)
+        keyDown(Key.MetaLeft)
+        pressKey(Key.DirectionLeft)
+        keyUp(Key.ShiftLeft)
+        keyUp(Key.MetaLeft)
+    }
+
+    override fun KeyInjectionScope.selectTextStart() {
+        keyDown(Key.ShiftLeft)
+        pressKey(Key.Home)
+        keyUp(Key.ShiftLeft)
+    }
+
+    override fun KeyInjectionScope.selectLineEnd() {
+        keyDown(Key.ShiftLeft)
+        keyDown(Key.MetaLeft)
+        pressKey(Key.DirectionRight)
+        keyUp(Key.ShiftLeft)
+        keyUp(Key.MetaLeft)
+    }
+
+    override fun KeyInjectionScope.selectTextEnd() {
+        keyDown(Key.ShiftLeft)
+        pressKey(Key.MoveEnd)
+        keyUp(Key.ShiftLeft)
+    }
+
+    override fun KeyInjectionScope.deleteAll() {
+        keyDown(Key.MetaLeft)
+        keyDown(Key.Delete)
+    }
+
+    override fun toString() = "MacOS"
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/KeyboardActions.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/KeyboardActions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation.text.selection.config
+package androidx.compose.foundation.text.selection
 
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.KeyInjectionScope


### PR DESCRIPTION
This is a part of a bigger job about commonizing all tests in foundation, however it exist as a separate PR because SelectionTests are somewhat special - without more intrusive changes we can not test different keyboard mappings in common. 