### PR TITLE
Fixed appearing of text editing menu in Selection Container in iOS

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -591,7 +591,7 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
         if (visibleRect.width < 0 || visibleRect.height < 0) return null
 
         val rootRect = visibleRect.translate(containerCoordinates.positionInRoot())
-        return rootRect.copy(bottom = visibleRect.bottom + HandleHeight.value * 4)
+        return rootRect.copy(bottom = rootRect.bottom + HandleHeight.value * 4)
     }
 
     // This is for PressGestureDetector to cancel the selection.

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -591,7 +591,7 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
         if (visibleRect.width < 0 || visibleRect.height < 0) return null
 
         val rootRect = visibleRect.translate(containerCoordinates.positionInRoot())
-        return rootRect.copy(bottom = rootRect.bottom + HandleHeight.value * 4)
+        return rootRect.copy(bottom = visibleRect.bottom + HandleHeight.value * 4)
     }
 
     // This is for PressGestureDetector to cancel the selection.

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Selection.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Selection.kt
@@ -26,8 +26,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.TextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.mpp.demo.textfield.ClearFocusBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -40,46 +42,60 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun SelectionExample() {
     var count by remember { mutableStateOf(0) }
-    Column {
-        Button(onClick = { count++ }) {
-            Text("Outside Count: $count")
-        }
-        SelectionContainer(
-            Modifier.padding(24.dp).fillMaxWidth()
-        ) {
-            Column {
-                Text(
-                    "I'm a selection container. Double tap on word to select a word." +
-                        " Triple tap on content to select whole paragraph.\nAnother paragraph for testing.\n" +
-                        "And another one."
-                )
-                Row {
-                    DisableSelection {
+    val textState = remember {
+        mutableStateOf(
+            buildString {
+                repeat(3) {
+                    appendLine("Text line $it")
+                }
+            }
+        )
+    }
+    ClearFocusBox {
+        Column {
+            Button(onClick = { count++ }) {
+                Text("Outside Count: $count")
+            }
+            SelectionContainer(
+                Modifier.padding(24.dp).fillMaxWidth()
+            ) {
+                Column {
+                    TextField(
+                        textState.value, { textState.value = it },
+                    )
+                    Text(
+                        "I'm a selection container. Double tap on word to select a word." +
+                            " Triple tap on content to select whole paragraph.\nAnother paragraph for testing.\n" +
+                            "And another one."
+                    )
+                    Row {
+                        DisableSelection {
+                            Button(onClick = { count++ }) {
+                                Text("DisableSelection Count: $count")
+                            }
+                        }
                         Button(onClick = { count++ }) {
-                            Text("DisableSelection Count: $count")
+                            Text("SelectionContainer Count: $count")
                         }
                     }
-                    Button(onClick = { count++ }) {
-                        Text("SelectionContainer Count: $count")
-                    }
+                    Text("I'm another Text() block. Let's try to select me!")
+                    Text("I'm yet another Text() with multiparagraph structure block.\nLet's try to select me!")
                 }
-                Text("I'm another Text() block. Let's try to select me!")
-                Text("I'm yet another Text() with multiparagraph structure block.\nLet's try to select me!")
             }
-        }
-        Column(
-            Modifier
-                .height(100.dp)
-                .padding(2.dp)
-                .border(1.dp, Color.Blue)
-                .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
-        ) {
-            SelectionContainer {
-                Text(
-                    text = "Select text and scroll\n".repeat(100),
-                    modifier = Modifier.fillMaxWidth(),
-                )
+            Column(
+                Modifier
+                    .height(100.dp)
+                    .padding(2.dp)
+                    .border(1.dp, Color.Blue)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                SelectionContainer {
+                    Text(
+                        text = "Select text and scroll\n".repeat(100),
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -305,6 +305,7 @@ internal class UIKitTextInputService(
                 NSLayoutConstraint.activateConstraints(
                     getConstraintsToFillParent(it, rootView)
                 )
+                it.becomeFirstResponder()
             }
 
             updateView()
@@ -342,7 +343,8 @@ internal class UIKitTextInputService(
      */
     override fun hide() {
         textUIView?.hideTextMenu()
-        if ((textUIView != null) && (currentInput == null)) {
+        if ((textUIView != null) && (currentInput == null)) { // means that editing context menu shown in selection container
+            textUIView?.resignFirstResponder()
             textUIView?.removeFromSuperview()
             textUIView = null
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -22,18 +22,32 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.text.input.*
+import androidx.compose.ui.scene.getConstraintsToFillParent
+import androidx.compose.ui.text.input.CommitTextCommand
+import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.EditProcessor
+import androidx.compose.ui.text.input.FinishComposingTextCommand
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.PlatformTextInputService
+import androidx.compose.ui.text.input.SetComposingRegionCommand
+import androidx.compose.ui.text.input.SetComposingTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.asCGRect
+import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.window.FocusStack
 import androidx.compose.ui.window.IntermediateTextInputUIView
 import androidx.compose.ui.window.KeyboardEventHandler
-import androidx.compose.ui.scene.getConstraintsToFillParent
-import androidx.compose.ui.unit.Density
 import kotlin.math.absoluteValue
 import kotlin.math.min
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
-import platform.UIKit.*
+import platform.UIKit.NSLayoutConstraint
+import platform.UIKit.UIView
+import platform.UIKit.reloadInputViews
 
 internal class UIKitTextInputService(
     private val updateView: () -> Unit,
@@ -257,16 +271,7 @@ internal class UIKitTextInputService(
         onCutRequested: (() -> Unit)?,
         onSelectAllRequested: (() -> Unit)?
     ) {
-        val skiaRect = with(densityProvider()) {
-            org.jetbrains.skia.Rect.makeLTRB(
-                l = rect.left / density,
-                t = rect.top / density,
-                r = rect.right / density,
-                b = rect.bottom / density,
-            )
-        }
-
-        if (textUIView == null ) {
+        if (textUIView == null) {
             // If showMenu() is called and textUIView is not created,
             // then it means that showMenu() called in SelectionContainer without any textfields,
             // and IntermediateTextInputView must be created to show an editing menu
@@ -274,9 +279,8 @@ internal class UIKitTextInputService(
             textUIView?.becomeFirstResponder()
             updateView()
         }
-
         textUIView?.showTextMenu(
-            targetRect = skiaRect,
+            targetRect = rect.toDpRect(densityProvider()).asCGRect(),
             textActions = object : TextActions {
                 override val copy: (() -> Unit)? = onCopyRequested
                 override val cut: (() -> Unit)? = onCutRequested

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -309,9 +309,6 @@ internal class UIKitTextInputService(
             }
 
             updateView()
-            rootView.layoutIfNeeded()
-            rootView.reloadInputViews()
-            textUIView?.reloadInputViews()
 
             textUIView?.let {
                 val skiaRect = with(densityProvider()) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -314,7 +314,6 @@ internal class UIKitTextInputService(
             NSLayoutConstraint.activateConstraints(
                 getConstraintsToFillParent(it, rootView)
             )
-            it.backgroundColor = UIColor.redColor.colorWithAlphaComponent(0.5)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -501,14 +501,8 @@ internal class IntermediateTextInputUIView(
      * @param targetRect - rectangle of selected text area
      * @param textActions - available (not null) actions in text menu
      */
-    fun showTextMenu(targetRect: org.jetbrains.skia.Rect, textActions: TextActions) {
-        val cgRect = CGRectMake(
-            x = targetRect.left.toDouble(),
-            y = targetRect.top.toDouble(),
-            width = targetRect.width.toDouble(),
-            height = targetRect.height.toDouble()
-        )
-        val isTargetVisible = CGRectIntersectsRect(bounds, cgRect)
+    fun showTextMenu(targetRect: CValue<CGRect>, textActions: TextActions) {
+        val isTargetVisible = CGRectIntersectsRect(bounds, targetRect)
 
         if (isTargetVisible) {
             // TODO: UIMenuController is deprecated since iOS 17 and not available on iOS 12
@@ -519,7 +513,7 @@ internal class IntermediateTextInputUIView(
             cancelContextMenuUpdate()
             CoroutineScope(Dispatchers.Main + menuMonitoringJob).launch {
                 delay(viewConfiguration.doubleTapTimeoutMillis)
-                menu.showMenuFromView(targetView = this@IntermediateTextInputUIView, cgRect)
+                menu.showMenuFromView(targetView = this@IntermediateTextInputUIView, targetRect)
             }
             _currentTextMenuActions = textActions
         } else {


### PR DESCRIPTION
## Proposed Changes

- Added creating a text interaction view (which is required to show the edit menu by long press / double tap on the text) in case when there is no one (i.e. only selection container presents of the screen without any other text editing views)
- Fixed its position on the screen (changes from androidx: https://github.com/JetBrains/compose-multiplatform-core/pull/1270)

## Testing

Test: Open test app, go Components -> Selection, try to select text in selection container

## Issues Fixed

Fixes: 
- https://youtrack.jetbrains.com/issue/COMPOSE-1190/iOS-Selection-Container-cant-show-options-menu
- https://github.com/JetBrains/compose-multiplatform/issues/4322

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
