### PR TITLE
Don't show code completion for non-existenst API in `commonMain` that fails on Android with `NoSuchMethodException`

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
@@ -110,7 +110,7 @@ internal fun Project.publishAndroidxReference(target: AbstractKotlinTarget, newR
                 // required for publication.
                 val configurationName = usage.name + "-published"
                 configurations.matching { it.name == configurationName }.all { conf ->
-                    newRootComponent.addUsageFromConfiguration(conf)
+                    newRootComponent.addUsageFromConfiguration(conf, usage)
                 }
             }
         }
@@ -130,14 +130,14 @@ internal class CustomRootComponent(
 
     private val extraUsages = mutableSetOf<UsageContext>()
 
-    fun addUsageFromConfiguration(configuration: Configuration) {
+    fun addUsageFromConfiguration(configuration: Configuration, defaultUsage: KotlinUsageContext) {
         val newDependency = customizeDependencyPerConfiguration(configuration)
 
         extraUsages.add(
             CustomUsage(
                 name = configuration.name,
                 attributes = configuration.attributes,
-                dependencies = setOf(newDependency)
+                dependencies = setOf(newDependency) + defaultUsage.dependencies
             )
         )
     }


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3503
Fixes https://youtrack.jetbrains.com/issue/COMPOSE-481/skikoMain-API-is-available-in-commonMain

When we apply redirecting on `androidx` artifacts, we replace this tree of dependencies:
```
app -> jb-foundation
app -> jb-foundation-android -> jb-ui-android -> jb-ui-graphics-android
```
by this tree:
```
app -> jb-foundation
app -> androidx-foundation-> androidx-ui-> androidx-ui-graphics
```
Because we don't match trees in different dependencies, KMP plugins can't resolve the available API properly. To solve this, we add additional dependencies to the root JB artifacts (which is safe, as they will be redirected).

Instead of:
```
    {
      "name": "releaseApiElements-published",
      "attributes": {
        "org.gradle.category": "library",
        "org.gradle.usage": "java-api",
        "org.jetbrains.kotlin.platform.type": "androidJvm"
      },
      "dependencies": [
        {
          "group": "androidx.compose.ui",
          "module": "ui",
          "version": {
            "requires": "1.6.4"
          }
        }
      ]
    },
```
([file](https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/ui/ui/1.6.2/ui-1.6.2.module?download=true))
we use now:
```
    {
      "name": "releaseApiElements-published",
      "attributes": {
        "org.gradle.category": "library",
        "org.gradle.usage": "java-api",
        "org.jetbrains.kotlin.platform.type": "androidJvm"
      },
      "dependencies": [
        {
          "group": "androidx.annotation",
          "module": "annotation",
          "version": {
            "requires": "1.5.0"
          }
        },
        {
          "group": "androidx.compose.ui",
          "module": "ui",
          "version": {
            "requires": "1.6.6"
          }
        },
        {
          "group": "org.jetbrains.compose.runtime",
          "module": "runtime-saveable",
          "version": {
            "requires": "0.0.0-igor.demin-fix-skiko-api-in-common-dev1610"
          }
        },
        {
          "group": "org.jetbrains.compose.ui",
          "module": "ui-geometry",
          "version": {
            "requires": "0.0.0-igor.demin-fix-skiko-api-in-common-dev1610"
          }
        },
        {
          "group": "org.jetbrains.compose.ui",
          "module": "ui-graphics",
          "version": {
            "requires": "0.0.0-igor.demin-fix-skiko-api-in-common-dev1610"
          }
        },
        {
          "group": "org.jetbrains.compose.ui",
          "module": "ui-text",
          "version": {
            "requires": "0.0.0-igor.demin-fix-skiko-api-in-common-dev1610"
          }
        },
        {
          "group": "org.jetbrains.compose.ui",
          "module": "ui-unit",
          "version": {
            "requires": "0.0.0-igor.demin-fix-skiko-api-in-common-dev1610"
          }
        },
        {
          "group": "org.jetbrains.compose.ui",
          "module": "ui-util",
          "version": {
            "requires": "0.0.0-igor.demin-fix-skiko-api-in-common-dev1610"
          }
        }
      ]
    },
```
([file](https://maven.pkg.jetbrains.space/public/p/compose/dev/org/jetbrains/compose/ui/ui/0.0.0-igor.demin-fix-skiko-api-in-common-dev1610/ui-0.0.0-igor.demin-fix-skiko-api-in-common-dev1610.module?download=true))

## Testing
The project from https://kmp.jetbrains.com works on different targets with `implementation(compose.ui)` commented (bug is reproduce only this way)
- use `0.0.0-igor.demin-fix-skiko-api-in-common-dev1610` built from this PR
- check that Android runs
- check that desktop runs
- check that skikoMain-only API doesn't appear in `commonMain`: `Modifier.onPointerEvent`
- but appears in desktopMain

## Release Notes
### Fixes - Multiple Platforms
- Don't show code completion for non-existenst API in `commonMain` that fails on Android with `NoSuchMethodException`