### PR TITLE
Add redirecting publication for lifecycle-common and lifecycle-runtime

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -60,22 +60,16 @@ Note that only desktop has API checks at the moment, but in the future it will b
 
 ### Publishing
 Compose Multiplatform core libraries can be published to local Maven with the following steps:
-1. Set `COMPOSE_CUSTOM_VERSION` environment variable
-```bash
-export COMPOSE_CUSTOM_VERSION=0.0.0-custom-version
-```
+1. Use these gradle properties to set the published libraries versions
 
-*Note:* instead of using an environment variable, it's possible to use new gradle properties:
 `-Pjetbrains.publication.version.COMPOSE=0.1.0-SNAPSHOT`,
 `-Pjetbrains.publication.version.LIFECYCLE=0.1.0-SNAPSHOT`
 
-The environment variable has a higher priority than the gradle property.
-There is no environment variable for LIFECYCLE custom version.
-Also, check `gradle.properties` file to learn more.
+`gradle.properties` file contains default values for the versions.
 
 2. Publish core libraries
 ```bash
-./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all
+./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=0.1.0-SNAPSHOT -Pjetbrains.publication.version.LIFECYCLE=0.1.0-SNAPSHOT
 ```
 `-Pcompose.platforms=all` could be replace with comma-separated list of platforms, such as `js,jvm,androidDebug,androidRelease,macosx64,uikit`.
 

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -64,6 +64,15 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 ```bash
 export COMPOSE_CUSTOM_VERSION=0.0.0-custom-version
 ```
