### PR TITLE
Fix maven publication

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -204,6 +204,7 @@ tasks.register("testComposeModules") { // used in https://github.com/JetBrains/a
 }
 
 val mavenCentral = MavenCentralProperties(project)
+val mavenCentralGroup = project.providers.gradleProperty("maven.central.group")
 if (mavenCentral.signArtifacts) {
     signing.useInMemoryPgpKeys(
         mavenCentral.signArtifactsKey.get(),
@@ -217,7 +218,7 @@ val preparedArtifactsRoot = publishingDir.map { it.dir("prepared") }
 val modulesFile = publishingDir.map { it.file("modules.txt") }
 
 val findComposeModules by tasks.registering(FindModulesInSpaceTask::class) {
-    requestedGroupId.set(project.providers.gradleProperty("maven.central.group"))
+    requestedGroupId.set(mavenCentralGroup)
     requestedVersion.set(mavenCentral.version)
     spaceInstanceUrl.set("https://public.jetbrains.space")
     spaceClientId.set(System.getenv("COMPOSE_REPO_USERNAME") ?: "")
@@ -254,7 +255,7 @@ val reuploadArtifactsToMavenCentral by tasks.registering(UploadToSonatypeTask::c
     user.set(mavenCentral.user)
     password.set(mavenCentral.password)
     autoCommitOnSuccess.set(mavenCentral.autoCommitOnSuccess)
-    stagingProfileName.set("org.jetbrains.compose")
+    stagingProfileName.set(mavenCentralGroup)
 }
 
 fun readComposeModules(


### PR DESCRIPTION
Fixes:
```
Execution failed for task ':mpp:reuploadArtifactsToMavenCentral'.
> Some modules violate Maven Central requirements:
  * org.jetbrains.androidx.core:core-bundle:1.0.0-dev1549 (files: /mnt/agent/work/8a20760945d0aeba/out/androidx/mpp/build/publishing/prepared/org.jetbrains.androidx.core/core-bundle/1.0.0-dev1549)
    * Module's group id 'org.jetbrains.androidx.core' does not match staging repo 'org.jetbrains.compose'
```

https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_Task5UploadToMavenCentral/4548100?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildProblemsSection=true