### PR TITLE
Fix finding graph without route

### DIFF
--- a/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavController.jb.kt
+++ b/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavController.jb.kt
@@ -853,7 +853,7 @@ public actual open class NavController {
         tempBackQueue.forEach { newEntry ->
             val parent = newEntry.destination.parent
             if (parent != null) {
-                val newParent = getBackStackEntry(parent.route!!)
+                val newParent = getBackStackEntry(parent)
                 linkChildToParent(newEntry, newParent)
             }
             backQueue.add(newEntry)
@@ -1069,9 +1069,9 @@ public actual open class NavController {
         // Link the newly added hierarchy and entry with the parent NavBackStackEntry
         // so that we can track how many destinations are associated with each NavGraph
         (hierarchy + backStackEntry).forEach {
-            val parentRoute = it.destination.parent?.route
-            if (parentRoute != null) {
-                linkChildToParent(it, getBackStackEntry(parentRoute))
+            val parent = it.destination.parent
+            if (parent != null) {
+                linkChildToParent(it, getBackStackEntry(parent))
             }
         }
     }
@@ -1225,6 +1225,17 @@ public actual open class NavController {
         }
         check(backQueue.isEmpty()) { "ViewModelStore should be set before setGraph call" }
         viewModel = NavControllerViewModel.getInstance(viewModelStore)
+    }
+
+    private fun getBackStackEntry(destination: NavDestination): NavBackStackEntry {
+        val lastFromBackStack: NavBackStackEntry? = backQueue.lastOrNull { entry ->
+            entry.destination == destination
+        }
+        requireNotNull(lastFromBackStack) {
+            "No destination $destination is on the NavController's back stack. The " +
+                "current destination is $currentDestination"
+        }
+        return lastFromBackStack
     }
 
     public actual fun getBackStackEntry(route: String): NavBackStackEntry {


### PR DESCRIPTION
Getting parent `BackStackEntry` by `destination` reference - no need to use string/links matching logic here.

## Testing

Test: manually for now, unit tests are in progress.

## Issues Fixed

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4684
