### PR TITLE
CfW: remove `kotlinWasmEnabled` gradle property

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -69,9 +69,6 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         println("Skiko version = $skikoVersion")
     }
 
-    override val isKotlinWasmTargetEnabled: Boolean
-        get() = project.properties["kotlinWasmEnabled"] == "true"
-
     override fun android(): Unit = multiplatformExtension.run {
         androidTarget()
 
@@ -108,7 +105,6 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
 
     @OptIn(ExperimentalWasmDsl::class)
     override fun wasm(): Unit = multiplatformExtension.run {
-        if (!isKotlinWasmTargetEnabled) return@run
         wasmJs {
             browser {
                 testTask(Action<KotlinJsTest> {

--- a/buildSrc/public/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtension.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtension.kt
@@ -58,6 +58,4 @@ abstract class AndroidXComposeMultiplatformExtension {
      * Configures native compilation tasks with flags to link required frameworks
      */
     abstract fun configureDarwinFlags(): Unit
-
-    abstract val isKotlinWasmTargetEnabled: Boolean
 }

--- a/collection/collection/build.gradle
+++ b/collection/collection/build.gradle
@@ -87,9 +87,7 @@ kotlin {
         jsMain.dependsOn(jsWasmMain)
         desktopMain.dependsOn(jbMain)
 
-        if (project.kotlinWasmEnabled.toBoolean()) {
-            wasmJsMain.dependsOn(jsWasmMain)
-        }
+        wasmJsMain.dependsOn(jsWasmMain)
 
         nativeMain.dependsOn(jsNativeMain)
         linuxArm64Main.dependsOn(nativeMain)

--- a/compose/animation/animation-core/build.gradle
+++ b/compose/animation/animation-core/build.gradle
@@ -126,13 +126,9 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             desktopMain.dependsOn(jbMain)
             jsNativeMain.dependsOn(jbMain)
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
-
-
 
             // TODO(b/214407011): These dependencies leak into instrumented tests as well. If you
             //  need to add Robolectric (which must be kept out of androidAndroidTest), use a top

--- a/compose/animation/animation-graphics/build.gradle
+++ b/compose/animation/animation-graphics/build.gradle
@@ -103,10 +103,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
 
             // TODO(b/214407011): These dependencies leak into instrumented tests as well. If you

--- a/compose/animation/animation/build.gradle
+++ b/compose/animation/animation/build.gradle
@@ -104,10 +104,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
 
             // TODO(b/214407011): These dependencies leak into instrumented tests as well. If you

--- a/compose/foundation/foundation-layout/build.gradle
+++ b/compose/foundation/foundation-layout/build.gradle
@@ -123,10 +123,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
 
             // TODO(b/214407011): These dependencies leak into instrumented tests as well. If you

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -139,10 +139,8 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
 
             commonTest {

--- a/compose/material/material-ripple/build.gradle
+++ b/compose/material/material-ripple/build.gradle
@@ -105,10 +105,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
         }
     }

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -135,10 +135,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
             }
 
             // TODO(b/214407011): These dependencies leak into instrumented tests as well. If you

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -135,12 +135,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             nativeMain.dependsOn(jsNativeMain)
             jsWasmMain.dependsOn(jsNativeMain)
             jsMain.dependsOn(jsWasmMain)
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                    }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
+                dependencies {
+                    implementation(libs.kotlinStdlib)
                 }
             }
 

--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -104,11 +104,9 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             jsMain {}
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                    }
+            wasmJsMain {
+                dependencies {
+                    implementation(libs.kotlinStdlib)
                 }
             }
 

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -159,10 +159,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsTest.dependsOn(jbTest)
             nativeTest.dependsOn(jbTest)
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain.dependsOn(jsWasmMain)
-                wasmJsTest.dependsOn(jbTest)
-            }
+            wasmJsMain.dependsOn(jsWasmMain)
+            wasmJsTest.dependsOn(jbTest)
 
             nativeMain {
                 dependsOn(jsNativeMain)

--- a/compose/ui/ui-geometry/build.gradle
+++ b/compose/ui/ui-geometry/build.gradle
@@ -77,14 +77,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             }
             desktopTest.kotlin.srcDirs("src/test/kotlin")
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                    }
+            wasmJsMain {
+                dependencies {
+                    implementation(libs.kotlinStdlib)
                 }
             }
-
         }
     }
 }

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -113,14 +113,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                        implementation(libs.create("skikoWasm"))
-                        implementation(libs.create("skikoWasmWasm"))
-                    }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
+                dependencies {
+                    implementation(libs.kotlinStdlib)
+                    implementation(libs.create("skikoWasm"))
+                    implementation(libs.create("skikoWasmWasm"))
                 }
             }
 

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -141,13 +141,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsWasmMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                    dependencies {
-                        implementation(libs.create("skikoWasm"))
-                        implementation(libs.create("skikoWasmWasm"))
-                    }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
+                dependencies {
+                    implementation(libs.create("skikoWasm"))
+                    implementation(libs.create("skikoWasmWasm"))
                 }
             }
 

--- a/compose/ui/ui-unit/build.gradle
+++ b/compose/ui/ui-unit/build.gradle
@@ -95,12 +95,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(jsNativeMain)
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsNativeMain)
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                    }
+            wasmJsMain {
+                dependsOn(jsNativeMain)
+                dependencies {
+                    implementation(libs.kotlinStdlib)
                 }
             }
 

--- a/compose/ui/ui-util/build.gradle
+++ b/compose/ui/ui-util/build.gradle
@@ -73,14 +73,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsMain.dependsOn(jbMain)
             desktopMain.dependsOn(jbMain)
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                    }
+            wasmJsMain {
+                dependencies {
+                    implementation(libs.kotlinStdlib)
                 }
-                wasmJsMain.dependsOn(jbMain)
             }
+            wasmJsMain.dependsOn(jbMain)
 
             commonTest.dependencies {
                 implementation(kotlin("test-junit"))

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -225,14 +225,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 }
             }
 
-            if (project.kotlinWasmEnabled.toBoolean()) {
-                wasmJsMain {
-                    dependsOn(jsWasmMain)
-                    dependencies {
-                        implementation(libs.kotlinStdlib)
-                        implementation(libs.create("skikoWasm"))
-                        implementation(libs.create("skikoWasmWasm"))
-                    }
+            wasmJsMain {
+                dependsOn(jsWasmMain)
+                dependencies {
+                    implementation(libs.kotlinStdlib)
+                    implementation(libs.create("skikoWasm"))
+                    implementation(libs.create("skikoWasmWasm"))
                 }
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -88,7 +88,6 @@ androidx.versionExtraCheckEnabled=false
 androidx.alternativeProjectUrl=https://github.com/JetBrains/compose-jb
 androidx.validateProjectStructure=false
 jetbrains.compose.jsCompilerTestsEnabled=true
-kotlinWasmEnabled=true
 kotlin.mpp.import.enableKgpDependencyResolution=true
 
 # We prefer to build compose-core libs using our published compose compiler plugin


### PR DESCRIPTION
k/wasm target is now always enabled and the property is redundant