### PR TITLE
Make sure that `compositionLocalContext` is initialized before composition

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/dialog/DialogCompositionLocals.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/dialog/DialogCompositionLocals.kt
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package androidx.compose.mpp.demo.components.popup
+package androidx.compose.mpp.demo.components.dialog
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -34,7 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.Dialog
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 
@@ -43,7 +42,13 @@ private val LocalString = staticCompositionLocalOf<String> {
 }
 
 @Composable
-fun PopupCompositionLocalExample() {
+fun DialogCompositionLocalExample() {
+    var dialogOpened: Boolean by remember { mutableStateOf(true) }
+    if (!dialogOpened) {
+        Button(onClick = { dialogOpened = true }) {
+            Text("OpenDialog")
+        }
+    }
     var current by remember { mutableStateOf("test 0") }
     LaunchedEffect(Unit) {
         var i = 1
@@ -54,12 +59,12 @@ fun PopupCompositionLocalExample() {
         }
     }
     CompositionLocalProvider(LocalString provides current) {
-        MaterialTheme {
-            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                Popup {
-                    Box(Modifier.size(200.dp).background(Color.Yellow), contentAlignment = Alignment.Center) {
-                        Text("LocalString: ${LocalString.current}")
-                    }
+        if (dialogOpened) {
+            Dialog(
+                onDismissRequest = { dialogOpened = false },
+            ) {
+                Box(Modifier.size(200.dp).background(Color.Yellow), contentAlignment = Alignment.Center) {
+                    Text("LocalString: ${LocalString.current}")
                 }
             }
         }

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/dialog/Dialogs.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/dialog/Dialogs.kt
@@ -21,6 +21,7 @@ import androidx.compose.mpp.demo.Screen
 val Dialogs = Screen.Selection(
     "Dialogs",
     DialogExample,
+    Screen.Example("CompositionLocal inside Dialog") { DialogCompositionLocalExample() },
     DialogWithTextField,
     FocusAndKeyInput,
 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -178,7 +178,9 @@ internal fun rememberComposeSceneLayer(
             layoutDirection = layoutDirection,
             focusable = focusable,
             compositionContext = parentComposition,
-        )
+        ).also {
+            it.compositionLocalContext = compositionLocalContext
+        }
     }
     layer.focusable = focusable
     DisposableEffect(Unit) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -58,7 +58,6 @@ internal class UIViewComposeSceneLayer(
     focusStack: FocusStack<UIView>?,
     windowContext: PlatformWindowContext,
     compositionContext: CompositionContext,
-    compositionLocalContext: CompositionLocalContext?,
 ) : ComposeSceneLayer {
 
     override var focusable: Boolean = focusStack != null
@@ -117,9 +116,7 @@ internal class UIViewComposeSceneLayer(
             coroutineContext = compositionContext.effectCoroutineContext,
             renderingUIViewFactory = ::createSkikoUIView,
             composeSceneFactory = ::createComposeScene
-        ).also {
-            it.compositionLocalContext = compositionLocalContext
-        }
+        )
     }
 
     init {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -362,7 +362,6 @@ internal class ComposeContainer(
                 focusStack = if (focusable) focusStack else null,
                 windowContext = windowContext,
                 compositionContext = compositionContext,
-                compositionLocalContext = mediator?.compositionLocalContext,
             )
     }
 


### PR DESCRIPTION
## Proposed Changes

- Initialize `compositionLocalContext` before any possible composition

## Testing

Test: code snippet from https://github.com/JetBrains/compose-multiplatform/issues/4281#issuecomment-1944366234

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4281
