### PR TITLE
Fix browser clipboard events handling on Windows

### DIFF
--- a/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
+++ b/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
@@ -19,12 +19,16 @@ package androidx.compose.foundation.text
 import androidx.compose.ui.dom.domEventOrNull
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
 import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.type
 import org.w3c.dom.events.KeyboardEvent
 
 actual val KeyEvent.isTypedEvent: Boolean
-    get() = type == KeyEventType.KeyDown && !isMetaPressed && domEventOrNull?.isPrintable() == true
+    get() = type == KeyEventType.KeyDown
+        && !isMetaPressed
+        && !isCtrlPressed
+        && domEventOrNull?.isPrintable() == true
 
 private fun KeyboardEvent.isPrintable(): Boolean {
     return key.firstOrNull()?.toString() == key

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/IsTypedEventTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/IsTypedEventTests.kt
@@ -60,6 +60,39 @@ class IsTypedEventTests {
     }
 
     @Test
+    fun shortcutsWithCtrlOnlyAreNotTyped() {
+        val keyDownEvents = listOf(
+            keyDownEvent('c', metaKey = false, ctrlKey = true),
+            keyDownEvent('p', metaKey = false, ctrlKey = true),
+            keyDownEvent('v', metaKey = false, ctrlKey = true)
+        )
+
+        keyDownEvents.forEach { event -> event.assertIsNotTyped() }
+    }
+
+    @Test
+    fun shortcutsWithMetaOnlyAreNotTyped() {
+        val keyDownEvents = listOf(
+            keyDownEvent('c', metaKey = true, ctrlKey = false),
+            keyDownEvent('p', metaKey = true, ctrlKey = false),
+            keyDownEvent('v', metaKey = true, ctrlKey = false)
+        )
+
+        keyDownEvents.forEach { event -> event.assertIsNotTyped() }
+    }
+
+    @Test
+    fun altProducesATypedEvent() {
+        val keyDownEvents = listOf(
+            keyDownEvent('c', altKey = true),
+            keyDownEvent('p', altKey = true),
+            keyDownEvent('v', altKey = true)
+        )
+
+        keyDownEvents.forEach { event -> event.assertIsTyped() }
+    }
+
+    @Test
     fun functionalsAreNotTyped() {
         val keyDownEvents = listOf(
             keyDownEvent("Backspace", code="Backspace"),


### PR DESCRIPTION

**Solution:** When Ctrl is pressed, isTypedEvent should return false


<!-- Optional -->
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4728

## Testing
<!-- Optional -->
Added two more unit tests.

## Release Notes
<!--
Optional, if omitted - won't be included in the changelog

Sections:
- Highlights
- Known issues
- Breaking changes
- Features
- Fixes

Subsections:
- Multiple Platforms
- iOS
- Desktop
- Web
- Resources
- Gradle Plugin
-->
### Fixes - Web

- _(prerelease fix)_ Fix Browser Clipboard Events and other shortcuts handling on Windows

