### PR TITLE
Initialize local `ViewModelStoreOwner` in `NavHost` as fallback instead of providing default `GlobalViewModelStoreOwner`

### DIFF
--- a/lifecycle/lifecycle-viewmodel-compose/src/jbMain/kotlin/androidx/lifecycle/viewmodel/compose/LocalViewModelStoreOwner.jb.kt
+++ b/lifecycle/lifecycle-viewmodel-compose/src/jbMain/kotlin/androidx/lifecycle/viewmodel/compose/LocalViewModelStoreOwner.jb.kt
@@ -17,13 +17,7 @@
 package androidx.lifecycle.viewmodel.compose
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 
-private object GlobalViewModelStoreOwner: ViewModelStoreOwner {
-    override val viewModelStore: ViewModelStore = ViewModelStore()
-}
-
 @Composable
-internal actual fun findViewModelStoreOwner(): ViewModelStoreOwner? =
-    GlobalViewModelStoreOwner
+internal actual fun findViewModelStoreOwner(): ViewModelStoreOwner? = null


### PR DESCRIPTION
## Proposed Changes

- Revert default value of `LocalViewModelStoreOwner` - it's  `null` again instead of `GlobalViewModelStoreOwner`
- Use local `ViewModelStoreOwner` in `NavHost` if `LocalViewModelStoreOwner` is empty

## Testing

Test: try mpp sample
