### PR TITLE
Fix CfW tests in ui:ui module

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/CanvasBasedWindowTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/CanvasBasedWindowTests.kt
@@ -215,7 +215,8 @@ internal fun createTypedEvent(c: Char = 'c'): KeyboardEvent =
         .keyDownEvent()
 
 internal fun createEventShouldNotBePrevented(): KeyboardEvent =
-    KeyboardEventInit(ctrlKey = true, cancelable = true)
+    KeyboardEventInit(ctrlKey = true, cancelable = true, key = "Control")
+        .withKeyCode()
         .keyDownEvent()
 
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.browser.document
 import kotlinx.coroutines.NonCancellable.isActive
+import kotlinx.coroutines.test.runTest
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.MouseEventInit
@@ -45,8 +46,8 @@ class MouseEventsTest {
     }
 
     @Test
-    fun testPointerEvents()  {
-        if (isHeadlessBrowser()) return
+    fun testPointerEvents() = runTest {
+        if (isHeadlessBrowser()) return@runTest
         val canvasElement = document.createElement("canvas") as HTMLCanvasElement
         canvasElement.setAttribute("id", canvasId)
         document.body!!.appendChild(canvasElement)
@@ -94,8 +95,8 @@ class MouseEventsTest {
 
     @OptIn(ExperimentalFoundationApi::class)
     @Test
-    fun testOnClickWithPointerMatchers() {
-        if (isHeadlessBrowser()) return
+    fun testOnClickWithPointerMatchers() = runTest {
+        if (isHeadlessBrowser()) return@runTest
         val canvasElement = document.createElement("canvas") as HTMLCanvasElement
         canvasElement.setAttribute("id", canvasId)
         document.body!!.appendChild(canvasElement)
@@ -127,8 +128,8 @@ class MouseEventsTest {
     }
 
     @Test
-    fun testPointerButtonIsNullForNoClickEvents() {
-        if (isHeadlessBrowser()) return
+    fun testPointerButtonIsNullForNoClickEvents() = runTest {
+        if (isHeadlessBrowser()) return@runTest
         val canvasElement = document.createElement("canvas") as HTMLCanvasElement
         canvasElement.setAttribute("id", canvasId)
         document.body!!.appendChild(canvasElement)


### PR DESCRIPTION
The tests didn't pass due to different issues.

- `CanvasBasedWindowTests.testPreventDefault` was failing due to missing `key` value in the native KeyboardEvent
- `ComposeWindowLifecycleTest.allEvents` didn't work properly due to browser policies: https://developer.mozilla.org/en-US/docs/Web/API/Window/blur (the window can't be blured from code). We open a new tab now to force `blur` evnet.
- MouseEventsTest: `runTest` was added to run the tests in TestScope. No logical reason to do so now. But it's needed as a workaround for some weird tests interference. 

The tests should be run with an extra property:

`./gradlew :compose:ui:ui:wasmJsBrowserTest -Pjetbrains.cfw.tests.useChrome=true`