### PR TITLE
[wasm][js] Correct density rounding in ComposeWindow::resize

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -308,8 +308,8 @@ internal class ComposeWindow(
         // FIXME: density is not integer
         val scale = density.density
 
-        val width = (boxSize.width * scaledDensity).toInt()
-        val height = (boxSize.height * scaledDensity).toInt()
+        val width = (boxSize.width * scale).toInt()
+        val height = (boxSize.height * scale).toInt()
 
         canvas.width = width
         canvas.height = height

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -305,7 +305,6 @@ internal class ComposeWindow(
     }
 
     fun resize(boxSize: IntSize) {
-        // FIXME: density is not integer
         val scale = density.density
 
         val width = (boxSize.width * scale).toInt()

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -306,10 +306,10 @@ internal class ComposeWindow(
 
     fun resize(boxSize: IntSize) {
         // FIXME: density is not integer
-        val scaledDensity = density.density.toInt()
+        val scaledDensity = density.density
 
-        val width = boxSize.width * scaledDensity
-        val height = boxSize.height * scaledDensity
+        val width = (boxSize.width * scaledDensity).toInt()
+        val height = (boxSize.height * scaledDensity).toInt()
 
         canvas.width = width
         canvas.height = height

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -306,7 +306,7 @@ internal class ComposeWindow(
 
     fun resize(boxSize: IntSize) {
         // FIXME: density is not integer
-        val scaledDensity = density.density
+        val scale = density.density
 
         val width = (boxSize.width * scaledDensity).toInt()
         val height = (boxSize.height * scaledDensity).toInt()


### PR DESCRIPTION
The problems happen when the scaling is not an integer (say, 125%, 150% etc.) - we need to round only after we've resolved dimensions. 

This supposedly fix issues we've encountered on Windows platform (see [COMPOSE-1170](https://youtrack.jetbrains.com/issue/COMPOSE-1170) and in certain android phones)