### PR TITLE
Fix unintended state reset on iOS

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -314,7 +314,13 @@ internal class ComposeContainer(
     }
 
     private fun createMediatorIfNeeded() {
-        val mediator = mediator ?: ComposeSceneMediator(
+        if (mediator == null) {
+            mediator = createMediator()
+        }
+    }
+
+    private fun createMediator(): ComposeSceneMediator {
+        val mediator = ComposeSceneMediator(
             container = view,
             configuration = configuration,
             focusStack = focusStack,
@@ -322,13 +328,12 @@ internal class ComposeContainer(
             coroutineContext = coroutineDispatcher,
             renderingUIViewFactory = ::createSkikoUIView,
             composeSceneFactory = ::createComposeScene,
-        ).also {
-            this.mediator = it
-            it.setContent {
-                ProvideContainerCompositionLocals(this, content)
-            }
+        )
+        mediator.setContent {
+            ProvideContainerCompositionLocals(this, content)
         }
         mediator.setLayout(SceneLayout.UseConstraintsToFillContainer)
+        return mediator
     }
 
     private fun dispose() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -324,10 +324,10 @@ internal class ComposeContainer(
             composeSceneFactory = ::createComposeScene,
         ).also {
             this.mediator = it
-        }
-        mediator.setContent {
-            ProvideContainerCompositionLocals(this) {
-                content()
+            it.setContent {
+                ProvideContainerCompositionLocals(this) {
+                    content()
+                }
             }
         }
         mediator.setLayout(SceneLayout.UseConstraintsToFillContainer)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -325,9 +325,7 @@ internal class ComposeContainer(
         ).also {
             this.mediator = it
             it.setContent {
-                ProvideContainerCompositionLocals(this) {
-                    content()
-                }
+                ProvideContainerCompositionLocals(this, content)
             }
         }
         mediator.setLayout(SceneLayout.UseConstraintsToFillContainer)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -233,7 +233,7 @@ internal class ComposeContainer(
         super.viewWillAppear(animated)
 
         isInsideSwiftUI = checkIfInsideSwiftUI()
-        setContent(content)
+        createMediatorIfNeeded()
         configuration.delegate.viewWillAppear(animated)
     }
 
@@ -313,7 +313,7 @@ internal class ComposeContainer(
         )
     }
 
-    private fun setContent(content: @Composable () -> Unit) {
+    private fun createMediatorIfNeeded() {
         val mediator = mediator ?: ComposeSceneMediator(
             container = view,
             configuration = configuration,


### PR DESCRIPTION
## Proposed Changes

Perform `setContent` only once per ComposeContainer mediator lifetime.

## Testing

Test: scenario described in [the comment](https://github.com/JetBrains/compose-multiplatform/issues/3698#issuecomment-1969572614) doesn't cause whole app recomposition with remembered state recreation

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/3698#issuecomment-1969572614
