### PR TITLE
add font rasterization settings in paragraph style

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -53,6 +53,7 @@ val MainScreen = Screen.Selection(
     Screen.FullscreenExample("ApplicationLayouts") { ApplicationLayouts(it) },
     Screen.Example("GraphicsLayerSettings") { GraphicsLayerSettings() },
     Screen.Example("Blending") { Blending() },
+    Screen.Example("FontRasterization") { FontRasterization() },
     AndroidTextFieldSamples,
 )
 

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontRasterization.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontRasterization.kt
@@ -28,7 +28,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.FontEdging
+import androidx.compose.ui.text.FontSmoothing
 import androidx.compose.ui.text.FontHinting
 import androidx.compose.ui.text.FontRasterizationSettings
 import androidx.compose.ui.text.PlatformParagraphStyle
@@ -41,18 +41,18 @@ fun FontRasterization() {
     MaterialTheme {
         val state = rememberScrollState()
         Column(Modifier.fillMaxSize().padding(10.dp).verticalScroll(state)) {
-            val hintingOptions = listOf(FontHinting.NONE, FontHinting.SLIGHT, FontHinting.NORMAL, FontHinting.FULL)
+            val hintingOptions = listOf(FontHinting.None, FontHinting.Slight, FontHinting.Normal, FontHinting.Full)
             val isAutoHintingForcedOptions = listOf(false, true)
             val subpixelOptions = listOf(false, true)
-            val edgingOptions = listOf(FontEdging.ALIAS, FontEdging.ANTI_ALIAS, FontEdging.SUBPIXEL_ANTI_ALIAS)
+            val smoothingOptions = listOf(FontSmoothing.None, FontSmoothing.AntiAlias, FontSmoothing.SubpixelAntiAlias)
             val text = "Lorem ipsum"
 
             for (subpixel in subpixelOptions) {
-                for (edging in edgingOptions) {
+                for (smoothing in smoothingOptions) {
                     for (hinting in hintingOptions) {
                         for (autoHintingForced in isAutoHintingForcedOptions) {
                             val fontRasterizationSettings = FontRasterizationSettings(
-                                edging = edging,
+                                smoothing = smoothing,
                                 hinting = hinting,
                                 subpixelPositioning = subpixel,
                                 autoHintingForced = autoHintingForced

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontRasterization.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontRasterization.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.FontEdging
+import androidx.compose.ui.text.FontHinting
+import androidx.compose.ui.text.FontRasterizationSettings
+import androidx.compose.ui.text.PlatformParagraphStyle
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FontRasterization() {
+    MaterialTheme {
+        val state = rememberScrollState()
+        Column(Modifier.fillMaxSize().padding(10.dp).verticalScroll(state)) {
+            val hintingOptions = listOf(FontHinting.NONE, FontHinting.SLIGHT, FontHinting.NORMAL, FontHinting.FULL)
+            val isAutoHintingForcedOptions = listOf(false, true)
+            val subpixelOptions = listOf(false, true)
+            val edgingOptions = listOf(FontEdging.ALIAS, FontEdging.ANTI_ALIAS, FontEdging.SUBPIXEL_ANTI_ALIAS)
+            val text = "Lorem ipsum"
+
+            for (subpixel in subpixelOptions) {
+                for (edging in edgingOptions) {
+                    for (hinting in hintingOptions) {
+                        for (autoHintingForced in isAutoHintingForcedOptions) {
+                            val fontRasterizationSettings = FontRasterizationSettings(
+                                edging = edging,
+                                hinting = hinting,
+                                subpixelPositioning = subpixel,
+                                autoHintingForced = autoHintingForced
+                            )
+                            BasicText(
+                                text = "$text [$fontRasterizationSettings]",
+                                style = TextStyle(
+                                    platformStyle = PlatformTextStyle(
+                                        null, PlatformParagraphStyle(fontRasterizationSettings)
+                                    )
+                                )
+                            )
+                            Spacer(Modifier.height(8.dp))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontRasterization.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontRasterization.kt
@@ -26,16 +26,17 @@ import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.FontSmoothing
+import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.FontHinting
 import androidx.compose.ui.text.FontRasterizationSettings
+import androidx.compose.ui.text.FontSmoothing
 import androidx.compose.ui.text.PlatformParagraphStyle
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalTextApi::class)
 @Composable
 fun FontRasterization() {
     MaterialTheme {

--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -127,7 +127,7 @@ public final class androidx/compose/ui/text/FontRasterizationSettings {
 }
 
 public final class androidx/compose/ui/text/FontRasterizationSettings$Companion {
-	public final fun getDefaultForCurrentPlatform ()Landroidx/compose/ui/text/FontRasterizationSettings;
+	public final fun getPlatformDefault ()Landroidx/compose/ui/text/FontRasterizationSettings;
 }
 
 public final class androidx/compose/ui/text/FontSmoothing : java/lang/Enum {

--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -356,6 +356,7 @@ public final class androidx/compose/ui/text/PlaceholderVerticalAlign$Companion {
 public final class androidx/compose/ui/text/PlatformParagraphStyle {
 	public static final field $stable I
 	public static final field Companion Landroidx/compose/ui/text/PlatformParagraphStyle$Companion;
+	public fun <init> ()V
 	public fun <init> (Landroidx/compose/ui/text/FontRasterizationSettings;)V
 	public synthetic fun <init> (Landroidx/compose/ui/text/FontRasterizationSettings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -103,6 +103,42 @@ public final class androidx/compose/ui/text/DesktopTextStyle_skikoKt {
 public abstract interface annotation class androidx/compose/ui/text/ExperimentalTextApi : java/lang/annotation/Annotation {
 }
 
+public final class androidx/compose/ui/text/FontHinting : java/lang/Enum {
+	public static final field Full Landroidx/compose/ui/text/FontHinting;
+	public static final field None Landroidx/compose/ui/text/FontHinting;
+	public static final field Normal Landroidx/compose/ui/text/FontHinting;
+	public static final field Slight Landroidx/compose/ui/text/FontHinting;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Landroidx/compose/ui/text/FontHinting;
+	public static fun values ()[Landroidx/compose/ui/text/FontHinting;
+}
+
+public final class androidx/compose/ui/text/FontRasterizationSettings {
+	public static final field $stable I
+	public static final field Companion Landroidx/compose/ui/text/FontRasterizationSettings$Companion;
+	public fun <init> (Landroidx/compose/ui/text/FontSmoothing;Landroidx/compose/ui/text/FontHinting;ZZ)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAutoHintingForced ()Z
+	public final fun getHinting ()Landroidx/compose/ui/text/FontHinting;
+	public final fun getSmoothing ()Landroidx/compose/ui/text/FontSmoothing;
+	public final fun getSubpixelPositioning ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/compose/ui/text/FontRasterizationSettings$Companion {
+	public final fun getDefaultForCurrentPlatform ()Landroidx/compose/ui/text/FontRasterizationSettings;
+}
+
+public final class androidx/compose/ui/text/FontSmoothing : java/lang/Enum {
+	public static final field AntiAlias Landroidx/compose/ui/text/FontSmoothing;
+	public static final field None Landroidx/compose/ui/text/FontSmoothing;
+	public static final field SubpixelAntiAlias Landroidx/compose/ui/text/FontSmoothing;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Landroidx/compose/ui/text/FontSmoothing;
+	public static fun values ()[Landroidx/compose/ui/text/FontSmoothing;
+}
+
 public abstract interface annotation class androidx/compose/ui/text/InternalTextApi : java/lang/annotation/Annotation {
 }
 
@@ -320,8 +356,10 @@ public final class androidx/compose/ui/text/PlaceholderVerticalAlign$Companion {
 public final class androidx/compose/ui/text/PlatformParagraphStyle {
 	public static final field $stable I
 	public static final field Companion Landroidx/compose/ui/text/PlatformParagraphStyle$Companion;
-	public fun <init> ()V
+	public fun <init> (Landroidx/compose/ui/text/FontRasterizationSettings;)V
+	public synthetic fun <init> (Landroidx/compose/ui/text/FontRasterizationSettings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFontRasterizationSettings ()Landroidx/compose/ui/text/FontRasterizationSettings;
 	public fun hashCode ()I
 	public final fun merge (Landroidx/compose/ui/text/PlatformParagraphStyle;)Landroidx/compose/ui/text/PlatformParagraphStyle;
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -22,21 +22,24 @@ import androidx.compose.ui.text.platform.currentPlatform
 /**
  * Whether edge pixels draw opaque or with partial transparency.
  */
-enum class FontEdging {
+enum class FontSmoothing {
     /**
      * no transparent pixels on glyph edges
      */
-    ALIAS,
+    /**
+     * no transparent pixels on glyph edges
+     */
+    None,
 
     /**
      * may have transparent pixels on glyph edges
      */
-    ANTI_ALIAS,
+    AntiAlias,
 
     /**
      * glyph positioned in pixel using transparency
      */
-    SUBPIXEL_ANTI_ALIAS;
+    SubpixelAntiAlias;
 }
 
 /**
@@ -46,26 +49,26 @@ enum class FontHinting {
     /**
      * glyph outlines unchanged
      */
-    NONE,
+    None,
 
     /**
      * minimal modification to improve constrast
      */
-    SLIGHT,
+    Slight,
 
     /**
      * glyph outlines modified to improve constrast
      */
-    NORMAL,
+    Normal,
 
     /**
      * modifies glyph outlines for maximum constrast
      */
-    FULL;
+    Full;
 }
 
 data class FontRasterizationSettings(
-    val edging: FontEdging,
+    val smoothing: FontSmoothing,
     val hinting: FontHinting,
     val subpixelPositioning: Boolean,
     val autoHintingForced: Boolean
@@ -75,20 +78,20 @@ data class FontRasterizationSettings(
             when (currentPlatform()) {
                 Platform.Windows -> FontRasterizationSettings(
                     subpixelPositioning = true,
-                    edging = FontEdging.SUBPIXEL_ANTI_ALIAS, // Most UIs still use ClearType on Windows, so we should match this
-                    hinting = FontHinting.NORMAL, // NONE would trigger some potentially unwanted behavior, but everything else is forced into NORMAL on Windows
+                    smoothing = FontSmoothing.SubpixelAntiAlias, // Most UIs still use ClearType on Windows, so we should match this
+                    hinting = FontHinting.Normal, // None would trigger some potentially unwanted behavior, but everything else is forced into Normal on Windows
                     autoHintingForced = false,
                 )
                 Platform.Linux, Platform.Android, Platform.Unknown -> FontRasterizationSettings(
                     subpixelPositioning = true,
-                    edging = FontEdging.SUBPIXEL_ANTI_ALIAS, // Not all distributions default to SUBPIXEL_ANTI_ALIAS, but we still do to ensure sharpness on Low-DPI displays
-                    hinting = FontHinting.SLIGHT, // Most distributions use SLIGHT now by default
+                    smoothing = FontSmoothing.SubpixelAntiAlias, // Not all distributions default to SubpixelAntiAlias, but we still do to ensure sharpness on Low-DPI displays
+                    hinting = FontHinting.Slight, // Most distributions use Slight now by default
                     autoHintingForced = false,
                 )
                 Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS -> FontRasterizationSettings(
                     subpixelPositioning = true,
-                    edging = FontEdging.ANTI_ALIAS, // macOS doesn't support SUBPIXEL_ANTI_ALIAS anymore as of Catalina
-                    hinting = FontHinting.NORMAL, // Completely ignored on macOS
+                    smoothing = FontSmoothing.AntiAlias, // macOS doesn't support SubpixelAntiAlias anymore as of Catalina
+                    hinting = FontHinting.Normal, // Completely ignored on macOS
                     autoHintingForced = false, // Completely ignored on macOS
                 )
             }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -27,9 +27,6 @@ enum class FontSmoothing {
     /**
      * no transparent pixels on glyph edges
      */
-    /**
-     * no transparent pixels on glyph edges
-     */
     None,
 
     /**

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.text
 
 import androidx.compose.ui.text.platform.Platform
 import androidx.compose.ui.text.platform.currentPlatform
+import org.jetbrains.skia.paragraph.FontRastrSettings
 
 /**
  * Whether edge pixels draw opaque or with partial transparency.
@@ -127,3 +128,23 @@ class FontRasterizationSettings(
             "autoHintingForced=$autoHintingForced)"
     }
 }
+
+internal fun FontSmoothing.toSkFontEdging() = when (this) {
+    FontSmoothing.None -> org.jetbrains.skia.FontEdging.ALIAS
+    FontSmoothing.AntiAlias -> org.jetbrains.skia.FontEdging.ANTI_ALIAS
+    FontSmoothing.SubpixelAntiAlias -> org.jetbrains.skia.FontEdging.SUBPIXEL_ANTI_ALIAS
+}
+
+internal fun FontHinting.toSkFontHinting() = when (this) {
+    FontHinting.None -> org.jetbrains.skia.FontHinting.NONE
+    FontHinting.Slight -> org.jetbrains.skia.FontHinting.SLIGHT
+    FontHinting.Normal -> org.jetbrains.skia.FontHinting.NORMAL
+    FontHinting.Full -> org.jetbrains.skia.FontHinting.FULL
+}
+
+internal fun FontRasterizationSettings.toSkFontRastrSettings() = FontRastrSettings(
+    edging = smoothing.toSkFontEdging(),
+    hinting = hinting.toSkFontHinting(),
+    subpixel = subpixelPositioning
+    // rasterizationSettings.autoHintingForced is ignored here for now because it's not supported in skia
+)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -74,7 +74,7 @@ class FontRasterizationSettings(
     val autoHintingForced: Boolean
 ) {
     companion object {
-        val defaultForCurrentPlatform by lazy {
+        val PlatformDefault by lazy {
             when (currentPlatform()) {
                 Platform.Windows -> FontRasterizationSettings(
                     subpixelPositioning = true,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.platform.currentPlatform
 /**
  * Whether edge pixels draw opaque or with partial transparency.
  */
+@ExperimentalTextApi
 enum class FontSmoothing {
     /**
      * no transparent pixels on glyph edges
@@ -45,6 +46,7 @@ enum class FontSmoothing {
 /**
  * Level of glyph outline adjustment
  */
+@ExperimentalTextApi
 enum class FontHinting {
     /**
      * glyph outlines unchanged
@@ -67,7 +69,8 @@ enum class FontHinting {
     Full;
 }
 
-data class FontRasterizationSettings(
+@ExperimentalTextApi
+class FontRasterizationSettings(
     val smoothing: FontSmoothing,
     val hinting: FontHinting,
     val subpixelPositioning: Boolean,
@@ -82,12 +85,14 @@ data class FontRasterizationSettings(
                     hinting = FontHinting.Normal, // None would trigger some potentially unwanted behavior, but everything else is forced into Normal on Windows
                     autoHintingForced = false,
                 )
+
                 Platform.Linux, Platform.Android, Platform.Unknown -> FontRasterizationSettings(
                     subpixelPositioning = true,
                     smoothing = FontSmoothing.SubpixelAntiAlias, // Not all distributions default to SubpixelAntiAlias, but we still do to ensure sharpness on Low-DPI displays
                     hinting = FontHinting.Slight, // Most distributions use Slight now by default
                     autoHintingForced = false,
                 )
+
                 Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS -> FontRasterizationSettings(
                     subpixelPositioning = true,
                     smoothing = FontSmoothing.AntiAlias, // macOS doesn't support SubpixelAntiAlias anymore as of Catalina
@@ -96,5 +101,32 @@ data class FontRasterizationSettings(
                 )
             }
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+
+        other as FontRasterizationSettings
+
+        if (smoothing != other.smoothing) return false
+        if (hinting != other.hinting) return false
+        if (subpixelPositioning != other.subpixelPositioning) return false
+        return autoHintingForced == other.autoHintingForced
+    }
+
+    override fun hashCode(): Int {
+        var result = smoothing.hashCode()
+        result = 31 * result + hinting.hashCode()
+        result = 31 * result + subpixelPositioning.hashCode()
+        result = 31 * result + autoHintingForced.hashCode()
+        return result
+    }
+
+    override fun toString(): String {
+        return "FontRasterizationSettings(smoothing=$smoothing, " +
+            "hinting=$hinting, " +
+            "subpixelPositioning=$subpixelPositioning, " +
+            "autoHintingForced=$autoHintingForced)"
     }
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import androidx.compose.ui.text.platform.Platform
+import androidx.compose.ui.text.platform.currentPlatform
+
+/**
+ * Whether edge pixels draw opaque or with partial transparency.
+ */
+enum class FontEdging {
+    /**
+     * no transparent pixels on glyph edges
+     */
+    ALIAS,
+
+    /**
+     * may have transparent pixels on glyph edges
+     */
+    ANTI_ALIAS,
+
+    /**
+     * glyph positioned in pixel using transparency
+     */
+    SUBPIXEL_ANTI_ALIAS;
+}
+
+/**
+ * Level of glyph outline adjustment
+ */
+enum class FontHinting {
+    /**
+     * glyph outlines unchanged
+     */
+    NONE,
+
+    /**
+     * minimal modification to improve constrast
+     */
+    SLIGHT,
+
+    /**
+     * glyph outlines modified to improve constrast
+     */
+    NORMAL,
+
+    /**
+     * modifies glyph outlines for maximum constrast
+     */
+    FULL;
+}
+
+data class FontRasterizationSettings(
+    val edging: FontEdging,
+    val hinting: FontHinting,
+    val subpixelPositioning: Boolean,
+    val autoHintingForced: Boolean
+) {
+    companion object {
+        val defaultForCurrentPlatform by lazy {
+            when (currentPlatform()) {
+                Platform.Windows -> FontRasterizationSettings(
+                    subpixelPositioning = true,
+                    edging = FontEdging.SUBPIXEL_ANTI_ALIAS, // Most UIs still use ClearType on Windows, so we should match this
+                    hinting = FontHinting.NORMAL, // NONE would trigger some potentially unwanted behavior, but everything else is forced into NORMAL on Windows
+                    autoHintingForced = false,
+                )
+                Platform.Linux, Platform.Android, Platform.Unknown -> FontRasterizationSettings(
+                    subpixelPositioning = true,
+                    edging = FontEdging.SUBPIXEL_ANTI_ALIAS, // Not all distributions default to SUBPIXEL_ANTI_ALIAS, but we still do to ensure sharpness on Low-DPI displays
+                    hinting = FontHinting.SLIGHT, // Most distributions use SLIGHT now by default
+                    autoHintingForced = false,
+                )
+                Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS -> FontRasterizationSettings(
+                    subpixelPositioning = true,
+                    edging = FontEdging.ANTI_ALIAS, // macOS doesn't support SUBPIXEL_ANTI_ALIAS anymore as of Catalina
+                    hinting = FontHinting.NORMAL, // Completely ignored on macOS
+                    autoHintingForced = false, // Completely ignored on macOS
+                )
+            }
+        }
+    }
+}

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -31,12 +31,12 @@ enum class FontSmoothing {
     None,
 
     /**
-     * may have transparent pixels on glyph edges
+     * change transparency of the pixels to fit the pixel grid
      */
     AntiAlias,
 
     /**
-     * glyph positioned in pixel using transparency
+     * change transparency and color of the pixels to fit the RGB subpixel grid
      */
     SubpixelAntiAlias;
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/FontRasterizationSettings.skiko.kt
@@ -79,15 +79,25 @@ class FontRasterizationSettings(
             when (currentPlatform()) {
                 Platform.Windows -> FontRasterizationSettings(
                     subpixelPositioning = true,
-                    smoothing = FontSmoothing.SubpixelAntiAlias, // Most UIs still use ClearType on Windows, so we should match this
+                    // Most UIs still use ClearType on Windows, so we should match this
+                    // We temporarily disabled `SubpixelAntiAlias` until we figure out
+                    // how to properly retrieve default OS settings
+                    smoothing = FontSmoothing.AntiAlias,
                     hinting = FontHinting.Normal, // None would trigger some potentially unwanted behavior, but everything else is forced into Normal on Windows
                     autoHintingForced = false,
                 )
 
-                Platform.Linux, Platform.Android, Platform.Unknown -> FontRasterizationSettings(
+                Platform.Linux, Platform.Unknown -> FontRasterizationSettings(
                     subpixelPositioning = true,
-                    smoothing = FontSmoothing.SubpixelAntiAlias, // Not all distributions default to SubpixelAntiAlias, but we still do to ensure sharpness on Low-DPI displays
+                    smoothing = FontSmoothing.AntiAlias,
                     hinting = FontHinting.Slight, // Most distributions use Slight now by default
+                    autoHintingForced = false,
+                )
+
+                Platform.Android -> FontRasterizationSettings(
+                    subpixelPositioning = true,
+                    smoothing = FontSmoothing.AntiAlias,
+                    hinting = FontHinting.Slight,
                     autoHintingForced = false,
                 )
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -83,7 +83,7 @@ actual class PlatformParagraphStyle {
     val fontRasterizationSettings: FontRasterizationSettings
 
     @ExperimentalTextApi
-    constructor(fontRasterizationSettings: FontRasterizationSettings = FontRasterizationSettings.defaultForCurrentPlatform) {
+    constructor(fontRasterizationSettings: FontRasterizationSettings = FontRasterizationSettings.PlatformDefault) {
         this.fontRasterizationSettings = fontRasterizationSettings
     }
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -81,6 +81,7 @@ actual class PlatformParagraphStyle {
 
     val fontRasterizationSettings: FontRasterizationSettings
 
+    @ExperimentalTextApi
     constructor(fontRasterizationSettings: FontRasterizationSettings = FontRasterizationSettings.defaultForCurrentPlatform) {
         this.fontRasterizationSettings = fontRasterizationSettings
     }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -57,9 +57,10 @@ actual class PlatformTextStyle {
         return true
     }
 
-    @Suppress("RedundantOverride")
     override fun hashCode(): Int {
-        return super.hashCode()
+        var result = spanStyle?.hashCode() ?: 0
+        result = 31 * result + (paragraphStyle?.hashCode() ?: 0)
+        return result
     }
 }
 
@@ -78,19 +79,27 @@ actual class PlatformParagraphStyle {
         actual val Default: PlatformParagraphStyle = PlatformParagraphStyle()
     }
 
+    val fontRasterizationSettings: FontRasterizationSettings
+
+    constructor(fontRasterizationSettings: FontRasterizationSettings = FontRasterizationSettings.defaultForCurrentPlatform) {
+        this.fontRasterizationSettings = fontRasterizationSettings
+    }
+
     actual fun merge(other: PlatformParagraphStyle?): PlatformParagraphStyle {
-        return this
+        if (other == null) return this
+        // merge strategy is simple overwrite for current params, update if a optional param happens
+        return other
     }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is PlatformParagraphStyle) return false
+        if (fontRasterizationSettings != other.fontRasterizationSettings) return false
         return true
     }
 
-    @Suppress("RedundantOverride")
     override fun hashCode(): Int {
-        return super.hashCode()
+        return fontRasterizationSettings.hashCode()
     }
 }
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -79,6 +79,7 @@ actual class PlatformParagraphStyle {
         actual val Default: PlatformParagraphStyle = PlatformParagraphStyle()
     }
 
+    @ExperimentalTextApi
     val fontRasterizationSettings: FontRasterizationSettings
 
     @ExperimentalTextApi

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/TextStyle.skiko.kt
@@ -82,6 +82,10 @@ actual class PlatformParagraphStyle {
     @ExperimentalTextApi
     val fontRasterizationSettings: FontRasterizationSettings
 
+    constructor() {
+        this.fontRasterizationSettings = FontRasterizationSettings.PlatformDefault
+    }
+
     @ExperimentalTextApi
     constructor(fontRasterizationSettings: FontRasterizationSettings = FontRasterizationSettings.PlatformDefault) {
         this.fontRasterizationSettings = fontRasterizationSettings

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -497,23 +497,7 @@ internal class ParagraphBuilder(
     private fun makeSkFontRasterizationSettings(style: TextStyle): SkFontRastrSettings {
         val rasterizationSettings = style.paragraphStyle.platformStyle?.fontRasterizationSettings
             ?: FontRasterizationSettings.PlatformDefault
-        val edging = when (rasterizationSettings.smoothing) {
-            FontSmoothing.None-> org.jetbrains.skia.FontEdging.ALIAS
-            FontSmoothing.AntiAlias -> org.jetbrains.skia.FontEdging.ANTI_ALIAS
-            FontSmoothing.SubpixelAntiAlias -> org.jetbrains.skia.FontEdging.SUBPIXEL_ANTI_ALIAS
-        }
-        val hinting = when (rasterizationSettings.hinting) {
-            FontHinting.None -> org.jetbrains.skia.FontHinting.NONE
-            FontHinting.Slight -> org.jetbrains.skia.FontHinting.SLIGHT
-            FontHinting.Normal -> org.jetbrains.skia.FontHinting.NORMAL
-            FontHinting.Full -> org.jetbrains.skia.FontHinting.FULL
-        }
-        return SkFontRastrSettings(
-            edging = edging,
-            hinting = hinting,
-            subpixel = rasterizationSettings.subpixelPositioning
-            // rasterizationSettings.autoHintingForced is ignored here for now because it's not supported in skia
-        )
+        return rasterizationSettings.toSkFontRastrSettings()
     }
 
     private fun textStyleToParagraphStyle(

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -497,16 +497,16 @@ internal class ParagraphBuilder(
     private fun makeSkFontRasterizationSettings(style: TextStyle): SkFontRastrSettings {
         val rasterizationSettings = style.paragraphStyle.platformStyle?.fontRasterizationSettings
             ?: FontRasterizationSettings.defaultForCurrentPlatform
-        val edging = when (rasterizationSettings.edging) {
-            FontEdging.ALIAS -> org.jetbrains.skia.FontEdging.ALIAS
-            FontEdging.ANTI_ALIAS -> org.jetbrains.skia.FontEdging.ANTI_ALIAS
-            FontEdging.SUBPIXEL_ANTI_ALIAS -> org.jetbrains.skia.FontEdging.SUBPIXEL_ANTI_ALIAS
+        val edging = when (rasterizationSettings.smoothing) {
+            FontSmoothing.None-> org.jetbrains.skia.FontEdging.ALIAS
+            FontSmoothing.AntiAlias -> org.jetbrains.skia.FontEdging.ANTI_ALIAS
+            FontSmoothing.SubpixelAntiAlias -> org.jetbrains.skia.FontEdging.SUBPIXEL_ANTI_ALIAS
         }
         val hinting = when (rasterizationSettings.hinting) {
-            FontHinting.NONE -> org.jetbrains.skia.FontHinting.NONE
-            FontHinting.SLIGHT -> org.jetbrains.skia.FontHinting.SLIGHT
-            FontHinting.NORMAL -> org.jetbrains.skia.FontHinting.NORMAL
-            FontHinting.FULL -> org.jetbrains.skia.FontHinting.FULL
+            FontHinting.None -> org.jetbrains.skia.FontHinting.NONE
+            FontHinting.Slight -> org.jetbrains.skia.FontHinting.SLIGHT
+            FontHinting.Normal -> org.jetbrains.skia.FontHinting.NORMAL
+            FontHinting.Full -> org.jetbrains.skia.FontHinting.FULL
         }
         return SkFontRastrSettings(
             edging = edging,

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaParagraph.skiko.kt
@@ -496,7 +496,7 @@ internal class ParagraphBuilder(
 
     private fun makeSkFontRasterizationSettings(style: TextStyle): SkFontRastrSettings {
         val rasterizationSettings = style.paragraphStyle.platformStyle?.fontRasterizationSettings
-            ?: FontRasterizationSettings.defaultForCurrentPlatform
+            ?: FontRasterizationSettings.PlatformDefault
         val edging = when (rasterizationSettings.smoothing) {
             FontSmoothing.None-> org.jetbrains.skia.FontEdging.ALIAS
             FontSmoothing.AntiAlias -> org.jetbrains.skia.FontEdging.ANTI_ALIAS


### PR DESCRIPTION
## Proposed Changes
Allow to configure font rasterization settings

## Testing
Check `FontRasterization` tab in demo application

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
