### PR TITLE
Check whether event type is KeyDown after processing typed events.

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text2/input/internal/TextFieldKeyEventHandler.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text2/input/internal/TextFieldKeyEventHandler.kt
@@ -76,10 +76,6 @@ internal abstract class TextFieldKeyEventHandler {
         singleLine: Boolean,
         onSubmit: () -> Unit
     ): Boolean {
-        if (event.type != KeyEventType.KeyDown) {
-            return false
-        }
-
         if (event.isTypedEvent) {
             val codePoint = deadKeyCombiner.consume(event)
             if (codePoint != null) {
@@ -95,6 +91,10 @@ internal abstract class TextFieldKeyEventHandler {
                     false
                 }
             }
+        }
+
+        if (event.type != KeyEventType.KeyDown) {
+            return false
         }
 
         val command = keyMapping.map(event)


### PR DESCRIPTION
## Proposed Changes

In BasicTextField2 input processing: Ignore non-`KeyDown` events only after processing typed events.
On the desktop, typed events are *not* `KeyDown` events, so checking for `KeyDown` first prevents processing typed events completely.

## Testing

Test: Tested a `BasicTextField2` manually.