### PR TITLE
Desktop window layer fixes

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.scene.skia.SwingSkiaLayerComponent
 import androidx.compose.ui.scene.skia.WindowSkiaLayerComponent
+import androidx.compose.ui.skiko.OverlaySkikoViewDecorator
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.util.fastForEach
@@ -47,6 +48,7 @@ import javax.swing.SwingUtilities
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineExceptionHandler
+import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.MainUIDispatcher
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
@@ -171,6 +173,7 @@ internal class ComposeContainer(
         if (!container.isDisplayable) return
 
         mediator.onChangeComponentPosition()
+        layers.fastForEach(DesktopComposeSceneLayer::onChangeWindowPosition)
     }
 
     private fun onChangeWindowSize() {
@@ -179,6 +182,13 @@ internal class ComposeContainer(
         windowContext.setContainerSize(windowContainer.sizeInPx)
         mediator.onChangeComponentSize()
         layers.fastForEach(DesktopComposeSceneLayer::onChangeWindowSize)
+    }
+
+    /**
+     * Callback to let layers draw overlay on main [mediator].
+     */
+    private fun onRenderOverlay(canvas: Canvas, width: Int, height: Int) {
+        layers.fastForEach { it.onRenderOverlay(canvas, width, height) }
     }
 
     fun onChangeWindowTransparency(value: Boolean) {
@@ -246,10 +256,15 @@ internal class ComposeContainer(
     }
 
     private fun createSkiaLayerComponent(mediator: ComposeSceneMediator): SkiaLayerComponent {
+        val skikoView = when (layerType) {
+            // Use overlay decorator to allow window layers draw scrim on the main window
+            LayerType.OnWindow -> OverlaySkikoViewDecorator(mediator, ::onRenderOverlay)
+            else -> mediator
+        }
         return if (useSwingGraphics) {
-            SwingSkiaLayerComponent(mediator, skiaLayerAnalytics)
+            SwingSkiaLayerComponent(mediator, skikoView, skiaLayerAnalytics)
         } else {
-            WindowSkiaLayerComponent(mediator, windowContext, skiaLayerAnalytics)
+            WindowSkiaLayerComponent(mediator, windowContext, skikoView, skiaLayerAnalytics)
         }
     }
 
@@ -290,7 +305,6 @@ internal class ComposeContainer(
                 skiaLayerAnalytics = skiaLayerAnalytics,
                 density = density,
                 layoutDirection = layoutDirection,
-                focusable = focusable,
                 compositionContext = compositionContext
             )
             LayerType.OnComponent -> SwingComposeSceneLayer(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -305,6 +305,7 @@ internal class ComposeContainer(
                 skiaLayerAnalytics = skiaLayerAnalytics,
                 density = density,
                 layoutDirection = layoutDirection,
+                focusable = focusable,
                 compositionContext = compositionContext
             )
             LayerType.OnComponent -> SwingComposeSceneLayer(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -16,10 +16,41 @@
 
 package androidx.compose.ui.scene
 
+import org.jetbrains.skia.Canvas
+
+/**
+ * Represents an abstract class for a desktop Compose scene layer.
+ *
+ * @see SwingComposeSceneLayer
+ * @see WindowComposeSceneLayer
+ */
 internal abstract class DesktopComposeSceneLayer : ComposeSceneLayer {
+
+    /**
+     * Called when the focus of the window containing main Compose view has changed.
+     */
     open fun onChangeWindowFocus() {
     }
 
+    /**
+     * Called when position of the window containing main Compose view has changed.
+     */
+    open fun onChangeWindowPosition() {
+    }
+
+    /**
+     * Called when size of the window containing main Compose view has changed.
+     */
     open fun onChangeWindowSize() {
+    }
+
+    /**
+     * Renders the overlay on the main Compose view canvas.
+     *
+     * @param canvas the canvas of the main Compose view
+     * @param width the width of the canvas
+     * @param height the height of the canvas
+     */
+    open fun onRenderOverlay(canvas: Canvas, width: Int, height: Int) {
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -96,13 +96,13 @@ internal class SwingComposeSceneLayer(
     override var density: Density = density
         set(value) {
             field = value
-            // TODO: Pass it to mediator/scene
+            _mediator?.onChangeDensity(value)
         }
 
     override var layoutDirection: LayoutDirection = layoutDirection
         set(value) {
             field = value
-            // TODO: Pass it to mediator/scene
+            _mediator?.onChangeLayoutDirection(value)
         }
 
     override var focusable: Boolean = focusable
@@ -186,7 +186,11 @@ internal class SwingComposeSceneLayer(
     }
 
     private fun createSkiaLayerComponent(mediator: ComposeSceneMediator): SkiaLayerComponent {
-        return SwingSkiaLayerComponent(mediator, skiaLayerAnalytics)
+        return SwingSkiaLayerComponent(
+            mediator = mediator,
+            skikoView = mediator,
+            skiaLayerAnalytics = skiaLayerAnalytics
+        )
     }
 
     private fun createComposeScene(mediator: ComposeSceneMediator): ComposeScene {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.awt.toAwtColor
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.platform.PlatformWindowContext
@@ -38,10 +39,15 @@ import androidx.compose.ui.window.layoutDirectionFor
 import androidx.compose.ui.window.sizeInPx
 import java.awt.Point
 import java.awt.Rectangle
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import java.awt.event.WindowEvent
+import java.awt.event.WindowFocusListener
 import javax.swing.JDialog
 import javax.swing.JLayeredPane
 import kotlin.math.ceil
 import kotlin.math.floor
+import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
 internal class WindowComposeSceneLayer(
@@ -49,7 +55,6 @@ internal class WindowComposeSceneLayer(
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
     density: Density,
     layoutDirection: LayoutDirection,
-    focusable: Boolean,
     compositionContext: CompositionContext
 ) : DesktopComposeSceneLayer() {
     private val window get() = requireNotNull(composeContainer.window)
@@ -78,38 +83,46 @@ internal class WindowComposeSceneLayer(
         dialog.contentPane = it
     }
 
+    private val windowPositionListener = object : ComponentAdapter() {
+        override fun componentMoved(e: ComponentEvent?) {
+            onChangeWindowPosition()
+        }
+    }
+
+    private val dialogFocusListener = object : WindowFocusListener {
+        override fun windowGainedFocus(e: WindowEvent?) = Unit
+        override fun windowLostFocus(e: WindowEvent?) {
+            // Use this as trigger of outside click
+            outsidePointerCallback?.invoke(PointerEventType.Press)
+            outsidePointerCallback?.invoke(PointerEventType.Release)
+        }
+    }
+
     private var _mediator: ComposeSceneMediator? = null
+    private var outsidePointerCallback: ((eventType: PointerEventType) -> Unit)? = null
 
     override var density: Density = density
         set(value) {
             field = value
-            // TODO: Pass it to mediator/scene
+            _mediator?.onChangeDensity(value)
         }
 
     override var layoutDirection: LayoutDirection = layoutDirection
         set(value) {
             field = value
-            // TODO: Pass it to mediator/scene
+            _mediator?.onChangeLayoutDirection(value)
         }
 
-    override var focusable: Boolean = focusable
-        set(value) {
-            field = value
-            // TODO: Pass it to mediator/scene
+    override var focusable
+        get() = true
+        set(_) {
+            // Ignore the value - window is always focusable
         }
 
     override var boundsInWindow: IntRect = IntRect.Zero
         set(value) {
             field = value
-
-            val scaledRectangle = value.toAwtRectangle(density)
-            dialog.location = getDialogLocation(scaledRectangle.x, scaledRectangle.y)
-            dialog.setSize(scaledRectangle.width, scaledRectangle.height)
-            _mediator?.contentComponent?.setSize(scaledRectangle.width, scaledRectangle.height)
-            _mediator?.sceneBoundsInPx = Rect(
-                offset = -value.topLeft.toOffset(),
-                size = windowContainer.sizeInPx
-            )
+            setDialogBounds(value)
         }
 
     override var compositionLocalContext: CompositionLocalContext?
@@ -117,10 +130,6 @@ internal class WindowComposeSceneLayer(
         set(value) { _mediator?.compositionLocalContext = value }
 
     override var scrimColor: Color? = null
-        set(value) {
-            field = value
-            // TODO: Draw scrim in the main window
-        }
 
     init {
         _mediator = ComposeSceneMediator(
@@ -140,6 +149,12 @@ internal class WindowComposeSceneLayer(
         dialog.location = getDialogLocation(0, 0)
         dialog.size = windowContainer.size
         dialog.isVisible = true
+        dialog.addWindowFocusListener(dialogFocusListener)
+
+        // Track window position in addition to [onChangeWindowPosition] because [windowContainer]
+        // might be not the same as real [window].
+        window.addComponentListener(windowPositionListener)
+
         composeContainer.attachLayer(this)
     }
 
@@ -148,6 +163,9 @@ internal class WindowComposeSceneLayer(
         _mediator?.dispose()
         _mediator = null
 
+        window.removeComponentListener(windowPositionListener)
+
+        dialog.removeWindowFocusListener(dialogFocusListener)
         dialog.dispose()
     }
 
@@ -168,16 +186,19 @@ internal class WindowComposeSceneLayer(
     override fun setOutsidePointerEventListener(
         onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)?
     ) {
-        // TODO
+        outsidePointerCallback = onOutsidePointerEvent
     }
 
     override fun calculateLocalPosition(positionInWindow: IntOffset): IntOffset {
         return positionInWindow
     }
 
-    override fun onChangeWindowSize() {
+    override fun onChangeWindowPosition() {
         val scaledRectangle = boundsInWindow.toAwtRectangle(density)
         dialog.location = getDialogLocation(scaledRectangle.x, scaledRectangle.y)
+    }
+
+    override fun onChangeWindowSize() {
         windowContext.setContainerSize(windowContainer.sizeInPx)
 
         // Update compose constrains based on main window size
@@ -187,8 +208,20 @@ internal class WindowComposeSceneLayer(
         )
     }
 
+    override fun onRenderOverlay(canvas: Canvas, width: Int, height: Int) {
+        val paint = scrimColor?.let { scrimColor ->
+            Paint().apply { color = scrimColor }.asFrameworkPaint()
+        } ?: return
+        canvas.drawRect(org.jetbrains.skia.Rect.makeWH(width.toFloat(), height.toFloat()), paint)
+    }
+
     private fun createSkiaLayerComponent(mediator: ComposeSceneMediator): SkiaLayerComponent {
-        return WindowSkiaLayerComponent(mediator, windowContext, skiaLayerAnalytics)
+        return WindowSkiaLayerComponent(
+            mediator = mediator,
+            windowContext = windowContext,
+            skikoView = mediator,
+            skiaLayerAnalytics = skiaLayerAnalytics
+        )
     }
 
     private fun createComposeScene(mediator: ComposeSceneMediator): ComposeScene {
@@ -210,6 +243,17 @@ internal class WindowComposeSceneLayer(
         return Point(
             locationOnScreen.x + x,
             locationOnScreen.y + y
+        )
+    }
+
+    private fun setDialogBounds(bounds: IntRect) {
+        val scaledRectangle = bounds.toAwtRectangle(density)
+        dialog.location = getDialogLocation(scaledRectangle.x, scaledRectangle.y)
+        dialog.setSize(scaledRectangle.width, scaledRectangle.height)
+        _mediator?.contentComponent?.setSize(scaledRectangle.width, scaledRectangle.height)
+        _mediator?.sceneBoundsInPx = Rect(
+            offset = -bounds.topLeft.toOffset(),
+            size = windowContainer.sizeInPx
         )
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -55,6 +55,7 @@ internal class WindowComposeSceneLayer(
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
     density: Density,
     layoutDirection: LayoutDirection,
+    focusable: Boolean,
     compositionContext: CompositionContext
 ) : DesktopComposeSceneLayer() {
     private val window get() = requireNotNull(composeContainer.window)
@@ -113,10 +114,10 @@ internal class WindowComposeSceneLayer(
             _mediator?.onChangeLayoutDirection(value)
         }
 
-    override var focusable
-        get() = true
-        set(_) {
-            // Ignore the value - window is always focusable
+    override var focusable: Boolean = focusable
+        set(value) {
+            field = value
+            // TODO: Pass it to mediator/scene
         }
 
     override var boundsInWindow: IntRect = IntRect.Zero
@@ -209,9 +210,8 @@ internal class WindowComposeSceneLayer(
     }
 
     override fun onRenderOverlay(canvas: Canvas, width: Int, height: Int) {
-        val paint = scrimColor?.let { scrimColor ->
-            Paint().apply { color = scrimColor }.asFrameworkPaint()
-        } ?: return
+        val scrimColor = scrimColor ?: return
+        val paint = Paint().apply { color = scrimColor }.asFrameworkPaint()
         canvas.drawRect(org.jetbrains.skia.Rect.makeWH(width.toFloat(), height.toFloat()), paint)
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -23,6 +23,7 @@ import javax.accessibility.Accessible
 import javax.accessibility.AccessibleContext
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
+import org.jetbrains.skiko.SkikoView
 import org.jetbrains.skiko.swing.SkiaSwingLayer
 
 /**
@@ -35,6 +36,7 @@ import org.jetbrains.skiko.swing.SkiaSwingLayer
 @OptIn(ExperimentalSkikoApi::class)
 internal class SwingSkiaLayerComponent(
     private val mediator: ComposeSceneMediator,
+    skikoView: SkikoView,
     skiaLayerAnalytics: SkiaLayerAnalytics,
 ) : SkiaLayerComponent {
     /**
@@ -42,11 +44,11 @@ internal class SwingSkiaLayerComponent(
      */
     override val contentComponent: SkiaSwingLayer =
         object : SkiaSwingLayer(
-            skikoView = mediator.skikoView,
+            skikoView = skikoView,
             analytics = skiaLayerAnalytics
         ) {
             override fun paint(g: Graphics) {
-                mediator.onChangeComponentDensity()
+                mediator.onChangeDensity()
                 super.paint(g)
             }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -24,6 +24,7 @@ import javax.accessibility.Accessible
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkiaLayerAnalytics
+import org.jetbrains.skiko.SkikoView
 
 /**
  * Provides a heavyweight AWT [contentComponent] used to render content (provided by client.skikoView) on-screen with Skia.
@@ -33,7 +34,8 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 internal class WindowSkiaLayerComponent(
     private val mediator: ComposeSceneMediator,
     private val windowContext: PlatformWindowContext,
-    skiaLayerAnalytics: SkiaLayerAnalytics,
+    skikoView: SkikoView,
+    skiaLayerAnalytics: SkiaLayerAnalytics
 ) : SkiaLayerComponent {
     /**
      * See also backend layer for swing interop in [SwingSkiaLayerComponent]
@@ -47,7 +49,7 @@ internal class WindowSkiaLayerComponent(
         analytics = skiaLayerAnalytics
     ) {
         override fun paint(g: Graphics) {
-            mediator.onChangeComponentDensity()
+            mediator.onChangeDensity()
             super.paint(g)
         }
 
@@ -96,7 +98,7 @@ internal class WindowSkiaLayerComponent(
     override val windowHandle by contentComponent::windowHandle
 
     init {
-        contentComponent.skikoView = mediator.skikoView
+        contentComponent.skikoView = skikoView
     }
 
     override fun dispose() {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/OverlaySkikoViewDecorator.desktop.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/OverlaySkikoViewDecorator.desktop.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.skiko
+
+import org.jetbrains.skia.Canvas
+import org.jetbrains.skiko.SkikoView
+
+/**
+ * Decorator for [SkikoView] which adds overlay rendering functionality.
+ *
+ * @param decorated The decorated [SkikoView] instance.
+ * @param onRenderOverlay Function to be called for rendering the overlay.
+ */
+internal class OverlaySkikoViewDecorator(
+    private val decorated: SkikoView,
+    private val onRenderOverlay: (canvas: Canvas, width: Int, height: Int) -> Unit
+) : SkikoView by decorated {
+    override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
+        decorated.onRender(canvas, width, height, nanoTime)
+        onRenderOverlay(canvas, width, height)
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Draw scrim on the main view when it's required by separate window layer
- Fix updating position of window layer - tracking the position of the real window in addition to the `windowContainer`
- Fix propagation of `density`/`layoutDirection`
- Use focus-lost callback as click outside trigger

## Testing

Test: Set `compose.layers.type = WINDOW` and try to use `Popup`/`Dialog`
TODO: screenshot auto-testing
