### PR TITLE
Sync all AccessibilityControllers when an a11y query is received.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -167,17 +167,6 @@ internal class AccessibilityController(
     }
 
     /**
-     * Called to notify us when an accessibility call is received from the system.
-     *
-     * This starts a process that actively synchronized the [ComposeAccessible]s with the semantics
-     * node tree.
-     */
-    fun notifyIsInUse() {
-        lastUseTimeNanos = System.nanoTime()
-        scheduleNodeSync()
-    }
-
-    /**
      * A channel that triggers the syncing of [ComposeAccessible]s with the semantics node tree.
      */
     private val nodeSyncChannel = Channel<Unit>(Channel.RENDEZVOUS)
@@ -205,21 +194,6 @@ internal class AccessibilityController(
     private val delayedNodeNotifications = mutableListOf<() -> Unit>()
 
     /**
-     * The time of the latest accessibility call from the system.
-     */
-    // Set initial value such that accessibilityRecentlyUsed is initially `false`
-    private var lastUseTimeNanos: Long = System.nanoTime() - (MaxIdleTimeNanos + 1)
-
-    /**
-     * Whether an accessibility call from the system has been received "recently".
-     *
-     * When this returns `false` the active syncing of [ComposeAccessible]s with the semantics node
-     * tree is paused.
-     */
-    private val accessibilityRecentlyUsed
-        get() = System.nanoTime() - lastUseTimeNanos < MaxIdleTimeNanos
-
-    /**
      * The coroutine syncing the [ComposeAccessible]s with the semantics node tree.
      */
     private var syncingJob: Job? = null
@@ -239,9 +213,9 @@ internal class AccessibilityController(
             throw IllegalStateException("Sync loop already running")
 
         syncingJob = CoroutineScope(context).launch {
-            while (true) {
-                nodeSyncChannel.receive()
-                if (accessibilityRecentlyUsed && !nodeMappingIsValid) {
+            AccessibilityUsage.runActiveController(this@AccessibilityController) {
+                while (true) {
+                    nodeSyncChannel.receive()
                     syncNodes()
                 }
             }
@@ -308,8 +282,10 @@ internal class AccessibilityController(
     /**
      * Schedules [syncNodes] to be called later.
      */
-    private fun scheduleNodeSync() {
-        nodeSyncChannel.trySend(Unit)
+    private fun scheduleNodeSyncIfNeeded() {
+        if (AccessibilityUsage.recentlyUsed && !nodeMappingIsValid) {
+            nodeSyncChannel.trySend(Unit)
+        }
     }
 
     /**
@@ -317,7 +293,7 @@ internal class AccessibilityController(
      */
     fun onSemanticsChange() {
         nodeMappingIsValid = false
-        scheduleNodeSync()
+        scheduleNodeSyncIfNeeded()
     }
 
     /**
@@ -327,7 +303,7 @@ internal class AccessibilityController(
     fun onLayoutChanged(@Suppress("UNUSED_PARAMETER") nodeId: Int) {
         // TODO: Only recompute the layout-related properties of the node
         nodeMappingIsValid = false
-        scheduleNodeSync()
+        scheduleNodeSyncIfNeeded()
     }
 
     /**
@@ -341,6 +317,69 @@ internal class AccessibilityController(
      */
     val rootAccessible: ComposeAccessible
         get() = accessibleByNodeId(rootSemanticNode.id)!!
+
+    /**
+     * Holds how recently the system has queried the program's accessibility state and manages
+     * enabling/disabling the syncing of [AccessibilityController]s with the semantic tree when the
+     * system has not queried the program's accessibility state for a while.
+     */
+    object AccessibilityUsage {
+
+        /**
+         * The time before we stop actively syncing [ComposeAccessible]s with the semantics node
+         * tree if we don't receive any accessibility calls from the system.
+         */
+        private val MaxIdleTimeNanos = 5.minutes.inWholeNanoseconds
+
+        /**
+         * The set of "live" [AccessibilityController]s.
+         */
+        private val activeControllers = mutableSetOf<AccessibilityController>()
+
+        /**
+         * The time of the latest accessibility call from the system.
+         */
+        // Set initial value such that accessibilityRecentlyUsed is initially `false`
+        private var lastUseTimeNanos: Long = System.nanoTime() - (MaxIdleTimeNanos + 1)
+
+        /**
+         * Called to notify us when an accessibility query is received from the system.
+         *
+         * This starts a process that actively synchronized the [ComposeAccessible]s with the
+         * semantics node tree.
+         */
+        fun notifyInUse() {
+            lastUseTimeNanos = System.nanoTime()
+            for (controller in activeControllers) {
+                controller.scheduleNodeSyncIfNeeded()
+            }
+        }
+
+        /**
+         * Whether an accessibility call from the system has been received "recently".
+         *
+         * When this returns `false` the active syncing of [ComposeAccessible]s with the semantics
+         * node tree is paused.
+         */
+        val recentlyUsed
+            get() = System.nanoTime() - lastUseTimeNanos < MaxIdleTimeNanos
+
+
+        /**
+         * Registers the given controller as an active one until [block] returns.
+         */
+        suspend fun runActiveController(
+            controller: AccessibilityController,
+            block: suspend () -> Unit
+        ) {
+            try {
+                activeControllers.add(controller)
+                block()
+            } finally {
+                activeControllers.remove(controller)
+            }
+        }
+    }
 }
 
 /**
@@ -369,9 +408,3 @@ internal fun Accessible.print(level: Int = 0) {
         }
     }
 }
-
-/**
- * The time before we stop actively syncing [ComposeAccessible]s with the semantics node tree if we
- * don't receive any accessibility calls from the system.
- */
-private val MaxIdleTimeNanos = 5.minutes.inWholeNanoseconds

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -343,6 +343,14 @@ internal class AccessibilityController(
         private var lastUseTimeNanos: Long = System.nanoTime() - (MaxIdleTimeNanos + 1)
 
         /**
+         * Resets this object to its initial state. This is needed for tests.
+         */
+        internal fun reset() {
+            assert(activeControllers.isEmpty())
+            lastUseTimeNanos = System.nanoTime() - (MaxIdleTimeNanos + 1)
+        }
+
+        /**
          * Called to notify us when an accessibility query is received from the system.
          *
          * This starts a process that actively synchronized the [ComposeAccessible]s with the

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -413,7 +413,7 @@ internal class ComposeAccessible(
         // -----------------------------------
 
         override fun getAccessibleRole(): AccessibleRole {
-            controller.notifyIsInUse()
+            AccessibilityController.AccessibilityUsage.notifyInUse()
             val fromSemanticRole = when (semanticsConfig.getOrNull(SemanticsProperties.Role)) {
                 Role.Button -> AccessibleRole.PUSH_BUTTON
                 Role.Checkbox -> AccessibleRole.CHECK_BOX

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SkikoComposeUiTest
-import androidx.compose.ui.test.defaultTestDispatcher
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runInternalSkikoComposeUiTest
 import androidx.compose.ui.toDpSize
@@ -53,10 +52,11 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import java.awt.Point
 import javax.accessibility.AccessibleComponent
+import javax.accessibility.AccessibleContext
 import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleText
-import javax.accessibility.AccessibleContext
 import kotlin.test.fail
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -239,7 +239,7 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
         semanticsOwnerListener.accessibilityControllers
     }
 
-    val testDispatcher = defaultTestDispatcher()
+    val testDispatcher = StandardTestDispatcher()
     runInternalSkikoComposeUiTest(
         semanticsOwnerListener = semanticsOwnerListener,
         coroutineDispatcher = testDispatcher

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -239,6 +239,9 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
         semanticsOwnerListener.accessibilityControllers
     }
 
+    // Reset the a11y usage, to avoid having one test affect the next
+    AccessibilityController.AccessibilityUsage.reset()
+
     val testDispatcher = StandardTestDispatcher()
     runInternalSkikoComposeUiTest(
         semanticsOwnerListener = semanticsOwnerListener,


### PR DESCRIPTION
In commit 0367360435a7bc8ec3d135988a0e82b6b0e15f90, the syncing of `AccessibilityController`s was broken by changing the `lastUseTime` property from being global to being local to an `AccessibilityController`. This resulted in a newly created `AccessibilityController` (e.g. for a Popup) not syncing immediately, essentially making its contents invisible to the OS's a11y.

RelNode: Fix syncing of `AccessibilityController` to correctly expose Dialog/Popup/DropdownMenu contents to the OS's a11y system.

## Proposed Changes
Make the accessibility `lastUseTime` flag global again, and correctly sync *all* live `AccessibilityController`s when it is modified.

## Testing
Tested manually with this:
```
fun main() = singleWindowApplication {
    var menuOpenState by remember { mutableStateOf(false) }
    Text("Menu", Modifier.semantics { role = Role.Button }.clickable { menuOpenState = !menuOpenState })
    DropdownMenu(
        expanded = menuOpenState,
        onDismissRequest = { menuOpenState = false },
        properties = PopupProperties(focusable = true)
    ) {
        DropdownMenuItem(onClick = {}) { Text("Menu item 1") }
        DropdownMenuItem(onClick = {}) { Text("Menu item 2") }
        DropdownMenuItem(onClick = {}) { Text("Menu item 3") }
    }
}
```

Unfortunately I couldn't make a working unit test for this because the querying itself (of accessibles) on an `AccessibleController` causes it to sync. A Heisenberg's accessible.


## Issues Fixed

Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-1303/VoiceOver-doesnt-read-DropDown-menu

