### PR TITLE
Don't throw exceptions if SemanticsOwnerListenerImpl.current is null, early exit instead

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -135,7 +135,7 @@ private class SemanticsOwnerListenerImpl(
     }
 
     override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
-        val current = checkNotNull(current)
+        val current = current ?: return
 
         if (current.first == semanticsOwner) {
             current.second.dispose()


### PR DESCRIPTION
## Proposed Changes

Replace throwing `SemanticsOwnerListenerImpl.current` check with early exit check.

## Testing

Test: N/A

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4315