### PR TITLE
Fix nested scrolling on mouse wheel

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -181,7 +181,7 @@ private class AnimatedMouseWheelScrollPhysics(
         }
         return with(scrollingLogic) {
             val delta = scrollDelta.reverseIfNeeded().toFloat()
-            if (canConsumeDelta(delta)) {
+            if (delta != 0f && canConsumeDelta(delta)) {
                 if (mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)) {
                     // In case of high-resolution wheel, such as a freely rotating wheel with no notches
                     // or trackpads, delta should apply directly without any delays.

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -226,7 +226,7 @@ private class AnimatedMouseWheelScrollPhysics(
          *  Touchpads emit just multiple mouse wheel events, so detecting start and end of this
          *  "gesture" is not straight forward.
          *  Ideally it should be resolved by catching real touches from input device instead of
-         *  waiting the next event with timeout (before resetting progress flag).
+         *  waiting the next event with timeout before resetting progress flag.
          */
         suspend fun waitNextScrollDelta(timeoutMillis: Long): Boolean {
             if (timeoutMillis < 0) return false
@@ -263,7 +263,10 @@ private class AnimatedMouseWheelScrollPhysics(
                         }
                         nextScrollDelta != null
                     }
-                    requiredAnimation = waitNextScrollDelta(ProgressTimeout - durationMillis)
+                    if (!requiredAnimation) {
+                        // If it's completed, wait the next event with timeout before resetting progress flag
+                        requiredAnimation = waitNextScrollDelta(ProgressTimeout - durationMillis)
+                    }
                 }
             }
         }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation.gestures
 
 import androidx.compose.animation.core.AnimationState
+import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateTo
 import androidx.compose.animation.core.tween
@@ -40,16 +41,11 @@ import androidx.compose.ui.util.fastForEach
 import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.roundToInt
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
-
-private val AnimationThreshold = 4.dp
-private val AnimationSpeed = 1.dp // dp / ms
-private const val MaxAnimationDuration: Int = 100 // ms
+import kotlinx.coroutines.withTimeoutOrNull
 
 internal class MouseWheelScrollNode(
     private val scrollingLogic: ScrollingLogic,
@@ -62,12 +58,13 @@ internal class MouseWheelScrollNode(
         mouseWheelScrollConfig = platformScrollConfig()
         physics = if (mouseWheelScrollConfig.isSmoothScrollingEnabled) {
             AnimatedMouseWheelScrollPhysics(
-                coroutineScope = coroutineScope,
                 mouseWheelScrollConfig = mouseWheelScrollConfig,
                 scrollingLogic = scrollingLogic,
                 density = { currentValueOf(LocalDensity) }
             ).apply {
-                launchAnimatedDispatchScroll()
+                coroutineScope.launch {
+                    receiveMouseWheelEvents()
+                }
             }
         } else {
             RawMouseWheelScrollPhysics(mouseWheelScrollConfig, scrollingLogic)
@@ -140,57 +137,27 @@ private class RawMouseWheelScrollPhysics(
 }
 
 private class AnimatedMouseWheelScrollPhysics(
-    private val coroutineScope: CoroutineScope,
     mouseWheelScrollConfig: ScrollConfig,
     scrollingLogic: ScrollingLogic,
     val density: () -> Density,
 ) : ScrollPhysics(mouseWheelScrollConfig, scrollingLogic) {
-    private var isAnimationRunning = false
-    private val channel = Channel<Float>(capacity = Channel.UNLIMITED)
+    private data class MouseWheelScrollDelta(
+        val value: Offset,
+        val shouldApplyImmediately: Boolean
+    ) {
+        operator fun plus(other: MouseWheelScrollDelta) = MouseWheelScrollDelta(
+            value = value + other.value,
+            shouldApplyImmediately = shouldApplyImmediately || other.shouldApplyImmediately
+        )
+    }
+    private val channel = Channel<MouseWheelScrollDelta>(capacity = Channel.UNLIMITED)
 
-    fun launchAnimatedDispatchScroll() = coroutineScope.launch {
+    suspend fun receiveMouseWheelEvents() {
         while (coroutineContext.isActive) {
-            val eventDelta = channel.receive()
-            isAnimationRunning = true
-
-            try {
-                val speed = with(density()) { AnimationSpeed.toPx() }
-                scrollingLogic.animatedDispatchScroll(eventDelta, speed) {
-                    // Sum delta from all pending events to avoid multiple animation restarts.
-                    channel.sumOrNull()
-                }
-            } finally {
-                isAnimationRunning = false
-            }
+            val scrollDelta = channel.receive()
+            val speed = with(density()) { AnimationSpeed.toPx() }
+            scrollingLogic.dispatchMouseWheelScroll(scrollDelta, speed)
         }
-    }
-
-    private fun animateWheelScroll(delta: Float) =
-        channel.trySend(delta).isSuccess
-
-    private fun ScrollingLogic.dispatchWheelScroll(delta: Float) {
-        val offset = delta.reverseIfNeeded().toOffset()
-        coroutineScope.launch {
-            scrollableState.userScroll {
-                dispatchScroll(offset, NestedScrollSource.Wheel)
-            }
-
-            /*
-             * TODO Set isScrollInProgress to true in case of touchpad.
-             *  Dispatching raw delta doesn't cause a progress indication even with wrapping in
-             *  `scrollableState.scroll` block, since it applies the change within single frame.
-             *  Touchpads emit just multiple mouse wheel events, so detecting start and end of this
-             *  "gesture" is not straight forward.
-             *  Ideally it should be resolved by catching real touches from input device instead of
-             *  introducing a timeout (after each event before resetting progress flag).
-             */
-        }
-    }
-
-    private fun ScrollScope.dispatchWheelScroll(delta: Float): Float = with(scrollingLogic) {
-        val offset = delta.reverseIfNeeded().toOffset()
-        val consumed = dispatchScroll(offset, NestedScrollSource.Wheel)
-        consumed.reverseIfNeeded().toFloat()
     }
 
     private suspend fun ScrollableState.userScroll(
@@ -204,30 +171,21 @@ private class AnimatedMouseWheelScrollPhysics(
         val scrollDelta = with(mouseWheelScrollConfig) {
             calculateMouseWheelScroll(pointerEvent, size)
         }
-        return with(scrollingLogic) {
-            val delta = scrollDelta.reverseIfNeeded().toFloat()
-            if (delta != 0f && canConsumeDelta(delta)) {
-                if (isAnimationRunning) {
-                    animateWheelScroll(delta)
-                } else {
-                    val thresholdInPx = AnimationThreshold.toPx()
-                    if (abs(delta) > thresholdInPx) {
-                        val thresholdDelta = if (delta > 0f) thresholdInPx else -thresholdInPx
-                        dispatchWheelScroll(thresholdDelta)
-                        animateWheelScroll(delta - thresholdDelta)
-                    } else {
-                        dispatchWheelScroll(delta)
-                        true
-                    }
-                }
-            } else false
-        }
+        return if (scrollingLogic.canConsumeDelta(scrollDelta)) {
+            channel.trySend(MouseWheelScrollDelta(
+                value = scrollDelta,
+
+                // In case of high-resolution wheel, such as a freely rotating wheel with
+                // no notches or trackpads, delta should apply immediately, without any delays.
+                shouldApplyImmediately = mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)
+            )).isSuccess
+        } else false
     }
 
-    private fun Channel<Float>.sumOrNull(): Float? {
-        val elements = untilNull { tryReceive().getOrNull() }.toList()
-        return if (elements.isEmpty()) null else elements.sum()
-    }
+    private fun Channel<MouseWheelScrollDelta>.sumOrNull() =
+        untilNull { tryReceive().getOrNull() }
+            .toList()
+            .reduceOrNull { accumulator, it -> accumulator + it }
 
     private fun <E> untilNull(builderAction: () -> E?) = sequence<E> {
         do {
@@ -237,60 +195,113 @@ private class AnimatedMouseWheelScrollPhysics(
         } while (element != null)
     }
 
-    private fun ScrollingLogic.canConsumeDelta(delta: Float): Boolean {
-        return if (delta > 0f) {
+    private fun ScrollingLogic.canConsumeDelta(scrollDelta: Offset): Boolean {
+        val delta = scrollDelta.reverseIfNeeded().toFloat() // Use only current axis
+        return if (delta == 0f) {
+            false // It means that it's for another axis and cannot be consumed
+        } else if (delta > 0f) {
             scrollableState.canScrollForward
         } else {
             scrollableState.canScrollBackward
         }
     }
 
-    private suspend fun ScrollingLogic.animatedDispatchScroll(
-        eventDelta: Float,
+    private suspend fun ScrollingLogic.dispatchMouseWheelScroll(
+        scrollDelta: MouseWheelScrollDelta,
         speed: Float, // px / ms
-        tryReceiveNext: () -> Float?
     ) {
-        var target = eventDelta
-        tryReceiveNext()?.let {
-            target += it
+        var targetScrollDelta = scrollDelta
+        // Sum delta from all pending events to avoid multiple animation restarts.
+        channel.sumOrNull()?.let {
+            targetScrollDelta += it
         }
-        if (target.isLowScrollingDelta()) {
+        var targetValue = targetScrollDelta.value.reverseIfNeeded().toFloat()
+        if (targetValue.isLowScrollingDelta()) {
             return
         }
-        var requiredAnimation = true
-        var lastValue = 0f
-        val anim = AnimationState(0f)
-        while (requiredAnimation && coroutineContext.isActive) {
-            requiredAnimation = false
-            val durationMillis = (abs(target - anim.value) / speed)
-                .roundToInt()
-                .coerceAtMost(MaxAnimationDuration)
-            scrollableState.userScroll {
-                anim.animateTo(
-                    target,
-                    animationSpec = tween(
-                        durationMillis = durationMillis,
-                        easing = LinearEasing
-                    ),
-                    sequentialAnimation = true
-                ) {
-                    val delta = value - lastValue
-                    if (!delta.isLowScrollingDelta()) {
-                        val consumedDelta = dispatchWheelScroll(delta)
-                        if (!(delta - consumedDelta).isLowScrollingDelta()) {
-                            cancelAnimation()
-                            return@animateTo
+
+        /*
+         * TODO Handle real down/up events from touchpad to set isScrollInProgress correctly.
+         *  Touchpads emit just multiple mouse wheel events, so detecting start and end of this
+         *  "gesture" is not straight forward.
+         *  Ideally it should be resolved by catching real touches from input device instead of
+         *  waiting the next event with timeout (before resetting progress flag).
+         */
+        suspend fun waitNextScrollDelta(timeoutMillis: Long): Boolean {
+            if (timeoutMillis < 0) return false
+            return withTimeoutOrNull(timeoutMillis) {
+                channel.receive()
+            }?.let {
+                targetScrollDelta = it
+                targetValue = targetScrollDelta.value.reverseIfNeeded().toFloat()
+
+                !targetValue.isLowScrollingDelta()
+            } ?: false
+        }
+
+        scrollableState.userScroll {
+            val animationState = AnimationState(0f)
+            var requiredAnimation = true
+            while (requiredAnimation) {
+                requiredAnimation = false
+                if (targetScrollDelta.shouldApplyImmediately) {
+                    dispatchMouseWheelScroll(targetValue)
+                    requiredAnimation = waitNextScrollDelta(ProgressTimeout)
+                } else {
+                    val durationMillis = (abs(targetValue - animationState.value) / speed)
+                        .roundToInt()
+                        .coerceAtMost(MaxAnimationDuration)
+                    animateMouseWheelScroll(animationState, targetValue, durationMillis) { lastValue ->
+                        // Sum delta from all pending events to avoid multiple animation restarts.
+                        val nextScrollDelta = channel.sumOrNull()
+                        if (nextScrollDelta != null) {
+                            targetScrollDelta += nextScrollDelta
+                            targetValue = targetScrollDelta.value.reverseIfNeeded().toFloat()
+
+                            requiredAnimation = !(targetValue - lastValue).isLowScrollingDelta()
                         }
-                        lastValue += delta
+                        nextScrollDelta != null
                     }
-                    tryReceiveNext()?.let {
-                        target += it
-                        requiredAnimation = !(target - lastValue).isLowScrollingDelta()
-                        cancelAnimation()
-                    }
+                    requiredAnimation = waitNextScrollDelta(ProgressTimeout - durationMillis)
                 }
             }
         }
+    }
+
+    private suspend fun ScrollScope.animateMouseWheelScroll(
+        animationState: AnimationState<Float, AnimationVector1D>,
+        targetValue: Float,
+        durationMillis: Int,
+        shouldCancelAnimation: (lastValue: Float) -> Boolean
+    ) {
+        var lastValue = animationState.value
+        animationState.animateTo(
+            targetValue,
+            animationSpec = tween(
+                durationMillis = durationMillis,
+                easing = LinearEasing
+            ),
+            sequentialAnimation = true
+        ) {
+            val delta = value - lastValue
+            if (!delta.isLowScrollingDelta()) {
+                val consumedDelta = dispatchMouseWheelScroll(delta)
+                if (!(delta - consumedDelta).isLowScrollingDelta()) {
+                    cancelAnimation()
+                    return@animateTo
+                }
+                lastValue += delta
+            }
+            if (shouldCancelAnimation(lastValue)) {
+                cancelAnimation()
+            }
+        }
+    }
+
+    private fun ScrollScope.dispatchMouseWheelScroll(delta: Float) = with(scrollingLogic) {
+        val offset = delta.reverseIfNeeded().toOffset()
+        val consumed = dispatchScroll(offset, NestedScrollSource.Wheel)
+        consumed.reverseIfNeeded().toFloat()
     }
 }
 
@@ -299,3 +310,7 @@ private class AnimatedMouseWheelScrollPhysics(
  * false otherwise
  */
 private inline fun Float.isLowScrollingDelta(): Boolean = abs(this) < 0.5f
+
+private val AnimationSpeed = 1.dp // dp / ms
+private const val MaxAnimationDuration = 100 // ms
+private const val ProgressTimeout = 100L // ms

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -20,22 +20,27 @@ import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.animateTo
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.MutatePriority
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.*
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.currentValueOf
-import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -51,15 +56,15 @@ internal class MouseWheelScrollNode(
         mouseWheelScrollConfig = platformScrollConfig()
         physics = if (mouseWheelScrollConfig.isSmoothScrollingEnabled) {
             AnimatedMouseWheelScrollPhysics(
-                mouseWheelScrollConfig,
-                scrollingLogic,
+                coroutineScope = coroutineScope,
+                mouseWheelScrollConfig = mouseWheelScrollConfig,
+                scrollingLogic = scrollingLogic,
                 density = { currentValueOf(LocalDensity) }
-            )
+            ).apply {
+                launchAnimatedDispatchScroll()
+            }
         } else {
             RawMouseWheelScrollPhysics(mouseWheelScrollConfig, scrollingLogic)
-        }
-        coroutineScope.launch {
-            physics.launch()
         }
     }
 
@@ -109,18 +114,17 @@ internal class MouseWheelScrollNode(
     private inline fun PointerEvent.consume() = changes.fastForEach { it.consume() }
 }
 
-private abstract class ScrollPhysics {
-    abstract var mouseWheelScrollConfig: ScrollConfig
-    abstract var scrollingLogic: ScrollingLogic
-
-    open suspend fun launch() = Unit
+private abstract class ScrollPhysics(
+    var mouseWheelScrollConfig: ScrollConfig,
+    var scrollingLogic: ScrollingLogic,
+) {
     abstract fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean
 }
 
 private class RawMouseWheelScrollPhysics(
-    override var mouseWheelScrollConfig: ScrollConfig,
-    override var scrollingLogic: ScrollingLogic,
-) : ScrollPhysics() {
+    mouseWheelScrollConfig: ScrollConfig,
+    scrollingLogic: ScrollingLogic,
+) : ScrollPhysics(mouseWheelScrollConfig, scrollingLogic) {
     override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
         val delta = with(mouseWheelScrollConfig) {
             calculateMouseWheelScroll(pointerEvent, size)
@@ -130,36 +134,28 @@ private class RawMouseWheelScrollPhysics(
 }
 
 private class AnimatedMouseWheelScrollPhysics(
-    override var mouseWheelScrollConfig: ScrollConfig,
-    override var scrollingLogic: ScrollingLogic,
+    private val coroutineScope: CoroutineScope,
+    mouseWheelScrollConfig: ScrollConfig,
+    scrollingLogic: ScrollingLogic,
     val density: () -> Density,
-) : ScrollPhysics() {
-    private var isAnimationRunning = false
+) : ScrollPhysics(mouseWheelScrollConfig, scrollingLogic) {
     private val channel = Channel<Float>(capacity = Channel.UNLIMITED)
 
-    override suspend fun launch() {
+    fun launchAnimatedDispatchScroll() = coroutineScope.launch {
         while (coroutineContext.isActive) {
-            val event = channel.receive()
-            isAnimationRunning = true
-            try {
-                scrollingLogic.animatedDispatchScroll(event, speed = 1f * density().density) {
-                    // Sum delta from all pending events to avoid multiple animation restarts.
-                    channel.sumOrNull()
-                }
-            } finally {
-                isAnimationRunning = false
+            val eventDelta = channel.receive()
+            scrollingLogic.animatedDispatchScroll(eventDelta, speed = 1f * density().density) {
+                // Sum delta from all pending events to avoid multiple animation restarts.
+                channel.sumOrNull()
             }
         }
     }
 
-    override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
-        val scrollDelta = with(mouseWheelScrollConfig) {
-            calculateMouseWheelScroll(pointerEvent, size)
-        }
-        return if (mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)) {
-            // In case of high-resolution wheel, such as a freely rotating wheel with no notches
-            // or trackpads, delta should apply directly without any delays.
-            scrollingLogic.dispatchRawDelta(scrollDelta) != Offset.Zero
+    private fun ScrollingLogic.dispatchPreciseWheelScroll(scrollDelta: Offset) {
+        coroutineScope.launch {
+            scrollableState.scroll(MutatePriority.UserInput) {
+                dispatchScroll(scrollDelta, NestedScrollSource.Wheel)
+            }
 
             /*
              * TODO Set isScrollInProgress to true in case of touchpad.
@@ -170,17 +166,31 @@ private class AnimatedMouseWheelScrollPhysics(
              *  Ideally it should be resolved by catching real touches from input device instead of
              *  introducing a timeout (after each event before resetting progress flag).
              */
-        } else with(scrollingLogic) {
+        }
+    }
+
+    private fun ScrollScope.dispatchWheelScroll(delta: Float): Float = with(scrollingLogic) {
+        val offset = delta.reverseIfNeeded().toOffset()
+        val consumed = dispatchScroll(offset, NestedScrollSource.Wheel)
+        consumed.reverseIfNeeded().toFloat()
+    }
+
+    override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
+        val scrollDelta = with(mouseWheelScrollConfig) {
+            calculateMouseWheelScroll(pointerEvent, size)
+        }
+        return with(scrollingLogic) {
             val delta = scrollDelta.reverseIfNeeded().toFloat()
-            if (isAnimationRunning) {
-                channel.trySend(delta).isSuccess
-            } else {
-                // Try to apply small delta immediately to conditionally consume
-                // an input event and to avoid useless animation.
-                tryToScrollBySmallDelta(delta, threshold = 4.dp.toPx()) {
-                    channel.trySend(it).isSuccess
+            if (canConsumeDelta(delta)) {
+                if (mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)) {
+                    // In case of high-resolution wheel, such as a freely rotating wheel with no notches
+                    // or trackpads, delta should apply directly without any delays.
+                    dispatchPreciseWheelScroll(scrollDelta)
+                    true
+                } else {
+                    channel.trySend(delta).isSuccess
                 }
-            }
+            } else false
         }
     }
 
@@ -197,19 +207,11 @@ private class AnimatedMouseWheelScrollPhysics(
         } while (element != null)
     }
 
-    private fun ScrollingLogic.tryToScrollBySmallDelta(
-        delta: Float,
-        threshold: Float = 4f,
-        fallback: (Float) -> Boolean
-    ): Boolean {
-        return if (abs(delta) > threshold) {
-            // Gather possibility to scroll by applying a piece of required delta.
-            val testDelta = if (delta > 0f) threshold else -threshold
-            val consumedDelta = scrollableState.dispatchRawDelta(testDelta)
-            consumedDelta != 0f && fallback(delta - testDelta)
+    private fun ScrollingLogic.canConsumeDelta(delta: Float): Boolean {
+        return if (delta > 0f) {
+            scrollableState.canScrollForward
         } else {
-            val consumedDelta = scrollableState.dispatchRawDelta(delta)
-            consumedDelta != 0f
+            scrollableState.canScrollBackward
         }
     }
 
@@ -235,7 +237,7 @@ private class AnimatedMouseWheelScrollPhysics(
                 .roundToInt()
                 .coerceAtMost(maxDurationMillis)
             try {
-                scrollableState.scroll {
+                scrollableState.scroll(MutatePriority.UserInput) {
                     anim.animateTo(
                         target,
                         animationSpec = tween(
@@ -246,7 +248,7 @@ private class AnimatedMouseWheelScrollPhysics(
                     ) {
                         val delta = value - lastValue
                         if (!delta.isLowScrollingDelta()) {
-                            val consumedDelta = scrollBy(delta)
+                            val consumedDelta = dispatchWheelScroll(delta)
                             if (!(delta - consumedDelta).isLowScrollingDelta()) {
                                 cancelAnimation()
                                 return@animateTo

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -219,6 +219,7 @@ private class AnimatedMouseWheelScrollPhysics(
         if (targetValue.isLowScrollingDelta()) {
             return
         }
+        var animationState = AnimationState(0f)
 
         /*
          * TODO Handle real down/up events from touchpad to set isScrollInProgress correctly.
@@ -234,13 +235,13 @@ private class AnimatedMouseWheelScrollPhysics(
             }?.let {
                 targetScrollDelta = it
                 targetValue = targetScrollDelta.value.reverseIfNeeded().toFloat()
+                animationState = AnimationState(0f) // Reset previous animation leftover
 
                 !targetValue.isLowScrollingDelta()
             } ?: false
         }
 
         scrollableState.userScroll {
-            val animationState = AnimationState(0f)
             var requiredAnimation = true
             while (requiredAnimation) {
                 requiredAnimation = false

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -587,7 +587,7 @@ internal interface ScrollConfig {
      * Enables animated transition of scroll on mouse wheel events.
      */
     val isSmoothScrollingEnabled: Boolean
-        get() = false
+        get() = true
 
     fun isPreciseWheelScroll(event: PointerEvent): Boolean = false
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -589,6 +589,8 @@ internal interface ScrollConfig {
     val isSmoothScrollingEnabled: Boolean
         get() = false
 
+    fun isPreciseWheelScroll(event: PointerEvent): Boolean = false
+
     fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset
 }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -589,8 +589,6 @@ internal interface ScrollConfig {
     val isSmoothScrollingEnabled: Boolean
         get() = false
 
-    fun isPreciseWheelScroll(event: PointerEvent): Boolean = false
-
     fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset
 }
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -48,6 +48,8 @@ internal actual fun CompositionLocalConsumerModifierNode.platformScrollConfig():
 internal abstract class DesktopScrollConfig : ScrollConfig {
     override var isSmoothScrollingEnabled = System.getProperty("compose.scrolling.smooth.enabled") != "false"
         internal set
+
+    override fun isPreciseWheelScroll(event: PointerEvent): Boolean = event.isPreciseWheelRotation
 }
 
 // TODO(demin): is this formula actually correct? some experimental values don't fit
@@ -111,3 +113,9 @@ private val PointerEvent.shouldScrollByPage
 
 private val PointerEvent.totalScrollDelta
     get() = this.changes.fastFold(Offset.Zero) { acc, c -> acc + c.scrollDelta }
+
+private val PointerEvent.isPreciseWheelRotation
+    get() = (awtEventOrNull as? MouseWheelEvent)?.isPreciseWheelRotation ?: false
+
+private val MouseWheelEvent.isPreciseWheelRotation
+    get() = abs(preciseWheelRotation - wheelRotation.toDouble()) > 0.001

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -48,8 +48,6 @@ internal actual fun CompositionLocalConsumerModifierNode.platformScrollConfig():
 internal abstract class DesktopScrollConfig : ScrollConfig {
     override var isSmoothScrollingEnabled = System.getProperty("compose.scrolling.smooth.enabled") != "false"
         internal set
-
-    override fun isPreciseWheelScroll(event: PointerEvent): Boolean = event.isPreciseWheelRotation
 }
 
 // TODO(demin): is this formula actually correct? some experimental values don't fit
@@ -113,9 +111,3 @@ private val PointerEvent.shouldScrollByPage
 
 private val PointerEvent.totalScrollDelta
     get() = this.changes.fastFold(Offset.Zero) { acc, c -> acc + c.scrollDelta }
-
-private val PointerEvent.isPreciseWheelRotation
-    get() = (awtEventOrNull as? MouseWheelEvent)?.isPreciseWheelRotation ?: false
-
-private val MouseWheelEvent.isPreciseWheelRotation
-    get() = abs(preciseWheelRotation - wheelRotation.toDouble()) > 0.001

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/gestures/JsScrollable.js.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/gestures/JsScrollable.js.kt
@@ -30,10 +30,6 @@ import androidx.compose.ui.util.fastFold
 internal actual fun CompositionLocalConsumerModifierNode.platformScrollConfig(): ScrollConfig = JsConfig
 
 private object JsConfig : ScrollConfig {
-
-    override val isSmoothScrollingEnabled: Boolean
-        get() = true
-
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
         // Note: The returned offset value here is not strictly accurate.
         // However, it serves two primary purposes:

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -768,17 +768,19 @@ class ScrollableTest {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun scrollable_nestedScroll_disabledForMouseWheel() = runSkikoComposeUiTest {
+    fun scrollable_nestedScroll_childPartialConsumptionForMouseWheel() = runSkikoComposeUiTest {
         var innerDrag = 0f
         var outerDrag = 0f
         val outerState = ScrollableState(
             consumeScrollDelta = {
+                // Since the child has already consumed half, the parent will consume the rest.
                 outerDrag += it
                 it
             }
         )
         val innerState = ScrollableState(
             consumeScrollDelta = {
+                // Child consumes half, leaving the rest for the parent to consume.
                 innerDrag += it / 2
                 it / 2
             }
@@ -812,7 +814,10 @@ class ScrollableTest {
         }
         runOnIdle {
             assertThat(innerDrag).isGreaterThan(0f)
-            assertThat(outerDrag).isEqualTo(0f)
+            assertThat(outerDrag).isGreaterThan(0f)
+            // Since child (inner) consumes half of the scroll, the parent (outer) consumes the
+            // remainder (which is half as well), so they will be equal.
+            assertThat(innerDrag).isEqualTo(outerDrag)
         }
     }
 

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
@@ -56,5 +56,6 @@ val Components = Screen.Selection(
     LazyLayouts,
     MaterialComponents,
     Material3Components,
+    Screen.Example("NestedScroll") { NestedScrollExample() },
     Screen.Example("Selection") { SelectionExample() }
 )

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/NestedScroll.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/NestedScroll.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
+
+// Copy from compose/ui/ui/samples/src/main/java/androidx/compose/ui/samples/NestedScrollSamples.kt
+@Composable
+fun NestedScrollExample() {
+    // here we use LazyColumn that has build-in nested scroll, but we want to act like a
+    // parent for this LazyColumn and participate in its nested scroll.
+    // Let's make a collapsing toolbar for LazyColumn
+    val toolbarHeight = 48.dp
+    val toolbarHeightPx = with(LocalDensity.current) { toolbarHeight.roundToPx().toFloat() }
+    // our offset to collapse toolbar
+    val toolbarOffsetHeightPx = remember { mutableStateOf(0f) }
+    // now, let's create connection to the nested scroll system and listen to the scroll
+    // happening inside child LazyColumn
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                // try to consume before LazyColumn to collapse toolbar if needed, hence pre-scroll
+                val delta = available.y
+                val newOffset = toolbarOffsetHeightPx.value + delta
+                toolbarOffsetHeightPx.value = newOffset.coerceIn(-toolbarHeightPx, 0f)
+                // here's the catch: let's pretend we consumed 0 in any case, since we want
+                // LazyColumn to scroll anyway for good UX
+                // We're basically watching scroll without taking it
+                return Offset.Zero
+            }
+        }
+    }
+    Box(
+        Modifier
+            .fillMaxSize()
+            // attach as a parent to the nested scroll system
+            .nestedScroll(nestedScrollConnection)
+    ) {
+        // our list with build in nested scroll support that will notify us about its scroll
+        LazyColumn(contentPadding = PaddingValues(top = toolbarHeight)) {
+            items(100) { index ->
+                Text("I'm item $index", modifier = Modifier.fillMaxWidth().padding(16.dp))
+            }
+        }
+        TopAppBar(
+            modifier = Modifier
+                .height(toolbarHeight)
+                .offset { IntOffset(x = 0, y = toolbarOffsetHeightPx.value.roundToInt()) },
+            title = { Text("toolbar offset is ${toolbarOffsetHeightPx.value}") }
+        )
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -371,7 +371,7 @@ class MouseMoveTest {
         val collector2 = EventCollector()
 
         setContent {
-            LazyColumn(Modifier.size(10.dp)) {
+            LazyColumn(Modifier.size(12.dp)) {
                 items(2) {
                     Box(
                         modifier = Modifier
@@ -382,16 +382,16 @@ class MouseMoveTest {
             }
         }
 
-        scene.sendPointerEvent(PointerEventType.Enter, Offset(0f, 0f))
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(5f, 5f))
         collector1.assertCounts(enter = 1, exit = 0)
         collector2.assertCounts(enter = 0, exit = 0)
 
-        scene.sendPointerEvent(PointerEventType.Scroll, Offset(0f, 0f), scrollDelta = Offset(0f, 10000f))
+        scene.sendPointerEvent(PointerEventType.Scroll, Offset(5f, 5f), scrollDelta = Offset(0f, 10000f))
         waitForIdle()
         collector1.assertCounts(enter = 1, exit = 1)
         collector2.assertCounts(enter = 1, exit = 0)
 
-        scene.sendPointerEvent(PointerEventType.Scroll, Offset(0f, 0f), scrollDelta = Offset(0f, -10000f))
+        scene.sendPointerEvent(PointerEventType.Scroll, Offset(5f, 5f), scrollDelta = Offset(0f, -10000f))
         waitForIdle()
         collector1.assertCounts(enter = 2, exit = 1)
         collector2.assertCounts(enter = 1, exit = 1)


### PR DESCRIPTION
## Proposed Changes

- Use `dispatchScroll` with a new `NestedScrollSource.Wheel` instead of direct call of `scrollBy`/`dispatchRawDelta`
- Set scrolling priority to `MutatePriority.UserInput` during mouse wheel scroll animation
- Move all scroll delta dispatching into a single coroutine
- Remove threshold (logic where small delta was applied without animation), `shouldApplyImmediately` flag based on `isPreciseWheelScroll` handles it instead.
- Wait `ProgressTimeout` after each mouse wheel event before resetting `isScrollInProgress` flag
- Enable this logic by default (old "raw" dispatching failed our tests on iOS)

## Testing

Test: Check "NestedScroll" page in mpp demo + unit tests

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/653
Fixes https://github.com/JetBrains/compose-multiplatform/issues/1423
