### PR TITLE
Support parsing navigation path arguments

### DIFF
--- a/navigation/navigation-common/api/desktop/navigation-common.api
+++ b/navigation/navigation-common/api/desktop/navigation-common.api
@@ -77,9 +77,11 @@ public final class androidx/navigation/NavBackStackEntry$Companion {
 public final class androidx/navigation/NavDeepLink {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Ljava/lang/String;
+	public final fun getMatchingArguments (Ljava/lang/String;Ljava/util/Map;)Landroidx/core/bundle/Bundle;
 	public final fun getMimeType ()Ljava/lang/String;
 	public final fun getUriPattern ()Ljava/lang/String;
 	public fun hashCode ()I
+	public final fun isExactDeepLink ()Z
 }
 
 public final class androidx/navigation/NavDeepLink$Builder {
@@ -111,6 +113,7 @@ public class androidx/navigation/NavDestination {
 	public final fun getRoute ()Ljava/lang/String;
 	public final fun hasRoute (Ljava/lang/String;Landroidx/core/bundle/Bundle;)Z
 	public fun hashCode ()I
+	public fun matchDeepLink (Ljava/lang/String;)Landroidx/navigation/NavDestination$DeepLinkMatch;
 	public final fun removeArgument (Ljava/lang/String;)V
 	public final fun setLabel (Ljava/lang/CharSequence;)V
 	public final fun setParent (Landroidx/navigation/NavGraph;)V
@@ -120,6 +123,15 @@ public class androidx/navigation/NavDestination {
 
 public final class androidx/navigation/NavDestination$Companion {
 	public final fun getHierarchy (Landroidx/navigation/NavDestination;)Lkotlin/sequences/Sequence;
+}
+
+public final class androidx/navigation/NavDestination$DeepLinkMatch : java/lang/Comparable {
+	public fun <init> (Landroidx/navigation/NavDestination;Landroidx/core/bundle/Bundle;Z)V
+	public fun compareTo (Landroidx/navigation/NavDestination$DeepLinkMatch;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public final fun getDestination ()Landroidx/navigation/NavDestination;
+	public final fun getMatchingArgs ()Landroidx/core/bundle/Bundle;
+	public final fun hasMatchingArgs (Landroidx/core/bundle/Bundle;)Z
 }
 
 public class androidx/navigation/NavDestinationBuilder {
@@ -152,6 +164,7 @@ public class androidx/navigation/NavGraph : androidx/navigation/NavDestination, 
 	public final fun getStartDestinationRoute ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun iterator ()Ljava/util/Iterator;
+	public fun matchDeepLink (Ljava/lang/String;)Landroidx/navigation/NavDestination$DeepLinkMatch;
 	public final fun remove (Landroidx/navigation/NavDestination;)V
 	public final fun setStartDestination (Ljava/lang/String;)V
 	public final fun setStartDestinationRoute (Ljava/lang/String;)V

--- a/navigation/navigation-common/src/androidMain/kotlin/androidx/navigation/NavDeepLink.android.kt
+++ b/navigation/navigation-common/src/androidMain/kotlin/androidx/navigation/NavDeepLink.android.kt
@@ -84,7 +84,7 @@ public actual class NavDeepLink internal actual constructor(
     internal val argumentsNames: List<String>
         get() = pathArgs + queryArgsMap.values.flatMap { it.arguments } + fragArgs
 
-    public var isExactDeepLink: Boolean = false
+    public actual var isExactDeepLink: Boolean = false
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         get
         internal set

--- a/navigation/navigation-common/src/androidMain/kotlin/androidx/navigation/NavDestination.android.kt
+++ b/navigation/navigation-common/src/androidMain/kotlin/androidx/navigation/NavDestination.android.kt
@@ -66,10 +66,10 @@ public actual open class NavDestination actual constructor(
     public annotation class ClassType(val value: KClass<*>)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public class DeepLinkMatch(
-        public val destination: NavDestination,
+    public actual class DeepLinkMatch(
+        public actual val destination: NavDestination,
         @get:Suppress("NullableCollection") // Needed for nullable bundle
-        public val matchingArgs: Bundle?,
+        public actual val matchingArgs: Bundle?,
         private val isExactDeepLink: Boolean,
         private val matchingPathSegments: Int,
         private val hasMatchingAction: Boolean,
@@ -123,7 +123,7 @@ public actual open class NavDestination actual constructor(
          * @param [arguments] The arguments to match with the matchingArgs stored in this
          * DeepLinkMatch.
          */
-        public fun hasMatchingArgs(arguments: Bundle?): Boolean {
+        public actual fun hasMatchingArgs(arguments: Bundle?): Boolean {
             if (arguments == null || matchingArgs == null) return false
 
             matchingArgs.keySet().forEach { key ->
@@ -368,7 +368,7 @@ public actual open class NavDestination actual constructor(
      * @return The matching [DeepLinkMatch], or null if no match was found.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public fun matchDeepLink(route: String): DeepLinkMatch? {
+    public actual fun matchDeepLink(route: String): DeepLinkMatch? {
         val request = NavDeepLinkRequest.Builder.fromUri(createRoute(route).toUri()).build()
         val matchingDeepLink = if (this is NavGraph) {
             matchDeepLinkExcludingChildren(request)
@@ -386,7 +386,7 @@ public actual open class NavDestination actual constructor(
      * extracted from the Uri, or null if no match was found.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public open fun matchDeepLink(navDeepLinkRequest: NavDeepLinkRequest): DeepLinkMatch? {
+    public actual open fun matchDeepLink(navDeepLinkRequest: NavDeepLinkRequest): DeepLinkMatch? {
         if (deepLinks.isEmpty()) {
             return null
         }

--- a/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/NavDeepLink.kt
@@ -44,6 +44,11 @@ public expect class NavDeepLink internal constructor(
      */
     public val mimeType: String?
 
+    public var isExactDeepLink: Boolean
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        get
+        internal set
+
     /**
      * A builder for constructing [NavDeepLink] instances.
      */

--- a/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/NavDestination.kt
+++ b/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/NavDestination.kt
@@ -34,6 +34,27 @@ import kotlin.jvm.JvmStatic
 public expect open class NavDestination(
     navigatorName: String
 ) {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public class DeepLinkMatch {
+        public val destination: NavDestination
+        public val matchingArgs: Bundle?
+
+        /**
+         * Returns true if all args from [DeepLinkMatch.matchingArgs] can be found within
+         * the [arguments].
+         *
+         * This returns true in these edge cases:
+         * 1. If the [arguments] contain more args than [DeepLinkMatch.matchingArgs].
+         * 2. If [DeepLinkMatch.matchingArgs] is empty
+         * 3. Argument has null value in both [DeepLinkMatch.matchingArgs] and [arguments]
+         * i.e. arguments/params with nullable values
+         *
+         * @param [arguments] The arguments to match with the matchingArgs stored in this
+         * DeepLinkMatch.
+         */
+        public fun hasMatchingArgs(arguments: Bundle?): Boolean
+    }
+
     /**
      * The name associated with this destination's [Navigator].
      */
@@ -155,6 +176,15 @@ public expect open class NavDestination(
      * @see NavController.navigate
      */
     public fun addDeepLink(navDeepLink: NavDeepLink)
+
+    /**
+     * Determines if this NavDestination has a deep link of this route.
+     *
+     * @param [route] The route to match against this [NavDestination.route]
+     * @return The matching [DeepLinkMatch], or null if no match was found.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public fun matchDeepLink(route: String): DeepLinkMatch?
 
     /**
      * Returns true if the [NavBackStackEntry.destination] contains the route.

--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDeepLink.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDeepLink.jb.kt
@@ -17,13 +17,111 @@
 package androidx.navigation
 
 import androidx.annotation.RestrictTo
+import androidx.core.bundle.Bundle
 import kotlin.jvm.JvmStatic
 
 public actual class NavDeepLink internal actual constructor(
     public actual val uriPattern: String?,
     public actual val action: String?,
-    public actual val  mimeType: String?
+    public actual val mimeType: String?
 ) {
+    // path
+    private val pathArgs = mutableListOf<String>()
+    private var pathRegex: String? = null
+    private val pathPattern by lazy {
+        pathRegex?.let { Regex(it, RegexOption.IGNORE_CASE) }
+    }
+
+    public actual var isExactDeepLink: Boolean = false
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        get
+        internal set
+
+    private fun buildRegex(
+        uri: String,
+        args: MutableList<String>,
+        uriRegex: StringBuilder,
+    ) {
+        var result = FILL_IN_PATTERN.find(uri)
+        var appendPos = 0
+        while (result != null) {
+            val argName = result.groups[1]!!.value
+            args.add(argName)
+            // Use Regex.escape() to treat the input string as a literal
+            if (result.range.first > appendPos) {
+                uriRegex.append(Regex.escape(uri.substring(appendPos, result.range.first)))
+            }
+            uriRegex.append("([^/]+?)")
+            appendPos = result.range.last + 1
+            result = result.next()
+        }
+        if (appendPos < uri.length) {
+            // Use Regex.escape() to treat the input string as a literal
+            uriRegex.append(Regex.escape(uri.substring(appendPos)))
+        }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public fun getMatchingArguments(
+        deepLink: String,
+        arguments: Map<String, NavArgument?>
+    ): Bundle? {
+        // first check overall uri pattern for quick return if general pattern does not match
+        val result = pathPattern?.find(deepLink) ?: return null
+
+        // get matching path and query arguments and store in bundle
+        val bundle = Bundle()
+        if (!getMatchingPathArguments(result, bundle, arguments)) return null
+
+        // TODO: Extract arguments from query and fragment part
+
+        // Check that all required arguments are present in bundle
+        val missingRequiredArguments = arguments.missingRequiredArguments { argName ->
+            !bundle.containsKey(argName)
+        }
+        if (missingRequiredArguments.isNotEmpty()) return null
+
+        return bundle
+    }
+
+    private fun getMatchingPathArguments(
+        result: MatchResult,
+        bundle: Bundle,
+        arguments: Map<String, NavArgument?>
+    ): Boolean {
+        this.pathArgs.mapIndexed { index, argumentName ->
+            // TODO: Decode Uri
+            val value = result.groups[index + 1]!!.value
+            val argument = arguments[argumentName]
+            try {
+                if (parseArgument(bundle, argumentName, value, argument)) {
+                    return false
+                }
+            } catch (e: IllegalArgumentException) {
+                // Failed to parse means this isn't a valid deep link
+                // for the given URI - i.e., the URI contains a non-integer
+                // value for an integer argument
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun parseArgument(
+        bundle: Bundle,
+        name: String,
+        value: String,
+        argument: NavArgument?
+    ): Boolean {
+        if (argument != null) {
+            val type = argument.type
+            type.parseAndPut(bundle, name, value)
+        } else {
+            bundle.putString(name, value)
+        }
+        return false
+    }
+
     override fun equals(other: Any?): Boolean {
         if (other == null || other !is NavDeepLink) return false
         return uriPattern == other.uriPattern &&
@@ -93,5 +191,36 @@ public actual class NavDeepLink internal actual constructor(
                 return builder
             }
         }
+    }
+
+    private companion object {
+        private val SCHEME_PATTERN = Regex("^[a-zA-Z]+[+\\w\\-.]*:")
+        private val FILL_IN_PATTERN = Regex("\\{(.+?)\\}")
+    }
+
+    private fun parsePath() {
+        if (uriPattern == null) return
+
+        val uriRegex = StringBuilder("^")
+        // append scheme pattern
+        if (!SCHEME_PATTERN.containsMatchIn(uriPattern)) {
+            uriRegex.append("http[s]?://")
+        }
+        // extract beginning of uriPattern until it hits either a query(?), a framgment(#), or
+        // end of uriPattern
+        Regex("(\\?|\\#|$)").find(uriPattern)?.let {
+            buildRegex(uriPattern.substring(0, it.range.first), pathArgs, uriRegex)
+            isExactDeepLink = !uriRegex.contains(".*") && !uriRegex.contains("([^/]+?)")
+            // Match either the end of string if all params are optional or match the
+            // question mark (or pound symbol) and 0 or more characters after it
+            uriRegex.append("($|(\\?(.)*)|(\\#(.)*))")
+        }
+        // we need to specifically escape any .* instances to ensure
+        // they are still treated as wildcards in our final regex
+        pathRegex = uriRegex.toString().replace(".*", "\\E.*\\Q")
+    }
+
+    init {
+        parsePath()
     }
 }

--- a/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavController.jb.kt
+++ b/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavController.jb.kt
@@ -25,11 +25,9 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStore
-import androidx.lifecycle.ViewModelStoreOwner
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import kotlin.jvm.JvmOverloads
-import kotlin.jvm.JvmStatic
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -1094,9 +1092,13 @@ public actual open class NavController {
             "Cannot navigate to $route. Navigation graph has not been set for " +
                 "NavController $this."
         }
-        val destination = _graph!!.findDestination(route)
-        if (destination != null) {
-            navigate(destination, null, navOptions, navigatorExtras)
+
+        val deepLinkMatch = _graph!!.matchDeepLink(route)
+        if (deepLinkMatch != null) {
+            val destination = deepLinkMatch.destination
+            val args = destination.addInDefaultArgs(deepLinkMatch.matchingArgs) ?: Bundle()
+            val node = deepLinkMatch.destination
+            navigate(node, args, navOptions, navigatorExtras)
         } else {
             throw IllegalArgumentException(
                 "Navigation destination that matches route $route cannot be found in the " +


### PR DESCRIPTION
## Proposed Changes

- Adopt basic deep-link matching
- Add parsing parameters from "path" (without support of parameters in URI's query or fragment parts)

## Testing

```kt
composable(route = "user/{id}") {
    println("id = " + it.arguments?.getString("id"))
}
```

```kt
navController.navigate("user/1")
```

## Issues Fixed

Fixes https://github.com/MatkovIvan/nav_cupcake/issues/4
