### PR TITLE
Fix additional windows creation with `COMPONENT` layer type

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -18,6 +18,8 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.scene.ComposeContainer
@@ -55,7 +57,13 @@ internal class ComposeWindowPanel(
         container = this,
         skiaLayerAnalytics = skiaLayerAnalytics,
         window = window,
-        useSwingGraphics = false
+        useSwingGraphics = false,
+        layerType = ComposeFeatureFlags.layerType.let {
+            // LayerType.OnComponent might be used only with rendering to Swing graphics,
+            // but it's always disabled here. Using fallback instead of [check] to support
+            // opening separate windows from [ComposePanel] with such layer type.
+            if (it == LayerType.OnComponent) LayerType.OnSameCanvas else it
+        }
     )
     private val composeContainer
         get() = requireNotNull(_composeContainer) {


### PR DESCRIPTION
## Proposed Changes

- Ignore `LayerType.OnComponent` in `ComposeWindowPanel` instead of crash-check because it might be triggered for creating second window/dialog from `ComposePanel` with enabled offscreen rendering and component layers type

## Testing

Test: try to create a new window via composable function from `ComposePanel` with `LayerType.OnComponent`