### PR TITLE
Fix invalid deeplink regex syntax

### DIFF
--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDeepLink.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDeepLink.jb.kt
@@ -208,12 +208,12 @@ public actual class NavDeepLink internal actual constructor(
         }
         // extract beginning of uriPattern until it hits either a query(?), a framgment(#), or
         // end of uriPattern
-        Regex("(\\?|\\#|$)").find(uriPattern)?.let {
+        Regex("(\\?|#|$)").find(uriPattern)?.let {
             buildRegex(uriPattern.substring(0, it.range.first), pathArgs, uriRegex)
             isExactDeepLink = !uriRegex.contains(".*") && !uriRegex.contains("([^/]+?)")
             // Match either the end of string if all params are optional or match the
             // question mark (or pound symbol) and 0 or more characters after it
-            uriRegex.append("($|(\\?(.)*)|(\\#(.)*))")
+            uriRegex.append("($|(\\?(.)*)|(#(.)*))")
         }
         // we need to specifically escape any .* instances to ensure
         // they are still treated as wildcards in our final regex


### PR DESCRIPTION
From [docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.text/-regex/):
> For JS
>
> Note that RegExp objects under the hood are constructed with [the "u" flag](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode) that enables Unicode-related features in regular expressions. This also makes the pattern syntax more strict, for example, prohibiting unnecessary escape sequences.

JS has stricter regex validation rules, so copied from android regexes doesn't work.

```
Invalid regular expression: /(\?|\#|$)/gu: Invalid escape
SyntaxError: Invalid regular expression: /(\?|\#|$)/gu: Invalid escape
SyntaxError: Invalid regular expression: /^multiplatform-app://androidx\.navigation/ConfigurablePopup($|(\?(.)*)|(\#(.)*))/giu: Invalid escape
```

IDEA also thinks that it's "redundant"

<img width="524" alt="image" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/ca91e003-4a77-4777-9287-ba4a32806943">


## Testing

Test: run mpp on JS target

## Issues Fixed

Fixes regression after https://github.com/JetBrains/compose-multiplatform-core/pull/1277