### PR TITLE
Fix a11y wrong bounds calculation

### DIFF
--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/unit/Density.jsNative.kt
@@ -55,3 +55,14 @@ internal fun Rect.toDpRect(density: Density): DpRect = with(density) {
         size = size.toDpSize()
     )
 }
+
+/**
+ * Convert a [DpRect] to a [Rect].
+ */
+@Stable
+internal fun DpRect.toRect(density: Density): Rect = with(density) {
+    Rect(
+        offset = DpOffset(left, top).toOffset(density),
+        size = size.toSize()
+    )
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.KeyEvent
@@ -83,6 +84,7 @@ import org.jetbrains.skiko.SkikoKeyboardEventKind
 import platform.CoreGraphics.CGAffineTransformIdentity
 import platform.CoreGraphics.CGAffineTransformInvert
 import platform.CoreGraphics.CGPoint
+import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
@@ -124,6 +126,7 @@ private class SemanticsOwnerListenerImpl(
     private val container: UIView,
     private val coroutineContext: CoroutineContext,
     private val getAccessibilitySyncOptions: () -> AccessibilitySyncOptions,
+    private val convertContainerWindowRectToRootWindowCGRect: (Rect) -> CValue<CGRect>,
     private val performEscape: () -> Boolean
 ) : PlatformContext.SemanticsOwnerListener {
     var current: Pair<SemanticsOwner, AccessibilityMediator>? = null
@@ -135,6 +138,7 @@ private class SemanticsOwnerListenerImpl(
                 semanticsOwner,
                 coroutineContext,
                 getAccessibilitySyncOptions,
+                convertContainerWindowRectToRootWindowCGRect,
                 performEscape
             )
         }
@@ -293,6 +297,9 @@ internal class ComposeSceneMediator(
             coroutineContext,
             getAccessibilitySyncOptions = {
                 configuration.accessibilitySyncOptions
+            },
+            convertContainerWindowRectToRootWindowCGRect = {
+                windowContext.convertContainerWindowRectToRootWindowCGRect(it)
             },
             performEscape = {
                 val down = onKeyboardEvent(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Extensions.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Extensions.uikit.kt
@@ -29,6 +29,7 @@ internal val UITraitEnvironmentProtocol.systemDensity: Density
         val contentSizeCategory =
             traitCollection.preferredContentSizeCategory ?: UIContentSizeCategoryUnspecified
         return Density(
+            // TODO: refactor to avoid mainScreen scale, window can be attached to different screens
             density = UIScreen.mainScreen.scale.toFloat(),
             fontScale = uiContentSizeCategoryToFontScaleMap[contentSizeCategory] ?: 1.0f
         )


### PR DESCRIPTION
## Proposed Changes

Fix the logical error where `boundsInWindow` is treated as view local coordinates.

## Testing

Test: Demo NativeModalWithNavigation now resolves correct `accessibilityFrame`. So is the case for the views whose frames don't match the app root UIWindow bounds.