### PR TITLE
Fix animation frozen after app went background

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/AnimationFreezeBug.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/AnimationFreezeBug.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.Switch
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import platform.UIKit.UIApplication
+import platform.Foundation.NSURL
+
+val AnimationFreezeBug = Screen.Example("AnimationFreezeBug") {
+    Column(modifier = Modifier.fillMaxSize()) {
+        var state by remember { mutableStateOf(true) }
+        Switch(checked = state, onCheckedChange = {
+            state = it
+            UIApplication.sharedApplication.openURL(NSURL.URLWithString("app-settings:")!!)
+        })
+    }
+}

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
@@ -35,5 +35,6 @@ val IosBugs = Screen.Selection(
     KeyboardIMEActionPopup,
     ProperContainmentDisposal,
     ComposeAndNativeScroll,
-    MeasureAndLayoutCrash
+    MeasureAndLayoutCrash,
+    AnimationFreezeBug,
 )

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.ComposeSceneKeyboardOffsetManager
+import androidx.compose.ui.window.ApplicationStateListener
 import androidx.compose.ui.window.FocusStack
 import androidx.compose.ui.window.InteractionUIView
 import androidx.compose.ui.window.KeyboardEventHandler
@@ -251,6 +252,15 @@ internal class ComposeSceneMediator(
 
     private val renderingView by lazy {
         renderingUIViewFactory(interopContext, renderDelegate)
+    }
+
+    private val applicationStateListener = ApplicationStateListener { isForeground ->
+        // Sometimes the application can trigger animation and go background before the animation is
+        // finished. The scheduled GPU work is performed, but no presentation can be done, causing
+        // mismatch between visual state and application state. This can be fixed by forcing
+        // a redraw when app returns to foreground, which will ensure that the visual state is in
+        // sync with the application state even if such sequence of events took a place.
+        onComposeSceneInvalidate()
     }
 
     /**
@@ -490,6 +500,7 @@ internal class ComposeSceneMediator(
 
     fun dispose() {
         uiKitTextInputService.stopInput()
+        applicationStateListener.dispose()
         focusStack?.popUntilNext(renderingView)
         keyboardManager.stop()
         renderingView.dispose()
@@ -501,7 +512,7 @@ internal class ComposeSceneMediator(
         interopContext.retrieve().actions.forEach { it.invoke() }
     }
 
-    fun onComposeSceneInvalidate() = renderingView.needRedraw()
+    private fun onComposeSceneInvalidate() = renderingView.needRedraw()
 
     fun setLayout(value: SceneLayout) {
         _layout = value

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -260,7 +260,7 @@ internal class ComposeSceneMediator(
         // mismatch between visual state and application state. This can be fixed by forcing
         // a redraw when app returns to foreground, which will ensure that the visual state is in
         // sync with the application state even if such sequence of events took a place.
-        onComposeSceneInvalidate()
+        renderingView.needRedraw()
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

Invalidate compose scene when the app goes foreground to trigger redraw.
The intent is to avoid the situation where last presented frames are discarded due to the app going background, leaving the visual content in older state.

## Testing

Test: Demo/IosBugs/AnimationFreezeBug the visual state always matches the animation final state when app goes to foreground.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4566