### PR TITLE
Fix 2 crashing bugs in basic string processing for BasicTextField2

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text2/input/internal/GapBuffer.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text2/input/internal/GapBuffer.kt
@@ -182,8 +182,8 @@ private class GapBuffer(initBuffer: CharArray, initGapStart: Int, initGapEnd: In
      * @param builder The output string builder
      */
     fun append(builder: StringBuilder) {
-        builder.appendRange(buffer, 0, gapStart)
-        builder.appendRange(buffer, gapEnd, capacity - gapEnd)
+        builder.appendRange(buffer, startIndex = 0, endIndex = gapStart)
+        builder.appendRange(value = buffer, startIndex = gapEnd, endIndex = capacity)
     }
 
     /**

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text2/input/internal/ToCharArray.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text2/input/internal/ToCharArray.skiko.kt
@@ -36,13 +36,14 @@ internal actual fun CharSequence.toCharArray(
             endIndex
         )
         else -> {
-            require(startIndex in indices && endIndex in 0..length) {
+            rangeCheck(start = startIndex, end = endIndex, length = length) {
                 "Expected source [$startIndex, $endIndex) to be in [0, $length)"
             }
             val copyLength = endIndex - startIndex
-            require(
-                destinationOffset in destination.indices &&
-                    destinationOffset + copyLength in 0..destination.size
+            rangeCheck(
+                start = destinationOffset,
+                end = destinationOffset + copyLength,
+                length = destination.size
             ) {
                 "Expected destination [$destinationOffset, ${destinationOffset + copyLength}) " +
                     "to be in [0, ${destination.size})"
@@ -53,4 +54,8 @@ internal actual fun CharSequence.toCharArray(
             }
         }
     }
+}
+
+private inline fun rangeCheck(start: Int, end: Int, length: Int, lazyMessage: () -> String) {
+    require((start >= 0) && (start <= end) && (end <= length), lazyMessage)
 }


### PR DESCRIPTION
- `CharSequence.toCharArray` had a bad range check and was crashing on an empty string.
- `GapBuffer.append` was calling `StringBuilder.appendRange` passing length in the 3rd argument, but the expected value is endIndex.

## Testing

Test: Manually.