### PR TITLE
Update MULTIPLATFORM.md (min. iOS 12 instead of 16.5)

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -130,7 +130,7 @@ Run native macos Arm64 sample:
  - Restart AppCode
  - Wait while project synchronization with Gradle
  - [Optional] To run on real iOS device 
-   - Device should be at least with iOS 16.5. And Xcode should be at least 14.3
+   - Device should be at least with iOS 12. And Xcode should be at least 14.3
    - Find your TEAM_ID with instruction https://github.com/JetBrains/compose-multiplatform-template#running-on-a-real-ios-device
    - Create file project.properties in the root of repository. Add property `TEAM_ID=[your team id]` without double quotes, for example `TEAM_ID=ABC123ABC1`.
  - Choose run configuration **iOS App**


### PR DESCRIPTION
We can run it on iOS 12 from the project (verified by Kpotko)