### PR TITLE
[wasm][js] Modify buttonFlags only on Press and Release

### DIFF
--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/native/ComposeLayer.jsNative.kt
@@ -62,7 +62,7 @@ internal class ComposeLayer(
                 }
                 onPointerEventWithMultitouch(event)
             } else {
-                // macos and desktop`s web don't work properly when using onPointerEventWithMultitouch
+                // TODO: check this statement: macos doesn't work properly when using onPointerEventWithMultitouch
                 onPointerEventNoMultitouch(event)
             }
         }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/events/Converters.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/events/Converters.kt
@@ -88,10 +88,10 @@ private fun MouseEvent.resolvePressedMouseButtons(
     // https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button
     val button = button.toInt()
 
-    buttonsFlags = if (kind == PointerEventType.Press) {
-        buttonsFlags.or(getButtonValue(button))
-    } else {
-        buttonsFlags.xor(getButtonValue(button))
+    buttonsFlags = when (kind) {
+        PointerEventType.Press -> buttonsFlags.or(getButtonValue(button))
+        PointerEventType.Release -> buttonsFlags.xor(getButtonValue(button))
+        else -> buttonsFlags
     }
 
     return MouseButtons(buttonsFlags)


### PR DESCRIPTION
Our code was written in the assumption that there's PointerEventType.Press and if not, it's release, but actually it's not the case. That leads to the fact that moving mouse lead to changes in button flags