### PR TITLE
Provide default values for uikit composition locals.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/LocalUIKitInteropContext.kt
@@ -40,7 +40,7 @@ internal interface UIKitInteropTransaction {
     companion object {
         val empty = object : UIKitInteropTransaction {
             override val actions: List<UIKitInteropAction>
-                get() = listOf()
+                get() = emptyList()
 
             override val state: UIKitInteropState
                 get() = UIKitInteropState.UNCHANGED

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
@@ -25,17 +25,13 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * Composition local for SafeArea of ComposeUIViewController
  */
 @InternalComposeApi
-val LocalSafeArea = staticCompositionLocalOf<PlatformInsets> {
-    error("CompositionLocal LocalSafeArea not present")
-}
+val LocalSafeArea = staticCompositionLocalOf { PlatformInsets.Zero }
 
 /**
  * Composition local for layoutMargins of ComposeUIViewController
  */
 @InternalComposeApi
-val LocalLayoutMargins = staticCompositionLocalOf<PlatformInsets> {
-    error("CompositionLocal LocalLayoutMargins not present")
-}
+val LocalLayoutMargins = staticCompositionLocalOf { PlatformInsets.Zero }
 
 @OptIn(InternalComposeApi::class)
 private object SafeAreaInsetsConfig : InsetsConfig {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.uikit
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.InternalComposeApi
-import androidx.compose.runtime.State
 import androidx.compose.runtime.staticCompositionLocalOf
 import platform.UIKit.*
 
@@ -35,7 +34,7 @@ enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
 
     companion object {
         fun getByRawValue(orientation: UIInterfaceOrientation): InterfaceOrientation? {
-            return values().firstOrNull {
+            return entries.firstOrNull {
                 it.rawValue == orientation
             }
         }
@@ -46,6 +45,4 @@ enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
  * Composition local for [InterfaceOrientation]
  */
 @InternalComposeApi
-val LocalInterfaceOrientation = staticCompositionLocalOf<InterfaceOrientation> {
-    error("CompositionLocal LocalInterfaceOrientation not present")
-}
+val LocalInterfaceOrientation = staticCompositionLocalOf { InterfaceOrientation.Portrait }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/KeyboardOverlapHeight.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/KeyboardOverlapHeight.uikit.kt
@@ -24,6 +24,4 @@ import androidx.compose.runtime.staticCompositionLocalOf
  * Composition local for height that is overlapped with keyboard over Compose view.
  */
 @InternalComposeApi
-val LocalKeyboardOverlapHeight = staticCompositionLocalOf<Float> {
-    error("CompositionLocal LocalKeyboardOverlapHeight not present")
-}
+val LocalKeyboardOverlapHeight = staticCompositionLocalOf { 0f }


### PR DESCRIPTION
## Proposed Changes

In order for the test API to work, we need to provide the regular (non-interop) composition locals an iOS app would expect.
This PR provides the following defaults:

  - LocalSafeArea = PlatformInsets.Zero
  - LocalLayoutMargins = PlatformInsets.Zero
  - LocalInterfaceOrientation = InterfaceOrientation.Portrait
  - LocalKeyboardOverlapHeight = 0f

## Testing

Test: Will let the CI run the tests.
