### PR TITLE
Publish additional targets for `lifecycle-runtime-compose`

### DIFF
--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -42,6 +42,9 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
+
+    linuxX64()
+    linuxArm64()
 }
 
 kotlin {

--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -48,6 +48,15 @@ androidXComposeMultiplatform {
 }
 
 kotlin {
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    mingwX64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -58,8 +58,7 @@ val mainComponents =
         ComposeComponent(":navigation:navigation-common", viewModelPlatforms),
         ComposeComponent(":navigation:navigation-runtime", viewModelPlatforms),
 
-        //To be added later: (also don't forget to add gradle.properties see in lifecycle-runtime for an example)
-        ComposeComponent(":lifecycle:lifecycle-runtime-compose"),
+        ComposeComponent(":lifecycle:lifecycle-runtime-compose", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":lifecycle:lifecycle-viewmodel-compose"),
         ComposeComponent(":navigation:navigation-compose"),
 


### PR DESCRIPTION
Adopted version of #1320: since `lifecycle-runtime-compose` module doesn't depend on Compose UI after #1304, it can be built/published for a few additional targets: `linux`, `watchos` and `tvos`

## Testing

- Publish to mavenLocal: `lifecycle-runtime-compose`
- Inspect the output

## Release Notes

### Features - Lifecycle
- Publish additional targets for `lifecycle-runtime-compose`
