### PR TITLE
Fixed appearing of text editing menu in iOS textfields by every tap

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -124,9 +124,9 @@ private fun getTapHandlerModifier(
                                     textLayoutResult = layoutResult,
                                     editProcessor = currentState.processor,
                                     offsetMapping = currentOffsetMapping,
-                                    showContextMenu = {
-                                        // it shouldn't be selection, but this is a way to call context menu in BasicTextField
-                                        currentManager.enterSelectionMode(true)
+                                    showContextMenu = { show ->
+                                        // it shouldn't be selection, but this is a way to call a context menu in BasicTextField
+                                        if (show) { currentManager.enterSelectionMode() } else { currentManager.exitSelectionMode() }
                                     },
                                     onValueChange = currentState.onValueChange
                                 )

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/CupertinoTextFieldDelegateTest.kt
@@ -51,7 +51,7 @@ class CupertinoTextFieldDelegateTest {
     ) {
         val actual = determineCursorDesiredOffset(
             offset = givenOffset,
-            createSimpleTextFieldValue(text = sampleText, cursorOffset = cursorOffset),
+            createSimpleTextFieldValue(text = sampleText, cursorOffset = cursorOffset).selection.start,
             textLayoutResult = createSimpleTextLayoutResultProxy(sampleText),
             currentText = sampleText
         )


### PR DESCRIPTION
## Proposed Changes

- Changed logic of appearing the text editing menu in iOS textfields: it won't be opened by every tap now.

## Testing

Test: Manual. Open test app, go Components -> Textfield -> Almost FullScreen, tap once to focus, tap again on the same position to call the menu

## Issues Fixed

Fixes: 
- https://youtrack.jetbrains.com/issue/COMPOSE-1189/iOS-textfield-context-menu-opens-by-every-tap
- https://youtrack.jetbrains.com/issue/COMPOSE-1028/iOS-TextField-adjust-calling-context-menu

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
