### PR TITLE
Fix memory leak caused by `CGColorCreate` on iOS

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RenderingUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/RenderingUIView.uikit.kt
@@ -87,10 +87,7 @@ internal class RenderingUIView(
             it.device = device as objcnames.protocols.MTLDeviceProtocol?
 
             it.pixelFormat = MTLPixelFormatBGRA8Unorm
-            doubleArrayOf(0.0, 0.0, 0.0, 0.0).usePinned { pinned ->
-                it.backgroundColor =
-                    CGColorCreate(CGColorSpaceCreateDeviceRGB(), pinned.addressOf(0))
-            }
+            it.backgroundColor = UIColor.clearColor.CGColor
             it.framebufferOnly = false
         }
     }


### PR DESCRIPTION
## Proposed Changes

Replace `CGColorCreate` with `UIColor.clearColor.CGColor`

## Testing

Test: Frequently open ModalBottomSheet or Popup, and then view memory leak information in `Instruments`.

Fix before:
<img width="720" alt="image" src="https://github.com/JetBrains/compose-multiplatform-core/assets/9105106/958839b6-9abd-4dbe-8ae2-6ed08412c8ab">

## Issues Fixed

Fixes: This is part of https://github.com/JetBrains/compose-multiplatform/issues/4626

