### PR TITLE
Improve iOS a11y sync behavior

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1037,17 +1037,14 @@ internal class AccessibilityMediator(
     fun onSemanticsChange() {
         debugLogger?.log("onSemanticsChange")
 
-        invalidationKind = SemanticsTreeInvalidationKind.COMPLETE
-        invalidationChannel.trySend(Unit)
+        invalidationChannel.trySend(SemanticsTreeInvalidation.SemanticsChanged)
     }
 
     fun onLayoutChange(nodeId: Int) {
         debugLogger?.log("onLayoutChange (nodeId=$nodeId)")
 
-        invalidatedBoundsNodeIds.add(nodeId)
-
         // unprocessedInvalidationKind will be set to BOUNDS in sync(), it's a strict subset of COMPLETE
-        invalidationChannel.trySend(Unit)
+        invalidationChannel.trySend(SemanticsTreeInvalidation.BoundsChanged(nodeId))
     }
 
     fun dispose() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -35,7 +35,6 @@ import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.readValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGRect

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -260,7 +260,7 @@ private class AccessibilityElement(
                 child.discardCachedAccessibilityFrameRecursively()
             }
         } else {
-            // Not calculated yet, or the subtree was already discarded
+            // Not calculated yet, or the subtree was already discarded. Do nothing.
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1001,8 +1001,9 @@ internal class AccessibilityMediator(
                 )
 
                 while (true) {
-                    // Consumes all the invalidations to select a proper strategy
-                    val invalidation = invalidationChannel.tryReceive().getOrNull() ?: break
+                    val result = invalidationChannel.tryReceive()
+
+                    val invalidation = result.getOrNull() ?: break
                     strategy = strategy.reduce(invalidation)
                 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -35,6 +35,7 @@ import kotlinx.cinterop.ExportObjCClass
 import kotlinx.cinterop.readValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGRect

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -998,9 +998,8 @@ internal class AccessibilityMediator(
                 )
 
                 while (true) {
-                    val result = invalidationChannel.tryReceive()
-
-                    val invalidation = result.getOrNull() ?: break
+                    // Consumes all the invalidations to select a proper strategy
+                    val invalidation = invalidationChannel.tryReceive().getOrNull() ?: break
                     strategy = strategy.reduce(invalidation)
                 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -992,7 +992,10 @@ internal class AccessibilityMediator(
         getAccessibilitySyncOptions().debugLoggerIfEnabled?.log("AccessibilityMediator for ${view} created")
 
         coroutineScope.launch {
-            while (isAlive) {
+            // The main loop that listens for invalidations and performs the tree syncing
+            // Will exit on CancellationException from within await on `invalidationChannel.receive()`
+            // when [job] is cancelled
+            while (true) {
                 var strategy = SemanticsTreeSyncStrategy.from(
                     invalidationChannel.receive()
                 )

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -255,9 +255,7 @@ private class AccessibilityElement(
         }
     }
     private fun discardCachedAccessibilityFrameRecursively() {
-        if (cachedProperties.containsKey(CachedAccessibilityPropertyKeys.accessibilityFrame)) {
-            cachedProperties.remove(CachedAccessibilityPropertyKeys.accessibilityFrame)
-
+        if (cachedProperties.remove(CachedAccessibilityPropertyKeys.accessibilityFrame) != null) {
             for (child in children) {
                 child.discardCachedAccessibilityFrameRecursively()
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1040,14 +1040,17 @@ internal class AccessibilityMediator(
     fun onSemanticsChange() {
         debugLogger?.log("onSemanticsChange")
 
-        invalidationChannel.trySend(SemanticsTreeInvalidation.SemanticsChanged)
+        invalidationKind = SemanticsTreeInvalidationKind.COMPLETE
+        invalidationChannel.trySend(Unit)
     }
 
     fun onLayoutChange(nodeId: Int) {
         debugLogger?.log("onLayoutChange (nodeId=$nodeId)")
 
+        invalidatedBoundsNodeIds.add(nodeId)
+
         // unprocessedInvalidationKind will be set to BOUNDS in sync(), it's a strict subset of COMPLETE
-        invalidationChannel.trySend(SemanticsTreeInvalidation.BoundsChanged(nodeId))
+        invalidationChannel.trySend(Unit)
     }
 
     fun dispose() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -96,7 +96,7 @@ private enum class SemanticsTreeInvalidationKind {
     COMPLETE,
 
     /**
-     * Only bounds of the nodes were changed, need to recompute the bounds of the nodes.
+     * Only bounds of the nodes were changed, need to recompute the bounds of the affected subtrees.
      */
     BOUNDS
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -979,6 +979,7 @@ internal class AccessibilityMediator(
 
                 while (invalidationChannel.tryReceive().isSuccess) {
                     // Do nothing, just consume the channel
+                    // Workaround for the channel buffering two invalidations despite the capacity of 1
                 }
 
                 val syncOptions = getAccessibilitySyncOptions()


### PR DESCRIPTION
## Proposed Changes

1. Implement desktop-like `sync` logic. The `render` can issue undefined amount of layout and semantics invalidation, that will be coalesced into a single `sync` every time it happens.

2. Implement different logic based on kind of invalidation to avoid extra when only bounds are changed.

3. Fix wrong refocusing logical bug.

## Testing

Test: N/A