### PR TITLE
Allow specifying a test coroutine dispatcher for `SkikoComposeUiTest`

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -45,6 +45,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.roundToInt
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -75,13 +76,14 @@ fun runSkikoComposeUiTest(
 }
 
 @InternalTestApi
-@OptIn(InternalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(InternalComposeUiApi::class, ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
 fun runInternalSkikoComposeUiTest(
     width: Int = 1024,
     height: Int = 768,
     density: Density = Density(1f),
     effectContext: CoroutineContext = EmptyCoroutineContext,
     semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
+    coroutineDispatcher: TestDispatcher = defaultTestDispatcher(),
     block: SkikoComposeUiTest.() -> Unit
 ) {
     SkikoComposeUiTest(
@@ -90,6 +92,7 @@ fun runInternalSkikoComposeUiTest(
         effectContext = effectContext,
         density = density,
         semanticsOwnerListener = semanticsOwnerListener,
+        coroutineDispatcher = coroutineDispatcher,
     ).runTest(block)
 }
 
@@ -100,18 +103,26 @@ fun runInternalSkikoComposeUiTest(
 private const val IDLING_RESOURCES_CHECK_INTERVAL_MS = 20L
 
 /**
+ * Returns the default [TestDispatcher] to use in tests.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@InternalTestApi
+fun defaultTestDispatcher() = UnconfinedTestDispatcher()
+
+/**
  * @param effectContext The [CoroutineContext] used to run the composition. The context for
  * `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context.
  */
 @ExperimentalTestApi
-@OptIn(ExperimentalCoroutinesApi::class, InternalTestApi::class, InternalComposeUiApi::class)
+@OptIn(InternalTestApi::class, InternalComposeUiApi::class)
 class SkikoComposeUiTest @InternalTestApi constructor(
     width: Int = 1024,
     height: Int = 768,
     // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
     effectContext: CoroutineContext = EmptyCoroutineContext,
     override val density: Density = Density(1f),
-    private val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener?
+    private val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener?,
+    coroutineDispatcher: TestDispatcher = defaultTestDispatcher(),
 ) : ComposeUiTest {
     init {
         require(effectContext == EmptyCoroutineContext) {
@@ -130,7 +141,7 @@ class SkikoComposeUiTest @InternalTestApi constructor(
         height = height,
         effectContext = effectContext,
         density = density,
-        semanticsOwnerListener = null
+        semanticsOwnerListener = null,
     )
 
     private class Session(
@@ -141,8 +152,6 @@ class SkikoComposeUiTest @InternalTestApi constructor(
 
     private val composeRootRegistry = ComposeRootRegistry()
 
-    @InternalTestApi
-    val coroutineDispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(coroutineDispatcher)
     override val mainClock: MainTestClock = MainTestClockImpl(
         testScheduler = coroutineDispatcher.scheduler,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.test.defaultTestDispatcher
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runInternalSkikoComposeUiTest
 import androidx.compose.ui.toDpSize
@@ -238,11 +239,13 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
         semanticsOwnerListener.accessibilityControllers
     }
 
+    val testDispatcher = defaultTestDispatcher()
     runInternalSkikoComposeUiTest(
-        semanticsOwnerListener = semanticsOwnerListener
+        semanticsOwnerListener = semanticsOwnerListener,
+        coroutineDispatcher = testDispatcher
     ) {
         semanticsOwnerListener.accessibilityControllers.forEach {
-            it.launchSyncLoop(coroutineDispatcher)
+            it.launchSyncLoop(testDispatcher)
         }
 
         val scope = ComposeA11yTestScope(


### PR DESCRIPTION
Allow specifying a test coroutine dispatcher for `SkikoComposeUiTest` instead of exposing its own.

Per discussion with Igor, we decided it was better to pass the test coroutine dispatcher into `SkikoComposeUiTest` rather than having it expose its own.

Note that it turns out that there is no need to save it as a property after the `SkikoComposeUiTest` object has been created.

## Testing

Test: AccessibilityTest(s)
