### PR TITLE
Compose as `LifecycleOwner`

### DIFF
--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -159,6 +159,8 @@ kotlin {
                 implementation(project(":compose:ui:ui"))
                 implementation(project(":compose:ui:ui-graphics"))
                 implementation(project(":compose:ui:ui-text"))
+                implementation(project(":lifecycle:lifecycle-common"))
+                implementation(project(":lifecycle:lifecycle-runtime"))
                 implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinCoroutinesCore)
                 api(libs.kotlinSerializationCore)
@@ -175,6 +177,7 @@ kotlin {
         val desktopMain by getting {
             dependsOn(skikoMain)
             dependencies {
+                implementation(libs.kotlinCoroutinesSwing)
                 implementation(libs.skikoCurrentOs)
                 implementation(project(":compose:desktop:desktop"))
             }

--- a/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
@@ -3,7 +3,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.Button
@@ -11,7 +14,9 @@ import androidx.compose.material.Text
 import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -20,8 +25,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
+import androidx.lifecycle.LifecycleEventObserver
 import platform.UIKit.*
 import platform.Foundation.*
 import platform.darwin.dispatch_async
@@ -64,8 +71,34 @@ private fun NativeModalWithNavigation() {
 
 @Composable
 private fun NativeNavigationPage() {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    val states = remember { mutableStateListOf<String>() }
+
+    val observer = remember {
+        LifecycleEventObserver { _, event ->
+            println(event)
+            states.add("${states.size} ${event.name}")
+        }
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
     Column(Modifier.fillMaxSize().background(Color.DarkGray), verticalArrangement = Arrangement.Center, horizontalAlignment = Alignment.CenterHorizontally) {
         val navigationController = LocalUIViewController.current.navigationController
+
+        LazyRow(Modifier.height(50.dp).fillMaxWidth()) {
+            items(states.size) { index ->
+                Box(Modifier.background(Color.White).padding(16.dp)) {
+                    Text(states[index], color = Color.Black)
+                }
+            }
+        }
 
         Button(onClick = {
             navigationController?.pushViewController(

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3046,6 +3046,10 @@ public final class androidx/compose/ui/platform/CompositionLocalsKt {
 	public static final fun getLocalWindowInfo ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
+public final class androidx/compose/ui/platform/CompositionLocals_skikoKt {
+	public static final fun getLocalLifecycleOwner ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
 public final class androidx/compose/ui/platform/DefaultViewConfiguration : androidx/compose/ui/platform/ViewConfiguration {
 	public static final field $stable I
 	public fun <init> (Landroidx/compose/ui/unit/Density;)V

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -170,6 +170,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
                 implementation(project(":annotation:annotation"))
+                implementation(project(":lifecycle:lifecycle-common"))
+                implementation(project(":lifecycle:lifecycle-runtime"))
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/AndroidCompositionLocals.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/AndroidCompositionLocals.android.kt
@@ -58,7 +58,7 @@ internal val LocalImageVectorCache = staticCompositionLocalOf<ImageVectorCache> 
 /**
  * The CompositionLocal containing the current [LifecycleOwner].
  */
-val LocalLifecycleOwner = staticCompositionLocalOf<LifecycleOwner> {
+actual val LocalLifecycleOwner = staticCompositionLocalOf<LifecycleOwner> {
     noLocalProvidedFor("LocalLifecycleOwner")
 }
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/CompositionLocals.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/CompositionLocals.kt
@@ -20,6 +20,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.autofill.Autofill
@@ -36,6 +37,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.TextInputService
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.lifecycle.LifecycleOwner
 
 /**
  * The CompositionLocal to provide communication with platform accessibility service.
@@ -171,6 +173,11 @@ val LocalViewConfiguration = staticCompositionLocalOf<ViewConfiguration> {
 val LocalWindowInfo = staticCompositionLocalOf<WindowInfo> {
     noLocalProvidedFor("LocalWindowInfo")
 }
+
+/**
+ * The CompositionLocal containing the current [LifecycleOwner].
+ */
+expect val LocalLifecycleOwner: ProvidableCompositionLocal<LifecycleOwner>
 
 internal val LocalPointerIconService = staticCompositionLocalOf<PointerIconService?> {
     null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.lifecycle.LifecycleOwner
+
+/**
+ * The CompositionLocal containing the current [LifecycleOwner].
+ */
+actual val LocalLifecycleOwner = staticCompositionLocalOf<LifecycleOwner> {
+    noLocalProvidedFor("LocalLifecycleOwner")
+}
+
+@Suppress("SameParameterValue")
+private fun noLocalProvidedFor(name: String): Nothing {
+    error("CompositionLocal $name not present")
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationStateListener.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationStateListener.uikit.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import kotlinx.cinterop.ObjCAction
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSSelectorFromString
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDidEnterBackgroundNotification
+import platform.UIKit.UIApplicationState
+import platform.UIKit.UIApplicationWillEnterForegroundNotification
+import platform.darwin.NSObject
+
+internal class ApplicationStateListener(
+    /**
+     * Callback which will be called with `true` when the app becomes active, and `false` when the app goes background
+     */
+    private val callback: (Boolean) -> Unit
+) : NSObject() {
+    init {
+        val notificationCenter = NSNotificationCenter.defaultCenter
+
+        notificationCenter.addObserver(
+            this,
+            NSSelectorFromString(::applicationWillEnterForeground.name),
+            UIApplicationWillEnterForegroundNotification,
+            null
+        )
+
+        notificationCenter.addObserver(
+            this,
+            NSSelectorFromString(::applicationDidEnterBackground.name),
+            UIApplicationDidEnterBackgroundNotification,
+            null
+        )
+    }
+
+    @ObjCAction
+    fun applicationWillEnterForeground() {
+        callback(true)
+    }
+
+    @ObjCAction
+    fun applicationDidEnterBackground() {
+        callback(false)
+    }
+
+    /**
+     * Deregister from [NSNotificationCenter]
+     */
+    fun dispose() {
+        val notificationCenter = NSNotificationCenter.defaultCenter
+
+        notificationCenter.removeObserver(this, UIApplicationWillEnterForegroundNotification, null)
+        notificationCenter.removeObserver(this, UIApplicationDidEnterBackgroundNotification, null)
+    }
+
+    companion object {
+        val isApplicationActive: Boolean
+            get() = UIApplication.sharedApplication.applicationState != UIApplicationState.UIApplicationStateBackground
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import kotlin.test.fail
+
+internal class ViewControllerBasedLifecycleOwner : LifecycleOwner {
+    private enum class Action {
+        VIEW_WILL_APPEAR,
+        VIEW_DID_DISAPPEAR,
+        APPLICATION_DID_ENTER_BACKGROUND,
+        APPLICATION_WILL_ENTER_FOREGROUND,
+        DISPOSE
+
+        // TODO: add actions for Popup and Dialog to behave like Android
+    }
+
+    private sealed interface State {
+        fun reduce(action: Action): State
+
+        class Created(
+            private val isApplicationForeground: Boolean,
+            private val lifecycle: LifecycleRegistry
+        ) : State {
+            override fun reduce(action: Action): State {
+                return when (action) {
+                    Action.VIEW_WILL_APPEAR -> {
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+                        if (isApplicationForeground) {
+                            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+                            Running(lifecycle = lifecycle)
+                        } else {
+                            Suspended(lifecycle = lifecycle)
+                        }
+                    }
+
+                    Action.VIEW_DID_DISAPPEAR -> {
+                        if (isApplicationForeground) {
+                            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+                        }
+
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+                        Created(isApplicationForeground = isApplicationForeground, lifecycle = lifecycle)
+                    }
+
+                    Action.APPLICATION_DID_ENTER_BACKGROUND -> {
+                        Created(isApplicationForeground = false, lifecycle = lifecycle)
+                    }
+
+                    Action.APPLICATION_WILL_ENTER_FOREGROUND -> {
+                        Created(isApplicationForeground = true, lifecycle = lifecycle)
+                    }
+
+                    Action.DISPOSE -> {
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+                        Disposed
+                    }
+                }
+            }
+        }
+        class Running(
+            private val lifecycle: LifecycleRegistry
+        ) : State {
+            override fun reduce(action: Action): State {
+                return when (action) {
+                    Action.VIEW_WILL_APPEAR -> {
+                        this
+                    }
+
+                    Action.VIEW_DID_DISAPPEAR -> {
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+                        Created(isApplicationForeground = true, lifecycle = lifecycle)
+                    }
+
+                    Action.APPLICATION_DID_ENTER_BACKGROUND -> {
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+                        Suspended(lifecycle = lifecycle)
+                    }
+
+                    Action.APPLICATION_WILL_ENTER_FOREGROUND -> {
+                        this
+                    }
+
+                    Action.DISPOSE -> {
+                        logWarning("'ViewControllerBasedLifecycleOwner' received 'Action.DISPOSE' while in 'State.Running'. Make sure that view controller containment API is used correctly. 'removeFromParent' must be called before 'dispose'")
+
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+                        Disposed
+                    }
+                }
+            }
+        }
+
+        class Suspended(private val lifecycle: LifecycleRegistry) : State {
+            override fun reduce(action: Action): State {
+                return when(action) {
+                    Action.VIEW_WILL_APPEAR -> {
+                        this
+                    }
+
+                    Action.VIEW_DID_DISAPPEAR -> {
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+                        Created(isApplicationForeground = false, lifecycle = lifecycle)
+                    }
+
+                    Action.APPLICATION_DID_ENTER_BACKGROUND -> {
+                        this
+                    }
+
+                    Action.APPLICATION_WILL_ENTER_FOREGROUND -> {
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+                        Running(lifecycle = lifecycle)
+                    }
+
+                    Action.DISPOSE -> {
+                        logWarning("'ViewControllerBasedLifecycleOwner' received 'Action.DISPOSE' while in 'State.Suspended'. Make sure that view controller containment API is used correctly. 'removeFromParent' must be called before 'dispose'")
+
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+                        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+                        Disposed
+                    }
+                }
+            }
+        }
+
+        object Disposed : State {
+            override fun reduce(action: Action): State {
+                when (action) {
+                    Action.VIEW_WILL_APPEAR, Action.VIEW_DID_DISAPPEAR, Action.DISPOSE -> {
+                        fail("Invalid '$action' for 'State.Disposed'")
+                    }
+                    Action.APPLICATION_DID_ENTER_BACKGROUND, Action.APPLICATION_WILL_ENTER_FOREGROUND -> {
+                        // no-op
+                        return this
+                    }
+                }
+            }
+        }
+    }
+
+    override val lifecycle = LifecycleRegistry(this)
+
+    private var state: State = State.Created(
+        isApplicationForeground = ApplicationStateListener.isApplicationActive,
+        lifecycle = lifecycle
+    )
+
+    private val applicationStateListener = ApplicationStateListener { isForeground ->
+        handleAction(
+            if (isForeground) Action.APPLICATION_WILL_ENTER_FOREGROUND
+            else Action.APPLICATION_DID_ENTER_BACKGROUND
+        )
+    }
+
+    init {
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+    }
+
+    fun dispose() {
+        handleAction(Action.DISPOSE)
+        applicationStateListener.dispose()
+    }
+
+    fun handleViewWillAppear() {
+        handleAction(Action.VIEW_WILL_APPEAR)
+    }
+
+    fun handleViewDidDisappear() {
+        handleAction(Action.VIEW_DID_DISAPPEAR)
+    }
+
+    private fun handleAction(action: Action) {
+        state = state.reduce(action)
+    }
+
+    companion object {
+        fun logWarning(message: String) {
+            println("Warning: ViewControllerBasedLifecycleOwner - $message")
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Cherry-pick [2950349: Move LocalLifecycleOwner to common](https://android-review.googlesource.com/c/platform/frameworks/support/+/2950349)
- Implement `LifecycleOwner` for Desktop, iOS and Web

## Testing

Test: Observe lifecycle events in mpp

## Fixed Issues

Fixes https://github.com/JetBrains/compose-multiplatform/issues/2915
