### PR TITLE
Keep adding interop order consistent between platforms

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -453,14 +453,15 @@ internal class ComposeSceneMediator(
 
     @OptIn(ExperimentalSkikoApi::class)
     private fun JLayeredPane.addToLayer(component: Component, layer: Int) {
+        val index = 0 // AWT renders it in the reverse order, so insert it to beginning
         if (renderApi == GraphicsApi.METAL && contentComponent !is SkiaSwingLayer) {
             // Applying layer on macOS makes our bridge non-transparent
             // But it draws always on top, so we can just add it as-is
             // TODO: Figure out why it makes difference in transparency
-            add(component, 0)
+            add(component, index)
         } else {
             setLayer(component, layer)
-            add(component, null, -1)
+            add(component, null, index)
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

- Inserting interop views in the reverse order to get direct order rendering. It's a hotfix to restore [1.5.x behaviour](https://github.com/JetBrains/compose-multiplatform-core/blob/v1.5.12/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowDelegate.desktop.kt#L77), the right order should rely on _rendering_, not adding order in the future.

## Testing

Test: run repruduction from the issue or "nasa" demo from this commit https://github.com/MatkovIvan/androidx/commit/6a3663deef96737e6b75c1f389c0a905c1e15bf3 (not in the main repo because it requires manually added jar)

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/1521#issuecomment-1965240338
