### PR TITLE
Fix a logical error causing Compose tree corruption and consequent crash on iOS

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/IosBugs.kt
@@ -34,5 +34,6 @@ val IosBugs = Screen.Selection(
     DropdownMenuIssue,
     KeyboardIMEActionPopup,
     ProperContainmentDisposal,
-    ComposeAndNativeScroll
+    ComposeAndNativeScroll,
+    MeasureAndLayoutCrash
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/MeasureAndLayoutCrash.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/MeasureAndLayoutCrash.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bugs
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.Checkbox
+import androidx.compose.material.Text
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+@Composable
+fun RowItem(index: Int) {
+    Row(modifier = Modifier.padding(end = 30.dp)) {
+        var state by remember(index) { mutableStateOf<Unit?>(null) }
+
+        LaunchedEffect(index) {
+            delay((100..200).random().toLong())
+            state = Unit
+        }
+        state?.let {
+            Text("Item $index")
+        }
+    }
+}
+
+@Composable
+fun RowItem(wrapInBox: Boolean, index: Int) {
+    if (wrapInBox) {
+        Box {
+            RowItem(index)
+        }
+    } else {
+        RowItem(index)
+    }
+}
+
+val MeasureAndLayoutCrash = Screen.Example("MeasureAndLayoutCrash") {
+    val lazyColumnState = rememberLazyListState()
+    var enableCrash by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.safeContentPadding()
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Checkbox(
+                checked = enableCrash,
+                onCheckedChange = { enableCrash = it },
+                modifier = Modifier.padding(16.dp),
+            )
+
+            Text("Enable crash")
+        }
+        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopCenter) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                state = lazyColumnState,
+            ) {
+                items(1000) { index ->
+                    RowItem(enableCrash, index)
+                }
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/node/SortedSet.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/node/SortedSet.jsNative.kt
@@ -27,6 +27,8 @@ internal actual class SortedSet<E> actual constructor(
         var index = list.binarySearch(element, comparator)
         if (index < 0) {
             index = -index - 1
+        } else {
+            return false
         }
         list.add(index, element)
         return true

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/SortedSetTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/SortedSetTest.kt
@@ -55,6 +55,16 @@ class SortedSetTest {
     }
 
     @Test
+    fun checkExistingWhenAdded() {
+        val set = sortedSetOf(1, 2, 3, 4, 5)
+        assertFalse(set.add(3))
+        assertFalse(set.add(4))
+        assertFalse(set.add(5))
+        assertTrue(set.add(6))
+        assertTrue(set.add(7))
+    }
+
+    @Test
     fun customComparator() {
         val set = sortedSetOf(compareBy { it.length }, "B", "AAA", "DD")
         assertOrderEquals(listOf("B", "DD", "AAA"), set)


### PR DESCRIPTION
## Proposed Changes

Add reduced reported issue repro, fix logical error in `SortedSet.add`.

## Testing

Test: `SortedSetTest.checkExistingWhenAdded`, no crash happens in reported scenario.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4422
