### PR TITLE
iOS modify lifecycle and containment

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.main.defaultUIKitMain
 import androidx.compose.ui.window.ComposeUIViewController
 import bugs.IosBugs
+import bugs.ProperContainmentDisposal
 import bugs.StartRecompositionCheck
 import platform.UIKit.UIViewController
 
@@ -27,6 +28,7 @@ fun IosDemo(arg: String, makeHostingController: ((Int) -> UIViewController)? = n
                 IosBugs,
                 NativeModalWithNaviationExample,
                 UIKitViewOrder,
+                ProperContainmentDisposal,
             ) + listOf(makeHostingController).mapNotNull {
                 it?.let {
                     SwiftUIInteropExample(it)

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/ProperContainmentDisposal.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/ProperContainmentDisposal.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bugs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.interop.LocalUIViewController
+import platform.AVFoundation.AVPlayer
+import platform.AVKit.AVPlayerViewController
+import platform.Foundation.NSURL
+
+val ProperContainmentDisposal = Screen.Example("Proper containment disposal") {
+    Box(Modifier.fillMaxSize().background(Color.DarkGray), contentAlignment = Alignment.Center) {
+        val viewController = LocalUIViewController.current
+        Button(onClick = {
+            val url = NSURL(string = "https://nonexisting")
+            val player = AVPlayer(uRL = url)
+            val playerController = AVPlayerViewController()
+            playerController.player = player
+            viewController.presentViewController(playerController, true, null)
+
+        }) {
+            Text("Present video player")
+        }
+    }
+}

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.h
@@ -20,7 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CMPViewController : UIViewController
 
+/// Indicates that view controller is considered alive in terms of structural containment.
+/// Overriding classes should call super.
 - (void)viewControllerDidEnterWindowHierarchy;
+
+/// Indicates that view controller is considered alive in terms of structural containment
+/// Overriding classes should call super.
 - (void)viewControllerDidLeaveWindowHierarchy;
 
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -56,6 +56,8 @@
         return YES;
     } else if (self.parentViewController != nil) {
         return [self.parentViewController cmp_isInWindowHierarchy];
+    } else if (self.presentingViewController != nil) {
+        return [self.presentingViewController cmp_isInWindowHierarchy];
     } else {
         return [self cmp_isRootViewController];
     }

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -25,13 +25,39 @@
 
 @implementation UIViewController(CMPUIKitUtilsPrivate)
 
+- (BOOL)cmp_isRootViewController {
+    // Check that it's not rootViewController of one of windows of one of the connected scenes.
+    // In most apps it will be a single scene with a single connected window.
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in [UIApplication.sharedApplication connectedScenes]) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                UIWindowScene *windowScene = (UIWindowScene *)scene;
+                
+                for (UIWindow *window in windowScene.windows) {
+                    if (window.rootViewController == self) {
+                        return YES;
+                    }
+                }
+            }
+        }
+    } else {
+        for (UIWindow* window in UIApplication.sharedApplication.windows) {
+            if (window.rootViewController == self) {
+                return YES;
+            }
+        }
+    }
+    
+    return NO;
+}
+
 - (BOOL)cmp_isInWindowHierarchy {
     if (self.view.window != nil) {
         return YES;
     } else if (self.parentViewController != nil) {
         return [self.parentViewController cmp_isInWindowHierarchy];
     } else {
-        return NO;
+        return [self cmp_isRootViewController];
     }
 }
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -91,19 +91,10 @@ typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
-    [self transitLifecycleToStarted];
+        
+    [self viewControllerDidEnterWindowHierarchy];
 }
 
