### PR TITLE
Fix Pager scroll with scrollable content on top

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -953,6 +953,9 @@ internal class DefaultFlingBehavior(
                         lastAnimationCycleCount++
                     }
                 } catch (exception: CancellationException) {
+                    // This is where the ScrollCancellationException should be caught,
+                    // but the parent class CancellationException is caught here for
+                    // backwards compatibility.
                     velocityLeft = animationState.velocity
                 }
                 velocityLeft
@@ -1003,3 +1006,5 @@ internal val UnityDensity = object : Density {
     override val fontScale: Float
         get() = 1f
 }
+
+internal class ScrollCancellationException(message: String?): CancellationException(message)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
@@ -28,6 +28,7 @@ import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollCancellationException
 import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.snapping.FinalSnappingItem
 import androidx.compose.foundation.gestures.snapping.MinFlingVelocityDp
@@ -896,7 +897,7 @@ private class DefaultPagerNestedScrollConnection(
         source: NestedScrollSource
     ): Offset {
         if (source == NestedScrollSource.Fling && available != Offset.Zero) {
-            throw CancellationException("")
+            throw ScrollCancellationException("")
         }
         return Offset.Zero
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
@@ -897,7 +897,7 @@ private class DefaultPagerNestedScrollConnection(
         source: NestedScrollSource
     ): Offset {
         if (source == NestedScrollSource.Fling && available != Offset.Zero) {
-            throw ScrollCancellationException("")
+            throw ScrollCancellationException("End of scrollable area reached")
         }
         return Offset.Zero
     }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/cupertino/CupertinoFlingBehavior.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/cupertino/CupertinoFlingBehavior.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.gestures.ScrollableDefaultFlingBehavior
 import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.ui.MotionDurationScale
 import kotlin.math.abs
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 
 internal class CupertinoFlingBehavior(
@@ -52,7 +53,11 @@ internal class CupertinoFlingBehavior(
                     initialVelocity = initialVelocity,
                 ).animateDecay(flingDecay) {
                     val delta = value - lastValue
-                    val consumed = scrollBy(delta)
+                    val consumed = try {
+                        scrollBy(delta)
+                    } catch (exception: CancellationException) {
+                        0.0f
+                    }
                     lastValue = value
                     velocityLeft = this.velocity
                     // avoid rounding errors and stop if anything is unconsumed

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/cupertino/CupertinoFlingBehavior.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/gestures/cupertino/CupertinoFlingBehavior.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.DecayAnimationSpec
 import androidx.compose.animation.core.animateDecay
 import androidx.compose.foundation.gestures.DefaultScrollMotionDurationScale
+import androidx.compose.foundation.gestures.ScrollCancellationException
 import androidx.compose.foundation.gestures.ScrollableDefaultFlingBehavior
 import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.ui.MotionDurationScale
@@ -55,7 +56,7 @@ internal class CupertinoFlingBehavior(
                     val delta = value - lastValue
                     val consumed = try {
                         scrollBy(delta)
-                    } catch (exception: CancellationException) {
+                    } catch (exception: ScrollCancellationException) {
                         0.0f
                     }
                     lastValue = value

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.unit.*
 import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.sign
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.isActive
 
 private enum class CupertinoScrollSource {

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -246,14 +246,7 @@ class CupertinoOverscrollEffect(
         performFling: suspend (Velocity) -> Velocity
     ) {
         val availableFlingVelocity = playInitialSpringAnimationIfNeeded(velocity)
-
-        var cancellationException: Throwable? = null
-        val velocityConsumedByFling = try {
-            performFling(availableFlingVelocity)
-        } catch (e: CancellationException) {
-            cancellationException = e
-            Velocity.Zero
-        }
+        val velocityConsumedByFling = performFling(availableFlingVelocity)
         val postFlingVelocity = availableFlingVelocity - velocityConsumedByFling
 
         playSpringAnimation(
@@ -261,9 +254,6 @@ class CupertinoOverscrollEffect(
             postFlingVelocity.toFloat(),
             CupertinoSpringAnimationReason.POSSIBLE_SPRING_IN_THE_END
         )
-        cancellationException?.let {
-            throw it
-        }
     }
 
     private fun Offset.toCupertinoOverscrollDirection(): CupertinoOverscrollDirection {


### PR DESCRIPTION
Fixes scrolling when the content scrolls in the same direction as its parent Pager node.

Related MR: https://github.com/JetBrains/compose-multiplatform-core/pull/1097
Related Issue: https://github.com/JetBrains/compose-multiplatform/issues/4279