### PR TITLE
iOS support `LiveRegion` semantics in a11y

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/AccessibilityLiveRegionExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/AccessibilityLiveRegionExample.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Text
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import kotlinx.coroutines.delay
+
+val AccessibilityLiveRegionExample = Screen.Example("Accessibility LiveRegion example") {
+    var number by remember { mutableStateOf(0) }
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text("Polite:")
+        Text("Number $number", modifier = Modifier.semantics {
+            liveRegion = LiveRegionMode.Polite
+        })
+
+        Text("Assertive:")
+        Text("Number $number", modifier = Modifier.semantics {
+            liveRegion = LiveRegionMode.Assertive
+        })
+    }
+
+    // Update the number every second
+    LaunchedEffect(Unit) {
+        while (true) {
+            number++
+            delay(1000)
+        }
+    }
+}

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
@@ -51,5 +51,6 @@ val IosSpecificFeatures = Screen.Selection(
     "iOS-specific features",
     NativeModalWithNaviationExample,
     HapticFeedbackExample,
-    LazyColumnWithInteropViewsExample
+    LazyColumnWithInteropViewsExample,
+    AccessibilityLiveRegionExample
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
@@ -51,4 +51,5 @@ val IosSpecificFeatures = Screen.Selection(
     "iOS-specific features",
     NativeModalWithNaviationExample,
     HapticFeedbackExample,
+    LazyColumnWithInteropViewsExample
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/LazyColumnWithInteropViewsExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/LazyColumnWithInteropViewsExample.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.unit.dp
+import platform.UIKit.UILabel
+
+val LazyColumnWithInteropViewsExample = Screen.Example("LazyColumn with interop views") {
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        items(100) {
+            if (it % 2 == 0) {
+                UIKitView(
+                    factory = {
+                        val view = UILabel()
+                        view.text = "UILabel $it"
+                        view
+                    },
+                    modifier = Modifier.fillMaxWidth().height(40.dp)
+                )
+            } else {
+                Text("Text $it", Modifier.height(40.dp))
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -999,7 +999,7 @@ internal class AccessibilityMediator(
     private var isAlive = true
 
     private var inflightScrollsCount = 0
-    private val needsRefocusingDueToScroll: Boolean
+    private val needsRedundantRefocusingOnSameElement: Boolean
         get() = inflightScrollsCount > 0
 
     /**
@@ -1278,7 +1278,7 @@ internal class AccessibilityMediator(
 
         val isFocusedElementDead = !isFocusedElementAlive
 
-        val needsRefocusing = needsInitialRefocusing || isFocusedElementDead || needsRefocusingDueToScroll
+        val needsRefocusing = needsInitialRefocusing || isFocusedElementDead
 
         val newElementToFocus = if (needsRefocusing) {
             debugLogger?.log("Needs refocusing")
@@ -1294,7 +1294,13 @@ internal class AccessibilityMediator(
 
             refocusedElement
         } else {
-            null // No need to refocus to anything
+            if (needsRedundantRefocusingOnSameElement) {
+                focusedElement?.semanticsNodeId?.let {
+                    accessibilityElementsMap[it]
+                }
+            } else {
+                null // No need to refocus to anything
+            }
         }
 
         return NodesSyncResult(newElementToFocus)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1070,6 +1070,7 @@ internal class AccessibilityMediator(
                     }
 
                     debugLogger?.log("AccessibilityMediator.sync took $time")
+                    debugLogger?.log("LayoutChanged, newElementToFocus: ${result.newElementToFocus}")
 
                     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, result.newElementToFocus)
                 }
@@ -1099,8 +1100,12 @@ internal class AccessibilityMediator(
                 null
             )
 
+            debugLogger?.log("PageScrolled")
+
             if (accessibilityElementsMap[focusedNode.id] == null) {
                 findElementInRect(rect = focusedRectInWindow)?.let {
+                    debugLogger?.log("LayoutChanged, result: $it")
+
                     UIAccessibilityPostNotification(
                         UIAccessibilityLayoutChangedNotification,
                         it
@@ -1278,10 +1283,6 @@ internal class AccessibilityMediator(
             }
 
             refocusedElement
-        } else {
-            focusedElement?.semanticsNodeId?.let {
-                accessibilityElementsMap[it]
-            }
         }
 
         return NodesSyncResult(newElementToFocus)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -624,6 +624,10 @@ private class AccessibilityElement(
                 }
             }
 
+            config.getOrNull(SemanticsProperties.LiveRegion)?.let {
+                result = result or UIAccessibilityTraitUpdatesFrequently
+            }
+
             config.getOrNull(SemanticsActions.OnClick)?.let {
                 result = result or UIAccessibilityTraitButton
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -603,7 +603,7 @@ private class AccessibilityElement(
             if (config.contains(SemanticsProperties.LiveRegion)) {
                 // TODO: LiveRegionMode in the config is currently ignored.
                 //  the default behavior due this flag set will actually do `Polite` announcements
-                //  to do `Assertive` announcements, we need to post a notification manually on each change
+                //  to do `Assertive` announcements, we need to post a notification explicitly on each change
                 //  which we need to track manually
                 result = result or UIAccessibilityTraitUpdatesFrequently
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -601,6 +601,10 @@ private class AccessibilityElement(
             val config = cachedConfig
 
             if (config.contains(SemanticsProperties.LiveRegion)) {
+                // TODO: LiveRegionMode in the config is currently ignored.
+                //  the default behavior due this flag set will actually do `Polite` announcements
+                //  to do `Assertive` announcements, we need to post a notification manually on each change
+                //  which we need to track manually
                 result = result or UIAccessibilityTraitUpdatesFrequently
             }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1283,6 +1283,8 @@ internal class AccessibilityMediator(
             }
 
             refocusedElement
+        } else {
+            null // No need to refocus to anything
         }
 
         return NodesSyncResult(newElementToFocus)


### PR DESCRIPTION
## Proposed Changes

Add `UIAccessibilityTraitUpdatesFrequently` to elements with associated `SemanticsNode` having a `LiveRegion` property.
Don't return a non-null refocused element if it's the same one before the sync unless it needs to happen (during the scroll to trigger private API).
This prevents accessibility focus change (forcing it to previous element) if the semantics tree is synced continuously due to bug in iOS (UIAccessibilityFocusedElement returns older value)

## Testing

Test: When a focused accessibility element has a `LiveRegion`, it will voice update in a given element.

## Issues Fixed
Incorrect refocusing when semantics are synced continuously.

