### PR TITLE
Window size resolution on wasm/js takes density into account

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/bug/BugReproducers.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/bug/BugReproducers.kt
@@ -26,5 +26,6 @@ val BugReproducers = Screen.Selection(
     IOSSelectionContainerCrash,
     IOSDynamicKeyboardType,
     NoPressInteractionInOutlinedTextField,
-    WebBaselineAlways0
+    WebBaselineAlways0,
+    ResizePopupCrashOnJS
 )

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/bug/ResizePopupCrashOnJS.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/bug/ResizePopupCrashOnJS.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bug
+
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterialApi::class)
+internal val ResizePopupCrashOnJS = Screen.Example("Resize Popup") {
+    MaterialTheme {
+        var expanded by remember { mutableStateOf(false) }
+        val items = listOf("Resize", "The", "Window")
+        var selectedOptionText by remember { mutableStateOf(items[0]) }
+        ExposedDropdownMenuBox(
+            expanded = expanded,
+            onExpandedChange = {
+                expanded = it
+            },
+        ) {
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp),
+                value = selectedOptionText,
+                onValueChange = {},
+                readOnly = true
+            )
+            ExposedDropdownMenu(
+                expanded = expanded,
+                onDismissRequest = {
+                    expanded = false
+                },
+            ) {
+                items.forEach { selectionOption ->
+                    DropdownMenuItem(
+                        onClick = {
+                            selectedOptionText = selectionOption
+                            expanded = false
+                        },
+                    ) {
+                        Text(selectionOption)
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -176,7 +176,7 @@ private class ComposeWindow(
         canvas.setAttribute("tabindex", "0")
         layer.layer.needRedraw()
 
-        _windowInfo.containerSize = IntSize(canvas.width, canvas.height)
+        onChangeWindowBounds()
         layer.setSize(canvas.width, canvas.height)
 
         layer.setDensity(density)
@@ -191,10 +191,15 @@ private class ComposeWindow(
     fun resize(newSize: IntSize) {
         canvas.width = newSize.width
         canvas.height = newSize.height
-        _windowInfo.containerSize = IntSize(canvas.width, canvas.height)
+        onChangeWindowBounds()
         layer.layer.attachTo(canvas)
         layer.setSize(canvas.width, canvas.height)
         layer.layer.needRedraw()
+    }
+
+    private fun onChangeWindowBounds() {
+        val density = density.density.toInt()
+        _windowInfo.containerSize = IntSize(canvas.width * density, canvas.height * density)
     }
 
     // TODO: need to call .dispose() on window close.


### PR DESCRIPTION
This is the fix to https://youtrack.jetbrains.com/issue/COMPOSE-969 however I want also to use this PR as an invitation to discuss couple of things. 

Let's introduce some terminology to have something to start with. I don't think my terminology is precise or even correct but however. So, we have physical dimensions - one that are de-facto will be shown when, for instance, you are making a screenshot.  The term "physical dimensions" is slightly misleading, since strictly speaking physical amount of pixels still can be different, but this is the closest we can get and not to be confused.  We also have logical dimensions, those are logical dimensions multiplied by some coefficient. This coefficient is called density (in browsers this usually is called [devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) and for modern displays with higher DPIs it can be, for instance, equal to 2. 

Now begins the part where I can mix up some concepts, so feel free to correct me wherever it's needed. 
Throughout the code we tend to work with physical dimensions while logical dimensions are used to actually render the content. However, when it comes to the size of the window screen, at dekstop we are resolving to the logical size of the screen (see androidx.compose.ui.scene.WindowComposeSceneLayer#onChangeWindowBounds). This caused troubles on the wasm/js part because - just like anything else throughout the code, we were relying on window size to be measure in physical units, not virtual ones. 

That said, the fix introduced can be suboptimal. First of all, this can cause some unexpected damage to the web target if somewhere in code we are relying on the window size - I've failed to find such places however this worries me a lot. 
But most importantly, what worries me that we are relying on different dimension units throughout the code. 

So, let's discuss. 

<img width="1920" alt="Screenshot 2024-02-15 at 11 42 09" src="https://github.com/JetBrains/compose-multiplatform-core/assets/25667761/c2a33190-d5c2-4869-8670-d06e088e758b">
