### PR TITLE
Add debug badge on top right corner for iOS

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4F82B86144E00465418 /* CMPOSLogger.m */; };
 		EA82F4FC2B86184F00465418 /* CMPOSLoggerInterval.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */; };
 		EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */ = {isa = PBXBuildFile; fileRef = EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */; };
+		EABD91312BC41A6E00455279 /* CMPDebugBadge.m in Sources */ = {isa = PBXBuildFile; fileRef = EABD91302BC41A6E00455279 /* CMPDebugBadge.m */; };
 		EAC703E32B8C826E001ECDA6 /* CMPAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */; };
 		EAC703E42B8C826E001ECDA6 /* CMPViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCDD2B18D135000B56B5 /* CMPViewController.m */; };
 		EAC703E52B8C826E001ECDA6 /* CMPOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4F82B86144E00465418 /* CMPOSLogger.m */; };
@@ -78,6 +79,8 @@
 		EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPOSLoggerInterval.m; sourceTree = "<group>"; };
 		EABD91292BC02B5F00455279 /* CMPInteropWrappingView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPInteropWrappingView.h; sourceTree = "<group>"; };
 		EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPInteropWrappingView.m; sourceTree = "<group>"; };
+		EABD912F2BC41A6E00455279 /* CMPDebugBadge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPDebugBadge.h; sourceTree = "<group>"; };
+		EABD91302BC41A6E00455279 /* CMPDebugBadge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPDebugBadge.m; sourceTree = "<group>"; };
 		EAC703DF2B8C8154001ECDA6 /* CMPUIKitUtilsTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CMPUIKitUtilsTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -124,6 +127,8 @@
 				EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */,
 				EABD91292BC02B5F00455279 /* CMPInteropWrappingView.h */,
 				EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */,
+				EABD912F2BC41A6E00455279 /* CMPDebugBadge.h */,
+				EABD91302BC41A6E00455279 /* CMPDebugBadge.m */,
 			);
 			path = CMPUIKitUtils;
 			sourceTree = "<group>";
@@ -297,6 +302,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EABD91312BC41A6E00455279 /* CMPDebugBadge.m in Sources */,
 				997DFCDE2B18D135000B56B5 /* CMPViewController.m in Sources */,
 				EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */,
 				EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */,

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDebugBadge.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDebugBadge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
-//! Project version number for CMPUIKitUtils.
-FOUNDATION_EXPORT double CMPUIKitUtilsVersionNumber;
+NS_ASSUME_NONNULL_BEGIN
 
-//! Project version string for CMPUIKitUtils.
-FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
+@interface CMPDebugBadge : UIView
 
-#import "CMPViewController.h"
-#import "CMPAccessibilityElement.h"
-#import "CMPAccessibilityContainer.h"
-#import "CMPOSLogger.h"
-#import "CMPDebugBadge.h"
+@end
+
+NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDebugBadge.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDebugBadge.m
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "CMPDebugBadge.h"
+
+@implementation CMPDebugBadge
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    
+    if (self) {
+        self.translatesAutoresizingMaskIntoConstraints = false;
+        self.opaque = false;
+        
+        [NSLayoutConstraint activateConstraints:@[
+            [self.widthAnchor constraintEqualToConstant:150.0],
+            [self.heightAnchor constraintEqualToConstant:30.0]
+        ]];
+    }
+    
+    return self;
+}
+
+- (void)drawRect:(CGRect)rect {
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSetFillColorWithColor(context, [UIColor systemRedColor].CGColor);
+
+    CGPoint p0 = CGPointMake(0.0, 0.0);
+    CGPoint p1 = CGPointMake(rect.size.width, rect.size.height);
+    CGPoint p2 = CGPointMake(rect.size.width, 0.0);
+    
+    CGPoint points[] = { p0, p1, p2 };
+    
+    CGContextAddLines(context, points, 3);
+    CGContextFillPath(context);
+
+    CGContextSaveGState(context);
+    
+    CGFloat angle = atan2(rect.size.height, rect.size.width);
+    CGContextRotateCTM(context, angle);
+
+    NSDictionary *textAttributes = @{
+        NSFontAttributeName: [UIFont boldSystemFontOfSize:12],
+        NSForegroundColorAttributeName: [UIColor whiteColor]
+    };
+    NSString *text = @"DEBUG";
+
+    CGSize textSize = [text sizeWithAttributes:textAttributes];
+    CGFloat diagonal = sqrt(rect.size.width * rect.size.width + rect.size.height * rect.size.height);
+    CGPoint textOrigin = CGPointMake(diagonal / 2.0 - textSize.width / 2 + 10.0, -textSize.height);
+
+    [text drawAtPoint:textOrigin withAttributes:textAttributes];
+
+    CGContextRestoreGState(context);
+}
+
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    
+    [self setNeedsDisplay];
+}
+
+@end

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RenderingUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RenderingUIView.uikit.kt
@@ -21,8 +21,10 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.interop.UIKitInteropContext
 import androidx.compose.ui.interop.UIKitInteropTransaction
+import androidx.compose.ui.uikit.utils.CMPDebugBadge
 import kotlin.math.floor
 import kotlin.math.roundToLong
+import kotlin.native.Platform.isDebugBinary
 import kotlinx.cinterop.*
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SkikoRenderDelegate
@@ -92,6 +94,17 @@ internal class RenderingUIView(
                     CGColorCreate(CGColorSpaceCreateDeviceRGB(), pinned.addressOf(0))
             }
             it.framebufferOnly = false
+        }
+
+        if (isDebugBinary) {
+            val badge = CMPDebugBadge(frame = CGRectZero.readValue())
+
+            addSubview(badge)
+
+            NSLayoutConstraint.activateConstraints(listOf(
+                badge.topAnchor.constraintEqualToAnchor(topAnchor),
+                badge.rightAnchor.constraintEqualToAnchor(rightAnchor)
+            ))
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Add `UIView` with `DEBUG` to the top right corner to debug builds of Compose

## Testing

Test: Build iOS target with `Debug` and `Release` configurations. Observe the badge present and not.

## Rationale

This acts as a reminder, that the actual performance doesn't reflect the release configuration.

<img width="843" alt="Screenshot 2024-04-08 at 14 52 10" src="https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/7b3d8702-47aa-4e14-80a8-876580d94e60">

