### PR TITLE
Fix content rect calculation in SelectionManager

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -591,7 +591,7 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
         if (visibleRect.width < 0 || visibleRect.height < 0) return null
 
         val rootRect = visibleRect.translate(containerCoordinates.positionInRoot())
-        return rootRect.copy(bottom = visibleRect.bottom + HandleHeight.value * 4)
+        return rootRect.copy(bottom = rootRect.bottom + HandleHeight.value * 4)
     }
 
     // This is for PressGestureDetector to cancel the selection.


### PR DESCRIPTION
## Proposed Changes

**Cherry-picked from androidx**

Fix a typo in `SelectionManager.getContentRect()` that results in an invalid rect being calculated, causing text toolbar to not show under certain conditions.

Fixes: b/332782845
Test: manual
Change-Id: I153b99f4146d870182af2898d9a675ed6ffa15e4

## Testing

Test: Open test app, go Components -> Selection, try to select text in selection container

## Issues Fixed

Fixes: appearing of editing menu in selection container in wrong position
https://youtrack.jetbrains.com/issue/COMPOSE-1190/iOS-Selection-Container-cant-show-options-menu
https://github.com/JetBrains/compose-multiplatform/issues/4322
b/332782845 in Google

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
