### PR TITLE
Fix propagation of LocalLocalization

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformCompositionLocals.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformCompositionLocals.kt
@@ -24,7 +24,8 @@ internal actual fun ProvidePlatformCompositionLocals(
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(
-        LocalLocalization provides defaultPlatformLocalization(),
+        // See https://issuetracker.google.com/issues/330036209 for why `arrayOf` is used.
+        values = arrayOf(LocalLocalization providesDefault defaultPlatformLocalization()),
         content = content
     )
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -228,7 +228,7 @@ suspend fun awaitApplication(
                                 // This is also provided in `ProvidePlatformCompositionLocals`, but
                                 // for backwards compatibility we need to provide it in the
                                 // application scope too.
-                                LocalLocalization provides defaultPlatformLocalization()
+                                LocalLocalization providesDefault defaultPlatformLocalization()
                             ) {
                                 applicationScope.content()
                             }


### PR DESCRIPTION
Currently, the user-provided `LocalLocalization` was overwritten in new scene scope (e.g. Window, Popup).

This PR uses `providesDefault` to provide the `LocalLocalization` for a new scene, which avoids overwriting any user-provided one.

## Testing

Test: Added new unit tests.
