### PR TITLE
Fix POM publication for `collection` and `annotation` dependencies

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -294,31 +294,22 @@ fun enableArtifactRedirectingPublishing(project: Project) {
 
     val ext = project.multiplatformExtension ?: error("expected a multiplatform project")
 
-    val oelGroupId = project.findProperty("artifactRedirecting.androidx.groupId") as? String
-
-    val newRootComponent: CustomRootComponent? = if (oelGroupId != null) {
-        val oelVersion = project.findProperty("artifactRedirecting.androidx.${project.name}.version") as? String
-        requireNotNull(oelVersion) {
-            "Please specify artifactRedirecting.androidx.${project.name}.version property"
-        }
-
+    val redirecting = project.artifactRedirecting()
+    val newRootComponent: CustomRootComponent? = if (redirecting != null) {
         val rootComponent = project
             .components
             .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
             .getByName("kotlin")
 
-        val newDependency = project.dependencies.create(oelGroupId, project.name, oelVersion)
+        val newDependency = project.dependencies.create(redirecting.groupId, project.name, redirecting.version)
         CustomRootComponent(rootComponent, newDependency)
     } else {
         null
     }
 
-    val oelTargetNames = (project.findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
-        .split(",").toSet()
-
     ext.targets.all { target ->
-        // TODO (o.k): support projects where oel publication is required for both android and native
-        if (target.name in oelTargetNames) {
+        // TODO (o.k): support projects where redirecting publication is required for both android and native
+        if (target.name in redirecting?.targetNames.orEmpty()) {
             project.publishAndroidxReference(target as KotlinOnlyTarget<*>, newRootComponent!!)
         } else if (target is KotlinAndroidTarget) {
             // TODO (o.k): try to get rid of this and reuse the same logic as above
@@ -326,6 +317,27 @@ fun enableArtifactRedirectingPublishing(project: Project) {
         }
     }
 }
+
+internal fun Project.artifactRedirecting(): ArtifactRedirecting? {
+    val groupId = findProperty("artifactRedirecting.androidx.groupId") as? String ?: return null
+    val version = findProperty("artifactRedirecting.androidx.$name.version") as? String
+    requireNotNull(version) {
+        "Please specify artifactRedirecting.androidx.$name.version property"
+    }
+    val targetNames = (findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
+        .split(",").toSet()
+    return ArtifactRedirecting(
+        groupId = groupId,
+        version = version,
+        targetNames = targetNames,
+    )
+}
+
+internal data class ArtifactRedirecting(
+    val groupId: String,
+    val version: String,
+    val targetNames: Set<String>,
+)
 
 private fun Project.publishAndroidxReference(target: KotlinAndroidTarget) {
     afterEvaluate {

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -373,6 +373,7 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
             project.configureSourceJarForMultiplatform()
             project.configureLintForMultiplatform(extension)
         }
+        project.addToProjectMap(extension)
     }
 
     @Suppress("UnstableApiUsage") // AGP DSL APIs


### PR DESCRIPTION
The current POM has wrong dependencies:
https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/foundation/foundation-desktop/1.6.10-dev1464/foundation-desktop-1.6.10-dev1464.pom?download=true:
```
    <dependency>
      <groupId>org.jetbrains.compose.annotation-internal</groupId>
      <artifactId>annotation-jvm</artifactId>
      <version>1.6.10-dev1464</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.compose.collection-internal</groupId>
      <artifactId>collection-jvm</artifactId>
      <version>1.6.10-dev1464</version>
      <scope>runtime</scope>
    </dependency>
```

We don't publish `org.jetbrains.compose.collection-internal:collection-jvm`, we redirect to `androidx.collection:collection-jvm`.

Everything is okay in Gradle, because it uses `.module` file instead of `.pom` where we have the groupId replaced. But it doesn't work in non Gradle environments.

It is a blocker for Android studio integration. The internal utility parses all pom dependencies, and it can't find `org.jetbrains.compose.collection-internal:collection-jvm`, because it doesn't exist.

Fixes https://youtrack.jetbrains.com/issue/COMPOSE-1067/Fix-pom-publication

## Testing
1. Comparing POM after building on CI
[Current publication](https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/foundation/foundation-desktop/1.6.10-dev1464/foundation-desktop-1.6.10-dev1464.pom?download=true)
[Modified publication](https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/foundation/foundation-desktop/0.0.0-fix-pom-dev1485/foundation-desktop-0.0.0-fix-pom-dev1485.pom?download=true)

2. Running desktop/multiplatform templates on `0.0.0-fix-pom-dev1485`