### PR TITLE
Call `SkiaLayerComponent.onComposeInvalidation()` only from the event dispatch thread

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
 import java.awt.Component
+import java.awt.EventQueue
 import java.awt.Rectangle
 import javax.swing.JComponent
 import kotlin.math.ceil
@@ -86,5 +87,18 @@ internal fun JComponent.setTransparent(transparent: Boolean) {
     } else {
         background = null
         isOpaque = false
+    }
+}
+
+/**
+ * Calls [block] synchronously on the event dispatching thread. If the calling thread is already the
+ * event dispatch thread, simply executes [block]; otherwise schedules [block] to run on event
+ * dispatching thread and waits for it to return.
+ */
+internal fun runOnEDTThread(block: () -> Unit) {
+    if (EventQueue.isDispatchThread()) {
+        block()
+    } else {
+        EventQueue.invokeAndWait(block)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.awt.OnlyValidPrimaryMouseButtonFilter
 import androidx.compose.ui.awt.SwingInteropContainer
+import androidx.compose.ui.awt.runOnEDTThread
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
@@ -492,9 +493,11 @@ internal class ComposeSceneMediator(
         }
     }
 
-    fun onComposeInvalidation() = catchExceptions {
-        if (isDisposed) return
-        skiaLayerComponent.onComposeInvalidation()
+    fun onComposeInvalidation() = runOnEDTThread {
+        catchExceptions {
+            if (isDisposed) return@catchExceptions
+            skiaLayerComponent.onComposeInvalidation()
+        }
     }
 
     fun onChangeComponentPosition() = catchExceptions {


### PR DESCRIPTION
Currently, `ComposeSceneMediator.onComposeInvalidation()` calls `SkiaLayerComponent.onComposeInvalidation()` directly. However, `ComposeSceneMediator.onComposeInvalidation()` is not guaranteed to be called from the event dispatch thread, whereas `SkiaLayerComponent.onComposeInvalidation()` must be called from the event dispatch thread. When it's called from another thread, it throws an exception.

RelNote: Fix crash when modifying Compose state from a non-UI thread.

## Proposed Changes
Make `ComposeSceneMediator.onComposeInvalidation()` call `SkiaLayerComponent.onComposeInvalidation()` on the event dispatch thread only.

## Testing

Test: Added a unit test, and also tested manually with the following:
```
var value by mutableStateOf(0)

fun main() = singleWindowApplication {
    val textMeasurer = rememberTextMeasurer()
    Canvas(Modifier.size(100.dp)) {
        drawText(textMeasurer, "$value")
    }
    LaunchedEffect(Unit) {
        withContext(Dispatchers.IO) {
            for (i in 1..5_000) {
                value = i
                Snapshot.sendApplyNotifications()
                delay((1..20).random().toLong())
            }
        }
    }
}
```

## Issues Fixed

Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4546