### PR TITLE
iOS context menu isn't showing in empty textfield

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -124,7 +124,11 @@ private fun getTapHandlerModifier(
                                     textLayoutResult = layoutResult,
                                     editProcessor = currentState.processor,
                                     offsetMapping = currentOffsetMapping,
-                                    showContextMenu = {},
+                                    showContextMenu = //{},
+                                    {
+                                        // it shouldn't be selection, but this is a way to call context menu in BasicTextField
+                                        manager.enterSelectionMode(true)
+                                    },
                                     onValueChange = currentState.onValueChange
                                 )
                             }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -124,8 +124,7 @@ private fun getTapHandlerModifier(
                                     textLayoutResult = layoutResult,
                                     editProcessor = currentState.processor,
                                     offsetMapping = currentOffsetMapping,
-                                    showContextMenu =
-                                    {
+                                    showContextMenu = {
                                         // it shouldn't be selection, but this is a way to call context menu in BasicTextField
                                         manager.enterSelectionMode(true)
                                     },

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -124,7 +124,7 @@ private fun getTapHandlerModifier(
                                     textLayoutResult = layoutResult,
                                     editProcessor = currentState.processor,
                                     offsetMapping = currentOffsetMapping,
-                                    showContextMenu = //{},
+                                    showContextMenu =
                                     {
                                         // it shouldn't be selection, but this is a way to call context menu in BasicTextField
                                         manager.enterSelectionMode(true)


### PR DESCRIPTION
## Proposed Changes

  - forwarded calling the context menu to tap handling function in ios textfield

## Fixes

Inability to open context menu in empty textfield by tapping on empty space or the caret, like native behavior.

Related issues:
https://github.com/JetBrains/compose-multiplatform/issues/4353
https://youtrack.jetbrains.com/issue/COMPOSE-1045/iOS-empty-textfield-context-menu

## Testing

Test: Copy something to clipboard, open test app, go Components -> TextField -> Keyboard Actions, focus empty text field, tap on the caret

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
