### PR TITLE
CfW: add k/wasm specific tests for IdentityArraySetTest

### DIFF
--- a/compose/material/material/src/wasmJsMain/kotlin/androidx/compose/material/internal/IdentityHashCode.wasm.kt
+++ b/compose/material/material/src/wasmJsMain/kotlin/androidx/compose/material/internal/IdentityHashCode.wasm.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.material.internal
 
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-789/CfW-properly-implement-identityHashCode-for-k-wasm
+// for details please see the same implementation in runtime
 internal actual fun identityHashCode(instance: Any?): Int {
     if (instance == null) {
         return 0

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/collection/IdentityArraySetTest.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/collection/IdentityArraySetTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.test.IgnoreJsTarget
 
 @OptIn(InternalComposeApi::class)
 class IdentityArraySetTest {
@@ -63,6 +64,7 @@ class IdentityArraySetTest {
     }
 
     @Test
+    @IgnoreJsTarget // because of different identityHashCode implementation
     fun addValueForward() {
         list.forEach { set.add(it) }
         assertEquals(list.size, set.size)
@@ -75,6 +77,7 @@ class IdentityArraySetTest {
     }
 
     @Test
+    @IgnoreJsTarget // because of different identityHashCode implementation
     fun addValueReversed() {
         list.asReversed().forEach { set.add(it) }
         assertEquals(list.size, set.size)
@@ -87,6 +90,7 @@ class IdentityArraySetTest {
     }
 
     @Test
+    @IgnoreJsTarget // because of different identityHashCode implementation
     fun addExistingValue() {
         list.forEach { set.add(it) }
         list.asReversed().forEach { set.add(it) }

--- a/compose/runtime/runtime/src/wasmJsMain/kotlin/androidx/compose/runtime/ActualJs.wasm.kt
+++ b/compose/runtime/runtime/src/wasmJsMain/kotlin/androidx/compose/runtime/ActualJs.wasm.kt
@@ -33,7 +33,18 @@ private external fun dynamicGetInt(obj: JsAny, index: String): Int?
 @JsFun("(obj) => typeof obj")
 private external fun jsTypeOf(a: JsAny?): String
 
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-789/CfW-properly-implement-identityHashCode-for-k-wasm
+/**
+ * We intentionally use the default `instance.hashCode()` here.
+ * The consequence is that the returned values can be more often not unique,
+ * but it's not required for correctness (absolute uniqueness can't be guaranteed on any platform).
+ * It has good performance comparing with alternatives.
+ *
+ * For more details have a look:
+ * https://kotlinlang.slack.com/archives/G010KHY484C/p1706547846376149
+ * Quote: "...we optimize for the case where hash code is unique, but it is not required for correctness"
+ *
+ * And here: https://jetbrains.slack.com/archives/C047QCXNLTX/p1706536405443729
+ */
 @InternalComposeApi
 actual fun identityHashCode(instance: Any?): Int {
     if (instance == null) {

--- a/compose/runtime/runtime/src/wasmJsTest/kotlin/androix/compose/runtime/collection/IdentityArraySetTests.wasm.kt
+++ b/compose/runtime/runtime/src/wasmJsTest/kotlin/androix/compose/runtime/collection/IdentityArraySetTests.wasm.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.compose.runtime.*
+import androidx.compose.runtime.collection.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * This is partial k/wasm-specific copy of [IdentityArraySetTest].
+ * K/wasm can't reuse some common tests because of different [identityHashCode] implementation,
+ * which doesn't guarantee unique values on k/wasm.
+ * Not unique values are okay for the purpose of [IdentityArraySet], [IdentityArrayIntMap] and [IdentityArrayMap].
+ * For details: https://kotlinlang.slack.com/archives/G010KHY484C/p1706547846376149
+ */
+@OptIn(InternalComposeApi::class)
+class IdentityArraySetWasmTest {
+    private val set: IdentityArraySet<IdentityArraySetTest.Stuff> = IdentityArraySet()
+
+    private val list = listOf(
+        IdentityArraySetTest.Stuff(10),
+        IdentityArraySetTest.Stuff(12),
+        IdentityArraySetTest.Stuff(1),
+        IdentityArraySetTest.Stuff(30),
+        IdentityArraySetTest.Stuff(10)
+    )
+
+    @Test
+    fun addValueForward() {
+        list.forEach { set.add(it) }
+        assertEquals(list.size, set.size)
+        var previousItem = set[0]
+        for (i in 1 until set.size) {
+            val item = set[i]
+            assertTrue(identityHashCode(previousItem) <= identityHashCode(item))
+            previousItem = item
+        }
+    }
+
+    @Test
+    fun addValueReversed() {
+        list.asReversed().forEach { set.add(it) }
+        assertEquals(list.size, set.size)
+        var previousItem = set[0]
+        for (i in 1 until set.size) {
+            val item = set[i]
+            assertTrue(identityHashCode(previousItem) <= identityHashCode(item))
+            previousItem = item
+        }
+    }
+
+    @Test
+    fun addExistingValue() {
+        list.forEach { set.add(it) }
+        list.asReversed().forEach { set.add(it) }
+
+        assertEquals(list.size, set.size)
+        var previousItem = set[0]
+        for (i in 1 until set.size) {
+            val item = set[i]
+            assertTrue(identityHashCode(previousItem) <= identityHashCode(item))
+            previousItem = item
+        }
+    }
+}


### PR DESCRIPTION
Reason: k/wasm implementation of identityHashCode doesn't guarantee unique value, therefore common tests do not pass on k/wasm.

k/wasm implementation of identityHashCode will keep using the default `instance.hashCode()`. It's sufficient for existing use cases.

For details about k/wasm implementation:
https://kotlinlang.slack.com/archives/G010KHY484C/p1706547846376149
https://jetbrains.slack.com/archives/C047QCXNLTX/p1706536405443729
___

Also, ignore the same common tests for web targets.


