### PR TITLE
Commonize BasicTooltipBox

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/BasicTooltipInternal.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/BasicTooltipInternal.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationExceptio
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.onLongClick
@@ -64,7 +63,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 @ExperimentalFoundationApi
-actual fun BasicTooltipBox(
+internal fun BasicTooltipBoxInternal(
     positionProvider: PopupPositionProvider,
     tooltip: @Composable () -> Unit,
     state: BasicTooltipState,
@@ -107,7 +106,7 @@ private fun WrappedAnchor(
     content: @Composable () -> Unit
 ) {
     val scope = rememberCoroutineScope()
-    val longPressLabel = stringResource(R.string.tooltip_label)
+    val longPressLabel = BasicTooltipStrings.label()
     Box(modifier = modifier
             .handleGestures(enableUserInput, state)
             .anchorSemantics(longPressLabel, enableUserInput, state, scope)
@@ -123,7 +122,7 @@ private fun TooltipPopup(
     focusable: Boolean,
     content: @Composable () -> Unit
 ) {
-    val tooltipDescription = stringResource(R.string.tooltip_description)
+    val tooltipDescription = BasicTooltipStrings.description()
     Popup(
         popupPositionProvider = positionProvider,
         onDismissRequest = {
@@ -131,7 +130,8 @@ private fun TooltipPopup(
                 scope.launch { state.dismiss() }
             }
         },
-        properties = PopupProperties(focusable = focusable)
+        // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-963/Discuss-fix-Tooltipfocusable-true-API) Discuss how to support focusable
+        properties = PopupProperties(focusable = false),
     ) {
         Box(
             modifier = Modifier.semantics {
@@ -219,3 +219,11 @@ private fun Modifier.anchorSemantics(
                 )
             }
     } else this
+
+internal expect object BasicTooltipStrings {
+    @Composable
+    fun label(): String
+
+    @Composable
+    fun description(): String
+}

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicTooltip.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicTooltip.skiko.kt
@@ -52,15 +52,6 @@ actual fun BasicTooltipBox(
     focusable: Boolean,
     enableUserInput: Boolean,
     content: @Composable () -> Unit
-) {
-    Box(modifier = modifier) {
-        content()
-        if (state.isVisible) {
-            Popup(
-                popupPositionProvider = positionProvider,
-                onDismissRequest = { state.dismiss() },
-                properties = PopupProperties(focusable = focusable),
-            ) { tooltip() }
-        }
-    }
-}
+) = BasicTooltipBoxInternal(
+    positionProvider, tooltip, state, modifier, focusable, enableUserInput, content
+)

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicTooltipInternal.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicTooltipInternal.skiko.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.runtime.Composable
+
+// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3360) Support localization
+//  the current values are copied from compose\foundation\foundation\src\androidMain\res\values-en-rGB\strings.xml
+internal actual object BasicTooltipStrings {
+    @Composable
+    actual fun label() = "show tooltip"
+    @Composable
+    actual fun description() = "tooltip"
+}

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/BasicTooltipInternal.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/BasicTooltipInternal.kt
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalMaterial3Api::class)
-
 package androidx.compose.material3
 
 import androidx.compose.foundation.MutatePriority
-import androidx.compose.foundation.R
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.waitForUpOrCancellation
@@ -33,7 +30,6 @@ import androidx.compose.ui.input.pointer.PointerEventTimeoutCancellationExceptio
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.onLongClick
@@ -71,7 +67,7 @@ import kotlinx.coroutines.launch
  */
 @Composable
 @ExperimentalMaterial3Api
-internal actual fun BasicTooltipBox(
+internal fun BasicTooltipBoxInternal(
     positionProvider: PopupPositionProvider,
     tooltip: @Composable () -> Unit,
     state: BasicTooltipState,
@@ -113,7 +109,7 @@ private fun WrappedAnchor(
     content: @Composable () -> Unit
 ) {
     val scope = rememberCoroutineScope()
-    val longPressLabel = stringResource(R.string.tooltip_label)
+    val longPressLabel = BasicTooltipStrings.label()
     Box(modifier = modifier
         .handleGestures(enableUserInput, state)
         .anchorSemantics(longPressLabel, enableUserInput, state, scope)
@@ -128,7 +124,7 @@ private fun TooltipPopup(
     focusable: Boolean,
     content: @Composable () -> Unit
 ) {
-    val tooltipDescription = stringResource(R.string.tooltip_description)
+    val tooltipDescription = BasicTooltipStrings.description()
     Popup(
         popupPositionProvider = positionProvider,
         onDismissRequest = {
@@ -136,7 +132,8 @@ private fun TooltipPopup(
                 scope.launch { state.dismiss() }
             }
         },
-        properties = PopupProperties(focusable = focusable)
+        // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-963/Discuss-fix-Tooltipfocusable-true-API) Discuss how to support focusable
+        properties = PopupProperties(focusable = false),
     ) {
         Box(
             modifier = Modifier.semantics {
@@ -222,3 +219,11 @@ private fun Modifier.anchorSemantics(
             )
         }
     } else this
+
+internal expect object BasicTooltipStrings {
+    @Composable
+    fun label(): String
+
+    @Composable
+    fun description(): String
+}

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/BasicTooltip.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/BasicTooltip.skiko.kt
@@ -55,16 +55,7 @@ internal actual fun BasicTooltipBox(
     focusable: Boolean,
     enableUserInput: Boolean,
     content: @Composable () -> Unit
-) {
-    Box(modifier = modifier) {
-        content()
-        if (state.isVisible) {
-            Popup(
-                popupPositionProvider = positionProvider,
-                onDismissRequest = { state.dismiss() },
-                properties = PopupProperties(focusable = focusable),
-            ) { tooltip() }
-        }
-    }
-}
+) = BasicTooltipBoxInternal(
+    positionProvider, tooltip, state, modifier, focusable, enableUserInput, content
+)
 

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/BasicTooltipInternal.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/BasicTooltipInternal.skiko.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material3
+
+import androidx.compose.runtime.Composable
+
+// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3360) Support localization
+//  the current values are copied from compose\foundation\foundation\src\androidMain\res\values-en-rGB\strings.xml
+internal actual object BasicTooltipStrings {
+    @Composable
+    actual fun label() = "show tooltip"
+    @Composable
+    actual fun description() = "tooltip"
+}


### PR DESCRIPTION
The implementation is moved from BasicTooltip.android.kt to BasicTooltipBoxInternal.kt and reused in the skiko actual. This implementation supports touch and mouse.

`TooltipBox(focusable=true)` doesn't have any affect after this PR, as it is incompatible with showing a tooltip hover.

## Testing
manual on this example:
```
    @Composable
    fun Content() {
        TooltipBox(
            positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
            tooltip = {
                PlainTooltip {
                    androidx.compose.material3.Text("Add to favorites")
                }
            },
            state = rememberTooltipState()
        ) {
            IconButton(
                onClick = { /* Icon button's click event */ }
            ) {
                androidx.compose.material3.Icon(
                    imageVector = Icons.Filled.Favorite,
                    contentDescription = "Localized Description"
                )
            }
        }
    }
```
## Issues Fixed
Fixes https://kotlinlang.slack.com/archives/C01D6HTPATV/p1707322539519799
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3539