### PR TITLE
Remove deprecated APIs in TooltipArea and PointerEvent.

### DIFF
--- a/compose/foundation/foundation/api/desktop/foundation.api
+++ b/compose/foundation/foundation/api/desktop/foundation.api
@@ -401,22 +401,20 @@ public final class androidx/compose/foundation/TooltipArea_desktopKt {
 }
 
 public abstract interface class androidx/compose/foundation/TooltipPlacement {
-	public abstract fun positionProvider (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
-	public fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
+	public abstract fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 
 public final class androidx/compose/foundation/TooltipPlacement$ComponentRect : androidx/compose/foundation/TooltipPlacement {
 	public static final field $stable I
 	public synthetic fun <init> (Landroidx/compose/ui/Alignment;Landroidx/compose/ui/Alignment;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Landroidx/compose/ui/Alignment;Landroidx/compose/ui/Alignment;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun positionProvider (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
+	public fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 
 public final class androidx/compose/foundation/TooltipPlacement$CursorPoint : androidx/compose/foundation/TooltipPlacement {
 	public static final field $stable I
 	public synthetic fun <init> (JLandroidx/compose/ui/Alignment;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLandroidx/compose/ui/Alignment;FLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun positionProvider (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 	public fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
@@ -210,23 +210,11 @@ private suspend fun PointerInputScope.detectDown(onDown: (Offset) -> Unit) {
 interface TooltipPlacement {
     /**
      * Returns [PopupPositionProvider] implementation.
-     */
-    @Deprecated(
-        message = "Use the overload that takes a cursor position; will be removed in Compose 1.5"
-    )
-    @Composable
-    fun positionProvider(): PopupPositionProvider
-
-    /**
-     * Returns [PopupPositionProvider] implementation.
      *
      * @param cursorPosition The position of the mouse cursor relative to the tooltip area.
      */
-    @Suppress("DEPRECATION")
     @Composable
-    fun positionProvider(cursorPosition: Offset): PopupPositionProvider {
-        return positionProvider()
-    }
+    fun positionProvider(cursorPosition: Offset): PopupPositionProvider
 
     /**
      * [TooltipPlacement] implementation for providing a [PopupPositionProvider] that calculates
@@ -242,15 +230,6 @@ interface TooltipPlacement {
         private val alignment: Alignment = Alignment.BottomEnd,
         private val windowMargin: Dp = 4.dp
     ) : TooltipPlacement {
-
-        @Suppress("OVERRIDE_DEPRECATION")
-        @Composable
-        override fun positionProvider(): PopupPositionProvider = rememberCursorPositionProvider(
-            offset = offset,
-            alignment = alignment,
-            windowMargin = windowMargin
-        )
-
         @OptIn(ExperimentalComposeUiApi::class)
         @Composable
         override fun positionProvider(cursorPosition: Offset) =
@@ -276,12 +255,12 @@ interface TooltipPlacement {
         private val alignment: Alignment = Alignment.BottomCenter,
         private val offset: DpOffset = DpOffset.Zero
     ) : TooltipPlacement {
-        @Suppress("OVERRIDE_DEPRECATION")
         @Composable
-        override fun positionProvider() = rememberComponentRectPositionProvider(
-            anchor,
-            alignment,
-            offset
-        )
+        override fun positionProvider(cursorPosition: Offset) =
+            rememberComponentRectPositionProvider(
+                anchor = anchor,
+                alignment = alignment,
+                offset = offset
+            )
     }
 }

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -1913,7 +1913,7 @@ public final class androidx/compose/ui/input/pointer/PointerEvent {
 	public final fun component2-ry648PA ()I
 	public final fun component3-k7X9c1A ()I
 	public final fun component5 ()Ljava/lang/Object;
-	public final fun copy-jTTBaPM (Ljava/util/List;IIILjava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;)Landroidx/compose/ui/input/pointer/PointerEvent;
+	public final synthetic fun copy-jTTBaPM (Ljava/util/List;IIILjava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;)Landroidx/compose/ui/input/pointer/PointerEvent;
 	public static synthetic fun copy-jTTBaPM$default (Landroidx/compose/ui/input/pointer/PointerEvent;Ljava/util/List;IIILjava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;ILjava/lang/Object;)Landroidx/compose/ui/input/pointer/PointerEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getButton-RaE_XpY ()Landroidx/compose/ui/input/pointer/PointerButton;

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/PointerEvent.skiko.kt
@@ -178,7 +178,10 @@ actual class PointerEvent internal constructor(
 
     // _button was internal, so no need for a component6
 
-    @Deprecated("Will be removed in 1.5")
+    @Deprecated(
+        message = "Removed in 1.6",
+        level = DeprecationLevel.HIDDEN
+    )
     @Suppress("LocalVariableName")
     fun copy(
         changes: List<PointerInputChange> = this.changes,


### PR DESCRIPTION
## Proposed Changes
Remove some APIs which we promised to remove back in 1.5:
  - `TooltipPlacement.positionProvider()`
  - `PointerEvent.copy`

## Testing

Test:
