### PR TITLE
Add dialog destination example

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/App.kt
@@ -1,94 +1,16 @@
 package androidx.compose.mpp.demo
 
-import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.union
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.Icon
-import androidx.compose.material.LocalContentAlpha
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProvideTextStyle
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.mpp.demo.bug.BugReproducers
-import androidx.compose.mpp.demo.components.Components
-import androidx.compose.mpp.demo.textfield.android.AndroidTextFieldSamples
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.IntOffset
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.dialog
 import androidx.navigation.compose.rememberNavController
-
-val MainScreen = Screen.Selection(
-    "Demo",
-    Components,
-    BugReproducers,
-    Screen.Example("Example1") { Example1() },
-    Screen.Example("ImageViewer") { ImageViewer() },
-    Screen.Example("TextDirection") { TextDirection() },
-    Screen.Example("FontFamilies") { FontFamilies() },
-    Screen.Example("LottieAnimation") { LottieAnimation() },
-    Screen.FullscreenExample("ApplicationLayouts") { ApplicationLayouts(it) },
-    Screen.Example("GraphicsLayerSettings") { GraphicsLayerSettings() },
-    Screen.Example("Blending") { Blending() },
-    Screen.Example("FontRasterization") { FontRasterization() },
-    Screen.Example("InteropOrder") { InteropOrder() },
-    AndroidTextFieldSamples,
-)
-
-sealed interface Screen {
-    val title: String
-
-    class Example(
-        override val title: String,
-        val backgroundColor: Color? = null,
-        val content: @Composable () -> Unit
-    ) : Screen
-
-    class Selection(
-        override val title: String,
-        val screens: List<Screen>
-    ) : Screen {
-        constructor(title: String, vararg screens: Screen) : this(title, listOf(*screens))
-
-        fun mergedWith(screens: List<Screen>): Selection {
-            return Selection(title, screens + this.screens)
-        }
-    }
-
-    class FullscreenExample(
-        override val title: String,
-        val content: @Composable (back: () -> Unit) -> Unit
-    ) : Screen
-}
 
 class App(
     private val initialScreenName: String? = null,
@@ -97,35 +19,16 @@ class App(
     @Composable
     fun Content() {
         val navController = rememberNavController()
+        val animationSpec = tween<IntOffset>(500)
         NavHost(
             navController = navController,
             startDestination = initialScreenName ?: MainScreen.title,
 
             // Custom animations
-            enterTransition = {
-                slideIntoContainer(
-                    AnimatedContentTransitionScope.SlideDirection.Left,
-                    animationSpec = tween(700)
-                )
-            },
-            exitTransition = {
-                slideOutOfContainer(
-                    AnimatedContentTransitionScope.SlideDirection.Left,
-                    animationSpec = tween(700)
-                )
-            },
-            popEnterTransition = {
-                slideIntoContainer(
-                    AnimatedContentTransitionScope.SlideDirection.Right,
-                    animationSpec = tween(700)
-                )
-            },
-            popExitTransition = {
-                slideOutOfContainer(
-                    AnimatedContentTransitionScope.SlideDirection.Right,
-                    animationSpec = tween(700)
-                )
-            }
+            enterTransition = { slideIntoContainer(SlideDirection.Left, animationSpec) },
+            exitTransition = { slideOutOfContainer(SlideDirection.Left, animationSpec) },
+            popEnterTransition = { slideIntoContainer(SlideDirection.Right, animationSpec) },
+            popExitTransition = { slideOutOfContainer(SlideDirection.Right, animationSpec) }
         ) {
             buildScreen(MainScreen.mergedWith(extraScreens), navController)
         }
@@ -137,142 +40,24 @@ class App(
                 buildScreen(i, navController)
             }
         }
-        composable(screen.title) { ScreenContent(screen, navController) }
+        if (screen is Screen.Dialog) {
+            dialog(screen.title) { ScreenContent(screen, navController) }
+        } else {
+            composable(screen.title) { ScreenContent(screen, navController) }
+        }
     }
 
     @Composable
     private fun ScreenContent(screen: Screen, navController: NavController) {
         val currentBackStack = remember(screen) { navController.currentBackStack.value }
         val firstEntry = remember(screen) { navController.previousBackStackEntry == null }
-        val title = currentBackStack.drop(1)
-            .joinToString("/") { it.destination.route ?: it.destination.displayName }
-        val back: (() -> Unit)? = if (!firstEntry) {
-            { navController.popBackStack() }
-        } else null
-        when (screen) {
-            is Screen.Example -> {
-                ExampleScaffold(
-                    title = title,
-                    back = back!!,
-                    backgroundColor = screen.backgroundColor,
-                    content = screen.content
-                )
-            }
-
-            is Screen.Selection -> {
-                SelectionScaffold(
-                    title = title,
-                    back = back,
-                ) {
-                    LazyColumn(Modifier.fillMaxSize()) {
-                        items(screen.screens) {
-                            Text(it.title, Modifier.clickable {
-                                navController.navigate(it.title)
-                            }.padding(16.dp).fillMaxWidth())
-                        }
-                    }
-                }
-            }
-
-            is Screen.FullscreenExample -> {
-                screen.content {
-                    navController.popBackStack()
-                }
-            }
-        }
-    }
-
-    @Composable
-    private fun ExampleScaffold(
-        title: String,
-        back: () -> Unit,
-        backgroundColor: Color?,
-        content: @Composable () -> Unit
-    ) {
-        Scaffold(
-            /*
-            Without using TopAppBar, this is recommended approach to apply multiplatform window insets
-            to Material2 Scaffold (otherwise there will be empty space above top app bar - as is here)
-            */
-            modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
-            topBar = {
-                TopAppBar(
-                    title = {
-                        Text(title)
-                    },
-                    navigationIcon = {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
-                            modifier = Modifier.clickable { back.invoke() }
-                        )
-                    }
-                )
-            },
-            backgroundColor = backgroundColor ?: MaterialTheme.colors.background
-        ) { innerPadding ->
-            Box(
-                Modifier.fillMaxSize().padding(innerPadding)
-            ) {
-                content()
-            }
-        }
-    }
-
-    @Composable
-    private fun SelectionScaffold(
-        title: String,
-        back: (() -> Unit)? = null,
-        content: @Composable () -> Unit
-    ) {
-        Scaffold(
-            topBar = {
-                /*
-                This is recommended approach of applying multiplatform window insets to Material2 Scaffold with using top app bar.
-                By that way, it is possible to fill area above top app bar with its background - as it works out of box in android development or with Material3 Scaffold
-                */
-                TopAppBar(
-                    contentPadding = WindowInsets.systemBars
-                        .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
-                        .union(WindowInsets(left = 20.dp))
-                        .asPaddingValues(),
-                    content = {
-                        CompositionLocalProvider(
-                            LocalContentAlpha provides ContentAlpha.high
-                        ) {
-                            Row(
-                                Modifier.fillMaxHeight().weight(1f),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                if (back != null) {
-                                    Icon(
-                                        Icons.Filled.ArrowBack,
-                                        contentDescription = "Back",
-                                        modifier = Modifier.clickable { back.invoke() }
-                                    )
-                                    Spacer(Modifier.width(16.dp))
-                                }
-                                ProvideTextStyle(value = MaterialTheme.typography.h6) {
-                                    Text(title)
-                                }
-                            }
-                        }
-                    }
-                )
-            },
-        ) { innerPadding ->
-            /*
-            In case of applying WindowInsets as content padding, it is strongly recommended to wrap
-            content of scaffold into box with these modifiers to support proper layout when device rotated
-            */
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
-                    .padding(innerPadding)
-            ) {
-                content()
-            }
-        }
+        screen.Content(
+            title = currentBackStack.drop(1)
+                .joinToString("/") { it.destination.route ?: it.destination.displayName },
+            navigate = { navController.navigate(it) },
+            back = if (!firstEntry) {
+                { navController.popBackStack() }
+            } else null
+        )
     }
 }

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/Blending.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/Blending.kt
@@ -16,36 +16,32 @@
 
 package androidx.compose.mpp.demo
 
