### PR TITLE
Auto focus

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -453,7 +453,7 @@ private class AccessibilityElement(
         }
 
         parent?.let {
-            return it.scrollIfPossible(direction, it.cachedConfig)
+            return it.scrollIfPossible(direction)
         }
 
         return false
@@ -464,7 +464,7 @@ private class AccessibilityElement(
             return false
         }
 
-        return scrollIfPossible(direction, cachedConfig)
+        return scrollIfPossible(direction)
     }
 
     override fun isAccessibilityElement(): Boolean =

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -453,7 +453,7 @@ private class AccessibilityElement(
         }
 
         parent?.let {
-            return it.scrollIfPossible(direction)
+            return it.scrollIfPossible(direction, it.cachedConfig)
         }
 
         return false
@@ -464,7 +464,7 @@ private class AccessibilityElement(
             return false
         }
 
-        return scrollIfPossible(direction)
+        return scrollIfPossible(direction, cachedConfig)
     }
 
     override fun isAccessibilityElement(): Boolean =

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -301,13 +301,11 @@ private class AccessibilityElement(
 
         AccessibilityMediator.focusedElement = this
 
-        mediator.debugLogger?.log(
-            listOf(
-                null,
-                "Focused on:",
-                cachedConfig
-            )
-        )
+        mediator.debugLogger?.apply {
+            log(null)
+            log("Focused on:")
+            log(cachedConfig)
+        }
 
         if (!isAlive) {
             return
@@ -647,15 +645,17 @@ private class AccessibilityElement(
         check(indexOfSelf != NSNotFound)
         check(container.accessibilityElementAtIndex(indexOfSelf) == this)
 
-        logger.log("${indent}AccessibilityElement_$semanticsNodeId")
-        logger.log("$indent  containmentChain: ${debugContainmentChain(this)}")
-        logger.log("$indent  isAccessibilityElement: $isAccessibilityElement")
-        logger.log("$indent  accessibilityLabel: $accessibilityLabel")
-        logger.log("$indent  accessibilityValue: $accessibilityValue")
-        logger.log("$indent  accessibilityTraits: $accessibilityTraits")
-        logger.log("$indent  accessibilityFrame: ${NSStringFromCGRect(accessibilityFrame)}")
-        logger.log("$indent  accessibilityIdentifier: $accessibilityIdentifier")
-        logger.log("$indent  accessibilityCustomActions: $accessibilityCustomActions")
+        logger.apply {
+            log("${indent}AccessibilityElement_$semanticsNodeId")
+            log("$indent  containmentChain: ${debugContainmentChain(this@AccessibilityElement)}")
+            log("$indent  isAccessibilityElement: $isAccessibilityElement")
+            log("$indent  accessibilityLabel: $accessibilityLabel")
+            log("$indent  accessibilityValue: $accessibilityValue")
+            log("$indent  accessibilityTraits: $accessibilityTraits")
+            log("$indent  accessibilityFrame: ${NSStringFromCGRect(accessibilityFrame)}")
+            log("$indent  accessibilityIdentifier: $accessibilityIdentifier")
+            log("$indent  accessibilityCustomActions: $accessibilityCustomActions")
+        }
     }
 }
 
@@ -1045,10 +1045,14 @@ internal class AccessibilityMediator constructor(
         }
 
         if (needsRefocusing) {
-            needsRefocusing = false
             val refocusedElement = checkNotNull(accessibilityElementsMap[rootSemanticsNodeId])
                 .findFocusableElement()
-            return NodesSyncResult.Success(refocusedElement)
+
+            if (refocusedElement != null) {
+                needsRefocusing = false
+                debugLogger?.log("Refocusing on $refocusedElement")
+                return NodesSyncResult.Success(refocusedElement)
+            }
         }
 
         // TODO: return refocused element if the old focus is not present in the new tree

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1049,7 +1049,8 @@ internal class AccessibilityMediator constructor(
         val focusedElement = UIAccessibilityFocusedElement(null)
 
         // TODO: in future the focused element could be the interop UIView that is detached from the
-        //  hierarchy, but still maitains the focus.
+        //  hierarchy, but still maintains the focus until the GC collects it, or AX services detect
+        //  that it's not reachable anymore through containment chain
         val isFocusedElementDead = focusedElement?.let {
             val accessibilityElement = it as? AccessibilityElement
             accessibilityElement?.isAlive ?: false

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGRectMake
 import platform.UIKit.NSStringFromCGRect
 import platform.UIKit.UIAccessibilityCustomAction
+import platform.UIKit.UIAccessibilityFocusedElement
 import platform.UIKit.UIAccessibilityIsVoiceOverRunning
 import platform.UIKit.UIAccessibilityLayoutChangedNotification
 import platform.UIKit.UIAccessibilityPostNotification
@@ -298,8 +299,6 @@ private class AccessibilityElement(
 
     override fun accessibilityElementDidBecomeFocused() {
         super.accessibilityElementDidBecomeFocused()
-
-        AccessibilityMediator.focusedElement = this
 
         mediator.debugLogger?.apply {
             log(null)
@@ -1047,6 +1046,10 @@ internal class AccessibilityMediator constructor(
             debugTraverse(it, view)
         }
 
+        val focusedElement = UIAccessibilityFocusedElement(null)
+
+        // TODO: in future the focused element could be the interop UIView that is detached from the
+        //  hierarchy, but still maitains the focus.
         val isFocusedElementDead = focusedElement?.let {
             val accessibilityElement = it as? AccessibilityElement
             accessibilityElement?.isAlive ?: false
@@ -1072,11 +1075,6 @@ internal class AccessibilityMediator constructor(
         }
 
         return NodesSyncResult.Success(newElementToFocus)
-    }
-
-    companion object {
-        // TODO: consider the cases when the focused elements are outside of Compose control.
-        var focusedElement: Any? = null
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -47,6 +47,7 @@ import platform.UIKit.UIAccessibilityCustomAction
 import platform.UIKit.UIAccessibilityIsVoiceOverRunning
 import platform.UIKit.UIAccessibilityLayoutChangedNotification
 import platform.UIKit.UIAccessibilityPostNotification
+import platform.UIKit.UIAccessibilityScreenChangedNotification
 import platform.UIKit.UIAccessibilityScrollDirection
 import platform.UIKit.UIAccessibilityScrollDirectionDown
 import platform.UIKit.UIAccessibilityScrollDirectionLeft
@@ -910,7 +911,12 @@ internal class AccessibilityMediator constructor(
 
                         is NodesSyncResult.Success -> {
                             debugLogger?.log("AccessibilityMediator.sync took $time")
-                            UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, immutableResult.newElementToFocus)
+
+                            if (immutableResult.newElementToFocus != null) {
+                                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, immutableResult.newElementToFocus)
+                            } else {
+                                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, null)
+                            }
                         }
                     }
                 }
@@ -1047,6 +1053,7 @@ internal class AccessibilityMediator constructor(
         }
 
         if (needsRefocusing) {
+            debugLogger?.log("Needs refocusing")
             val refocusedElement = checkNotNull(accessibilityElementsMap[rootSemanticsNodeId])
                 .findFocusableElement()
 
@@ -1054,6 +1061,8 @@ internal class AccessibilityMediator constructor(
                 needsRefocusing = false
                 debugLogger?.log("Refocusing on $refocusedElement")
                 return NodesSyncResult.Success(refocusedElement)
+            } else {
+                debugLogger?.log("No focusable element found")
             }
         }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -47,7 +47,6 @@ import platform.UIKit.UIAccessibilityCustomAction
 import platform.UIKit.UIAccessibilityIsVoiceOverRunning
 import platform.UIKit.UIAccessibilityLayoutChangedNotification
 import platform.UIKit.UIAccessibilityPostNotification
-import platform.UIKit.UIAccessibilityScreenChangedNotification
 import platform.UIKit.UIAccessibilityScrollDirection
 import platform.UIKit.UIAccessibilityScrollDirectionDown
 import platform.UIKit.UIAccessibilityScrollDirectionLeft
@@ -844,7 +843,7 @@ internal class AccessibilityMediator constructor(
      * Indicates that this mediator was just created and the accessibility focus should be set on the
      * first eligible element.
      */
-    private var needsRefocusing = true
+    private var needsInitialRefocusing = true
     private var isAlive = true
 
     var debugLogger: AccessibilityDebugLogger? = null
@@ -1053,9 +1052,7 @@ internal class AccessibilityMediator constructor(
             accessibilityElement?.isAlive ?: false
         } ?: false
 
-        if (isFocusedElementDead) {
-            needsRefocusing = true
-        }
+        val needsRefocusing = needsInitialRefocusing || isFocusedElementDead
 
         val newElementToFocus = if (needsRefocusing) {
             debugLogger?.log("Needs refocusing")
@@ -1063,7 +1060,7 @@ internal class AccessibilityMediator constructor(
                 .findFocusableElement()
 
             if (refocusedElement != null) {
-                needsRefocusing = false
+                needsInitialRefocusing = false
                 debugLogger?.log("Refocusing on $refocusedElement")
             } else {
                 debugLogger?.log("No focusable element found")

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -912,11 +912,7 @@ internal class AccessibilityMediator constructor(
                         is NodesSyncResult.Success -> {
                             debugLogger?.log("AccessibilityMediator.sync took $time")
 
-                            if (immutableResult.newElementToFocus != null) {
-                                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, immutableResult.newElementToFocus)
-                            } else {
-                                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, null)
-                            }
+                            UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, immutableResult.newElementToFocus)
                         }
                     }
                 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1028,7 +1028,7 @@ internal class AccessibilityMediator constructor(
      *  of the issue and associated performance overhead.
      */
     private fun sync(): NodesSyncResult {
-        // TODO: investigate what needs to be done to reflect that this hiearchy is probably covered
+        // TODO: investigate what needs to be done to reflect that this hierarchy is probably covered
         //   by sibling overlay
 
         if (!isCurrentComposeAccessibleTreeDirty) {
@@ -1061,7 +1061,7 @@ internal class AccessibilityMediator constructor(
             needsRefocusing = true
         }
 
-        if (needsRefocusing) {
+        val newElementToFocus = if (needsRefocusing) {
             debugLogger?.log("Needs refocusing")
             val refocusedElement = checkNotNull(accessibilityElementsMap[rootSemanticsNodeId])
                 .findFocusableElement()
@@ -1069,16 +1069,16 @@ internal class AccessibilityMediator constructor(
             if (refocusedElement != null) {
                 needsRefocusing = false
                 debugLogger?.log("Refocusing on $refocusedElement")
-                return NodesSyncResult.Success(refocusedElement)
             } else {
                 debugLogger?.log("No focusable element found")
             }
+
+            refocusedElement
+        } else {
+            null
         }
 
-        // TODO: return refocused element if the old focus is not present in the new tree
-        //  reverse engineer the logic of iOS Accessibility services that is performed when the
-        //  focused object is deallocated
-        return NodesSyncResult.Success(null)
+        return NodesSyncResult.Success(newElementToFocus)
     }
 
     companion object {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1075,6 +1075,7 @@ internal class AccessibilityMediator constructor(
     }
 
     companion object {
+        // TODO: consider the cases when the focused elements are outside of Compose control.
         var focusedElement: Any? = null
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -636,6 +636,8 @@ private class AccessibilityElement(
         element.parent = this@AccessibilityElement
     }
 
+    private fun debugContainmentChain() = debugContainmentChain(this)
+
     fun debugLog(logger: AccessibilityDebugLogger, depth: Int) {
         val indent = " ".repeat(depth * 2)
 
@@ -647,7 +649,7 @@ private class AccessibilityElement(
 
         logger.apply {
             log("${indent}AccessibilityElement_$semanticsNodeId")
-            log("$indent  containmentChain: ${debugContainmentChain(this@AccessibilityElement)}")
+            log("$indent  containmentChain: ${debugContainmentChain()}")
             log("$indent  isAccessibilityElement: $isAccessibilityElement")
             log("$indent  accessibilityLabel: $accessibilityLabel")
             log("$indent  accessibilityValue: $accessibilityValue")

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1052,6 +1052,15 @@ internal class AccessibilityMediator constructor(
             debugTraverse(it, view)
         }
 
+        val isFocusedElementDead = focusedElement?.let {
+            val accessibilityElement = it as? AccessibilityElement
+            accessibilityElement?.isAlive ?: false
+        } ?: false
+
+        if (isFocusedElementDead) {
+            needsRefocusing = true
+        }
+
         if (needsRefocusing) {
             debugLogger?.log("Needs refocusing")
             val refocusedElement = checkNotNull(accessibilityElementsMap[rootSemanticsNodeId])


### PR DESCRIPTION
## Proposed Changes

1. Refocus if the previous focused element was removed from the tree.
2. Refocus on first sync of newly created `AccessibilityMediator`, this is also a base ground for further work with popups and dialogues refocusing, that will create a separate `AccessibilityMediator`

## Testing

Test: N/A