### PR TITLE
Fix a11y initialization for Desktop

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -108,6 +108,12 @@ internal class ComposeSceneMediator(
 
     val skikoView: SkikoView = DesktopSkikoView()
 
+    private val semanticsOwnerListener = DesktopSemanticsOwnerListener()
+    var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
+    val accessible: Accessible = ComposeSceneAccessible {
+        semanticsOwnerListener.accessibilityControllers
+    }
+
     private val platformComponent = DesktopPlatformComponent()
     private val textInputService = DesktopTextInputService(platformComponent)
     private val _platformContext = DesktopPlatformContext()
@@ -224,17 +230,11 @@ internal class ComposeSceneMediator(
             }
         }
 
-    private val semanticsOwnerListener = DesktopSemanticsOwnerListener()
-    var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
-
     private val scene by lazy { composeSceneFactory(this) }
     val focusManager get() = scene.focusManager
     var compositionLocalContext: CompositionLocalContext?
         get() = scene.compositionLocalContext
         set(value) { scene.compositionLocalContext = value }
-    val accessible: Accessible = ComposeSceneAccessible {
-        semanticsOwnerListener.accessibilityControllers
-    }
 
     /**
      * Provides the size of ComposeScene content inside infinity constraints

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -39,7 +39,11 @@ internal class WindowSkiaLayerComponent(
      * See also backend layer for swing interop in [SwingSkiaLayerComponent]
      */
     override val contentComponent: SkiaLayer = object : SkiaLayer(
-        externalAccessibleFactory = { mediator.accessible },
+        externalAccessibleFactory = {
+            // It depends on initialization order, so explicitly
+            // apply `checkNotNull` for "non-null" field.
+            checkNotNull(mediator.accessible)
+        },
         analytics = skiaLayerAnalytics
     ) {
         override fun paint(g: Graphics) {


### PR DESCRIPTION
## Proposed Changes

- Fix init order
- Add explicit null check to early detect possible regressions

## Testing

Test: try to use a11y in desktop app