### PR TITLE
Fixed multiple examples in androidx.compose.ui.window for desktop target

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -71,7 +71,7 @@ import kotlin.system.exitProcess
  *
  * ```
  * fun main() = application {
- *     val isSplashScreenShowing by remember { mutableStateOf(true) }
+ *     var isSplashScreenShowing by remember { mutableStateOf(true) }
  *
  *     LaunchedEffect(Unit) {
  *         delay(2000)
@@ -79,9 +79,9 @@ import kotlin.system.exitProcess
  *     }
  *
  *     if (isSplashScreenShowing) {
- *         Window(title = "Splash") {}
+ *         Window(::exitApplication, title = "Splash") {}
  *     } else {
- *         Window(title = "App") {}
+ *         Window(::exitApplication, title = "App") {}
  *     }
  * }
  * ```
@@ -163,7 +163,7 @@ fun CoroutineScope.launchApplication(
  * ```
  * fun main() = runBlocking {
  *     awaitApplication {
- *         val isSplashScreenShowing by remember { mutableStateOf(true) }
+ *         var isSplashScreenShowing by remember { mutableStateOf(true) }
  *
  *         LaunchedEffect(Unit) {
  *             delay(2000)
@@ -171,9 +171,9 @@ fun CoroutineScope.launchApplication(
  *         }
  *
  *         if (isSplashScreenShowing) {
- *             Window(title = "Splash") {}
+ *             Window(::exitApplication, title = "Splash") {}
  *         } else {
- *             Window(title = "App") {}
+ *             Window(::exitApplication, title = "App") {}
  *         }
  *     }
  * }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -132,9 +132,9 @@ fun DialogWindow(
  * ```
  * @Composable
  * fun main() = application {
- *     val isDialogOpen by remember { mutableStateOf(true) }
+ *     var isDialogOpen by remember { mutableStateOf(true) }
  *     if (isDialogOpen) {
- *         Dialog(onCloseRequest = { isDialogOpen = false })
+ *         Dialog(onCloseRequest = { isDialogOpen = false }) {}
  *     }
  * }
  * ```

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -63,16 +63,16 @@ import javax.swing.JMenuBar
  * windows and stop all effects defined in [application]):
  * ```
  * fun main() = application {
- *     Window(onCloseRequest = ::exitApplication)
+ *     Window(onCloseRequest = ::exitApplication) {}
  * }
  * ```
  *
  * or if it only needed to close the main window without closing all other opened windows:
  * ```
  * fun main() = application {
- *     val isOpen by remember { mutableStateOf(true) }
+ *     var isOpen by remember { mutableStateOf(true) }
  *     if (isOpen) {
- *         Window(onCloseRequest = { isOpen = false })
+ *         Window(onCloseRequest = { isOpen = false }) {}
  *     }
  * }
  * ```


### PR DESCRIPTION
As reported in https://github.com/JetBrains/compose-multiplatform/issues/4553

I first saw the incorrect modification of a `val` in the `application` function documentation, then, upon further inspection and accidentally opening the wrong file in the same package, found multiple instances of non-compiling code in examples.
