### PR TITLE
Minor cleanup in DatePicker and TimePicker

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePicker.kt
@@ -85,7 +85,6 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.Role
@@ -105,7 +104,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
@@ -520,17 +518,20 @@ object DatePickerDefaults {
      * A date format skeleton used to format the date picker's year selection menu button (e.g.
      * "March 2021")
      */
+    @Suppress("ConstPropertyName")
     const val YearMonthSkeleton: String = "yMMMM"
 
     /**
      * A date format skeleton used to format a selected date (e.g. "Mar 27, 2021")
      */
+    @Suppress("ConstPropertyName")
     const val YearAbbrMonthDaySkeleton: String = "yMMMd"
 
     /**
      * A date format skeleton used to format a selected date to be used as content description for
      * screen readers (e.g. "Saturday, March 27, 2021")
      */
+    @Suppress("ConstPropertyName")
     const val YearMonthWeekdayDaySkeleton: String = "yMMMMEEEEd"
 }
 
@@ -735,7 +736,7 @@ class DatePickerColors internal constructor(
  */
 @ExperimentalMaterial3Api
 @Immutable
-class DatePickerFormatter constructor(
+class DatePickerFormatter(
     internal val yearSelectionSkeleton: String = DatePickerDefaults.YearMonthSkeleton,
     internal val selectedDateSkeleton: String = DatePickerDefaults.YearAbbrMonthDaySkeleton,
     internal val selectedDateDescriptionSkeleton: String =
@@ -830,7 +831,7 @@ value class DisplayMode internal constructor(internal val value: Int) {
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Stable
-internal class StateData constructor(
+internal class StateData(
     initialSelectedStartDateMillis: Long?,
     initialSelectedEndDateMillis: Long?,
     initialDisplayedMonthMillis: Long?,

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePicker.kt
@@ -53,11 +53,11 @@ import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.DateRange
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.tokens.DatePickerModalTokens
 import androidx.compose.material3.tokens.MotionTokens
 import androidx.compose.runtime.Composable
@@ -1798,24 +1798,15 @@ private fun MonthsNavigation(
         // Show arrows for traversing months (only visible when the year selection is off)
         if (!yearPickerVisible) {
             Row {
-                val rtl = LocalLayoutDirection.current == LayoutDirection.Rtl
                 IconButton(onClick = onPreviousClicked, enabled = previousAvailable) {
                     Icon(
-                        if (rtl) {
-                            Icons.Filled.KeyboardArrowRight
-                        } else {
-                            Icons.Filled.KeyboardArrowLeft
-                        },
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                         contentDescription = getString(Strings.DatePickerSwitchToPreviousMonth)
                     )
                 }
                 IconButton(onClick = onNextClicked, enabled = nextAvailable) {
                     Icon(
-                        if (rtl) {
-                            Icons.Filled.KeyboardArrowLeft
-                        } else {
-                            Icons.Filled.KeyboardArrowRight
-                        },
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = getString(Strings.DatePickerSwitchToNextMonth)
                     )
                 }

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/DatePicker.kt
@@ -94,7 +94,7 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.horizontalScrollAxisRange
-import androidx.compose.ui.semantics.isContainer
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.role
@@ -1020,7 +1020,7 @@ internal fun DateEntryContainer(
     Column(
         modifier = modifier
             .sizeIn(minWidth = DatePickerModalTokens.ContainerWidth)
-            .semantics { isContainer = true }
+            .semantics { isTraversalGroup = true }
     ) {
         DatePickerHeader(
             modifier = Modifier,
@@ -1100,7 +1100,7 @@ private fun SwitchableDateEntryContent(
     Crossfade(
         targetState = state.displayMode,
         animationSpec = spring(),
-        modifier = Modifier.semantics { isContainer = true }) { mode ->
+        modifier = Modifier.semantics { isTraversalGroup = true }) { mode ->
         when (mode) {
             DisplayMode.Picker -> DatePickerContent(
                 stateData = state.stateData,

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
@@ -131,7 +131,7 @@ import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.isContainer
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selectableGroup
@@ -978,7 +978,7 @@ private fun PeriodToggleImpl(
     Layout(
         modifier = modifier
             .semantics {
-                isContainer = true
+                isTraversalGroup = true
                 this.contentDescription = contentDescription
             }
             .selectableGroup()
@@ -1131,7 +1131,7 @@ internal fun ClockFace(
             .background(shape = CircleShape, color = colors.clockDialColor)
             .size(ClockDialContainerSize)
             .semantics {
-                isContainer = false
+                isTraversalGroup = false
                 selectableGroup()
             },
         targetState = state.values,


### PR DESCRIPTION
## Proposed Changes
- Replace deprecated `semantics { isContainer = true }` with `isTraversalGroup`.
- Replaced explicitly selected RTL/LTR icons with auto-mirrored ones.

## Testing

Test: Looked at the datepicker in LTR and RTL layout:
```
fun main() = singleWindowApplication {
    Column {
        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
            DatePicker(
                state = rememberDatePickerState()
            )
        }
        CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
            DatePicker(
                state = rememberDatePickerState()
            )
        }
    }
}
```