-- (void)didMoveToParentViewController:(UIViewController *)parent {
-    [super didMoveToParentViewController:parent];
-    
-    if (parent) {
-        [self transitLifecycleToStarted];
-    }
-}
-
-/// This method can be triggered by both `viewWillAppear` and `didMoveToParentViewController`. Mind that in second case the `view` could still not be constructed (adding `UIViewController`  to inactive tab of `UITabBarController`, for example), so the `ComposeScene` is not neccessarily created at this point.
 - (void)transitLifecycleToStarted {
     switch (_lifecycleState) {
         case CMPViewControllerLifecycleStateDestroyed:
@@ -145,6 +136,7 @@ typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
 }
 
 - (void)viewControllerDidEnterWindowHierarchy {
+    [self transitLifecycleToStarted];
 }
 
 - (void)viewControllerDidLeaveWindowHierarchy {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import AVKit
 import XCTest
 
 final class CMPViewControllerTests: XCTestCase {
@@ -166,6 +167,29 @@ final class CMPViewControllerTests: XCTestCase {
         }
 
         expect(viewControllers: [viewController1, viewController2, viewController3], toBeInHierarchy: false)
+    }
+    
+    @MainActor
+    public func testFullscreenPresentationOnTop() async {
+        let viewController = TestViewController()
+        appDelegate.window?.rootViewController = viewController
+        
+        expect(viewController: viewController, toBeInHierarchy: true)
+        
+        let urlStr = "https://nonexisting"
+        let url = URL(string: urlStr)!
+        let player = AVPlayer(url: url)
+        let playerController = AVPlayerViewController()
+        playerController.player = player
+        
+        viewController.present(playerController, animated: false)
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        expect(viewController: viewController, toBeInHierarchy: true)
+        playerController.dismiss(animated: false)
+        
+        appDelegate.window?.rootViewController = UIViewController()
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        expect(viewController: viewController, toBeInHierarchy: false)
     }
 }
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
@@ -191,6 +191,31 @@ final class CMPViewControllerTests: XCTestCase {
         try? await Task.sleep(nanoseconds: 2_000_000_000)
         expect(viewController: viewController, toBeInHierarchy: false)
     }
+    
+    @MainActor
+    public func testFullScreenPresentationSandwich() async {
+        let viewController0 = UIViewController()
+        
+        appDelegate.window?.rootViewController = viewController0
+        
+        let viewController1 = TestViewController()
+        viewController1.modalPresentationStyle = .fullScreen
+        
+        let viewController2 = TestViewController()
+        viewController2.modalPresentationStyle = .fullScreen
+        
+        expect(viewControllers: [viewController1, viewController2], toBeInHierarchy: false)
+        
+        viewController0.present(viewController1, animated: false)
+        viewController1.present(viewController2, animated: false)
+        
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        expect(viewControllers: [viewController1, viewController2], toBeInHierarchy: true)
+        
+        viewController0.dismiss(animated: false)
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        expect(viewControllers: [viewController1, viewController2], toBeInHierarchy: false)
+    }
 }
 
 private class TestViewController: CMPViewController {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/Utils/XCTestCase.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/Utils/XCTestCase.swift
@@ -17,31 +17,22 @@
 import XCTest
 
 extension XCTestCase {
-    /// Non UI Thread blocking delay for at least given time interval.
-    func delay(_ delay: TimeInterval) {
-        let baseExpectation = expectation(description: name)
-        DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + delay) {
-            DispatchQueue.main.async {
-                baseExpectation.fulfill()
-            }
-        }
-        wait(for: [baseExpectation], timeout: delay + 5)
-    }
-
     /// Awaits for expectation without blocking UI thread.
-    func wait(for expectation: @escaping () -> Bool,
-              timeout: TimeInterval = 1.0,
-              file: String = #file,
-              function: String = #function,
-              line: Int = #line) {
+    @MainActor
+    func expect(        
+        timeout: TimeInterval,
+        expectation: @escaping () -> Bool
+    ) async {
         let start = Date()
-        var isExpected = expectation()
-        while !isExpected && Date().timeIntervalSince(start) < timeout {
-            delay(0.001)
-            isExpected = expectation()
+        var isExpectationMet = expectation()
+        
+        while !isExpectationMet && Date().timeIntervalSince(start) < timeout {
+            try? await Task.sleep(nanoseconds: 100_000) // 100ms
+            isExpectationMet = expectation()            
         }
-        if !isExpected {
-            XCTFail("Timeout reached for expectation at \(file) - \(function) line \(line)")
+        
+        if !isExpectationMet {
+            XCTFail("Timeout")
         }
     }
 }

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/Utils/XCTestCase.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/Utils/XCTestCase.swift
@@ -21,6 +21,7 @@ extension XCTestCase {
     @MainActor
     func expect(        
         timeout: TimeInterval,
+        line: Int,
         expectation: @escaping () -> Bool
     ) async {
         let start = Date()
@@ -32,7 +33,7 @@ extension XCTestCase {
         }
         
         if !isExpectationMet {
-            XCTFail("Timeout")
+            XCTFail("Timeout at line \(line)")
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Define state of `being alive` for `CMPViewController` as an interval from the first `viewWillAppear` until a moment where following criteria is met:

1. Not `rootViewController` of any connected scene `UIWindow`.
2. Not transitively or directly contained by any `UIViewController` passing (1), via either `parent<->child` or `presenting<->presented` chain.

## Testing

Test: CMPViewControllerTests.swift in CMPUIKitUtils, ProperContainmentDisposal in ComposeDemo.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4188
