### PR TITLE
Move the effects and synthetic events dispatching to after the draw phase in the render loop.

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
@@ -73,31 +73,24 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.RootMeasurePolicy.measure
 import androidx.compose.ui.platform.renderingTest
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performKeyPress
-import androidx.compose.ui.test.performMouseInput
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertFalse
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
-@OptIn(InternalTestApi::class, ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(InternalTestApi::class, ExperimentalComposeUiApi::class)
 class ComposeSceneTest {
     @get:Rule
     val screenshotRule = DesktopScreenshotTestRule("compose/ui/ui-desktop")
@@ -703,125 +696,6 @@ class ComposeSceneTest {
             assertThat(field1FocusState!!.isFocused).isTrue()
             assertThat(field2FocusState!!.isFocused).isFalse()
         }
-    }
-
-    // Test that we're draining the effect dispatcher completely before starting the draw phase
-    @Test
-    fun allEffectsRunBeforeDraw() = runApplicationTest {
-        var flag by mutableStateOf(false)
-        val events = mutableListOf<String>()
-        launchTestApplication {
-            Window(onCloseRequest = {}) {
-                LaunchedEffect(flag) {
-                    if (flag) {
-                        launch {
-                            launch {
-                                launch {
-                                    launch {
-                                        launch {
-                                            launch {
-                                                events.add("effect")
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                Canvas(Modifier.size(100.dp)) {
-                    if (flag) {
-                        events.add("draw")
-                    }
-                }
-            }
-        }
-        awaitIdle()
-
-        flag = true
-        awaitIdle()
-        assertEquals(listOf("effect", "draw"), events)
-    }
-
-    // Test that effects are run before synthetic events are delivered.
-    // This is important because the effects may be registering to receive the events. For example
-    // when a new element appears under the mouse pointer and registers to mouse-enter events.
-    @Test
-    fun effectsRunBeforeSyntheticEvents() = runComposeUiTest {
-        var flag by mutableStateOf(false)
-        val events = mutableListOf<String>()
-
-        setContent {
-            Box(
-                modifier = Modifier
-                    .size(100.dp)
-                    .testTag("container"),
-                contentAlignment = Alignment.Center
-            ) {
-                if (flag) {
-                    Box(
-                        modifier = Modifier
-                            .size(50.dp)
-                            .onPointerEvent(eventType = PointerEventType.Enter) {
-                                events.add("mouse-enter")
-                            }
-                    )
-
-                    LaunchedEffect(Unit) {
-                        events.add("effect")
-                    }
-                }
-            }
-        }
-
-        onNodeWithTag("container").performMouseInput {
-            moveTo(Offset(50f, 50f))
-        }
-        flag = true
-        waitForIdle()
-
-        assertEquals(listOf("effect", "mouse-enter"), events)
-    }
-
-    // Test that synthetic events are dispatched before the drawing phase.
-    @Test
-    fun syntheticEventsDispatchedBeforeDraw() = runComposeUiTest {
-        var flag by mutableStateOf(false)
-        val events = mutableListOf<String>()
-
-        setContent {
-            Box(
-                modifier = Modifier
-                    .size(100.dp)
-                    .testTag("container"),
-                contentAlignment = Alignment.Center
-            ) {
-                if (flag) {
-                    Box(
-                        modifier = Modifier
-                            .size(50.dp)
-                            .onPointerEvent(eventType = PointerEventType.Enter) {
-                                events.add("mouse-enter")
-                            }
-                    )
-
-                    Canvas(Modifier.size(100.dp)) {
-                        if (flag) {
-                            events.add("draw")
-                        }
-                    }
-                }
-            }
-        }
-
-        onNodeWithTag("container").performMouseInput {
-            moveTo(Offset(50f, 50f))
-        }
-        flag = true
-        waitForIdle()
-
-        assertEquals(listOf("mouse-enter", "draw"), events)
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneTest.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.RootMeasurePolicy.measure
 import androidx.compose.ui.platform.renderingTest
-import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.test.junit4.createComposeRule

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
@@ -17,19 +17,20 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.scene.MultiLayerComposeScene
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
-import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.FrameDispatcher
 import org.jetbrains.skiko.MainUIDispatcher
-import kotlin.coroutines.CoroutineContext
 
 internal fun renderingTest(
     width: Int,
@@ -57,12 +58,12 @@ internal class RenderingTestScope(
     }
 
     val surface: Surface = Surface.makeRasterN32Premul(width, height)
-    private val canvas: Canvas = surface.canvas
-    val scene = ComposeScene(
+    private val canvas = surface.canvas.asComposeCanvas()
+    val scene = MultiLayerComposeScene(
         coroutineContext = coroutineContext,
         invalidate = frameDispatcher::scheduleFrame
     ).apply {
-        constraints = Constraints(maxWidth = width, maxHeight = height)
+        size = IntSize(width = width, height = height)
     }
 
     var density: Float
@@ -85,7 +86,7 @@ internal class RenderingTestScope(
     }
 
     private fun onRender(timeNanos: Long) {
-        canvas.clear(Color.Transparent.toArgb())
+        canvas.nativeCanvas.clear(Color.Transparent.toArgb())
         scene.render(canvas, timeNanos)
         onRender.complete(Unit)
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -40,7 +40,7 @@ internal class FlushCoroutineDispatcher(
 ) : CoroutineDispatcher(), Delay {
     // Dispatcher should always be alive, even if Job is cancelled. Otherwise coroutines which
     // use this dispatcher won't be properly cancelled.
-    // TODO replace it by scope.coroutineContext[Dispatcher] when it will be no longer experimental
+    // TODO replace it by scope.coroutineContext[CoroutineDispatcher] when it will be no longer experimental
     private val scope = CoroutineScope(scope.coroutineContext.minusKey(Job))
     private val tasks = mutableSetOf<Runnable>()
     private val delayedTasks = mutableSetOf<Runnable>()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -63,6 +63,9 @@ internal abstract class BaseComposeScene(
             processKeyEvent = ::processKeyEvent
         )
 
+    // Store this to avoid creating a lambda every frame
+    private val updatePointerPosition = inputHandler::updatePointerPosition
+
     private val frameClock = BroadcastFrameClock(onNewAwaiters = ::invalidateIfNeeded)
     private val recomposer: ComposeSceneRecomposer =
         ComposeSceneRecomposer(coroutineContext, frameClock)
@@ -133,7 +136,7 @@ internal abstract class BaseComposeScene(
          * It's required before setting content to apply changed parameters
          * before first recomposition. Otherwise, it can lead to double recomposition.
          */
-        recomposer.performScheduledTasks()
+        recomposer.performScheduledRecomposerTasks()
 
         composition?.dispose()
         composition = createComposition {
@@ -143,31 +146,30 @@ internal abstract class BaseComposeScene(
             )
         }
 
-        recomposer.performScheduledTasks()
+        recomposer.performScheduledRecomposerTasks()
     }
 
     override fun render(canvas: Canvas, nanoTime: Long) =
         postponeInvalidation("BaseComposeScene:render") {
-            // Note that on Android the order is slightly different:
-            // - Recomposition
-            // - Layout
-            // - Draw
-            // - Composition effects
-            // - Synthetic events
-            // We do this differently in order to be able to observe changes made by synthetic events
-            // in the drawing phase, thus reducing the time before they are visible on screen.
-            //
-            // It is important, however, to run the composition effects before the synthetic events are
-            // dispatched, in order to allow registering for these events before they are sent.
-            // Otherwise, events like a synthetic mouse-enter sent due to a new element appearing under
-            // the pointer would be missed by e.g. InteractionSource.collectHoverAsState
-            recomposer.performScheduledTasks()
-            frameClock.sendFrame(nanoTime)           // Recomposition
-            doLayout()                               // Layout
-            recomposer.performScheduledEffects()     // Composition effects (e.g. LaunchedEffect)
-            inputHandler.updatePointerPosition()     // Synthetic move event
+            // We try to run the phases here in the same order Android does.
+
+            // Flush composition effects (e.g. LaunchedEffect, coroutines launched in
+            // rememberCoroutineScope()) before everything else
+            recomposer.performScheduledEffects()
+
+            recomposer.performScheduledRecomposerTasks()
+            frameClock.sendFrame(nanoTime) // withFrameMillis/Nanos and recomposition
+
+            doLayout()  // Layout
+
+            // Schedule synthetic events to be sent after `render` completes
+            if (inputHandler.hasInvalidations) {
+                recomposer.scheduleAsEffect(updatePointerPosition)
+            }
+
+            // Draw
             snapshotInvalidationTracker.onDraw()
-            draw(canvas)                             // Draw
+            draw(canvas)
         }
 
     override fun sendPointerEvent(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -98,8 +98,7 @@ internal abstract class BaseComposeScene(
     private var hasPendingDraws = true
     protected fun invalidateIfNeeded() {
         hasPendingDraws = frameClock.hasAwaiters ||
-            snapshotInvalidationTracker.hasInvalidations ||
-            inputHandler.hasInvalidations
+            snapshotInvalidationTracker.hasInvalidations
         if (hasPendingDraws && !isInvalidationDisabled && !isClosed && composition != null) {
             invalidate()
         }
@@ -163,7 +162,7 @@ internal abstract class BaseComposeScene(
             doLayout()  // Layout
 
             // Schedule synthetic events to be sent after `render` completes
-            if (inputHandler.hasInvalidations) {
+            if (inputHandler.needUpdatePointerPosition) {
                 recomposer.scheduleAsEffect(updatePointerPosition)
             }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -64,10 +64,9 @@ internal class ComposeSceneInputHandler(
         get() = pointerPositions.values.firstOrNull()
 
     /**
-     * Indicates if there were invalidations and triggering [BaseComposeScene.measureAndLayout]
-     * is now required.
+     * Indicates whether [updatePointerPosition] needs to be called.
      */
-    val hasInvalidations: Boolean
+    val needUpdatePointerPosition: Boolean
         get() = syntheticEventSender.needUpdatePointerPosition
 
     fun onPointerEvent(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcherTest.kt
@@ -17,14 +17,12 @@
 package androidx.compose.ui.platform
 
 import kotlinx.coroutines.test.runTest
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.*
 
-@OptIn(ExperimentalCoroutinesApi::class)
 class FlushCoroutineDispatcherTest {
 
     @Test

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.scene.BaseComposeScene
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+
+/**
+ * Tests the ordering of the phases of the [BaseComposeScene.render] loop.
+ */
+@OptIn(ExperimentalTestApi::class, InternalTestApi::class)
+class RenderPhasesTest {
+    /**
+     * Test the order of the basic phases:
+     * 1. withFrameMillis/Nanos
+     * 2. Composition
+     * 3. Layout
+     * 4. Draw
+     * 5. Effects launched in the composition.
+     */
+    @Test
+    fun testBasicOrder() = runInternalSkikoComposeUiTest(
+        coroutineDispatcher = StandardTestDispatcher()
+    ) {
+        mainClock.autoAdvance = false
+
+        val phases = mutableListOf<String>()
+        var logPhases by mutableStateOf(false)
+
+        setContent {
+            LaunchedEffect(Unit) {
+                var stop = false
+                while(!stop) {
+                    withFrameNanos {
+                        if (logPhases) {
+                            phases.add("frame")
+                            stop = true
+                        }
+                    }
+                }
+            }
+
+            if (logPhases) {
+                phases.add("composition")
+            }
+
+            Layout(
+                modifier = Modifier.size(100.dp),
+                measurePolicy = { _, _ ->
+                    if (logPhases) {
+                        phases.add("layout")
+                    }
+
+                    layout(100, 100) { }
+                }
+            )
+
+            Canvas(Modifier.size(100.dp)) {
+                if (logPhases) {
+                    phases.add("draw")
+                }
+            }
+
+            LaunchedEffect(logPhases) {
+                if (logPhases) {
+                    phases.add("effects")
+                }
+            }
+        }
+
+        assertContentEquals(emptyList(), phases)
+        logPhases = true
+        mainClock.advanceTimeByFrame()
+        waitForIdle()  // Make the effects run
+        assertContentEquals(
+            expected = listOf("frame", "composition", "layout", "draw", "effects"),
+            actual = phases
+        )
+    }
+
+    /**
+     * Test that synthetic events are delivered after effects have run.
+     */
+    @Test
+    fun syntheticEventsDispatchedAfterEffects() = runInternalSkikoComposeUiTest(
+        coroutineDispatcher = StandardTestDispatcher()
+    ) {
+        val phases = mutableListOf<String>()
+        var showNewBox by mutableStateOf(false)
+
+        setContent {
+            Box(Modifier.size(100.dp).testTag("box")) {
+                if (showNewBox) {
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                            .onPointerEvent(eventType = PointerEventType.Enter) {
+                                phases.add("syntheticEvent")
+                            }
+                    )
+                    LaunchedEffect(Unit) {
+                        phases.add("effects")
+                    }
+                }
+            }
+        }
+
+        assertContentEquals(emptyList(), phases)
+        onNodeWithTag("box").performMouseInput {
+            moveTo(Offset(50f, 50f))
+        }
+        showNewBox = true
+        waitForIdle()
+        assertContentEquals(
+            expected = listOf("effects", "syntheticEvent"),
+            actual = phases
+        )
+    }
+
+    /**
+     * Test that coroutines launched in a composition's [rememberCoroutineScope] execute in the
+     * correct order, and only after the draw phase.
+     */
+    @Test
+    fun coroutinesDispatchedAfterDraw() = runInternalSkikoComposeUiTest(
+        coroutineDispatcher = StandardTestDispatcher()
+    ) {
+        mainClock.autoAdvance = false
+
+        val phases = mutableListOf<String>()
+        var startTest by mutableStateOf(false)
+        setContent {
+            val coroutineScope = rememberCoroutineScope()
+
+            LaunchedEffect(Unit) {
+                while(true) {
+                    withFrameMillis {
+                        if (startTest) {
+                            coroutineScope.launch {
+                                phases.add("launchedWithFrame")
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (startTest) {
+                coroutineScope.launch {
+                    phases.add("launchedFromComposition")
+                }
+            }
+
+            LaunchedEffect(startTest) {
+                if (startTest) {
+                    coroutineScope.launch {
+                        phases.add("launchedFromEffect")
+                    }
+                }
+            }
+
+            Canvas(Modifier.size(100.dp)) {
+                if (startTest) {
+                    phases.add("draw")
+                }
+            }
+        }
+
+        assertContentEquals(emptyList(), phases)
+        startTest = true
+        mainClock.advanceTimeByFrame()
+        waitForIdle()  // Make the effects run
+        assertContentEquals(
+            expected = listOf("draw", "launchedWithFrame", "launchedFromComposition", "launchedFromEffect"),
+            actual = phases
+        )
+    }
+}


### PR DESCRIPTION
While investigating [this](https://github.com/JetBrains/compose-multiplatform/issues/4438#issuecomment-2031371245), we've discovered that `LazyColumn` moves its elements synchronously when scrolled (only if the scrolling causes new items to become visible).

Additionally, we currently run coroutines launched in a composition's `rememberCoroutineScope` between the layout and draw phases (due to https://github.com/JetBrains/compose-multiplatform-core/pull/1034 and our desire to send the synthetic events before the draw phase, to avoid a one-frame delay when scrolling a list that highlights the item under the mouse).

Together these two create a problem (visible in the video linked above) because when the `LazyColumn` is scrolled from a launched coroutine, it moves its element to the position where they would normally appear only on the next frame, which causes a visible "jump".

## Proposed Changes
After much consideration (with @igordmn) we decided to strictly adhere to the ordering of the phases as they are done on Android:
1. Flush any pending effects.
2. Composition (which can schedule effects to be run after `render` completes).
3. Layout
4. Schedule synthetic events, if any, to be delivered after `render` completes.
5. Draw
6. (after `render`) scheduled composition effects.
7. (after `render`) scheduled synthetic events.

## Testing

Test: Tested the "jumpy" lazy column manually, and added unit tests to verify the order of the render phases.

The manual test:
```
import androidx.compose.foundation.ScrollState
import androidx.compose.foundation.border
import androidx.compose.foundation.gestures.scrollBy
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.Column
import androidx.compose.foundation.layout.Row
import androidx.compose.foundation.layout.fillMaxHeight
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.foundation.layout.fillMaxWidth
import androidx.compose.foundation.layout.height
import androidx.compose.foundation.lazy.LazyColumn
import androidx.compose.foundation.lazy.LazyListState
import androidx.compose.foundation.rememberScrollState
import androidx.compose.foundation.verticalScroll
import androidx.compose.material.Text
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.runtime.getValue
import androidx.compose.runtime.mutableStateOf
import androidx.compose.runtime.remember
import androidx.compose.runtime.setValue
import androidx.compose.runtime.withFrameMillis
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.Modifier
import androidx.compose.ui.draw.drawBehind
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.input.pointer.PointerEventType
import androidx.compose.ui.input.pointer.onPointerEvent
import androidx.compose.ui.text.TextStyle
import androidx.compose.ui.unit.dp
import androidx.compose.ui.unit.sp
import androidx.compose.ui.window.singleWindowApplication
import kotlinx.coroutines.launch

val scrollState = ScrollState(0)
val lazyColumnState = LazyListState(0, 0)

fun main() = singleWindowApplication { 
    Box(modifier = Modifier.fillMaxSize()) {
        Row {
            Column(
                modifier = Modifier
                    .fillMaxHeight()
                    .weight(1f)
                    .verticalScroll(scrollState)
            ) {
                (0..100).forEach { index ->
                    Text(
                        "Column item $index",
                        style = TextStyle(fontSize = 30.sp),
                        modifier = Modifier.height(150.dp).fillMaxWidth().border(
                            width = 1.dp,
                            color = Color.Black
                        )
                    )
                }
            }


            LazyColumn(
                state = lazyColumnState,
                modifier = Modifier.fillMaxHeight().weight(1f)
            ) {
                items(100) { index ->
                    Text(
                        "LazyColumn item $index",
                        style = TextStyle(fontSize = 30.sp),
                        modifier = Modifier.height(150.dp).fillMaxWidth().border(
                            width = 1.dp,
                            color = Color.Black
                        )
                    )
                }
            }
        }

        LaunchedEffect(Unit) {
            var direction = 0
            var startTime = 0L
            var frameCount = 0
            while (true) {
                withFrameMillis { millis ->
                    frameCount += 1
                    if (frameCount.mod(1) == 0) {
                        if (direction == 0) {
                            startTime = millis
                            direction = 1
                        }
                        else if (millis - startTime > 10000) {
                            startTime = millis
                            direction = -direction
                        }
                        val scrollDelta = 5 * direction
                        launch {
                            scrollState.scrollBy(scrollDelta.toFloat())
                            lazyColumnState.scrollBy(scrollDelta.toFloat())
                        }
                    }
                }
            }
        }
    }
}
```

This PR should be verified by QA.

## Issues Fixed

Possibly fixes https://github.com/JetBrains/compose-multiplatform/issues/4438
