### PR TITLE
[a11y] Coalesce multiple calls to AccessibilityController.onSemanticsChange

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -95,6 +95,7 @@ internal class RootNodeOwner(
     val platformContext: PlatformContext,
     private val snapshotInvalidationTracker: SnapshotInvalidationTracker,
     private val inputHandler: ComposeSceneInputHandler,
+    private val onSemanticsChange: (SemanticsOwner) -> Unit,
 ) {
     // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2944)
     //  Check if ComposePanel/SwingPanel focus interop work correctly with new features of
@@ -379,11 +380,11 @@ internal class RootNodeOwner(
         )
 
         override fun onSemanticsChange() {
-            platformContext.semanticsOwnerListener?.onSemanticsChange(semanticsOwner)
+            onSemanticsChange(semanticsOwner)
         }
 
         override fun onLayoutChange(layoutNode: LayoutNode) {
-            platformContext.semanticsOwnerListener?.onSemanticsChange(semanticsOwner)
+            onSemanticsChange(semanticsOwner)
         }
 
         override fun getFocusDirection(keyEvent: KeyEvent): FocusDirection? {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -120,6 +120,7 @@ private class MultiLayerComposeSceneImpl(
         platformContext = composeSceneContext.platformContext,
         snapshotInvalidationTracker = snapshotInvalidationTracker,
         inputHandler = inputHandler,
+        onSemanticsChange = ::onSemanticsChange
     )
 
     override var density: Density = density
@@ -400,23 +401,25 @@ private class MultiLayerComposeSceneImpl(
         compositionContext = compositionContext,
     )
 
-    private fun onOwnerAppended(owner: RootNodeOwner) {
+    override fun onOwnerAppended(owner: RootNodeOwner) {
         if (_focusManager.isFocused) {
             owner.focusOwner.takeFocus()
         } else {
             owner.focusOwner.releaseFocus()
         }
-        semanticsOwnerListener?.onSemanticsOwnerAppended(owner.semanticsOwner)
+
+        super.onOwnerAppended(owner)
     }
 
-    private fun onOwnerRemoved(owner: RootNodeOwner) {
+    override fun onOwnerRemoved(owner: RootNodeOwner) {
         if (owner == lastHoverOwner) {
             lastHoverOwner = null
         }
         if (owner == gestureOwner) {
             gestureOwner = null
         }
-        semanticsOwnerListener?.onSemanticsOwnerRemoved(owner.semanticsOwner)
+
+        super.onOwnerRemoved(owner)
     }
 
     private fun attachLayer(layer: AttachedComposeSceneLayer) {
@@ -502,6 +505,7 @@ private class MultiLayerComposeSceneImpl(
             },
             snapshotInvalidationTracker = snapshotInvalidationTracker,
             inputHandler = inputHandler,
+            onSemanticsChange = this@MultiLayerComposeSceneImpl::onSemanticsChange
         )
         private var composition: Composition? = null
         private var outsidePointerCallback: ((eventType: PointerEventType) -> Unit)? = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
@@ -97,6 +97,7 @@ private class SingleLayerComposeSceneImpl(
             platformContext = composeSceneContext.platformContext,
             snapshotInvalidationTracker = snapshotInvalidationTracker,
             inputHandler = inputHandler,
+            onSemanticsChange = ::onSemanticsChange
         )
     }
 
@@ -187,13 +188,10 @@ private class SingleLayerComposeSceneImpl(
         compositionContext = compositionContext
     )
 
-    private fun onOwnerAppended(owner: RootNodeOwner) {
+    override fun onOwnerAppended(owner: RootNodeOwner) {
         owner.focusOwner.takeFocus()
-        semanticsOwnerListener?.onSemanticsOwnerAppended(owner.semanticsOwner)
-    }
 
-    private fun onOwnerRemoved(owner: RootNodeOwner) {
-        semanticsOwnerListener?.onSemanticsOwnerRemoved(owner.semanticsOwner)
+        super.onOwnerAppended(owner)
     }
 
     private inner class ComposeSceneFocusManagerImpl : ComposeSceneFocusManager {


### PR DESCRIPTION
Previously, `AccessibilityController.syncLoop` would sync the node tree at most once every 100ms. After the [recent changes](https://github.com/JetBrains/compose-multiplatform-core/pull/1137), it will sync immediately, as needed.

Unfortunately, during recomposition and layout (`ComposeScene.render`), `PlatformContext.SemanticsOwnerListener.onSemanticsChange` will get called for every node that changed, resulting in many calls to `AccessibilityController.onSemanticsChange`.

As I am writing this I realized that this isn't a serious problem, because `AccessibilityController.launchSyncLoop` launches the coroutine on the main dispatcher, and `ComposeScene.render` runs on the same thread, so all the many calls to  `AccessibilityController.onSemanticsChange` from within `ComposeScene.render` will anyway result in one `AccessibilityController.syncNodes`.

So the only reason to merge this PR is purely aesthetic.

## Proposed Changes

ComposeScene will collect the `SemanticsOwner`s that have changed during rendering and event dispatching, and will make one `onSemanticsChange` for each one afterwards.

## Testing

Test: Tested manually to verify that `AccessibilityController.onSemanticsChange` doesn't get called many times in one frame when a `Box` size is animated.
