### PR TITLE
Suppress a warning that 'expect'/'actual' classes are in Beta

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
@@ -127,6 +127,9 @@ class AndroidXComposeImplPlugin : Plugin<Project> {
                 projectAfterEvaluate.tasks.withType(KotlinCompile::class.java).configureEach { compile ->
                     // Needed to enable `expect` and `actual` keywords
                     compile.kotlinOptions.freeCompilerArgs += "-Xmulti-platform"
+
+                    // Suppress a warning that 'expect'/'actual' classes are in Beta.
+                    compile.kotlinOptions.freeCompilerArgs += "-Xexpect-actual-classes"
                 }
             }
 


### PR DESCRIPTION
## Proposed Changes

Just reducing the noise on CI for building this project. 'expect'/'actual' classes are an essential part of Compose Multiplatform, so this warning doesn't say anything useful.

## Testing

Test: N/A
