### PR TITLE
Fix crash on loading UITextLoupeSession on old iOS versions

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/PlatformMagnifier.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/PlatformMagnifier.uikit.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.uikit.utils.CMPTextLoupeSession
 import kotlin.math.roundToInt
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.getAndUpdate
@@ -31,7 +32,6 @@ import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIColor
-import platform.UIKit.UITextLoupeSession
 import platform.UIKit.UIView
 
 @Stable
@@ -103,7 +103,7 @@ internal object PlatformMagnifierFactoryIos17Impl : PlatformMagnifierFactory {
                 }
 
                 checkNotNull(
-                    UITextLoupeSession.beginLoupeSessionAtPoint(
+                    CMPTextLoupeSession.beginLoupeSessionAtPoint(
                         point = CGPointMake(it.x.toDouble(), it.y.toDouble()),
                         fromSelectionWidgetView = null,
                         inView = view
@@ -119,7 +119,7 @@ internal object PlatformMagnifierFactoryIos17Impl : PlatformMagnifierFactory {
 
     class PlatformMagnifierImpl(
         val density: Float,
-        val loupeSessionFactory: (Offset) -> UITextLoupeSession
+        val loupeSessionFactory: (Offset) -> CMPTextLoupeSession
     ) : PlatformMagnifier {
 
         override val size: IntSize = IntSize(
@@ -127,7 +127,7 @@ internal object PlatformMagnifierFactoryIos17Impl : PlatformMagnifierFactory {
             (80 * density).roundToInt()
         )
 
-        private val loupeSession = atomic<UITextLoupeSession?>(null)
+        private val loupeSession = atomic<CMPTextLoupeSession?>(null)
 
         override fun updateContent() {
             // is not required. loupe redraws automatically

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		997DFCF32B18DE59000B56B5 /* MockAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCF22B18DE59000B56B5 /* MockAppDelegate.swift */; };
 		997DFCF52B18E276000B56B5 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCF42B18E276000B56B5 /* XCTestCase.swift */; };
 		997DFCFD2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCFC2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift */; };
+		99DCAB0E2BD00F5C002E6AC7 /* CMPTextLoupeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */; };
 		EA70A7EB2B27106100300068 /* CMPAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */; };
 		EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E92B27106100300068 /* CMPAccessibilityContainer.m */; };
 		EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4F82B86144E00465418 /* CMPOSLogger.m */; };
@@ -67,6 +68,8 @@
 		997DFCF42B18E276000B56B5 /* XCTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestCase.swift; sourceTree = "<group>"; };
 		997DFCFA2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CMPUIKitUtilsTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		997DFCFC2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPUIKitUtilsTestApp.swift; sourceTree = "<group>"; };
+		99DCAB0C2BD00F5C002E6AC7 /* CMPTextLoupeSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPTextLoupeSession.h; sourceTree = "<group>"; };
+		99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPTextLoupeSession.m; sourceTree = "<group>"; };
 		EA70A7E62B27106100300068 /* CMPAccessibilityElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMPAccessibilityElement.h; sourceTree = "<group>"; };
 		EA70A7E72B27106100300068 /* CMPMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMPMacros.h; sourceTree = "<group>"; };
 		EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMPAccessibilityElement.m; sourceTree = "<group>"; };
@@ -124,6 +127,8 @@
 				EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */,
 				EABD91292BC02B5F00455279 /* CMPInteropWrappingView.h */,
 				EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */,
+				99DCAB0C2BD00F5C002E6AC7 /* CMPTextLoupeSession.h */,
+				99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */,
 			);
 			path = CMPUIKitUtils;
 			sourceTree = "<group>";
@@ -302,6 +307,7 @@
 				EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */,
 				EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */,
 				EA70A7EB2B27106100300068 /* CMPAccessibilityElement.m in Sources */,
+				99DCAB0E2BD00F5C002E6AC7 /* CMPTextLoupeSession.m in Sources */,
 				EA82F4FC2B86184F00465418 /* CMPOSLoggerInterval.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.h
@@ -1,0 +1,28 @@
+//
+//  CMPTextLoupeSession.h
+//  CMPUIKitUtils
+//
+//  Created by Andrei.Salavei on 17.04.24.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Wrapper class around UITextLoupeSession that prevents class type loading for iOS < 17.0
+API_AVAILABLE(ios(17.0))
+@interface CMPTextLoupeSession : NSObject
+
+- (id)init NS_UNAVAILABLE;
+
++ (nullable instancetype)beginLoupeSessionAtPoint:(CGPoint)point
+                          fromSelectionWidgetView:(nullable UIView *)selectionWidget
+                                           inView:(UIView *)interactionView;
+
+- (void)moveToPoint:(CGPoint)point withCaretRect:(CGRect)caretRect trackingCaret:(BOOL)tracksCaret;
+
+- (void)invalidate;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.h
@@ -1,9 +1,18 @@
-//
-//  CMPTextLoupeSession.h
-//  CMPUIKitUtils
-//
-//  Created by Andrei.Salavei on 17.04.24.
-//
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import <UIKit/UIKit.h>
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.m
@@ -1,9 +1,18 @@
-//
-//  CMPTextLoupeSession.m
-//  CMPUIKitUtils
-//
-//  Created by Andrei.Salavei on 17.04.24.
-//
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import "CMPTextLoupeSession.h"
 #import <UIKit/UIKit.h>

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPTextLoupeSession.m
@@ -1,0 +1,43 @@
+//
+//  CMPTextLoupeSession.m
+//  CMPUIKitUtils
+//
+//  Created by Andrei.Salavei on 17.04.24.
+//
+
+#import "CMPTextLoupeSession.h"
+#import <UIKit/UIKit.h>
+
+@implementation CMPTextLoupeSession {
+    id _session;
+}
+
++ (nullable instancetype)beginLoupeSessionAtPoint:(CGPoint)point
+                          fromSelectionWidgetView:(nullable UIView *)selectionWidget
+                                           inView:(UIView *)interactionView {
+    CMPTextLoupeSession *session = [CMPTextLoupeSession new];
+    if (@available(iOS 17, *)) {
+        session->_session = [UITextLoupeSession beginLoupeSessionAtPoint:point
+                                                 fromSelectionWidgetView:selectionWidget
+                                                                  inView:interactionView];
+    } else {
+        [NSException raise:@"UITextLoupeSession is not available" format:@"The method must be called from iOS 17+"];
+    }
+    return session;
+}
+
+- (UITextLoupeSession *)session API_AVAILABLE(ios(17.0)) {
+    return (UITextLoupeSession *)_session;
+}
+
+- (void)moveToPoint:(CGPoint)point
+      withCaretRect:(CGRect)caretRect
+      trackingCaret:(BOOL)tracksCaret API_AVAILABLE(ios(17.0)) {
+    [self.session moveToPoint:point withCaretRect:caretRect trackingCaret:tracksCaret];
+}
+
+- (void)invalidate API_AVAILABLE(ios(17.0)) {
+    [self.session invalidate];
+}
+
+@end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
@@ -26,3 +26,4 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 #import "CMPAccessibilityElement.h"
 #import "CMPAccessibilityContainer.h"
 #import "CMPOSLogger.h"
+#import "CMPTextLoupeSession.h"


### PR DESCRIPTION
## Proposed Changes
Create wrapper around UITextLoupeSession class to prevent class loading by K/N on older iOS where the class does not exist.

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4644