### PR TITLE
Add ability to change opacity for compose view

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -97,10 +97,9 @@ internal class UIViewComposeSceneLayer(
     }
 
     private fun createSkikoUIView(renderDelegate: RenderingUIView.Delegate): RenderingUIView =
-        RenderingUIView(
-            renderDelegate = renderDelegate,
-            transparency = true,
-        )
+        RenderingUIView(renderDelegate = renderDelegate).apply {
+            opaque = true
+        }
 
     private fun createComposeScene(
         invalidate: () -> Unit,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -98,7 +98,7 @@ internal class UIViewComposeSceneLayer(
 
     private fun createSkikoUIView(renderDelegate: RenderingUIView.Delegate): RenderingUIView =
         RenderingUIView(renderDelegate = renderDelegate).apply {
-            opaque = true
+            opaque = false
         }
 
     private fun createComposeScene(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -35,6 +35,11 @@ class ComposeUIViewControllerConfiguration {
 
     @ExperimentalComposeApi
     var platformLayers: Boolean = false
+
+    /**
+     * Determines whether the Compose view should have an opaque background.
+     */
+    var opaque: Boolean = true
 }
 
 /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -39,6 +39,7 @@ class ComposeUIViewControllerConfiguration {
     /**
      * Determines whether the Compose view should have an opaque background.
      */
+    @ExperimentalComposeApi
     var opaque: Boolean = true
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -38,6 +38,7 @@ class ComposeUIViewControllerConfiguration {
 
     /**
      * Determines whether the Compose view should have an opaque background.
+     * Warning: disabling opaque layer may affect performance.
      */
     @ExperimentalComposeApi
     var opaque: Boolean = true

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -143,8 +143,9 @@ internal class ComposeContainer(
 
     override fun loadView() {
         view = UIView().apply {
-            backgroundColor = UIColor.whiteColor
             setClipsToBounds(true)
+            opaque = configuration.opaque
+            backgroundColor = if (configuration.opaque) UIColor.whiteColor else UIColor.clearColor
         } // rootView needs to interop with UIKit
     }
 
@@ -283,10 +284,9 @@ internal class ComposeContainer(
     }
 
     private fun createSkikoUIView(renderRelegate: RenderingUIView.Delegate): RenderingUIView =
-        RenderingUIView(
-            renderDelegate = renderRelegate,
-            transparency = false,
-        )
+        RenderingUIView(renderDelegate = renderRelegate).apply {
+            opaque = configuration.opaque
+        }
 
     @OptIn(ExperimentalComposeApi::class)
     private fun createComposeScene(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -275,17 +275,6 @@ internal class ComposeContainer(
     fun createComposeSceneContext(platformContext: PlatformContext): ComposeSceneContext =
         ComposeSceneContextImpl(platformContext)
 
-    private fun getContentSizeCategory(): UIContentSizeCategory =
-        traitCollection.preferredContentSizeCategory ?: UIContentSizeCategoryUnspecified
-
-    private fun getSystemDensity(): Density {
-        val contentSizeCategory = getContentSizeCategory()
-        return Density(
-            density = UIScreen.mainScreen.scale.toFloat(),
-            fontScale = uiContentSizeCategoryToFontScaleMap[contentSizeCategory] ?: 1.0f
-        )
-    }
-
     @OptIn(ExperimentalComposeApi::class)
     private fun createSkikoUIView(renderRelegate: RenderingUIView.Delegate): RenderingUIView =
         RenderingUIView(renderDelegate = renderRelegate).apply {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -141,6 +141,7 @@ internal class ComposeContainer(
         }
     }
 
+    @OptIn(ExperimentalComposeApi::class)
     override fun loadView() {
         view = UIView().apply {
             setClipsToBounds(true)
@@ -283,6 +284,7 @@ internal class ComposeContainer(
         )
     }
 
+    @OptIn(ExperimentalComposeApi::class)
     private fun createSkikoUIView(renderRelegate: RenderingUIView.Delegate): RenderingUIView =
         RenderingUIView(renderDelegate = renderRelegate).apply {
             opaque = configuration.opaque

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RenderingUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RenderingUIView.uikit.kt
@@ -32,7 +32,6 @@ import platform.UIKit.*
 
 internal class RenderingUIView(
     private val renderDelegate: Delegate,
-    private val transparency: Boolean,
 ) : UIView(
     frame = CGRectMake(
         x = 0.0,
@@ -68,13 +67,17 @@ internal class RenderingUIView(
 
             override fun retrieveInteropTransaction(): UIKitInteropTransaction =
                 renderDelegate.retrieveInteropTransaction()
-        },
-        transparency = transparency,
+        }
     )
+
+    override fun setOpaque(opaque: Boolean) {
+        super.setOpaque(opaque)
+
+        redrawer.opaque = opaque
+    }
 
     init {
         userInteractionEnabled = false
-        opaque = !transparency
 
         metalLayer.also {
             // Workaround for KN compiler bug
@@ -87,7 +90,6 @@ internal class RenderingUIView(
                 it.backgroundColor =
                     CGColorCreate(CGColorSpaceCreateDeviceRGB(), pinned.addressOf(0))
             }
-            it.setOpaque(!transparency)//todo check if remove
             it.framebufferOnly = false
         }
     }


### PR DESCRIPTION
Usage example: 
```
val viewController = ComposeUIViewController(
    configure = { opaque = false }, // Make compose scene background transparent
    content = ::SomeComposeNode
)
```

Related issue: https://github.com/JetBrains/compose-multiplatform/issues/4108