### PR TITLE
Fix click outside and scrim drawing for `WINDOW` layers

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -17,10 +17,13 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntRect
 import java.awt.Component
-import java.awt.Transparency
+import java.awt.Rectangle
 import javax.swing.JComponent
-import org.jetbrains.skiko.ClipRectangle
+import kotlin.math.ceil
+import kotlin.math.floor
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
@@ -34,6 +37,18 @@ internal fun Component.isParentOf(component: Component?): Boolean {
         parent = parent.parent
     }
     return false
+}
+
+internal fun IntRect.toAwtRectangle(density: Density): Rectangle {
+    val left = floor(left / density.density).toInt()
+    val top = floor(top / density.density).toInt()
+    val right = ceil(right / density.density).toInt()
+    val bottom = ceil(bottom / density.density).toInt()
+    val width = right - left
+    val height = bottom - top
+    return Rectangle(
+        left, top, width, height
+    )
 }
 
 internal fun Color.toAwtColor() = java.awt.Color(red, green, blue, alpha)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -16,6 +16,21 @@
 
 package androidx.compose.ui.scene
 
+import androidx.annotation.CallSuper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.ui.awt.AwtEventFilter
+import androidx.compose.ui.awt.AwtEventFilters
+import androidx.compose.ui.awt.OnlyValidPrimaryMouseButtonFilter
+import androidx.compose.ui.awt.toAwtRectangle
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.fastForEachReversed
+import java.awt.event.KeyEvent
+import java.awt.event.MouseEvent
+import javax.swing.SwingUtilities
 import org.jetbrains.skia.Canvas
 
 /**
@@ -24,7 +39,67 @@ import org.jetbrains.skia.Canvas
  * @see SwingComposeSceneLayer
  * @see WindowComposeSceneLayer
  */
