### PR TITLE
Add Linux targets to lifecycle-runtime-compose

### DIFF
--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -42,6 +42,9 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
+
+    linuxX64()
+    linuxArm64()
 }
 
 kotlin {


### PR DESCRIPTION
Since flipping the dependency between this module and Compose UI, we can now support all possible targets of the Compose runtime here rather than being bound by what Compose UI supports.

Test: `gw :lifecycle:lifecycle-runtime-compose:assemble`