### PR TITLE
Update mergeAOSP.sh for the new merging strategy

### DIFF
--- a/mergeAOSP.sh
+++ b/mergeAOSP.sh
@@ -2,33 +2,13 @@
 set -e
 
 if [ -z "$1" ]; then
-echo "Specify the previous and the current merged versions. For example: ./mergeAOSP.sh 1.5.1 1.6.0-alpha08"
+echo "Specify the commit. For example: ./mergeAOSP.sh jetpack-compose/1.5.1"
 exit 1
 fi
 
-if [ -z "$2" ]; then
-echo "Specify the previous and the current merged versions. For example: ./mergeAOSP.sh 1.5.1 1.6.0-alpha08"
-exit 1
-fi
+COMMIT=$1
 
-PREVIOUS_VERSION=$1
-CURRENT_VERSION=$2
-
-# create a branch with reverted commits that exists only in the previous version. This can happen often, as release branches can contain cherry-picks from unmerged CL's
-
-CURRENT_COMMIT=$(git rev-parse --abbrev-ref HEAD)
-MERGE_BASE=$(git merge-base jetpack-compose/$PREVIOUS_VERSION jetpack-compose/$CURRENT_VERSION)
-MERGE_BRANCH=sync-androidx/revert/revert-${PREVIOUS_VERSION}_merge-${CURRENT_VERSION}
-git checkout $MERGE_BASE -b $MERGE_BRANCH
-PREVIOUS_MERGE_RESULT=$(git merge jetpack-compose/$PREVIOUS_VERSION --no-ff)
-if [ "$PREVIOUS_MERGE_RESULT" != "Already up to date." ]; then
-git revert HEAD -m 1 --no-edit
-fi
-git merge jetpack-compose/$CURRENT_VERSION
-git checkout $CURRENT_COMMIT
-
-git merge $MERGE_BRANCH --no-commit --no-ff || true
-git branch -D $MERGE_BRANCH
+git merge $COMMIT --no-commit --no-ff || true
 
 git checkout --no-overlay HEAD --ours -- './buildSrc' || true
 git checkout --no-overlay HEAD --ours -- './compose/*/build.gradle' || true
@@ -50,13 +30,3 @@ git checkout --no-overlay HEAD --ours -- './compose/*/desktopMain/*' || true
 git checkout --no-overlay HEAD --ours -- './compose/*/skikoTest/*' || true
 git checkout --no-overlay HEAD --ours -- './compose/*/desktopTest/*' || true
 git checkout --no-overlay HEAD --ours -- './compose/desktop/*' || true
-# some files are small, and git can thin that some other file was renamed, and we can have conflicts with AOSP
-git checkout --no-overlay HEAD --ours -- './compose/mpp/demo/*' || true
-git checkout --no-overlay $MERGE_BRANCH --theirs -- './busytown/*' || true
-git checkout --no-overlay $MERGE_BRANCH --theirs -- './buildSrc-tests/*' || true
-git checkout --no-overlay $MERGE_BRANCH --theirs -- './*/api/*.txt' || true
-git checkout --no-overlay $MERGE_BRANCH --theirs -- './*/api/*.ignore' || true
-git checkout --no-overlay $MERGE_BRANCH --theirs -- './compose/material/material/icons/generator/api/**.txt' || true
-
-#material3 only for now, there is a lot of issues with it right now, we'll fix them soon, and we shouldn't reset it after that
-git checkout --no-overlay HEAD --ours -- './compose/material3/*' || true

--- a/mergeAOSP.sh
+++ b/mergeAOSP.sh
@@ -1,8 +1,12 @@
+## This script simplifies merge of AOSP branches to the JetBrains fork.
+## The JetBrains fork contains multiple files/folders that are fully developed independently of AOSP,
+## and should not be updated by the upstream version
+
 #!/bin/bash
 set -e
 
 if [ -z "$1" ]; then
-echo "Specify the commit. For example: ./mergeAOSP.sh jetpack-compose/1.5.1"
+echo "Specify the commit. For example: ./mergeAOSP.sh androidx/compose-ui/1.6.0-alpha08"
 exit 1
 fi
 

--- a/mergeAOSP.sh
+++ b/mergeAOSP.sh
@@ -1,8 +1,9 @@
+#!/bin/bash
+
 ## This script simplifies merge of AOSP branches to the JetBrains fork.
 ## The JetBrains fork contains multiple files/folders that are fully developed independently of AOSP,
 ## and should not be updated by the upstream version
 
-#!/bin/bash
 set -e
 
 if [ -z "$1" ]; then


### PR DESCRIPTION
This script can be used to merge any commit from androidx-main branch.

The old script was for complicated merge of specific versions.