### PR TITLE
Fix a wrong `compose-internal-annotations` version

### DIFF
--- a/annotation/annotation/build.gradle
+++ b/annotation/annotation/build.gradle
@@ -66,7 +66,6 @@ kotlin {
 androidx {
     name = "Annotation"
     type = LibraryType.PUBLISHED_LIBRARY
-    mavenVersion = LibraryVersions.ANNOTATION
     inceptionYear = "2013"
     description = "Provides source annotations for tooling and readability."
 }


### PR DESCRIPTION
It was 1.8.0-alpha01. But it should be <COMPOSE_VERSION>.

Removed, as the version should be got from:
```
ANNOTATION = { group = "org.jetbrains.compose.annotation-internal", atomicGroupVersion = "versions.COMPOSE", overrideInclude = [ ":annotation:annotation" ] }
```
in libraryversions.toml

Fixes https://youtrack.jetbrains.com/issue/COMPOSE-952/Fix-compose-internal-annotations-version-from-1.8.0-alpha01-to-COMPOSEVERSION

In the future we will probably make this library public and won't use a Compose version (we also will need to use maven relocation to keep compatibility)