### PR TITLE
Fix possible hierarchy corruption during removing `ComposePanel` with `LayerType.OnComponent`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -32,6 +32,7 @@ import java.awt.event.FocusEvent
 import java.awt.event.FocusListener
 import java.util.*
 import javax.swing.JLayeredPane
+import javax.swing.SwingUtilities
 import javax.swing.SwingUtilities.isEventDispatchThread
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
@@ -235,7 +236,13 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     override fun removeNotify() {
         _composeContainer?.removeNotify()
         if (isDisposeOnRemove) {
-            dispose()
+
+            // [dispose] might trigger hierarchy change for example removing [LayerType.OnComponent]
+            // layers. That will conflict with removing this [ComposePanel]. To avoid such
+            // issues we need to call [dispose] after leaving this method.
+            SwingUtilities.invokeLater {
+                dispose()
+            }
         }
         super.removeNotify()
     }


### PR DESCRIPTION
## Proposed Changes

- `dispose` might trigger hierarchy change for example removing `LayerType.OnComponent` layers. That will conflict with removing this `ComposePanel`. To avoid such issues we need to call `dispose` after leaving this method.

## Testing

Test: remove `ComposePanel` when it has opened layers attached to its parent
