### PR TITLE
Revert `NewInstanceFactory` and `Factory.from` to AOSP state

### DIFF
--- a/lifecycle/lifecycle-viewmodel/src/androidMain/kotlin/androidx/lifecycle/ViewModelProvider.android.kt
+++ b/lifecycle/lifecycle-viewmodel/src/androidMain/kotlin/androidx/lifecycle/ViewModelProvider.android.kt
@@ -157,9 +157,17 @@ public actual open class ViewModelProvider private constructor(
             extras: CreationExtras,
         ): T = create(modelClass.java, extras)
 
-        public actual companion object {
+        public companion object {
+            /**
+             * Creates an [InitializerViewModelFactory] using the given initializers.
+             *
+             * @param initializers the class initializer pairs used for the factory to create
+             * simple view models
+             *
+             * @see [InitializerViewModelFactory]
+             */
             @JvmStatic
-            public actual fun from(vararg initializers: ViewModelInitializer<*>): Factory =
+            public fun from(vararg initializers: ViewModelInitializer<*>): Factory =
                 ViewModelProviders.createInitializerFactory(*initializers)
         }
     }

--- a/lifecycle/lifecycle-viewmodel/src/commonMain/kotlin/androidx/lifecycle/ViewModelProvider.kt
+++ b/lifecycle/lifecycle-viewmodel/src/commonMain/kotlin/androidx/lifecycle/ViewModelProvider.kt
@@ -19,11 +19,8 @@ package androidx.lifecycle
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.viewmodel.CreationExtras
-import androidx.lifecycle.viewmodel.InitializerViewModelFactory
-import androidx.lifecycle.viewmodel.ViewModelInitializer
 import androidx.lifecycle.viewmodel.internal.DefaultViewModelProviderFactory
 import androidx.lifecycle.viewmodel.internal.ViewModelProviders
-import kotlin.jvm.JvmStatic
 import kotlin.reflect.KClass
 
 /**
@@ -83,19 +80,6 @@ public expect class ViewModelProvider {
             modelClass: KClass<T>,
             extras: CreationExtras,
         ): T
-
-        public companion object {
-            /**
-             * Creates an [InitializerViewModelFactory] using the given initializers.
-             *
-             * @param initializers the class initializer pairs used for the factory to create
-             * simple view models
-             *
-             * @see [InitializerViewModelFactory]
-             */
-            @JvmStatic
-            public fun from(vararg initializers: ViewModelInitializer<*>): Factory
-        }
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/lifecycle/lifecycle-viewmodel/src/desktopMain/kotlin/androidx/lifecycle/ViewModelProvider.desktop.kt
+++ b/lifecycle/lifecycle-viewmodel/src/desktopMain/kotlin/androidx/lifecycle/ViewModelProvider.desktop.kt
@@ -19,10 +19,7 @@ package androidx.lifecycle
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.viewmodel.CreationExtras
-import androidx.lifecycle.viewmodel.InitializerViewModelFactory
-import androidx.lifecycle.viewmodel.ViewModelInitializer
 import androidx.lifecycle.viewmodel.ViewModelProviderImpl
-import androidx.lifecycle.viewmodel.internal.JvmViewModelProviders
 import androidx.lifecycle.viewmodel.internal.ViewModelProviders
 import kotlin.reflect.KClass
 
@@ -45,53 +42,11 @@ public actual class ViewModelProvider private constructor(
             modelClass: KClass<T>,
             extras: CreationExtras,
         ): T = ViewModelProviders.unsupportedCreateViewModel()
-
-        public actual companion object {
-            @JvmStatic
-            public actual fun from(vararg initializers: ViewModelInitializer<*>): Factory =
-                ViewModelProviders.createInitializerFactory(*initializers)
-        }
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     public actual open class OnRequeryFactory {
         public actual open fun onRequery(viewModel: ViewModel) {}
-    }
-
-    /**
-     * Simple factory, which calls empty constructor on the give class.
-     */
-    public open class NewInstanceFactory
-    /**
-     * Construct a new [NewInstanceFactory] instance.
-     *
-     * Use [NewInstanceFactory.instance] to get a default instance of [NewInstanceFactory].
-     */
-    @Suppress("SingletonConstructor")
-    constructor() : Factory {
-        public override fun <T : ViewModel> create(
-            modelClass: KClass<T>,
-            extras: CreationExtras,
-        ): T = JvmViewModelProviders.createViewModel(modelClass.java)
-
-        public companion object {
-            private var _instance: NewInstanceFactory? = null
-
-            /**
-             * Retrieve a singleton instance of NewInstanceFactory.
-             *
-             * @return A valid [NewInstanceFactory]
-             */
-            @JvmStatic
-            public val instance: NewInstanceFactory
-                @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-                get() {
-                    if (_instance == null) {
-                        _instance = NewInstanceFactory()
-                    }
-                    return _instance!!
-                }
-        }
     }
 
     public actual companion object {

--- a/lifecycle/lifecycle-viewmodel/src/nonJvmMain/kotlin/androidx/lifecycle/ViewModelProvider.nonJvm.kt
+++ b/lifecycle/lifecycle-viewmodel/src/nonJvmMain/kotlin/androidx/lifecycle/ViewModelProvider.nonJvm.kt
@@ -19,11 +19,8 @@ package androidx.lifecycle
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.viewmodel.CreationExtras
-import androidx.lifecycle.viewmodel.InitializerViewModelFactory
-import androidx.lifecycle.viewmodel.ViewModelInitializer
 import androidx.lifecycle.viewmodel.ViewModelProviderImpl
 import androidx.lifecycle.viewmodel.internal.ViewModelProviders
-import kotlin.jvm.JvmStatic
 import kotlin.reflect.KClass
 
 public actual class ViewModelProvider private constructor(
@@ -45,12 +42,6 @@ public actual class ViewModelProvider private constructor(
             modelClass: KClass<T>,
             extras: CreationExtras,
         ): T = ViewModelProviders.unsupportedCreateViewModel()
-
-        public actual companion object {
-            @JvmStatic
-            public actual fun from(vararg initializers: ViewModelInitializer<*>): Factory =
-                ViewModelProviders.createInitializerFactory(*initializers)
-        }
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
## Proposed Changes

- Revert commonization of `NewInstanceFactory` and `Factory.from` based on https://android-review.googlesource.com/c/platform/frameworks/support/+/3007004 feedback

## Testing

Test: N/A