### PR TITLE
Provide `ViewModelStoreOwner` by Compose view

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3059,6 +3059,10 @@ public final class androidx/compose/ui/platform/DefaultViewConfiguration : andro
 	public fun getTouchSlop ()F
 }
 
+public final class androidx/compose/ui/platform/DefaultViewModelOwnerStore_skikoKt {
+	public static final fun findComposeDefaultViewModelStoreOwner (Landroidx/compose/runtime/Composer;I)Landroidx/lifecycle/ViewModelStoreOwner;
+}
+
 public abstract interface class androidx/compose/ui/platform/InfiniteAnimationPolicy : kotlin/coroutines/CoroutineContext$Element {
 	public static final field Key Landroidx/compose/ui/platform/InfiniteAnimationPolicy$Key;
 	public fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -172,6 +172,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":annotation:annotation"))
                 implementation(project(":lifecycle:lifecycle-common"))
                 implementation(project(":lifecycle:lifecycle-runtime"))
+                implementation(project(":lifecycle:lifecycle-viewmodel"))
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.platform.LocalViewModelStoreOwner
+import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
@@ -494,6 +494,6 @@ private fun ProvideContainerCompositionLocals(
     content: @Composable () -> Unit,
 ) = CompositionLocalProvider(
     LocalLifecycleOwner provides composeContainer,
-    LocalViewModelStoreOwner provides composeContainer,
+    LocalInternalViewModelStoreOwner provides composeContainer,
     content = content
 )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
@@ -47,6 +48,8 @@ import androidx.compose.ui.window.sizeInPx
 import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import java.awt.Component
 import java.awt.Window
 import java.awt.event.ComponentEvent
