### PR TITLE
Support a11y for interop views

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -127,10 +127,7 @@ class App(
                 )
             }
         ) {
-            buildScreen(MainScreen, navController)
-            for (i in extraScreens) {
-                buildScreen(i, navController)
-            }
+            buildScreen(MainScreen.mergedWith(extraScreens), navController)
         }
     }
 

--- a/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
@@ -133,6 +133,7 @@ private fun NativeNavigationPage() {
                 UIKitView(
                     factory = {
                         val view = UIImageView()
+                        view.isAccessibilityElement = true
                         view.accessibilityLabel = "Cat image $index"
                         view.contentMode = UIViewContentMode.UIViewContentModeScaleAspectFill
                         view.clipsToBounds = true

--- a/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/NativePopupExample.kt
@@ -133,6 +133,7 @@ private fun NativeNavigationPage() {
                 UIKitView(
                     factory = {
                         val view = UIImageView()
+                        view.accessibilityLabel = "Cat image $index"
                         view.contentMode = UIViewContentMode.UIViewContentModeScaleAspectFill
                         view.clipsToBounds = true
                         view

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E92B27106100300068 /* CMPAccessibilityContainer.m */; };
 		EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4F82B86144E00465418 /* CMPOSLogger.m */; };
 		EA82F4FC2B86184F00465418 /* CMPOSLoggerInterval.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */; };
+		EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */ = {isa = PBXBuildFile; fileRef = EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */; };
 		EAC703E32B8C826E001ECDA6 /* CMPAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */; };
 		EAC703E42B8C826E001ECDA6 /* CMPViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCDD2B18D135000B56B5 /* CMPViewController.m */; };
 		EAC703E52B8C826E001ECDA6 /* CMPOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4F82B86144E00465418 /* CMPOSLogger.m */; };
@@ -75,6 +76,8 @@
 		EA82F4F82B86144E00465418 /* CMPOSLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPOSLogger.m; sourceTree = "<group>"; };
 		EA82F4FA2B86184F00465418 /* CMPOSLoggerInterval.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPOSLoggerInterval.h; sourceTree = "<group>"; };
 		EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPOSLoggerInterval.m; sourceTree = "<group>"; };
+		EABD91292BC02B5F00455279 /* CMPInteropWrappingView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPInteropWrappingView.h; sourceTree = "<group>"; };
+		EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPInteropWrappingView.m; sourceTree = "<group>"; };
 		EAC703DF2B8C8154001ECDA6 /* CMPUIKitUtilsTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CMPUIKitUtilsTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -119,6 +122,8 @@
 				EA82F4F82B86144E00465418 /* CMPOSLogger.m */,
 				EA82F4FA2B86184F00465418 /* CMPOSLoggerInterval.h */,
 				EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */,
+				EABD91292BC02B5F00455279 /* CMPInteropWrappingView.h */,
+				EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */,
 			);
 			path = CMPUIKitUtils;
 			sourceTree = "<group>";
@@ -293,6 +298,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				997DFCDE2B18D135000B56B5 /* CMPViewController.m in Sources */,
+				EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */,
 				EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */,
 				EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */,
 				EA70A7EB2B27106100300068 /* CMPAccessibilityElement.m in Sources */,

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.h
@@ -1,0 +1,19 @@
+//
+//  CMPInteropWrappingView.h
+//  CMPUIKitUtils
+//
+//  Created by Ilia.Semenov on 05/04/2024.
+//
+
+#import <UIKit/UIKit.h>
+#import "CMPMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CMPInteropWrappingView : UIView
+
+- (__nullable id)accessibilityContainer CMP_MUST_BE_OVERRIDED;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.h
@@ -1,9 +1,18 @@
-//
-//  CMPInteropWrappingView.h
-//  CMPUIKitUtils
-//
-//  Created by Ilia.Semenov on 05/04/2024.
-//
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import <UIKit/UIKit.h>
 #import "CMPMacros.h"

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.m
@@ -1,0 +1,16 @@
+//
+//  CMPInteropWrappingView.m
+//  CMPUIKitUtils
+//
+//  Created by Ilia.Semenov on 05/04/2024.
+//
+
+#import "CMPInteropWrappingView.h"
+
+@implementation CMPInteropWrappingView
+
+- (__nullable id)accessibilityContainer {
+    CMP_MUST_BE_OVERRIDED_INVARIANT_VIOLATION
+}
+
+@end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.m
@@ -1,9 +1,18 @@
-//
-//  CMPInteropWrappingView.m
-//  CMPUIKitUtils
-//
-//  Created by Ilia.Semenov on 05/04/2024.
-//
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import "CMPInteropWrappingView.h"
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -57,12 +57,23 @@ import platform.UIKit.addChildViewController
 import platform.UIKit.didMoveToParentViewController
 import platform.UIKit.removeFromParentViewController
 import platform.UIKit.willMoveToParentViewController
+import androidx.compose.ui.uikit.utils.CMPInteropWrappingView
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRectZero
 
 private val STUB_CALLBACK_WITH_RECEIVER: Any.() -> Unit = {}
 private val DefaultViewResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setFrame(rect) }
 private val DefaultViewControllerResize: UIViewController.(CValue<CGRect>) -> Unit = { rect -> this.view.setFrame(rect) }
 
