### PR TITLE
Move applying `binary-compatibility-validator` to JB plugin

### DIFF
--- a/buildSrc/apply/applyJetBrainsAndroidXImplPlugin.gradle
+++ b/buildSrc/apply/applyJetBrainsAndroidXImplPlugin.gradle
@@ -1,0 +1,9 @@
+import androidx.build.jetbrains.JetBrainsAndroidXImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.rootProject.ext["buildSrcOut"]}/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: JetBrainsAndroidXImplPlugin

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/JetbrainsAndroidXPlugin.kt
@@ -18,125 +18,18 @@
 
 package androidx.build
 
-import androidx.build.jetbrains.artifactRedirecting
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.create
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
-import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinSoftwareComponentWithCoordinatesAndPublication
-import org.jetbrains.kotlin.konan.target.KonanTarget
 
-open class JetbrainsExtensions(
-    val project: Project,
-    val multiplatformExtension: KotlinMultiplatformExtension
-) {
-
-    // check for example here: https://maven.google.com/web/index.html?q=lifecyc#androidx.lifecycle
-    val defaultKonanTargetsPublishedByAndroidx = setOf(
-        KonanTarget.LINUX_X64,
-        KonanTarget.IOS_X64,
-        KonanTarget.IOS_ARM64,
-        KonanTarget.IOS_SIMULATOR_ARM64,
-        KonanTarget.MACOS_X64,
-        KonanTarget.MACOS_ARM64,
-    )
-
-    @JvmOverloads
-    fun configureKNativeRedirectingDependenciesInKlibManifest(
-        konanTargets: Set<KonanTarget> = defaultKonanTargetsPublishedByAndroidx
-    ) {
-        multiplatformExtension.targets.all {
-            if (it is KotlinNativeTarget && it.konanTarget in konanTargets) {
-                it.substituteForRedirectedPublishedDependencies()
-            }
-        }
-    }
-
-    /**
-     * When https://youtrack.jetbrains.com/issue/KT-61096 is implemented,
-     * this workaround won't be needed anymore:
-     *
-     * K/Native stores the dependencies in klib manifest and tries to resolve them during compilation.
-     * Since we use project dependency - implementation(project(...)), the klib manifest will reference
-     * our groupId (for example org.jetbrains.compose.collection-internal instead of androidx.collection).
-     * Therefore, the dependency can't be resolved since we don't publish libs for some k/native targets.
-     *
-     * To workaround that, we need to make sure
-     * that the project dependency is substituted by a module dependency (from androidx).
-     * We do this here. It should be called only for those k/native targets which require
-     * redirection to androidx artefacts.
-     *
-     * For available androidx targets see:
-     * https://maven.google.com/web/index.html#androidx.annotation
-     * https://maven.google.com/web/index.html#androidx.collection
-     * https://maven.google.com/web/index.html#androidx.lifecycle
-     */
-    fun KotlinNativeTarget.substituteForRedirectedPublishedDependencies() {
-        val comp = compilations.getByName("main")
-        val androidAnnotationVersion =
-            project.findProperty("artifactRedirecting.androidx.annotation.version")!!
-        val androidCollectionVersion =
-            project.findProperty("artifactRedirecting.androidx.collection.version")!!
-        val androidLifecycleVersion =
-            project.findProperty("artifactRedirecting.androidx.lifecycle.version")!!
-        listOf(
-            comp.configurations.compileDependencyConfiguration,
-            comp.configurations.runtimeDependencyConfiguration,
-            comp.configurations.apiConfiguration,
-            comp.configurations.implementationConfiguration,
-            comp.configurations.runtimeOnlyConfiguration,
-            comp.configurations.compileOnlyConfiguration,
-        ).forEach { c ->
-            c?.resolutionStrategy {
-
-                // TODO: It should be based on config
-                it.dependencySubstitution {
-                    it.substitute(it.project(":annotation:annotation"))
-                        .using(it.module("androidx.annotation:annotation:$androidAnnotationVersion"))
-                    it.substitute(it.project(":collection:collection"))
-                        .using(it.module("androidx.collection:collection:$androidCollectionVersion"))
-                    it.substitute(it.project(":lifecycle:lifecycle-common"))
-                        .using(it.module("androidx.lifecycle:lifecycle-common:$androidLifecycleVersion"))
-                    it.substitute(it.project(":lifecycle:lifecycle-runtime"))
-                        .using(it.module("androidx.lifecycle:lifecycle-runtime:$androidLifecycleVersion"))
-                    it.substitute(it.project(":lifecycle:lifecycle-viewmodel"))
-                        .using(it.module("androidx.lifecycle:lifecycle-viewmodel:$androidLifecycleVersion"))
-                }
-            }
-        }
-    }
-
-}
+// TODO: Rename to JetBrainsAndroidXPlugin
 class JetbrainsAndroidXPlugin : Plugin<Project> {
-
-    @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
     override fun apply(project: Project) {
-        project.plugins.all { plugin ->
-            if (plugin is KotlinMultiplatformPluginWrapper) {
-                onKotlinMultiplatformPluginApplied(project)
-            }
-        }
-    }
-
-    private fun onKotlinMultiplatformPluginApplied(project: Project) {
-        enableArtifactRedirectingPublishing(project)
-        val multiplatformExtension =
-            project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-
-        val extension = project.extensions.create<JetbrainsExtensions>(
-            "jetbrainsExtension",
-            project,
-            multiplatformExtension
+        val supportRoot = project.getSupportRootFolder()
+        project.apply(
+            mapOf<String, String>(
+                "from" to "$supportRoot/buildSrc/apply/applyJetBrainsAndroidXImplPlugin.gradle"
+            )
         )
-
-        // Note: Currently we call it unconditionally since Androidx provides the same set of
-        // Konan targets for all multiplatform libs they publish.
-        // In the future we might need to call it with non-default konan targets set in some modules
-        extension.configureKNativeRedirectingDependenciesInKlibManifest()
     }
 
     companion object {
@@ -146,52 +39,5 @@ class JetbrainsAndroidXPlugin : Plugin<Project> {
         fun applyAndConfigure(
             project: Project
         ) {}
-    }
-}
-
-private val Project.multiplatformExtension
-    get() = extensions.findByType(KotlinMultiplatformExtension::class.java)
-
-fun Project.experimentalArtifactRedirectingPublication() : Boolean = findProperty("artifactRedirecting.publication") == "true"
-fun Project.artifactRedirectingAndroidxVersion() : String? = findProperty("artifactRedirecting.androidx.compose.version") as String?
-fun Project.artifactRedirectingAndroidxFoundationVersion() : String? = findProperty("artifactRedirecting.androidx.compose.foundation.version") as String?
-fun Project.artifactRedirectingAndroidxMaterial3Version() : String? = findProperty("artifactRedirecting.androidx.compose.material3.version") as String?
-fun Project.artifactRedirectingAndroidxMaterialVersion() : String? = findProperty("artifactRedirecting.androidx.compose.material.version") as String?
-
-fun enableArtifactRedirectingPublishing(project: Project) {
-    if (!project.experimentalArtifactRedirectingPublication()) return
-
-    if (project.experimentalArtifactRedirectingPublication() && (project.artifactRedirectingAndroidxVersion() == null)) {
-        error("androidx version should be specified for OEL publications")
-    }
-
-    val ext = project.multiplatformExtension ?: error("expected a multiplatform project")
-
-    val redirecting = project.artifactRedirecting()
-    val newRootComponent: CustomRootComponent = run {
-        val rootComponent = project
-            .components
-            .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
-            .getByName("kotlin")
-
-        CustomRootComponent(rootComponent) { configuration ->
-            val targetName = redirecting.targetVersions.keys.firstOrNull {
-                // we rely on the fact that configuration name starts with target name
-                configuration.name.startsWith(it)
-            }
-            val targetVersion = redirecting.versionForTargetOrDefault(targetName ?: "")
-            project.dependencies.create(
-                redirecting.groupId, project.name, targetVersion
-            )
-        }
-    }
-
-    val oelTargetNames = (project.findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
-        .split(",").toSet()
-
-    ext.targets.all { target ->
-        if (target.name in oelTargetNames || target is KotlinAndroidTarget) {
-            project.publishAndroidxReference(target as AbstractKotlinTarget, newRootComponent)
-        }
     }
 }

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
@@ -310,9 +310,6 @@ class AndroidXComposeImplPlugin : Plugin<Project> {
                     "multiplatformExtension is null (multiplatform plugin not enabled?)"
             }
 
-            val androidXExtension = project.extensions.findByType(AndroidXExtension::class.java)
-                ?: throw Exception("You have applied AndroidXComposePlugin without AndroidXPlugin")
-
             /*
             The following configures source sets - note:
 
@@ -343,10 +340,6 @@ class AndroidXComposeImplPlugin : Plugin<Project> {
                 }
                 if (multiplatformExtension.targets.findByName("desktop") != null) {
                     tasks.named("desktopTestClasses").also(::addToBuildOnServer)
-                }
-
-                if (androidXExtension.type == LibraryType.PUBLISHED_LIBRARY) {
-                    project.apply(plugin = "org.jetbrains.kotlinx.binary-compatibility-validator")
                 }
             }
         }

--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetBrainsAndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetBrainsAndroidXImplPlugin.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("unused")
+
+package androidx.build.jetbrains
+
+import androidx.build.AndroidXExtension
+import androidx.build.multiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.create
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinSoftwareComponentWithCoordinatesAndPublication
+import org.jetbrains.kotlin.konan.target.KonanTarget
+
+open class JetbrainsExtensions(
+    val project: Project,
+    val multiplatformExtension: KotlinMultiplatformExtension
+) {
+
+    // check for example here: https://maven.google.com/web/index.html?q=lifecyc#androidx.lifecycle
+    val defaultKonanTargetsPublishedByAndroidx = setOf(
+        KonanTarget.LINUX_X64,
+        KonanTarget.IOS_X64,
+        KonanTarget.IOS_ARM64,
+        KonanTarget.IOS_SIMULATOR_ARM64,
+        KonanTarget.MACOS_X64,
+        KonanTarget.MACOS_ARM64,
+    )
+
+    @JvmOverloads
+    fun configureKNativeRedirectingDependenciesInKlibManifest(
+        konanTargets: Set<KonanTarget> = defaultKonanTargetsPublishedByAndroidx
+    ) {
+        multiplatformExtension.targets.all {
+            if (it is KotlinNativeTarget && it.konanTarget in konanTargets) {
+                it.substituteForRedirectedPublishedDependencies()
+            }
+        }
+    }
+
+    /**
+     * When https://youtrack.jetbrains.com/issue/KT-61096 is implemented,
+     * this workaround won't be needed anymore:
+     *
+     * K/Native stores the dependencies in klib manifest and tries to resolve them during compilation.
+     * Since we use project dependency - implementation(project(...)), the klib manifest will reference
+     * our groupId (for example org.jetbrains.compose.collection-internal instead of androidx.collection).
+     * Therefore, the dependency can't be resolved since we don't publish libs for some k/native targets.
+     *
+     * To workaround that, we need to make sure
+     * that the project dependency is substituted by a module dependency (from androidx).
+     * We do this here. It should be called only for those k/native targets which require
+     * redirection to androidx artefacts.
+     *
+     * For available androidx targets see:
+     * https://maven.google.com/web/index.html#androidx.annotation
+     * https://maven.google.com/web/index.html#androidx.collection
+     * https://maven.google.com/web/index.html#androidx.lifecycle
+     */
+    fun KotlinNativeTarget.substituteForRedirectedPublishedDependencies() {
+        val comp = compilations.getByName("main")
+        val androidAnnotationVersion =
+            project.findProperty("artifactRedirecting.androidx.annotation.version")!!
+        val androidCollectionVersion =
+            project.findProperty("artifactRedirecting.androidx.collection.version")!!
+        val androidLifecycleVersion =
+            project.findProperty("artifactRedirecting.androidx.lifecycle.version")!!
+        listOf(
+            comp.configurations.compileDependencyConfiguration,
+            comp.configurations.runtimeDependencyConfiguration,
+            comp.configurations.apiConfiguration,
+            comp.configurations.implementationConfiguration,
+            comp.configurations.runtimeOnlyConfiguration,
+            comp.configurations.compileOnlyConfiguration,
+        ).forEach { c ->
+            c?.resolutionStrategy {
+
+                // TODO: It should be based on config
+                it.dependencySubstitution {
+                    it.substitute(it.project(":annotation:annotation"))
+                        .using(it.module("androidx.annotation:annotation:$androidAnnotationVersion"))
+                    it.substitute(it.project(":collection:collection"))
+                        .using(it.module("androidx.collection:collection:$androidCollectionVersion"))
+                    it.substitute(it.project(":lifecycle:lifecycle-common"))
+                        .using(it.module("androidx.lifecycle:lifecycle-common:$androidLifecycleVersion"))
+                    it.substitute(it.project(":lifecycle:lifecycle-runtime"))
+                        .using(it.module("androidx.lifecycle:lifecycle-runtime:$androidLifecycleVersion"))
+                    it.substitute(it.project(":lifecycle:lifecycle-viewmodel"))
+                        .using(it.module("androidx.lifecycle:lifecycle-viewmodel:$androidLifecycleVersion"))
+                }
+            }
+        }
+    }
+
+}
+class JetBrainsAndroidXImplPlugin : Plugin<Project> {
+
+    @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
+    override fun apply(project: Project) {
+        project.plugins.all { plugin ->
+            if (plugin is KotlinMultiplatformPluginWrapper) {
+                onKotlinMultiplatformPluginApplied(project)
+            }
+        }
+    }
+
+    private fun onKotlinMultiplatformPluginApplied(project: Project) {
+        enableArtifactRedirectingPublishing(project)
+        enableBinaryCompatibilityValidator(project)
+        val multiplatformExtension =
+            project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+
+        val extension = project.extensions.create<JetbrainsExtensions>(
+            "jetbrainsExtension",
+            project,
+            multiplatformExtension
+        )
+
+        // Note: Currently we call it unconditionally since Androidx provides the same set of
+        // Konan targets for all multiplatform libs they publish.
+        // In the future we might need to call it with non-default konan targets set in some modules
+        extension.configureKNativeRedirectingDependenciesInKlibManifest()
+    }
+}
+
+private fun Project.experimentalArtifactRedirectingPublication() : Boolean = findProperty("artifactRedirecting.publication") == "true"
+private fun Project.artifactRedirectingAndroidxVersion() : String? = findProperty("artifactRedirecting.androidx.compose.version") as String?
+private fun Project.artifactRedirectingAndroidxFoundationVersion() : String? = findProperty("artifactRedirecting.androidx.compose.foundation.version") as String?
+private fun Project.artifactRedirectingAndroidxMaterial3Version() : String? = findProperty("artifactRedirecting.androidx.compose.material3.version") as String?
+private fun Project.artifactRedirectingAndroidxMaterialVersion() : String? = findProperty("artifactRedirecting.androidx.compose.material.version") as String?
+
+private fun enableArtifactRedirectingPublishing(project: Project) {
+    if (!project.experimentalArtifactRedirectingPublication()) return
+
+    if (project.experimentalArtifactRedirectingPublication() && (project.artifactRedirectingAndroidxVersion() == null)) {
+        error("androidx version should be specified for OEL publications")
+    }
+
+    val ext = project.multiplatformExtension ?: error("expected a multiplatform project")
+
+    val redirecting = project.artifactRedirecting()
+    val newRootComponent: CustomRootComponent = run {
+        val rootComponent = project
+            .components
+            .withType(KotlinSoftwareComponentWithCoordinatesAndPublication::class.java)
+            .getByName("kotlin")
+
+        CustomRootComponent(rootComponent) { configuration ->
+            val targetName = redirecting.targetVersions.keys.firstOrNull {
+                // we rely on the fact that configuration name starts with target name
+                configuration.name.startsWith(it)
+            }
+            val targetVersion = redirecting.versionForTargetOrDefault(targetName ?: "")
+            project.dependencies.create(
+                redirecting.groupId, project.name, targetVersion
+            )
+        }
+    }
+
+    val oelTargetNames = (project.findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
+        .split(",").toSet()
+
+    ext.targets.all { target ->
+        if (target.name in oelTargetNames || target is KotlinAndroidTarget) {
+            project.publishAndroidxReference(target as AbstractKotlinTarget, newRootComponent)
+        }
+    }
+}
+
+private fun enableBinaryCompatibilityValidator(project: Project) {
+    val androidXExtension = project.extensions.findByType(AndroidXExtension::class.java)
+        ?: throw Exception("You have applied AndroidXComposePlugin without AndroidXPlugin")
+    project.afterEvaluate {
+        if (androidXExtension.shouldPublish()) {
+            project.apply(plugin = "org.jetbrains.kotlinx.binary-compatibility-validator")
+        }
+    }
+}

--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.build
+package androidx.build.jetbrains
 
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.mpp.*

--- a/compose/ui/ui-test-junit4/api/desktop/ui-test-junit4.api
+++ b/compose/ui/ui-test-junit4/api/desktop/ui-test-junit4.api
@@ -1,0 +1,153 @@
+public abstract interface class androidx/compose/ui/test/junit4/ComposeContentTestRule : androidx/compose/ui/test/junit4/ComposeTestRule {
+	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
+}
+
+public abstract interface class androidx/compose/ui/test/junit4/ComposeTestRule : androidx/compose/ui/test/SemanticsNodeInteractionsProvider, org/junit/rules/TestRule {
+	public abstract fun awaitIdle (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
+	public abstract fun getMainClock ()Landroidx/compose/ui/test/MainTestClock;
+	public abstract fun registerIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public abstract fun runOnIdle (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun runOnUiThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun unregisterIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public abstract fun waitForIdle ()V
+	public abstract fun waitUntil (JLkotlin/jvm/functions/Function0;)V
+	public static synthetic fun waitUntil$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public abstract fun waitUntilAtLeastOneExists (Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public static synthetic fun waitUntilAtLeastOneExists$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public abstract fun waitUntilDoesNotExist (Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public static synthetic fun waitUntilDoesNotExist$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public abstract fun waitUntilExactlyOneExists (Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public static synthetic fun waitUntilExactlyOneExists$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public abstract fun waitUntilNodeCount (Landroidx/compose/ui/test/SemanticsMatcher;IJ)V
+	public static synthetic fun waitUntilNodeCount$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;IJILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/junit4/ComposeTestRule$DefaultImpls {
+	public static synthetic fun waitUntil$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun waitUntilAtLeastOneExists$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public static synthetic fun waitUntilDoesNotExist$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public static synthetic fun waitUntilExactlyOneExists$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public static synthetic fun waitUntilNodeCount$default (Landroidx/compose/ui/test/junit4/ComposeTestRule;Landroidx/compose/ui/test/SemanticsMatcher;IJILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/junit4/DesktopComposeTestRule : androidx/compose/ui/test/junit4/ComposeContentTestRule {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
+	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+	public fun awaitIdle (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getDensity ()Landroidx/compose/ui/unit/Density;
+	public fun getMainClock ()Landroidx/compose/ui/test/MainTestClock;
+	public final fun getScene ()Landroidx/compose/ui/scene/ComposeScene;
+	public fun onAllNodes (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public fun onNode (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public fun registerIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public fun runOnIdle (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun runOnUiThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun setContent (Lkotlin/jvm/functions/Function2;)V
+	public final fun setScene (Landroidx/compose/ui/scene/ComposeScene;)V
+	public fun unregisterIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public fun waitForIdle ()V
+	public fun waitUntil (JLkotlin/jvm/functions/Function0;)V
+	public fun waitUntilAtLeastOneExists (Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public fun waitUntilDoesNotExist (Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public fun waitUntilExactlyOneExists (Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public fun waitUntilNodeCount (Landroidx/compose/ui/test/SemanticsMatcher;IJ)V
+}
+
+public final class androidx/compose/ui/test/junit4/DesktopComposeTestRule_desktopKt {
+	public static final fun createComposeRule ()Landroidx/compose/ui/test/junit4/ComposeContentTestRule;
+	public static final fun createComposeRule (Lkotlin/coroutines/CoroutineContext;)Landroidx/compose/ui/test/junit4/ComposeContentTestRule;
+	public static synthetic fun createComposeRule$default (Lkotlin/coroutines/CoroutineContext;ILjava/lang/Object;)Landroidx/compose/ui/test/junit4/ComposeContentTestRule;
+}
+
+public final class androidx/compose/ui/test/junit4/GoldenConfig {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Landroidx/compose/ui/test/junit4/GoldenConfig;
+	public static synthetic fun copy$default (Landroidx/compose/ui/test/junit4/GoldenConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Landroidx/compose/ui/test/junit4/GoldenConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFsGoldenPath ()Ljava/lang/String;
+	public final fun getModulePrefix ()Ljava/lang/String;
+	public final fun getRepoGoldenPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/compose/ui/test/junit4/ScreenshotResultProto {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Landroidx/compose/ui/test/junit4/ScreenshotResultProto;
+	public static synthetic fun copy$default (Landroidx/compose/ui/test/junit4/ScreenshotResultProto;Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Landroidx/compose/ui/test/junit4/ScreenshotResultProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComparisonStatistics ()Ljava/lang/String;
+	public final fun getCurrentScreenshotFileName ()Ljava/lang/String;
+	public final fun getDiffImageFileName ()Ljava/lang/String;
+	public final fun getExpectedImageFileName ()Ljava/lang/String;
+	public final fun getLocationOfGoldenInRepo ()Ljava/lang/String;
+	public final fun getRepoRootPath ()Ljava/lang/String;
+	public final fun getResult ()Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/compose/ui/test/junit4/ScreenshotResultProto$Status : java/lang/Enum {
+	public static final field FAILED Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public static final field MISSING_GOLDEN Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public static final field PASSED Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public static final field SIZE_MISMATCH Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public static final field UNSPECIFIED Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+	public static fun values ()[Landroidx/compose/ui/test/junit4/ScreenshotResultProto$Status;
+}
+
+public final class androidx/compose/ui/test/junit4/ScreenshotTestRule : org/junit/rules/TestRule {
+	public static final field $stable I
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
+	public final fun getConfig ()Landroidx/compose/ui/test/junit4/GoldenConfig;
+	public final fun getExecutionQueue ()Ljava/util/LinkedList;
+	public final fun snap (Lorg/jetbrains/skia/Surface;Ljava/lang/String;)V
+	public static synthetic fun snap$default (Landroidx/compose/ui/test/junit4/ScreenshotTestRule;Lorg/jetbrains/skia/Surface;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun write (Lorg/jetbrains/skia/Image;Ljava/lang/String;)V
+	public static synthetic fun write$default (Landroidx/compose/ui/test/junit4/ScreenshotTestRule;Lorg/jetbrains/skia/Image;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/junit4/SkiaTestAlbum {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/junit4/GoldenConfig;)V
+	public final fun check ()Landroidx/compose/ui/test/junit4/SkiaTestAlbum$Report;
+	public final fun getConfig ()Landroidx/compose/ui/test/junit4/GoldenConfig;
+	public final fun snap (Lorg/jetbrains/skia/Surface;Ljava/lang/String;)V
+	public final fun write (Lorg/jetbrains/skia/Image;Ljava/lang/String;)V
+}
+
+public final class androidx/compose/ui/test/junit4/SkiaTestAlbum$Report {
+	public static final field $stable I
+	public fun <init> (Ljava/util/Map;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Landroidx/compose/ui/test/junit4/SkiaTestAlbum$Report;
+	public static synthetic fun copy$default (Landroidx/compose/ui/test/junit4/SkiaTestAlbum$Report;Ljava/util/Map;ILjava/lang/Object;)Landroidx/compose/ui/test/junit4/SkiaTestAlbum$Report;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getScreenshots ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/compose/ui/test/junit4/SkiaTest_desktopKt {
+	public static final fun DesktopScreenshotTestRule (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Landroidx/compose/ui/test/junit4/ScreenshotTestRule;
+	public static synthetic fun DesktopScreenshotTestRule$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Landroidx/compose/ui/test/junit4/ScreenshotTestRule;
+}
+

--- a/compose/ui/ui-test/api/desktop/ui-test.api
+++ b/compose/ui/ui-test/api/desktop/ui-test.api
@@ -1,0 +1,801 @@
+public final class androidx/compose/ui/test/ActionsKt {
+	public static final fun performClick (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performGesture (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performKeyInput (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performMouseInput (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performMultiModalInput (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performRotaryScrollInput (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performScrollTo (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performScrollToIndex (Landroidx/compose/ui/test/SemanticsNodeInteraction;I)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performScrollToKey (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performScrollToNode (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun performSemanticsAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/semantics/SemanticsPropertyKey;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final synthetic fun performSemanticsAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/semantics/SemanticsPropertyKey;)V
+	public static final fun performSemanticsAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/semantics/SemanticsPropertyKey;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final synthetic fun performSemanticsAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/semantics/SemanticsPropertyKey;Lkotlin/jvm/functions/Function1;)V
+	public static final fun performTouchInput (Landroidx/compose/ui/test/SemanticsNodeInteraction;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun requestFocus (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+}
+
+public final class androidx/compose/ui/test/Actions_skikoMainKt {
+	public static final fun scrollBy-ghNngFA (Landroidx/compose/ui/test/SemanticsNodeInteraction;FFLandroidx/compose/ui/unit/Density;)V
+	public static synthetic fun scrollBy-ghNngFA$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;FFLandroidx/compose/ui/unit/Density;ILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/AssertionsKt {
+	public static final fun assert (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/SemanticsMatcher;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun assert$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/test/SemanticsMatcher;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertAll (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun assertAny (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun assertContentDescriptionContains (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ZZ)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun assertContentDescriptionContains$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertContentDescriptionEquals (Landroidx/compose/ui/test/SemanticsNodeInteraction;[Ljava/lang/String;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertCountEquals (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;I)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun assertHasClickAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertHasNoClickAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsDisplayed (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsEnabled (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsFocused (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsNotDisplayed (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsNotEnabled (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsNotFocused (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsNotSelected (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsOff (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsOn (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsSelectable (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsSelected (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsToggleable (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertRangeInfoEquals (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/semantics/ProgressBarRangeInfo;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertTextContains (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ZZ)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun assertTextContains$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertTextEquals (Landroidx/compose/ui/test/SemanticsNodeInteraction;[Ljava/lang/String;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun assertTextEquals$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;[Ljava/lang/String;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertValueEquals (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun isDisplayed (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Z
+	public static final fun isNotDisplayed (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Z
+}
+
+public final class androidx/compose/ui/test/BoundsAssertionsKt {
+	public static final fun assertHeightIsAtLeast-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertHeightIsEqualTo-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertIsEqualTo-cWfXhoU (FFLjava/lang/String;F)V
+	public static synthetic fun assertIsEqualTo-cWfXhoU$default (FFLjava/lang/String;FILjava/lang/Object;)V
+	public static final fun assertLeftPositionInRootIsEqualTo-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertPositionInRootIsEqualTo-VpY3zN4 (Landroidx/compose/ui/test/SemanticsNodeInteraction;FF)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertTopPositionInRootIsEqualTo-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertTouchHeightIsEqualTo-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertTouchWidthIsEqualTo-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertWidthIsAtLeast-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun assertWidthIsEqualTo-3ABfNKs (Landroidx/compose/ui/test/SemanticsNodeInteraction;F)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun getAlignmentLinePosition (Landroidx/compose/ui/test/SemanticsNodeInteraction;Landroidx/compose/ui/layout/AlignmentLine;)F
+	public static final fun getBoundsInRoot (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/unit/DpRect;
+	public static final fun getUnclippedBoundsInRoot (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/unit/DpRect;
+}
+
+public final class androidx/compose/ui/test/ComposeTimeoutException : java/lang/Throwable {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface class androidx/compose/ui/test/ComposeUiTest : androidx/compose/ui/test/SemanticsNodeInteractionsProvider {
+	public abstract fun awaitIdle (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
+	public abstract fun getMainClock ()Landroidx/compose/ui/test/MainTestClock;
+	public abstract fun registerIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public abstract fun runOnIdle (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun runOnUiThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun setContent (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun unregisterIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public abstract fun waitForIdle ()V
+	public abstract fun waitUntil (JLkotlin/jvm/functions/Function0;)V
+	public static synthetic fun waitUntil$default (Landroidx/compose/ui/test/ComposeUiTest;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/ComposeUiTestKt {
+	public static final fun waitUntilAtLeastOneExists (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public static synthetic fun waitUntilAtLeastOneExists$default (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public static final fun waitUntilDoesNotExist (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public static synthetic fun waitUntilDoesNotExist$default (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public static final fun waitUntilExactlyOneExists (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;J)V
+	public static synthetic fun waitUntilExactlyOneExists$default (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;JILjava/lang/Object;)V
+	public static final fun waitUntilNodeCount (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;IJ)V
+	public static synthetic fun waitUntilNodeCount$default (Landroidx/compose/ui/test/ComposeUiTest;Landroidx/compose/ui/test/SemanticsMatcher;IJILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/ComposeUiTest_desktopKt {
+	public static final fun runDesktopComposeUiTest (IILkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun runDesktopComposeUiTest$default (IILkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/ComposeUiTest_skikoMainKt {
+	public static final fun defaultTestDispatcher ()Lkotlinx/coroutines/test/TestDispatcher;
+	public static final fun runComposeUiTest (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun runComposeUiTest$default (Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun runInternalSkikoComposeUiTest (IILandroidx/compose/ui/unit/Density;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener;Lkotlinx/coroutines/test/TestDispatcher;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun runInternalSkikoComposeUiTest$default (IILandroidx/compose/ui/unit/Density;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener;Lkotlinx/coroutines/test/TestDispatcher;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static final fun runSkikoComposeUiTest-Cqks5Fs (JLandroidx/compose/ui/unit/Density;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun runSkikoComposeUiTest-Cqks5Fs$default (JLandroidx/compose/ui/unit/Density;Lkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public abstract interface annotation class androidx/compose/ui/test/ExperimentalTestApi : java/lang/annotation/Annotation {
+}
+
+public final class androidx/compose/ui/test/FiltersKt {
+	public static final fun hasAnyAncestor (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasAnyChild (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasAnyDescendant (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasAnySibling (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasClickAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasContentDescription (Ljava/lang/String;ZZ)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static synthetic fun hasContentDescription$default (Ljava/lang/String;ZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasContentDescriptionExactly ([Ljava/lang/String;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasImeAction-KlQnJC8 (I)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasInsertTextAtCursorAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasNoClickAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasNoScrollAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasParent (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasPerformImeAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasProgressBarRangeInfo (Landroidx/compose/ui/semantics/ProgressBarRangeInfo;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasRequestFocusAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasScrollAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasScrollToIndexAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasScrollToKeyAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasScrollToNodeAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasSetTextAction ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasStateDescription (Ljava/lang/String;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasTestTag (Ljava/lang/String;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasText (Ljava/lang/String;ZZ)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static synthetic fun hasText$default (Ljava/lang/String;ZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun hasTextExactly ([Ljava/lang/String;Z)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static synthetic fun hasTextExactly$default ([Ljava/lang/String;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isDialog ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isEnabled ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isFocusable ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isFocused ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isHeading ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isNotEnabled ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isNotFocusable ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isNotFocused ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isNotSelected ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isOff ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isOn ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isPopup ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isRoot ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isSelectable ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isSelected ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public static final fun isToggleable ()Landroidx/compose/ui/test/SemanticsMatcher;
+}
+
+public final class androidx/compose/ui/test/FindersKt {
+	public static final fun onAllNodesWithContentDescription (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZ)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static synthetic fun onAllNodesWithContentDescription$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun onAllNodesWithTag (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;Z)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static synthetic fun onAllNodesWithTag$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun onAllNodesWithText (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZ)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static synthetic fun onAllNodesWithText$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun onNodeWithContentDescription (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZ)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun onNodeWithContentDescription$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onNodeWithTag (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun onNodeWithTag$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onNodeWithText (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZ)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun onNodeWithText$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Ljava/lang/String;ZZZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onRoot (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun onRoot$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+}
+
+public final class androidx/compose/ui/test/GestureScope {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/semantics/SemanticsNode;Landroidx/compose/ui/test/TestContext;)V
+	public final fun getDelegateScope ()Landroidx/compose/ui/test/MultiModalInjectionScope;
+	public final fun getVisibleSize-YbymL2g ()J
+}
+
+public final class androidx/compose/ui/test/GestureScopeKt {
+	public static final fun advanceEventTime (Landroidx/compose/ui/test/GestureScope;J)V
+	public static final fun cancel (Landroidx/compose/ui/test/GestureScope;)V
+	public static final fun click-Uv8p0NA (Landroidx/compose/ui/test/GestureScope;J)V
+	public static synthetic fun click-Uv8p0NA$default (Landroidx/compose/ui/test/GestureScope;JILjava/lang/Object;)V
+	public static final fun doubleClick-d-4ec7I (Landroidx/compose/ui/test/GestureScope;JJ)V
+	public static synthetic fun doubleClick-d-4ec7I$default (Landroidx/compose/ui/test/GestureScope;JJILjava/lang/Object;)V
+	public static final fun down-0AR0LA0 (Landroidx/compose/ui/test/GestureScope;IJ)V
+	public static final fun down-Uv8p0NA (Landroidx/compose/ui/test/GestureScope;J)V
+	public static final fun getBottom (Landroidx/compose/ui/test/GestureScope;)F
+	public static final fun getBottomCenter (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getBottomLeft (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getBottomRight (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getCenter (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getCenterLeft (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getCenterRight (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getCenterX (Landroidx/compose/ui/test/GestureScope;)F
+	public static final fun getCenterY (Landroidx/compose/ui/test/GestureScope;)F
+	public static final fun getHeight (Landroidx/compose/ui/test/GestureScope;)I
+	public static final fun getLeft (Landroidx/compose/ui/test/GestureScope;)F
+	public static final fun getRight (Landroidx/compose/ui/test/GestureScope;)F
+	public static final fun getTop (Landroidx/compose/ui/test/GestureScope;)F
+	public static final fun getTopCenter (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getTopLeft (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getTopRight (Landroidx/compose/ui/test/GestureScope;)J
+	public static final fun getWidth (Landroidx/compose/ui/test/GestureScope;)I
+	public static final fun longClick-d-4ec7I (Landroidx/compose/ui/test/GestureScope;JJ)V
+	public static synthetic fun longClick-d-4ec7I$default (Landroidx/compose/ui/test/GestureScope;JJILjava/lang/Object;)V
+	public static final fun move (Landroidx/compose/ui/test/GestureScope;)V
+	public static final fun moveBy-0AR0LA0 (Landroidx/compose/ui/test/GestureScope;IJ)V
+	public static final fun moveBy-Uv8p0NA (Landroidx/compose/ui/test/GestureScope;J)V
+	public static final fun movePointerBy-0AR0LA0 (Landroidx/compose/ui/test/GestureScope;IJ)V
+	public static final fun movePointerTo-0AR0LA0 (Landroidx/compose/ui/test/GestureScope;IJ)V
+	public static final fun moveTo-0AR0LA0 (Landroidx/compose/ui/test/GestureScope;IJ)V
+	public static final fun moveTo-Uv8p0NA (Landroidx/compose/ui/test/GestureScope;J)V
+	public static final fun percentOffset (Landroidx/compose/ui/test/GestureScope;FF)J
+	public static synthetic fun percentOffset$default (Landroidx/compose/ui/test/GestureScope;FFILjava/lang/Object;)J
+	public static final fun pinch-_QUENCA (Landroidx/compose/ui/test/GestureScope;JJJJJ)V
+	public static synthetic fun pinch-_QUENCA$default (Landroidx/compose/ui/test/GestureScope;JJJJJILjava/lang/Object;)V
+	public static final fun swipe-DUneCvk (Landroidx/compose/ui/test/GestureScope;JJJ)V
+	public static synthetic fun swipe-DUneCvk$default (Landroidx/compose/ui/test/GestureScope;JJJILjava/lang/Object;)V
+	public static final fun swipeDown (Landroidx/compose/ui/test/GestureScope;)V
+	public static final fun swipeDown (Landroidx/compose/ui/test/GestureScope;FFJ)V
+	public static synthetic fun swipeDown$default (Landroidx/compose/ui/test/GestureScope;FFJILjava/lang/Object;)V
+	public static final fun swipeLeft (Landroidx/compose/ui/test/GestureScope;)V
+	public static final fun swipeLeft (Landroidx/compose/ui/test/GestureScope;FFJ)V
+	public static synthetic fun swipeLeft$default (Landroidx/compose/ui/test/GestureScope;FFJILjava/lang/Object;)V
+	public static final fun swipeRight (Landroidx/compose/ui/test/GestureScope;)V
+	public static final fun swipeRight (Landroidx/compose/ui/test/GestureScope;FFJ)V
+	public static synthetic fun swipeRight$default (Landroidx/compose/ui/test/GestureScope;FFJILjava/lang/Object;)V
+	public static final fun swipeUp (Landroidx/compose/ui/test/GestureScope;)V
+	public static final fun swipeUp (Landroidx/compose/ui/test/GestureScope;FFJ)V
+	public static synthetic fun swipeUp$default (Landroidx/compose/ui/test/GestureScope;FFJILjava/lang/Object;)V
+	public static final fun swipeWithVelocity-5iVPX68 (Landroidx/compose/ui/test/GestureScope;JJFJ)V
+	public static synthetic fun swipeWithVelocity-5iVPX68$default (Landroidx/compose/ui/test/GestureScope;JJFJILjava/lang/Object;)V
+	public static final fun up (Landroidx/compose/ui/test/GestureScope;I)V
+	public static synthetic fun up$default (Landroidx/compose/ui/test/GestureScope;IILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/GlobalAssertions {
+	public static final fun addGlobalAssertion (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static final fun invokeGlobalAssertions (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun invokeGlobalAssertions (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun removeGlobalAssertion (Ljava/lang/String;)V
+}
+
+public abstract interface class androidx/compose/ui/test/IdlingResource {
+	public fun getDiagnosticMessageIfBusy ()Ljava/lang/String;
+	public abstract fun isIdleNow ()Z
+}
+
+public final class androidx/compose/ui/test/IdlingResource$DefaultImpls {
+	public static fun getDiagnosticMessageIfBusy (Landroidx/compose/ui/test/IdlingResource;)Ljava/lang/String;
+}
+
+public abstract interface class androidx/compose/ui/test/InjectionScope : androidx/compose/ui/unit/Density {
+	public abstract fun advanceEventTime (J)V
+	public static synthetic fun advanceEventTime$default (Landroidx/compose/ui/test/InjectionScope;JILjava/lang/Object;)V
+	public fun getBottom ()F
+	public fun getBottomCenter-F1C5BW0 ()J
+	public fun getBottomLeft-F1C5BW0 ()J
+	public fun getBottomRight-F1C5BW0 ()J
+	public fun getCenter-F1C5BW0 ()J
+	public fun getCenterLeft-F1C5BW0 ()J
+	public fun getCenterRight-F1C5BW0 ()J
+	public fun getCenterX ()F
+	public fun getCenterY ()F
+	public fun getEventPeriodMillis ()J
+	public fun getHeight ()I
+	public fun getLeft ()F
+	public fun getRight ()F
+	public fun getTop ()F
+	public fun getTopCenter-F1C5BW0 ()J
+	public fun getTopLeft-F1C5BW0 ()J
+	public fun getTopRight-F1C5BW0 ()J
+	public abstract fun getViewConfiguration ()Landroidx/compose/ui/platform/ViewConfiguration;
+	public abstract fun getVisibleSize-YbymL2g ()J
+	public fun getWidth ()I
+	public fun percentOffset-dBAh8RU (FF)J
+	public static synthetic fun percentOffset-dBAh8RU$default (Landroidx/compose/ui/test/InjectionScope;FFILjava/lang/Object;)J
+}
+
+public final class androidx/compose/ui/test/InjectionScope$DefaultImpls {
+	public static synthetic fun advanceEventTime$default (Landroidx/compose/ui/test/InjectionScope;JILjava/lang/Object;)V
+	public static fun getBottom (Landroidx/compose/ui/test/InjectionScope;)F
+	public static fun getBottomCenter-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getBottomLeft-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getBottomRight-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getCenter-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getCenterLeft-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getCenterRight-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getCenterX (Landroidx/compose/ui/test/InjectionScope;)F
+	public static fun getCenterY (Landroidx/compose/ui/test/InjectionScope;)F
+	public static fun getEventPeriodMillis (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getHeight (Landroidx/compose/ui/test/InjectionScope;)I
+	public static fun getLeft (Landroidx/compose/ui/test/InjectionScope;)F
+	public static fun getRight (Landroidx/compose/ui/test/InjectionScope;)F
+	public static fun getTop (Landroidx/compose/ui/test/InjectionScope;)F
+	public static fun getTopCenter-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getTopLeft-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getTopRight-F1C5BW0 (Landroidx/compose/ui/test/InjectionScope;)J
+	public static fun getWidth (Landroidx/compose/ui/test/InjectionScope;)I
+	public static fun percentOffset-dBAh8RU (Landroidx/compose/ui/test/InjectionScope;FF)J
+	public static synthetic fun percentOffset-dBAh8RU$default (Landroidx/compose/ui/test/InjectionScope;FFILjava/lang/Object;)J
+	public static fun roundToPx--R2X_6o (Landroidx/compose/ui/test/InjectionScope;J)I
+	public static fun roundToPx-0680j_4 (Landroidx/compose/ui/test/InjectionScope;F)I
+	public static fun toDp-GaN1DYA (Landroidx/compose/ui/test/InjectionScope;J)F
+	public static fun toDp-u2uoSUM (Landroidx/compose/ui/test/InjectionScope;F)F
+	public static fun toDp-u2uoSUM (Landroidx/compose/ui/test/InjectionScope;I)F
+	public static fun toDpSize-k-rfVVM (Landroidx/compose/ui/test/InjectionScope;J)J
+	public static fun toPx--R2X_6o (Landroidx/compose/ui/test/InjectionScope;J)F
+	public static fun toPx-0680j_4 (Landroidx/compose/ui/test/InjectionScope;F)F
+	public static fun toRect (Landroidx/compose/ui/test/InjectionScope;Landroidx/compose/ui/unit/DpRect;)Landroidx/compose/ui/geometry/Rect;
+	public static fun toSize-XkaWNTQ (Landroidx/compose/ui/test/InjectionScope;J)J
+	public static fun toSp-0xMU5do (Landroidx/compose/ui/test/InjectionScope;F)J
+	public static fun toSp-kPz2Gy4 (Landroidx/compose/ui/test/InjectionScope;F)J
+	public static fun toSp-kPz2Gy4 (Landroidx/compose/ui/test/InjectionScope;I)J
+}
+
+public abstract interface annotation class androidx/compose/ui/test/InternalTestApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class androidx/compose/ui/test/KeyInjectionScope : androidx/compose/ui/test/InjectionScope {
+	public abstract fun isCapsLockOn ()Z
+	public abstract fun isKeyDown-YVgTNJs (J)Z
+	public abstract fun isNumLockOn ()Z
+	public abstract fun isScrollLockOn ()Z
+	public abstract fun keyDown-YVgTNJs (J)V
+	public abstract fun keyUp-YVgTNJs (J)V
+}
+
+public final class androidx/compose/ui/test/KeyInjectionScope$DefaultImpls {
+	public static fun getBottom (Landroidx/compose/ui/test/KeyInjectionScope;)F
+	public static fun getBottomCenter-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getBottomLeft-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getBottomRight-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getCenter-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getCenterLeft-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getCenterRight-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getCenterX (Landroidx/compose/ui/test/KeyInjectionScope;)F
+	public static fun getCenterY (Landroidx/compose/ui/test/KeyInjectionScope;)F
+	public static fun getEventPeriodMillis (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getHeight (Landroidx/compose/ui/test/KeyInjectionScope;)I
+	public static fun getLeft (Landroidx/compose/ui/test/KeyInjectionScope;)F
+	public static fun getRight (Landroidx/compose/ui/test/KeyInjectionScope;)F
+	public static fun getTop (Landroidx/compose/ui/test/KeyInjectionScope;)F
+	public static fun getTopCenter-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getTopLeft-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getTopRight-F1C5BW0 (Landroidx/compose/ui/test/KeyInjectionScope;)J
+	public static fun getWidth (Landroidx/compose/ui/test/KeyInjectionScope;)I
+	public static fun percentOffset-dBAh8RU (Landroidx/compose/ui/test/KeyInjectionScope;FF)J
+	public static fun roundToPx--R2X_6o (Landroidx/compose/ui/test/KeyInjectionScope;J)I
+	public static fun roundToPx-0680j_4 (Landroidx/compose/ui/test/KeyInjectionScope;F)I
+	public static fun toDp-GaN1DYA (Landroidx/compose/ui/test/KeyInjectionScope;J)F
+	public static fun toDp-u2uoSUM (Landroidx/compose/ui/test/KeyInjectionScope;F)F
+	public static fun toDp-u2uoSUM (Landroidx/compose/ui/test/KeyInjectionScope;I)F
+	public static fun toDpSize-k-rfVVM (Landroidx/compose/ui/test/KeyInjectionScope;J)J
+	public static fun toPx--R2X_6o (Landroidx/compose/ui/test/KeyInjectionScope;J)F
+	public static fun toPx-0680j_4 (Landroidx/compose/ui/test/KeyInjectionScope;F)F
+	public static fun toRect (Landroidx/compose/ui/test/KeyInjectionScope;Landroidx/compose/ui/unit/DpRect;)Landroidx/compose/ui/geometry/Rect;
+	public static fun toSize-XkaWNTQ (Landroidx/compose/ui/test/KeyInjectionScope;J)J
+	public static fun toSp-0xMU5do (Landroidx/compose/ui/test/KeyInjectionScope;F)J
+	public static fun toSp-kPz2Gy4 (Landroidx/compose/ui/test/KeyInjectionScope;F)J
+	public static fun toSp-kPz2Gy4 (Landroidx/compose/ui/test/KeyInjectionScope;I)J
+}
+
+public final class androidx/compose/ui/test/KeyInjectionScopeKt {
+	public static final fun isAltDown (Landroidx/compose/ui/test/KeyInjectionScope;)Z
+	public static final fun isCtrlDown (Landroidx/compose/ui/test/KeyInjectionScope;)Z
+	public static final fun isFnDown (Landroidx/compose/ui/test/KeyInjectionScope;)Z
+	public static final fun isMetaDown (Landroidx/compose/ui/test/KeyInjectionScope;)Z
+	public static final fun isShiftDown (Landroidx/compose/ui/test/KeyInjectionScope;)Z
+	public static final fun pressKey-KChvXf4 (Landroidx/compose/ui/test/KeyInjectionScope;JJ)V
+	public static synthetic fun pressKey-KChvXf4$default (Landroidx/compose/ui/test/KeyInjectionScope;JJILjava/lang/Object;)V
+	public static final fun withKeyDown-KChvXf4 (Landroidx/compose/ui/test/KeyInjectionScope;JLkotlin/jvm/functions/Function1;)V
+	public static final fun withKeyToggled-KChvXf4 (Landroidx/compose/ui/test/KeyInjectionScope;JLkotlin/jvm/functions/Function1;)V
+	public static final fun withKeysDown (Landroidx/compose/ui/test/KeyInjectionScope;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public static final fun withKeysToggled (Landroidx/compose/ui/test/KeyInjectionScope;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class androidx/compose/ui/test/KeyInputHelpersKt {
+	public static final fun performKeyPress-34rOyRA (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/Object;)Z
+}
+
+public abstract interface class androidx/compose/ui/test/MainTestClock {
+	public abstract fun advanceTimeBy (JZ)V
+	public static synthetic fun advanceTimeBy$default (Landroidx/compose/ui/test/MainTestClock;JZILjava/lang/Object;)V
+	public abstract fun advanceTimeByFrame ()V
+	public abstract fun advanceTimeUntil (JLkotlin/jvm/functions/Function0;)V
+	public static synthetic fun advanceTimeUntil$default (Landroidx/compose/ui/test/MainTestClock;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public abstract fun getAutoAdvance ()Z
+	public abstract fun getCurrentTime ()J
+	public abstract fun setAutoAdvance (Z)V
+}
+
+public final class androidx/compose/ui/test/MainTestClock$DefaultImpls {
+	public static synthetic fun advanceTimeBy$default (Landroidx/compose/ui/test/MainTestClock;JZILjava/lang/Object;)V
+	public static synthetic fun advanceTimeUntil$default (Landroidx/compose/ui/test/MainTestClock;JLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
+public final class androidx/compose/ui/test/MouseButton {
+	public static final field Companion Landroidx/compose/ui/test/MouseButton$Companion;
+	public static final synthetic fun box-impl (I)Landroidx/compose/ui/test/MouseButton;
+	public static fun constructor-impl (I)I
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getButtonId ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class androidx/compose/ui/test/MouseButton$Companion {
+	public final fun getPrimary-ipIFwKQ ()I
+	public final fun getSecondary-ipIFwKQ ()I
+	public final fun getTertiary-ipIFwKQ ()I
+}
+
+public abstract interface class androidx/compose/ui/test/MouseInjectionScope : androidx/compose/ui/test/InjectionScope {
+	public abstract fun cancel (J)V
+	public static synthetic fun cancel$default (Landroidx/compose/ui/test/MouseInjectionScope;JILjava/lang/Object;)V
+	public abstract fun enter-3MmeM6k (JJ)V
+	public static synthetic fun enter-3MmeM6k$default (Landroidx/compose/ui/test/MouseInjectionScope;JJILjava/lang/Object;)V
+	public abstract fun exit-3MmeM6k (JJ)V
+	public static synthetic fun exit-3MmeM6k$default (Landroidx/compose/ui/test/MouseInjectionScope;JJILjava/lang/Object;)V
+	public abstract fun getCurrentPosition-F1C5BW0 ()J
+	public fun moveBy-3MmeM6k (JJ)V
+	public static synthetic fun moveBy-3MmeM6k$default (Landroidx/compose/ui/test/MouseInjectionScope;JJILjava/lang/Object;)V
+	public abstract fun moveTo-3MmeM6k (JJ)V
+	public static synthetic fun moveTo-3MmeM6k$default (Landroidx/compose/ui/test/MouseInjectionScope;JJILjava/lang/Object;)V
+	public abstract fun press-SMKQcqU (I)V
+	public static synthetic fun press-SMKQcqU$default (Landroidx/compose/ui/test/MouseInjectionScope;IILjava/lang/Object;)V
+	public abstract fun release-SMKQcqU (I)V
+	public static synthetic fun release-SMKQcqU$default (Landroidx/compose/ui/test/MouseInjectionScope;IILjava/lang/Object;)V
+	public abstract fun scroll-I7Dg0i0 (FI)V
+	public static synthetic fun scroll-I7Dg0i0$default (Landroidx/compose/ui/test/MouseInjectionScope;FIILjava/lang/Object;)V
+	public fun updatePointerBy-k-4lQ0M (J)V
+	public abstract fun updatePointerTo-k-4lQ0M (J)V
+}
+
+public final class androidx/compose/ui/test/MouseInjectionScopeKt {
+	public static final fun animateAlong (Landroidx/compose/ui/test/MouseInjectionScope;Lkotlin/jvm/functions/Function1;J)V
+	public static synthetic fun animateAlong$default (Landroidx/compose/ui/test/MouseInjectionScope;Lkotlin/jvm/functions/Function1;JILjava/lang/Object;)V
+	public static final fun animateBy-d-4ec7I (Landroidx/compose/ui/test/MouseInjectionScope;JJ)V
+	public static synthetic fun animateBy-d-4ec7I$default (Landroidx/compose/ui/test/MouseInjectionScope;JJILjava/lang/Object;)V
+	public static final fun animateTo-d-4ec7I (Landroidx/compose/ui/test/MouseInjectionScope;JJ)V
+	public static synthetic fun animateTo-d-4ec7I$default (Landroidx/compose/ui/test/MouseInjectionScope;JJILjava/lang/Object;)V
+	public static final fun click-Uv8p0NA (Landroidx/compose/ui/test/MouseInjectionScope;J)V
+	public static synthetic fun click-Uv8p0NA$default (Landroidx/compose/ui/test/MouseInjectionScope;JILjava/lang/Object;)V
+	public static final fun doubleClick-Uv8p0NA (Landroidx/compose/ui/test/MouseInjectionScope;J)V
+	public static synthetic fun doubleClick-Uv8p0NA$default (Landroidx/compose/ui/test/MouseInjectionScope;JILjava/lang/Object;)V
+	public static final fun dragAndDrop-DUneCvk (Landroidx/compose/ui/test/MouseInjectionScope;JJJ)V
+	public static synthetic fun dragAndDrop-DUneCvk$default (Landroidx/compose/ui/test/MouseInjectionScope;JJJILjava/lang/Object;)V
+	public static final fun longClick-Uv8p0NA (Landroidx/compose/ui/test/MouseInjectionScope;J)V
+	public static synthetic fun longClick-Uv8p0NA$default (Landroidx/compose/ui/test/MouseInjectionScope;JILjava/lang/Object;)V
+	public static final fun rightClick-Uv8p0NA (Landroidx/compose/ui/test/MouseInjectionScope;J)V
+	public static synthetic fun rightClick-Uv8p0NA$default (Landroidx/compose/ui/test/MouseInjectionScope;JILjava/lang/Object;)V
+	public static final fun smoothScroll-rNbqR-4 (Landroidx/compose/ui/test/MouseInjectionScope;FJI)V
+	public static synthetic fun smoothScroll-rNbqR-4$default (Landroidx/compose/ui/test/MouseInjectionScope;FJIILjava/lang/Object;)V
+	public static final fun tripleClick-Uv8p0NA (Landroidx/compose/ui/test/MouseInjectionScope;J)V
+	public static synthetic fun tripleClick-Uv8p0NA$default (Landroidx/compose/ui/test/MouseInjectionScope;JILjava/lang/Object;)V
+}
+
+public abstract interface class androidx/compose/ui/test/MultiModalInjectionScope : androidx/compose/ui/test/InjectionScope {
+	public abstract fun key (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun mouse (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun rotary (Lkotlin/jvm/functions/Function1;)V
+	public abstract fun touch (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class androidx/compose/ui/test/OutputKt {
+	public static final fun printToLog (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;I)V
+	public static final fun printToLog (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;Ljava/lang/String;I)V
+	public static synthetic fun printToLog$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;IILjava/lang/Object;)V
+	public static synthetic fun printToLog$default (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;Ljava/lang/String;IILjava/lang/Object;)V
+	public static final fun printToString (Landroidx/compose/ui/test/SemanticsNodeInteraction;I)Ljava/lang/String;
+	public static final fun printToString (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;I)Ljava/lang/String;
+	public static synthetic fun printToString$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;IILjava/lang/Object;)Ljava/lang/String;
+	public static synthetic fun printToString$default (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;IILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class androidx/compose/ui/test/PlatformTextInputMethodOverrideKt {
+	public static final fun PlatformTextInputMethodTestOverride (Landroidx/compose/ui/platform/PlatformTextInputSession;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract interface class androidx/compose/ui/test/RotaryInjectionScope : androidx/compose/ui/test/InjectionScope {
+	public abstract fun rotateToScrollHorizontally (F)V
+	public abstract fun rotateToScrollVertically (F)V
+}
+
+public final class androidx/compose/ui/test/ScrollWheel {
+	public static final field Companion Landroidx/compose/ui/test/ScrollWheel$Companion;
+	public static final synthetic fun box-impl (I)Landroidx/compose/ui/test/ScrollWheel;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (ILjava/lang/Object;)Z
+	public static final fun equals-impl0 (II)Z
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public static fun hashCode-impl (I)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (I)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()I
+}
+
+public final class androidx/compose/ui/test/ScrollWheel$Companion {
+	public final fun getHorizontal-LTdd5XU ()I
+	public final fun getVertical-LTdd5XU ()I
+}
+
+public final class androidx/compose/ui/test/SelectionResult {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCustomErrorOnNoMatch ()Ljava/lang/String;
+	public final fun getSelectedNodes ()Ljava/util/List;
+}
+
+public final class androidx/compose/ui/test/SelectorsKt {
+	public static final fun filter (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun filterToOne (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onAncestors (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun onChild (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onChildAt (Landroidx/compose/ui/test/SemanticsNodeInteraction;I)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onChildren (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static final fun onFirst (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onLast (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onParent (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onSibling (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static final fun onSiblings (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+}
+
+public final class androidx/compose/ui/test/SemanticsMatcher {
+	public static final field $stable I
+	public static final field Companion Landroidx/compose/ui/test/SemanticsMatcher$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun and (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun matches (Landroidx/compose/ui/semantics/SemanticsNode;)Z
+	public final fun matchesAny (Ljava/lang/Iterable;)Z
+	public final fun not ()Landroidx/compose/ui/test/SemanticsMatcher;
+	public final fun or (Landroidx/compose/ui/test/SemanticsMatcher;)Landroidx/compose/ui/test/SemanticsMatcher;
+}
+
+public final class androidx/compose/ui/test/SemanticsMatcher$Companion {
+	public final fun expectValue (Landroidx/compose/ui/semantics/SemanticsPropertyKey;Ljava/lang/Object;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public final fun keyIsDefined (Landroidx/compose/ui/semantics/SemanticsPropertyKey;)Landroidx/compose/ui/test/SemanticsMatcher;
+	public final fun keyNotDefined (Landroidx/compose/ui/semantics/SemanticsPropertyKey;)Landroidx/compose/ui/test/SemanticsMatcher;
+}
+
+public final class androidx/compose/ui/test/SemanticsNodeInteraction {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/TestContext;ZLandroidx/compose/ui/test/SemanticsMatcher;)V
+	public fun <init> (Landroidx/compose/ui/test/TestContext;ZLandroidx/compose/ui/test/SemanticsSelector;)V
+	public final fun assertDoesNotExist ()V
+	public final fun assertExists (Ljava/lang/String;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun assertExists$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public final fun assertIsDeactivated (Ljava/lang/String;)V
+	public static synthetic fun assertIsDeactivated$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun fetchSemanticsNode (Ljava/lang/String;)Landroidx/compose/ui/semantics/SemanticsNode;
+	public static synthetic fun fetchSemanticsNode$default (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;ILjava/lang/Object;)Landroidx/compose/ui/semantics/SemanticsNode;
+}
+
+public final class androidx/compose/ui/test/SemanticsNodeInteractionCollection {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/TestContext;ZLandroidx/compose/ui/test/SemanticsMatcher;)V
+	public fun <init> (Landroidx/compose/ui/test/TestContext;ZLandroidx/compose/ui/test/SemanticsSelector;)V
+	public final fun fetchSemanticsNodes (ZLjava/lang/String;)Ljava/util/List;
+	public static synthetic fun fetchSemanticsNodes$default (Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;ZLjava/lang/String;ILjava/lang/Object;)Ljava/util/List;
+	public final fun get (I)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+}
+
+public abstract interface class androidx/compose/ui/test/SemanticsNodeInteractionsProvider {
+	public abstract fun onAllNodes (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static synthetic fun onAllNodes$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Landroidx/compose/ui/test/SemanticsMatcher;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public abstract fun onNode (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public static synthetic fun onNode$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Landroidx/compose/ui/test/SemanticsMatcher;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+}
+
+public final class androidx/compose/ui/test/SemanticsNodeInteractionsProvider$DefaultImpls {
+	public static synthetic fun onAllNodes$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Landroidx/compose/ui/test/SemanticsMatcher;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public static synthetic fun onNode$default (Landroidx/compose/ui/test/SemanticsNodeInteractionsProvider;Landroidx/compose/ui/test/SemanticsMatcher;ZILjava/lang/Object;)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+}
+
+public final class androidx/compose/ui/test/SemanticsSelector {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;ZLandroidx/compose/ui/test/SemanticsSelector;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLandroidx/compose/ui/test/SemanticsSelector;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun map (Ljava/lang/Iterable;Ljava/lang/String;)Landroidx/compose/ui/test/SelectionResult;
+}
+
+public final class androidx/compose/ui/test/SkikoComposeUiTest : androidx/compose/ui/test/ComposeUiTest {
+	public static final field $stable I
+	public field scene Landroidx/compose/ui/scene/ComposeScene;
+	public fun <init> (IILkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;)V
+	public synthetic fun <init> (IILkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IILkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener;Lkotlinx/coroutines/test/TestDispatcher;)V
+	public synthetic fun <init> (IILkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener;Lkotlinx/coroutines/test/TestDispatcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun awaitIdle (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun captureToImage ()Landroidx/compose/ui/graphics/ImageBitmap;
+	public final fun captureToImage (Landroidx/compose/ui/semantics/SemanticsNode;)Landroidx/compose/ui/graphics/ImageBitmap;
+	public final fun captureToImage (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/graphics/ImageBitmap;
+	public fun getDensity ()Landroidx/compose/ui/unit/Density;
+	public fun getMainClock ()Landroidx/compose/ui/test/MainTestClock;
+	public final fun getScene ()Landroidx/compose/ui/scene/ComposeScene;
+	public fun onAllNodes (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteractionCollection;
+	public fun onNode (Landroidx/compose/ui/test/SemanticsMatcher;Z)Landroidx/compose/ui/test/SemanticsNodeInteraction;
+	public fun registerIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public fun runOnIdle (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun runOnUiThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public final fun runTest (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun setContent (Lkotlin/jvm/functions/Function2;)V
+	public final fun setScene (Landroidx/compose/ui/scene/ComposeScene;)V
+	public fun unregisterIdlingResource (Landroidx/compose/ui/test/IdlingResource;)V
+	public fun waitForIdle ()V
+	public fun waitUntil (JLkotlin/jvm/functions/Function0;)V
+}
+
+public final class androidx/compose/ui/test/SkikoImageHelpersKt {
+	public static final fun captureToImage (Landroidx/compose/ui/test/SemanticsNodeInteraction;)Landroidx/compose/ui/graphics/ImageBitmap;
+}
+
+public final class androidx/compose/ui/test/StateRestorationTester {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/ui/test/ComposeUiTest;)V
+	public final fun emulateSaveAndRestore ()V
+	public final fun setContent (Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class androidx/compose/ui/test/TestContext {
+	public static final field $stable I
+}
+
+public final class androidx/compose/ui/test/TestMonotonicFrameClock : androidx/compose/runtime/MonotonicFrameClock {
+	public static final field $stable I
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;JLkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
+	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
+	public final fun getContinuationInterceptor ()Lkotlin/coroutines/ContinuationInterceptor;
+	public final fun getFrameDelayNanos ()J
+	public final fun getHasAwaiters ()Z
+	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
+	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+	public fun withFrameNanos (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class androidx/compose/ui/test/TestMonotonicFrameClock_jvmKt {
+	public static final fun getFrameDelayMillis (Landroidx/compose/ui/test/TestMonotonicFrameClock;)J
+}
+
+public abstract interface class androidx/compose/ui/test/TestOwner {
+	public abstract fun getMainClock ()Landroidx/compose/ui/test/MainTestClock;
+	public abstract fun getRoots (Z)Ljava/util/Set;
+	public abstract fun runOnUiThread (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class androidx/compose/ui/test/TestOwnerKt {
+	public static final fun createTestContext (Landroidx/compose/ui/test/TestOwner;)Landroidx/compose/ui/test/TestContext;
+}
+
+public final class androidx/compose/ui/test/TextActionsKt {
+	public static final fun performImeAction (Landroidx/compose/ui/test/SemanticsNodeInteraction;)V
+	public static final fun performTextClearance (Landroidx/compose/ui/test/SemanticsNodeInteraction;)V
+	public static final fun performTextInput (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;)V
+	public static final fun performTextInputSelection-FDrldGo (Landroidx/compose/ui/test/SemanticsNodeInteraction;J)V
+	public static final fun performTextReplacement (Landroidx/compose/ui/test/SemanticsNodeInteraction;Ljava/lang/String;)V
+}
+
+public abstract interface class androidx/compose/ui/test/TouchInjectionScope : androidx/compose/ui/test/InjectionScope {
+	public abstract fun cancel (J)V
+	public static synthetic fun cancel$default (Landroidx/compose/ui/test/TouchInjectionScope;JILjava/lang/Object;)V
+	public abstract fun currentPosition-x-9fifI (I)Landroidx/compose/ui/geometry/Offset;
+	public static synthetic fun currentPosition-x-9fifI$default (Landroidx/compose/ui/test/TouchInjectionScope;IILjava/lang/Object;)Landroidx/compose/ui/geometry/Offset;
+	public abstract fun down-Uv8p0NA (IJ)V
+	public fun down-k-4lQ0M (J)V
+	public abstract fun move (J)V
+	public static synthetic fun move$default (Landroidx/compose/ui/test/TouchInjectionScope;JILjava/lang/Object;)V
+	public fun moveBy-3MmeM6k (JJ)V
+	public static synthetic fun moveBy-3MmeM6k$default (Landroidx/compose/ui/test/TouchInjectionScope;JJILjava/lang/Object;)V
+	public fun moveBy-d-4ec7I (IJJ)V
+	public static synthetic fun moveBy-d-4ec7I$default (Landroidx/compose/ui/test/TouchInjectionScope;IJJILjava/lang/Object;)V
+	public fun moveTo-3MmeM6k (JJ)V
+	public static synthetic fun moveTo-3MmeM6k$default (Landroidx/compose/ui/test/TouchInjectionScope;JJILjava/lang/Object;)V
+	public fun moveTo-d-4ec7I (IJJ)V
+	public static synthetic fun moveTo-d-4ec7I$default (Landroidx/compose/ui/test/TouchInjectionScope;IJJILjava/lang/Object;)V
+	public fun moveWithHistory (Ljava/util/List;Ljava/util/List;J)V
+	public static synthetic fun moveWithHistory$default (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;Ljava/util/List;JILjava/lang/Object;)V
+	public abstract fun moveWithHistoryMultiPointer (Ljava/util/List;Ljava/util/List;J)V
+	public static synthetic fun moveWithHistoryMultiPointer$default (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;Ljava/util/List;JILjava/lang/Object;)V
+	public abstract fun up (I)V
+	public static synthetic fun up$default (Landroidx/compose/ui/test/TouchInjectionScope;IILjava/lang/Object;)V
+	public fun updatePointerBy-Uv8p0NA (IJ)V
+	public abstract fun updatePointerTo-Uv8p0NA (IJ)V
+}
+
+public final class androidx/compose/ui/test/TouchInjectionScope$DefaultImpls {
+	public static synthetic fun cancel$default (Landroidx/compose/ui/test/TouchInjectionScope;JILjava/lang/Object;)V
+	public static synthetic fun currentPosition-x-9fifI$default (Landroidx/compose/ui/test/TouchInjectionScope;IILjava/lang/Object;)Landroidx/compose/ui/geometry/Offset;
+	public static fun down-k-4lQ0M (Landroidx/compose/ui/test/TouchInjectionScope;J)V
+	public static fun getBottom (Landroidx/compose/ui/test/TouchInjectionScope;)F
+	public static fun getBottomCenter-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getBottomLeft-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getBottomRight-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getCenter-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getCenterLeft-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getCenterRight-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getCenterX (Landroidx/compose/ui/test/TouchInjectionScope;)F
+	public static fun getCenterY (Landroidx/compose/ui/test/TouchInjectionScope;)F
+	public static fun getEventPeriodMillis (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getHeight (Landroidx/compose/ui/test/TouchInjectionScope;)I
+	public static fun getLeft (Landroidx/compose/ui/test/TouchInjectionScope;)F
+	public static fun getRight (Landroidx/compose/ui/test/TouchInjectionScope;)F
+	public static fun getTop (Landroidx/compose/ui/test/TouchInjectionScope;)F
+	public static fun getTopCenter-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getTopLeft-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getTopRight-F1C5BW0 (Landroidx/compose/ui/test/TouchInjectionScope;)J
+	public static fun getWidth (Landroidx/compose/ui/test/TouchInjectionScope;)I
+	public static synthetic fun move$default (Landroidx/compose/ui/test/TouchInjectionScope;JILjava/lang/Object;)V
+	public static fun moveBy-3MmeM6k (Landroidx/compose/ui/test/TouchInjectionScope;JJ)V
+	public static synthetic fun moveBy-3MmeM6k$default (Landroidx/compose/ui/test/TouchInjectionScope;JJILjava/lang/Object;)V
+	public static fun moveBy-d-4ec7I (Landroidx/compose/ui/test/TouchInjectionScope;IJJ)V
+	public static synthetic fun moveBy-d-4ec7I$default (Landroidx/compose/ui/test/TouchInjectionScope;IJJILjava/lang/Object;)V
+	public static fun moveTo-3MmeM6k (Landroidx/compose/ui/test/TouchInjectionScope;JJ)V
+	public static synthetic fun moveTo-3MmeM6k$default (Landroidx/compose/ui/test/TouchInjectionScope;JJILjava/lang/Object;)V
+	public static fun moveTo-d-4ec7I (Landroidx/compose/ui/test/TouchInjectionScope;IJJ)V
+	public static synthetic fun moveTo-d-4ec7I$default (Landroidx/compose/ui/test/TouchInjectionScope;IJJILjava/lang/Object;)V
+	public static fun moveWithHistory (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;Ljava/util/List;J)V
+	public static synthetic fun moveWithHistory$default (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;Ljava/util/List;JILjava/lang/Object;)V
+	public static synthetic fun moveWithHistoryMultiPointer$default (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;Ljava/util/List;JILjava/lang/Object;)V
+	public static fun percentOffset-dBAh8RU (Landroidx/compose/ui/test/TouchInjectionScope;FF)J
+	public static fun roundToPx--R2X_6o (Landroidx/compose/ui/test/TouchInjectionScope;J)I
+	public static fun roundToPx-0680j_4 (Landroidx/compose/ui/test/TouchInjectionScope;F)I
+	public static fun toDp-GaN1DYA (Landroidx/compose/ui/test/TouchInjectionScope;J)F
+	public static fun toDp-u2uoSUM (Landroidx/compose/ui/test/TouchInjectionScope;F)F
+	public static fun toDp-u2uoSUM (Landroidx/compose/ui/test/TouchInjectionScope;I)F
+	public static fun toDpSize-k-rfVVM (Landroidx/compose/ui/test/TouchInjectionScope;J)J
+	public static fun toPx--R2X_6o (Landroidx/compose/ui/test/TouchInjectionScope;J)F
+	public static fun toPx-0680j_4 (Landroidx/compose/ui/test/TouchInjectionScope;F)F
+	public static fun toRect (Landroidx/compose/ui/test/TouchInjectionScope;Landroidx/compose/ui/unit/DpRect;)Landroidx/compose/ui/geometry/Rect;
+	public static fun toSize-XkaWNTQ (Landroidx/compose/ui/test/TouchInjectionScope;J)J
+	public static fun toSp-0xMU5do (Landroidx/compose/ui/test/TouchInjectionScope;F)J
+	public static fun toSp-kPz2Gy4 (Landroidx/compose/ui/test/TouchInjectionScope;F)J
+	public static fun toSp-kPz2Gy4 (Landroidx/compose/ui/test/TouchInjectionScope;I)J
+	public static synthetic fun up$default (Landroidx/compose/ui/test/TouchInjectionScope;IILjava/lang/Object;)V
+	public static fun updatePointerBy-Uv8p0NA (Landroidx/compose/ui/test/TouchInjectionScope;IJ)V
+}
+
+public final class androidx/compose/ui/test/TouchInjectionScopeKt {
+	public static final fun click-Uv8p0NA (Landroidx/compose/ui/test/TouchInjectionScope;J)V
+	public static synthetic fun click-Uv8p0NA$default (Landroidx/compose/ui/test/TouchInjectionScope;JILjava/lang/Object;)V
+	public static final fun doubleClick-d-4ec7I (Landroidx/compose/ui/test/TouchInjectionScope;JJ)V
+	public static synthetic fun doubleClick-d-4ec7I$default (Landroidx/compose/ui/test/TouchInjectionScope;JJILjava/lang/Object;)V
+	public static final fun longClick-d-4ec7I (Landroidx/compose/ui/test/TouchInjectionScope;JJ)V
+	public static synthetic fun longClick-d-4ec7I$default (Landroidx/compose/ui/test/TouchInjectionScope;JJILjava/lang/Object;)V
+	public static final fun multiTouchSwipe (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;JLjava/util/List;)V
+	public static synthetic fun multiTouchSwipe$default (Landroidx/compose/ui/test/TouchInjectionScope;Ljava/util/List;JLjava/util/List;ILjava/lang/Object;)V
+	public static final fun pinch-_QUENCA (Landroidx/compose/ui/test/TouchInjectionScope;JJJJJ)V
+	public static synthetic fun pinch-_QUENCA$default (Landroidx/compose/ui/test/TouchInjectionScope;JJJJJILjava/lang/Object;)V
+	public static final fun swipe (Landroidx/compose/ui/test/TouchInjectionScope;Lkotlin/jvm/functions/Function1;JLjava/util/List;)V
+	public static synthetic fun swipe$default (Landroidx/compose/ui/test/TouchInjectionScope;Lkotlin/jvm/functions/Function1;JLjava/util/List;ILjava/lang/Object;)V
+	public static final fun swipe-DUneCvk (Landroidx/compose/ui/test/TouchInjectionScope;JJJ)V
+	public static synthetic fun swipe-DUneCvk$default (Landroidx/compose/ui/test/TouchInjectionScope;JJJILjava/lang/Object;)V
+	public static final fun swipeDown (Landroidx/compose/ui/test/TouchInjectionScope;FFJ)V
+	public static synthetic fun swipeDown$default (Landroidx/compose/ui/test/TouchInjectionScope;FFJILjava/lang/Object;)V
+	public static final fun swipeLeft (Landroidx/compose/ui/test/TouchInjectionScope;FFJ)V
+	public static synthetic fun swipeLeft$default (Landroidx/compose/ui/test/TouchInjectionScope;FFJILjava/lang/Object;)V
+	public static final fun swipeRight (Landroidx/compose/ui/test/TouchInjectionScope;FFJ)V
+	public static synthetic fun swipeRight$default (Landroidx/compose/ui/test/TouchInjectionScope;FFJILjava/lang/Object;)V
+	public static final fun swipeUp (Landroidx/compose/ui/test/TouchInjectionScope;FFJ)V
+	public static synthetic fun swipeUp$default (Landroidx/compose/ui/test/TouchInjectionScope;FFJILjava/lang/Object;)V
+	public static final fun swipeWithVelocity-5iVPX68 (Landroidx/compose/ui/test/TouchInjectionScope;JJFJ)V
+	public static synthetic fun swipeWithVelocity-5iVPX68$default (Landroidx/compose/ui/test/TouchInjectionScope;JJFJILjava/lang/Object;)V
+}
+
+public abstract class androidx/compose/ui/test/internal/DelayPropagatingContinuationInterceptorWrapper : kotlin/coroutines/AbstractCoroutineContextElement, kotlin/coroutines/ContinuationInterceptor, kotlinx/coroutines/Delay {
+	public static final field $stable I
+	public fun <init> (Lkotlin/coroutines/ContinuationInterceptor;)V
+	public fun delay (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
+	public fun invokeOnTimeout (JLjava/lang/Runnable;Lkotlin/coroutines/CoroutineContext;)Lkotlinx/coroutines/DisposableHandle;
+	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
+	public fun releaseInterceptedContinuation (Lkotlin/coroutines/Continuation;)V
+	public fun scheduleResumeAfterDelay (JLkotlinx/coroutines/CancellableContinuation;)V
+}
+

--- a/lifecycle/lifecycle-runtime/api/desktop/lifecycle-runtime.api
+++ b/lifecycle/lifecycle-runtime/api/desktop/lifecycle-runtime.api
@@ -1,0 +1,47 @@
+public final class androidx/lifecycle/FlowExtKt {
+	public static final fun flowWithLifecycle (Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun flowWithLifecycle$default (Lkotlinx/coroutines/flow/Flow;Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class androidx/lifecycle/LifecycleDestroyedException : java/util/concurrent/CancellationException {
+	public fun <init> ()V
+}
+
+public class androidx/lifecycle/LifecycleRegistry : androidx/lifecycle/Lifecycle {
+	public static final field Companion Landroidx/lifecycle/LifecycleRegistry$Companion;
+	public fun <init> (Landroidx/lifecycle/LifecycleOwner;)V
+	public synthetic fun <init> (Landroidx/lifecycle/LifecycleOwner;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun addObserver (Landroidx/lifecycle/LifecycleObserver;)V
+	public static final fun createUnsafe (Landroidx/lifecycle/LifecycleOwner;)Landroidx/lifecycle/LifecycleRegistry;
+	public fun getCurrentState ()Landroidx/lifecycle/Lifecycle$State;
+	public fun getCurrentStateFlow ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getObserverCount ()I
+	public fun handleLifecycleEvent (Landroidx/lifecycle/Lifecycle$Event;)V
+	public fun markState (Landroidx/lifecycle/Lifecycle$State;)V
+	public static final fun min$lifecycle_runtime (Landroidx/lifecycle/Lifecycle$State;Landroidx/lifecycle/Lifecycle$State;)Landroidx/lifecycle/Lifecycle$State;
+	public fun removeObserver (Landroidx/lifecycle/LifecycleObserver;)V
+	public fun setCurrentState (Landroidx/lifecycle/Lifecycle$State;)V
+}
+
+public final class androidx/lifecycle/LifecycleRegistry$Companion {
+	public final fun createUnsafe (Landroidx/lifecycle/LifecycleOwner;)Landroidx/lifecycle/LifecycleRegistry;
+}
+
+public final class androidx/lifecycle/RepeatOnLifecycleKt {
+	public static final fun repeatOnLifecycle (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun repeatOnLifecycle (Landroidx/lifecycle/LifecycleOwner;Landroidx/lifecycle/Lifecycle$State;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class androidx/lifecycle/WithLifecycleStateKt {
+	public static final fun suspendWithStateAtLeastUnchecked (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;ZLkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withCreated (Landroidx/lifecycle/Lifecycle;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withCreated (Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withResumed (Landroidx/lifecycle/Lifecycle;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withResumed (Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withStarted (Landroidx/lifecycle/Lifecycle;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withStarted (Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withStateAtLeast (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withStateAtLeast (Landroidx/lifecycle/LifecycleOwner;Landroidx/lifecycle/Lifecycle$State;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun withStateAtLeastUnchecked (Landroidx/lifecycle/Lifecycle;Landroidx/lifecycle/Lifecycle$State;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+

--- a/lifecycle/lifecycle-viewmodel-compose/api/desktop/lifecycle-viewmodel-compose.api
+++ b/lifecycle/lifecycle-viewmodel-compose/api/desktop/lifecycle-viewmodel-compose.api
@@ -1,0 +1,24 @@
+public final class androidx/lifecycle/viewmodel/compose/LocalViewModelStoreOwner {
+	public static final field $stable I
+	public static final field INSTANCE Landroidx/lifecycle/viewmodel/compose/LocalViewModelStoreOwner;
+	public final fun getCurrent (Landroidx/compose/runtime/Composer;I)Landroidx/lifecycle/ViewModelStoreOwner;
+	public final fun provides (Landroidx/lifecycle/ViewModelStoreOwner;)Landroidx/compose/runtime/ProvidedValue;
+}
+
+public abstract interface annotation class androidx/lifecycle/viewmodel/compose/SavedStateHandleSaveableApi : java/lang/annotation/Annotation {
+}
+
+public final class androidx/lifecycle/viewmodel/compose/SavedStateHandleSaverKt {
+	public static final fun saveable (Landroidx/lifecycle/SavedStateHandle;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;)Lkotlin/properties/PropertyDelegateProvider;
+	public static final fun saveable (Landroidx/lifecycle/SavedStateHandle;Ljava/lang/String;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;)Landroidx/compose/runtime/MutableState;
+	public static final fun saveable (Landroidx/lifecycle/SavedStateHandle;Ljava/lang/String;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static synthetic fun saveable$default (Landroidx/lifecycle/SavedStateHandle;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlin/properties/PropertyDelegateProvider;
+	public static synthetic fun saveable$default (Landroidx/lifecycle/SavedStateHandle;Ljava/lang/String;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun saveableMutableState (Landroidx/lifecycle/SavedStateHandle;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;)Lkotlin/properties/PropertyDelegateProvider;
+	public static synthetic fun saveableMutableState$default (Landroidx/lifecycle/SavedStateHandle;Landroidx/compose/runtime/saveable/Saver;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlin/properties/PropertyDelegateProvider;
+}
+
+public final class androidx/lifecycle/viewmodel/compose/ViewModel_jbKt {
+	public static final fun viewModel (Lkotlin/reflect/KClass;Landroidx/lifecycle/ViewModelStoreOwner;Ljava/lang/String;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;Landroidx/compose/runtime/Composer;II)Landroidx/lifecycle/ViewModel;
+}
+

--- a/lifecycle/lifecycle-viewmodel-savedstate/api/desktop/lifecycle-viewmodel-savedstate.api
+++ b/lifecycle/lifecycle-viewmodel-savedstate/api/desktop/lifecycle-viewmodel-savedstate.api
@@ -1,0 +1,36 @@
+public abstract class androidx/lifecycle/AbstractSavedStateViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
+	public fun <init> ()V
+	public fun <init> (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/core/bundle/Bundle;)V
+	protected fun create (Ljava/lang/String;Lkotlin/reflect/KClass;Landroidx/lifecycle/SavedStateHandle;)Landroidx/lifecycle/ViewModel;
+	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
+}
+
+public final class androidx/lifecycle/SavedStateHandle {
+	public static final field Companion Landroidx/lifecycle/SavedStateHandle$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public final fun clearSavedStateProvider (Ljava/lang/String;)V
+	public final fun contains (Ljava/lang/String;)Z
+	public static final fun createHandle (Landroidx/core/bundle/Bundle;Landroidx/core/bundle/Bundle;)Landroidx/lifecycle/SavedStateHandle;
+	public final fun get (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun getStateFlow (Ljava/lang/String;Ljava/lang/Object;)Lkotlinx/coroutines/flow/StateFlow;
+	public final fun keys ()Ljava/util/Set;
+	public final fun remove (Ljava/lang/String;)Ljava/lang/Object;
+	public final fun savedStateProvider ()Landroidx/savedstate/SavedStateRegistry$SavedStateProvider;
+	public final fun set (Ljava/lang/String;Ljava/lang/Object;)V
+	public final fun setSavedStateProvider (Ljava/lang/String;Landroidx/savedstate/SavedStateRegistry$SavedStateProvider;)V
+}
+
+public final class androidx/lifecycle/SavedStateHandle$Companion {
+	public final fun createHandle (Landroidx/core/bundle/Bundle;Landroidx/core/bundle/Bundle;)Landroidx/lifecycle/SavedStateHandle;
+	public final fun validateValue (Ljava/lang/Object;)Z
+}
+
+public final class androidx/lifecycle/SavedStateHandleSupport {
+	public static final field DEFAULT_ARGS_KEY Landroidx/lifecycle/viewmodel/CreationExtras$Key;
+	public static final field SAVED_STATE_REGISTRY_OWNER_KEY Landroidx/lifecycle/viewmodel/CreationExtras$Key;
+	public static final field VIEW_MODEL_STORE_OWNER_KEY Landroidx/lifecycle/viewmodel/CreationExtras$Key;
+	public static final fun createSavedStateHandle (Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/SavedStateHandle;
+	public static final fun enableSavedStateHandles (Landroidx/savedstate/SavedStateRegistryOwner;)V
+}
+

--- a/lifecycle/lifecycle-viewmodel/api/desktop/lifecycle-viewmodel.api
+++ b/lifecycle/lifecycle-viewmodel/api/desktop/lifecycle-viewmodel.api
@@ -1,0 +1,106 @@
+public abstract interface class androidx/lifecycle/HasDefaultViewModelProviderFactory {
+	public fun getDefaultViewModelCreationExtras ()Landroidx/lifecycle/viewmodel/CreationExtras;
+	public abstract fun getDefaultViewModelProviderFactory ()Landroidx/lifecycle/ViewModelProvider$Factory;
+}
+
+public abstract class androidx/lifecycle/ViewModel {
+	public fun <init> ()V
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;[Ljava/lang/AutoCloseable;)V
+	public synthetic fun <init> ([Ljava/io/Closeable;)V
+	public fun <init> ([Ljava/lang/AutoCloseable;)V
+	public synthetic fun addCloseable (Ljava/io/Closeable;)V
+	public fun addCloseable (Ljava/lang/AutoCloseable;)V
+	public final fun addCloseable (Ljava/lang/String;Ljava/lang/AutoCloseable;)V
+	public final fun getCloseable (Ljava/lang/String;)Ljava/lang/AutoCloseable;
+	protected fun onCleared ()V
+}
+
+public final class androidx/lifecycle/ViewModelKt {
+	public static final fun getViewModelScope (Landroidx/lifecycle/ViewModel;)Lkotlinx/coroutines/CoroutineScope;
+}
+
+public final class androidx/lifecycle/ViewModelLazy : kotlin/Lazy {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getValue ()Landroidx/lifecycle/ViewModel;
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun isInitialized ()Z
+}
+
+public final class androidx/lifecycle/ViewModelProvider {
+	public static final field Companion Landroidx/lifecycle/ViewModelProvider$Companion;
+	public static final field VIEW_MODEL_KEY Landroidx/lifecycle/viewmodel/CreationExtras$Key;
+	public synthetic fun <init> (Landroidx/lifecycle/viewmodel/ViewModelProviderImpl;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Landroidx/lifecycle/ViewModelStore;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModelProvider;
+	public static final fun create (Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModelProvider;
+	public final fun get (Ljava/lang/String;Lkotlin/reflect/KClass;)Landroidx/lifecycle/ViewModel;
+	public final fun get (Lkotlin/reflect/KClass;)Landroidx/lifecycle/ViewModel;
+}
+
+public final class androidx/lifecycle/ViewModelProvider$Companion {
+	public final fun create (Landroidx/lifecycle/ViewModelStore;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModelProvider;
+	public final fun create (Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModelProvider;
+	public static synthetic fun create$default (Landroidx/lifecycle/ViewModelProvider$Companion;Landroidx/lifecycle/ViewModelStore;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;ILjava/lang/Object;)Landroidx/lifecycle/ViewModelProvider;
+	public static synthetic fun create$default (Landroidx/lifecycle/ViewModelProvider$Companion;Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/lifecycle/ViewModelProvider$Factory;Landroidx/lifecycle/viewmodel/CreationExtras;ILjava/lang/Object;)Landroidx/lifecycle/ViewModelProvider;
+}
+
+public abstract interface class androidx/lifecycle/ViewModelProvider$Factory {
+	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
+}
+
+public class androidx/lifecycle/ViewModelProvider$OnRequeryFactory {
+	public fun <init> ()V
+	public fun onRequery (Landroidx/lifecycle/ViewModel;)V
+}
+
+public class androidx/lifecycle/ViewModelStore {
+	public fun <init> ()V
+	public final fun clear ()V
+	public final fun get (Ljava/lang/String;)Landroidx/lifecycle/ViewModel;
+	public final fun keys ()Ljava/util/Set;
+	public final fun put (Ljava/lang/String;Landroidx/lifecycle/ViewModel;)V
+}
+
+public abstract interface class androidx/lifecycle/ViewModelStoreOwner {
+	public abstract fun getViewModelStore ()Landroidx/lifecycle/ViewModelStore;
+}
+
+public abstract class androidx/lifecycle/viewmodel/CreationExtras {
+	public abstract fun get (Landroidx/lifecycle/viewmodel/CreationExtras$Key;)Ljava/lang/Object;
+}
+
+public final class androidx/lifecycle/viewmodel/CreationExtras$Empty : androidx/lifecycle/viewmodel/CreationExtras {
+	public static final field INSTANCE Landroidx/lifecycle/viewmodel/CreationExtras$Empty;
+	public fun get (Landroidx/lifecycle/viewmodel/CreationExtras$Key;)Ljava/lang/Object;
+}
+
+public abstract interface class androidx/lifecycle/viewmodel/CreationExtras$Key {
+}
+
+public final class androidx/lifecycle/viewmodel/InitializerViewModelFactoryBuilder {
+	public fun <init> ()V
+	public final fun addInitializer (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+	public final fun build ()Landroidx/lifecycle/ViewModelProvider$Factory;
+}
+
+public final class androidx/lifecycle/viewmodel/InitializerViewModelFactoryKt {
+	public static final fun viewModelFactory (Lkotlin/jvm/functions/Function1;)Landroidx/lifecycle/ViewModelProvider$Factory;
+}
+
+public final class androidx/lifecycle/viewmodel/MutableCreationExtras : androidx/lifecycle/viewmodel/CreationExtras {
+	public fun <init> ()V
+	public fun <init> (Landroidx/lifecycle/viewmodel/CreationExtras;)V
+	public synthetic fun <init> (Landroidx/lifecycle/viewmodel/CreationExtras;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun get (Landroidx/lifecycle/viewmodel/CreationExtras$Key;)Ljava/lang/Object;
+	public final fun set (Landroidx/lifecycle/viewmodel/CreationExtras$Key;Ljava/lang/Object;)V
+}
+
+public abstract interface annotation class androidx/lifecycle/viewmodel/ViewModelFactoryDsl : java/lang/annotation/Annotation {
+}
+
+public final class androidx/lifecycle/viewmodel/ViewModelInitializer {
+	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)V
+}
+

--- a/navigation/navigation-common/api/desktop/navigation-common.api
+++ b/navigation/navigation-common/api/desktop/navigation-common.api
@@ -1,0 +1,339 @@
+public abstract interface class androidx/navigation/FloatingWindow {
+}
+
+public final class androidx/navigation/NamedNavArgument {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Landroidx/navigation/NavArgument;
+	public final fun getArgument ()Landroidx/navigation/NavArgument;
+	public final fun getName ()Ljava/lang/String;
+}
+
+public final class androidx/navigation/NamedNavArgumentKt {
+	public static final fun navArgument (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Landroidx/navigation/NamedNavArgument;
+}
+
+public final class androidx/navigation/NavArgument {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getType ()Landroidx/navigation/NavType;
+	public fun hashCode ()I
+	public final fun isDefaultValuePresent ()Z
+	public final fun isNullable ()Z
+	public final fun putDefaultValue (Ljava/lang/String;Landroidx/core/bundle/Bundle;)V
+	public fun toString ()Ljava/lang/String;
+	public final fun verify (Ljava/lang/String;Landroidx/core/bundle/Bundle;)Z
+}
+
+public final class androidx/navigation/NavArgument$Builder {
+	public fun <init> ()V
+	public final fun build ()Landroidx/navigation/NavArgument;
+	public final fun setDefaultValue (Ljava/lang/Object;)Landroidx/navigation/NavArgument$Builder;
+	public final fun setIsNullable (Z)Landroidx/navigation/NavArgument$Builder;
+	public final fun setType (Landroidx/navigation/NavType;)Landroidx/navigation/NavArgument$Builder;
+}
+
+public final class androidx/navigation/NavArgumentBuilder {
+	public fun <init> ()V
+	public final fun build ()Landroidx/navigation/NavArgument;
+	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getNullable ()Z
+	public final fun getType ()Landroidx/navigation/NavType;
+	public final fun setDefaultValue (Ljava/lang/Object;)V
+	public final fun setNullable (Z)V
+	public final fun setType (Landroidx/navigation/NavType;)V
+}
+
+public final class androidx/navigation/NavBackStackEntry : androidx/lifecycle/HasDefaultViewModelProviderFactory, androidx/lifecycle/LifecycleOwner, androidx/lifecycle/ViewModelStoreOwner, androidx/savedstate/SavedStateRegistryOwner {
+	public static final field Companion Landroidx/navigation/NavBackStackEntry$Companion;
+	public fun <init> (Landroidx/navigation/NavBackStackEntry;Landroidx/core/bundle/Bundle;)V
+	public synthetic fun <init> (Landroidx/navigation/NavBackStackEntry;Landroidx/core/bundle/Bundle;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;Landroidx/lifecycle/Lifecycle$State;Landroidx/navigation/NavViewModelStoreProvider;Ljava/lang/String;Landroidx/core/bundle/Bundle;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Landroidx/core/bundle/Bundle;
+	public fun getDefaultViewModelCreationExtras ()Landroidx/lifecycle/viewmodel/CreationExtras;
+	public fun getDefaultViewModelProviderFactory ()Landroidx/lifecycle/ViewModelProvider$Factory;
+	public final fun getDestination ()Landroidx/navigation/NavDestination;
+	public final fun getId ()Ljava/lang/String;
+	public fun getLifecycle ()Landroidx/lifecycle/Lifecycle;
+	public final fun getMaxLifecycle ()Landroidx/lifecycle/Lifecycle$State;
+	public final fun getSavedStateHandle ()Landroidx/lifecycle/SavedStateHandle;
+	public fun getSavedStateRegistry ()Landroidx/savedstate/SavedStateRegistry;
+	public fun getViewModelStore ()Landroidx/lifecycle/ViewModelStore;
+	public final fun handleLifecycleEvent (Landroidx/lifecycle/Lifecycle$Event;)V
+	public fun hashCode ()I
+	public final fun saveState (Landroidx/core/bundle/Bundle;)V
+	public final fun setDestination (Landroidx/navigation/NavDestination;)V
+	public final fun setMaxLifecycle (Landroidx/lifecycle/Lifecycle$State;)V
+	public fun toString ()Ljava/lang/String;
+	public final fun updateState ()V
+}
+
+public final class androidx/navigation/NavBackStackEntry$Companion {
+	public final fun create (Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;Landroidx/lifecycle/Lifecycle$State;Landroidx/navigation/NavViewModelStoreProvider;Ljava/lang/String;Landroidx/core/bundle/Bundle;)Landroidx/navigation/NavBackStackEntry;
+	public static synthetic fun create$default (Landroidx/navigation/NavBackStackEntry$Companion;Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;Landroidx/lifecycle/Lifecycle$State;Landroidx/navigation/NavViewModelStoreProvider;Ljava/lang/String;Landroidx/core/bundle/Bundle;ILjava/lang/Object;)Landroidx/navigation/NavBackStackEntry;
+	public final fun randomId ()Ljava/lang/String;
+}
+
+public final class androidx/navigation/NavDeepLink {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getUriPattern ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
+public final class androidx/navigation/NavDeepLink$Builder {
+	public fun <init> ()V
+	public final fun build ()Landroidx/navigation/NavDeepLink;
+	public static final fun fromAction (Ljava/lang/String;)Landroidx/navigation/NavDeepLink$Builder;
+	public static final fun fromMimeType (Ljava/lang/String;)Landroidx/navigation/NavDeepLink$Builder;
+	public static final fun fromUriPattern (Ljava/lang/String;)Landroidx/navigation/NavDeepLink$Builder;
+	public final fun setAction (Ljava/lang/String;)Landroidx/navigation/NavDeepLink$Builder;
+	public final fun setMimeType (Ljava/lang/String;)Landroidx/navigation/NavDeepLink$Builder;
+	public final fun setUriPattern (Ljava/lang/String;)Landroidx/navigation/NavDeepLink$Builder;
+}
+
+public class androidx/navigation/NavDestination {
+	public static final field Companion Landroidx/navigation/NavDestination$Companion;
+	public fun <init> (Landroidx/navigation/Navigator;)V
+	public fun <init> (Ljava/lang/String;)V
+	public final fun addArgument (Ljava/lang/String;Landroidx/navigation/NavArgument;)V
+	public final fun addDeepLink (Landroidx/navigation/NavDeepLink;)V
+	public final fun addDeepLink (Ljava/lang/String;)V
+	public final fun addInDefaultArgs (Landroidx/core/bundle/Bundle;)Landroidx/core/bundle/Bundle;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/util/Map;
+	public fun getDisplayName ()Ljava/lang/String;
+	public static final fun getHierarchy (Landroidx/navigation/NavDestination;)Lkotlin/sequences/Sequence;
+	public final fun getLabel ()Ljava/lang/CharSequence;
+	public final fun getNavigatorName ()Ljava/lang/String;
+	public final fun getParent ()Landroidx/navigation/NavGraph;
+	public final fun getRoute ()Ljava/lang/String;
+	public final fun hasRoute (Ljava/lang/String;Landroidx/core/bundle/Bundle;)Z
+	public fun hashCode ()I
+	public final fun removeArgument (Ljava/lang/String;)V
+	public final fun setLabel (Ljava/lang/CharSequence;)V
+	public final fun setParent (Landroidx/navigation/NavGraph;)V
+	public final fun setRoute (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/navigation/NavDestination$Companion {
+	public final fun getHierarchy (Landroidx/navigation/NavDestination;)Lkotlin/sequences/Sequence;
+}
+
+public class androidx/navigation/NavDestinationBuilder {
+	public fun <init> (Landroidx/navigation/Navigator;Ljava/lang/String;)V
+	public final fun argument (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun build ()Landroidx/navigation/NavDestination;
+	public final fun getLabel ()Ljava/lang/CharSequence;
+	protected final fun getNavigator ()Landroidx/navigation/Navigator;
+	public final fun getRoute ()Ljava/lang/String;
+	public final fun setLabel (Ljava/lang/CharSequence;)V
+}
+
+public abstract interface annotation class androidx/navigation/NavDestinationDsl : java/lang/annotation/Annotation {
+}
+
+public class androidx/navigation/NavGraph : androidx/navigation/NavDestination, java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
+	public static final field Companion Landroidx/navigation/NavGraph$Companion;
+	public fun <init> (Landroidx/navigation/Navigator;)V
+	public final fun addAll (Landroidx/navigation/NavGraph;)V
+	public final fun addDestination (Landroidx/navigation/NavDestination;)V
+	public final fun addDestinations (Ljava/util/Collection;)V
+	public final fun addDestinations ([Landroidx/navigation/NavDestination;)V
+	public final fun clear ()V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun findNode (Ljava/lang/String;)Landroidx/navigation/NavDestination;
+	public final fun findNode (Ljava/lang/String;Z)Landroidx/navigation/NavDestination;
+	public static final fun findStartDestination (Landroidx/navigation/NavGraph;)Landroidx/navigation/NavDestination;
+	public fun getDisplayName ()Ljava/lang/String;
+	public final fun getNodes ()Ljava/util/Map;
+	public final fun getStartDestinationRoute ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun iterator ()Ljava/util/Iterator;
+	public final fun remove (Landroidx/navigation/NavDestination;)V
+	public final fun setStartDestination (Ljava/lang/String;)V
+	public final fun setStartDestinationRoute (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/navigation/NavGraph$Companion {
+	public final fun findStartDestination (Landroidx/navigation/NavGraph;)Landroidx/navigation/NavDestination;
+}
+
+public class androidx/navigation/NavGraphBuilder : androidx/navigation/NavDestinationBuilder {
+	public fun <init> (Landroidx/navigation/NavigatorProvider;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun addDestination (Landroidx/navigation/NavDestination;)V
+	public synthetic fun build ()Landroidx/navigation/NavDestination;
+	public fun build ()Landroidx/navigation/NavGraph;
+	public final fun destination (Landroidx/navigation/NavDestinationBuilder;)V
+	public final fun getProvider ()Landroidx/navigation/NavigatorProvider;
+	public final fun unaryPlus (Landroidx/navigation/NavDestination;)V
+}
+
+public final class androidx/navigation/NavGraphBuilder_jbKt {
+	public static final fun navigation (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static final fun navigation (Landroidx/navigation/NavigatorProvider;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Landroidx/navigation/NavGraph;
+	public static synthetic fun navigation$default (Landroidx/navigation/NavigatorProvider;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/navigation/NavGraph;
+}
+
+public class androidx/navigation/NavGraphNavigator : androidx/navigation/Navigator {
+	public fun <init> (Landroidx/navigation/NavigatorProvider;)V
+	public synthetic fun createDestination ()Landroidx/navigation/NavDestination;
+	public fun createDestination ()Landroidx/navigation/NavGraph;
+	public final fun getBackStack ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun navigate (Ljava/util/List;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)V
+}
+
+public final class androidx/navigation/NavGraph_jbKt {
+	public static final fun contains (Landroidx/navigation/NavGraph;Ljava/lang/String;)Z
+	public static final fun get (Landroidx/navigation/NavGraph;Ljava/lang/String;)Landroidx/navigation/NavDestination;
+	public static final fun minusAssign (Landroidx/navigation/NavGraph;Landroidx/navigation/NavDestination;)V
+	public static final fun plusAssign (Landroidx/navigation/NavGraph;Landroidx/navigation/NavDestination;)V
+	public static final fun plusAssign (Landroidx/navigation/NavGraph;Landroidx/navigation/NavGraph;)V
+}
+
+public final class androidx/navigation/NavOptions {
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPopUpToRoute ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPopUpToInclusive ()Z
+	public final fun shouldLaunchSingleTop ()Z
+	public final fun shouldPopUpToSaveState ()Z
+	public final fun shouldRestoreState ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/navigation/NavOptions$Builder {
+	public fun <init> ()V
+	public final fun build ()Landroidx/navigation/NavOptions;
+	public final fun setLaunchSingleTop (Z)Landroidx/navigation/NavOptions$Builder;
+	public final fun setPopUpTo (Ljava/lang/String;Z)Landroidx/navigation/NavOptions$Builder;
+	public final fun setPopUpTo (Ljava/lang/String;ZZ)Landroidx/navigation/NavOptions$Builder;
+	public static synthetic fun setPopUpTo$default (Landroidx/navigation/NavOptions$Builder;Ljava/lang/String;ZZILjava/lang/Object;)Landroidx/navigation/NavOptions$Builder;
+	public final fun setRestoreState (Z)Landroidx/navigation/NavOptions$Builder;
+}
+
+public final class androidx/navigation/NavOptionsBuilder {
+	public fun <init> ()V
+	public final fun getLaunchSingleTop ()Z
+	public final fun getPopUpToRoute ()Ljava/lang/String;
+	public final fun getRestoreState ()Z
+	public final fun popUpTo (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun popUpTo$default (Landroidx/navigation/NavOptionsBuilder;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun setLaunchSingleTop (Z)V
+	public final fun setRestoreState (Z)V
+}
+
+public final class androidx/navigation/NavOptionsBuilderKt {
+	public static final fun navOptions (Lkotlin/jvm/functions/Function1;)Landroidx/navigation/NavOptions;
+}
+
+public abstract interface annotation class androidx/navigation/NavOptionsDsl : java/lang/annotation/Annotation {
+}
+
+public abstract class androidx/navigation/NavType {
+	public static final field BoolArrayType Landroidx/navigation/NavType;
+	public static final field BoolType Landroidx/navigation/NavType;
+	public static final field Companion Landroidx/navigation/NavType$Companion;
+	public static final field FloatArrayType Landroidx/navigation/NavType;
+	public static final field FloatType Landroidx/navigation/NavType;
+	public static final field IntArrayType Landroidx/navigation/NavType;
+	public static final field IntType Landroidx/navigation/NavType;
+	public static final field LongArrayType Landroidx/navigation/NavType;
+	public static final field LongType Landroidx/navigation/NavType;
+	public static final field StringArrayType Landroidx/navigation/NavType;
+	public static final field StringType Landroidx/navigation/NavType;
+	public fun <init> (Z)V
+	public static fun fromArgType (Ljava/lang/String;Ljava/lang/String;)Landroidx/navigation/NavType;
+	public abstract fun get (Landroidx/core/bundle/Bundle;Ljava/lang/String;)Ljava/lang/Object;
+	public fun getName ()Ljava/lang/String;
+	public static final fun inferFromValue (Ljava/lang/String;)Landroidx/navigation/NavType;
+	public static final fun inferFromValueType (Ljava/lang/Object;)Landroidx/navigation/NavType;
+	public fun isNullableAllowed ()Z
+	public final fun parseAndPut (Landroidx/core/bundle/Bundle;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
+	public final fun parseAndPut (Landroidx/core/bundle/Bundle;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun parseValue (Ljava/lang/String;)Ljava/lang/Object;
+	public fun parseValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun put (Landroidx/core/bundle/Bundle;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun serializeAsValue (Ljava/lang/Object;)Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public fun valueEquals (Ljava/lang/Object;Ljava/lang/Object;)Z
+}
+
+public final class androidx/navigation/NavType$Companion {
+	public fun fromArgType (Ljava/lang/String;Ljava/lang/String;)Landroidx/navigation/NavType;
+	public final fun inferFromValue (Ljava/lang/String;)Landroidx/navigation/NavType;
+	public final fun inferFromValueType (Ljava/lang/Object;)Landroidx/navigation/NavType;
+}
+
+public abstract interface class androidx/navigation/NavViewModelStoreProvider {
+	public abstract fun getViewModelStore (Ljava/lang/String;)Landroidx/lifecycle/ViewModelStore;
+}
+
+public abstract class androidx/navigation/Navigator {
+	public fun <init> (Ljava/lang/String;)V
+	public abstract fun createDestination ()Landroidx/navigation/NavDestination;
+	public final fun getName ()Ljava/lang/String;
+	protected final fun getState ()Landroidx/navigation/NavigatorState;
+	public final fun isAttached ()Z
+	public fun navigate (Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)Landroidx/navigation/NavDestination;
+	public fun navigate (Ljava/util/List;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)V
+	public fun onAttach (Landroidx/navigation/NavigatorState;)V
+	public fun onLaunchSingleTop (Landroidx/navigation/NavBackStackEntry;)V
+	public fun onRestoreState (Landroidx/core/bundle/Bundle;)V
+	public fun onSaveState ()Landroidx/core/bundle/Bundle;
+	public fun popBackStack ()Z
+	public fun popBackStack (Landroidx/navigation/NavBackStackEntry;Z)V
+}
+
+public abstract interface class androidx/navigation/Navigator$Extras {
+}
+
+public class androidx/navigation/NavigatorProvider {
+	public fun <init> ()V
+	public final fun addNavigator (Landroidx/navigation/Navigator;)Landroidx/navigation/Navigator;
+	public fun addNavigator (Ljava/lang/String;Landroidx/navigation/Navigator;)Landroidx/navigation/Navigator;
+	public fun getNavigator (Ljava/lang/String;)Landroidx/navigation/Navigator;
+	public final fun getNavigators ()Ljava/util/Map;
+}
+
+public final class androidx/navigation/NavigatorProvider_jbKt {
+	public static final fun get (Landroidx/navigation/NavigatorProvider;Ljava/lang/String;)Landroidx/navigation/Navigator;
+	public static final fun plusAssign (Landroidx/navigation/NavigatorProvider;Landroidx/navigation/Navigator;)V
+	public static final fun set (Landroidx/navigation/NavigatorProvider;Ljava/lang/String;Landroidx/navigation/Navigator;)Landroidx/navigation/Navigator;
+}
+
+public abstract class androidx/navigation/NavigatorState {
+	public fun <init> ()V
+	public abstract fun createBackStackEntry (Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;)Landroidx/navigation/NavBackStackEntry;
+	public final fun getBackStack ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getTransitionsInProgress ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun isNavigating ()Z
+	public fun markTransitionComplete (Landroidx/navigation/NavBackStackEntry;)V
+	public fun onLaunchSingleTop (Landroidx/navigation/NavBackStackEntry;)V
+	public fun onLaunchSingleTopWithTransition (Landroidx/navigation/NavBackStackEntry;)V
+	public fun pop (Landroidx/navigation/NavBackStackEntry;Z)V
+	public fun popWithTransition (Landroidx/navigation/NavBackStackEntry;Z)V
+	public fun prepareForTransition (Landroidx/navigation/NavBackStackEntry;)V
+	public fun push (Landroidx/navigation/NavBackStackEntry;)V
+	public fun pushWithTransition (Landroidx/navigation/NavBackStackEntry;)V
+	public final fun setNavigating (Z)V
+}
+
+public final class androidx/navigation/NoOpNavigator : androidx/navigation/Navigator {
+	public fun <init> ()V
+	public fun createDestination ()Landroidx/navigation/NavDestination;
+	public fun navigate (Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)Landroidx/navigation/NavDestination;
+	public fun popBackStack ()Z
+}
+
+public final class androidx/navigation/PopUpToBuilder {
+	public fun <init> ()V
+	public final fun getInclusive ()Z
+	public final fun getSaveState ()Z
+	public final fun setInclusive (Z)V
+	public final fun setSaveState (Z)V
+}
+

--- a/navigation/navigation-compose/api/desktop/navigation-compose.api
+++ b/navigation/navigation-compose/api/desktop/navigation-compose.api
@@ -1,0 +1,85 @@
+public final class androidx/navigation/compose/ComposableSingletons$ComposeNavigator_jbKt {
+	public static final field INSTANCE Landroidx/navigation/compose/ComposableSingletons$ComposeNavigator_jbKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
+	public fun <init> ()V
+	public final fun getLambda-1$navigation_compose ()Lkotlin/jvm/functions/Function4;
+}
+
+public final class androidx/navigation/compose/ComposableSingletons$DialogNavigator_jbKt {
+	public static final field INSTANCE Landroidx/navigation/compose/ComposableSingletons$DialogNavigator_jbKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$navigation_compose ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class androidx/navigation/compose/ComposeNavigator : androidx/navigation/Navigator {
+	public static final field $stable I
+	public fun <init> ()V
+	public synthetic fun createDestination ()Landroidx/navigation/NavDestination;
+	public fun createDestination ()Landroidx/navigation/compose/ComposeNavigator$Destination;
+	public final fun getBackStack ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun navigate (Ljava/util/List;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)V
+	public final fun onTransitionComplete (Landroidx/navigation/NavBackStackEntry;)V
+	public fun popBackStack (Landroidx/navigation/NavBackStackEntry;Z)V
+	public final fun prepareForTransition (Landroidx/navigation/NavBackStackEntry;)V
+}
+
+public final class androidx/navigation/compose/ComposeNavigator$Destination : androidx/navigation/NavDestination {
+	public static final field $stable I
+	public fun <init> (Landroidx/navigation/compose/ComposeNavigator;Lkotlin/jvm/functions/Function4;)V
+}
+
+public final class androidx/navigation/compose/DialogHostKt {
+	public static final fun DialogHost (Landroidx/navigation/compose/DialogNavigator;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class androidx/navigation/compose/DialogNavigator : androidx/navigation/Navigator {
+	public static final field $stable I
+	public fun <init> ()V
+	public synthetic fun createDestination ()Landroidx/navigation/NavDestination;
+	public fun createDestination ()Landroidx/navigation/compose/DialogNavigator$Destination;
+	public fun navigate (Ljava/util/List;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)V
+	public fun popBackStack (Landroidx/navigation/NavBackStackEntry;Z)V
+}
+
+public final class androidx/navigation/compose/DialogNavigator$Destination : androidx/navigation/NavDestination, androidx/navigation/FloatingWindow {
+	public static final field $stable I
+	public fun <init> (Landroidx/navigation/compose/DialogNavigator;Landroidx/compose/ui/window/DialogProperties;Lkotlin/jvm/functions/Function3;)V
+	public synthetic fun <init> (Landroidx/navigation/compose/DialogNavigator;Landroidx/compose/ui/window/DialogProperties;Lkotlin/jvm/functions/Function3;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class androidx/navigation/compose/NavBackStackEntryProvider_jbKt {
+	public static final fun LocalOwnersProvider (Landroidx/navigation/NavBackStackEntry;Landroidx/compose/runtime/saveable/SaveableStateHolder;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class androidx/navigation/compose/NavGraphBuilderKt {
+	public static final fun composable (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
+	public static final synthetic fun composable (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
+	public static final synthetic fun composable (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun composable$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)V
+	public static synthetic fun composable$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)V
+	public static synthetic fun composable$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static final fun dialog (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Landroidx/compose/ui/window/DialogProperties;Lkotlin/jvm/functions/Function3;)V
+	public static synthetic fun dialog$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Landroidx/compose/ui/window/DialogProperties;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static final synthetic fun navigation (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public static final synthetic fun navigation (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static final fun navigation (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun navigation$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun navigation$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public static synthetic fun navigation$default (Landroidx/navigation/NavGraphBuilder;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class androidx/navigation/compose/NavHostController_jbKt {
+	public static final fun currentBackStackEntryAsState (Landroidx/navigation/NavController;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static final fun rememberNavController ([Landroidx/navigation/Navigator;Landroidx/compose/runtime/Composer;I)Landroidx/navigation/NavHostController;
+}
+
+public final class androidx/navigation/compose/NavHostKt {
+	public static final synthetic fun NavHost (Landroidx/navigation/NavHostController;Landroidx/navigation/NavGraph;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final synthetic fun NavHost (Landroidx/navigation/NavHostController;Landroidx/navigation/NavGraph;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Landroidx/navigation/NavHostController;Landroidx/navigation/NavGraph;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final synthetic fun NavHost (Landroidx/navigation/NavHostController;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavHost (Landroidx/navigation/NavHostController;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final synthetic fun NavHost (Landroidx/navigation/NavHostController;Ljava/lang/String;Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+}
+

--- a/navigation/navigation-runtime/api/desktop/navigation-runtime.api
+++ b/navigation/navigation-runtime/api/desktop/navigation-runtime.api
@@ -1,0 +1,66 @@
+public class androidx/navigation/NavController {
+	public static final field Companion Landroidx/navigation/NavController$Companion;
+	public fun <init> ()V
+	public fun addOnDestinationChangedListener (Landroidx/navigation/NavController$OnDestinationChangedListener;)V
+	public final fun clearBackStack (Ljava/lang/String;)Z
+	public final fun findDestination (Ljava/lang/String;)Landroidx/navigation/NavDestination;
+	public final fun getBackStackEntry (Ljava/lang/String;)Landroidx/navigation/NavBackStackEntry;
+	public final fun getCurrentBackStack ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getCurrentBackStackEntry ()Landroidx/navigation/NavBackStackEntry;
+	public final fun getCurrentBackStackEntryFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getCurrentDestination ()Landroidx/navigation/NavDestination;
+	public fun getGraph ()Landroidx/navigation/NavGraph;
+	public fun getNavigatorProvider ()Landroidx/navigation/NavigatorProvider;
+	public fun getPreviousBackStackEntry ()Landroidx/navigation/NavBackStackEntry;
+	public final fun getVisibleEntries ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun navigate (Ljava/lang/String;)V
+	public final fun navigate (Ljava/lang/String;Landroidx/navigation/NavOptions;)V
+	public final fun navigate (Ljava/lang/String;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;)V
+	public final fun navigate (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun navigate$default (Landroidx/navigation/NavController;Ljava/lang/String;Landroidx/navigation/NavOptions;Landroidx/navigation/Navigator$Extras;ILjava/lang/Object;)V
+	public fun navigateUp ()Z
+	public fun popBackStack ()Z
+	public final fun popBackStack (Ljava/lang/String;Z)Z
+	public final fun popBackStack (Ljava/lang/String;ZZ)Z
+	public static synthetic fun popBackStack$default (Landroidx/navigation/NavController;Ljava/lang/String;ZZILjava/lang/Object;)Z
+	public fun removeOnDestinationChangedListener (Landroidx/navigation/NavController$OnDestinationChangedListener;)V
+	public fun restoreState (Landroidx/core/bundle/Bundle;)V
+	public fun saveState ()Landroidx/core/bundle/Bundle;
+	public fun setGraph (Landroidx/navigation/NavGraph;)V
+	public fun setGraph (Landroidx/navigation/NavGraph;Landroidx/core/bundle/Bundle;)V
+	public fun setLifecycleOwner (Landroidx/lifecycle/LifecycleOwner;)V
+	public fun setNavigatorProvider (Landroidx/navigation/NavigatorProvider;)V
+	public fun setViewModelStore (Landroidx/lifecycle/ViewModelStore;)V
+}
+
+public final class androidx/navigation/NavController$Companion {
+}
+
+public abstract interface class androidx/navigation/NavController$OnDestinationChangedListener {
+	public abstract fun onDestinationChanged (Landroidx/navigation/NavController;Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;)V
+}
+
+public final class androidx/navigation/NavController_jbKt {
+	public static final fun createGraph (Landroidx/navigation/NavController;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Landroidx/navigation/NavGraph;
+	public static synthetic fun createGraph$default (Landroidx/navigation/NavController;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/navigation/NavGraph;
+}
+
+public abstract interface class androidx/navigation/NavHost {
+	public abstract fun getNavController ()Landroidx/navigation/NavController;
+}
+
+public class androidx/navigation/NavHostController : androidx/navigation/NavController {
+	public fun <init> ()V
+	public final fun setLifecycleOwner (Landroidx/lifecycle/LifecycleOwner;)V
+	public final fun setViewModelStore (Landroidx/lifecycle/ViewModelStore;)V
+}
+
+public final class androidx/navigation/NavHost_jbKt {
+	public static final fun createGraph (Landroidx/navigation/NavHost;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Landroidx/navigation/NavGraph;
+	public static synthetic fun createGraph$default (Landroidx/navigation/NavHost;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/navigation/NavGraph;
+}
+
+public final class androidx/navigation/Navigation {
+	public static final field INSTANCE Landroidx/navigation/Navigation;
+}
+

--- a/savedstate/savedstate/api/desktop/savedstate.api
+++ b/savedstate/savedstate/api/desktop/savedstate.api
@@ -1,0 +1,35 @@
+public final class androidx/savedstate/SavedStateRegistry {
+	public final fun consumeRestoredStateForKey (Ljava/lang/String;)Landroidx/core/bundle/Bundle;
+	public final fun getSavedStateProvider (Ljava/lang/String;)Landroidx/savedstate/SavedStateRegistry$SavedStateProvider;
+	public final fun isRestored ()Z
+	public final fun registerSavedStateProvider (Ljava/lang/String;Landroidx/savedstate/SavedStateRegistry$SavedStateProvider;)V
+	public final fun runOnNextRecreation (Ljava/lang/Class;)V
+	public final fun unregisterSavedStateProvider (Ljava/lang/String;)V
+}
+
+public abstract interface class androidx/savedstate/SavedStateRegistry$AutoRecreated {
+	public abstract fun onRecreated (Landroidx/savedstate/SavedStateRegistryOwner;)V
+}
+
+public abstract interface class androidx/savedstate/SavedStateRegistry$SavedStateProvider {
+	public abstract fun saveState ()Landroidx/core/bundle/Bundle;
+}
+
+public final class androidx/savedstate/SavedStateRegistryController {
+	public static final field Companion Landroidx/savedstate/SavedStateRegistryController$Companion;
+	public synthetic fun <init> (Landroidx/savedstate/SavedStateRegistryOwner;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun create (Landroidx/savedstate/SavedStateRegistryOwner;)Landroidx/savedstate/SavedStateRegistryController;
+	public final fun getSavedStateRegistry ()Landroidx/savedstate/SavedStateRegistry;
+	public final fun performAttach ()V
+	public final fun performRestore (Landroidx/core/bundle/Bundle;)V
+	public final fun performSave (Landroidx/core/bundle/Bundle;)V
+}
+
+public final class androidx/savedstate/SavedStateRegistryController$Companion {
+	public final fun create (Landroidx/savedstate/SavedStateRegistryOwner;)Landroidx/savedstate/SavedStateRegistryController;
+}
+
+public abstract interface class androidx/savedstate/SavedStateRegistryOwner : androidx/lifecycle/LifecycleOwner {
+	public abstract fun getSavedStateRegistry ()Landroidx/savedstate/SavedStateRegistry;
+}
+


### PR DESCRIPTION
## Proposed Changes

- Split `JetbrainsAndroidXPlugin` and `JetBrainsAndroidXImplPlugin` (for referring `AndroidXExtension`)
- Move applying `binary-compatibility-validator` to `JetBrainsAndroidXImplPlugin`
- Fix check to `shouldPublish()`
- Generate API dumps for new modules