### PR TITLE
Trigger fling callbacks on mouse wheel scroll

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -32,10 +32,9 @@ import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DelegatingNode
-import androidx.compose.ui.node.ObserverModifierNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
@@ -43,68 +42,54 @@ import kotlin.coroutines.coroutineContext
 import kotlin.math.abs
 import kotlin.math.roundToInt
 import kotlin.math.sign
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withTimeoutOrNull
 
 internal class MouseWheelScrollNode(
     private val scrollingLogic: ScrollingLogic,
-    private var _enabled: Boolean,
-) : DelegatingNode(), CompositionLocalConsumerModifierNode, ObserverModifierNode {
+    private var enabled: Boolean,
+    private var onScrollStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit,
+) : DelegatingNode(), CompositionLocalConsumerModifierNode {
     private lateinit var mouseWheelScrollConfig: ScrollConfig
-    private lateinit var physics: ScrollPhysics
 
     override fun onAttach() {
         mouseWheelScrollConfig = platformScrollConfig()
-        physics = if (mouseWheelScrollConfig.isSmoothScrollingEnabled) {
-            AnimatedMouseWheelScrollPhysics(
-                mouseWheelScrollConfig = mouseWheelScrollConfig,
-                scrollingLogic = scrollingLogic,
-                density = { currentValueOf(LocalDensity) }
-            ).apply {
-                coroutineScope.launch {
-                    receiveMouseWheelEvents()
-                }
-            }
-        } else {
-            RawMouseWheelScrollPhysics(mouseWheelScrollConfig, scrollingLogic)
+        coroutineScope.launch {
+            receiveMouseWheelEvents()
         }
     }
 
-    // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-731/Scrollable-doesnt-react-on-density-changes)
-    //  it isn't called, because LocalDensity is staticCompositionLocalOf
-    override fun onObservedReadsChanged() {
-        physics.mouseWheelScrollConfig = mouseWheelScrollConfig
-        physics.scrollingLogic = scrollingLogic
-    }
-
     private val pointerInputNode = delegate(SuspendingPointerInputModifierNode {
-        if (_enabled) {
+        if (enabled) {
             mouseWheelInput()
         }
     })
 
-    var enabled
-        get() = _enabled
-        set(value) {
-            if (_enabled != value) {
-                _enabled = value
-                pointerInputNode.resetPointerInputHandler()
-            }
+    fun update(
+        enabled: Boolean,
+        onScrollStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit,
+    ) {
+        var resetPointerInputHandling = false
+        if (this.enabled != enabled) {
+            this.enabled = enabled
+            resetPointerInputHandling = true
         }
+        this.onScrollStopped = onScrollStopped
+        if (resetPointerInputHandling) {
+            pointerInputNode.resetPointerInputHandler()
+        }
+    }
 
     private suspend fun PointerInputScope.mouseWheelInput() = awaitPointerEventScope {
         while (coroutineScope.isActive) {
             val event = awaitScrollEvent()
             if (!event.isConsumed) {
-                val consumed = with(physics) { onMouseWheel(event) }
+                val consumed = onMouseWheel(event)
                 if (consumed) {
                     event.consume()
                 }
@@ -122,32 +107,7 @@ internal class MouseWheelScrollNode(
 
     private inline val PointerEvent.isConsumed: Boolean get() = changes.fastAny { it.isConsumed }
     private inline fun PointerEvent.consume() = changes.fastForEach { it.consume() }
-}
 
-private abstract class ScrollPhysics(
-    var mouseWheelScrollConfig: ScrollConfig,
-    var scrollingLogic: ScrollingLogic,
-) {
-    abstract fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean
-}
-
-private class RawMouseWheelScrollPhysics(
-    mouseWheelScrollConfig: ScrollConfig,
-    scrollingLogic: ScrollingLogic,
-) : ScrollPhysics(mouseWheelScrollConfig, scrollingLogic) {
-    override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
-        val delta = with(mouseWheelScrollConfig) {
-            calculateMouseWheelScroll(pointerEvent, size)
-        }
-        return scrollingLogic.dispatchRawDelta(delta) != Offset.Zero
-    }
-}
-
-private class AnimatedMouseWheelScrollPhysics(
-    mouseWheelScrollConfig: ScrollConfig,
-    scrollingLogic: ScrollingLogic,
-    val density: () -> Density,
-) : ScrollPhysics(mouseWheelScrollConfig, scrollingLogic) {
     private data class MouseWheelScrollDelta(
         val value: Offset,
         val shouldApplyImmediately: Boolean
@@ -159,10 +119,10 @@ private class AnimatedMouseWheelScrollPhysics(
     }
     private val channel = Channel<MouseWheelScrollDelta>(capacity = Channel.UNLIMITED)
 
-    suspend fun receiveMouseWheelEvents() {
+    private suspend fun receiveMouseWheelEvents() {
         while (coroutineContext.isActive) {
             val scrollDelta = channel.receive()
-            val density = density()
+            val density = currentValueOf(LocalDensity)
             val threshold = with(density) { AnimationThreshold.toPx() }
             val speed = with(density) { AnimationSpeed.toPx() }
             scrollingLogic.dispatchMouseWheelScroll(scrollDelta, threshold, speed)
@@ -176,17 +136,18 @@ private class AnimatedMouseWheelScrollPhysics(
         scroll(MutatePriority.UserInput, block)
     }
 
-    override fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
+    private fun PointerInputScope.onMouseWheel(pointerEvent: PointerEvent): Boolean {
         val scrollDelta = with(mouseWheelScrollConfig) {
             calculateMouseWheelScroll(pointerEvent, size)
         }
         return if (scrollingLogic.canConsumeDelta(scrollDelta)) {
             channel.trySend(MouseWheelScrollDelta(
                 value = scrollDelta,
+                shouldApplyImmediately = !mouseWheelScrollConfig.isSmoothScrollingEnabled
 
-                // In case of high-resolution wheel, such as a freely rotating wheel with
-                // no notches or trackpads, delta should apply immediately, without any delays.
-                shouldApplyImmediately = mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)
+                    // In case of high-resolution wheel, such as a freely rotating wheel with
+                    // no notches or trackpads, delta should apply immediately, without any delays.
+                    || mouseWheelScrollConfig.isPreciseWheelScroll(pointerEvent)
             )).isSuccess
         } else false
     }
@@ -311,6 +272,9 @@ private class AnimatedMouseWheelScrollPhysics(
                 }
             }
         }
+
+        // Since there was a pause (see [waitNextScrollDelta]), current velocity is zero.
+        coroutineScope.onScrollStopped(Velocity.Zero)
     }
 
     private suspend fun ScrollScope.animateMouseWheelScroll(

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -272,9 +272,9 @@ internal class MouseWheelScrollNode(
                 }
             }
         }
-
-        // Since there was a pause (see [waitNextScrollDelta]), current velocity is zero.
-        coroutineScope.onScrollStopped(Velocity.Zero)
+        val velocityPxInMs = minOf(abs(targetValue) / MaxAnimationDuration, speed)
+        val velocity = Velocity.Zero.update(sign(targetValue).reverseIfNeeded() * velocityPxInMs * 1000)
+        coroutineScope.onScrollStopped(velocity)
     }
 
     private suspend fun ScrollScope.animateMouseWheelScroll(
@@ -323,4 +323,4 @@ private inline fun Float.isLowScrollingDelta(): Boolean = abs(this) < 0.5f
 private val AnimationThreshold = 6.dp // (AnimationSpeed * MaxAnimationDuration) / (1000ms / 60Hz)
 private val AnimationSpeed = 1.dp // dp / ms
 private const val MaxAnimationDuration = 100 // ms
-private const val ScrollProgressTimeout = 100L // ms
+private const val ScrollProgressTimeout = 50L // ms

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/MouseWheelScrollable.kt
@@ -52,8 +52,8 @@ import kotlinx.coroutines.withTimeoutOrNull
 
 internal class MouseWheelScrollNode(
     private val scrollingLogic: ScrollingLogic,
+    private val onScrollStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit,
     private var enabled: Boolean,
-    private var onScrollStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit,
 ) : DelegatingNode(), CompositionLocalConsumerModifierNode {
     private lateinit var mouseWheelScrollConfig: ScrollConfig
 
@@ -72,14 +72,12 @@ internal class MouseWheelScrollNode(
 
     fun update(
         enabled: Boolean,
-        onScrollStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit,
     ) {
         var resetPointerInputHandling = false
         if (this.enabled != enabled) {
             this.enabled = enabled
             resetPointerInputHandling = true
         }
-        this.onScrollStopped = onScrollStopped
         if (resetPointerInputHandling) {
             pointerInputNode.resetPointerInputHandler()
         }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -608,7 +608,7 @@ private class ScrollableGesturesNode(
 ) : DelegatingNode() {
     val draggableState = ScrollDraggableState(scrollLogic)
     private val startDragImmediately = { scrollLogic.shouldScrollImmediately() }
-    private val onDragStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit = { velocity ->
+    private val onScrollStopped: suspend CoroutineScope.(velocity: Velocity) -> Unit = { velocity ->
         nestedScrollDispatcher.coroutineScope.launch {
             scrollLogic.onDragStopped(velocity)
         }
@@ -622,13 +622,19 @@ private class ScrollableGesturesNode(
             interactionSource = interactionSource,
             reverseDirection = false,
             startDragImmediately = startDragImmediately,
-            onDragStopped = onDragStopped,
+            onDragStopped = onScrollStopped,
             canDrag = CanDragCalculation,
             onDragStarted = NoOpOnDragStarted
         )
     )
 
-    val mouseWheelScrollNode = delegate(MouseWheelScrollNode(scrollLogic, enabled))
+    val mouseWheelScrollNode = delegate(
+        MouseWheelScrollNode(
+            scrollingLogic = scrollLogic,
+            enabled = enabled,
+            onScrollStopped = onScrollStopped,
+        )
+    )
 
     fun update(
         orientation: Orientation,
@@ -645,11 +651,14 @@ private class ScrollableGesturesNode(
             reverseDirection = false,
             startDragImmediately = startDragImmediately,
             onDragStarted = NoOpOnDragStarted,
-            onDragStopped = onDragStopped,
+            onDragStopped = onScrollStopped,
             canDrag = CanDragCalculation
         )
 
-        mouseWheelScrollNode.enabled = enabled
+        mouseWheelScrollNode.update(
+            enabled = enabled,
+            onScrollStopped = onScrollStopped
+        )
     }
 }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -523,9 +523,6 @@ interface BringIntoViewSpec {
     }
 }
 
-@Composable
-internal expect fun rememberFlingBehavior(): FlingBehavior
-
 /**
  * Contains the default values used by [scrollable]
  */
@@ -535,7 +532,7 @@ object ScrollableDefaults {
      * Create and remember default [FlingBehavior] that will represent natural fling curve.
      */
     @Composable
-    fun flingBehavior(): FlingBehavior = rememberFlingBehavior()
+    fun flingBehavior(): FlingBehavior = rememberPlatformDefaultFlingBehavior()
 
     /**
      * Create and remember default [OverscrollEffect] that will be used for showing over scroll
@@ -927,10 +924,13 @@ internal interface ScrollableDefaultFlingBehavior : FlingBehavior {
 /**
  * This method returns [ScrollableDefaultFlingBehavior] whose density will be managed by the
  * [ScrollableElement] because it's not created inside [Composable] context.
- * This is different from [rememberFlingBehavior] which creates [FlingBehavior] whose density
+ * This is different from [rememberPlatformDefaultFlingBehavior] which creates [FlingBehavior] whose density
  * depends on [LocalDensity] and is automatically resolved.
  */
 internal expect fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior
+
+@Composable
+internal expect fun rememberPlatformDefaultFlingBehavior(): FlingBehavior
 
 internal class DefaultFlingBehavior(
     var flingDecay: DecayAnimationSpec<Float>,
@@ -983,7 +983,7 @@ internal class DefaultFlingBehavior(
  */
 internal val ModifierLocalScrollableContainer = modifierLocalOf { false }
 
-internal val NoOpFlingBehavior = object : FlingBehavior {
+internal val NoOpFlingBehavior = object : ScrollableDefaultFlingBehavior {
     override suspend fun ScrollScope.performFling(initialVelocity: Float): Float = 0f
 }
 

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jsWasm.kt
@@ -16,11 +16,21 @@
 
 package androidx.compose.foundation.gestures
 
+import androidx.compose.animation.SplineBasedFloatDecayAnimationSpec
+import androidx.compose.animation.core.generateDecayAnimationSpec
+import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    NoOpFlingBehavior
+    DefaultFlingBehavior(
+        SplineBasedFloatDecayAnimationSpec(UnityDensity).generateDecayAnimationSpec()
+    )
 
 @Composable
-internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
-    NoOpFlingBehavior
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior {
+    val flingSpec = rememberSplineBasedDecay<Float>()
+    return remember(flingSpec) {
+        DefaultFlingBehavior(flingSpec)
+    }
+}

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jsWasm.kt
@@ -16,21 +16,11 @@
 
 package androidx.compose.foundation.gestures
 
-import androidx.compose.animation.SplineBasedFloatDecayAnimationSpec
-import androidx.compose.animation.core.generateDecayAnimationSpec
-import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    DefaultFlingBehavior(
-        SplineBasedFloatDecayAnimationSpec(UnityDensity).generateDecayAnimationSpec()
-    )
+    NoOpFlingBehavior
 
 @Composable
-internal actual fun rememberFlingBehavior(): FlingBehavior {
-    val flingSpec = rememberSplineBasedDecay<Float>()
-    return remember(flingSpec) {
-        DefaultFlingBehavior(flingSpec)
-    }
-}
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
+    NoOpFlingBehavior

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jvm.kt
@@ -16,11 +16,21 @@
 
 package androidx.compose.foundation.gestures
 
+import androidx.compose.animation.SplineBasedFloatDecayAnimationSpec
+import androidx.compose.animation.core.generateDecayAnimationSpec
+import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    NoOpFlingBehavior
+    DefaultFlingBehavior(
+        SplineBasedFloatDecayAnimationSpec(UnityDensity).generateDecayAnimationSpec()
+    )
 
 @Composable
-internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
-    NoOpFlingBehavior
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior {
+    val flingSpec = rememberSplineBasedDecay<Float>()
+    return remember(flingSpec) {
+        DefaultFlingBehavior(flingSpec)
+    }
+}

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/gestures/Scrollable.jvm.kt
@@ -16,21 +16,11 @@
 
 package androidx.compose.foundation.gestures
 
-import androidx.compose.animation.SplineBasedFloatDecayAnimationSpec
-import androidx.compose.animation.core.generateDecayAnimationSpec
-import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    DefaultFlingBehavior(
-        SplineBasedFloatDecayAnimationSpec(UnityDensity).generateDecayAnimationSpec()
-    )
+    NoOpFlingBehavior
 
 @Composable
-internal actual fun rememberFlingBehavior(): FlingBehavior {
-    val flingSpec = rememberSplineBasedDecay<Float>()
-    return remember(flingSpec) {
-        DefaultFlingBehavior(flingSpec)
-    }
-}
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
+    NoOpFlingBehavior

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/gestures/Scrollable.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/gestures/Scrollable.macos.kt
@@ -16,11 +16,21 @@
 
 package androidx.compose.foundation.gestures
 
+import androidx.compose.animation.SplineBasedFloatDecayAnimationSpec
+import androidx.compose.animation.core.generateDecayAnimationSpec
+import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    NoOpFlingBehavior
+    DefaultFlingBehavior(
+        SplineBasedFloatDecayAnimationSpec(UnityDensity).generateDecayAnimationSpec()
+    )
 
 @Composable
-internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
-    NoOpFlingBehavior
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior {
+    val flingSpec = rememberSplineBasedDecay<Float>()
+    return remember(flingSpec) {
+        DefaultFlingBehavior(flingSpec)
+    }
+}

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/gestures/Scrollable.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/gestures/Scrollable.macos.kt
@@ -16,21 +16,11 @@
 
 package androidx.compose.foundation.gestures
 
-import androidx.compose.animation.SplineBasedFloatDecayAnimationSpec
-import androidx.compose.animation.core.generateDecayAnimationSpec
-import androidx.compose.animation.rememberSplineBasedDecay
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    DefaultFlingBehavior(
-        SplineBasedFloatDecayAnimationSpec(UnityDensity).generateDecayAnimationSpec()
-    )
+    NoOpFlingBehavior
 
 @Composable
-internal actual fun rememberFlingBehavior(): FlingBehavior {
-    val flingSpec = rememberSplineBasedDecay<Float>()
-    return remember(flingSpec) {
-        DefaultFlingBehavior(flingSpec)
-    }
-}
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
+    NoOpFlingBehavior

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
@@ -45,15 +45,13 @@ import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import org.jetbrains.skiko.KotlinBackend
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
-import org.jetbrains.skiko.kotlinBackend
 
 @OptIn(ExperimentalTestApi::class)
 class SkikoScrollableTest {
     @Test
-    fun proper_default_fling_behavior() = runComposeUiTest {
+    fun properDefaultFlingBehavior() = runComposeUiTest {
         val state by mutableStateOf(LazyListState())
 
         setContent {
@@ -78,10 +76,10 @@ class SkikoScrollableTest {
 
     // bug https://github.com/JetBrains/compose-multiplatform/issues/3551 (mouse didn't work)
     @Test
-    fun recreating_list_state_shouldn_t_break_mouse_scrolling() = runComposeUiTest {
+    fun recreatingListStateShouldNotBreakMouseScrolling() = runComposeUiTest {
         var state by mutableStateOf(LazyListState())
         setContent {
-            LazyColumn(state = state, modifier = Modifier.testTag("list").fillMaxSize()) {
+            LazyColumn(Modifier.testTag("list").size(50.dp, 150.dp), state = state) {
                 items(1000) {
                     Box(Modifier.size(50.dp))
                 }
@@ -106,12 +104,10 @@ class SkikoScrollableTest {
 
     // bug https://github.com/JetBrains/compose-multiplatform/issues/3551 (touch always worked)
     @Test
-    fun recreating_list_state_shouldn_t_break_touch_scrolling() = runComposeUiTest {
-        if (kotlinBackend == KotlinBackend.Native) return@runComposeUiTest
-
+    fun recreatingListStateShouldNotBreakTouchScrolling() = runComposeUiTest {
         var state by mutableStateOf(LazyListState())
         setContent {
-            LazyColumn(state = state, modifier = Modifier.testTag("list").fillMaxSize()) {
+            LazyColumn(Modifier.testTag("list").size(50.dp, 150.dp), state = state) {
                 items(1000) {
                     Box(Modifier.size(50.dp))
                 }
@@ -121,7 +117,7 @@ class SkikoScrollableTest {
         runOnIdle { assertTrue(state.firstVisibleItemIndex == 0) }
 
         onNodeWithTag("list").performTouchInput {
-            swipe(Offset(30f, 30f), Offset(30f, 10f))
+            swipe(Offset(30f, 90f), Offset(30f, 10f))
         }
         runOnIdle { assertTrue(state.firstVisibleItemIndex > 0) }
 
@@ -129,7 +125,7 @@ class SkikoScrollableTest {
         runOnIdle { assertTrue(state.firstVisibleItemIndex == 0) }
 
         onNodeWithTag("list").performTouchInput {
-            swipe(Offset(30f, 30f), Offset(30f, 10f))
+            swipe(Offset(30f, 90f), Offset(30f, 10f))
         }
         runOnIdle { assertTrue(state.firstVisibleItemIndex > 0) }
     }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/Scrollable.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/Scrollable.uikit.kt
@@ -26,7 +26,7 @@ internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavi
     CupertinoFlingBehavior(CupertinoScrollDecayAnimationSpec().generateDecayAnimationSpec())
 
 @Composable
-internal actual fun rememberFlingBehavior(): FlingBehavior =
+internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =
     // Unlike other platforms, we don't need to remember it based on density,
     // because it's density independent
     remember {

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
@@ -57,5 +57,6 @@ val Components = Screen.Selection(
     MaterialComponents,
     Material3Components,
     Screen.Example("NestedScroll") { NestedScrollExample() },
-    Screen.Example("Selection") { SelectionExample() }
+    Screen.Example("Selection") { SelectionExample() },
+    Screen.Example("Pager") { PagerExample() },
 )

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Pager.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Pager.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import kotlin.random.Random
+
+@Composable
+fun PagerExample() {
+    Column(Modifier.fillMaxSize()) {
+        HorisintalPagerExample(Modifier.weight(1f))
+        VerticalPagerExample(Modifier.weight(1f))
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun HorisintalPagerExample(modifier: Modifier) {
+    val pagerState = rememberPagerState(pageCount = {
+        10
+    })
+    HorizontalPager(state = pagerState, modifier = modifier) { page ->
+        val background = rememberSaveable(key = "HorizontalPager: $page") {
+            Color(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
+        }
+        Box(Modifier.fillMaxSize().background(background), contentAlignment = Alignment.Center) {
+            Text(
+                text = "HorizontalPager: $page",
+                style = MaterialTheme.typography.h1
+            )
+        }
+    }
+
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun VerticalPagerExample(modifier: Modifier) {
+    val pagerState = rememberPagerState(pageCount = {
+        10
+    })
+    VerticalPager(state = pagerState, modifier = modifier) { page ->
+        val background = rememberSaveable(key = "VerticalPager: $page") {
+            Color(Random.nextInt(256), Random.nextInt(256), Random.nextInt(256))
+        }
+        Box(Modifier.fillMaxSize().background(background), contentAlignment = Alignment.Center) {
+            Text(
+                text = "VerticalPager: $page",
+                style = MaterialTheme.typography.h1
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes

- Based on #1055
- Trigger `onScrollStopped` callback after mouse wheel scroll
- Ignore `ScrollableDefaultFlingBehavior`s during mouse scroll to avoid breaking changes
- Remove scrolling via `dispatchRawDelta`, `isSmoothScrollingEnabled = false` will just disable animation instead
- Add pager test page in mpp demo

## Testing

Test: run pager page in mpp demo

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/3447
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3454