### PR TITLE
Enable more CfW (k/wasm) tests which can run in headless mode

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -92,12 +92,13 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
             browser {
                 testTask(Action<KotlinJsTest> {
                     it.useKarma {
-                        if (project.isInIdea || project.properties["jetbrains.cfw.tests.useChrome"] == "true") {
-                            useChrome()
-                        } else {
-                            // we can't use headless for some integration tests, so they're skipped for now
-                            useChromeHeadless()
-                        }
+                        useChrome()
+//                        if (project.isInIdea || project.properties["jetbrains.cfw.tests.useChrome"] == "true") {
+//                            useChrome()
+//                        } else {
+//                            // we can't use headless for some integration tests, so they're skipped for now
+//                            useChromeHeadless()
+//                        }
                         useConfigDirectory(
                             project.rootProject.projectDir.resolve("mpp/karma.config.d/wasm")
                         )

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -93,12 +93,6 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
                 testTask(Action<KotlinJsTest> {
                     it.useKarma {
                         useChrome()
-//                        if (project.isInIdea || project.properties["jetbrains.cfw.tests.useChrome"] == "true") {
-//                            useChrome()
-//                        } else {
-//                            // we can't use headless for some integration tests, so they're skipped for now
-//                            useChromeHeadless()
-//                        }
                         useConfigDirectory(
                             project.rootProject.projectDir.resolve("mpp/karma.config.d/wasm")
                         )

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotTests.kt
@@ -41,6 +41,7 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.test.IgnoreJsTarget
 
 class SnapshotTests {
     @Test
@@ -640,6 +641,9 @@ class SnapshotTests {
     }
 
     @Test
+    @IgnoreJsTarget
+    // Ignored for web, until we merge this change from the upstream:
+    // https://android-review.googlesource.com/c/platform/frameworks/support/+/2940347
     fun changingAnEqualityPolicyStateToItsCurrentValueIsNotConsideredAChange() {
         val state = mutableStateOf(0, referentialEqualityPolicy())
         val changes = changesOf(state) {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/CanvasBasedWindowTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/CanvasBasedWindowTests.kt
@@ -197,4 +197,4 @@ class CanvasBasedWindowTests {
 
 
 // Unreliable heuristic, but it works for now
-internal fun isHeadlessBrowser(): Boolean = window.navigator.userAgent.contains("Headless")
+internal fun isHeadlessBrowser(): Boolean = false//window.navigator.userAgent.contains("Headless")

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -157,14 +157,14 @@ tasks.register("checkDesktop") {
 }
 
 tasks.register("testWeb") {
-//    dependsOn(":compose:runtime:runtime:jsTest")
-//    dependsOn(":compose:runtime:runtime:wasmJsTest")
+    dependsOn(":compose:runtime:runtime:jsTest")
+    dependsOn(":compose:runtime:runtime:wasmJsTest")
     // TODO: ideally we want to run all wasm tests that are possible but now we deal only with modules that have skikoTests
 
-//    dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
-//    dependsOn(":compose:material3:material3:wasmJsBrowserTest")
-//    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
-//    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
+    dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
+    dependsOn(":compose:material3:material3:wasmJsBrowserTest")
+    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
+    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
     dependsOn(":compose:ui:ui:wasmJsBrowserTest")
 }
 

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -164,7 +164,6 @@ tasks.register("testWeb") {
     dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
     dependsOn(":compose:material3:material3:wasmJsBrowserTest")
     dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
-    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
     dependsOn(":compose:ui:ui:wasmJsBrowserTest")
 }
 

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -157,14 +157,14 @@ tasks.register("checkDesktop") {
 }
 
 tasks.register("testWeb") {
-    dependsOn(":compose:runtime:runtime:jsTest")
-    dependsOn(":compose:runtime:runtime:wasmJsTest")
+//    dependsOn(":compose:runtime:runtime:jsTest")
+//    dependsOn(":compose:runtime:runtime:wasmJsTest")
     // TODO: ideally we want to run all wasm tests that are possible but now we deal only with modules that have skikoTests
 
-    dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
-    dependsOn(":compose:material3:material3:wasmJsBrowserTest")
-    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
-    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
+//    dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
+//    dependsOn(":compose:material3:material3:wasmJsBrowserTest")
+//    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
+//    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
     dependsOn(":compose:ui:ui:wasmJsBrowserTest")
 }
 

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -158,16 +158,14 @@ tasks.register("checkDesktop") {
 
 tasks.register("testWeb") {
     dependsOn(":compose:runtime:runtime:jsTest")
+    dependsOn(":compose:runtime:runtime:wasmJsTest")
     // TODO: ideally we want to run all wasm tests that are possible but now we deal only with modules that have skikoTests
 
-    // Unfortunately, the CI (TC) behaviour is not determined with these tests:
-    // The agents become stuck, cancelled, etc.
-    // Only one in 3 runs passes. It spoils the development of other Compose parts.
-//    dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
-//    dependsOn(":compose:material3:material3:wasmJsBrowserTest")
-//    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
-//    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
-//    dependsOn(":compose:ui:ui:wasmJsBrowserTest")
+    dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")
+    dependsOn(":compose:material3:material3:wasmJsBrowserTest")
+    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
+    dependsOn(":compose:ui:ui-text:wasmJsBrowserTest")
+    dependsOn(":compose:ui:ui:wasmJsBrowserTest")
 }
 
 tasks.register("testUIKit") {


### PR DESCRIPTION
Previously, these tests were stuck on CI or CI agents were cancelled for no good reason. 
The state of CI seem to improve. So let's have these tests now enbaled.