### PR TITLE
Re-validate interop container after resizing component

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
@@ -75,7 +75,7 @@ internal class SwingInteropContainer(
             index + nonInteropComponents
         })
 
-        // Sometimes Swing displays the rest of interop views in incorrect order after removing,
+        // Sometimes Swing displays the rest of interop views in incorrect order after adding,
         // so we need to force re-validate it.
         container.validate()
         container.repaint()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -146,8 +146,15 @@ internal class ComposeContainer(
         layers.fastForEach(DesktopComposeSceneLayer::close)
     }
 
-    override fun componentResized(e: ComponentEvent?) = onChangeWindowPosition()
-    override fun componentMoved(e: ComponentEvent?) = onChangeWindowSize()
+    override fun componentResized(e: ComponentEvent?)  {
+        onChangeWindowSize()
+
+        // Sometimes Swing displays interop views in incorrect order after resizing,
+        // so we need to force re-validate it.
+        container.validate()
+        container.repaint()
+    }
+    override fun componentMoved(e: ComponentEvent?) = onChangeWindowPosition()
     override fun componentShown(e: ComponentEvent?) = Unit
     override fun componentHidden(e: ComponentEvent?) = Unit
 


### PR DESCRIPTION
## Proposed Changes

Additional fix for #1145 and #1147

- Re-validate interop container after resizing component
- Fix incorrect calls - `componentResized` -> `onChangeWindowSize` and  `componentMoved` -> `onChangeWindowPosition`

## Testing

Test: Resize a window on "InteropOrder" mpp page (reproduced on macOS)

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform-core/pull/1145#discussion_r1508149219