### PR TITLE
Set the ComposeSceneLayer's content in DisposableEffect rather than in the composition

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -197,7 +197,7 @@ internal fun rememberComposeSceneLayer(
  * Sets the content of the layer to [content].
  */
 @Composable
-internal fun ComposeSceneLayer.applyContent(content: @Composable () -> Unit) {
+internal fun ComposeSceneLayer.Content(content: @Composable () -> Unit) {
     val currentContent by rememberUpdatedState(content)
     DisposableEffect(this) {
         setContent {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -20,8 +20,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -189,4 +191,18 @@ internal fun rememberComposeSceneLayer(
         }
     }
     return layer
+}
+
+/**
+ * Sets the content of the layer to [content].
+ */
+@Composable
+internal fun ComposeSceneLayer.applyContent(content: @Composable () -> Unit) {
+    val currentContent by rememberUpdatedState(content)
+    DisposableEffect(this) {
+        setContent {
+            currentContent()
+        }
+        onDispose {  }
+    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.union
 import androidx.compose.ui.scene.ComposeSceneLayer
-import androidx.compose.ui.scene.applyContent
+import androidx.compose.ui.scene.Content
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
@@ -191,7 +191,7 @@ private fun DialogLayout(
     layer.scrimColor = properties.scrimColor
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
-    layer.applyContent {
+    layer.Content {
         val containerSize = LocalWindowInfo.current.containerSize
         val measurePolicy = rememberDialogMeasurePolicy(
             layer = layer,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -18,7 +18,9 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
@@ -35,13 +37,13 @@ import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.platform.union
 import androidx.compose.ui.scene.ComposeSceneLayer
+import androidx.compose.ui.scene.applyContent
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.dialog
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.center
-import androidx.compose.ui.unit.dp
 
 /**
  * The default scrim opacity.
@@ -181,6 +183,7 @@ private fun DialogLayout(
     onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
+    val currentContent by rememberUpdatedState(content)
     val platformInsets = properties.platformInsets
     val layer = rememberComposeSceneLayer(
         focusable = true
@@ -188,7 +191,7 @@ private fun DialogLayout(
     layer.scrimColor = properties.scrimColor
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
-    rememberLayerContent(layer) {
+    layer.applyContent {
         val containerSize = LocalWindowInfo.current.containerSize
         val measurePolicy = rememberDialogMeasurePolicy(
             layer = layer,
@@ -201,7 +204,7 @@ private fun DialogLayout(
             ime = properties.useSoftwareKeyboardInset,
         ) {
             Layout(
-                content = content,
+                content = currentContent,
                 modifier = modifier,
                 measurePolicy = measurePolicy
             )
@@ -223,13 +226,6 @@ private val DialogProperties.platformInsets: PlatformInsets
         }
         return safeInsets.union(ime)
     }
-
-@Composable
-private fun rememberLayerContent(layer: ComposeSceneLayer, content: @Composable () -> Unit) {
-    remember(layer, content) {
-        layer.setContent(content)
-    }
-}
 
 @Composable
 private fun rememberDialogMeasurePolicy(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.scene.ComposeSceneLayer
-import androidx.compose.ui.scene.applyContent
+import androidx.compose.ui.scene.Content
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
@@ -448,8 +448,8 @@ private fun PopupLayout(
     )
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
-    layer.applyContent {
-        val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@applyContent
+    layer.Content {
+        val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@Content
         val containerSize = LocalWindowInfo.current.containerSize
         val layoutDirection = LocalLayoutDirection.current
         val measurePolicy = rememberPopupMeasurePolicy(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
 import androidx.compose.ui.scene.ComposeSceneLayer
+import androidx.compose.ui.scene.applyContent
 import androidx.compose.ui.scene.rememberComposeSceneLayer
 import androidx.compose.ui.semantics.popup
 import androidx.compose.ui.semantics.semantics
@@ -438,6 +439,7 @@ private fun PopupLayout(
     onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
+    val currentContent by rememberUpdatedState(content)
     val platformInsets = properties.platformInsets
     var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
     EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
@@ -446,8 +448,8 @@ private fun PopupLayout(
     )
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
-    rememberLayerContent(layer) {
-        val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@rememberLayerContent
+    layer.applyContent {
+        val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@applyContent
         val containerSize = LocalWindowInfo.current.containerSize
         val layoutDirection = LocalLayoutDirection.current
         val measurePolicy = rememberPopupMeasurePolicy(
@@ -464,7 +466,7 @@ private fun PopupLayout(
             ime = false,
         ) {
             Layout(
-                content = content,
+                content = currentContent,
                 modifier = modifier,
                 measurePolicy = measurePolicy
             )
@@ -478,13 +480,6 @@ private val PopupProperties.platformInsets: PlatformInsets
     } else {
         PlatformInsets.Zero
     }
-
-@Composable
-private fun rememberLayerContent(layer: ComposeSceneLayer, content: @Composable () -> Unit) {
-    remember(layer, content) {
-        layer.setContent(content)
-    }
-}
 
 private fun Modifier.parentBoundsInWindow(
     onBoundsChanged: (IntRect) -> Unit


### PR DESCRIPTION
We currently set the `ComposeSceneLayer`'s content in the composition phase of its parent. This causes the initial state reads and writes of the child composition to register in the parent composition, which then breaks recomposition when the values of these states changes.

See the [discussion in Slack](https://kotlinlang.slack.com/archives/G010KHY484C/p1713196188769809).

RelNote: Fix initial composition of `Dialog` to correctly respond to changes of states that were both written and read in it. This fixes, for example, `DateRangePicker` ignoring first date change after being shown.

## Proposed Changes
Move setting the layer's content into a `DisposableEffect`.

## Testing

Test: Tested manually and added a new unit test.

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4609

