### PR TITLE
CfW: fix browser key events consumption

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -94,7 +94,8 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
             browser {
                 testTask(Action<KotlinJsTest> {
                     it.useKarma {
-                        useChromeHeadless()
+                        //useChromeHeadless()
+                        useChrome()
                         useConfigDirectory(
                             project.rootProject.projectDir.resolve("mpp/karma.config.d/wasm")
                         )

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -94,7 +94,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
             browser {
                 testTask(Action<KotlinJsTest> {
                     it.useKarma {
-                        //useChromeHeadless()
+                        //useChromeHeadless() // can't use headless for some integration tests
                         useChrome()
                         useConfigDirectory(
                             project.rootProject.projectDir.resolve("mpp/karma.config.d/wasm")

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -304,9 +304,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(skikoTest)
             }
             jsTest {
+                kotlin.srcDir("src/webTest/kotlin")
                 dependsOn(skikoTest)
             }
             wasmJsTest {
+                kotlin.srcDir("src/webTest/kotlin")
                 dependsOn(skikoTest)
             }
 

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -53,7 +53,7 @@ internal class ComposeLayer(
     // Should be set to an actual value by ComposeWindow implementation
     private var density = Density(1f)
 
-    private inner class ComponentImpl : SkikoView {
+    private inner class ComponentImpl : SkikoViewExtension {
         override val input = this@ComposeLayer.input
 
         override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
@@ -61,8 +61,12 @@ internal class ComposeLayer(
         }
 
         override fun onKeyboardEvent(event: SkikoKeyboardEvent) {
-            if (isDisposed) return
-            scene.sendKeyEvent(KeyEvent(event))
+            onKeyboardEventWithResult(event)
+        }
+
+        override fun onKeyboardEventWithResult(event: SkikoKeyboardEvent): Boolean {
+            if (isDisposed) return false
+            return scene.sendKeyEvent(KeyEvent(event))
         }
 
         override fun onPointerEvent(event: SkikoPointerEvent) {
@@ -183,4 +187,8 @@ internal fun SkikoPointerEvent.getScrollDelta(): Offset {
     }?.let {
         Offset(it.deltaX.toFloat(), it.deltaY.toFloat())
     } ?: Offset.Zero
+}
+
+internal interface SkikoViewExtension : SkikoView {
+    fun onKeyboardEventWithResult(event: SkikoKeyboardEvent): Boolean
 }

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -53,7 +53,7 @@ internal class ComposeLayer(
     // Should be set to an actual value by ComposeWindow implementation
     private var density = Density(1f)
 
-    private inner class ComponentImpl : SkikoViewExtension {
+    private inner class ComponentImpl : SkikoViewExtended {
         override val input = this@ComposeLayer.input
 
         override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
@@ -120,7 +120,7 @@ internal class ComposeLayer(
         }
     }
 
-    private val view = ComponentImpl()
+    internal val view: SkikoViewExtended = ComponentImpl()
 
     init {
         layer.skikoView = view
@@ -189,6 +189,6 @@ internal fun SkikoPointerEvent.getScrollDelta(): Offset {
     } ?: Offset.Zero
 }
 
-internal interface SkikoViewExtension : SkikoView {
+internal interface SkikoViewExtended : SkikoView {
     fun onKeyboardEventWithResult(event: SkikoKeyboardEvent): Boolean
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.events.toSkikoScrollEvent
 import androidx.compose.ui.input.pointer.BrowserCursor
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.native.ComposeLayer
-import androidx.compose.ui.native.SkikoViewExtension
+import androidx.compose.ui.native.SkikoViewExtended
 import androidx.compose.ui.platform.JSTextInputService
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.ViewConfiguration
@@ -45,7 +45,6 @@ import kotlinx.coroutines.isActive
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoKeyboardEventKind
 import org.jetbrains.skiko.SkikoPointerEventKind
-import org.jetbrains.skiko.SkikoView
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.HTMLTitleElement
@@ -96,10 +95,11 @@ private class ComposeWindow(
 
     val canvas = document.getElementById(canvasId) as HTMLCanvasElement
 
-    private fun <T : Event> HTMLCanvasElement.addTypedEvent(type: String, handler: (event: T, skikoView: SkikoViewExtension) -> Unit) {
-        addEventListener(type, { event ->
-            layer.layer?.skikoView?.let { skikoView -> handler(event as T, skikoView as SkikoViewExtension) }
-        })
+    private fun <T : Event> HTMLCanvasElement.addTypedEvent(
+        type: String,
+        handler: (event: T, skikoView: SkikoViewExtended) -> Unit
+    ) {
+        this.addEventListener(type, { event -> handler(event as T, layer.view) })
     }
 
     private fun initEvents(canvas: HTMLCanvasElement) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.events.toSkikoScrollEvent
 import androidx.compose.ui.input.pointer.BrowserCursor
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.native.ComposeLayer
+import androidx.compose.ui.native.SkikoViewExtension
 import androidx.compose.ui.platform.JSTextInputService
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.ViewConfiguration
@@ -95,9 +96,9 @@ private class ComposeWindow(
 
     val canvas = document.getElementById(canvasId) as HTMLCanvasElement
 
-    private fun <T : Event> HTMLCanvasElement.addTypedEvent(type: String, handler: (event: T, skikoView: SkikoView) -> Unit) {
+    private fun <T : Event> HTMLCanvasElement.addTypedEvent(type: String, handler: (event: T, skikoView: SkikoViewExtension) -> Unit) {
         addEventListener(type, { event ->
-            layer.layer?.skikoView?.let { skikoView -> handler(event as T, skikoView) }
+            layer.layer?.skikoView?.let { skikoView -> handler(event as T, skikoView as SkikoViewExtension) }
         })
     }
 
@@ -159,13 +160,13 @@ private class ComposeWindow(
         })
 
         canvas.addTypedEvent<KeyboardEvent>("keydown") { event, skikoView ->
-            event.preventDefault()
-            skikoView.onKeyboardEvent(event.toSkikoEvent(SkikoKeyboardEventKind.DOWN))
+            val processed = skikoView.onKeyboardEventWithResult(event.toSkikoEvent(SkikoKeyboardEventKind.DOWN))
+            if (processed) event.preventDefault()
         }
 
         canvas.addTypedEvent<KeyboardEvent>("keyup") { event, skikoView ->
-            event.preventDefault()
-            skikoView.onKeyboardEvent(event.toSkikoEvent(SkikoKeyboardEventKind.UP))
+            val processed = skikoView.onKeyboardEventWithResult(event.toSkikoEvent(SkikoKeyboardEventKind.UP))
+            if (processed) event.preventDefault()
         }
     }
 

--- a/compose/ui/ui/src/webTest/kotlin/CanvasBasedWindowTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/CanvasBasedWindowTests.kt
@@ -1,0 +1,85 @@
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.TextField
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import kotlin.test.Test
+import kotlinx.browser.document
+import org.w3c.dom.HTMLCanvasElement
+import androidx.compose.ui.window.*
+import kotlin.test.AfterTest
+import kotlin.test.Ignore
+import kotlin.test.assertEquals
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.w3c.dom.events.KeyboardEvent
+
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class CanvasBasedWindowTests {
+
+    private val canvasId = "canvas1"
+    
+    @AfterTest
+    fun cleanup() {
+        document.getElementById(canvasId)?.remove()
+    }
+    
+    @Test
+    fun canCreate() {
+        val canvasElement = document.createElement("canvas") as HTMLCanvasElement
+        canvasElement.setAttribute("id", canvasId)
+        document.body!!.appendChild(canvasElement)
+        CanvasBasedWindow(canvasElementId = canvasId) {  }
+    }
+
+    @Test
+    fun canCreateCanvasBasedWindow() = runTest {
+        val canvasElement = document.createElement("canvas") as HTMLCanvasElement
+        canvasElement.setAttribute("id", canvasId)
+        document.body!!.appendChild(canvasElement)
+
+
+        val fr = FocusRequester()
+        CanvasBasedWindow(canvasElementId = canvasId) {
+            TextField(
+                value = "",
+                onValueChange = {},
+                modifier = Modifier.fillMaxSize().focusRequester(fr)
+            )
+            SideEffect {
+                fr.requestFocus()
+            }
+        }
+
+        val stack = mutableListOf<Boolean>()
+        canvasElement.addEventListener("keydown", { event ->
+            stack.add(event.defaultPrevented)
+        })
+
+        val event = createKeyboardEvent()
+        canvasElement.dispatchEvent(event)
+        delay(100)
+
+        assertEquals(1, stack.size)
+        assertEquals(true, stack.last())
+    }
+}
+
+private fun createKeyboardEvent(): KeyboardEvent =
+    js("new KeyboardEvent('keydown', {key: 'c', code: 'KeyC', keyCode: 67, ctrlKey: true, metaKey: true, cancelable: true})")

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -66,18 +66,3 @@ const KarmaWebpackOutputPlugin = {
 
 config.plugins.push(KarmaWebpackOutputPlugin);
 config.frameworks.push("webpack-output");
-
-// config.browsers = ['ChromeHeadlessWithWebGL'];
-// config.customLaunchers = {
-//     ChromeHeadlessWithWebGL: {
-//         base: 'ChromeHeadless',
-//         flags: [
-//             // '--headless',
-//             '--use-gl=desktop',
-//             '--enable-webgl',
-//             '--ignore-gpu-blocklist',
-//             '--disable-gpu',
-//             '--no-sandbox'
-//         ]
-//     }
-// };

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -66,3 +66,18 @@ const KarmaWebpackOutputPlugin = {
 
 config.plugins.push(KarmaWebpackOutputPlugin);
 config.frameworks.push("webpack-output");
+
+// config.browsers = ['ChromeHeadlessWithWebGL'];
+// config.customLaunchers = {
+//     ChromeHeadlessWithWebGL: {
+//         base: 'ChromeHeadless',
+//         flags: [
+//             // '--headless',
+//             '--use-gl=desktop',
+//             '--enable-webgl',
+//             '--ignore-gpu-blocklist',
+//             '--disable-gpu',
+//             '--no-sandbox'
+//         ]
+//     }
+// };


### PR DESCRIPTION
**Fixes:**
https://github.com/JetBrains/compose-multiplatform/issues/4399

**Solution:**
Introduce new method `override fun onKeyboardEventWithResult(event: SkikoKeyboardEvent): Boolean` to know whether Compose processed a key event or not.
If Compose processed a key event, then we call preventDefault.