### PR TITLE
Fix selection handles crossed

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.uikit.kt
@@ -71,7 +71,7 @@ internal actual fun SelectionHandle(
 
     val handleColor = LocalTextSelectionColors.current.handleColor
     Popup(
-        popupPositionProvider = remember {
+        popupPositionProvider = remember(isLeft) {
             object : PopupPositionProvider {
                 override fun calculatePosition(
                     anchorBounds: IntRect,


### PR DESCRIPTION
After merge with androidx-main SelectionHandles works incorrect in crossed state

Issue https://youtrack.jetbrains.com/issue/COMPOSE-866