### PR TITLE
Cache lazily computed a11y properties and SemanticsConfig

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -137,7 +137,7 @@ private class AccessibilityElement(
 
     /**
      * The latest configuration after the last sync with the Compose semantics tree.
-     * It's used avoid unnecessary recomputation of merged configs in when accessing
+     * It's used avoid unnecessary recomputation of merged configs when accessing
      * [SemanticsNode.config]
      */
     private val cachedConfig: SemanticsConfiguration

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -367,7 +367,9 @@ private class AccessibilityElement(
         }
     }
 
-    private fun scrollIfPossible(direction: UIAccessibilityScrollDirection, config: SemanticsConfiguration): Boolean {
+    private fun scrollIfPossible(direction: UIAccessibilityScrollDirection): Boolean {
+        val config = cachedConfig
+
         val (width, height) = semanticsNode.size
 
         // TODO: reverse engineer proper dimension scale
@@ -451,7 +453,7 @@ private class AccessibilityElement(
         }
 
         parent?.let {
-            return it.scrollIfPossible(direction, it.cachedConfig)
+            return it.scrollIfPossible(direction)
         }
 
         return false
@@ -462,7 +464,7 @@ private class AccessibilityElement(
             return false
         }
 
-        return scrollIfPossible(direction, cachedConfig)
+        return scrollIfPossible(direction)
     }
 
     override fun isAccessibilityElement(): Boolean =

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -81,6 +81,18 @@ interface AccessibilityDebugLogger {
     fun log(message: Any?)
 }
 
+private class CachedAccessibilityPropertyKey<V>
+
+private object CachedAccessibilityPropertyKeys {
+    val accessibilityLabel = CachedAccessibilityPropertyKey<String?>()
+    val isAccessibilityElement = CachedAccessibilityPropertyKey<Boolean>()
+    val accessibilityIdentifier = CachedAccessibilityPropertyKey<String>()
+    val accessibilityHint = CachedAccessibilityPropertyKey<String?>()
+    val accessibilityCustomActions = CachedAccessibilityPropertyKey<List<UIAccessibilityCustomAction>>()
+    val accessibilityTraits = CachedAccessibilityPropertyKey<UIAccessibilityTraits>()
+    val accessibilityValue = CachedAccessibilityPropertyKey<String?>()
+    val accessibilityFrame = CachedAccessibilityPropertyKey<CValue<CGRect>>()
+}
 
 /**
  * Represents a projection of the Compose semantics node to the iOS world.
@@ -123,7 +135,33 @@ private class AccessibilityElement(
     var isAlive = true
         private set
 
+    /**
+     * The latest configuration after the last sync with the Compose semantics tree.
+     * It's used avoid unnecessary recomputation of merged configs in when accessing
+     * [SemanticsNode.config]
+     */
+    private val cachedConfig: SemanticsConfiguration
+        get() {
+            val config = _cachedConfig
+
+            if (config != null) {
+                return config
+            } else {
+                val newConfig = semanticsNode.config
+                _cachedConfig = newConfig
+                return newConfig
+            }
+        }
+    private var _cachedConfig: SemanticsConfiguration? = null
+
+    /**
+     * A cache for the properties that are computed from the [SemanticsNode.config] and are communicated
+     * to iOS Accessibility services.
+     */
+    private val cachedProperties = mutableMapOf<CachedAccessibilityPropertyKey<*>, Any?>()
+
     private var children = mutableListOf<AccessibilityElement>()
+
 
     /**
      * Constructed lazily if :
@@ -184,6 +222,11 @@ private class AccessibilityElement(
         return null
     }
 
+    fun discardCache() {
+        _cachedConfig = null
+        cachedProperties.clear()
+    }
+
     fun dispose() {
         check(isAlive) {
             "AccessibilityElement is already disposed"
@@ -192,32 +235,44 @@ private class AccessibilityElement(
         isAlive = false
     }
 
-    override fun accessibilityLabel(): String? {
-        val config = semanticsNode.config
-
-        val contentDescription = config.getOrNull(SemanticsProperties.ContentDescription)?.joinToString("\n")
-        if (contentDescription != null) {
-            return contentDescription
+    /**
+     * Returns the value for the given [key] from the cache if it's present, otherwise computes the
+     * value using the given [block] and caches it.
+     */
+    @Suppress("UNCHECKED_CAST") // cast is safe because the set value is constrained by the key T
+    private inline fun <T>getOrElse(key: CachedAccessibilityPropertyKey<T>, crossinline block: () -> T): T {
+        val value = cachedProperties.getOrElse(key) {
+            val newValue = block()
+            cachedProperties[key] = newValue
+            newValue
         }
 
-        val editableText = config.getOrNull(SemanticsProperties.EditableText)?.text
-
-        if (editableText != null) {
-            return editableText
-        }
-
-        val text =
-            config.getOrNull(SemanticsProperties.Text)?.joinToString("\n") { it.text }
-
-        return text
+        return value as T
     }
+
+    override fun accessibilityLabel(): String? =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityLabel) {
+            val config = cachedConfig
+
+            val contentDescription =
+                config.getOrNull(SemanticsProperties.ContentDescription)?.joinToString("\n")
+
+            if (contentDescription != null) {
+                contentDescription
+            } else {
+                val editableText = config.getOrNull(SemanticsProperties.EditableText)?.text
+
+                editableText ?: config.getOrNull(SemanticsProperties.Text)
+                    ?.joinToString("\n") { it.text }
+            }
+        }
 
     override fun accessibilityActivate(): Boolean {
         if (!isAlive || !semanticsNode.isValid) {
             return false
         }
 
-        val onClick = semanticsNode.config.getOrNull(SemanticsActions.OnClick) ?: return false
+        val onClick = cachedConfig.getOrNull(SemanticsActions.OnClick) ?: return false
         val action = onClick.action ?: return false
 
         return action()
@@ -248,7 +303,7 @@ private class AccessibilityElement(
             listOf(
                 null,
                 "Focused on:",
-                semanticsNode.config
+                cachedConfig
             )
         )
 
@@ -303,7 +358,7 @@ private class AccessibilityElement(
         }
 
         // if has scrollBy action, invoke it, otherwise try to scroll the parent
-        val action = semanticsNode.config.getOrNull(SemanticsActions.ScrollBy)?.action
+        val action = cachedConfig.getOrNull(SemanticsActions.ScrollBy)?.action
 
         if (action != null) {
             action(dx, dy)
@@ -396,7 +451,7 @@ private class AccessibilityElement(
         }
 
         parent?.let {
-            return it.scrollIfPossible(direction, it.semanticsNode.config)
+            return it.scrollIfPossible(direction, it.cachedConfig)
         }
 
         return false
@@ -407,111 +462,117 @@ private class AccessibilityElement(
             return false
         }
 
-        return scrollIfPossible(direction, semanticsNode.config)
+        return scrollIfPossible(direction, cachedConfig)
     }
 
-    override fun isAccessibilityElement(): Boolean {
-        val config = semanticsNode.config
+    override fun isAccessibilityElement(): Boolean =
+        getOrElse(CachedAccessibilityPropertyKeys.isAccessibilityElement) {
+            val config = cachedConfig
 
-        if (config.contains(SemanticsProperties.InvisibleToUser)) {
-            return false
+            if (config.contains(SemanticsProperties.InvisibleToUser)) {
+                false
+            } else {
+                // TODO: investigate if it can it be a traversal group _and_ contain properties that should
+                //  be communicated to iOS?
+                if (config.getOrNull(SemanticsProperties.IsTraversalGroup) == true) {
+                    false
+                } else {
+                    config.containsImportantForAccessibility()
+                }
+            }
         }
 
-        // TODO: investigate if it can it be a traversal group _and_ contain properties that should
-        //  be communicated to iOS?
-        if (config.getOrNull(SemanticsProperties.IsTraversalGroup) == true) {
-            return false
+    override fun accessibilityIdentifier(): String =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityIdentifier) {
+            cachedConfig.getOrNull(SemanticsProperties.TestTag)
+                ?: "AccessibilityElement for SemanticsNode(id=$semanticsNodeId)"
         }
 
-        return config.containsImportantForAccessibility()
-    }
+    override fun accessibilityHint(): String? =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityHint) {
+            cachedConfig.getOrNull(SemanticsActions.OnClick)?.label
+        }
 
-    override fun accessibilityIdentifier(): String {
-        return semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
-            ?: "AccessibilityElement for SemanticsNode(id=$semanticsNodeId)"
-    }
+    override fun accessibilityCustomActions(): List<UIAccessibilityCustomAction> =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityCustomActions) {
+            cachedConfig.getOrNull(SemanticsActions.CustomActions)?.let { actions ->
+                actions.map {
+                    UIAccessibilityCustomAction(
+                        name = it.label,
+                        actionHandler = { _ ->
+                            it.action.invoke()
+                        }
+                    )
+                }
+            } ?: emptyList()
+        }
 
