### PR TITLE
Locale-aware date formatting for desktop

### DIFF
--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -33,6 +33,12 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     actual val firstDayOfWeek: Int
         get() = delegate.firstDayOfWeek
 
+    private val dateFormatter by lazy {
+        DateTimeFormatter
+            .ofLocalizedDate(FormatStyle.LONG)
+            .localizedBy(locale)
+    }
+
     actual fun formatWithPattern(
         utcTimeMillis: Long,
         pattern: String,
@@ -54,17 +60,14 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
 
         // date picker headline and semantics are localized,
         // year picker is transformed to readable format
+
         val pattern = when(skeleton){
             DatePickerDefaults.YearAbbrMonthDaySkeleton -> {
-                return DateTimeFormatter
-                    .ofLocalizedDate(FormatStyle.LONG)
-                    .localizedBy(locale)
+                return dateFormatter
                     .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
             }
             DatePickerDefaults.YearMonthWeekdayDaySkeleton -> {
-                return DateTimeFormatter
-                    .ofLocalizedDate(FormatStyle.FULL)
-                    .localizedBy(locale)
+                return dateFormatter
                     .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
             }
             DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -45,20 +45,16 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         skeleton: String
     ): String {
         // Note: there is no equivalent in Java for Android's DateFormat.getBestDateTimePattern.
-        // The JDK SimpleDateFormat expects a pattern, so the results will be "2023Jan7",
+        // The JDK SimpleDateFormat expects a pattern, so the results for unrecognized skeletons will be "2023Jan7",
         // "2023January", etc. in case a skeleton holds an actual ICU skeleton and not a pattern.
 
         // TODO: support ICU skeleton on JVM
         // Maybe it will be supported in kotlinx.datetime in the future.
-        // See https://github.com/Kotlin/kotlinx-datetime/pull/251
-
-        // date picker headline and semantics are localized,
-        // year picker is transformed to readable format
 
         val pattern = when(skeleton){
             DatePickerDefaults.YearAbbrMonthDaySkeleton -> {
                 return DateTimeFormatter
-                    .ofLocalizedDate(FormatStyle.LONG)
+                    .ofLocalizedDate(FormatStyle.MEDIUM)
                     .localizedBy(locale)
                     .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
             }
@@ -68,7 +64,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
                     .localizedBy(locale)
                     .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
             }
-            DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"
+            DatePickerDefaults.YearMonthSkeleton -> "LLLL yyyy" // L is a pattern for standalone month (without day)
             else -> skeleton
         }
         return formatWithPattern(utcTimeMillis, pattern)

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -19,9 +19,14 @@ package androidx.compose.material3
 import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.time.DayOfWeek
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 import java.time.format.TextStyle
 
 
+@OptIn(ExperimentalMaterial3Api::class)
 internal actual class PlatformDateFormat actual constructor(private val locale: CalendarLocale) {
     private val delegate = LegacyCalendarModelImpl(locale)
 
@@ -47,11 +52,22 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         // Maybe it will be supported in kotlinx.datetime in the future.
         // See https://github.com/Kotlin/kotlinx-datetime/pull/251
 
-        // stub: not localized but at least readable variant
+        // date picker headline and semantics are localized,
+        // year picker is transformed to readable format
         val pattern = when(skeleton){
+            DatePickerDefaults.YearAbbrMonthDaySkeleton -> {
+                return DateTimeFormatter
+                    .ofLocalizedDate(FormatStyle.LONG)
+                    .localizedBy(locale)
+                    .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
+            }
+            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> {
+                return DateTimeFormatter
+                    .ofLocalizedDate(FormatStyle.FULL)
+                    .localizedBy(locale)
+                    .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
+            }
             DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"
-            DatePickerDefaults.YearAbbrMonthDaySkeleton -> "MMM d, yyyy"
-            DatePickerDefaults.YearMonthWeekdayDaySkeleton -> "EEEE, MMMM d, yyyy"
             else -> skeleton
         }
         return formatWithPattern(utcTimeMillis, pattern)

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/PlatformDateFormat.desktop.kt
@@ -33,12 +33,6 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     actual val firstDayOfWeek: Int
         get() = delegate.firstDayOfWeek
 
-    private val dateFormatter by lazy {
-        DateTimeFormatter
-            .ofLocalizedDate(FormatStyle.LONG)
-            .localizedBy(locale)
-    }
-
     actual fun formatWithPattern(
         utcTimeMillis: Long,
         pattern: String,
@@ -63,11 +57,15 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
 
         val pattern = when(skeleton){
             DatePickerDefaults.YearAbbrMonthDaySkeleton -> {
-                return dateFormatter
+                return DateTimeFormatter
+                    .ofLocalizedDate(FormatStyle.LONG)
+                    .localizedBy(locale)
                     .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
             }
             DatePickerDefaults.YearMonthWeekdayDaySkeleton -> {
-                return dateFormatter
+                return DateTimeFormatter
+                    .ofLocalizedDate(FormatStyle.FULL)
+                    .localizedBy(locale)
                     .format(Instant.ofEpochMilli(utcTimeMillis).atOffset(ZoneOffset.UTC))
             }
             DatePickerDefaults.YearMonthSkeleton -> "MMMM yyyy"


### PR DESCRIPTION
It's not a complete solution - just localization for default m3 skeletons. User-provided variants will still be ugly  :( 

Before and after:

<img width="300" alt="Снимок экрана 2024-02-29 в 21 17 28" src="https://github.com/JetBrains/compose-multiplatform-core/assets/63979218/4560e92d-f0a4-4d0b-85bb-34756dd5a938">

<img width="300" alt="Screenshot 2024-03-04 at 17 22 51" src="https://github.com/JetBrains/compose-multiplatform-core/assets/63979218/eef72277-8bbe-4edf-bc6b-a5b7d0085634">