-internal val NativeViewSemanticsKey = AccessibilityKey<UIView>(
+internal class InteropWrappingView: CMPInteropWrappingView(frame = CGRectZero.readValue()) {
+    var actualAccessibilityContainer: Any? = null
+
+    override fun accessibilityContainer(): Any? {
+        return actualAccessibilityContainer
+    }
+}
+
+internal val NativeViewSemanticsKey = AccessibilityKey<CMPInteropWrappingView>(
     name = "InteropView",
     mergePolicy = { _, _ ->
         throw IllegalStateException(
@@ -278,7 +289,7 @@ private abstract class EmbeddedInteropComponent<T : Any>(
     val interopContainer: UIKitInteropContainer,
     val onRelease: (T) -> Unit
 ) {
-    val wrappingView = UIView()
+    val wrappingView = InteropWrappingView()
     lateinit var component: T
     lateinit var updater: Updater<T>
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -34,6 +34,9 @@ import androidx.compose.ui.layout.EmptyLayout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.AccessibilityKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.uikit.toUIColor
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -58,6 +61,17 @@ import platform.UIKit.willMoveToParentViewController
 private val STUB_CALLBACK_WITH_RECEIVER: Any.() -> Unit = {}
 private val DefaultViewResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setFrame(rect) }
 private val DefaultViewControllerResize: UIViewController.(CValue<CGRect>) -> Unit = { rect -> this.view.setFrame(rect) }
+
+internal val NativeViewSemanticsKey = AccessibilityKey<UIView>(
+    name = "InteropView",
+    mergePolicy = { _, _ ->
+        throw IllegalStateException(
+            "Can't merge NativeView semantics property."
+        )
+    }
+)
+
+private var SemanticsPropertyReceiver.nativeView by NativeViewSemanticsKey
 
 /**
  * @param factory The block creating the [UIView] to be composed.
@@ -103,7 +117,7 @@ fun <T : UIView> UIKitView(
                 val rect = newRectInPixels.toRect().toDpRect(density)
 
                 interopContext.deferAction {
-                    embeddedInteropComponent.container.setFrame(rect.asCGRect())
+                    embeddedInteropComponent.wrappingView.setFrame(rect.asCGRect())
                 }
 
                 if (rectInPixels.width != newRectInPixels.width || rectInPixels.height != newRectInPixels.height) {
@@ -119,12 +133,14 @@ fun <T : UIView> UIKitView(
         }.drawBehind {
             // Clear interop area to make visible the component under our canvas.
             drawRect(Color.Transparent, blendMode = BlendMode.Clear)
-        }.trackUIKitInterop(embeddedInteropComponent.container).let {
+        }.trackUIKitInterop(embeddedInteropComponent.wrappingView).let {
             if (interactive) {
                 it.then(InteropViewCatchPointerModifier())
             } else {
                 it
             }
+        }.semantics {
+            nativeView = embeddedInteropComponent.wrappingView
         }
     )
 
@@ -203,7 +219,7 @@ fun <T : UIViewController> UIKitViewController(
                 val rect = newRectInPixels.toRect().toDpRect(density)
 
                 interopContext.deferAction {
-                    embeddedInteropComponent.container.setFrame(rect.asCGRect())
+                    embeddedInteropComponent.wrappingView.setFrame(rect.asCGRect())
                 }
 
                 if (rectInPixels.width != newRectInPixels.width || rectInPixels.height != newRectInPixels.height) {
@@ -219,12 +235,14 @@ fun <T : UIViewController> UIKitViewController(
         }.drawBehind {
             // Clear interop area to make visible the component under our canvas.
             drawRect(Color.Transparent, blendMode = BlendMode.Clear)
-        }.trackUIKitInterop(embeddedInteropComponent.container).let {
+        }.trackUIKitInterop(embeddedInteropComponent.wrappingView).let {
             if (interactive) {
                 it.then(InteropViewCatchPointerModifier())
             } else {
                 it
             }
+        }.semantics {
+            nativeView = embeddedInteropComponent.wrappingView
         }
     )
 
@@ -260,15 +278,15 @@ private abstract class EmbeddedInteropComponent<T : Any>(
     val interopContainer: UIKitInteropContainer,
     val onRelease: (T) -> Unit
 ) {
-    var container = UIView()
+    val wrappingView = UIView()
     lateinit var component: T
     lateinit var updater: Updater<T>
 
     fun setBackgroundColor(color: Color) {
         if (color == Color.Unspecified) {
-            container.backgroundColor = interopContainer.containerView.backgroundColor
+            wrappingView.backgroundColor = interopContainer.containerView.backgroundColor
         } else {
-            container.backgroundColor = color.toUIColor()
+            wrappingView.backgroundColor = color.toUIColor()
         }
     }
 
@@ -276,13 +294,13 @@ private abstract class EmbeddedInteropComponent<T : Any>(
     abstract fun removeFromHierarchy()
 
     protected fun addViewToHierarchy(view: UIView) {
-        container.addSubview(view)
-        interopContainer.addInteropView(container)
+        wrappingView.addSubview(view)
+        interopContainer.addInteropView(wrappingView)
     }
 
     protected fun removeViewFromHierarchy(view: UIView) {
         view.removeFromSuperview()
-        interopContainer.removeInteropView(container)
+        interopContainer.removeInteropView(wrappingView)
         updater.dispose()
         onRelease(component)
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -73,7 +73,7 @@ internal class InteropWrappingView: CMPInteropWrappingView(frame = CGRectZero.re
     }
 }
 
-internal val NativeViewSemanticsKey = AccessibilityKey<CMPInteropWrappingView>(
+internal val NativeViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
     name = "InteropView",
     mergePolicy = { _, _ ->
         throw IllegalStateException(


### PR DESCRIPTION
## Proposed Changes

Make the native views created using `UIKitView` and `UIKitViewController` reachable by AX services.

## Testing

Test: NativeModalWithNavigation cats images are interop views reachable by using the VoiceOver controls.

## Issues fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4290

## Example

`UIImageView` focused by using the VoiceOver controls

<img src="https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/c0180252-1275-42cb-b952-967d89b04a04" alt="drawing" width="300"/>