### PR TITLE
Support software keyboard inset in `Dialog`

### DIFF
--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -74,8 +74,6 @@ actual val WindowInsets.Companion.displayCutout: WindowInsets
 /**
  * An insets type representing the window of an "input method",
  * for iOS IME representing the software keyboard.
- *
- * TODO: Animation doesn't work on iOS yet
  */
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3858,8 +3858,8 @@ public final class androidx/compose/ui/window/DialogProperties {
 	public static final field $stable I
 	public fun <init> (ZZZ)V
 	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (ZZZZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (ZZZZJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZZZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZZZJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZ[Ljava/lang/Void;Z)V
 	public synthetic fun <init> (ZZ[Ljava/lang/Void;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -3868,6 +3868,7 @@ public final class androidx/compose/ui/window/DialogProperties {
 	public final fun getScrimColor-0d7_KjU ()J
 	public final fun getUsePlatformDefaultWidth ()Z
 	public final fun getUsePlatformInsets ()Z
+	public final fun getUseSoftwareKeyboardInset ()Z
 	public fun hashCode ()I
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformInsets.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformInsets.skiko.kt
@@ -67,6 +67,13 @@ class PlatformInsets(
     }
 }
 
+internal fun PlatformInsets.union(insets: PlatformInsets) = PlatformInsets(
+    left = maxOf(left, insets.left),
+    top = maxOf(top, insets.top),
+    right = maxOf(right, insets.right),
+    bottom = maxOf(bottom, insets.bottom)
+)
+
 internal fun PlatformInsets.exclude(insets: PlatformInsets) = PlatformInsets(
     left = (left - insets.left).coerceAtLeast(0.dp),
     top = (top - insets.top).coerceAtLeast(0.dp),
@@ -80,18 +87,32 @@ internal interface InsetsConfig {
     val safeInsets: PlatformInsets
         @Composable get
 
+    val ime: PlatformInsets
+        @Composable get
+
     // Don't make it public, it should be implementation details for creating new root layout nodes.
     // TODO: Ensure encapsulation and proper control flow during refactoring [Owner]s
     @Composable
-    fun excludeSafeInsets(content: @Composable () -> Unit)
+    fun excludeInsets(
+        safeInsets: Boolean,
+        ime: Boolean,
+        content: @Composable () -> Unit
+    )
 }
 
 internal object ZeroInsetsConfig : InsetsConfig {
     override val safeInsets: PlatformInsets
         @Composable get() = PlatformInsets.Zero
 
+    override val ime: PlatformInsets
+        @Composable get() = PlatformInsets.Zero
+
     @Composable
-    override fun excludeSafeInsets(content: @Composable () -> Unit) {
+    override fun excludeInsets(
+        safeInsets: Boolean,
+        ime: Boolean,
+        content: @Composable () -> Unit
+    ) {
         content()
     }
 }
@@ -103,6 +124,6 @@ internal object ZeroInsetsConfig : InsetsConfig {
  * different on each platform.
  *
  * TODO: Stabilize and make the window paddings in the foundation-layout module depend on it.
- *  There is a plan to potentially move this variable into the [Platform] interface.
+ *  There is a plan to potentially move this variable into the [PlatformContext] interface.
  */
 internal expect var PlatformInsetsConfig: InsetsConfig

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.ZeroInsetsConfig
+import androidx.compose.ui.platform.union
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.popup
@@ -433,7 +434,7 @@ private fun PopupLayout(
     onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
-    val platformInsets = properties.insetsConfig.safeInsets
+    val platformInsets = properties.platformInsets
     var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
     EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
     val layer = rememberComposeSceneLayer(
@@ -454,7 +455,10 @@ private fun PopupLayout(
             layoutDirection = layoutDirection,
             parentBoundsInWindow = parentBoundsInWindow
         )
-        properties.insetsConfig.excludeSafeInsets {
+        PlatformInsetsConfig.excludeInsets(
+            safeInsets = properties.usePlatformInsets,
+            ime = false,
+        ) {
             Layout(
                 content = content,
                 modifier = modifier,
@@ -463,6 +467,13 @@ private fun PopupLayout(
         }
     }
 }
+
+private val PopupProperties.platformInsets: PlatformInsets
+    @Composable get() = if (usePlatformInsets) {
+        PlatformInsetsConfig.safeInsets
+    } else {
+        PlatformInsets.Zero
+    }
 
 @Composable
 private fun rememberLayerContent(layer: ComposeSceneLayer, content: @Composable () -> Unit) {
@@ -479,9 +490,6 @@ private fun EmptyLayout(modifier: Modifier = Modifier) = Layout(
         layout(0, 0) {}
     }
 )
-
-private val PopupProperties.insetsConfig: InsetsConfig
-    get() = if (usePlatformInsets) PlatformInsetsConfig else ZeroInsetsConfig
 
 private fun Modifier.parentBoundsInWindow(
     onBoundsChanged: (IntRect) -> Unit

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -74,8 +74,15 @@ class PopupTest {
             override val safeInsets: PlatformInsets
                 @Composable get() = insets
 
+            override val ime: PlatformInsets
+                @Composable get() = PlatformInsets.Zero
+
             @Composable
-            override fun excludeSafeInsets(content: @Composable () -> Unit) {
+            override fun excludeInsets(
+                safeInsets: Boolean,
+                ime: Boolean,
+                content: @Composable () -> Unit
+            ) {
                 content()
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.uikit.LocalKeyboardOverlapHeight
+import androidx.compose.ui.unit.dp
 
 /**
  * Composition local for SafeArea of ComposeUIViewController
@@ -38,13 +40,22 @@ private object SafeAreaInsetsConfig : InsetsConfig {
     override val safeInsets: PlatformInsets
         @Composable get() = LocalSafeArea.current
 
+    override val ime: PlatformInsets
+        @Composable get() = PlatformInsets(bottom = LocalKeyboardOverlapHeight.current.dp)
+
     @Composable
-    override fun excludeSafeInsets(content: @Composable () -> Unit) {
+    override fun excludeInsets(
+        safeInsets: Boolean,
+        ime: Boolean,
+        content: @Composable () -> Unit
+    ) {
         val safeArea = LocalSafeArea.current
         val layoutMargins = LocalLayoutMargins.current
+        val keyboardOverlapHeight = LocalKeyboardOverlapHeight.current
         CompositionLocalProvider(
-            LocalSafeArea provides PlatformInsets(),
-            LocalLayoutMargins provides layoutMargins.exclude(safeArea),
+            LocalSafeArea provides if (safeInsets) PlatformInsets() else safeArea,
+            LocalLayoutMargins provides if (safeInsets) layoutMargins.exclude(safeArea) else layoutMargins,
+            LocalKeyboardOverlapHeight provides if (ime) 0f else keyboardOverlapHeight,
             content = content
         )
     }


### PR DESCRIPTION
## Proposed Changes

- Add a way to include software keyboard height into `Dialog` centering calculation.
- Add `DialogProperties.useSoftwareKeyboardInset` option to disable this behavior.
- Align default behavior with Android (software keyboard affects `Dialog`)

## Known issues

- Animation lags with `platformLayers = true` on iOS

## Testing

Test: run mpp, DialogWithTextField page

`useSoftwareKeyboardInset = true` | `useSoftwareKeyboardInset = false`
--- | ---
![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 09 07](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/efc5100b-12c4-44ae-944e-46a76226abfb) | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 29 56](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/45bcf869-0696-4bf9-9b2c-d78682bab8a9)


## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4210