### PR TITLE
Fix missing case for loading `SystemFont` on iOS

### DIFF
--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeFont.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/platform/NativeFont.native.kt
@@ -17,8 +17,12 @@ package androidx.compose.ui.text.platform
 
 import kotlin.native.Platform as NativePlatform
 import org.jetbrains.skia.Typeface as SkTypeface
+import org.jetbrains.skia.FontStyle as SkFontStyle
 import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontStyle
 import org.jetbrains.skia.Data
+import org.jetbrains.skia.FontSlant
+import org.jetbrains.skia.FontWidth
 
 internal actual fun loadTypeface(font: Font): SkTypeface {
     if (font !is PlatformFont) {
@@ -27,10 +31,18 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
     @Suppress("REDUNDANT_ELSE_IN_WHEN")
     return when (font) {
         is LoadedFont -> SkTypeface.makeFromData(Data.makeFromBytes(font.getData()))
+        is SystemFont -> SkTypeface.makeFromName(font.identity, font.skFontStyle)
         // TODO: compilation fails without `else` see https://youtrack.jetbrains.com/issue/KT-43875
         else -> throw IllegalArgumentException("Unsupported font type: $font")
     }
 }
+
+private val Font.skFontStyle: SkFontStyle
+    get() = SkFontStyle(
+        weight = weight.weight,
+        width = FontWidth.NORMAL,
+        slant = if (style == FontStyle.Italic) FontSlant.ITALIC else FontSlant.UPRIGHT
+    )
 
 internal actual fun currentPlatform(): Platform = when (NativePlatform.osFamily) {
     OsFamily.MACOSX -> Platform.MacOS


### PR DESCRIPTION
## Proposed Changes

- Missing piece of #898
- It's a copy-paste of already existing code.

## Testing

Test: try to use `SystemFont` on iOS

```kt
FontFamily(SystemFont("Helvetica")),
FontFamily(SystemFont("Times New Roman")),
FontFamily(SystemFont("Courier")),
```

![Simulator Screenshot - iPhone 15 Pro - 2024-01-23 at 14 02 50](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/56738d38-41fd-40c1-9408-0f3cacb38a2d)