### PR TITLE
Don't crash, and allow selection in SelectionContainer to start when drag starts below the bounds of the visible text

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/MultiWidgetSelectionDelegate.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/MultiWidgetSelectionDelegate.kt
@@ -217,8 +217,8 @@ internal fun SelectionLayoutBuilder.appendSelectableInfo(
     val bounds = Rect(
         0.0f,
         0.0f,
-        textLayoutResult.multiParagraph.width.toFloat(),
-        textLayoutResult.multiParagraph.height.toFloat()
+        textLayoutResult.size.width.toFloat(),
+        textLayoutResult.size.height.toFloat()
     )
 
     val currentXDirection = getXDirection(localPosition, bounds)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.dragAndDrop
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalTestApi::class)
+class SelectionContainerTest {
+    @Test
+    fun selectionWorksWhenDraggingFromBelowText() = runComposeUiTest {
+        var selection by mutableStateOf<Selection?>(null)
+        val text = "Line 1\nLine2"
+        setContent {
+            SelectionContainer(
+                modifier = Modifier.size(500.dp).testTag("selection_container"),
+                selection = selection,
+                onSelectionChange = {
+                    selection = it
+                }
+            ) {
+                BasicText(
+                    text = text,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+
+        onNodeWithTag("selection_container").performMouseInput {
+            dragAndDrop(
+                start = Offset(250f, 499f),
+                end = Offset.Zero
+            )
+        }
+
+        assertEquals(
+            expected = TextRange(text.length, 0),
+            actual = selection?.toTextRange()
+        )
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerUiTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerUiTest.kt
@@ -38,7 +38,7 @@ import kotlin.test.assertEquals
  * is that [PointerIconService] is needed for some of the tests, and it is internal in `ui`.
  */
 @OptIn(ExperimentalTestApi::class)
-class SelectionContainerTest {
+class SelectionContainerUiTest {
     @Test
     fun selectionContainerSetsTextPointerIcon() = runComposeUiTest {
         lateinit var pointerIconService: PointerIconService


### PR DESCRIPTION
See the explanation for this change [here](https://github.com/JetBrains/compose-multiplatform/issues/4555#issuecomment-2027508735).

## Proposed Changes
Use `textLayoutResult.size` rather than `textLayoutResult.multiParagraph` when determining the text bounds for starting the selection in `SelectionContainer`. This is how Android does it.


## Testing

Test: Tested manually, and added a new unit test.
This PR should be verified by QA.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4555
