### PR TITLE
Filter events if there are focusable `WINDOW` layers

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.awt
+
+import java.awt.Component
+import java.awt.Rectangle
+import java.awt.event.KeyEvent
+import java.awt.event.MouseEvent
+import javax.swing.SwingUtilities
+
+internal interface AwtEventFilter {
+    fun shouldSendMouseEvent(event: MouseEvent): Boolean = true
+    fun shouldSendKeyEvent(event: KeyEvent): Boolean = true
+
+    companion object {
+        val Empty = object : AwtEventFilter {
+        }
+    }
+}
+
+internal class AwtEventFilters(
+    private vararg val filters: AwtEventFilter
+) : AwtEventFilter {
+    override fun shouldSendMouseEvent(event: MouseEvent): Boolean {
+        return filters.all { it.shouldSendMouseEvent(event) }
+    }
+
+    override fun shouldSendKeyEvent(event: KeyEvent): Boolean {
+        return filters.all { it.shouldSendKeyEvent(event) }
+    }
+}
+
+/**
+ * Filter out mouse events that report the primary button has changed state to pressed,
+ * but aren't themselves a mouse press event. This is needed because on macOS, AWT sends
+ * us spurious enter/exit events that report the primary button as pressed when resizing
+ * the window by its corner/edge. This causes false-positives in detectTapGestures.
+ * See https://github.com/JetBrains/compose-multiplatform/issues/2850 for more details.
+*/
+internal object PrimaryMouseButtonFilter : AwtEventFilter {
+    private var isPrimaryButtonPressed = false
+
+    override fun shouldSendMouseEvent(event: MouseEvent): Boolean {
+        val eventReportsPrimaryButtonPressed =
+            (event.modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
+        if ((event.button == MouseEvent.BUTTON1) &&
+            ((event.id == MouseEvent.MOUSE_PRESSED) ||
+                (event.id == MouseEvent.MOUSE_RELEASED))) {
+            isPrimaryButtonPressed = eventReportsPrimaryButtonPressed  // Update state
+        }
+        if (eventReportsPrimaryButtonPressed && !isPrimaryButtonPressed) {
+            return false  // Ignore such events
+        }
+
+        return true
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
@@ -16,11 +16,8 @@
 
 package androidx.compose.ui.awt
 
-import java.awt.Component
-import java.awt.Rectangle
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
-import javax.swing.SwingUtilities
 
 internal interface AwtEventFilter {
     fun shouldSendMouseEvent(event: MouseEvent): Boolean = true
@@ -51,7 +48,7 @@ internal class AwtEventFilters(
  * the window by its corner/edge. This causes false-positives in detectTapGestures.
  * See https://github.com/JetBrains/compose-multiplatform/issues/2850 for more details.
 */
-internal object PrimaryMouseButtonFilter : AwtEventFilter {
+internal object OnlyValidPrimaryMouseButtonFilter : AwtEventFilter {
     private var isPrimaryButtonPressed = false
 
     override fun shouldSendMouseEvent(event: MouseEvent): Boolean {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.awt.AwtEventFilter
 import androidx.compose.ui.awt.AwtEventFilters
-import androidx.compose.ui.awt.PrimaryMouseButtonFilter
+import androidx.compose.ui.awt.OnlyValidPrimaryMouseButtonFilter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
@@ -122,7 +122,7 @@ internal class ComposeContainer(
             exceptionHandler?.onException(it) ?: throw it
         },
         eventFilter = AwtEventFilters(
-            PrimaryMouseButtonFilter,
+            OnlyValidPrimaryMouseButtonFilter,
             FocusableLayerEventFilter()
         ),
         coroutineContext = coroutineContext,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -16,11 +16,16 @@
 
 package androidx.compose.ui.scene
 
+import java.awt.event.MouseEvent as AwtMouseEvent
+import java.awt.event.KeyEvent as AwtKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.LayerType
+import androidx.compose.ui.awt.AwtEventFilter
+import androidx.compose.ui.awt.AwtEventFilters
+import androidx.compose.ui.awt.PrimaryMouseButtonFilter
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
@@ -116,6 +121,10 @@ internal class ComposeContainer(
         exceptionHandler = {
             exceptionHandler?.onException(it) ?: throw it
         },
+        eventFilter = AwtEventFilters(
+            PrimaryMouseButtonFilter,
+            FocusableLayerEventFilter()
+        ),
         coroutineContext = coroutineContext,
         skiaLayerComponentFactory = ::createSkiaLayerComponent,
         composeSceneFactory = ::createComposeScene,
@@ -352,6 +361,13 @@ internal class ComposeContainer(
         override fun handleException(context: CoroutineContext, exception: Throwable) {
             exceptionHandler?.onException(exception) ?: throw exception
         }
+    }
+
+    private inner class FocusableLayerEventFilter : AwtEventFilter {
+        private val noFocusableLayers get() = layers.all { !it.focusable }
+
+        override fun shouldSendMouseEvent(event: AwtMouseEvent): Boolean = noFocusableLayers
+        override fun shouldSendKeyEvent(event: AwtKeyEvent): Boolean = noFocusableLayers
     }
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.awt.AwtEventFilter
-import androidx.compose.ui.awt.PrimaryMouseButtonFilter
+import androidx.compose.ui.awt.OnlyValidPrimaryMouseButtonFilter
 import androidx.compose.ui.awt.SwingInteropContainer
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
@@ -103,7 +103,7 @@ internal class ComposeSceneMediator(
     /**
      * Decides which AWT events should be delivered, and which should be filtered out
      */
-    private val eventFilter: AwtEventFilter = PrimaryMouseButtonFilter,
+    private val eventFilter: AwtEventFilter = OnlyValidPrimaryMouseButtonFilter,
 
     val coroutineContext: CoroutineContext,
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.awt.AwtEventFilter
+import androidx.compose.ui.awt.PrimaryMouseButtonFilter
 import androidx.compose.ui.awt.SwingInteropContainer
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
@@ -97,6 +99,11 @@ internal class ComposeSceneMediator(
     private val container: Container,
     private val windowContext: PlatformWindowContext,
     private var exceptionHandler: WindowExceptionHandler?,
+
+    /**
+     * Decides which AWT events should be delivered, and which should be filtered out
+     */
+    private val eventFilter: AwtEventFilter = PrimaryMouseButtonFilter,
 
     val coroutineContext: CoroutineContext,
 
@@ -361,42 +368,6 @@ internal class ComposeSceneMediator(
         }
     }
 
-    // Decides which AWT events should be delivered, and which should be filtered out
-    private val awtEventFilter = object {
-        var isPrimaryButtonPressed = false
-
-        fun shouldSendMouseEvent(event: MouseEvent): Boolean {
-            // AWT can send events after the window is disposed
-            if (isDisposed) {
-                return false
-            }
-
-            // Filter out mouse events that report the primary button has changed state to pressed,
-            // but aren't themselves a mouse press event. This is needed because on macOS, AWT sends
-            // us spurious enter/exit events that report the primary button as pressed when resizing
-            // the window by its corner/edge. This causes false-positives in detectTapGestures.
-            // See https://github.com/JetBrains/compose-multiplatform/issues/2850 for more details.
-            val eventReportsPrimaryButtonPressed =
-                (event.modifiersEx and MouseEvent.BUTTON1_DOWN_MASK) != 0
-            if ((event.button == MouseEvent.BUTTON1) &&
-                ((event.id == MouseEvent.MOUSE_PRESSED) ||
-                    (event.id == MouseEvent.MOUSE_RELEASED))) {
-                isPrimaryButtonPressed = eventReportsPrimaryButtonPressed  // Update state
-            }
-            if (eventReportsPrimaryButtonPressed && !isPrimaryButtonPressed) {
-                return false  // Ignore such events
-            }
-
-            return true
-        }
-
-        @Suppress("UNUSED_PARAMETER")
-        fun shouldSendKeyEvent(event: KeyEvent): Boolean {
-            // AWT can send events after the window is disposed
-            return !isDisposed
-        }
-    }
-
     private val MouseEvent.position: Offset
         get() {
             val pointInContainer = SwingUtilities.convertPoint(component, point, container)
@@ -406,7 +377,11 @@ internal class ComposeSceneMediator(
         }
 
     private fun onMouseEvent(event: MouseEvent): Unit = catchExceptions {
-        if (!awtEventFilter.shouldSendMouseEvent(event)) {
+        // AWT can send events after the window is disposed
+        if (isDisposed) {
+            return
+        }
+        if (!eventFilter.shouldSendMouseEvent(event)) {
             return
         }
         if (keyboardModifiersRequireUpdate) {
@@ -419,7 +394,11 @@ internal class ComposeSceneMediator(
     }
 
     private fun onMouseWheelEvent(event: MouseWheelEvent): Unit = catchExceptions {
-        if (!awtEventFilter.shouldSendMouseEvent(event)) {
+        // AWT can send events after the window is disposed
+        if (isDisposed) {
+            return
+        }
+        if (!eventFilter.shouldSendMouseEvent(event)) {
             return
         }
         processMouseEvent {
@@ -428,7 +407,11 @@ internal class ComposeSceneMediator(
     }
 
     private fun onKeyEvent(event: KeyEvent) = catchExceptions {
-        if (!awtEventFilter.shouldSendKeyEvent(event)) {
+        // AWT can send events after the window is disposed
+        if (isDisposed) {
+            return
+        }
+        if (!eventFilter.shouldSendKeyEvent(event)) {
             return
         }
         textInputService.onKeyEvent(event)


### PR DESCRIPTION
## Proposed Changes

- Filter events if there are focusable `WINDOW` layers

## Testing

Test: open focusable `WINDOW` layer without `dismissOnClickOutside`, try to click on the main content

