### PR TITLE
Fix mouse input above interop view

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -264,8 +264,8 @@ internal class ComposeSceneMediator(
         container.addToLayer(invisibleComponent, contentLayer)
         container.addToLayer(contentComponent, contentLayer)
 
-        // Adding after adding invisibleComponent and contentComponent
-        // to react only on changes with interopLayer
+        // Adding a listener after adding [invisibleComponent] and [contentComponent]
+        // to react only on changes with [interopLayer].
         container.addContainerListener(containerListener)
 
         // It will be enabled dynamically. See DesktopPlatformComponent
@@ -321,7 +321,7 @@ internal class ComposeSceneMediator(
                 return false
             }
 
-            // Filter out mouse events if [ComposeScene] already processing mouse event,
+            // Filter out mouse event if [ComposeScene] is already processing this mouse event,
             // or it was already received via another listener.
             if (event == lastMouseEvent.get()) {
                 return false
@@ -373,7 +373,7 @@ internal class ComposeSceneMediator(
         // in the next cases:
         // - [SwingPanel] might manually spawn a new AWT event for interop view
         //   (see [InteropPointerInputModifier] for details)
-        // - Precaution of changes inside JDK if the same event will be sent to multiple components
+        // - Precaution of changes inside JDK if the same event is sent to multiple components
         //   inside [container] (the mouse listener is added into several components)
         lastMouseEvent = WeakReference(event)
         scene.onMouseEvent(event.position, event)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -114,9 +114,6 @@ internal class ComposeSceneMediator(
         }
 
         private fun addClipComponent(component: Component) {
-            if (useInteropBlending) {
-                return
-            }
             val clipRectangle = ClipComponent(component)
             clipMap[component] = clipRectangle
             skiaLayerComponent.clipComponents.add(clipRectangle)


### PR DESCRIPTION
## Proposed Changes

- Add one more mouse listener for a case when AWT dispatches all events only to interop view

## Testing

Test: try to click on the button above `SwingPanel` on macOS

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform-core/pull/915#issuecomment-1948687175
