### PR TITLE
iOS textfield with visual transformation crashes after single tap

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 
 @Composable
 internal fun Modifier.cupertinoTextFieldPointer(
@@ -108,14 +109,25 @@ private fun getTapHandlerModifier(
                     )
                     if (currentState.handleState != HandleState.Selection) {
                         currentState.layoutResult?.let { layoutResult ->
-                            TextFieldDelegate.cupertinoSetCursorOffsetFocused(
-                                position = touchPointOffset,
-                                textLayoutResult = layoutResult,
-                                editProcessor = currentState.processor,
-                                offsetMapping = currentOffsetMapping,
-                                showContextMenu = {},
-                                onValueChange = currentState.onValueChange
-                            )
+                            // TODO: Research native behavior with any text transformations (which adds symbols like with using NSNumberFormatter)
+                            if (manager.visualTransformation != VisualTransformation.None) {
+                                TextFieldDelegate.setCursorOffset(
+                                    touchPointOffset,
+                                    layoutResult,
+                                    currentState.processor,
+                                    currentOffsetMapping,
+                                    currentState.onValueChange
+                                )
+                            } else {
+                                TextFieldDelegate.cupertinoSetCursorOffsetFocused(
+                                    position = touchPointOffset,
+                                    textLayoutResult = layoutResult,
+                                    editProcessor = currentState.processor,
+                                    offsetMapping = currentOffsetMapping,
+                                    showContextMenu = {},
+                                    onValueChange = currentState.onValueChange
+                                )
+                            }
                         }
                     } else {
                         currentManager.deselect(touchPointOffset)

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.skiko.kt
@@ -46,7 +46,7 @@ internal fun TextFieldDelegate.Companion.cupertinoSetCursorOffsetFocused(
     val offset =
         offsetMapping.transformedToOriginal(textLayoutResult.getOffsetForPosition(position))
     val currentValue = editProcessor.toTextFieldValue()
-    val currentText = currentValue.text
+    val currentText = textLayoutResult.value.layoutInput.text.toString()
 
     val cursorDesiredOffset = determineCursorDesiredOffset(
         offset,
@@ -119,6 +119,7 @@ private fun TextLayoutResultProxy.isFirstHalfOfWordTapped(
     currentText: String
 ): Boolean {
     val wordBoundary = value.getWordBoundary(caretOffset)
+    // current text is taken from value.layoutInput.text, so value.getWordBoundary() should work correctly.
     val word = currentText.substring(wordBoundary.start, wordBoundary.end)
     val middleIndex = wordBoundary.start + word.midpointPositionWithUnicodeSymbols()
     return caretOffset < middleIndex


### PR DESCRIPTION
fixed crash on iOS in textfield with visual transformation which changes amount of visible symbols

## Proposed Changes

  - Changed way of getting current text
  - Disabled custom cupertino behavior for textfield with visual transformation

## Testing

Test: Open any textfield in test app, try to type something and tap on the text, it shouldn't crash

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4206

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