+
+*Note:* instead of using an environment variable, it's possible to use new gradle properties:
+`-Pjetbrains.publication.version.COMPOSE=0.1.0-SNAPSHOT`,
+`-Pjetbrains.publication.version.LIFECYCLE=0.1.0-SNAPSHOT`
+
+The environment variable has a higher priority than the gradle property.
+There is no environment variable for LIFECYCLE custom version.
+Also, check `gradle.properties` file to learn more.
+
 2. Publish core libraries
 ```bash
 ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
@@ -82,7 +82,7 @@ open class JetbrainsExtensions(
         val androidCollectionVersion =
             project.findProperty("artifactRedirecting.androidx.collection.version")!!
         val androidLifecycleVersion =
-            project.findProperty("artifactRedirecting.androidx.lifecycle.version")
+            project.findProperty("artifactRedirecting.androidx.lifecycle.version")!!
         listOf(
             comp.configurations.compileDependencyConfiguration,
             comp.configurations.runtimeDependencyConfiguration,
@@ -97,12 +97,10 @@ open class JetbrainsExtensions(
                         .using(it.module("androidx.annotation:annotation:$androidAnnotationVersion"))
                     it.substitute(it.project(":collection:collection"))
                         .using(it.module("androidx.collection:collection:$androidCollectionVersion"))
-                    if (androidLifecycleVersion != null) {
-                        it.substitute(it.project(":lifecycle:lifecycle-common"))
-                            .using(it.module("androidx.lifecycle:lifecycle-common:$androidLifecycleVersion"))
-                        it.substitute(it.project(":lifecycle:lifecycle-runtime"))
-                            .using(it.module("androidx.lifecycle:lifecycle-runtime:$androidLifecycleVersion"))
-                    }
+                    it.substitute(it.project(":lifecycle:lifecycle-common"))
+                        .using(it.module("androidx.lifecycle:lifecycle-common:$androidLifecycleVersion"))
+                    it.substitute(it.project(":lifecycle:lifecycle-runtime"))
+                        .using(it.module("androidx.lifecycle:lifecycle-runtime:$androidLifecycleVersion"))
                 }
             }
         }

--- a/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -21,6 +21,9 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
     UikitX64("UiKit"),
     UikitArm64("UiKit"),
     UikitSimArm64("UiKit"),
+    IosX64("Ios"),
+    IosArm64("Ios"),
+    IosSimulatorArm64("Ios"),
     TvosArm64("TvOs"),
     TvosX64("TvOs"),
     TvosSimulatorArm64("TvOs"),
@@ -46,7 +49,14 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
         listOf(name, *alternativeNames).any { it.equals(nameCandidate, ignoreCase = true) }
 
     companion object {
-        val ALL = EnumSet.allOf(ComposePlatforms::class.java)
+        val IOS = EnumSet.of(
+            ComposePlatforms.IosX64,
+            ComposePlatforms.IosArm64,
+            ComposePlatforms.IosSimulatorArm64,
+        )
+
+        // exclude IOS by default, because ALL includes UIKIT instead
+        val ALL = EnumSet.allOf(ComposePlatforms::class.java) - IOS
 
         val JVM_BASED = EnumSet.of(
             ComposePlatforms.Desktop,
@@ -54,7 +64,7 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
             ComposePlatforms.AndroidRelease
         )
 
-        val IOS = EnumSet.of(
+        val UIKIT = EnumSet.of(
             ComposePlatforms.UikitX64,
             ComposePlatforms.UikitArm64,
             ComposePlatforms.UikitSimArm64

--- a/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -79,19 +79,6 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
             ComposePlatforms.MingwX64,
         )
 
-        // Let's not publish those for some libs until we have a reason to do so
-        // For example: lifecycle
-        val SKIP_EXTRA_TARGETS = EnumSet.of(
-            ComposePlatforms.TvosArm64,
-            ComposePlatforms.TvosX64,
-            ComposePlatforms.TvosSimulatorArm64,
-            ComposePlatforms.WatchosArm64,
-            ComposePlatforms.WatchosArm32,
-            ComposePlatforms.WatchosX64,
-            ComposePlatforms.WatchosSimulatorArm64,
-            ComposePlatforms.MingwX64,
-        )
-
         /**
          * Maps comma separated list of platforms into a set of [ComposePlatforms]
          * The function is case- and whitespace-insensetive.

--- a/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -79,6 +79,19 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
             ComposePlatforms.MingwX64,
         )
 
+        // Let's not publish those for some libs until we have a reason to do so
+        // For example: lifecycle
+        val SKIP_EXTRA_TARGETS = EnumSet.of(
+            ComposePlatforms.TvosArm64,
+            ComposePlatforms.TvosX64,
+            ComposePlatforms.TvosSimulatorArm64,
+            ComposePlatforms.WatchosArm64,
+            ComposePlatforms.WatchosArm32,
+            ComposePlatforms.WatchosX64,
+            ComposePlatforms.WatchosSimulatorArm64,
+            ComposePlatforms.MingwX64,
+        )
+
         /**
          * Maps comma separated list of platforms into a set of [ComposePlatforms]
          * The function is case- and whitespace-insensetive.

--- a/gradle.properties
+++ b/gradle.properties
@@ -113,10 +113,8 @@ artifactRedirecting.androidx.annotation.version=1.8.0-alpha01
 artifactRedirecting.androidx.annotation.targetVersions=jvm=1.7.1,default=1.8.0-alpha01
 artifactRedirecting.androidx.lifecycle.version=2.8.0-alpha02
 
-jetbrains.publication.configuration=\
-  COMPOSE:group=androidx.compose,newGroup=org.jetbrains.compose;\
-  LIFECYCLE:group=androidx.lifecycle,newGroup=org.jetbrains.androidx.lifecycle;
-
+# Here we define the versions of the libraries published by JB
+# Note: an environment variable COMPOSE_CUSTOM_VERSION has a higher priority than the gradle property
 jetbrains.publication.version.COMPOSE=0.1.0-SNAPSHOT
 jetbrains.publication.version.LIFECYCLE=0.1.0-SNAPSHOT
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -113,6 +113,13 @@ artifactRedirecting.androidx.annotation.version=1.8.0-alpha01
 artifactRedirecting.androidx.annotation.targetVersions=jvm=1.7.1,default=1.8.0-alpha01
 artifactRedirecting.androidx.lifecycle.version=2.8.0-alpha02
 
+jetbrains.publication.configuration=\
+  COMPOSE:group=androidx.compose,newGroup=org.jetbrains.compose;\
+  LIFECYCLE:group=androidx.lifecycle,newGroup=org.jetbrains.androidx.lifecycle;
+
+jetbrains.publication.version.COMPOSE=0.1.0-SNAPSHOT
+jetbrains.publication.version.LIFECYCLE=0.1.0-SNAPSHOT
+
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableNativeIrTransformation=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -111,6 +111,7 @@ artifactRedirecting.androidx.collection.version=1.4.0
 artifactRedirecting.androidx.annotation.version=1.8.0-alpha01
 # TODO: per-target-versioning for annotation is temporary, delete it and keep the line above (after stable 1.8.0)
 artifactRedirecting.androidx.annotation.targetVersions=jvm=1.7.1,default=1.8.0-alpha01
+artifactRedirecting.androidx.lifecycle.version=2.8.0-alpha02
 
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true

--- a/kruth/kruth/build.gradle
+++ b/kruth/kruth/build.gradle
@@ -48,6 +48,7 @@ kotlin {
         browser()
     }
     wasmJs()
+    linuxArm64()
 
     sourceSets {
         commonMain {

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -235,7 +235,7 @@ KRUTH = { group = "androidx.kruth", atomicGroupVersion = "versions.KRUTH" }
 LEANBACK = { group = "androidx.leanback" }
 LEGACY = { group = "androidx.legacy" }
 LIBYUV = { group = "libyuv", atomicGroupVersion = "versions.LIBYUV" }
-LIFECYCLE = { group = "org.jetbrains.compose.lifecycle-internal", atomicGroupVersion = "versions.COMPOSE" , overrideInclude = [ ":lifecycle:lifecycle-common", ":lifecycle:lifecycle-runtime", ":lifecycle:lifecycle-runtime-compose" ]}
+LIFECYCLE = { group = "androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE" , overrideInclude = [ ":lifecycle:lifecycle-common", ":lifecycle:lifecycle-runtime", ":lifecycle:lifecycle-runtime-compose" ]}
 LIFECYCLE_EXTENSIONS = { group = "androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE_EXTENSIONS", overrideInclude = [ ":lifecycle:lifecycle-extensions" ] }
 LOADER = { group = "androidx.loader", atomicGroupVersion = "versions.LOADER" }
 MEDIA = { group = "androidx.media" }

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -235,7 +235,7 @@ KRUTH = { group = "androidx.kruth", atomicGroupVersion = "versions.KRUTH" }
 LEANBACK = { group = "androidx.leanback" }
 LEGACY = { group = "androidx.legacy" }
 LIBYUV = { group = "libyuv", atomicGroupVersion = "versions.LIBYUV" }
-LIFECYCLE = { group = "androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE" , overrideInclude = [ ":lifecycle:lifecycle-common", ":lifecycle:lifecycle-runtime", ":lifecycle:lifecycle-runtime-compose" ]}
+LIFECYCLE = { group = "org.jetbrains.androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE" , overrideInclude = [ ":lifecycle:lifecycle-common", ":lifecycle:lifecycle-runtime", ":lifecycle:lifecycle-runtime-compose" ]}
 LIFECYCLE_EXTENSIONS = { group = "androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE_EXTENSIONS", overrideInclude = [ ":lifecycle:lifecycle-extensions" ] }
 LOADER = { group = "androidx.loader", atomicGroupVersion = "versions.LOADER" }
 MEDIA = { group = "androidx.media" }

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -235,7 +235,7 @@ KRUTH = { group = "androidx.kruth", atomicGroupVersion = "versions.KRUTH" }
 LEANBACK = { group = "androidx.leanback" }
 LEGACY = { group = "androidx.legacy" }
 LIBYUV = { group = "libyuv", atomicGroupVersion = "versions.LIBYUV" }
-LIFECYCLE = { group = "androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE" }
+LIFECYCLE = { group = "org.jetbrains.compose.lifecycle-internal", atomicGroupVersion = "versions.COMPOSE" , overrideInclude = [ ":lifecycle:lifecycle-common", ":lifecycle:lifecycle-runtime", ":lifecycle:lifecycle-runtime-compose" ]}
 LIFECYCLE_EXTENSIONS = { group = "androidx.lifecycle", atomicGroupVersion = "versions.LIFECYCLE_EXTENSIONS", overrideInclude = [ ":lifecycle:lifecycle-extensions" ] }
 LOADER = { group = "androidx.loader", atomicGroupVersion = "versions.LOADER" }
 MEDIA = { group = "androidx.media" }

--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -54,6 +54,7 @@ kotlin {
         browser()
     }
     wasmJs()
+    linuxArm64()
 
     explicitApi = ExplicitApiMode.Strict
 

--- a/lifecycle/lifecycle-common/gradle.properties
+++ b/lifecycle/lifecycle-common/gradle.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-artifactRedirecting.publication.targetNames=jvm,macosX64,macosArm64,uikitX64,uikitArm64,uikitSimArm64,linuxX64
+artifactRedirecting.publication.targetNames=jvm,macosX64,macosArm64,iosX64,iosArm64,iosSimulatorArm64,linuxX64
 artifactRedirecting.androidx.groupId=androidx.lifecycle

--- a/lifecycle/lifecycle-common/gradle.properties
+++ b/lifecycle/lifecycle-common/gradle.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2024 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+artifactRedirecting.publication.targetNames=jvm,macosX64,macosArm64,uikitX64,uikitArm64,uikitSimArm64,linuxX64
+artifactRedirecting.androidx.groupId=androidx.lifecycle

--- a/lifecycle/lifecycle-runtime/build.gradle
+++ b/lifecycle/lifecycle-runtime/build.gradle
@@ -42,6 +42,7 @@ kotlin {
         browser()
     }
     wasmJs()
+    linuxArm64()
 
     explicitApi = ExplicitApiMode.Strict
 

--- a/lifecycle/lifecycle-runtime/gradle.properties
+++ b/lifecycle/lifecycle-runtime/gradle.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-artifactRedirecting.publication.targetNames=android,desktop,macosX64,macosArm64,uikitX64,uikitArm64,uikitSimArm64,linuxX64
+artifactRedirecting.publication.targetNames=android,desktop,macosX64,macosArm64,iosX64,iosArm64,iosSimulatorArm64,linuxX64
 artifactRedirecting.androidx.groupId=androidx.lifecycle

--- a/lifecycle/lifecycle-runtime/gradle.properties
+++ b/lifecycle/lifecycle-runtime/gradle.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2024 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+artifactRedirecting.publication.targetNames=android,desktop,macosX64,macosArm64,uikitX64,uikitArm64,uikitSimArm64,linuxX64
+artifactRedirecting.androidx.groupId=androidx.lifecycle

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -25,7 +25,9 @@ open class ComposePublishingTask : AbstractComposePublishingTask() {
 val composeProperties = ComposeProperties(project)
 
 val PublishedLifecyclePlatforms = ComposePlatforms.ALL -
-    ComposePlatforms.NO_SKIKO +
+    ComposePlatforms.NO_SKIKO -
+    ComposePlatforms.UIKIT + // the target names in Lifecycle are ios, not uikit
+    ComposePlatforms.IOS +
     ComposePlatforms.LinuxX64 +
     ComposePlatforms.LinuxArm64
 
@@ -78,7 +80,7 @@ val mainComponents =
         ),
         ComposeComponent(
             ":compose:ui:ui-uikit",
-            supportedPlatforms = ComposePlatforms.IOS
+            supportedPlatforms = ComposePlatforms.UIKIT
         ),
         ComposeComponent(":compose:ui:ui-unit"),
         ComposeComponent(":compose:ui:ui-util"),

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -25,8 +25,9 @@ open class ComposePublishingTask : AbstractComposePublishingTask() {
 val composeProperties = ComposeProperties(project)
 
 val PublishedLifecyclePlatforms = ComposePlatforms.ALL -
-    ComposePlatforms.SKIP_EXTRA_TARGETS -
-    ComposePlatforms.LinuxArm64 // not published by androidx too
+    ComposePlatforms.NO_SKIKO +
+    ComposePlatforms.LinuxX64 +
+    ComposePlatforms.LinuxArm64
 
 val mainComponents =
     listOf(

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -24,10 +24,28 @@ open class ComposePublishingTask : AbstractComposePublishingTask() {
 
 val composeProperties = ComposeProperties(project)
 
+val PublishedLifecyclePlatforms = ComposePlatforms.ALL -
+    ComposePlatforms.SKIP_EXTRA_TARGETS -
+    ComposePlatforms.LinuxArm64 // not published by androidx too
+
 val mainComponents =
     listOf(
         ComposeComponent(":annotation:annotation", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
         ComposeComponent(":collection:collection", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
+        ComposeComponent(
+            path = ":lifecycle:lifecycle-common",
+            // No android target here - jvm artefact will be used for android apps as well
+            supportedPlatforms = PublishedLifecyclePlatforms - ComposePlatforms.ANDROID
+        ),
+        ComposeComponent(
+            path = ":lifecycle:lifecycle-runtime",
+            supportedPlatforms = PublishedLifecyclePlatforms
+        ),
+        //To be added later: (also don't forget to add gradle.properties see in lifecycle-runtime for an example)
+        //ComposeComponent(
+        //    path = ":lifecycle:lifecycle-runtime-compose",
+        //    supportedPlatforms = PublishedLifecyclePlatforms
+        //),
         ComposeComponent(":compose:animation:animation"),
         ComposeComponent(":compose:animation:animation-core"),
         ComposeComponent(":compose:animation:animation-graphics"),


### PR DESCRIPTION
**Redirecting to:** 2.8.0-alpha02
**We publish the artefacts only for this targets:** k/js, k/wasm + a common (root)


**Our groupId:** `org.jebtrains.androidx.lifecycle`

We can publish the lifecycle group with our custom version by using a gradle property:
`-Pjetbrains.publication.version.LIFECYCLE=0.1.0-SNAPSHOT`