-import androidx.compose.animation.core.*
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.RadioButton
-import androidx.compose.material.Slider
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.geometry.center
 import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.compositeOver
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope.Companion.DefaultBlendMode
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import kotlin.math.min
-import kotlin.math.round
-import kotlin.math.roundToInt
-
 
 @Composable
 fun Blending() {

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontFamilies.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/FontFamilies.kt
@@ -16,18 +16,18 @@
 
 package androidx.compose.mpp.demo
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 
 
 @Composable
@@ -55,7 +55,7 @@ fun FontFamilies() {
 }
 
 @Composable
-fun FontFamilyShowcase(fontFamily: FontFamily) {
+private fun FontFamilyShowcase(fontFamily: FontFamily) {
     Column {
         Text(
             text = "$fontFamily"

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/LottieAnimation.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/LottieAnimation.kt
@@ -46,7 +46,7 @@ fun LottieAnimation() {
 }
 
 @Composable
-fun InfiniteAnimation(animation: Animation, modifier: Modifier) {
+private fun InfiniteAnimation(animation: Animation, modifier: Modifier) {
     val infiniteTransition = rememberInfiniteTransition()
     val time by infiniteTransition.animateFloat(
         initialValue = 0f,

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/MainScreen.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/MainScreen.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.mpp.demo.bug.BugReproducers
+import androidx.compose.mpp.demo.components.Components
+import androidx.compose.mpp.demo.textfield.android.AndroidTextFieldSamples
+
+val MainScreen = Screen.Selection(
+    "Demo",
+    Components,
+    BugReproducers,
+    Screen.Example("Example1") { Example1() },
+    Screen.Example("ImageViewer") { ImageViewer() },
+    Screen.Example("TextDirection") { TextDirection() },
+    Screen.Example("FontFamilies") { FontFamilies() },
+    Screen.Example("LottieAnimation") { LottieAnimation() },
+    Screen.Fullscreen("ApplicationLayouts") { ApplicationLayouts(it) },
+    Screen.Example("GraphicsLayerSettings") { GraphicsLayerSettings() },
+    Screen.Example("Blending") { Blending() },
+    Screen.Example("FontRasterization") { FontRasterization() },
+    Screen.Example("InteropOrder") { InteropOrder() },
+    AndroidTextFieldSamples,
+)

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/Screen.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/Screen.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Icon
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+sealed interface Screen {
+    val title: String
+
+    class Example(
+        override val title: String,
+        val backgroundColor: Color? = null,
+        val content: @Composable () -> Unit
+    ) : Screen {
+
+        @Composable
+        override fun Content(title: String, navigate: (String) -> Unit, back: (() -> Unit)?) {
+            ExampleScaffold(
+                title = title,
+                back = back!!,
+                backgroundColor = backgroundColor,
+                content = content
+            )
+        }
+    }
+
+    class Selection(
+        override val title: String,
+        val screens: List<Screen>
+    ) : Screen {
+        constructor(title: String, vararg screens: Screen) : this(title, listOf(*screens))
+
+        fun mergedWith(screens: List<Screen>): Selection {
+            return Selection(title, screens + this.screens)
+        }
+
+        @Composable
+        override fun Content(title: String, navigate: (String) -> Unit, back: (() -> Unit)?) {
+            SelectionScaffold(
+                title = title,
+                back = back,
+            ) {
+                LazyColumn(Modifier.fillMaxSize()) {
+                    items(screens) {
+                        Text(it.title, Modifier.clickable {
+                            navigate(it.title)
+                        }.padding(16.dp).fillMaxWidth())
+                    }
+                }
+            }
+        }
+    }
+
+    class Fullscreen(
+        override val title: String,
+        val content: @Composable (back: () -> Unit) -> Unit
+    ) : Screen {
+
+        @Composable
+        override fun Content(title: String, navigate: (String) -> Unit, back: (() -> Unit)?) {
+            content(back!!)
+        }
+    }
+
+    class Dialog(
+        override val title: String,
+        val content: @Composable () -> Unit
+    ) : Screen {
+
+        @Composable
+        override fun Content(title: String, navigate: (String) -> Unit, back: (() -> Unit)?) {
+            content()
+        }
+    }
+
+    @Composable
+    fun Content(title: String, navigate: (String) -> Unit, back: (() -> Unit)?)
+}
+
+@Composable
+private fun ExampleScaffold(
+    title: String,
+    back: () -> Unit,
+    backgroundColor: Color?,
+    content: @Composable () -> Unit
+) {
+    Scaffold(
+        /*
+        Without using TopAppBar, this is recommended approach to apply multiplatform window insets
+        to Material2 Scaffold (otherwise there will be empty space above top app bar - as is here)
+        */
+        modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars),
+        topBar = { ExampleTopBar(title, back) },
+        backgroundColor = backgroundColor ?: MaterialTheme.colors.background
+    ) { innerPadding ->
+        Box(Modifier.fillMaxSize().padding(innerPadding)) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ExampleTopBar(
+    title: String,
+    back: () -> Unit,
+) {
+    TopAppBar(
+        title = { Text(title) },
+        navigationIcon = { ArrowBackIcon(back) }
+    )
+}
+
+@Composable
+private fun SelectionScaffold(
+    title: String,
+    back: (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    Scaffold(
+        topBar = { SelectionTopBar(title, back) },
+    ) { innerPadding ->
+        /*
+         * In case of applying WindowInsets as content padding, it is strongly recommended to wrap
+         * content of scaffold into box with these modifiers to support proper layout when device rotated
+         */
+        val horizontalInsets = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)
+        Box(Modifier.fillMaxSize().windowInsetsPadding(horizontalInsets).padding(innerPadding)) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun SelectionTopBar(
+    title: String,
+    back: (() -> Unit)? = null,
+) {
+    /*
+     * This is recommended approach of applying multiplatform window insets to Material2 Scaffold
+     * with using top app bar.
+     * By that way, it is possible to fill area above top app bar with its background - as it works
+     * out of box in android development or with Material3 Scaffold
+     */
+    TopAppBar(
+        contentPadding = WindowInsets.systemBars
+            .only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal)
+            .union(WindowInsets(left = 20.dp))
+            .asPaddingValues(),
+        content = {
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.high) {
+                Row(
+                    Modifier.fillMaxHeight().weight(1f),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (back != null) {
+                        ArrowBackIcon(back)
+                        Spacer(Modifier.width(16.dp))
+                    }
+                    ProvideTextStyle(value = MaterialTheme.typography.h6) {
+                        Text(title)
+                    }
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun ArrowBackIcon(back: () -> Unit) {
+    Icon(
+        Icons.AutoMirrored.Filled.ArrowBack,
+        contentDescription = "Back",
+        modifier = Modifier.clickable(onClick = back)
+    )
+}
+

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.mpp.demo.components
 
-import androidx.compose.mpp.demo.LazyLayouts
 import androidx.compose.mpp.demo.Screen
 import androidx.compose.mpp.demo.components.dialog.Dialogs
 import androidx.compose.mpp.demo.components.material.AlertDialogExample

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/LazyLayouts.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/LazyLayouts.kt
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package androidx.compose.mpp.demo
+package androidx.compose.mpp.demo.components
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.*
@@ -30,6 +29,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
 import androidx.compose.foundation.lazy.staggeredgrid.items
 import androidx.compose.material.Button
 import androidx.compose.material.Text
+import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/dialog/Dialogs.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/dialog/Dialogs.kt
@@ -16,7 +16,16 @@
 
 package androidx.compose.mpp.demo.components.dialog
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.mpp.demo.LottieAnimation
 import androidx.compose.mpp.demo.Screen
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 val Dialogs = Screen.Selection(
     "Dialogs",
@@ -24,4 +33,14 @@ val Dialogs = Screen.Selection(
     Screen.Example("CompositionLocal inside Dialog") { DialogCompositionLocalExample() },
     DialogWithTextField,
     FocusAndKeyInput,
+    Screen.Dialog("Dialog destination") {
+        // Just example of content that should be already inside dialog
+        Box(Modifier
+            .size(300.dp)
+            .shadow(10.dp, CircleShape)
+            .background(Color.White)
+        ) {
+            LottieAnimation()
+        }
+    }
 )


### PR DESCRIPTION
## Proposed Changes

- Add "Dialog destination" navigation example
- Split App, Screen and MainScreen into separate files
- Shorten navigation animation a bit

## Testing

Test: Components -> Dialog -> Dialog destination
