### PR TITLE
Fix sharing composition locals with new platform layers

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/popup/PopupCompositionLocals.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/popup/PopupCompositionLocals.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components.popup
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+
+val LocalString = staticCompositionLocalOf<String> {
+    error("CompositionLocal LocalString not present")
+}
+
+@Composable
+fun PopupCompositionLocalExample() {
+    CompositionLocalProvider(LocalString provides "test") {
+        MaterialTheme {
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Popup {
+                    Box(Modifier.size(200.dp).background(Color.Yellow), contentAlignment = Alignment.Center) {
+                        Text("LocalString: ${LocalString.current}")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/popup/Popups.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/popup/Popups.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.window.Popup
 val Popups = Screen.Selection(
     "Popups",
     Screen.Example("ConfigurablePopup") { ConfigurablePopup() },
+    Screen.Example("CompositionLocal inside Popup") { PopupCompositionLocalExample() },
     FixedSizePopup,
     HalfScreenPopup,
     Screen.Example("Dropdown inside Popup") {

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3389,11 +3389,13 @@ public abstract interface class androidx/compose/ui/scene/ComposeSceneLayer {
 	public abstract fun calculateLocalPosition-qkQi6aY (J)J
 	public abstract fun close ()V
 	public abstract fun getBoundsInWindow ()Landroidx/compose/ui/unit/IntRect;
+	public abstract fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
 	public abstract fun getFocusable ()Z
 	public abstract fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
 	public abstract fun getScrimColor-QN2ZGVo ()Landroidx/compose/ui/graphics/Color;
 	public abstract fun setBoundsInWindow (Landroidx/compose/ui/unit/IntRect;)V
+	public abstract fun setCompositionLocalContext (Landroidx/compose/runtime/CompositionLocalContext;)V
 	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun setDensity (Landroidx/compose/ui/unit/Density;)V
 	public abstract fun setFocusable (Z)V

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.awt.toAwtColor
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -121,6 +122,10 @@ internal class SwingComposeSceneLayer(
                 /* destination = */ container)
             _mediator?.contentComponent?.bounds = localBounds
         }
+
+    override var compositionLocalContext: CompositionLocalContext?
+        get() = _mediator?.compositionLocalContext
+        set(value) { _mediator?.compositionLocalContext = value }
 
     override var scrimColor: Color? = null
         set(value) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.awt.toAwtColor
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -106,6 +107,10 @@ internal class WindowComposeSceneLayer(
             _mediator?.sceneBoundsInPx = IntRect(-value.topLeft, windowContainer.sizeInPx)
         }
 
+    override var compositionLocalContext: CompositionLocalContext?
+        get() = _mediator?.compositionLocalContext
+        set(value) { _mediator?.compositionLocalContext = value }
+
     override var scrimColor: Color? = null
         set(value) {
             field = value
@@ -136,6 +141,8 @@ internal class WindowComposeSceneLayer(
     override fun close() {
         composeContainer.detachLayer(this)
         _mediator?.dispose()
+        _mediator = null
+
         dialog.dispose()
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -17,10 +17,14 @@
 package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -28,6 +32,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -65,6 +70,13 @@ interface ComposeSceneLayer {
      * happen during recompositions.
      */
     var boundsInWindow: IntRect
+
+    /**
+     * Composition locals context which will be provided for the Composable content, which is set by [setContent].
+     *
+     * `null` if no composition locals should be provided.
+     */
+    var compositionLocalContext: CompositionLocalContext?
 
     /**
      * The color of the background fill. It can be set to null if no background drawing is necessary.
@@ -159,6 +171,7 @@ internal fun rememberComposeSceneLayer(
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val parentComposition = rememberCompositionContext()
+    val compositionLocalContext by rememberUpdatedState(currentCompositionLocalContext)
     val layer = remember {
         scene.createLayer(
             density = density,
@@ -168,6 +181,7 @@ internal fun rememberComposeSceneLayer(
         )
     }
     layer.focusable = focusable
+    layer.compositionLocalContext = compositionLocalContext
     DisposableEffect(Unit) {
         onDispose {
             layer.close()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -181,7 +181,6 @@ internal fun rememberComposeSceneLayer(
         )
     }
     layer.focusable = focusable
-    layer.compositionLocalContext = compositionLocalContext
     DisposableEffect(Unit) {
         onDispose {
             layer.close()
@@ -190,6 +189,7 @@ internal fun rememberComposeSceneLayer(
     SideEffect {
         layer.density = density
         layer.layoutDirection = layoutDirection
+        layer.compositionLocalContext = compositionLocalContext
     }
     return layer
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -582,8 +582,8 @@ private class MultiLayerComposeSceneImpl(
             check(!isClosed) { "AttachedComposeSceneLayer is closed" }
             composition?.dispose()
             composition = owner.setContent(
-                parent = compositionContext,
-                { compositionLocalContext }
+                parent = this@AttachedComposeSceneLayer.compositionContext,
+                { this@AttachedComposeSceneLayer.compositionLocalContext }
             ) {
                 owner.setRootModifier(background then keyInput)
                 content()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -511,6 +512,7 @@ private class MultiLayerComposeSceneImpl(
          * This scenario is important when user code relies on hover events to show tooltips.
          */
         override var boundsInWindow: IntRect by mutableStateOf(IntRect.Zero)
+        override var compositionLocalContext: CompositionLocalContext? = null
         override var scrimColor: Color? by mutableStateOf(null)
         override var focusable: Boolean = focusable
             set(value) {
@@ -579,7 +581,10 @@ private class MultiLayerComposeSceneImpl(
         override fun setContent(content: @Composable () -> Unit) {
             check(!isClosed) { "AttachedComposeSceneLayer is closed" }
             composition?.dispose()
-            composition = owner.setContent(parent = compositionContext) {
+            composition = owner.setContent(
+                parent = compositionContext,
+                { compositionLocalContext }
+            ) {
                 owner.setRootModifier(background then keyInput)
                 content()
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -126,6 +126,9 @@ internal class UIViewComposeSceneLayer(
                 SceneLayout.Bounds(rect = value)
             )
         }
+
+    override var compositionLocalContext: CompositionLocalContext? by mediator::compositionLocalContext
+
     override var scrimColor: Color? = null
         get() = field
         set(value) {


### PR DESCRIPTION
## Proposed Changes

- Pass `CompositionLocalContext` to all layers
- Adds a new property to a class that is marked as internal (via annotation).

## Testing

Test: unit tests currently runs without platform layers, so existing tests didn't find this issue (TODO). Added a separate page to mpp demo for manual testing for now.

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4281
