### PR TITLE
Fix nested scroll when Pager involved in scrolling process

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
@@ -895,10 +895,7 @@ private class DefaultPagerNestedScrollConnection(
         available: Offset,
         source: NestedScrollSource
     ): Offset {
-        if (source == NestedScrollSource.Fling &&
-            (orientation == Orientation.Horizontal && available.x != 0f) ||
-            (orientation == Orientation.Vertical && available.y != 0f)
-        ) {
+        if (source == NestedScrollSource.Fling && available.toFloat() != 0f) {
             throw CancellationException("End of scrollable area reached")
         }
         return Offset.Zero
@@ -907,6 +904,9 @@ private class DefaultPagerNestedScrollConnection(
     override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
         return available.consumeOnOrientation(orientation)
     }
+
+    private fun Offset.toFloat(): Float =
+        if (orientation == Orientation.Horizontal) this.x else this.y
 }
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/Pager.kt
@@ -895,7 +895,10 @@ private class DefaultPagerNestedScrollConnection(
         available: Offset,
         source: NestedScrollSource
     ): Offset {
-        if (source == NestedScrollSource.Fling && available != Offset.Zero) {
+        if (source == NestedScrollSource.Fling &&
+            (orientation == Orientation.Horizontal && available.x != 0f) ||
+            (orientation == Orientation.Vertical && available.y != 0f)
+        ) {
             throw CancellationException("End of scrollable area reached")
         }
         return Offset.Zero


### PR DESCRIPTION
Fix scroll interruption by Pager component when the scroll happens in perpendicular direction

## Proposed Changes

Do not interrupt scrolling if it occurs in a perpendicular direction to the Pager.

## Testing

Test: see description here: https://github.com/JetBrains/compose-multiplatform/issues/4395

## Issues Fixed

Fixes: The bug on https://github.com/JetBrains/compose-multiplatform/issues/4395
