### PR TITLE
Fix `Pager` direction detection for mouse wheel

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
@@ -597,7 +597,7 @@ private fun SnapLayoutInfoProvider(
         override fun calculateSnappingOffset(currentVelocity: Float): Float {
             val (lowerBoundOffset, upperBoundOffset) = searchForSnappingBounds()
 
-            val isForward = pagerState.isScrollingForward()
+            val isForward = pagerState.isScrollingForward(currentVelocity)
 
             debugLog { "isForward=$isForward" }
 
@@ -956,7 +956,11 @@ private inline fun debugLog(generateMsg: () -> String) {
 }
 
 @OptIn(ExperimentalFoundationApi::class)
-private fun PagerState.isScrollingForward() = dragGestureDelta() < 0
+private fun PagerState.isScrollingForward(velocity: Float) = if (isNotGestureAction()) {
+    velocity
+} else {
+    dragGestureDelta()
+} < 0
 
 @OptIn(ExperimentalFoundationApi::class)
 private fun PagerState.dragGestureDelta() = if (layoutInfo.orientation == Orientation.Horizontal) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/PagerState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/PagerState.kt
@@ -638,7 +638,7 @@ abstract class PagerState(
             sign(scrollDelta) == sign(-upDownDifference.x)
         } || isNotGestureAction()
 
-    private fun isNotGestureAction(): Boolean =
+    internal fun isNotGestureAction(): Boolean =
         upDownDifference.x.toInt() == 0 && upDownDifference.y.toInt() == 0
 
     private fun notifyPrefetch(delta: Float, info: PagerLayoutInfo) {


### PR DESCRIPTION
## Proposed Changes

`Pager` uses `upDownDifference` as a source of a scrolling direction that is not correct in the case of mouse wheel scrolling. This PR adds fallback to a velocity direction if drag distance is zero.

## Testing

Test: try to scroll back `Pager` in mpp

Before

https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/d40d41e8-398a-4108-b05f-c06989ca26e1

After

https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/05394ff3-6c51-4e30-b771-af9c07e516b5



