### PR TITLE
Fix `NaN` font metrics by initializing typeface for `TextStyle`

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -224,6 +224,7 @@ internal data class ComputedStyle(
                 fontSynthesis ?: FontSynthesis.None
             ).value as FontLoadResult
             res.fontFamilies = resolved.aliases.toTypedArray()
+            res.typeface = resolved.typeface
         }
 
         baselineShift?.let {


### PR DESCRIPTION
otherwise fontMetrics that we are using below  might be unreliable
see: https://github.com/JetBrains/skia/blob/6843251caf4eb4134ab91e98c8063df3cab792b1/modules/skparagraph/src/TextStyle.cpp#L172

if `fTypeface` isn't initialized we will get some default metrics, it may be e.g. all zeroes in some configurations, and it may lead to Inf and NaN values

## Proposed Changes

  -
  -
  -

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
