### PR TITLE
iOS use platformLayers=true by default

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -34,7 +34,7 @@ class ComposeUIViewControllerConfiguration {
     var delegate = object : ComposeUIViewControllerDelegate {}
 
     @ExperimentalComposeApi
-    var platformLayers: Boolean = false
+    var platformLayers: Boolean = true
 }
 
 /**


### PR DESCRIPTION
We changed default iOS behavior for Dialogs and Popups. Now they will be opened in new platfrom layer, and will be positioned on fully available Application size.
It means that you may use Compose as a small part of iOS Application, but Dialogs may be opened bigger that initial Compose size.

For example, let's use Compose as a small part of SwiftUI screen:
```Swift
struct ContentView: View {
    var body: some View {
        ComposeView()
                .frame(width: 200, height: 200)
    }
}
```
And Kotlin Code:
```Kotlin
    ComposeUIViewController {
        Box(Modifier.fillMaxSize().background(Color.Blue.copy(0.5f)))
    }
```

<img width="565" alt="image" src="https://github.com/JetBrains/compose-multiplatform-core/assets/99798741/a44f3d4b-23b4-4276-9f34-5d15cc9fa35a">

As you can see Compose layouts just in small rectangle inside SwiftUI.


Now, let's add Dialog to Kotlin Code to display Dialog:
```Kotlin
    ComposeUIViewController {
        var isDialogOpened by remember { mutableStateOf(false) }
        Box(Modifier.fillMaxSize().background(Color.Blue.copy(0.5f))) {
            Button(onClick = { isDialogOpened = true }) {
                Text("Open Dialog")
            }
        }
        if (isDialogOpened) {
            Dialog(
                onDismissRequest = { isDialogOpened = false }
            ) {
                Box(Modifier.size(400.dp).background(Color.Yellow.copy(0.5f))) {
                    Text("I am Dialog")
                }
            }
        }
    }
```
And result will be:

<img width="565" alt="image" src="https://github.com/JetBrains/compose-multiplatform-core/assets/99798741/f694ce46-4122-44a8-befc-04e5f92355b6">

Now, Dialogs and Popups may have size bigger than initial Compose view.

But also we provide ability to switch this behavior to old once with flag platfomLayer:
```Kotlin
ComposeUIViewController(
        configure = {
            platformLayers = false
        }
    ) {
// your Compose code
}
```