### PR TITLE
Refactor publication and artifacts redirecting configuration

### DIFF
--- a/annotation/annotation/build.gradle
+++ b/annotation/annotation/build.gradle
@@ -1,4 +1,5 @@
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
@@ -8,9 +9,11 @@ plugins {
 
     //  TODO move all functionality to Compose-independent plugin (`collection` shouldn't depend on Compose concepts)
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 androidXComposeMultiplatform {
     js()

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
@@ -57,14 +57,18 @@ open class JetbrainsExtensions(
     }
 
     /**
+     * When https://youtrack.jetbrains.com/issue/KT-61096 is implemented,
+     * this workaround won't be needed anymore:
+     *
      * K/Native stores the dependencies in klib manifest and tries to resolve them during compilation.
      * Since we use project dependency - implementation(project(...)), the klib manifest will reference
      * our groupId (for example org.jetbrains.compose.collection-internal instead of androidx.collection).
      * Therefore, the dependency can't be resolved since we don't publish libs for some k/native targets.
      *
-     * To fix that, we need to make sure
+     * To workaround that, we need to make sure
      * that the project dependency is substituted by a module dependency (from androidx).
-     * We do this here. It should be called only for appropriate k/native targets.
+     * We do this here. It should be called only for those k/native targets which require
+     * redirection to androidx artefacts.
      *
      * For available androidx targets see:
      * https://maven.google.com/web/index.html#androidx.annotation

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
@@ -30,7 +30,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinSoftwareComponentWithCoordinatesAndPublication
 import org.jetbrains.kotlin.konan.target.KonanTarget
 
-@Suppress("UNUSED_PARAMETER")
 open class JetbrainsExtensions(
     val project: Project,
     val multiplatformExtension: KotlinMultiplatformExtension
@@ -136,7 +135,7 @@ class JetbrainsAndroidXPlugin : Plugin<Project> {
 
     companion object {
 
-        @Suppress("UNUSED_PARAMETER", "UNUSED_VARIABLE")
+        @Suppress("UNUSED_PARAMETER")
         @JvmStatic
         fun applyAndConfigure(
             project: Project

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("unused")
+
+package androidx.build
+
+import androidx.build.jetbrains.artifactRedirecting
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinSoftwareComponentWithCoordinatesAndPublication
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+@Suppress("UNUSED_PARAMETER")
+open class JetbrainsExtensions(
+    val project: Project,
+    val multiplatformExtension: KotlinMultiplatformExtension
+) {
+
+    // check for example here: https://maven.google.com/web/index.html?q=lifecyc#androidx.lifecycle
+    val defaultKonanTargetsPublishedByAndroidx = setOf(
+        KonanTarget.LINUX_X64,
+        KonanTarget.IOS_X64,
+        KonanTarget.IOS_ARM64,
+        KonanTarget.IOS_SIMULATOR_ARM64,
+        KonanTarget.MACOS_X64,
+        KonanTarget.MACOS_ARM64,
+    )
+
+    @JvmOverloads
+    fun configureKNativeRedirectingDependenciesInKlibManifest(
+        konanTargets: Set<KonanTarget> = defaultKonanTargetsPublishedByAndroidx
+    ) {
+        multiplatformExtension.targets.all {
+            if (it is KotlinNativeTarget && it.konanTarget in konanTargets) {
+                it.substituteForRedirectedPublishedDependencies()
+            }
+        }
+    }
+
+    /**
+     * K/Native stores the dependencies in klib manifest and tries to resolve them during compilation.
+     * Since we use project dependency - implementation(project(...)), the klib manifest will reference
+     * our groupId (for example org.jetbrains.compose.collection-internal instead of androidx.collection).
+     * Therefore, the dependency can't be resolved since we don't publish libs for some k/native targets.
+     *
+     * To fix that, we need to make sure
+     * that the project dependency is substituted by a module dependency (from androidx).
+     * We do this here. It should be called only for appropriate k/native targets.
+     *
+     * For available androidx targets see:
+     * https://maven.google.com/web/index.html#androidx.annotation
+     * https://maven.google.com/web/index.html#androidx.collection
+     * https://maven.google.com/web/index.html#androidx.lifecycle
+     */
+    fun KotlinNativeTarget.substituteForRedirectedPublishedDependencies() {
+        val comp = compilations.getByName("main")
+        val androidAnnotationVersion =
+            project.findProperty("artifactRedirecting.androidx.annotation.version")!!
+        val androidCollectionVersion =
+            project.findProperty("artifactRedirecting.androidx.collection.version")!!
+        val androidLifecycleVersion =
+            project.findProperty("artifactRedirecting.androidx.lifecycle.version")
+        listOf(
+            comp.configurations.compileDependencyConfiguration,
+            comp.configurations.runtimeDependencyConfiguration,
+            comp.configurations.apiConfiguration,
+            comp.configurations.implementationConfiguration,
+            comp.configurations.runtimeOnlyConfiguration,
+            comp.configurations.compileOnlyConfiguration,
+        ).forEach { c ->
+            c?.resolutionStrategy {
+                it.dependencySubstitution {
+                    it.substitute(it.project(":annotation:annotation"))
+                        .using(it.module("androidx.annotation:annotation:$androidAnnotationVersion"))
+                    it.substitute(it.project(":collection:collection"))
+                        .using(it.module("androidx.collection:collection:$androidCollectionVersion"))
+                    if (androidLifecycleVersion != null) {
+                        it.substitute(it.project(":lifecycle:lifecycle-common"))
+                            .using(it.module("androidx.lifecycle:lifecycle-common:$androidLifecycleVersion"))
+                        it.substitute(it.project(":lifecycle:lifecycle-runtime"))
+                            .using(it.module("androidx.lifecycle:lifecycle-runtime:$androidLifecycleVersion"))
+                    }
+                }
+            }
+        }
+    }
+
+}
+class JetbrainsAndroidXPlugin : Plugin<Project> {
+
+    @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
+    override fun apply(project: Project) {
+        project.plugins.all { plugin ->
+            if (plugin is KotlinMultiplatformPluginWrapper) {
+                onKotlinMultiplatformPluginApplied(project)
+            }
+        }
+    }
+
+    private fun onKotlinMultiplatformPluginApplied(project: Project) {
+        enableArtifactRedirectingPublishing(project)
+        val multiplatformExtension =
+            project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+
+        val extension = project.extensions.create<JetbrainsExtensions>(
+            "jetbrainsExtension",
+            project,
+            multiplatformExtension
+        )
+
+        // Note: Currently we call it unconditionally since Androidx provides the same set of
+        // Konan targets for all multiplatform libs they publish.
+        // In the future we might need to call it with non-default konan targets set in some modules
+        extension.configureKNativeRedirectingDependenciesInKlibManifest()
+    }
+
+    companion object {
+
+        @Suppress("UNUSED_PARAMETER", "UNUSED_VARIABLE")
+        @JvmStatic
+        fun applyAndConfigure(
+            project: Project
+        ) {}
+    }
+}
+
+private val Project.multiplatformExtension
+    get() = extensions.findByType(KotlinMultiplatformExtension::class.java)
+
+fun Project.experimentalArtifactRedirectingPublication() : Boolean = findProperty("artifactRedirecting.publication") == "true"
+fun Project.artifactRedirectingAndroidxVersion() : String? = findProperty("artifactRedirecting.androidx.compose.version") as String?
+fun Project.artifactRedirectingAndroidxFoundationVersion() : String? = findProperty("artifactRedirecting.androidx.compose.foundation.version") as String?
+fun Project.artifactRedirectingAndroidxMaterial3Version() : String? = findProperty("artifactRedirecting.androidx.compose.material3.version") as String?
+fun Project.artifactRedirectingAndroidxMaterialVersion() : String? = findProperty("artifactRedirecting.androidx.compose.material.version") as String?
+
+fun enableArtifactRedirectingPublishing(project: Project) {
+    if (!project.experimentalArtifactRedirectingPublication()) return
+
+    if (project.experimentalArtifactRedirectingPublication() && (project.artifactRedirectingAndroidxVersion() == null)) {
+        error("androidx version should be specified for OEL publications")
+    }
+
+    val ext = project.multiplatformExtension ?: error("expected a multiplatform project")
+
+    val redirecting = project.artifactRedirecting()
+    val newRootComponent: CustomRootComponent = run {
+        val rootComponent = project
+            .components
+            .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
+            .getByName("kotlin")
+
+        val newDependency = project.dependencies.create(redirecting.groupId, project.name, redirecting.version)
+        CustomRootComponent(rootComponent, newDependency)
+    }
+
+    val oelTargetNames = (project.findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
+        .split(",").toSet()
+
+    ext.targets.all { target ->
+        if (target.name in oelTargetNames || target is KotlinAndroidTarget) {
+            project.publishAndroidxReference(target as AbstractKotlinTarget, newRootComponent)
+        }
+    }
+}

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidxRedirectingPublicationHelpers.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidxRedirectingPublicationHelpers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidxRedirectingPublicationHelpers.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidxRedirectingPublicationHelpers.kt
@@ -58,7 +58,7 @@ internal class CustomUsage(
 }
 
 @OptIn(InternalKotlinGradlePluginApi::class)
-internal fun Project.publishAndroidxReference(target: KotlinOnlyTarget<*>, newRootComponent: CustomRootComponent) {
+internal fun Project.publishAndroidxReference(target: AbstractKotlinTarget, newRootComponent: CustomRootComponent) {
     afterEvaluate {
         extensions.getByType(PublishingExtension::class.java).apply {
             val kotlinMultiplatform = publications
@@ -101,6 +101,7 @@ internal fun Project.publishAndroidxReference(target: KotlinOnlyTarget<*>, newRo
             val usages = when (component) {
                 is KotlinVariant -> component.usages
                 is KotlinVariantWithMetadataVariant -> component.usages
+                is JointAndroidKotlinTargetComponent -> component.usages
                 else -> emptyList()
             }
 

--- a/buildSrc/plugins/src/main/resources/META-INF/gradle-plugins/JetbrainsAndroidXPlugin.properties
+++ b/buildSrc/plugins/src/main/resources/META-INF/gradle-plugins/JetbrainsAndroidXPlugin.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2024 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=androidx.build.JetbrainsAndroidXPlugin

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
@@ -87,7 +87,6 @@ class AndroidXComposeImplPlugin : Plugin<Project> {
 
                     if (plugin is KotlinMultiplatformPluginWrapper) {
                         project.configureForMultiplatform()
-                        enableArtifactRedirectingPublishing(project)
                     }
                 }
             }

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -17,25 +17,19 @@
 package androidx.build
 
 import javax.inject.Inject
-import org.gradle.api.Project
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.gradle.api.Action
-import org.jetbrains.kotlin.gradle.plugin.mpp.*
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
+import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import org.gradle.kotlin.dsl.creating
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getValue
-import org.jetbrains.kotlin.konan.target.KonanTarget
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
-import org.gradle.kotlin.dsl.create
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
+import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.tomlj.Toml
 
 open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
@@ -164,21 +158,11 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
     }
 
     override fun darwin(): Unit = multiplatformExtension.run {
-        macosX64() {
-            substituteForOelPublishedDependencies()
-        }
-        macosArm64() {
-            substituteForOelPublishedDependencies()
-        }
-        iosX64("uikitX64") {
-            substituteForOelPublishedDependencies()
-        }
-        iosArm64("uikitArm64") {
-            substituteForOelPublishedDependencies()
-        }
-        iosSimulatorArm64("uikitSimArm64") {
-            substituteForOelPublishedDependencies()
-        }
+        macosX64()
+        macosArm64()
+        iosX64("uikitX64")
+        iosArm64("uikitArm64")
+        iosSimulatorArm64("uikitSimArm64")
 
         val commonMain = sourceSets.getByName("commonMain")
         val nativeMain = sourceSets.create("nativeMain")
@@ -222,9 +206,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
     }
 
     override fun linuxX64(): Unit = multiplatformExtension.run {
-        linuxX64 {
-            substituteForOelPublishedDependencies()
-        }
+        linuxX64()
     }
 
     override fun linuxArm64(): Unit = multiplatformExtension.run {
@@ -284,201 +266,6 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
             iosX64("uikitX64") { configureFreeCompilerArgs() }
             iosArm64("uikitArm64") { configureFreeCompilerArgs() }
             iosSimulatorArm64("uikitSimArm64") { configureFreeCompilerArgs() }
-        }
-    }
-}
-
-fun Project.experimentalArtifactRedirectingPublication() : Boolean = findProperty("artifactRedirecting.publication") == "true"
-fun Project.artifactRedirectingAndroidxVersion() : String? = findProperty("artifactRedirecting.androidx.version") as String?
-fun Project.artifactRedirectingAndroidxFoundationVersion() : String? = findProperty("artifactRedirecting.androidx.foundation.version") as String?
-fun Project.artifactRedirectingAndroidxMaterial3Version() : String? = findProperty("artifactRedirecting.androidx.material3.version") as String?
-fun Project.artifactRedirectingAndroidxMaterialVersion() : String? = findProperty("artifactRedirecting.androidx.material.version") as String?
-
-fun enableArtifactRedirectingPublishing(project: Project) {
-    if (!project.experimentalArtifactRedirectingPublication()) return
-
-    if (project.experimentalArtifactRedirectingPublication() && (project.artifactRedirectingAndroidxVersion() == null)) {
-        error("androidx version should be specified for OEL publications")
-    }
-
-    val ext = project.multiplatformExtension ?: error("expected a multiplatform project")
-
-    val redirecting = project.artifactRedirecting()
-    val newRootComponent: CustomRootComponent? = if (redirecting != null) {
-        val rootComponent = project
-            .components
-            .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
-            .getByName("kotlin")
-
-        val newDependency = project.dependencies.create(redirecting.groupId, project.name, redirecting.version)
-        CustomRootComponent(rootComponent, newDependency)
-    } else {
-        null
-    }
-
-    ext.targets.all { target ->
-        // TODO (o.k): support projects where redirecting publication is required for both android and native
-        if (target.name in redirecting?.targetNames.orEmpty()) {
-            project.publishAndroidxReference(target as KotlinOnlyTarget<*>, newRootComponent!!)
-        } else if (target is KotlinAndroidTarget) {
-            // TODO (o.k): try to get rid of this and reuse the same logic as above
-            project.publishAndroidxReference(target)
-        }
-    }
-}
-
-internal fun Project.artifactRedirecting(): ArtifactRedirecting? {
-    val groupId = findProperty("artifactRedirecting.androidx.groupId") as? String ?: return null
-    val version = findProperty("artifactRedirecting.androidx.$name.version") as? String
-    requireNotNull(version) {
-        "Please specify artifactRedirecting.androidx.$name.version property"
-    }
-    val targetNames = (findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
-        .split(",").toSet()
-    return ArtifactRedirecting(
-        groupId = groupId,
-        version = version,
-        targetNames = targetNames,
-    )
-}
-
-internal data class ArtifactRedirecting(
-    val groupId: String,
-    val version: String,
-    val targetNames: Set<String>,
-)
-
-private fun Project.publishAndroidxReference(target: KotlinAndroidTarget) {
-    afterEvaluate {
-        // Take root component which should contain "variants" (aka usages)
-        // this component gets published as "main/common" module
-        // that we want to add as android ones.
-        val rootComponent = target.project
-            .components
-            .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
-            .getByName("kotlin")
-
-        val composeVersion = requireNotNull(target.project.artifactRedirectingAndroidxVersion()) {
-            "Please specify artifactRedirecting.androidx.version property"
-        }
-        val material3Version =
-            requireNotNull(target.project.artifactRedirectingAndroidxMaterial3Version()) {
-                "Please specify artifactRedirecting.androidx.material3.version property"
-            }
-        val foundationVersion =
-            target.project.artifactRedirectingAndroidxFoundationVersion() ?: composeVersion
-        val materialVersion =
-            target.project.artifactRedirectingAndroidxMaterialVersion() ?: composeVersion
-
-        val groupId = target.project.group.toString()
-        val version = if (groupId.contains("org.jetbrains.compose.material3")) {
-            material3Version
-        } else if (groupId.contains("org.jetbrains.compose.foundation")) {
-            foundationVersion
-        } else if (groupId.contains("org.jetbrains.compose.material")) {
-            materialVersion
-        } else {
-            composeVersion
-        }
-        val dependencyGroup = target.project.group.toString().replace(
-            "org.jetbrains.compose",
-            "androidx.compose"
-        )
-        val newDependency = target.project.dependencies.create(dependencyGroup, name, version)
-
-
-        // We can't add more usages to rootComponent, so we must decorate it
-        val newRootComponent = CustomRootComponent(rootComponent, newDependency)
-
-        extensions.getByType(PublishingExtension::class.java).apply {
-            val kotlinMultiplatform = publications
-                .getByName("kotlinMultiplatform") as MavenPublication
-
-            publications.create("kotlinMultiplatformDecorated", MavenPublication::class.java) {
-                it.artifactId = kotlinMultiplatform.artifactId
-                it.groupId = kotlinMultiplatform.groupId
-                it.version = kotlinMultiplatform.version
-
-                it.from(newRootComponent)
-            }
-        }
-
-        // Disable all publication tasks that uses OLD rootSoftwareComponent: we don't want to
-        // accidentally publish two "root" components
-        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
-            if (it.publication.name == "kotlinMultiplatform") it.enabled = false
-        }
-
-        target.kotlinComponents.forEach { component ->
-            val componentName = component.name
-
-            if (component is KotlinVariant)
-                component.publishable = false
-
-            extensions.getByType(PublishingExtension::class.java)
-                .publications.withType(DefaultMavenPublication::class.java)
-                    // isAlias is needed for Gradle to ignore the fact that there's a
-                    // publication that is not referenced as an available-at variant of the root module
-                    // and has the Maven coordinates that are different from those of the root module
-                    // FIXME: internal Gradle API! We would rather not create the publications,
-                    //        but some API for that is needed in the Kotlin Gradle plugin
-                    .all { publication ->
-                        if (publication.name == componentName) {
-                            publication.isAlias = true
-                        }
-                    }
-
-            val usages = when (component) {
-                is KotlinVariant -> component.usages
-                is JointAndroidKotlinTargetComponent -> component.usages
-                else -> emptyList()
-            }
-
-            usages.forEach { usage ->
-                // Use -published configuration because it would have correct attribute set
-                // required for publication.
-                val configurationName = usage.name + "-published"
-                configurations.matching { it.name == configurationName }.all { conf ->
-                    newRootComponent.addUsageFromConfiguration(conf)
-                }
-            }
-        }
-    }
-}
-
-/**
- * K/Native stores the dependencies in klib manifest and tries to resolve them during compilation.
- * Since we use project dependency - implementation(project(...)), the klib manifest will reference
- * our groupId (for example org.jetbrains.compose.collection-internal instead of androidx.collection).
- * Therefore, the dependency can't be resolved since we don't publish libs for some k/native targets.
- *
- * To fix that, we need to make sure
- * that the project dependency is substituted by a module dependency (from androidx).
- * We do this here. It should be called only for appropriate k/native targets.
- *
- * For available androidx targets see:
- * https://maven.google.com/web/index.html#androidx.annotation
- * https://maven.google.com/web/index.html#androidx.collection
- */
-private fun KotlinNativeTarget.substituteForOelPublishedDependencies() {
-    val comp = compilations.getByName("main")
-    val androidAnnotationVersion = project.findProperty("artifactRedirecting.androidx.annotation.version")!!
-    val androidCollectionVersion = project.findProperty("artifactRedirecting.androidx.collection.version")!!
-    listOf(
-        comp.configurations.compileDependencyConfiguration,
-        comp.configurations.runtimeDependencyConfiguration,
-        comp.configurations.apiConfiguration,
-        comp.configurations.implementationConfiguration,
-        comp.configurations.runtimeOnlyConfiguration,
-        comp.configurations.compileOnlyConfiguration,
-    ).forEach {
-        it?.resolutionStrategy {
-            it.dependencySubstitution {
-                it.substitute(it.project(":annotation:annotation"))
-                    .using(it.module("androidx.annotation:annotation:$androidAnnotationVersion"))
-                it.substitute(it.project(":collection:collection"))
-                    .using(it.module("androidx.collection:collection:$androidCollectionVersion"))
-            }
         }
     }
 }

--- a/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
@@ -59,6 +59,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
 import org.xml.sax.InputSource
 import org.xml.sax.XMLReader
+import androidx.build.jetbrains.ArtifactRedirecting
+import androidx.build.jetbrains.artifactRedirecting
 
 fun Project.configureMavenArtifactUpload(
     extension: AndroidXExtension,

--- a/buildSrc/public/src/main/kotlin/androidx/build/jetbrains/ArtifactRedirecting.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/jetbrains/ArtifactRedirecting.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.build.jetbrains
+
+import org.gradle.api.Project
+
+data class ArtifactRedirecting(
+    val groupId: String,
+    val version: String,
+    val targetNames: Set<String>,
+)
+
+fun Project.artifactRedirecting(): ArtifactRedirecting {
+    val groupId = findProperty("artifactRedirecting.androidx.groupId") as? String
+    // for androidx.compose modules we didn't add this property to every gradle.properties,
+    // but we can comply to this convention:
+        ?: project.group.toString().replace("org.jetbrains.", "androidx.")
+
+    val version = findProperty("artifactRedirecting.${groupId}.version") as? String
+        // artifactRedirecting for compose was added before all other libs,
+        // therefore it's a default:
+        ?: findProperty("artifactRedirecting.androidx.compose.version") as String
+
+    val targetNames = (findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
+        .split(",").toSet()
+
+    return ArtifactRedirecting(
+        groupId = groupId,
+        version = version,
+        targetNames = targetNames,
+    )
+}

--- a/collection/collection/build.gradle
+++ b/collection/collection/build.gradle
@@ -17,6 +17,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
@@ -24,9 +25,11 @@ plugins {
 
     //  TODO move all functionality to Compose-independent plugin (`collection` shouldn't depend on Compose concepts)
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 androidXComposeMultiplatform {
     js()

--- a/compose/animation/animation-core/build.gradle
+++ b/compose/animation/animation-core/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -24,9 +25,11 @@ plugins {
     id("com.android.library")
     id("AndroidXComposePlugin")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
     if (!AndroidXComposePlugin.isMultiplatformEnabled(project)) {

--- a/compose/animation/animation-graphics/build.gradle
+++ b/compose/animation/animation-graphics/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -23,9 +24,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
     if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {

--- a/compose/animation/animation/build.gradle
+++ b/compose/animation/animation/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -23,9 +24,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
     if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {

--- a/compose/foundation/foundation-layout/build.gradle
+++ b/compose/foundation/foundation-layout/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
@@ -25,9 +26,11 @@ plugins {
     id("com.android.library")
     id("AndroidXComposePlugin")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/material/material-icons-core/build.gradle
+++ b/compose/material/material-icons-core/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import androidx.compose.material.icons.generator.tasks.IconGenerationTask
 
@@ -23,9 +24,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if (!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     dependencies {

--- a/compose/material/material-icons-extended/build.gradle
+++ b/compose/material/material-icons-extended/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import androidx.build.RunApiTasks
 import androidx.compose.material.icons.generator.tasks.IconGenerationTask
@@ -24,9 +25,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 IconGenerationTask.registerExtendedIconMainProject(
         project,

--- a/compose/material/material-ripple/build.gradle
+++ b/compose/material/material-ripple/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
@@ -22,10 +23,12 @@ plugins {
     id("com.android.library")
     id("AndroidXComposePlugin")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
     //id("AndroidXPaparazziPlugin") // isn't supported on Windows
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/material3/material3-window-size-class/build.gradle
+++ b/compose/material3/material3-window-size-class/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import androidx.build.Publish
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -23,9 +24,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
@@ -22,10 +23,12 @@ plugins {
     id("com.android.library")
     id("AndroidXComposePlugin")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
     //id("AndroidXPaparazziPlugin") // isn't supported on Windows
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/mpp/demo-uikit/build.gradle.kts
+++ b/compose/mpp/demo-uikit/build.gradle.kts
@@ -1,17 +1,18 @@
 import androidx.build.AndroidXComposePlugin
 import java.util.Properties
 import org.jetbrains.kotlin.gradle.dsl.KotlinNativeBinaryContainer
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinTargetWithBinaries
+import androidx.build.JetbrainsAndroidXPlugin
 
 plugins {
     id("AndroidXPlugin")
     id("AndroidXComposePlugin")
     id("kotlin-multiplatform")
     id("org.jetbrains.gradle.apple.applePlugin") version "222.4550-0.22"
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 repositories {
     mavenLocal()
@@ -34,21 +35,18 @@ kotlin {
         binaries {
             configureFramework()
         }
-        substituteForOelPublishedDependencies()
     }
     if (isArm64Host) {
         iosSimulatorArm64 {
             binaries {
                 configureFramework()
             }
-            substituteForOelPublishedDependencies()
         }
     } else {
         iosX64 {
             binaries {
                 configureFramework()
             }
-            substituteForOelPublishedDependencies()
         }
     }
     sourceSets {
@@ -112,30 +110,6 @@ apple {
 
         dependencies {
             // Here we can add additional dependencies to Swift sourceSet
-        }
-    }
-}
-
-// TODO (o.k): this is copy-pasted from AndroidXComposeImplPlugin!!! Avoid duplication and refactor this
-fun KotlinNativeTarget.substituteForOelPublishedDependencies() {
-    val comp = compilations.getByName("main")
-    val androidAnnotationVersion = project.findProperty("artifactRedirecting.androidx.annotation.version")!!
-    val androidCollectionVersion = project.findProperty("artifactRedirecting.androidx.collection.version")!!
-    listOf(
-        comp.configurations.compileDependencyConfiguration,
-        comp.configurations.runtimeDependencyConfiguration,
-        comp.configurations.apiConfiguration,
-        comp.configurations.implementationConfiguration,
-        comp.configurations.runtimeOnlyConfiguration,
-        comp.configurations.compileOnlyConfiguration,
-    ).forEach {
-        it?.resolutionStrategy {
-            dependencySubstitution {
-                substitute(project(":annotation:annotation"))
-                    .using(module("androidx.annotation:annotation:$androidAnnotationVersion"))
-                substitute(project(":collection:collection"))
-                    .using(module("androidx.collection:collection:$androidCollectionVersion"))
-            }
         }
     }
 }

--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import java.util.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
@@ -27,9 +28,11 @@ plugins {
     id("kotlin-multiplatform")
 //  [1.4 Update]  id("application")
     kotlin("plugin.serialization") version "1.9.21"
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 
@@ -89,7 +92,6 @@ kotlin {
                 freeCompilerArgs += "-Xdisable-phases=VerifyBitcode"
             }
         }
-        substituteForOelPublishedDependencies()
     }
     macosArm64() {
         binaries {
@@ -102,7 +104,6 @@ kotlin {
                 freeCompilerArgs += "-Xdisable-phases=VerifyBitcode"
             }
         }
-        substituteForOelPublishedDependencies()
     }
     iosX64("uikitX64") {
         binaries {
@@ -117,7 +118,6 @@ kotlin {
                 freeCompilerArgs += "-Xdisable-phases=VerifyBitcode"
             }
         }
-        substituteForOelPublishedDependencies()
     }
     iosArm64("uikitArm64") {
         binaries {
@@ -132,7 +132,6 @@ kotlin {
                 freeCompilerArgs += "-Xdisable-phases=VerifyBitcode"
             }
         }
-        substituteForOelPublishedDependencies()
     }
     iosSimulatorArm64("uikitSimArm64") {
         binaries {
@@ -147,7 +146,6 @@ kotlin {
                 freeCompilerArgs += "-Xdisable-phases=VerifyBitcode"
             }
         }
-        substituteForOelPublishedDependencies()
     }
     sourceSets {
         val commonMain by getting {
@@ -293,28 +291,4 @@ project.tasks.withType<org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile>().config
         "-Xwasm-generate-wat",
         "-Xwasm-enable-array-range-checks"
     )
-}
-
-// TODO (o.k): this is copy-pasted from AndroidXComposeImplPlugin!!! Avoid duplication and refactor this
-fun KotlinNativeTarget.substituteForOelPublishedDependencies() {
-    val comp = compilations.getByName("main")
-    val androidAnnotationVersion = project.findProperty("artifactRedirecting.androidx.annotation.version")!!
-    val androidCollectionVersion = project.findProperty("artifactRedirecting.androidx.collection.version")!!
-    listOf(
-        comp.configurations.compileDependencyConfiguration,
-        comp.configurations.runtimeDependencyConfiguration,
-        comp.configurations.apiConfiguration,
-        comp.configurations.implementationConfiguration,
-        comp.configurations.runtimeOnlyConfiguration,
-        comp.configurations.compileOnlyConfiguration,
-    ).forEach {
-        it?.resolutionStrategy {
-            dependencySubstitution {
-                substitute(project(":annotation:annotation"))
-                    .using(module("androidx.annotation:annotation:$androidAnnotationVersion"))
-                substitute(project(":collection:collection"))
-                    .using(module("androidx.collection:collection:$androidCollectionVersion"))
-            }
-        }
-    }
 }

--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -23,9 +24,11 @@ plugins {
     id("AndroidXPlugin")
     id("AndroidXComposePlugin")
     id("com.android.library")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXComposePlugin")
     id("com.android.library")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/compose/ui/ui-geometry/build.gradle
+++ b/compose/ui/ui-geometry/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     dependencies {

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     dependencies {

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 android {
     lintOptions {

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 android {
     if (!AndroidXComposePlugin.isMultiplatformEnabled(project)) {

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
@@ -23,9 +24,11 @@ plugins {
     id("com.android.library")
     id("AndroidXComposePlugin")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     dependencies {

--- a/compose/ui/ui-tooling-data/build.gradle
+++ b/compose/ui/ui-tooling-data/build.gradle
@@ -16,6 +16,7 @@
 
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -23,9 +24,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 

--- a/compose/ui/ui-tooling-preview/build.gradle
+++ b/compose/ui/ui-tooling-preview/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id("AndroidXPlugin")
     id("AndroidXComposePlugin")
     id("com.android.library")
+    id("JetbrainsAndroidXPlugin")
 }
 
 def desktopEnabled = KmpPlatformsKt.enableDesktop(project)

--- a/compose/ui/ui-tooling/build.gradle
+++ b/compose/ui/ui-tooling/build.gradle
@@ -22,6 +22,7 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 def desktopEnabled = KmpPlatformsKt.enableDesktop(project)

--- a/compose/ui/ui-uikit/build.gradle
+++ b/compose/ui/ui-uikit/build.gradle
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
+
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
     id("AndroidXPlugin")
     id("kotlin-multiplatform")
+    id("JetbrainsAndroidXPlugin")
 }
+
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 kotlin {
     iosX64("uikitX64") {

--- a/compose/ui/ui-unit/build.gradle
+++ b/compose/ui/ui-unit/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     dependencies {

--- a/compose/ui/ui-util/build.gradle
+++ b/compose/ui/ui-util/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -22,9 +23,11 @@ plugins {
     id("AndroidXPlugin")
     id("com.android.library")
     id("AndroidXComposePlugin")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     dependencies {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -15,6 +15,7 @@
  */
 
 import androidx.build.AndroidXComposePlugin
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.LibraryType
 
 plugins {
@@ -22,9 +23,11 @@ plugins {
     id("com.android.library")
     id("AndroidXComposePlugin")
     id("kotlinx-atomicfu")
+    id("JetbrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 dependencies {
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -101,11 +101,12 @@ jetbrains.compose.compiler.version=1.5.8.1
 # To know which version, should be used, see compose/frameworks/support/libraryversions.toml
 artifactRedirecting.publication=true
 # Look for `COMPOSE` in libraryversions.toml
-artifactRedirecting.androidx.version=1.6.3
+artifactRedirecting.androidx.compose.version=1.6.3
 # Look for `COMPOSE_MATERIAL3` in libraryversions.toml
-artifactRedirecting.androidx.material3.version=1.2.1
-artifactRedirecting.androidx.foundation.version=1.6.3
-artifactRedirecting.androidx.material.version=1.6.3
+artifactRedirecting.androidx.compose.material3.version=1.2.1
+artifactRedirecting.androidx.compose.foundation.version=1.6.3
+artifactRedirecting.androidx.compose.material.version=1.6.3
+# We use artifactRedirecting not only for Compose libs:
 artifactRedirecting.androidx.collection.version=1.4.0
 artifactRedirecting.androidx.annotation.version=1.7.1
 


### PR DESCRIPTION
With this PR it's much easier to add new modules with redirecting publication.
I use this approach in my branch for lifecycle publication. But want to merge it to jb-main first. 

Now we have our dedicated `JetbrainsAndroidXPlugin` which configures `artifacts redirection` when applied (requires that Kotlin MPP plugin is applied too).