@@ -85,7 +88,7 @@ internal class ComposeContainer(
 
     private val useSwingGraphics: Boolean = ComposeFeatureFlags.useSwingGraphics,
     private val layerType: LayerType = ComposeFeatureFlags.layerType,
-) : ComponentListener, WindowFocusListener, WindowListener, LifecycleOwner {
+) : ComponentListener, WindowFocusListener, WindowListener, LifecycleOwner, ViewModelStoreOwner {
     val windowContext = PlatformWindowContext()
     var window: Window? = null
         private set
@@ -150,6 +153,8 @@ internal class ComposeContainer(
     val preferredSize by mediator::preferredSize
 
     override val lifecycle = LifecycleRegistry(this)
+    override val viewModelStore = ViewModelStore()
+
     private var isDisposed = false
     private var isDetached = true
     private var isMinimized = false
@@ -167,6 +172,7 @@ internal class ComposeContainer(
     fun dispose() {
         isDisposed = true
         updateLifecycleState()
+        viewModelStore.clear()
 
         _windowContainer?.removeComponentListener(this)
         mediator.dispose()
@@ -488,5 +494,6 @@ private fun ProvideContainerCompositionLocals(
     content: @Composable () -> Unit,
 ) = CompositionLocalProvider(
     LocalLifecycleOwner provides composeContainer,
+    LocalViewModelStoreOwner provides composeContainer,
     content = content
 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
@@ -27,9 +27,11 @@ import androidx.lifecycle.ViewModelStoreOwner
  *
  * @hide
  */
-internal val LocalViewModelStoreOwner = staticCompositionLocalOf<ViewModelStoreOwner?> { null }
+internal val LocalInternalViewModelStoreOwner = staticCompositionLocalOf<ViewModelStoreOwner?> {
+    null
+}
 
 @InternalComposeApi
 @Composable
 fun findComposeDefaultViewModelStoreOwner(): ViewModelStoreOwner? =
-    LocalViewModelStoreOwner.current
+    LocalInternalViewModelStoreOwner.current

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
@@ -14,14 +14,22 @@
  * limitations under the License.
  */
 
-package androidx.lifecycle.viewmodel.compose
+package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.InternalComposeApi
-import androidx.compose.ui.platform.findComposeDefaultViewModelStoreOwner
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.lifecycle.ViewModelStoreOwner
 
-@OptIn(InternalComposeApi::class)
+/**
+ * Internal helper to provide [ViewModelStoreOwner] from Compose UI module.
+ * In applications please use [androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner].
+ *
+ * @hide
+ */
+internal val LocalViewModelStoreOwner = staticCompositionLocalOf<ViewModelStoreOwner?> { null }
+
+@InternalComposeApi
 @Composable
-internal actual fun findViewTreeViewModelStoreOwner(): ViewModelStoreOwner? =
-    findComposeDefaultViewModelStoreOwner()
+fun findComposeDefaultViewModelStoreOwner(): ViewModelStoreOwner? =
+    LocalViewModelStoreOwner.current

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.interop.UIKitInteropContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeScene
@@ -91,12 +92,14 @@ import platform.darwin.dispatch_get_main_queue
 
 private val coroutineDispatcher = Dispatchers.Main
 
+// TODO: Move to androidx.compose.ui.scene
 @OptIn(InternalComposeApi::class)
 @ExportObjCClass
 internal class ComposeContainer(
     private val configuration: ComposeUIViewControllerConfiguration,
     private val content: @Composable () -> Unit,
 ) : CMPViewController(nibName = null, bundle = null) {
+    // TODO: Rename and make private
     val lifecycleOwner = ViewControllerBasedLifecycleOwner()
     val hapticFeedback = CupertinoHapticFeedback()
 
@@ -441,6 +444,7 @@ internal fun ProvideContainerCompositionLocals(
         LocalInterfaceOrientation provides interfaceOrientationState.value,
         LocalSystemTheme provides systemThemeState.value,
         LocalLifecycleOwner provides lifecycleOwner,
+        LocalViewModelStoreOwner provides lifecycleOwner,
         content = content
     )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.interop.LocalUIViewController
 import androidx.compose.ui.interop.UIKitInteropContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.platform.LocalViewModelStoreOwner
+import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeScene
@@ -444,7 +444,7 @@ internal fun ProvideContainerCompositionLocals(
         LocalInterfaceOrientation provides interfaceOrientationState.value,
         LocalSystemTheme provides systemThemeState.value,
         LocalLifecycleOwner provides lifecycleOwner,
-        LocalViewModelStoreOwner provides lifecycleOwner,
+        LocalInternalViewModelStoreOwner provides lifecycleOwner,
         content = content
     )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
@@ -19,12 +19,16 @@ package androidx.compose.ui.window
 import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import platform.Foundation.NSNotificationCenter
 
+// TODO: Rename and move to androidx.compose.ui.platform
 internal class ViewControllerBasedLifecycleOwner(
     notificationCenter: NSNotificationCenter = NSNotificationCenter.defaultCenter,
-) : LifecycleOwner {
+) : LifecycleOwner, ViewModelStoreOwner {
     override val lifecycle = LifecycleRegistry(this)
+    override val viewModelStore = ViewModelStore()
 
     private var isViewAppeared = false
     private var isAppForeground = ApplicationStateListener.isApplicationActive
@@ -41,6 +45,7 @@ internal class ViewControllerBasedLifecycleOwner(
 
     fun dispose() {
         applicationStateListener.dispose()
+        viewModelStore.clear()
         isDisposed = true
         updateLifecycleState()
     }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.platform.WindowInfoImpl
@@ -49,6 +50,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
 import kotlin.coroutines.coroutineContext
 import kotlinx.browser.document
 import kotlinx.browser.window
@@ -148,7 +151,7 @@ internal class ComposeWindow(
     private val canvas: HTMLCanvasElement,
     content: @Composable () -> Unit,
     private val state: ComposeWindowState
-) : LifecycleOwner {
+) : LifecycleOwner, ViewModelStoreOwner {
     private val density: Density = Density(
         density = actualDensity.toFloat(),
         fontScale = 1f
@@ -194,8 +197,8 @@ internal class ComposeWindow(
     )
     private val systemThemeObserver = getSystemThemeObserver()
 
-    private val lifecycleOwner = LifecycleRegistry(this)
-    override val lifecycle: Lifecycle get() = lifecycleOwner
+    override val lifecycle = LifecycleRegistry(this)
+    override val viewModelStore = ViewModelStore()
 
     private fun <T : Event> addTypedEvent(
         type: String,
@@ -271,11 +274,11 @@ internal class ComposeWindow(
         }
 
         state.globalEvents.addDisposableEvent("focus") {
-            lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
         }
 
         state.globalEvents.addDisposableEvent("blur") {
-            lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
         }
     }
 
@@ -290,6 +293,7 @@ internal class ComposeWindow(
             CompositionLocalProvider(
                 LocalSystemTheme provides systemThemeObserver.currentSystemTheme.value,
                 LocalLifecycleOwner provides this,
+                LocalViewModelStoreOwner provides this,
                 content = {
                     content()
                     rememberCoroutineScope().launch {
@@ -301,7 +305,7 @@ internal class ComposeWindow(
             )
         }
 
-        lifecycleOwner.handleLifecycleEvent(if (document.hasFocus()) Lifecycle.Event.ON_RESUME else Lifecycle.Event.ON_START)
+        lifecycle.handleLifecycleEvent(if (document.hasFocus()) Lifecycle.Event.ON_RESUME else Lifecycle.Event.ON_START)
     }
 
     fun resize(boxSize: IntSize) {
@@ -327,7 +331,9 @@ internal class ComposeWindow(
 
     // TODO: need to call .dispose() on window close.
     fun dispose() {
-        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        viewModelStore.clear()
+
         layer.dispose()
         systemThemeObserver.dispose()
         state.dispose()

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.native.ComposeLayer
 import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.platform.LocalViewModelStoreOwner
+import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.platform.WindowInfoImpl
@@ -64,8 +64,6 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.jetbrains.skiko.SkiaLayer
 import org.w3c.dom.AddEventListenerOptions
-import org.w3c.dom.DOMRect
-import org.w3c.dom.DOMRectReadOnly
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLStyleElement
@@ -293,7 +291,7 @@ internal class ComposeWindow(
             CompositionLocalProvider(
                 LocalSystemTheme provides systemThemeObserver.currentSystemTheme.value,
                 LocalLifecycleOwner provides this,
-                LocalViewModelStoreOwner provides this,
+                LocalInternalViewModelStoreOwner provides this,
                 content = {
                     content()
                     rememberCoroutineScope().launch {

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -41,8 +41,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.ViewModelStore
-import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestination
@@ -54,25 +52,6 @@ import androidx.navigation.Navigator
 import androidx.navigation.createGraph
 import androidx.navigation.get
 import kotlin.jvm.JvmSuppressWildcards
-
-private class ComposeViewModelStoreOwner: ViewModelStoreOwner {
-    override val viewModelStore: ViewModelStore = ViewModelStore()
-    fun dispose() { viewModelStore.clear() }
-}
-
-/**
- * Return remembered [ViewModelStoreOwner] with the scope of current composable.
- *
- * TODO: Consider to move it to `lifecycle-viewmodel-compose` and upstream this to AOSP.
- */
-@Composable
-private fun rememberViewModelStoreOwner(): ViewModelStoreOwner {
-    val viewModelStoreOwner = remember { ComposeViewModelStoreOwner() }
-    DisposableEffect(viewModelStoreOwner) {
-        onDispose { viewModelStoreOwner.dispose() }
-    }
-    return viewModelStoreOwner
-}
 
 /**
  * Provides in place in the Compose hierarchy for self contained navigation to occur.
@@ -329,7 +308,9 @@ public fun NavHost(
 ) {
 
     val lifecycleOwner = LocalLifecycleOwner.current
-    val viewModelStoreOwner = LocalViewModelStoreOwner.current ?: rememberViewModelStoreOwner()
+    val viewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "NavHost requires a ViewModelStoreOwner to be provided via LocalViewModelStoreOwner"
+    }
 
     navController.setViewModelStore(viewModelStoreOwner.viewModelStore)
 


### PR DESCRIPTION
## Proposed Changes

- Add `lifecycle-viewmodel` dependency to `compose:ui`
- Implement `ViewModelStoreOwner` in compose view for Desktop, iOS and Web
- Remove `ViewModelStoreOwner` workaround from `NavHost`
- Use `findComposeDefaultViewModelStoreOwner` to find `ViewModelStoreOwner` from `compose:ui`

## Testing

Test: Try to use `ViewModel` outside of `NavHost` without implementing own `ViewModelStoreOwner`
