### PR TITLE
Apply hack for window transparency to `WINDOW` layer too

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -89,39 +89,10 @@ internal class ComposeWindowPanel(
                 }
                 field = value
                 composeContainer.onChangeWindowTransparency(value)
-
-                /*
-                 * Windows makes clicks on transparent pixels fall through, but it doesn't work
-                 * with GPU accelerated rendering since this check requires having access to pixels from CPU.
-                 *
-                 * JVM doesn't allow override this behaviour with low-level windows methods, so hack this in this way.
-                 * Based on tests, it doesn't affect resulting pixel color.
-                 *
-                 * Note: Do not set isOpaque = false for this container
-                 */
-                if (value && hostOs == OS.Windows) {
-                    background = Color(0, 0, 0, 1)
-                    isOpaque = true
-                } else {
-                    background = null
-                    isOpaque = false
-                }
-
-                window.background = if (value && !skikoTransparentWindowHack) Color(0, 0, 0, 0) else null
+                setTransparent(value)
+                window.background = getTransparentWindowBackground(value, renderApi)
             }
         }
-
-    /**
-     * There is a hack inside skiko OpenGL and Software redrawers for Windows that makes current
-     * window transparent without setting `background` to JDK's window. It's done by getting native
-     * component parent and calling `DwmEnableBlurBehindWindow`.
-     *
-     * FIXME: Make OpenGL work inside transparent window (background == Color(0, 0, 0, 0)) without this hack.
-     *
-     * See `enableTransparentWindow` (skiko/src/awtMain/cpp/windows/window_util.cc)
-     */
-    private val skikoTransparentWindowHack: Boolean
-        get() = hostOs == OS.Windows && renderApi != GraphicsApi.DIRECT3D
 
     init {
         layout = null

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -19,6 +19,8 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.awt.getTransparentWindowBackground
+import androidx.compose.ui.awt.setTransparent
 import androidx.compose.ui.awt.toAwtColor
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
@@ -64,7 +66,10 @@ internal class WindowComposeSceneLayer(
     ).also {
         it.isAlwaysOnTop = true
         it.isUndecorated = true
-        it.background = Color.Transparent.toAwtColor()
+        it.background = getTransparentWindowBackground(
+            isWindowTransparent = true,
+            renderApi = composeContainer.renderApi
+        )
     }
     private val container = object : JLayeredPane() {
         override fun addNotify() {
@@ -73,7 +78,7 @@ internal class WindowComposeSceneLayer(
         }
     }.also {
         it.layout = null
-        it.isOpaque = false
+        it.setTransparent(true)
 
         dialog.contentPane = it
     }


### PR DESCRIPTION
## Proposed Changes

- Apply hack for window transparency that we already had for main window to `WINDOW` layer too

## Testing

Test: Try mouse input at `WINDOW` layers on Windows

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform-core/pull/1181#issuecomment-1991851134