### PR TITLE
Allow per-target versions configuration for redirecting publication

### DIFF
--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
@@ -172,8 +172,16 @@ fun enableArtifactRedirectingPublishing(project: Project) {
             .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
             .getByName("kotlin")
 
-        val newDependency = project.dependencies.create(redirecting.groupId, project.name, redirecting.version)
-        CustomRootComponent(rootComponent, newDependency)
+        CustomRootComponent(rootComponent) { configuration ->
+            val targetName = redirecting.targetVersions.keys.firstOrNull {
+                // we rely on the fact that configuration name starts with target name
+                configuration.name.startsWith(it)
+            }
+            val targetVersion = redirecting.versionForTargetOrDefault(targetName ?: "")
+            project.dependencies.create(
+                redirecting.groupId, project.name, targetVersion
+            )
+        }
     }
 
     val oelTargetNames = (project.findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidxRedirectingPublicationHelpers.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidxRedirectingPublicationHelpers.kt
@@ -119,7 +119,7 @@ internal fun Project.publishAndroidxReference(target: AbstractKotlinTarget, newR
 
 internal class CustomRootComponent(
     val rootComponent: KotlinSoftwareComponentWithCoordinatesAndPublication,
-    val newDependency: ModuleDependency
+    val customizeDependencyPerConfiguration: (Configuration) -> ModuleDependency
 ) : SoftwareComponentInternal, ComponentWithVariants, ComponentWithCoordinates {
     override fun getName(): String = "kotlinDecoratedRootComponent"
     override fun getVariants(): Set<SoftwareComponent> = rootComponent.variants
@@ -131,6 +131,8 @@ internal class CustomRootComponent(
     private val extraUsages = mutableSetOf<UsageContext>()
 
     fun addUsageFromConfiguration(configuration: Configuration) {
+        val newDependency = customizeDependencyPerConfiguration(configuration)
+
         extraUsages.add(
             CustomUsage(
                 name = configuration.name,

--- a/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/MavenUploadHelper.kt
@@ -289,7 +289,7 @@ internal fun modifyPomDependency(
     val shouldReplace = redirecting.targetNames.contains(target)
     if (shouldReplace) {
         groupId.text = redirecting.groupId
-        version.text = redirecting.version
+        version.text = redirecting.versionForTargetOrDefault(target)
     }
     return dependency
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -109,6 +109,8 @@ artifactRedirecting.androidx.compose.material.version=1.6.3
 # We use artifactRedirecting not only for Compose libs:
 artifactRedirecting.androidx.collection.version=1.4.0
 artifactRedirecting.androidx.annotation.version=1.8.0-alpha01
+# TODO: per-target-versioning for annotation is temporary, delete it and keep the line above (after stable 1.8.0)
+artifactRedirecting.androidx.annotation.targetVersions=jvm=1.7.1,default=1.8.0-alpha01
 
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true


### PR DESCRIPTION
If such a need occurs again, the only needed change would be to have a gradle property with target/version mapping. Like this:

```
artifactRedirecting.androidx.annotation.targetVersions=jvm=1.7.1,default=1.8.0-alpha01
```

Note: the keys (target names) should match those declared in module/gradle.properties. For example in annotation/gradle.properties:
```
artifactRedirecting.publication.targetNames=jvm,macosX64,macosArm64,uikitX64,uikitArm64,uikitSimArm64,linuxX64
```

