### PR TITLE
Publish additional targets for non-compose modules

### DIFF
--- a/buildSrc/src/main/kotlin/ComposePlatforms.kt
+++ b/buildSrc/src/main/kotlin/ComposePlatforms.kt
@@ -67,6 +67,23 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
             ComposePlatforms.IosSimulatorArm64
         )
 
+        val TV_OS = EnumSet.of(
+            ComposePlatforms.TvosArm64,
+            ComposePlatforms.TvosX64,
+            ComposePlatforms.TvosSimulatorArm64
+        )
+
+        val WATCH_OS = EnumSet.of(
+            ComposePlatforms.WatchosArm64,
+            ComposePlatforms.WatchosArm32,
+            ComposePlatforms.WatchosX64,
+            ComposePlatforms.WatchosSimulatorArm64
+        )
+
+        val WINDOWS_NATIVE = EnumSet.of(
+            ComposePlatforms.MingwX64
+        )
+
         val ANDROID = EnumSet.of(
             ComposePlatforms.AndroidDebug,
             ComposePlatforms.AndroidRelease
@@ -90,7 +107,7 @@ enum class ComposePlatforms(vararg val alternativeNames: String) {
         val SKIKO_SUPPORT = EnumSet.of(KotlinMultiplatform) + JVM_BASED + UI_KIT + MACOS + WEB
 
         val ALL = EnumSet.allOf(ComposePlatforms::class.java) - IOS
-        val ALL_AOSP = EnumSet.of(KotlinMultiplatform) + JVM_BASED + IOS + LINUX + MACOS + WEB
+        val ALL_AOSP = EnumSet.allOf(ComposePlatforms::class.java) - UI_KIT
 
         /**
          * Maps comma separated list of platforms into a set of [ComposePlatforms]

--- a/core/core-bundle/build.gradle
+++ b/core/core-bundle/build.gradle
@@ -45,6 +45,15 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    mingwX64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/kruth/kruth/build.gradle
+++ b/kruth/kruth/build.gradle
@@ -49,6 +49,15 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    mingwX64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -55,6 +55,15 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    mingwX64()
+
     explicitApi = ExplicitApiMode.Strict
 
     sourceSets {

--- a/lifecycle/lifecycle-runtime/build.gradle
+++ b/lifecycle/lifecycle-runtime/build.gradle
@@ -43,6 +43,15 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    mingwX64()
+
     explicitApi = ExplicitApiMode.Strict
 
     sourceSets {

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -53,6 +53,14 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/lifecycle/lifecycle-viewmodel/build.gradle
+++ b/lifecycle/lifecycle-viewmodel/build.gradle
@@ -59,6 +59,16 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    // TODO: mingwX64 requires Lock actual implementation.
+    //  Or copy approach from :collection:collection - use unstable atomicFu
+
     explicitApi = ExplicitApiMode.Strict
 
     sourceSets {
@@ -127,7 +137,7 @@ kotlin {
             if (target.platformType == KotlinPlatformType.native) {
                 target.compilations["main"].defaultSourceSet {
                     def konanTargetFamily = target.konanTarget.family
-                    if (konanTargetFamily == Family.OSX || konanTargetFamily == Family.IOS) {
+                    if (konanTargetFamily.appleFamily) {
                         dependsOn(darwinMain)
                     } else if (konanTargetFamily == Family.LINUX) {
                         dependsOn(linuxMain)

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -26,6 +26,9 @@ open class ComposePublishingTask : AbstractComposePublishingTask() {
 
 val composeProperties = ComposeProperties(project)
 
+// TODO: Align with other modules
+val viewModelPlatforms = ComposePlatforms.ALL_AOSP - ComposePlatforms.WINDOWS_NATIVE
+
 val mainComponents =
     listOf(
         ComposeComponent(":annotation:annotation", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
@@ -41,7 +44,7 @@ val mainComponents =
         ),
         ComposeComponent(
             path = ":lifecycle:lifecycle-viewmodel",
-            supportedPlatforms = ComposePlatforms.ALL_AOSP
+            supportedPlatforms = viewModelPlatforms
         ),
 
         ComposeComponent(
@@ -49,11 +52,11 @@ val mainComponents =
             supportedPlatforms = ComposePlatforms.ALL_AOSP,
             neverRedirect = true
         ),
-        ComposeComponent(":savedstate:savedstate", ComposePlatforms.ALL_AOSP),
-        ComposeComponent(":lifecycle:lifecycle-viewmodel-savedstate", ComposePlatforms.ALL_AOSP),
+        ComposeComponent(":savedstate:savedstate", viewModelPlatforms),
+        ComposeComponent(":lifecycle:lifecycle-viewmodel-savedstate", viewModelPlatforms),
 
-        ComposeComponent(":navigation:navigation-common", ComposePlatforms.ALL_AOSP),
-        ComposeComponent(":navigation:navigation-runtime", ComposePlatforms.ALL_AOSP),
+        ComposeComponent(":navigation:navigation-common", viewModelPlatforms),
+        ComposeComponent(":navigation:navigation-runtime", viewModelPlatforms),
 
         //To be added later: (also don't forget to add gradle.properties see in lifecycle-runtime for an example)
         ComposeComponent(":lifecycle:lifecycle-runtime-compose"),

--- a/navigation/navigation-common/build.gradle
+++ b/navigation/navigation-common/build.gradle
@@ -60,6 +60,14 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+
     sourceSets {
         commonMain {
             dependencies {
@@ -147,7 +155,7 @@ kotlin {
             if (target.platformType == KotlinPlatformType.native) {
                 target.compilations["main"].defaultSourceSet {
                     def konanTargetFamily = target.konanTarget.family
-                    if (konanTargetFamily == Family.OSX || konanTargetFamily == Family.IOS) {
+                    if (konanTargetFamily.appleFamily) {
                         dependsOn(darwinMain)
                     } else if (konanTargetFamily == Family.LINUX) {
                         dependsOn(linuxMain)

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -53,6 +53,14 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/savedstate/savedstate/build.gradle
+++ b/savedstate/savedstate/build.gradle
@@ -37,6 +37,14 @@ kotlin {
     }
     wasmJs()
 
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+
     sourceSets {
         commonMain {
             dependencies {


### PR DESCRIPTION
## Proposed Changes

- Add `watchos` and `tvos` to non-compose modules (lifecycle + navigation)
- Add `mingwx64` for non-viewmodel modules

## Testing

Test: run `./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all`, verify result

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4645
