### PR TITLE
Fix a crash if `Popup`'s constraints larger than `WindowInfo` (internal incorrect state)

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -525,10 +525,7 @@ private fun rememberPopupMeasurePolicy(
                 boundsWithoutInsets, sizeWithoutInsets, layoutDirection, contentSize
             )
             if (properties.clippingEnabled) {
-                IntOffset(
-                    x = positionInWindow.x.coerceIn(0, sizeWithoutInsets.width - contentSize.width),
-                    y = positionInWindow.y.coerceIn(0, sizeWithoutInsets.height - contentSize.height)
-                )
+                clipPosition(positionInWindow, contentSize, sizeWithoutInsets)
             } else {
                 positionInWindow
             }
@@ -537,6 +534,16 @@ private fun rememberPopupMeasurePolicy(
         layer.calculateLocalPosition(positionWithInsets)
     }
 }
+
+private fun clipPosition(position: IntOffset, contentSize: IntSize, containerSize: IntSize) =
+    IntOffset(
+        x = if (contentSize.width < containerSize.width) {
+            position.x.coerceIn(0, containerSize.width - contentSize.width)
+        } else 0,
+        y = if (contentSize.height < containerSize.height) {
+            position.y.coerceIn(0, containerSize.height - contentSize.height)
+        } else 0
+    )
 
 private fun KeyEvent.isDismissRequest() =
     type == KeyEventType.KeyDown && key == Key.Escape

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
@@ -35,7 +35,7 @@ internal fun RootMeasurePolicy(
     platformInsets: PlatformInsets,
     usePlatformDefaultWidth: Boolean,
     calculatePosition: MeasureScope.(contentSize: IntSize) -> IntOffset,
-) = MeasurePolicy {measurables, constraints ->
+) = MeasurePolicy { measurables, constraints ->
     val platformConstraints = applyPlatformConstrains(
         constraints, platformInsets, usePlatformDefaultWidth
     )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.assertReceivedNoEvents
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -45,8 +46,12 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
+import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.platform.ZeroInsetsConfig
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.scene.ComposeSceneContext
+import androidx.compose.ui.scene.MultiLayerComposeScene
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -65,6 +70,9 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.fail
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.skia.Surface
 
 @OptIn(ExperimentalTestApi::class)
 class PopupTest {
@@ -660,5 +668,33 @@ class PopupTest {
 
         // It should not generate extra Exit/Enter events
         background.events.assertReceivedNoEvents()
+    }
+
+    @Test
+    fun popupContentLargerThanWindowInfoContainer() = runTest(StandardTestDispatcher()) {
+        lateinit var scene: ComposeScene
+        val surface = Surface.makeRasterN32Premul(100, 100)
+        fun invalidate() {
+            scene.render(surface.canvas.asComposeCanvas(), 1)
+        }
+        scene = MultiLayerComposeScene(
+            composeSceneContext = object : ComposeSceneContext {
+            }.also {
+                val windowInfo = it.platformContext.windowInfo as WindowInfoImpl
+                windowInfo.containerSize = IntSize(50, 50)
+            },
+            invalidate = ::invalidate
+        )
+        try {
+            scene.boundsInWindow = IntRect(0, 0, 100, 100)
+            scene.setContent {
+                Popup {
+                    Box(Modifier.size(200.dp))
+                }
+            }
+            invalidate()
+        } finally {
+            scene.close()
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes

- Do not crash during `Popup` placement event if a platform didn't correctly initialize `ComposeScene`/`WindowInfo`

## Testing

Test: run `popupContentLargerThanWindowInfoContainer` unit test

## Issues Fixed

Fixes (partially) https://github.com/JetBrains/compose-multiplatform/issues/4254