-    override fun accessibilityHint(): String? {
-        return semanticsNode.config.getOrNull(SemanticsActions.OnClick)?.label
-    }
+    override fun accessibilityTraits(): UIAccessibilityTraits =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityTraits) {
+            var result = UIAccessibilityTraitNone
 
-    override fun accessibilityCustomActions(): List<UIAccessibilityCustomAction> {
-        return semanticsNode.config.getOrNull(SemanticsActions.CustomActions)?.let { actions ->
-            actions.map {
-                UIAccessibilityCustomAction(
-                    name = it.label,
-                    actionHandler = { _ ->
-                        it.action.invoke()
+            val config = cachedConfig
+
+            if (config.contains(SemanticsProperties.LiveRegion)) {
+                result = result or UIAccessibilityTraitUpdatesFrequently
+            }
+
+            if (config.contains(SemanticsProperties.Disabled)) {
+                result = result or UIAccessibilityTraitNotEnabled
+            }
+
+            if (config.contains(SemanticsProperties.Heading)) {
+                result = result or UIAccessibilityTraitHeader
+            }
+
+            config.getOrNull(SemanticsProperties.ToggleableState)?.let { state ->
+                when (state) {
+                    ToggleableState.On -> {
+                        result = result or UIAccessibilityTraitSelected
                     }
-                )
-            }
-        } ?: emptyList()
-    }
 
-    override fun accessibilityTraits(): UIAccessibilityTraits {
-        var result = UIAccessibilityTraitNone
-
-        val config = semanticsNode.config
-
-        if (config.contains(SemanticsProperties.LiveRegion)) {
-            result = result or UIAccessibilityTraitUpdatesFrequently
-        }
-
-        if (config.contains(SemanticsProperties.Disabled)) {
-            result = result or UIAccessibilityTraitNotEnabled
-        }
-
-        if (config.contains(SemanticsProperties.Heading)) {
-            result = result or UIAccessibilityTraitHeader
-        }
-
-        config.getOrNull(SemanticsProperties.ToggleableState)?.let { state ->
-            when (state) {
-                ToggleableState.On -> {
-                    result = result or UIAccessibilityTraitSelected
-                }
-
-                ToggleableState.Off, ToggleableState.Indeterminate -> {
-                    // Do nothing
+                    ToggleableState.Off, ToggleableState.Indeterminate -> {
+                        // Do nothing
+                    }
                 }
             }
-        }
 
-        config.getOrNull(SemanticsActions.OnClick)?.let {
-            result = result or UIAccessibilityTraitButton
-        }
+            config.getOrNull(SemanticsActions.OnClick)?.let {
+                result = result or UIAccessibilityTraitButton
+            }
 
-        config.getOrNull(SemanticsProperties.Role)?.let { role ->
-            when (role) {
-                Role.Button, Role.RadioButton, Role.Checkbox, Role.Switch -> {
-                    result = result or UIAccessibilityTraitButton
-                }
+            config.getOrNull(SemanticsProperties.Role)?.let { role ->
+                when (role) {
+                    Role.Button, Role.RadioButton, Role.Checkbox, Role.Switch -> {
+                        result = result or UIAccessibilityTraitButton
+                    }
 
-                Role.DropdownList -> {
-                    result = result or UIAccessibilityTraitAdjustable
-                }
+                    Role.DropdownList -> {
+                        result = result or UIAccessibilityTraitAdjustable
+                    }
 
-                Role.Image -> {
-                    result = result or UIAccessibilityTraitImage
+                    Role.Image -> {
+                        result = result or UIAccessibilityTraitImage
+                    }
                 }
             }
+
+            result
         }
 
-        return result
-    }
 
+    override fun accessibilityValue(): String? =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityValue) {
+            cachedConfig.getOrNull(SemanticsProperties.StateDescription)
+        }
 
-    override fun accessibilityValue(): String? {
-        return semanticsNode.config.getOrNull(SemanticsProperties.StateDescription)
-    }
-
-    override fun accessibilityFrame(): CValue<CGRect> {
-        return mediator.convertRectToWindowSpaceCGRect(semanticsNode.boundsInWindow)
-    }
+    override fun accessibilityFrame(): CValue<CGRect> =
+        getOrElse(CachedAccessibilityPropertyKeys.accessibilityFrame) {
+            mediator.convertRectToWindowSpaceCGRect(semanticsNode.boundsInWindow)
+        }
 
     // TODO: check the reference/value semantics for SemanticsNode, perhaps it doesn't need
-    //  recreation at all cache config to avoid traversing subtree for merging semantics and
-    //  excessive copy on [semanticsNode.config] call
+    //  recreation at all
     fun updateWithNewSemanticsNode(newSemanticsNode: SemanticsNode) {
         check(semanticsNode.id == newSemanticsNode.id)
         // TODO: track that SemanticsProperties.LiveRegion is present and conditionally start
@@ -911,6 +972,10 @@ internal class AccessibilityMediator constructor(
             }
 
             isPresent
+        }
+
+        for (element in accessibilityElementsMap.values) {
+            element.discardCache()
         }
 
         return checkNotNull(rootAccessibilityElement.resolveAccessibilityContainer()) {


### PR DESCRIPTION
## Proposed Changes

Cache `SemanticsNode.config` and computed accessibility properties between invalidations.

## Testing

Test: N/A

## Issues Fixed

Fixes: unnecessary merged subtree traversing and recomputations of properties.