### PR TITLE
[Desktop] Fix changing WindowPlacement from Fullscreen to Maximized

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -194,6 +194,7 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
                     isFullscreen = true
                 }
                 WindowPlacement.Maximized -> {
+                    isFullscreen = false
                     isMaximized = true
                 }
                 WindowPlacement.Floating -> {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -310,6 +310,130 @@ class WindowStateTest {
         assertThat(window.placement).isEqualTo(WindowPlacement.Floating)
     }
 
+    @Test
+    fun `from floating to fullscreen to floating`() = runApplicationTest(
+        useDelay = isLinux || isMacOs,
+        delayMillis = 1000
+    ) {
+        val state = WindowState(size = DpSize(200.dp, 200.dp))
+        lateinit var window: ComposeWindow
+
+        launchTestApplication {
+            Window(onCloseRequest = {}, state) {
+                window = this.window
+            }
+        }
+
+        awaitIdle()
+
+        // Enter fullscreen from floating
+        state.placement = WindowPlacement.Floating
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Floating)
+
+        state.placement = WindowPlacement.Fullscreen
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Fullscreen)
+
+        // Exit fullscreen to floating
+        state.placement = WindowPlacement.Floating
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Floating)
+    }
+
+    @Test
+    fun `from maximized to fullscreen to floating`() = runApplicationTest(
+        useDelay = isLinux || isMacOs,
+        delayMillis = 1000
+    ) {
+        val state = WindowState(size = DpSize(200.dp, 200.dp))
+        lateinit var window: ComposeWindow
+
+        launchTestApplication {
+            Window(onCloseRequest = {}, state) {
+                window = this.window
+            }
+        }
+
+        awaitIdle()
+
+        // Enter fullscreen from maximized
+        state.placement = WindowPlacement.Maximized
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Maximized)
+
+        state.placement = WindowPlacement.Fullscreen
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Fullscreen)
+
+        // Exit fullscreen to floating
+        state.placement = WindowPlacement.Floating
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Floating)
+    }
+
+    @Test
+    fun `from maximized to fullscreen to maximized`() = runApplicationTest(
+        useDelay = isLinux || isMacOs,
+        delayMillis = 1000
+    ) {
+        val state = WindowState(size = DpSize(200.dp, 200.dp))
+        lateinit var window: ComposeWindow
+
+        launchTestApplication {
+            Window(onCloseRequest = {}, state) {
+                window = this.window
+            }
+        }
+
+        awaitIdle()
+
+        // Enter fullscreen from maximized
+        state.placement = WindowPlacement.Maximized
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Maximized)
+
+        state.placement = WindowPlacement.Fullscreen
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Fullscreen)
+
+        // Exit fullscreen to maximized
+        state.placement = WindowPlacement.Maximized
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Maximized)
+    }
+
+    @Test
+    fun `from floating to fullscreen to maximized`() = runApplicationTest(
+        useDelay = isLinux || isMacOs,
+        delayMillis = 1000
+    ) {
+        val state = WindowState(size = DpSize(200.dp, 200.dp))
+        lateinit var window: ComposeWindow
+
+        launchTestApplication {
+            Window(onCloseRequest = {}, state) {
+                window = this.window
+            }
+        }
+
+        awaitIdle()
+
+        // Enter fullscreen from floating
+        state.placement = WindowPlacement.Floating
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Floating)
+
+        state.placement = WindowPlacement.Fullscreen
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Fullscreen)
+
+        // Exit fullscreen to maximized
+        state.placement = WindowPlacement.Maximized
+        awaitIdle()
+        assertThat(window.placement).isEqualTo(WindowPlacement.Maximized)
+    }
+
     // https://github.com/JetBrains/compose-multiplatform/issues/3003
     @Test
     fun `WindowState placement after showing fullscreen window`() = runApplicationTest(


### PR DESCRIPTION
## Proposed Changes

When the `WindowPlacement` is set to `Maximized`, I changed the `isFullscreen` value to false to make sure that we exit fullscreen.
It's fixing the issue in mac, I still didn't try it on windows to make sure that it's not causing any issues.

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

I wasn't able to test this change since `isFullscreen` is private.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4380

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
