### PR TITLE
Fix Material3 slider getting stuck while dragging

### DIFF
--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -175,6 +175,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             skikoTest.dependencies {
                 implementation(libs.kotlinTest)
+                implementation(project(":compose:ui:ui-test"))
             }
 
             desktopTest {

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt
@@ -267,18 +267,17 @@ fun Slider(
     val state = remember(
         steps,
         valueRange,
-        onValueChangeFinished
     ) {
         SliderState(
             value,
             steps,
             onValueChangeFinished,
             valueRange
-
         )
     }
 
     state.onValueChange = onValueChange
+    state.onValueChangeFinished = onValueChangeFinished
     state.value = value
 
     Slider(
@@ -1789,7 +1788,7 @@ class SliderState(
     value: Float = 0f,
     @IntRange(from = 0)
     val steps: Int = 0,
-    val onValueChangeFinished: (() -> Unit)? = null,
+    onValueChangeFinished: (() -> Unit)? = null,
     val valueRange: ClosedFloatingPointRange<Float> = 0f..1f
 ) : DraggableState {
 
@@ -1842,6 +1841,9 @@ class SliderState(
      */
     internal var onValueChange: ((Float) -> Unit)? = null
 
+    var onValueChangeFinished: (() -> Unit)? = onValueChangeFinished
+        internal set
+
     internal val tickFractions = stepsToTickFractions(steps)
     private var totalWidth by mutableIntStateOf(0)
     internal var isRtl = false
@@ -1868,7 +1870,7 @@ class SliderState(
     internal val gestureEndAction = {
         if (!isDragging) {
             // check isDragging in case the change is still in progress (touch -> drag case)
-            onValueChangeFinished?.invoke()
+            this.onValueChangeFinished?.invoke()
         }
     }
 

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/SliderTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/SliderTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.material3
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class SliderTest {
+    @Test
+    fun changingOnValueChangeFinishedDoesNotTriggerFinish() = runComposeUiTest {
+        var finish1Called = false
+        fun onFinish1() { finish1Called = true }
+
+        var finish2Called = false
+        fun onFinish2() { finish2Called = true }
+
+        var useFinish2 by mutableStateOf(false)
+
+        setContent {
+            var value by remember { mutableStateOf(0f) }
+            Slider(
+                value = value,
+                onValueChange = { value = it },
+                onValueChangeFinished = if (useFinish2) ::onFinish2 else ::onFinish1,
+                modifier = Modifier.testTag("slider")
+            )
+        }
+
+        onNodeWithTag("slider").apply {
+            val size = fetchSemanticsNode().size
+            performMouseInput {
+                moveTo(Offset(x = 0f, y = size.height / 2f))
+                press()
+                moveTo(Offset(x = size.width / 4f, y = size.height / 2f))
+                useFinish2 = true
+                moveTo(Offset(x = size.width / 2f, y = size.height / 2f))
+            }
+        }
+
+        assertFalse(finish1Called)
+        assertFalse(finish2Called)
+
+        onNodeWithTag("slider").performMouseInput {
+            release()
+        }
+
+        assertFalse(finish1Called)
+        assertTrue(finish2Called)
+    }
+}


### PR DESCRIPTION
...due to recreation of `SliderState` when `onValueChangeFinished` changes

## Proposed Changes
- Change `SliderState.onValueChangeFinished` to be `var` with `internal set`.
- In `Slider`, remove `onValueChangeFinished` from the list of keys used when remembering `SlideState`.
- Update `SliderState.onValueChangeFinished` whenever the `onValueChangeFinished` argument changes.

## Testing

Test: Added a unit test.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4366
