### PR TITLE
[a11y] Pass the id of the node whose layout changed to accessibility controllers

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3152,6 +3152,7 @@ public abstract interface class androidx/compose/ui/platform/PlatformContext$Roo
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener {
+	public abstract fun onLayoutChange (Landroidx/compose/ui/semantics/SemanticsOwner;I)V
 	public abstract fun onSemanticsChange (Landroidx/compose/ui/semantics/SemanticsOwner;)V
 	public abstract fun onSemanticsOwnerAppended (Landroidx/compose/ui/semantics/SemanticsOwner;)V
 	public abstract fun onSemanticsOwnerRemoved (Landroidx/compose/ui/semantics/SemanticsOwner;)V

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -316,6 +316,16 @@ internal class AccessibilityController(
     }
 
     /**
+     * Invoked when the position and/or size of the [SemanticsNode] with the given semantics id
+     * changed.
+     */
+    fun onLayoutChanged(@Suppress("UNUSED_PARAMETER") nodeId: Int) {
+        // TODO: Only recompute the layout-related properties of the node
+        nodeMappingIsValid = false
+        syncNodesChannel.trySend(Unit)
+    }
+
+    /**
      * The [SemanticsNode] that is the root of the semantics node tree.
      */
     private val rootSemanticNode: SemanticsNode

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -77,7 +77,6 @@ import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
 import org.jetbrains.skia.Canvas
-import org.jetbrains.skiko.ClipComponent
 import org.jetbrains.skiko.ClipRectangle
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.GraphicsApi
@@ -633,6 +632,10 @@ internal class ComposeSceneMediator(
 
         override fun onSemanticsChange(semanticsOwner: SemanticsOwner) {
             _accessibilityControllers[semanticsOwner]?.onSemanticsChange()
+        }
+
+        override fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int) {
+            _accessibilityControllers[semanticsOwner]?.onLayoutChanged(nodeId = semanticsNodeId)
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -383,7 +383,10 @@ internal class RootNodeOwner(
         }
 
         override fun onLayoutChange(layoutNode: LayoutNode) {
-            platformContext.semanticsOwnerListener?.onSemanticsChange(semanticsOwner)
+            platformContext.semanticsOwnerListener?.onLayoutChange(
+                semanticsOwner = semanticsOwner,
+                semanticsNodeId = layoutNode.semanticsId
+            )
         }
 
         override fun getFocusDirection(keyEvent: KeyEvent): FocusDirection? {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.Owner
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.scene.ComposeScene
@@ -125,6 +126,15 @@ interface PlatformContext {
          * @see Owner.onSemanticsChange
          */
         fun onSemanticsChange(semanticsOwner: SemanticsOwner)
+
+        /**
+         * Callback method that is called when the position and/or size of the [LayoutNode] with
+         * the given semantics id changed.
+         *
+         * Note that the id, rather than the [LayoutNode] itself, is passed here because
+         * [LayoutNode] is an internal type, so it can't be exposed in a public method.
+         */
+        fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int)
     }
 
     companion object {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -967,6 +967,14 @@ internal class AccessibilityMediator(
         isCurrentComposeAccessibleTreeDirty = true
     }
 
+    fun onLayoutChange(nodeId: Int) {
+        debugLogger?.log("onLayoutChange (nodeId=$nodeId)")
+
+        // TODO: Only recompute the layout-related properties of the node
+        isCurrentComposeAccessibleTreeDirty = true
+
+    }
+
     fun convertRectToWindowSpaceCGRect(rect: Rect): CValue<CGRect> {
         val window = view.window ?: return CGRectMake(0.0, 0.0, 0.0, 0.0)
         val density = Density(window.screen.scale.toFloat())

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -156,6 +156,14 @@ private class SemanticsOwnerListenerImpl(
             current.second.onSemanticsChange()
         }
     }
+
+    override fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int) {
+        val current = current ?: return
+
+        if (current.first == semanticsOwner) {
+            current.second.onLayoutChange(nodeId = semanticsNodeId)
+        }
+    }
 }
 
 private class RenderingUIViewDelegateImpl(


### PR DESCRIPTION
Currently, when the layout of a single node changes, we call onSemanticsChange on (desktop) `AccessibilityController` and (iOS) `AccessibilityMediator`, which causes them to re-sync the entire node tree.

## Proposed Changes

Pass the semantics id of the node whose layout changed to the accessibility controllers, so they can invalidate the tree more granularly. Note that this PR only passes the information; the actual granular handling will be done in separate PR(s).


## Testing

Test: Manually, only on the desktop.
