### PR TITLE
Propagate composition locals to layers in the (re)composition phase

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -19,12 +19,9 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.currentCompositionLocalContext
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -172,27 +169,24 @@ internal fun rememberComposeSceneLayer(
     val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val parentComposition = rememberCompositionContext()
-    val compositionLocalContext by rememberUpdatedState(currentCompositionLocalContext)
+    val compositionLocalContext = currentCompositionLocalContext
     val layer = remember {
         scene.createLayer(
             density = density,
             layoutDirection = layoutDirection,
             focusable = focusable,
             compositionContext = parentComposition,
-        ).also {
-            it.compositionLocalContext = compositionLocalContext
-        }
+        )
     }
     layer.focusable = focusable
+    layer.compositionLocalContext = compositionLocalContext
+    layer.density = density
+    layer.layoutDirection = layoutDirection
+
     DisposableEffect(Unit) {
         onDispose {
             layer.close()
         }
-    }
-    SideEffect {
-        layer.density = density
-        layer.layoutDirection = layoutDirection
-        layer.compositionLocalContext = compositionLocalContext
     }
     return layer
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -516,7 +516,13 @@ private class MultiLayerComposeSceneImpl(
          * This scenario is important when user code relies on hover events to show tooltips.
          */
         override var boundsInWindow: IntRect by mutableStateOf(IntRect.Zero)
+
+        @Deprecated(
+            message = "Should not be used in this implementation",
+            level = DeprecationLevel.ERROR
+        )
         override var compositionLocalContext: CompositionLocalContext? = null
+
         override var scrimColor: Color? by mutableStateOf(null)
         override var focusable: Boolean = focusable
             set(value) {
@@ -581,7 +587,14 @@ private class MultiLayerComposeSceneImpl(
             composition?.dispose()
             composition = owner.setContent(
                 parent = this@AttachedComposeSceneLayer.compositionContext,
-                { this@AttachedComposeSceneLayer.compositionLocalContext }
+                {
+                    /*
+                     * Do not use `compositionLocalContext` here - composition locals already
+                     * available from `compositionContext` and explicitly overriding it might cause
+                     * issues. See https://github.com/JetBrains/compose-multiplatform/issues/4558
+                     */
+                    null
+                }
             ) {
                 owner.setRootModifier(background then keyInput)
                 content()


### PR DESCRIPTION
When the value of a composition local that is provided outside a `Popup` changes, typically, the order of events is:

1. The value changes, triggering a recomposition of the function with `CompositionLocalProvider`.
2. The function with `CompositionLocalProvider` is recomposed, modifying the composition local context, which triggers `rememberComposeSceneLayer` to recompose, as it reads `currentCompositionLocalContext`.
3. `rememberComposeSceneLayer` is recomposed.
4. The `SideEffect` in  `rememberComposeSceneLayer` is executed, changing the `compositionLocalContext` of the layer, which triggers recomposition of the layer (popup) content.
5. The layer content is recomposed and it sees the updated composition local value.

However, if the layer content is recomposed (for unrelated reasons) in the same frame as `rememberComposeSceneLayer`, it will read an old value of the composition local.

The question then is why doesn't the layer content recompose again when the `SideEffect` updates compositionLocalContext. The answer is that `MultiLayerComposeScene.compositionLocalContext` is not a Compose state.

## Proposed Changes
Apply compositionLocalContext, density and layoutDirection to layer immediately in rememberComposeSceneLayer.

## Testing

Test: Added a unit test

This PR should be verified by QA.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4558
