### PR TITLE
[wasm][js] correct Key.isTypedEvent behavior 

### DIFF
--- a/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
+++ b/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
@@ -26,7 +26,7 @@ import org.w3c.dom.events.KeyboardEvent
 actual val KeyEvent.isTypedEvent: Boolean
     get() = type == KeyEventType.KeyDown && !isMetaPressed && domEventOrNull?.isPrintable() == true
 
-fun KeyboardEvent.isPrintable(): Boolean {
+private fun KeyboardEvent.isPrintable(): Boolean {
     return key.firstOrNull()?.toString() == key
 }
 

--- a/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
+++ b/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
@@ -20,7 +20,13 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.input.key.utf16CodePoint
+import androidx.compose.ui.input.key.webEventOrNull
+import org.w3c.dom.events.KeyboardEvent
 
 actual val KeyEvent.isTypedEvent: Boolean
-    get() = type == KeyEventType.KeyDown && !isMetaPressed && utf16CodePoint != 0
+    get() = type == KeyEventType.KeyDown && !isMetaPressed && webEventOrNull?.isPrintable() == true
+
+fun KeyboardEvent.isPrintable(): Boolean {
+    return key.firstOrNull()?.toString() == key
+}
+

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/key/KeyEvent.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/key/KeyEvent.skiko.kt
@@ -80,7 +80,7 @@ fun KeyEvent(
             isAltPressed = isAltPressed,
             isShiftPressed = isShiftPressed
         ),
-        nativeEvent = nativeEvent as? InternalKeyEvent
+        nativeEvent = nativeEvent
     )
 )
 

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/dom/Events.dom.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/dom/Events.dom.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation.text
+package androidx.compose.ui.dom
 
-import androidx.compose.ui.dom.domEventOrNull
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.key.internal
 import org.w3c.dom.events.KeyboardEvent
 
-actual val KeyEvent.isTypedEvent: Boolean
-    get() = type == KeyEventType.KeyDown && !isMetaPressed && domEventOrNull?.isPrintable() == true
 
-fun KeyboardEvent.isPrintable(): Boolean {
-    return key.firstOrNull()?.toString() == key
-}
-
+/**
+ * The original raw native KeyboardEvent event
+ *
+ * Null if:
+ * - the native event is sent by another framework (when Compose UI is embed into it)
+ * - there is no native event (in tests, for example, or when Compose sends a synthetic event)
+ *
+ */
+val KeyEvent.domEventOrNull: KeyboardEvent?
+    get() = internal.nativeEvent as? KeyboardEvent?

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/input/key/KeyEvent.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/input/key/KeyEvent.web.kt
@@ -41,18 +41,6 @@ private fun KeyboardEvent.toInputModifiers(): PointerKeyboardModifiers {
     )
 }
 
-/**
- * The original raw native KeyboardEvent event
- *
- * Null if:
- * - the native event is sent by another framework (when Compose UI is embed into it)
- * - there is no native event (in tests, for example, or when Compose sends a synthetic event)
- *
- */
-val KeyEvent.webEventOrNull: KeyboardEvent?
-    get() = internal.nativeEvent as? KeyboardEvent?
-
-
 internal fun KeyboardEvent.toComposeEvent(): KeyEvent {
     return KeyEvent(
         nativeKeyEvent = InternalKeyEvent(

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/input/key/KeyEvent.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/input/key/KeyEvent.web.kt
@@ -41,6 +41,18 @@ private fun KeyboardEvent.toInputModifiers(): PointerKeyboardModifiers {
     )
 }
 
+/**
+ * The original raw native KeyboardEvent event
+ *
+ * Null if:
+ * - the native event is sent by another framework (when Compose UI is embed into it)
+ * - there is no native event (in tests, for example, or when Compose sends a synthetic event)
+ *
+ */
+val KeyEvent.webEventOrNull: KeyboardEvent?
+    get() = internal.nativeEvent as? KeyboardEvent?
+
+
 internal fun KeyboardEvent.toComposeEvent(): KeyEvent {
     return KeyEvent(
         nativeKeyEvent = InternalKeyEvent(


### PR DESCRIPTION
This behaviour was lost with the very last wave of de-skikoization of events. 
The way we are resolving typed characters on wasm / js is actually a hack, this should be done the other way.

The goal of this PR however is to return this behaviour because the lack of it was a bug.
With whatever we come next, with whatever we'll invent and it will be better - we'll do it separately