### PR TITLE
fix: prevent protected composable export to objc

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/hiddenfromobjc/AddHiddenFromObjCLowering.kt
@@ -66,7 +66,7 @@ class AddHiddenFromObjCLowering(
 
     override fun visitFunction(declaration: IrFunction): IrStatement {
         val f = super.visitFunction(declaration) as IrFunction
-        if (f.isLocal || f.visibility != DescriptorVisibilities.PUBLIC) return f
+        if (f.isLocal || !(f.visibility == DescriptorVisibilities.PUBLIC || f.visibility == DescriptorVisibilities.PROTECTED)) return f
 
         val shouldAdd = f.hasComposableAnnotation() ||
             f.typeParameters.any { it.defaultType.hasComposable() } ||


### PR DESCRIPTION
https://github.com/JetBrains/compose-multiplatform/issues/4055

protected composable functions were trying to be exported for calls from ObjC, resulting in signature mismatches due to Composable functions transformation