### PR TITLE
Fix crash when `view.window` is not available during `viewWillLayoutSubviews` call

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -101,7 +101,6 @@ internal class ComposeContainer(
     @OptIn(ExperimentalComposeApi::class)
     private val windowContainer: UIView
         get() = if (configuration.platformLayers) {
-            // TODO: if window is nil like in 4310, this value is no longer updated before next viewWillLayoutSubviews
             view.window ?: view
         } else view
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -100,8 +100,9 @@ internal class ComposeContainer(
 
     @OptIn(ExperimentalComposeApi::class)
     private val windowContainer: UIView
-        get() = if (configuration.platformLayers) checkNotNull(view.window) {
-            "ComposeUIViewController.view should be attached to window"
+        get() = if (configuration.platformLayers) {
+            // TODO: if window is nil like in 4310, this value is no longer updated before next viewWillLayoutSubviews
+            view.window ?: view
         } else view
 
     /*
@@ -174,6 +175,11 @@ internal class ComposeContainer(
         currentInterfaceOrientation?.let {
             interfaceOrientationState.value = it
         }
+
+        updateWindowContainer()
+    }
+
+    private fun updateWindowContainer() {
         val scale = windowContainer.systemDensity.density
         val size = windowContainer.frame.useContents<CGRect, IntSize> {
             IntSize(
@@ -239,6 +245,9 @@ internal class ComposeContainer(
         layers.fastForEach {
             it.viewDidAppear(animated)
         }
+
+        updateWindowContainer()
+
         configuration.delegate.viewDidAppear(animated)
     }
 


### PR DESCRIPTION
## Proposed Changes

Use the view instead of a window as a fallback when layout was performed until it was added to the hierarchy on iOS below 17

## Testing

Test: run a reproduction from the issue

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4310
