### PR TITLE
update Lifecycle handling on iOS based on feedback

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.asComposeCanvas
@@ -68,7 +67,7 @@ import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.ComposeSceneKeyboardOffsetManager
-import androidx.compose.ui.window.ApplicationStateListener
+import androidx.compose.ui.window.ApplicationForegroundStateListener
 import androidx.compose.ui.window.FocusStack
 import androidx.compose.ui.window.InteractionUIView
 import androidx.compose.ui.window.KeyboardEventHandler
@@ -254,7 +253,7 @@ internal class ComposeSceneMediator(
         renderingUIViewFactory(interopContext, renderDelegate)
     }
 
-    private val applicationStateListener = ApplicationStateListener { isForeground ->
+    private val applicationForegroundStateListener = ApplicationForegroundStateListener { isForeground ->
         // Sometimes the application can trigger animation and go background before the animation is
         // finished. The scheduled GPU work is performed, but no presentation can be done, causing
         // mismatch between visual state and application state. This can be fixed by forcing
@@ -500,7 +499,7 @@ internal class ComposeSceneMediator(
 
     fun dispose() {
         uiKitTextInputService.stopInput()
-        applicationStateListener.dispose()
+        applicationForegroundStateListener.dispose()
         focusStack?.popUntilNext(renderingView)
         keyboardManager.stop()
         renderingView.dispose()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationActiveStateListener.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationActiveStateListener.uikit.kt
@@ -39,17 +39,17 @@ internal class ApplicationActiveStateListener(
 ) : NSObject() {
     init {
         notificationCenter.addObserver(
-            this,
-            NSSelectorFromString(::applicationDidBecomeActive.name),
-            UIApplicationDidBecomeActiveNotification,
-            null
+            observer = this,
+            selector = NSSelectorFromString(::applicationDidBecomeActive.name),
+            name = UIApplicationDidBecomeActiveNotification,
+            `object` = null
         )
 
         notificationCenter.addObserver(
-            this,
-            NSSelectorFromString(::applicationWillResignActive.name),
-            UIApplicationWillResignActiveNotification,
-            null
+            observer = this,
+            selector = NSSelectorFromString(::applicationWillResignActive.name),
+            name = UIApplicationWillResignActiveNotification,
+            `object` = null
         )
     }
 
@@ -67,7 +67,7 @@ internal class ApplicationActiveStateListener(
      * Deregister from [NSNotificationCenter]
      */
     fun dispose() {
-        notificationCenter.removeObserver(this, UIApplicationDidBecomeActiveNotification, null)
-        notificationCenter.removeObserver(this, UIApplicationWillResignActiveNotification, null)
+        notificationCenter.removeObserver(observer = this, name = UIApplicationDidBecomeActiveNotification, `object` = null)
+        notificationCenter.removeObserver(observer = this, name = UIApplicationWillResignActiveNotification, `object` = null)
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationForegroundStateListener.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationForegroundStateListener.uikit.kt
@@ -37,17 +37,17 @@ internal class ApplicationForegroundStateListener(
 ) : NSObject() {
     init {
         notificationCenter.addObserver(
-            this,
-            NSSelectorFromString(::applicationWillEnterForeground.name),
-            UIApplicationWillEnterForegroundNotification,
-            null
+            observer = this,
+            selector = NSSelectorFromString(::applicationWillEnterForeground.name),
+            name = UIApplicationWillEnterForegroundNotification,
+            `object` = null
         )
 
         notificationCenter.addObserver(
-            this,
-            NSSelectorFromString(::applicationDidEnterBackground.name),
-            UIApplicationDidEnterBackgroundNotification,
-            null
+            observer = this,
+            selector = NSSelectorFromString(::applicationDidEnterBackground.name),
+            name = UIApplicationDidEnterBackgroundNotification,
+            `object` = null
         )
     }
 
@@ -65,8 +65,8 @@ internal class ApplicationForegroundStateListener(
      * Deregister from [NSNotificationCenter]
      */
     fun dispose() {
-        notificationCenter.removeObserver(this, UIApplicationWillEnterForegroundNotification, null)
-        notificationCenter.removeObserver(this, UIApplicationDidEnterBackgroundNotification, null)
+        notificationCenter.removeObserver(observer = this, name = UIApplicationWillEnterForegroundNotification, `object` = null)
+        notificationCenter.removeObserver(observer = this, name = UIApplicationDidEnterBackgroundNotification, `object` = null)
     }
 
     companion object {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationForegroundStateListener.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ApplicationForegroundStateListener.uikit.kt
@@ -25,7 +25,7 @@ import platform.UIKit.UIApplicationState
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
 import platform.darwin.NSObject
 
-internal class ApplicationStateListener(
+internal class ApplicationForegroundStateListener(
     /**
      * [NSNotificationCenter] to listen to, can be customized for tests purposes
      */
@@ -33,7 +33,7 @@ internal class ApplicationStateListener(
     /**
      * Callback which will be called with `true` when the app becomes active, and `false` when the app goes background
      */
-    private val onApplicationStateChanged: (Boolean) -> Unit
+    private val onApplicationForegroundStateChanged: (Boolean) -> Unit
 ) : NSObject() {
     init {
         notificationCenter.addObserver(
@@ -53,12 +53,12 @@ internal class ApplicationStateListener(
 
     @ObjCAction
     fun applicationWillEnterForeground() {
-        onApplicationStateChanged(true)
+        onApplicationForegroundStateChanged(true)
     }
 
     @ObjCAction
     fun applicationDidEnterBackground() {
-        onApplicationStateChanged(false)
+        onApplicationForegroundStateChanged(false)
     }
 
     /**
@@ -70,7 +70,7 @@ internal class ApplicationStateListener(
     }
 
     companion object {
-        val isApplicationActive: Boolean
+        val isApplicationForeground: Boolean
             get() = UIApplication.sharedApplication.applicationState != UIApplicationState.UIApplicationStateBackground
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -37,8 +37,6 @@ import platform.Foundation.NSRunLoopCommonModes
 import platform.Foundation.NSTimeInterval
 import platform.Metal.MTLCommandQueueProtocol
 import platform.Metal.MTLDeviceProtocol
-import platform.UIKit.UIApplication
-import platform.UIKit.UIApplicationState
 
 private class DisplayLinkConditions(
     val setPausedCallback: (Boolean) -> Unit
@@ -226,7 +224,7 @@ internal class MetalRedrawer(
         caDisplayLink?.paused = paused
     }
 
-    private val applicationStateListener = ApplicationStateListener { isApplicationActive ->
+    private val applicationForegroundStateListener = ApplicationForegroundStateListener { isApplicationActive ->
         displayLinkConditions.isApplicationActive = isApplicationActive
 
         if (!isApplicationActive) {
@@ -244,7 +242,7 @@ internal class MetalRedrawer(
         // and won't receive UIApplicationWillEnterForegroundNotification
         // so we compare the state with UIApplicationStateBackground instead of UIApplicationStateActive
         displayLinkConditions.isApplicationActive =
-            ApplicationStateListener.isApplicationActive
+            ApplicationForegroundStateListener.isApplicationForeground
 
         caDisplayLink.addToRunLoop(NSRunLoop.mainRunLoop, NSRunLoopCommonModes)
 
@@ -256,7 +254,7 @@ internal class MetalRedrawer(
 
         releaseCachedCommandQueue(queue)
 
-        applicationStateListener.dispose()
+        applicationForegroundStateListener.dispose()
 
         caDisplayLink?.invalidate()
         caDisplayLink = null

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
@@ -32,10 +32,16 @@ internal class ViewControllerBasedLifecycleOwner(
 
     private var isViewAppeared = false
     private var isAppForeground = ApplicationStateListener.isApplicationActive
+    private var isAppActive = isAppForeground
     private var isDisposed = false
 
     private val applicationStateListener = ApplicationStateListener(notificationCenter) { isForeground ->
         isAppForeground = isForeground
+        updateLifecycleState()
+    }
+
+    private val applicationActiveStateListener = ApplicationActiveStateListener(notificationCenter) { isActive ->
+        isAppActive = isActive
         updateLifecycleState()
     }
 
@@ -45,6 +51,7 @@ internal class ViewControllerBasedLifecycleOwner(
 
     fun dispose() {
         applicationStateListener.dispose()
+        applicationActiveStateListener.dispose()
         viewModelStore.clear()
         isDisposed = true
         updateLifecycleState()
@@ -63,8 +70,8 @@ internal class ViewControllerBasedLifecycleOwner(
     private fun updateLifecycleState() {
         lifecycle.currentState = when {
             isDisposed -> State.DESTROYED
-            isViewAppeared && isAppForeground -> State.RESUMED
-            isViewAppeared -> State.STARTED
+            isViewAppeared && isAppForeground && isAppActive -> State.RESUMED
+            isViewAppeared && isAppForeground && !isAppActive -> State.STARTED
             else -> State.CREATED
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwner.uikit.kt
@@ -31,11 +31,11 @@ internal class ViewControllerBasedLifecycleOwner(
     override val viewModelStore = ViewModelStore()
 
     private var isViewAppeared = false
-    private var isAppForeground = ApplicationStateListener.isApplicationActive
+    private var isAppForeground = ApplicationForegroundStateListener.isApplicationForeground
     private var isAppActive = isAppForeground
     private var isDisposed = false
 
-    private val applicationStateListener = ApplicationStateListener(notificationCenter) { isForeground ->
+    private val applicationForegroundStateListener = ApplicationForegroundStateListener(notificationCenter) { isForeground ->
         isAppForeground = isForeground
         updateLifecycleState()
     }
@@ -50,7 +50,7 @@ internal class ViewControllerBasedLifecycleOwner(
     }
 
     fun dispose() {
-        applicationStateListener.dispose()
+        applicationForegroundStateListener.dispose()
         applicationActiveStateListener.dispose()
         viewModelStore.clear()
         isDisposed = true

--- a/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
@@ -22,8 +22,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import platform.Foundation.NSNotificationCenter
 import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDidBecomeActiveNotification
 import platform.UIKit.UIApplicationDidEnterBackgroundNotification
 import platform.UIKit.UIApplicationWillEnterForegroundNotification
+import platform.UIKit.UIApplicationWillResignActiveNotification
 
 class ViewControllerBasedLifecycleOwnerTest {
     @Test
@@ -35,8 +37,16 @@ class ViewControllerBasedLifecycleOwnerTest {
         lifecycleOwner.handleViewWillAppear()
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
 
-        notificationCenter.postNotificationName(UIApplicationDidEnterBackgroundNotification, UIApplication.sharedApplication)
+        // app is visible, but not active, e.g. App switcher is shown
+        notificationCenter.postNotificationName(UIApplicationWillResignActiveNotification, UIApplication.sharedApplication)
         assertEquals(Lifecycle.State.STARTED, lifecycleOwner.lifecycle.currentState)
+
+        notificationCenter.postNotificationName(UIApplicationDidBecomeActiveNotification, UIApplication.sharedApplication)
+        assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
+
+        // app in background, e.g. Home button is pressed
+        notificationCenter.postNotificationName(UIApplicationDidEnterBackgroundNotification, UIApplication.sharedApplication)
+        assertEquals(Lifecycle.State.CREATED, lifecycleOwner.lifecycle.currentState)
 
         notificationCenter.postNotificationName(UIApplicationWillEnterForegroundNotification, UIApplication.sharedApplication)
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)


### PR DESCRIPTION
Distinguish active/non-active and foreground/background states

## Proposed Changes

There is no one-to-one match between Android and iOS states and events. Previously application foreground/background state was used to distinguish between STARTED and RESUMED Lifecycle states. However, Android Activity documentation indicates that STARTED state indicates that application is visible but no active (i.e. doesn't have focus). This is not the case with previous implementation.

Instead `willResignActive`/`didBecomeActive` notifications are now used to provide lifecycle events.

## Testing

Check how the lifecycle state behaves when pressing the home button, and when swiping up from the bottom of the screen to reveal the app switcher. (MPP Demo App - iOS-specific features - Native modal with navigation)

Test: ViewControllerBasedLifecycleOwnerTest