### PR TITLE
Apply JetbrainsAndroidXPlugin in lifecycle modules too

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -108,7 +108,7 @@ artifactRedirecting.androidx.compose.foundation.version=1.6.3
 artifactRedirecting.androidx.compose.material.version=1.6.3
 # We use artifactRedirecting not only for Compose libs:
 artifactRedirecting.androidx.collection.version=1.4.0
-artifactRedirecting.androidx.annotation.version=1.7.1
+artifactRedirecting.androidx.annotation.version=1.8.0-alpha01
 
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true

--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -22,6 +22,8 @@
  * modifying its settings.
  */
 
+
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.PlatformIdentifier
 import androidx.build.Publish
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
@@ -29,7 +31,10 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 
 plugins {
     id("AndroidXPlugin")
+    id("JetbrainsAndroidXPlugin")
 }
+
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 androidXMultiplatform {
     jvm {

--- a/lifecycle/lifecycle-runtime/build.gradle
+++ b/lifecycle/lifecycle-runtime/build.gradle
@@ -6,6 +6,8 @@
  * modifying its settings.
  */
 
+
+import androidx.build.JetbrainsAndroidXPlugin
 import androidx.build.KmpPlatformsKt
 import androidx.build.PlatformIdentifier
 import androidx.build.Publish
@@ -15,7 +17,10 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 plugins {
     id("AndroidXPlugin")
     id("com.android.library")
+    id("JetbrainsAndroidXPlugin")
 }
+
+JetbrainsAndroidXPlugin.applyAndConfigure(project)
 
 def jsEnabled = KmpPlatformsKt.enableJs(project)
 def wasmEnabled = KmpPlatformsKt.enableWasm(project)


### PR DESCRIPTION
JetbrainsAndroidXPlugin is needed to configure redirecting publication and to substitute project dependencies by module dependensies (only for libs published by androidx for macos, ios, jvm...)

Also, we have to use annotation version 1.8.0-alpha01 because lifecycle uses MainThread which is available in common only in 1.8.0-alpha01