### PR TITLE
Add transactions to FocusOwnerImpl takeFocus and releaseFocus to prevent crash when a window is re-shown

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOwnerImpl.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOwnerImpl.kt
@@ -104,7 +104,7 @@ internal class FocusOwnerImpl(
      * focus to one of the focus modifiers in the component hierarchy.
      */
     override fun takeFocus() {
-        return focusTransactionManager.withExistingTransaction {
+        return focusTransactionManager.withExistingTransaction {  // cherry-picked from 8f81d46e
             // If the focus state is not Inactive, it indicates that the focus state is already
             // set (possibly by dispatchWindowFocusChanged). So we don't update the state.
             if (rootFocusNode.focusState == Inactive) {
@@ -122,7 +122,7 @@ internal class FocusOwnerImpl(
      * all the focus modifiers in the component hierarchy.
      */
     override fun releaseFocus() {
-        focusTransactionManager.withExistingTransaction {
+        focusTransactionManager.withExistingTransaction {  // cherry-picked from 8f81d46e
             rootFocusNode.clearFocus(forced = true, refreshFocusEvents = true)
         }
     }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOwnerImpl.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/focus/FocusOwnerImpl.kt
@@ -104,12 +104,14 @@ internal class FocusOwnerImpl(
      * focus to one of the focus modifiers in the component hierarchy.
      */
     override fun takeFocus() {
-        // If the focus state is not Inactive, it indicates that the focus state is already
-        // set (possibly by dispatchWindowFocusChanged). So we don't update the state.
-        if (rootFocusNode.focusState == Inactive) {
-            rootFocusNode.focusState = Active
-            // TODO(b/152535715): propagate focus to children based on child focusability.
-            //  moveFocus(FocusDirection.Enter)
+        return focusTransactionManager.withExistingTransaction {
+            // If the focus state is not Inactive, it indicates that the focus state is already
+            // set (possibly by dispatchWindowFocusChanged). So we don't update the state.
+            if (rootFocusNode.focusState == Inactive) {
+                rootFocusNode.focusState = Active
+                // TODO(b/152535715): propagate focus to children based on child focusability.
+                //  moveFocus(FocusDirection.Enter)
+            }
         }
     }
 
@@ -120,7 +122,9 @@ internal class FocusOwnerImpl(
      * all the focus modifiers in the component hierarchy.
      */
     override fun releaseFocus() {
-        rootFocusNode.clearFocus(forced = true, refreshFocusEvents = true)
+        focusTransactionManager.withExistingTransaction {
+            rootFocusNode.clearFocus(forced = true, refreshFocusEvents = true)
+        }
     }
 
     /**


### PR DESCRIPTION
When a window becomes hidden and visible again, we call `FocusOwnerImpl.takeFocus` and `FocusOwnerImpl.releaseFocus`. These functions are not currently wrapped in a transaction, which causes these calls to remain uncommitted. If the nodes on which focus was requested/released then become detached, the following transaction will crash attempting to commit.

## Proposed Changes
Wrap `FocusOwnerImpl.takeFocus` and `FocusOwnerImpl.releaseFocus` with a transaction.

## Testing

Test: Tested manually with this reproducer:

```
import androidx.compose.material.*
import androidx.compose.runtime.*
import androidx.compose.ui.*
import androidx.compose.ui.focus.FocusRequester
import androidx.compose.ui.focus.focusRequester
import androidx.compose.ui.window.*
import kotlinx.coroutines.delay

fun main() = application {
    var windowVisible by remember { mutableStateOf(true) }
    var showUi1 by remember { mutableStateOf(true) }
    Window(
        onCloseRequest = {},
        visible = windowVisible
    ) {
        if (showUi1) {
            val focusRequester = remember { FocusRequester() }
            TextField(value = "", onValueChange = {}, Modifier.focusRequester(focusRequester))
            LaunchedEffect(Unit) {
                focusRequester.requestFocus()
            }
        }
        else {
            val focusRequester = remember { FocusRequester() }
            TextField(value = "", onValueChange = {}, Modifier.focusRequester(focusRequester))
            LaunchedEffect(Unit) {
                focusRequester.requestFocus()
            }
        }
    }

    LaunchedEffect(Unit) {
        delay(2000)
        windowVisible = false
        delay(2000)
        showUi1 = false
        windowVisible = true
    }
}
```

This PR should be verified by QA.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4552
