### PR TITLE
remove useless ON_CREATED event for WASM Lifecycle handling

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -82,7 +82,7 @@ private abstract external class ExtendedTouchEvent : TouchEvent {
     val force: Double
 }
 
-private interface ComposeWindowState {
+internal interface ComposeWindowState {
     fun init() {}
     fun sizeFlow(): Flow<IntSize>
 
@@ -106,7 +106,7 @@ private interface ComposeWindowState {
     }
 }
 
-private class DefaultWindowState(private val viewportContainer: Element) : ComposeWindowState {
+internal class DefaultWindowState(private val viewportContainer: Element) : ComposeWindowState {
     private val channel = Channel<IntSize>(CONFLATED)
 
     override val globalEvents = EventTargetListener(window)
@@ -144,7 +144,7 @@ private class DefaultWindowState(private val viewportContainer: Element) : Compo
 }
 
 @OptIn(InternalComposeApi::class)
-private class ComposeWindow(
+internal class ComposeWindow(
     private val canvas: HTMLCanvasElement,
     content: @Composable () -> Unit,
     private val state: ComposeWindowState
@@ -277,8 +277,6 @@ private class ComposeWindow(
         state.globalEvents.addDisposableEvent("blur") {
             lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
         }
-
-        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
     }
 
     init {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.lifecycle.Lifecycle
+import isHeadlessBrowser
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.browser.document
+import org.w3c.dom.HTMLCanvasElement
+import org.w3c.dom.events.FocusEvent
+
+
+class ComposeWindowLifecycleTest {
+    private val canvasId = "canvas1"
+
+
+    @AfterTest
+    fun cleanup() {
+        document.getElementById(canvasId)?.remove()
+    }
+
+    @Test
+    fun allEvents() {
+        if (isHeadlessBrowser()) return
+        val canvas = document.createElement("canvas") as HTMLCanvasElement
+        canvas.setAttribute("id", canvasId)
+        document.body!!.appendChild(canvas)
+
+        val lifecycleOwner = ComposeWindow(
+            canvas = canvas,
+            content = {},
+            state = DefaultWindowState(document.documentElement!!)
+        )
+
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
+
+        document.dispatchEvent(FocusEvent("blur"))
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner.lifecycle.currentState)
+
+        document.dispatchEvent(FocusEvent("focus"))
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
+    }
+}


### PR DESCRIPTION
It cannot be handled anyway because ON_STARTED/ON_RESUME will be called immediately after and web target is single-threaded

Fixes comment from #1198

## Testing

Test: added ComposeWindowLifecycleTest