### PR TITLE
Revert "Do not measure clipped graphics"

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/RenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/RenderNodeLayer.skiko.kt
@@ -19,7 +19,6 @@ package androidx.compose.ui.platform
 import org.jetbrains.skia.Rect as SkRect
 import androidx.compose.ui.geometry.MutableRect
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Canvas
@@ -43,7 +42,6 @@ import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toSkiaRRect
-import androidx.compose.ui.graphics.toSkiaRect
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -239,12 +237,11 @@ internal class RenderNodeLayer(
 
     override fun drawLayer(canvas: Canvas) {
         if (picture == null) {
-            val bounds = size.toSize().toRect()
             val pictureCanvas = pictureRecorder.beginRecording(
-                bounds = if (clip) bounds.toSkiaRect() else PICTURE_BOUNDS,
-                bbh = if (clip) null else bbhFactory
+                bounds = PICTURE_BOUNDS,
+                bbh = bbhFactory
             )
-            performDrawLayer(pictureCanvas.asComposeCanvas(), bounds)
+            performDrawLayer(pictureCanvas.asComposeCanvas())
             picture = pictureRecorder.finishRecordingAsPicture()
         }
 
@@ -263,7 +260,7 @@ internal class RenderNodeLayer(
         matrix.timesAssign(inverseMatrix)
     }
 
-    private fun performDrawLayer(canvas: Canvas, bounds: Rect) {
+    private fun performDrawLayer(canvas: Canvas) {
         if (alpha > 0) {
             if (shadowElevation > 0) {
                 drawShadow(canvas)
@@ -284,6 +281,7 @@ internal class RenderNodeLayer(
                     currentRenderEffect != null ||
                     compositingStrategy == CompositingStrategy.Offscreen
             if (requiresLayer) {
+                val bounds = size.toSize().toRect()
                 canvas.saveLayer(
                     bounds,
                     Paint().apply {


### PR DESCRIPTION
This reverts commit ac6cd203452bcdebfd5cd5bd34f32bacf4d70f20. It was incorrect last-minute optimization in #1190

## Testing

Test: See #1190

