### PR TITLE
Fix drawing a rect with negative size

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
@@ -117,7 +117,15 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
     }
 
     override fun drawRect(left: Float, top: Float, right: Float, bottom: Float, paint: Paint) {
-        skia.drawRect(SkRect.makeLTRB(left, top, right, bottom), paint.skia)
+        /*
+         * Do not use makeLTRB here because it adds additional checks (like left <= right) that
+         * might lead to a crash. It's not required here because skia sorts it internally.
+         * See https://github.com/JetBrains/skia/blob/skiko-m105/src/core/SkCanvas.cpp#L1776-L1778
+         *
+         * Please note that "negative" size is used in material components to support RTL.
+         */
+        val rect = SkRect(left, top, right, bottom)
+        skia.drawRect(rect, paint.skia)
     }
 
     override fun drawRoundRect(


### PR DESCRIPTION
## Proposed Changes

- Fix a crash `Rect::makeLTRB expected l <= r` by just dropping this check - it's handled by skia under the hood and we have a code in common that uses such logic to support RTL.

## Testing

Test: Run code snippet from the issue.
(TODO: add more unit tests)

<img width="563" alt="Screenshot 2024-02-07 at 11 29 46" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/8c91acca-d5c0-4285-a85c-5dca101d11ba">

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4250
