### PR TITLE
reuploadArtifactsToMavenCentral. Read requestedGroupId from Gradle properties

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -208,7 +208,7 @@ val preparedArtifactsRoot = publishingDir.map { it.dir("prepared") }
 val modulesFile = publishingDir.map { it.file("modules.txt") }
 
 val findComposeModules by tasks.registering(FindModulesInSpaceTask::class) {
-    requestedGroupId.set("org.jetbrains.compose")
+    requestedGroupId.set(project.providers.gradleProperty("maven.central.group"))
     requestedVersion.set(mavenCentral.version)
     spaceInstanceUrl.set("https://public.jetbrains.space")
     spaceClientId.set(System.getenv("COMPOSE_REPO_USERNAME") ?: "")


### PR DESCRIPTION
It is passed by CI this way now:
```
fun BuildSteps.uploadFromMavenSpaceToMavenCentral(
    group: String,
    version: String
) {
            ...
            ./gradlew reuploadArtifactsToMavenCentral --info --stacktrace -Pmaven.central.sign=true -Pmaven.central.group=$group -Pmaven.central.version=$version -Pmaven.central.staging.close.after.upload=true
            ...
    }
}
```
- `-Pmaven.central.group` is added
- `-Pmaven.central.version` was there and it is read [here](https://github.com/JetBrains/compose-multiplatform/blob/7d20ee38f2bed0d3a13df1239fc5dc0d23bfa77a/build-helpers/publishing/src/main/kotlin/org/jetbrains/compose/internal/publishing/MavenCentralProperties.kt#L14)

It is needed for new lifecycle libraries (orj.jetbrains.androidx.lifecycle)