### PR TITLE
CfW: make independent lifecycle events for different ComposeWindows (per canvas)

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -301,7 +301,7 @@ internal class ComposeWindow(
             )
         }
 
-        lifecycleOwner.handleLifecycleEvent(if (document.hasFocus()) Lifecycle.Event.ON_RESUME else Lifecycle.Event.ON_START)
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_START)
     }
 
     fun resize(boxSize: IntSize) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -270,11 +270,11 @@ internal class ComposeWindow(
             if (processed) event.preventDefault()
         }
 
-        state.globalEvents.addDisposableEvent("focus") {
+        canvasEvents.addDisposableEvent("focus") {
             lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
         }
 
-        state.globalEvents.addDisposableEvent("blur") {
+        canvasEvents.addDisposableEvent("blur") {
             lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
         }
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -22,16 +22,19 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.w3c.dom.HTMLCanvasElement
 
 
 class ComposeWindowLifecycleTest {
     private val canvasId = "canvas1"
+    private val canvasId2 = "canvas2"
 
 
     @AfterTest
     fun cleanup() {
         document.getElementById(canvasId)?.remove()
+        document.getElementById(canvasId2)?.remove()
     }
 
     @Test
@@ -58,5 +61,48 @@ class ComposeWindowLifecycleTest {
 
         canvas.focus()
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
+    }
+
+    @Test
+    fun twoComposeWindowsLifecycleShouldBeIndependent() {
+        if (isHeadlessBrowser()) return
+        val canvas1 = document.createElement("canvas") as HTMLCanvasElement
+        canvas1.setAttribute("id", canvasId)
+        document.body!!.appendChild(canvas1)
+
+        val lifecycleOwner1 = ComposeWindow(
+            canvas = canvas1,
+            content = {},
+            state = DefaultWindowState(document.documentElement!!)
+        )
+
+        val canvas2 = document.createElement("canvas") as HTMLCanvasElement
+        canvas2.setAttribute("id", canvasId2)
+        document.body!!.appendChild(canvas2)
+
+        val lifecycleOwner2 = ComposeWindow(
+            canvas = canvas2,
+            content = {},
+            state = DefaultWindowState(document.documentElement!!)
+        )
+
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner1.lifecycle.currentState)
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner2.lifecycle.currentState)
+
+        canvas1.focus()
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner1.lifecycle.currentState)
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner2.lifecycle.currentState)
+
+        canvas2.focus()
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner1.lifecycle.currentState)
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner2.lifecycle.currentState)
+
+        canvas1.focus()
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner1.lifecycle.currentState)
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner2.lifecycle.currentState)
+
+        canvas1.blur()
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner1.lifecycle.currentState)
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner2.lifecycle.currentState)
     }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -23,7 +23,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.browser.document
 import org.w3c.dom.HTMLCanvasElement
-import org.w3c.dom.events.FocusEvent
 
 
 class ComposeWindowLifecycleTest {
@@ -48,12 +47,16 @@ class ComposeWindowLifecycleTest {
             state = DefaultWindowState(document.documentElement!!)
         )
 
-        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
-
-        document.dispatchEvent(FocusEvent("blur"))
+        // the ComposeWindow is not focused when created
         assertEquals(Lifecycle.State.STARTED, lifecycleOwner.lifecycle.currentState)
 
-        document.dispatchEvent(FocusEvent("focus"))
+        canvas.focus()
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
+
+        canvas.blur()
+        assertEquals(Lifecycle.State.STARTED, lifecycleOwner.lifecycle.currentState)
+
+        canvas.focus()
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
     }
 }


### PR DESCRIPTION
**Problem:**
Currently, all ComposeWindow instances (in compose for web) have a shared lifecycle state (based on the browser window state). 
**Solution:**
We can make them independent, based on the focus/blured state of each canvas element.

Updated the test. 

Test: `./gradlew :compose:ui:ui:cleanWasmJsBrowserTest :compose:ui:ui:wasmJsBrowserTest -Pjetbrains.cfw.tests.useChrome=true`