### PR TITLE
fix: value class primary construction selection

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerParamTransformer.kt
@@ -312,7 +312,7 @@ class ComposerParamTransformer(
                 this
             )
         } else {
-            val ctor = classSymbol!!.constructors.first()
+            val ctor = classSymbol!!.constructors.first { it.owner.isPrimary }
             val underlyingType = getInlineClassUnderlyingType(classSymbol.owner)
 
             // TODO(lmr): We should not be calling the constructor here, but this seems like a


### PR DESCRIPTION
https://github.com/JetBrains/compose-multiplatform/issues/3643

the constructor for dummy default value was chosen incorrectly due to different order of constructors for native and non-native targets