### PR TITLE
a11y fix logging bug

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -751,10 +751,7 @@ internal class AccessibilityMediator constructor(
 ) {
     private var isAlive = true
 
-    private var latestSyncOptions: AccessibilitySyncOptions = getAccessibilitySyncOptions()
-
-    val debugLogger: AccessibilityDebugLogger?
-        get() = latestSyncOptions.debugLogger
+    private var debugLogger: AccessibilityDebugLogger? = null
 
     var rootSemanticsNodeId: Int = -1
 
@@ -789,14 +786,20 @@ internal class AccessibilityMediator constructor(
             while (isAlive) {
                 var result: NodesSyncResult
 
-                latestSyncOptions = getAccessibilitySyncOptions()
+                val syncOptions = getAccessibilitySyncOptions()
 
-                val shouldPerformSync = when (latestSyncOptions) {
+                val shouldPerformSync = when (syncOptions) {
                     is AccessibilitySyncOptions.Never -> false
                     is AccessibilitySyncOptions.WhenRequiredByAccessibilityServices -> {
                         UIAccessibilityIsVoiceOverRunning()
                     }
                     is AccessibilitySyncOptions.Always -> true
+                }
+
+                debugLogger = if (shouldPerformSync) {
+                    syncOptions.debugLogger
+                } else {
+                    null
                 }
 
                 if (shouldPerformSync) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -751,7 +751,8 @@ internal class AccessibilityMediator constructor(
 ) {
     private var isAlive = true
 
-    private var debugLogger: AccessibilityDebugLogger? = null
+    var debugLogger: AccessibilityDebugLogger? = null
+        private set
 
     var rootSemanticsNodeId: Int = -1
 


### PR DESCRIPTION
## Testing

Test: N/A

## Issues Fixed

Fixes: a11y is always debug-logged, if `debugLogger` is not null, should be only logged, when actual syncing is happening.