### PR TITLE
Listen to browser clipboard events and bind them with Compose TextFieldSelectionManager and SelectionManager

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.kt
@@ -19,11 +19,9 @@ package androidx.compose.foundation.text
 import androidx.compose.runtime.Composable
 
 @Composable
-internal actual inline fun rememberClipboardEventsHandler(
-    crossinline onPaste: (String) -> Unit,
-    crossinline onCopy: () -> String?,
-    crossinline onCut: () -> String?,
+internal expect inline fun rememberClipboardEventsHandler(
+    crossinline onPaste: (String) -> Unit = {},
+    crossinline onCopy: () -> String? = { null },
+    crossinline onCut: () -> String? = { null },
     isEnabled: Boolean
-) {
-    // nothing to do
-}
+)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -304,6 +304,8 @@ internal fun CoreTextField(
     val coroutineScope = rememberCoroutineScope()
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
 
+    rememberClipboardEventsHandler(manager, state.hasFocus)
+
     // Focus
     val focusModifier = Modifier.textFieldFocusModifier(
         enabled = enabled,
@@ -1191,3 +1193,9 @@ private fun notifyFocusedRect(
 internal const val USE_WINDOW_FOCUS_ENABLED = false
 internal fun isWindowFocusedBehindFlag(windowInfo: WindowInfo) =
     if (USE_WINDOW_FOCUS_ENABLED) windowInfo.isWindowFocused else true
+
+@Composable
+internal expect inline fun rememberClipboardEventsHandler(
+    textFieldSelectionManager: TextFieldSelectionManager,
+    isFocused: Boolean
+)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -33,9 +33,7 @@ import androidx.compose.foundation.text.selection.SimpleLayout
 import androidx.compose.foundation.text.selection.TextFieldSelectionHandle
 import androidx.compose.foundation.text.selection.TextFieldSelectionManager
 import androidx.compose.foundation.text.selection.isSelectionHandleInVisibleBound
-import androidx.compose.foundation.text.selection.selectionGestureInput
 import androidx.compose.foundation.text.selection.textFieldMagnifier
-import androidx.compose.foundation.text.selection.updateSelectionTouchMode
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -63,7 +61,6 @@ import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.layout.IntrinsicMeasurable
@@ -304,7 +301,12 @@ internal fun CoreTextField(
     val coroutineScope = rememberCoroutineScope()
     val bringIntoViewRequester = remember { BringIntoViewRequester() }
 
-    rememberClipboardEventsHandler(manager, state.hasFocus)
+    rememberClipboardEventsHandler(
+        isEnabled = state.hasFocus,
+        onCopy = { manager.onCopyWithResult() },
+        onCut = { manager.onCutWithResult() },
+        onPaste = { manager.paste(AnnotatedString(it)) }
+    )
 
     // Focus
     val focusModifier = Modifier.textFieldFocusModifier(
@@ -1193,9 +1195,3 @@ private fun notifyFocusedRect(
 internal const val USE_WINDOW_FOCUS_ENABLED = false
 internal fun isWindowFocusedBehindFlag(windowInfo: WindowInfo) =
     if (USE_WINDOW_FOCUS_ENABLED) windowInfo.isWindowFocused else true
-
-@Composable
-internal expect inline fun rememberClipboardEventsHandler(
-    textFieldSelectionManager: TextFieldSelectionManager,
-    isFocused: Boolean
-)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
@@ -18,6 +18,7 @@ package androidx.compose.foundation.text.selection
 
 import androidx.compose.foundation.text.ContextMenuArea
 import androidx.compose.foundation.text.detectDownAndDragGesturesWithObserver
+import androidx.compose.foundation.text.rememberClipboardEventsHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
@@ -94,6 +95,11 @@ internal fun SelectionContainer(
     manager.textToolbar = LocalTextToolbar.current
     manager.onSelectionChange = onSelectionChange
     manager.selection = selection
+
+    rememberClipboardEventsHandler(
+        onCopy = { manager.getSelectedText()?.text },
+        isEnabled = manager.isNonEmptySelection()
+    )
 
     ContextMenuArea(manager) {
         CompositionLocalProvider(LocalSelectionRegistrar provides registrarImpl) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -162,7 +162,7 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
             .focusable()
             .updateSelectionTouchMode { isInTouchMode = it }
             .onKeyEvent {
-                if (isCopyKeyEvent(it)) {
+                if (!skipCopyKeyEvent && isCopyKeyEvent(it)) {
                     copy()
                     true
                 } else {
@@ -1028,3 +1028,7 @@ private suspend fun AwaitPointerEventScope.awaitPointerEventWhereAllChanges(
     pass: PointerEventPass = PointerEventPass.Main,
     predicate: (PointerInputChange) -> Boolean,
 ) = awaitPointerEvent(pass).takeIf { it.changes.fastAll(predicate) }
+
+
+// We skip `isCopyKeyEvent(it)` on web, because should handle browser 'copy' event
+internal expect val SelectionManager.skipCopyKeyEvent: Boolean

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
@@ -16,57 +16,56 @@
 
 package androidx.compose.foundation.text
 
-import androidx.compose.foundation.text.selection.TextFieldSelectionManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.NonRestartableComposable
-import androidx.compose.ui.text.AnnotatedString
 import kotlinx.browser.document
 import org.w3c.dom.clipboard.ClipboardEvent
-import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventListener
 
 @Composable
 @NonRestartableComposable
 internal actual inline fun rememberClipboardEventsHandler(
-    textFieldSelectionManager: TextFieldSelectionManager,
-    isFocused: Boolean
+    crossinline onPaste: (String) -> Unit,
+    crossinline onCopy: () -> String?,
+    crossinline onCut: () -> String?,
+    isEnabled: Boolean
 ) {
-    if (isFocused) {
-        DisposableEffect(textFieldSelectionManager) {
+    if (isEnabled) {
+        DisposableEffect(Unit) {
 
-            val onCopy = EventListener { event ->
-                val textToCopy = textFieldSelectionManager.onCopyWithResult()
+            val copyListener = EventListener { event ->
+                val textToCopy = onCopy()
                 if (textToCopy != null && event is ClipboardEvent) {
                     event.clipboardData?.setData("text/plain", textToCopy)
                     event.preventDefault()
                 }
             }
 
-            val onPaste = EventListener { event ->
+            val pasteListener = EventListener { event ->
                 if (event is ClipboardEvent) {
                     val textToPaste = event.clipboardData?.getData("text/plain") ?: ""
-                    event.preventDefault()
-                    textFieldSelectionManager.paste(AnnotatedString(textToPaste))
-                }
-            }
-
-            val onCut = EventListener { event ->
-                if (event is ClipboardEvent) {
-                    val cutText = textFieldSelectionManager.onCutWithResult()
-                    event.clipboardData?.setData("text/plain", cutText ?: "")
+                    onPaste(textToPaste)
                     event.preventDefault()
                 }
             }
 
-            document.addEventListener("copy", onCopy)
-            document.addEventListener("paste", onPaste)
-            document.addEventListener("cut", onCut)
+            val cutListener = EventListener { event ->
+                val cutText = onCut()
+                if (cutText != null && event is ClipboardEvent) {
+                    event.clipboardData?.setData("text/plain", cutText)
+                    event.preventDefault()
+                }
+            }
+
+            document.addEventListener("copy", copyListener)
+            document.addEventListener("paste", pasteListener)
+            document.addEventListener("cut", cutListener)
 
             onDispose {
-                document.removeEventListener("copy", onCopy)
-                document.removeEventListener("paste", onPaste)
-                document.removeEventListener("cut", onCut)
+                document.removeEventListener("copy", copyListener)
+                document.removeEventListener("paste", pasteListener)
+                document.removeEventListener("cut", cutListener)
             }
         }
     }

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
@@ -35,7 +35,7 @@ internal actual inline fun rememberClipboardEventsHandler(
     if (isFocused) {
         DisposableEffect(textFieldSelectionManager) {
 
-            val onCopy = EventListenerWrapper { event ->
+            val onCopy = EventListener { event ->
                 val textToCopy = textFieldSelectionManager.onCopyWithResult()
                 if (textToCopy != null && event is ClipboardEvent) {
                     event.clipboardData?.setData("text/plain", textToCopy)
@@ -43,7 +43,7 @@ internal actual inline fun rememberClipboardEventsHandler(
                 }
             }
 
-            val onPaste = EventListenerWrapper { event ->
+            val onPaste = EventListener { event ->
                 if (event is ClipboardEvent) {
                     val textToPaste = event.clipboardData?.getData("text/plain") ?: ""
                     event.preventDefault()
@@ -51,7 +51,7 @@ internal actual inline fun rememberClipboardEventsHandler(
                 }
             }
 
-            val onCut = EventListenerWrapper { event ->
+            val onCut = EventListener { event ->
                 if (event is ClipboardEvent) {
                     val cutText = textFieldSelectionManager.onCutWithResult()
                     event.clipboardData?.setData("text/plain", cutText ?: "")
@@ -63,7 +63,7 @@ internal actual inline fun rememberClipboardEventsHandler(
             document.addEventListener("paste", onPaste)
             document.addEventListener("cut", onCut)
 
-            return@DisposableEffect onDispose {
+            onDispose {
                 document.removeEventListener("copy", onCopy)
                 document.removeEventListener("paste", onPaste)
                 document.removeEventListener("cut", onCut)
@@ -71,6 +71,3 @@ internal actual inline fun rememberClipboardEventsHandler(
         }
     }
 }
-
-private fun EventListenerWrapper(handler: (Event) -> Unit): EventListener =
-    EventListener { handler(it) }

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.text.selection.TextFieldSelectionManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.browser.document
+import org.w3c.dom.clipboard.ClipboardEvent
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventListener
+
+@Composable
+@NonRestartableComposable
+internal actual inline fun rememberClipboardEventsHandler(
+    textFieldSelectionManager: TextFieldSelectionManager,
+    isFocused: Boolean
+) {
+    if (isFocused) {
+        DisposableEffect(textFieldSelectionManager) {
+
+            val onCopy = EventListenerWrapper { event ->
+                val textToCopy = textFieldSelectionManager.onCopyWithResult()
+                if (textToCopy != null && event is ClipboardEvent) {
+                    event.clipboardData?.setData("text/plain", textToCopy)
+                    event.preventDefault()
+                }
+            }
+
+            val onPaste = EventListenerWrapper { event ->
+                if (event is ClipboardEvent) {
+                    val textToPaste = event.clipboardData?.getData("text/plain") ?: ""
+                    event.preventDefault()
+                    textFieldSelectionManager.paste(AnnotatedString(textToPaste))
+                }
+            }
+
+            val onCut = EventListenerWrapper { event ->
+                if (event is ClipboardEvent) {
+                    val cutText = textFieldSelectionManager.onCutWithResult()
+                    event.clipboardData?.setData("text/plain", cutText ?: "")
+                    event.preventDefault()
+                }
+            }
+
+            document.addEventListener("copy", onCopy)
+            document.addEventListener("paste", onPaste)
+            document.addEventListener("cut", onCut)
+
+            return@DisposableEffect onDispose {
+                document.removeEventListener("copy", onCopy)
+                document.removeEventListener("paste", onPaste)
+                document.removeEventListener("cut", onCut)
+            }
+        }
+    }
+}
+
+private fun EventListenerWrapper(handler: (Event) -> Unit): EventListener =
+    EventListener { handler(it) }

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
@@ -16,14 +16,31 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 
 internal actual val platformDefaultKeyMapping: KeyMapping = createPlatformDefaultKeyMapping(hostOs)
 
 internal fun createPlatformDefaultKeyMapping(platform: OS): KeyMapping {
-    return when (platform) {
+    val keyMapping = when (platform) {
         OS.MacOS -> createMacosDefaultKeyMapping()
         else -> defaultKeyMapping
+    }
+    return object : KeyMapping {
+        private val clipboardKeys = setOf(Key.C, Key.V, Key.X)
+
+        override fun map(event: KeyEvent): KeyCommand? {
+            val isCtrlOrCmd = if (hostOs.isMacOS) event.isMetaPressed else event.isCtrlPressed
+            if (isCtrlOrCmd && event.key in clipboardKeys) {
+                // we let a browser dispatch a clipboard event
+                return null
+            }
+            return keyMapping.map(event)
+        }
     }
 }

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.web.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.web.kt
@@ -41,3 +41,6 @@ internal actual fun isCopyKeyEvent(keyEvent: KeyEvent): Boolean {
  */
 internal actual fun Modifier.selectionMagnifier(manager: SelectionManager): Modifier =
     TODO("implement js selectionMagnifier")
+
+internal actual val SelectionManager.skipCopyKeyEvent: Boolean
+    get() = true

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/Actuals.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/Actuals.jvm.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.text.selection.TextFieldSelectionManager
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual inline fun rememberClipboardEventsHandler(
+    textFieldSelectionManager: TextFieldSelectionManager,
+    isFocused: Boolean
+) {
+    // nothing to do
+}

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.jvm.kt
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation.text
+package androidx.compose.foundation.text.selection
 
-import androidx.compose.runtime.Composable
-
-@Composable
-internal actual inline fun rememberClipboardEventsHandler(
-    crossinline onPaste: (String) -> Unit,
-    crossinline onCopy: () -> String?,
-    crossinline onCut: () -> String?,
-    isEnabled: Boolean
-) {
-    // nothing to do
-}
+internal actual val SelectionManager.skipCopyKeyEvent: Boolean
+    get() = false

--- a/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/Actuals.native.kt
+++ b/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/Actuals.native.kt
@@ -16,13 +16,14 @@
 
 package androidx.compose.foundation.text
 
-import androidx.compose.foundation.text.selection.TextFieldSelectionManager
 import androidx.compose.runtime.Composable
 
 @Composable
 internal actual inline fun rememberClipboardEventsHandler(
-    textFieldSelectionManager: TextFieldSelectionManager,
-    isFocused: Boolean
+    crossinline onPaste: (String) -> Unit,
+    crossinline onCopy: () -> String?,
+    crossinline onCut: () -> String?,
+    isEnabled: Boolean
 ) {
     // nothing to do
 }

--- a/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/Actuals.native.kt
+++ b/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/Actuals.native.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.text.selection.TextFieldSelectionManager
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual inline fun rememberClipboardEventsHandler(
+    textFieldSelectionManager: TextFieldSelectionManager,
+    isFocused: Boolean
+) {
+    // nothing to do
+}

--- a/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.native.kt
+++ b/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.native.kt
@@ -14,16 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation.text
+package androidx.compose.foundation.text.selection
 
-import androidx.compose.runtime.Composable
-
-@Composable
-internal actual inline fun rememberClipboardEventsHandler(
-    crossinline onPaste: (String) -> Unit,
-    crossinline onCopy: () -> String?,
-    crossinline onCut: () -> String?,
-    isEnabled: Boolean
-) {
-    // nothing to do
-}
+internal actual val SelectionManager.skipCopyKeyEvent: Boolean
+    get() = false

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.wasm.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.text.selection.TextFieldSelectionManager
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.browser.document
+import org.w3c.dom.clipboard.ClipboardEvent
+import org.w3c.dom.events.Event
+import org.w3c.dom.events.EventListener
+
+@Composable
+@NonRestartableComposable
+internal actual inline fun rememberClipboardEventsHandler(
+    textFieldSelectionManager: TextFieldSelectionManager,
+    isFocused: Boolean
+) {
+    if (isFocused) {
+        DisposableEffect(textFieldSelectionManager) {
+
+            val onCopy = EventListenerWrapper { event ->
+                val textToCopy = textFieldSelectionManager.onCopyWithResult()
+                if (textToCopy != null && event is ClipboardEvent) {
+                    event.clipboardData?.setData("text/plain", textToCopy)
+                    event.preventDefault()
+                }
+            }
+
+            val onPaste = EventListenerWrapper { event ->
+                if (event is ClipboardEvent) {
+                    val textToPaste = event.clipboardData?.getData("text/plain") ?: ""
+                    event.preventDefault()
+                    textFieldSelectionManager.paste(AnnotatedString(textToPaste))
+                }
+            }
+
+            val onCut = EventListenerWrapper { event ->
+                if (event is ClipboardEvent) {
+                    val cutText = textFieldSelectionManager.onCutWithResult()
+                    event.clipboardData?.setData("text/plain", cutText ?: "")
+                    event.preventDefault()
+                }
+            }
+
+            document.addEventListener("copy", onCopy)
+            document.addEventListener("paste", onPaste)
+            document.addEventListener("cut", onCut)
+
+            return@DisposableEffect onDispose {
+                document.removeEventListener("copy", onCopy)
+                document.removeEventListener("paste", onPaste)
+                document.removeEventListener("cut", onCut)
+            }
+        }
+    }
+}
+
+private fun EventListenerWrapper(handler: (Event) -> Unit): EventListener =
+    js("(event) => { handler(event) }")

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.wasm.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.AnnotatedString
 import kotlinx.browser.document
 import org.w3c.dom.clipboard.ClipboardEvent
 import org.w3c.dom.events.Event
-import org.w3c.dom.events.EventListener
+import org.w3c.dom.events.EventListener as EventListenerInterface
 
 @Composable
 @NonRestartableComposable
@@ -35,7 +35,7 @@ internal actual inline fun rememberClipboardEventsHandler(
     if (isFocused) {
         DisposableEffect(textFieldSelectionManager) {
 
-            val onCopy = EventListenerWrapper { event ->
+            val onCopy = EventListener { event ->
                 val textToCopy = textFieldSelectionManager.onCopyWithResult()
                 if (textToCopy != null && event is ClipboardEvent) {
                     event.clipboardData?.setData("text/plain", textToCopy)
@@ -43,7 +43,7 @@ internal actual inline fun rememberClipboardEventsHandler(
                 }
             }
 
-            val onPaste = EventListenerWrapper { event ->
+            val onPaste = EventListener { event ->
                 if (event is ClipboardEvent) {
                     val textToPaste = event.clipboardData?.getData("text/plain") ?: ""
                     event.preventDefault()
@@ -51,7 +51,7 @@ internal actual inline fun rememberClipboardEventsHandler(
                 }
             }
 
-            val onCut = EventListenerWrapper { event ->
+            val onCut = EventListener { event ->
                 if (event is ClipboardEvent) {
                     val cutText = textFieldSelectionManager.onCutWithResult()
                     event.clipboardData?.setData("text/plain", cutText ?: "")
@@ -63,7 +63,7 @@ internal actual inline fun rememberClipboardEventsHandler(
             document.addEventListener("paste", onPaste)
             document.addEventListener("cut", onCut)
 
-            return@DisposableEffect onDispose {
+            onDispose {
                 document.removeEventListener("copy", onCopy)
                 document.removeEventListener("paste", onPaste)
                 document.removeEventListener("cut", onCut)
@@ -72,5 +72,5 @@ internal actual inline fun rememberClipboardEventsHandler(
     }
 }
 
-private fun EventListenerWrapper(handler: (Event) -> Unit): EventListener =
+private fun EventListener(handler: (Event) -> Unit): EventListenerInterface =
     js("(event) => { handler(event) }")

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -46,6 +46,9 @@ import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.jetbrains.skiko.SkiaLayer
+import org.jetbrains.skiko.SkikoInputModifiers
+import org.jetbrains.skiko.SkikoKey
+import org.jetbrains.skiko.SkikoKeyboardEvent
 import org.jetbrains.skiko.SkikoKeyboardEventKind
 import org.jetbrains.skiko.SkikoPointerEventKind
 import org.w3c.dom.AddEventListenerOptions
@@ -219,7 +222,13 @@ private class ComposeWindow(
             event.preventDefault()
         })
 
+        val setOfClipboardKeys = setOf(SkikoKey.KEY_V, SkikoKey.KEY_C, SkikoKey.KEY_X)
         addTypedEvent<KeyboardEvent>("keydown") { event ->
+            val skikoEvent: SkikoKeyboardEvent = event.toSkikoEvent(SkikoKeyboardEventKind.DOWN)
+            if (skikoEvent.key in setOfClipboardKeys && skikoEvent.modifiers != SkikoInputModifiers.EMPTY) {
+                // we let a browser dispatch a clipboard event
+                return@addTypedEvent
+            }
             val processed = layer.view.onKeyboardEventWithResult(event.toSkikoEvent(SkikoKeyboardEventKind.DOWN))
             if (processed) event.preventDefault()
         }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.js.kt
@@ -222,13 +222,7 @@ private class ComposeWindow(
             event.preventDefault()
         })
 
-        val setOfClipboardKeys = setOf(SkikoKey.KEY_V, SkikoKey.KEY_C, SkikoKey.KEY_X)
         addTypedEvent<KeyboardEvent>("keydown") { event ->
-            val skikoEvent: SkikoKeyboardEvent = event.toSkikoEvent(SkikoKeyboardEventKind.DOWN)
-            if (skikoEvent.key in setOfClipboardKeys && skikoEvent.modifiers != SkikoInputModifiers.EMPTY) {
-                // we let a browser dispatch a clipboard event
-                return@addTypedEvent
-            }
             val processed = layer.view.onKeyboardEventWithResult(event.toSkikoEvent(SkikoKeyboardEventKind.DOWN))
             if (processed) event.preventDefault()
         }


### PR DESCRIPTION
**Notes:** 
I had to almost copy/paste the code for k/js and k/wasm because of k/wasm-js and k/js-js interop differences. The function is not too big, so I consider it as a compromise. 

**Test in mpp:demo:**
- Components -> Selection : select some text and press Cmd + C or Ctrl + C, try to paste it then somewhere
- Components -> TextFields -> Almost FullScreen: Try all cobminations


