### PR TITLE
fix PasswordType behavior

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
@@ -81,6 +81,8 @@ internal interface SkikoUITextInputTraits {
 
 }
 
+internal object EmptyInputTraits : SkikoUITextInputTraits
+
 internal fun getUITextInputTraits(currentImeOptions: ImeOptions?) =
     object : SkikoUITextInputTraits {
         override fun keyboardType(): UIKeyboardType =

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -132,6 +132,7 @@ internal class UIKitTextInputService(
         currentImeActionHandler = null
         hideSoftwareKeyboard()
 
+        textUIView?.inputTraits = EmptyInputTraits
         textUIView?.input = null
         textUIView?.let { view ->
             mainScope.launch {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.IOSSkikoInput
 import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.TextActions
@@ -80,7 +81,7 @@ internal class IntermediateTextInputUIView(
     private var _inputDelegate: UITextInputDelegateProtocol? = null
     var input: IOSSkikoInput? = null
     private var _currentTextMenuActions: TextActions? = null
-    var inputTraits: SkikoUITextInputTraits = object : SkikoUITextInputTraits {}
+    var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
 
     override fun canBecomeFirstResponder() = true
 


### PR DESCRIPTION
## Proposed Changes

  - clears inputTraits from textUIView after unfocus. 

## Testing

Check Demo project IosBugs / KeyboardPasswordType on iOS 17 simulator. Switch focus between TextField's. Password type should be applied only for first TextField.

## Issues Fixed

 - https://youtrack.jetbrains.com/issue/COMPOSE-1018/iOS-PasswordType-changes-only-after-second-focused-TextField
