### PR TITLE
Delay tap indication inside scroll on iOS

### DIFF
--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/Clickable.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/Clickable.jsNative.kt
@@ -16,11 +16,8 @@
 
 package androidx.compose.foundation
 
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import org.jetbrains.skiko.SkikoKey
@@ -30,9 +27,6 @@ internal actual fun CompositionLocalConsumerModifierNode
     .isComposeRootInScrollableContainer(): Boolean {
     return false
 }
-
-// TODO: b/168524931 - should this depend on the input device?
-internal actual val TapIndicationDelay: Long = 0L
 
 /**
  * Whether the specified [KeyEvent] represents a user intent to perform a click.

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/Clickable.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/Clickable.jsWasm.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+// TODO: b/168524931 - should this depend on the input device?
+internal actual val TapIndicationDelay: Long = 0L

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/Clickable.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/Clickable.macos.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+// TODO: b/168524931 - should this depend on the input device?
+internal actual val TapIndicationDelay: Long = 0L

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Clickable.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Clickable.uikit.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+// Equals to UIScrollView's delay with `delaysContentTouches` enabled.
+internal actual val TapIndicationDelay: Long = 150L


### PR DESCRIPTION
## Proposed Changes
Make touch indication delay to be corresponding with iOS default delay of UIScrollVIew.

Issue: https://github.com/JetBrains/compose-multiplatform/issues/4324