### PR TITLE
Provide the ability to specify artifact redirect for individual module

### DIFF
--- a/buildSrc/public/src/main/kotlin/androidx/build/jetbrains/ArtifactRedirecting.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/jetbrains/ArtifactRedirecting.kt
@@ -35,13 +35,17 @@ fun Project.artifactRedirecting(): ArtifactRedirecting {
     // but we can comply to this convention:
         ?: project.group.toString().replace("org.jetbrains.", "androidx.")
 
+    val fullId = groupId + "." + project.name
+
     val targetNames = (findProperty("artifactRedirecting.publication.targetNames") as? String ?: "")
         .split(",").toSet()
 
-    var defaultVersion: String = findProperty("artifactRedirecting.${groupId}.version") as? String
+    var defaultVersion: String =
+        findProperty("artifactRedirecting.${fullId}.version") as? String ?:
+        findProperty("artifactRedirecting.${groupId}.version") as? String ?:
         // artifactRedirecting for compose was added before all other libs,
         // therefore it's a default:
-        ?: findProperty("artifactRedirecting.androidx.compose.version") as String
+        findProperty("artifactRedirecting.androidx.compose.version") as String
 
     val targetVersionsMap = mutableMapOf<String, String>()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -111,11 +111,22 @@ artifactRedirecting.androidx.collection.version=1.4.0
 artifactRedirecting.androidx.annotation.version=1.8.0-alpha02
 # TODO: per-target-versioning for annotation is temporary, delete it and keep the line above (after stable 1.8.0)
 artifactRedirecting.androidx.annotation.targetVersions=jvm=1.7.1,default=1.8.0-alpha02
-# FIXME: lifecycle-common, lifecycle-runtime should redirect to 2.7.0
-# FIXME: lifecycle-runtime-compose should redirect to <= 2.8.0-alpha02
+# Lifecycle group and modules versions are set according to https://youtrack.jetbrains.com/issue/COMPOSE-1306
 artifactRedirecting.androidx.lifecycle.version=2.8.0-alpha04
+artifactRedirecting.androidx.lifecycle.lifecycle-runtime-compose.version=2.8.0-alpha02
+# FIXME: in 1.6.10 we should publish our artifacts of  lifecycle-common and lifecycle-runtime with 2.7.0 version and redirect only for android:
+artifactRedirecting.androidx.lifecycle.lifecycle-common.version=2.8.0-alpha04
+artifactRedirecting.androidx.lifecycle.lifecycle-runtime.version=2.8.0-alpha04
 artifactRedirecting.androidx.navigation.version=2.8.0-alpha05
 artifactRedirecting.androidx.savedstate.version=1.2.1
+
+# For the purpose of substituteForRedirectedPublishedDependencies (look for it in the code)
+artifactRedirecting.modules-for-knative-manifest=\
+  :annotation:annotation=artifactRedirecting.androidx.annotation.version,\
+  :collection:collection=artifactRedirecting.androidx.collection.version,\
+  :lifecycle:lifecycle-common=artifactRedirecting.androidx.lifecycle.lifecycle-common.version,\
+  :lifecycle:lifecycle-runtime=artifactRedirecting.androidx.lifecycle.lifecycle-runtime.version,\
+  :lifecycle:lifecycle-viewmodel=artifactRedirecting.androidx.lifecycle.version
 
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -284,7 +284,7 @@ fun allTasksWith(name: String) =
 // ./gradlew printAllArtifactRedirectingVersions -PfilterProjectPath=lifecycle
 // or just ./gradlew printAllArtifactRedirectingVersions
 val printAllArtifactRedirectingVersions = tasks.register("printAllArtifactRedirectingVersions") {
-    val filter = project.property("filterProjectPath") as? String ?: ""
+    val filter = project.properties["filterProjectPath"] as? String ?: ""
     doLast {
         val map = mainComponents.filter { it.path.contains(filter) }
             .joinToString("\n\n", prefix = "\n") {

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -281,14 +281,19 @@ fun allTasksWith(name: String) =
     rootProject.subprojects.flatMap { it.tasks.filter { it.name == name } }
 
 
+// ./gradlew printAllArtifactRedirectingVersions -PfilterProjectPath=lifecycle
+// or just ./gradlew printAllArtifactRedirectingVersions
 val printAllArtifactRedirectingVersions = tasks.register("printAllArtifactRedirectingVersions") {
-    val map = mainComponents.map {
-        val p = rootProject.findProject(it.path)!!
-        it.path + " --> \n" + p.artifactRedirecting().prettyText()
-    }.joinToString("\n\n", prefix = "\n")
+    val filter = project.property("filterProjectPath") as? String ?: ""
+    doLast {
+        val map = mainComponents.filter { it.path.contains(filter) }
+            .joinToString("\n\n", prefix = "\n") {
+            val p = rootProject.findProject(it.path)!!
+            it.path + " --> \n" + p.artifactRedirecting().prettyText()
+        }
 
-
-    println(map)
+        println(map)
+    }
 }
 
 fun ArtifactRedirecting.prettyText(): String {

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -1,3 +1,5 @@
+import androidx.build.jetbrains.ArtifactRedirecting
+import androidx.build.jetbrains.artifactRedirecting
 import org.jetbrains.compose.internal.publishing.*
 
 plugins {
@@ -277,3 +279,29 @@ fun readComposeModules(
 
 fun allTasksWith(name: String) =
     rootProject.subprojects.flatMap { it.tasks.filter { it.name == name } }
+
+
+val printAllArtifactRedirectingVersions = tasks.register("printAllArtifactRedirectingVersions") {
+    val map = mainComponents.map {
+        val p = rootProject.findProject(it.path)!!
+        it.path + " --> \n" + p.artifactRedirecting().prettyText()
+    }.joinToString("\n\n", prefix = "\n")
+
+
+    println(map)
+}
+
+fun ArtifactRedirecting.prettyText(): String {
+    fun formatLine(line: String): String {
+        return "   $line\n"
+    }
+
+    val allLines = arrayOf(
+        "redirectGroupId = ${this.groupId}",
+        "redirectDefaultVersion = ${this.defaultVersion}",
+        "redirectForTargets = [${this.targetNames.joinToString().takeIf { it.isNotBlank() } ?: "android"}]",
+        "redirectTargetVersions = ${this.targetVersions}"
+    )
+
+    return allLines.joinToString("") { formatLine(it) }
+}

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -297,10 +297,6 @@ val printAllArtifactRedirectingVersions = tasks.register("printAllArtifactRedire
 }
 
 fun ArtifactRedirecting.prettyText(): String {
-    fun formatLine(line: String): String {
-        return "   $line\n"
-    }
-
     val allLines = arrayOf(
         "redirectGroupId = ${this.groupId}",
         "redirectDefaultVersion = ${this.defaultVersion}",
@@ -308,5 +304,5 @@ fun ArtifactRedirecting.prettyText(): String {
         "redirectTargetVersions = ${this.targetVersions}"
     )
 
-    return allLines.joinToString("") { formatLine(it) }
+    return allLines.joinToString("") { " ".repeat(3) + "$it\n" }
 }


### PR DESCRIPTION
It's possible now like this:

```
// for the group:
artifactRedirecting.androidx.lifecycle.version=2.8.0-alpha04

// and for individual modules (has a priority over a group version):
artifactRedirecting.androidx.lifecycle.lifecycle-runtime-compose.version=2.8.0-alpha02
artifactRedirecting.androidx.lifecycle.lifecycle-common.version=2.8.0-alpha04
artifactRedirecting.androidx.lifecycle.lifecycle-runtime.version=2.8.0-alpha04
```

For debug purposes, I added a new task 
`./gradlew printAllArtifactRedirectingVersions -PfilterProjectPath=lifecycle`

It prints like this:

```
:lifecycle:lifecycle-common --> 
   redirectGroupId = androidx.lifecycle
   redirectDefaultVersion = 2.8.0-alpha04
   redirectForTargets = [jvm, macosX64, macosArm64, iosX64, iosArm64, iosSimulatorArm64, linuxX64]
   redirectTargetVersions = {}


:lifecycle:lifecycle-runtime --> 
   redirectGroupId = androidx.lifecycle
   redirectDefaultVersion = 2.8.0-alpha04
   redirectForTargets = [android, desktop, macosX64, macosArm64, iosX64, iosArm64, iosSimulatorArm64, linuxX64]
   redirectTargetVersions = {}


:lifecycle:lifecycle-viewmodel --> 
   redirectGroupId = androidx.lifecycle
   redirectDefaultVersion = 2.8.0-alpha04
   redirectForTargets = [android, desktop, macosX64, macosArm64, iosX64, iosArm64, iosSimulatorArm64, linuxX64]
   redirectTargetVersions = {}


:lifecycle:lifecycle-viewmodel-savedstate --> 
   redirectGroupId = androidx.lifecycle
   redirectDefaultVersion = 2.8.0-alpha04
   redirectForTargets = [android]
   redirectTargetVersions = {}


:lifecycle:lifecycle-runtime-compose --> 
   redirectGroupId = androidx.lifecycle
   redirectDefaultVersion = 2.8.0-alpha02
   redirectForTargets = [android]
   redirectTargetVersions = {}


:lifecycle:lifecycle-viewmodel-compose --> 
   redirectGroupId = androidx.lifecycle
   redirectDefaultVersion = 2.8.0-alpha04
   redirectForTargets = [android]
   redirectTargetVersions = {}
           
```