-internal abstract class DesktopComposeSceneLayer : ComposeSceneLayer {
+internal abstract class DesktopComposeSceneLayer(
+    protected val composeContainer: ComposeContainer,
+    density: Density,
+    layoutDirection: LayoutDirection,
+) : ComposeSceneLayer {
+    protected val windowContainer get() = composeContainer.windowContainer
+    protected val layersAbove get() = composeContainer.layersAbove(this)
+    protected val eventFilter get() = AwtEventFilters(
+        OnlyValidPrimaryMouseButtonFilter,
+        DetectEventOutsideLayer(),
+        FocusableLayerEventFilter()
+    )
+
+    protected abstract val mediator: ComposeSceneMediator?
+
+    private var outsidePointerCallback: ((eventType: PointerEventType) -> Unit)? = null
+    private var isClosed = false
+
+    final override var density: Density = density
+        set(value) {
+            field = value
+            mediator?.onChangeDensity(value)
+        }
+
+    final override var layoutDirection: LayoutDirection = layoutDirection
+        set(value) {
+            field = value
+            mediator?.onChangeLayoutDirection(value)
+        }
+
+    final override var compositionLocalContext: CompositionLocalContext?
+        get() = mediator?.compositionLocalContext
+        set(value) { mediator?.compositionLocalContext = value }
+
+    @CallSuper
+    override fun close() {
+        isClosed = true
+    }
+
+    final override fun setContent(content: @Composable () -> Unit) {
+        mediator?.setContent(content)
+    }
+
+    final override fun setKeyEventListener(
+        onPreviewKeyEvent: ((androidx.compose.ui.input.key.KeyEvent) -> Boolean)?,
+        onKeyEvent: ((androidx.compose.ui.input.key.KeyEvent) -> Boolean)?
+    ) {
+        mediator?.setKeyEventListeners(
+            onPreviewKeyEvent = onPreviewKeyEvent ?: { false },
+            onKeyEvent = onKeyEvent ?: { false }
+        )
+    }
+
+    final override fun setOutsidePointerEventListener(
+        onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)?
+    ) {
+        outsidePointerCallback = onOutsidePointerEvent
+    }
+
+    override fun calculateLocalPosition(positionInWindow: IntOffset) =
+        positionInWindow // [ComposeScene] is equal to [windowContainer] for the layer.
 
     /**
      * Called when the focus of the window containing main Compose view has changed.
@@ -45,12 +120,72 @@ internal abstract class DesktopComposeSceneLayer : ComposeSceneLayer {
     }
 
     /**
-     * Renders the overlay on the main Compose view canvas.
-     *
-     * @param canvas the canvas of the main Compose view
-     * @param width the width of the canvas
-     * @param height the height of the canvas
+     * Called when the layers in [composeContainer] have changed.
      */
-    open fun onRenderOverlay(canvas: Canvas, width: Int, height: Int) {
+    open fun onLayersChange() {
+    }
+
+    /**
+     * Renders an overlay on the canvas.
+     *
+     * @param canvas the canvas to render on
+     * @param width the width of the overlay
+     * @param height the height of the overlay
+     * @param transparent a flag indicating whether [canvas] is transparent
+     */
+    open fun onRenderOverlay(canvas: Canvas, width: Int, height: Int, transparent: Boolean) {
+    }
+
+    /**
+     * This method is called when a mouse event occurs outside of this layer.
+     *
+     * @param event the mouse event
+     */
+    fun onMouseEventOutside(event: MouseEvent) {
+        if (isClosed || !event.isMainAction() || inBounds(event)) {
+            return
+        }
+        val eventType = when (event.id) {
+            MouseEvent.MOUSE_PRESSED -> PointerEventType.Press
+            MouseEvent.MOUSE_RELEASED -> PointerEventType.Release
+            else -> return
+        }
+        outsidePointerCallback?.invoke(eventType)
+    }
+
+    private fun inBounds(event: MouseEvent): Boolean {
+        val point = if (event.component != windowContainer) {
+            SwingUtilities.convertPoint(event.component, event.point, windowContainer)
+        } else {
+            event.point
+        }
+        return boundsInWindow.toAwtRectangle(density).contains(point)
+    }
+
+    /**
+     * Detect and trigger [DesktopComposeSceneLayer.onMouseEventOutside] if event happened below
+     * focused layer.
+     */
+    private inner class DetectEventOutsideLayer : AwtEventFilter {
+        override fun shouldSendMouseEvent(event: MouseEvent): Boolean {
+            layersAbove.toList().fastForEachReversed {
+                it.onMouseEventOutside(event)
+                if (it.focusable) {
+                    return true
+                }
+            }
+            return true
+        }
+    }
+
+    private inner class FocusableLayerEventFilter : AwtEventFilter {
+        private val noFocusableLayersAbove: Boolean
+            get() = layersAbove.all { !it.focusable }
+
+        override fun shouldSendMouseEvent(event: MouseEvent): Boolean = noFocusableLayersAbove
+        override fun shouldSendKeyEvent(event: KeyEvent): Boolean = focusable && noFocusableLayersAbove
     }
 }
+
+private fun MouseEvent.isMainAction() =
+    button == MouseEvent.BUTTON1

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -56,6 +55,7 @@ import androidx.compose.ui.unit.round
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
+import androidx.compose.ui.window.getDialogScrimBlendMode
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 
@@ -530,20 +530,14 @@ private class MultiLayerComposeSceneImpl(
                 invalidateIfNeeded()
             }
 
-        private val dialogScrimBlendMode
-            get() = if (composeSceneContext.platformContext.isWindowTransparent) {
-                // Use background alpha channel to respect transparent window shape.
-                BlendMode.SrcAtop
-            } else {
-                BlendMode.SrcOver
-            }
-
         private val background: Modifier
             get() = scrimColor?.let {
                 Modifier.drawBehind {
                     drawRect(
                         color = it,
-                        blendMode = dialogScrimBlendMode
+                        blendMode = getDialogScrimBlendMode(
+                            composeSceneContext.platformContext.isWindowTransparent
+                        )
                     )
                 }
             } ?: Modifier

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -251,3 +252,11 @@ private fun rememberDialogMeasurePolicy(
 
 private fun KeyEvent.isDismissRequest() =
     type == KeyEventType.KeyDown && key == Key.Escape
+
+internal fun getDialogScrimBlendMode(isWindowTransparent: Boolean) =
+    if (isWindowTransparent) {
+        // Use background alpha channel to respect transparent window shape.
+        BlendMode.SrcAtop
+    } else {
+        BlendMode.SrcOver
+    }


### PR DESCRIPTION
## Proposed Changes

- Detect mouse input on previous layers to trigger "outside" events instead of generating it on focus lost
- Draw scrim (with right blend mode) on all previous layers instead of just main content

## Testing

Test: Set `compose.layers.type = WINDOW` and try to use `Popup`/`Dialog`

https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/994717e5-401b-4ff0-9c31-b18d829e7da7

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform-core/pull/1187#discussion_r1521887293
