### PR TITLE
Fix zero size layout in iOS interop

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/bugs/ComposeAndNativeScroll.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/bugs/ComposeAndNativeScroll.kt
@@ -81,7 +81,7 @@ val ComposeAndNativeScroll = Screen.Example("ScrollDraggingTest") {
         Spacer(Modifier.height(10.dp))
         Text("UIKit:")
         Box(modifier = Modifier.height(ItemsHeight.dp)) {
-            UIKitView(::makeScrollView, Modifier.height(ItemsHeight.dp))
+            UIKitView(::makeScrollView, Modifier.fillMaxSize())
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/EmptyLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/EmptyLayout.skiko.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Modifier
 internal fun EmptyLayout(modifier: Modifier) = Layout(
     content = {},
     modifier = modifier,
-    measurePolicy = { _, _ ->
-        layout(0, 0) {}
+    measurePolicy = { _, constraints ->
+        layout(constraints.minWidth, constraints.minHeight) {}
     }
 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OverlayLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OverlayLayout.skiko.kt
@@ -32,8 +32,8 @@ internal fun OverlayLayout(modifier: Modifier, content: @Composable () -> Unit) 
     measurePolicy = { measurables, constraints ->
         val placeables = measurables.map { it.measure(constraints) }
         layout(
-            placeables.maxOfOrNull { it.width } ?: 0,
-            placeables.maxOfOrNull { it.height } ?: 0
+            placeables.maxOfOrNull { it.width } ?: constraints.minWidth,
+            placeables.maxOfOrNull { it.height } ?: constraints.minHeight
         ) {
             placeables.forEach {
                 it.place(0, 0)


### PR DESCRIPTION
## Proposed Changes

Regression after #1145 (more specific is - https://github.com/JetBrains/compose-multiplatform-core/pull/1145/commits/156b2ee13ec8bd513d62b9e9b7d3ac788641aa22) - it was replaced by a zero-size layout that prevented drawing anything and might lead to crashes in native views due to a zero size.
Please note that before we had incorrect/inconsistent behavior - iOS interop occupied max available space. This PR aligns behaviour with [`AndroidView`](https://github.com/JetBrains/compose-multiplatform-core/blob/v1.6.0/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/viewinterop/AndroidViewHolder.android.kt#L387) and just [`Box`](https://github.com/JetBrains/compose-multiplatform-core/blob/v1.6.0/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Box.kt#L212-L214)

## Testing

Test: mpp demo, pages with interop

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4447
