### PR TITLE
Fix visibility of selection handles in iOS when text is RTL or BiDi

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.android.kt
@@ -65,6 +65,13 @@ internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManag
     }
 }
 
+/**
+ * Whether the selection handle is in the visible bound of the TextField.
+ */
+internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
+    isStartHandle: Boolean
+): Boolean = isSelectionHandleInVisibleBoundDefault(isStartHandle)
+
 internal fun TextFieldSelectionManager.contextMenuBuilder(
     contextMenuState: ContextMenuState
 ): ContextMenuScope.() -> Unit = {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
@@ -1079,7 +1079,12 @@ internal fun TextFieldSelectionHandle(
 /**
  * Whether the selection handle is in the visible bound of the TextField.
  */
-internal fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
+internal expect fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
+    isStartHandle: Boolean
+): Boolean
+
+
+internal fun TextFieldSelectionManager.isSelectionHandleInVisibleBoundDefault(
     isStartHandle: Boolean
 ): Boolean = state?.layoutCoordinates?.visibleBounds()?.containsInclusive(
     getHandlePosition(isStartHandle)

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.desktop.kt
@@ -24,3 +24,10 @@ import androidx.compose.ui.input.pointer.PointerEvent
  * Magnification is not supported on desktop.
  */
 internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManager): Modifier = this
+
+/**
+ * Whether the selection handle is in the visible bound of the TextField.
+ */
+internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
+    isStartHandle: Boolean
+): Boolean = isSelectionHandleInVisibleBoundDefault(isStartHandle)

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.js.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.js.kt
@@ -19,3 +19,10 @@ package androidx.compose.foundation.text.selection
 import androidx.compose.ui.Modifier
 
 internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManager): Modifier = this
+
+/**
+ * Whether the selection handle is in the visible bound of the TextField.
+ */
+internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
+    isStartHandle: Boolean
+): Boolean = isSelectionHandleInVisibleBoundDefault(isStartHandle)

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.macos.kt
@@ -22,3 +22,10 @@ import androidx.compose.ui.Modifier
  * Magnification is not supported on desktop.
  */
 internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManager): Modifier = this
+
+/**
+ * Whether the selection handle is in the visible bound of the TextField.
+ */
+internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
+    isStartHandle: Boolean
+): Boolean = isSelectionHandleInVisibleBoundDefault(isStartHandle)

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.uikit.kt
@@ -138,6 +138,14 @@ private fun calculateSelectionMagnifierCenterIOS(
 private const val HideThresholdDp = 36
 
 /**
+ * Multiplier for height tolerance calculation.
+ * iOS has different location for the knobs of selection handles (leading - top, trailing - bottom),
+ * and they might be not seen in mixed BiDi text, so this tolerance is required for their visibility in this case
+ * if more than 80% of selection handle is visible, it should be shown
+ */
+private const val HeightToleranceFactor = 0.2f
+
+/**
  * Whether the selection handle is in the visible bound of the TextField.
  */
 internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
@@ -158,10 +166,8 @@ internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
         if (line >= textLayoutResult.lineCount) return Offset.Unspecified
 
         val x = textLayoutResult.getHorizontalPosition(offset, isStartHandle, value.selection.reversed)
-        // iOS has different location for the knobs of selection handles (leading - top, trailing - bottom),
-        // and they might be not seen in mixed LTR + RTL text, so this tolerance is required for their visibility in this case
-        val heightTolerance = textLayoutResult.multiParagraph.getLineHeight(line) * 0.2f
-        // if more than 80% of selection handle is visible, it should be shown
+
+        val heightTolerance = textLayoutResult.multiParagraph.getLineHeight(line) * HeightToleranceFactor
         val y = if (isStartHandle) textLayoutResult.getLineTop(line) + heightTolerance else textLayoutResult.getLineBottom(line) - heightTolerance
 
         return Offset(x, y)

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.uikit.kt
@@ -164,7 +164,6 @@ internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
 }
 
 internal fun isSelectionHandleIsVisible(isStartHandle: Boolean, position: Offset, height: Float, visibleBounds: Rect): Boolean {
-    println("isSelectionHandleIsVisible: $isStartHandle, (x: ${position.x}, y: ${position.y}), $height, (left: ${visibleBounds.left}, top: ${visibleBounds.top}, right: ${visibleBounds.right}, bottom: ${visibleBounds.bottom})")
     val containsHorizontal = position.x in visibleBounds.left..visibleBounds.right
     val heightTolerance = height * HeightToleranceFactor
     val toleratedY =

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.uikit.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 
@@ -155,14 +156,19 @@ internal actual fun TextFieldSelectionManager.isSelectionHandleInVisibleBound(
 
     val handlePositionInText = if (isStartHandle) value.selection.start else value.selection.end
     val line = state?.layoutResult?.value?.getLineForOffset(handlePositionInText) ?: 0
-    val selectionHandleHeight =
+    val handleHeight =
         state?.layoutResult?.value?.multiParagraph?.getLineHeight(line) ?: 0f
     val handleOffset = getHandlePosition(isStartHandle)
 
-    val containsHorizontal = handleOffset.x in visibleBounds.left..visibleBounds.right
-    val heightTolerance = selectionHandleHeight * HeightToleranceFactor
+    return isSelectionHandleIsVisible(isStartHandle, handleOffset, handleHeight, visibleBounds)
+}
+
+internal fun isSelectionHandleIsVisible(isStartHandle: Boolean, position: Offset, height: Float, visibleBounds: Rect): Boolean {
+    println("isSelectionHandleIsVisible: $isStartHandle, (x: ${position.x}, y: ${position.y}), $height, (left: ${visibleBounds.left}, top: ${visibleBounds.top}, right: ${visibleBounds.right}, bottom: ${visibleBounds.bottom})")
+    val containsHorizontal = position.x in visibleBounds.left..visibleBounds.right
+    val heightTolerance = height * HeightToleranceFactor
     val toleratedY =
-        if (isStartHandle) handleOffset.y - selectionHandleHeight + heightTolerance else handleOffset.y - heightTolerance
+        if (isStartHandle) position.y - height + heightTolerance else position.y - heightTolerance
     val containsVertical = toleratedY in visibleBounds.top..visibleBounds.bottom
 
     return containsHorizontal && containsVertical

--- a/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
+++ b/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
@@ -24,7 +24,7 @@ import kotlin.test.Test
 @OptIn(ExperimentalNativeApi::class)
 class TextFieldSelectionManagerTest {
     @Test
-    fun selectionHandlesInLtrTextAreVisible() {
+    fun isSelectionHandleIsVisible_ltr_text() {
         // Text = "I am TextField"
         val isStartVisible = isSelectionHandleIsVisible(
             true,
@@ -42,7 +42,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesInRtlTextAreVisible() {
+    fun isSelectionHandleIsVisible_rtl_text() {
         // Text = "أنا حقل النص"
         val isStartVisible = isSelectionHandleIsVisible(
             true,
@@ -60,7 +60,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesInBiDiTextAreVisible() {
+    fun isSelectionHandleIsVisible_bidi_text() {
         // Text = "I am TextField أنا حقل النص"
         val isStartVisible = isSelectionHandleIsVisible(
             true,
@@ -78,7 +78,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesInLtrTextAreInvisible() {
+    fun isSelectionHandleIsVisible_ltr_text_not_visible() {
         // Text = "I am TextField"
         val isStartInvisible = !isSelectionHandleIsVisible(
             true,
@@ -96,7 +96,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesInRtlTextAreInvisible() {
+    fun isSelectionHandleIsVisible_rtl_text_not_visible() {
         // Text = "أنا حقل النص"
         val isStartInvisible = !isSelectionHandleIsVisible(
             true,
@@ -114,7 +114,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesInBiDiTextAreInvisible() {
+    fun isSelectionHandleIsVisible_bidi_text_not_visible() {
         // Text = "I am TextField أنا حقل النص"
         val isStartInvisible = !isSelectionHandleIsVisible(
             true,
@@ -132,7 +132,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesStartIsInvisibleEndIsVisible() {
+    fun isSelectionHandleIsVisible_start_is_invisible_end_is_visible() {
         /* Selected text in multiline scrollable textfield, start handle is located above then visible bounds */
         val isStartInvisible = !isSelectionHandleIsVisible(
             true,
@@ -150,7 +150,7 @@ class TextFieldSelectionManagerTest {
     }
 
     @Test
-    fun selectionHandlesStartIsVisibleEndIsInvisible() {
+    fun isSelectionHandleIsVisible_start_is_visible_end_is_invisible() {
         /* Selected text in multiline scrollable textfield, end handle is located beneath then visible bounds */
         val isStartVisible = isSelectionHandleIsVisible(
             true,

--- a/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
+++ b/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalNativeApi::class)
 class TextFieldSelectionManagerTest {
@@ -38,7 +40,8 @@ class TextFieldSelectionManagerTest {
             50.0f,
             Rect(Offset(0f, 0f), Offset(744.0f, 50.0f))
         )
-        assert(isStartVisible && isEndVisible)
+        assertTrue(isStartVisible)
+        assertTrue(isEndVisible)
     }
 
     @Test
@@ -56,7 +59,8 @@ class TextFieldSelectionManagerTest {
             54.0f,
             Rect(Offset(0f, 0f), Offset(744.0f, 54.0f))
         )
-        assert(isStartVisible && isEndVisible)
+        assertTrue(isStartVisible)
+        assertTrue(isEndVisible)
     }
 
     @Test
@@ -74,67 +78,71 @@ class TextFieldSelectionManagerTest {
             54.0f,
             Rect(Offset(0f, 0f), Offset(744.0f, 54.0f))
         )
-        assert(isStartVisible && isEndVisible)
+        assertTrue(isStartVisible)
+        assertTrue(isEndVisible)
     }
 
     @Test
     fun isSelectionHandleIsVisible_ltr_text_not_visible() {
         // Text = "I am TextField"
-        val isStartInvisible = !isSelectionHandleIsVisible(
+        val isStartVisible = isSelectionHandleIsVisible(
             true,
             Offset(94.58f, 50.0f),
             50.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        val isEndInvisible = !isSelectionHandleIsVisible(
+        val isEndVisible = isSelectionHandleIsVisible(
             false,
             Offset(272.38f, 50.0f),
             50.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        assert(isStartInvisible && isEndInvisible)
+        assertFalse(isStartVisible)
+        assertFalse(isEndVisible)
     }
 
     @Test
     fun isSelectionHandleIsVisible_rtl_text_not_visible() {
         // Text = "أنا حقل النص"
-        val isStartInvisible = !isSelectionHandleIsVisible(
+        val isStartVisible = isSelectionHandleIsVisible(
             true,
             Offset(153.84f, 56.0f),
             54.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        val isEndInvisible = !isSelectionHandleIsVisible(
+        val isEndVisible = isSelectionHandleIsVisible(
             false,
             Offset(92.93f, 56.0f),
             54.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        assert(isStartInvisible && isEndInvisible)
+        assertFalse(isStartVisible)
+        assertFalse(isEndVisible)
     }
 
     @Test
     fun isSelectionHandleIsVisible_bidi_text_not_visible() {
         // Text = "I am TextField أنا حقل النص"
-        val isStartInvisible = !isSelectionHandleIsVisible(
+        val isStartVisible = isSelectionHandleIsVisible(
             true,
             Offset(365.31f, 56.0f),
             54.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        val isEndInvisible = !isSelectionHandleIsVisible(
+        val isEndVisible = isSelectionHandleIsVisible(
             false,
             Offset(284.2f, 56.0f),
             54.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        assert(isStartInvisible && isEndInvisible)
+        assertFalse(isStartVisible)
+        assertFalse(isEndVisible)
     }
 
     @Test
     fun isSelectionHandleIsVisible_start_is_invisible_end_is_visible() {
         /* Selected text in multiline scrollable textfield, start handle is located above then visible bounds */
-        val isStartInvisible = !isSelectionHandleIsVisible(
+        val isStartVisible = isSelectionHandleIsVisible(
             true,
             Offset(94.79f, 250.0f),
             50.0f,
@@ -146,7 +154,8 @@ class TextFieldSelectionManagerTest {
             50.0f,
             Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
         )
-        assert(isStartInvisible && isEndVisible)
+        assertFalse(isStartVisible)
+        assertTrue(isEndVisible)
     }
 
     @Test
@@ -158,12 +167,13 @@ class TextFieldSelectionManagerTest {
             50.0f,
             Rect(Offset(0f, 211.0f), Offset(1194.0f, 2224.0f))
         )
-        val isEndInvisible = !isSelectionHandleIsVisible(
+        val isEndVisible = isSelectionHandleIsVisible(
             false,
             Offset(82.97f, 2250.0f),
             54.0f,
             Rect(Offset(0f, 211.0f), Offset(744.0f, 54.0f))
         )
-        assert(isStartVisible && isEndInvisible)
+        assertTrue(isStartVisible)
+        assertFalse(isEndVisible)
     }
 }

--- a/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
+++ b/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
@@ -17,27 +17,153 @@
 package androidx.compose.foundation.text.selection
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import kotlin.experimental.ExperimentalNativeApi
 import kotlin.test.Test
 
+@OptIn(ExperimentalNativeApi::class)
 class TextFieldSelectionManagerTest {
-    private val selectionManager = TextFieldSelectionManager()
     @Test
-    fun selectionHandlesInLtrTextSingleLineAreVisible() {
-        val a = selectionManager.isSelectionHandleInVisibleBound(true)
+    fun selectionHandlesInLtrTextAreVisible() {
+        // Text = "I am TextField"
+        val isStartVisible = isSelectionHandleIsVisible(
+            true,
+            Offset(94.58f, 50.0f),
+            50.0f,
+            Rect(Offset(0f, 0f), Offset(744.0f, 50.0f))
+        )
+        val isEndVisible = isSelectionHandleIsVisible(
+            false,
+            Offset(272.38f, 50.0f),
+            50.0f,
+            Rect(Offset(0f, 0f), Offset(744.0f, 50.0f))
+        )
+        assert(isStartVisible && isEndVisible)
     }
 
     @Test
-    fun selectionHandlesInRtlTextSingleLineAreVisible() {
-
+    fun selectionHandlesInRtlTextAreVisible() {
+        // Text = "أنا حقل النص"
+        val isStartVisible = isSelectionHandleIsVisible(
+            true,
+            Offset(153.84f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 0f), Offset(744.0f, 54.0f))
+        )
+        val isEndVisible = isSelectionHandleIsVisible(
+            false,
+            Offset(92.93f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 0f), Offset(744.0f, 54.0f))
+        )
+        assert(isStartVisible && isEndVisible)
     }
 
     @Test
-    fun selectionHandlesInBiDiTextSingleLineAreVisible() {
-
+    fun selectionHandlesInBiDiTextAreVisible() {
+        // Text = "I am TextField أنا حقل النص"
+        val isStartVisible = isSelectionHandleIsVisible(
+            true,
+            Offset(365.31f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 0f), Offset(744.0f, 54.0f))
+        )
+        val isEndVisible = isSelectionHandleIsVisible(
+            false,
+            Offset(284.2f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 0f), Offset(744.0f, 54.0f))
+        )
+        assert(isStartVisible && isEndVisible)
     }
 
-    /*
-    1. TextFieldState
-    2.
-     */
+    @Test
+    fun selectionHandlesInLtrTextAreInvisible() {
+        // Text = "I am TextField"
+        val isStartInvisible = !isSelectionHandleIsVisible(
+            true,
+            Offset(94.58f, 50.0f),
+            50.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        val isEndInvisible = !isSelectionHandleIsVisible(
+            false,
+            Offset(272.38f, 50.0f),
+            50.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        assert(isStartInvisible && isEndInvisible)
+    }
+
+    @Test
+    fun selectionHandlesInRtlTextAreInvisible() {
+        // Text = "أنا حقل النص"
+        val isStartInvisible = !isSelectionHandleIsVisible(
+            true,
+            Offset(153.84f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        val isEndInvisible = !isSelectionHandleIsVisible(
+            false,
+            Offset(92.93f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        assert(isStartInvisible && isEndInvisible)
+    }
+
+    @Test
+    fun selectionHandlesInBiDiTextAreInvisible() {
+        // Text = "I am TextField أنا حقل النص"
+        val isStartInvisible = !isSelectionHandleIsVisible(
+            true,
+            Offset(365.31f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        val isEndInvisible = !isSelectionHandleIsVisible(
+            false,
+            Offset(284.2f, 56.0f),
+            54.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        assert(isStartInvisible && isEndInvisible)
+    }
+
+    @Test
+    fun selectionHandlesStartIsInvisibleEndIsVisible() {
+        /* Selected text in multiline scrollable textfield, start handle is located above then visible bounds */
+        val isStartInvisible = !isSelectionHandleIsVisible(
+            true,
+            Offset(94.79f, 250.0f),
+            50.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        val isEndVisible = isSelectionHandleIsVisible(
+            false,
+            Offset(164.29f, 250.0f),
+            50.0f,
+            Rect(Offset(0f, 217.0f), Offset(1194.0f, 2230.0f))
+        )
+        assert(isStartInvisible && isEndVisible)
+    }
+
+    @Test
+    fun selectionHandlesStartIsVisibleEndIsInvisible() {
+        /* Selected text in multiline scrollable textfield, end handle is located beneath then visible bounds */
+        val isStartVisible = isSelectionHandleIsVisible(
+            true,
+            Offset(0.0f, 2250.0f),
+            50.0f,
+            Rect(Offset(0f, 211.0f), Offset(1194.0f, 2224.0f))
+        )
+        val isEndInvisible = !isSelectionHandleIsVisible(
+            false,
+            Offset(82.97f, 2250.0f),
+            54.0f,
+            Rect(Offset(0f, 211.0f), Offset(744.0f, 54.0f))
+        )
+        assert(isStartVisible && isEndInvisible)
+    }
 }

--- a/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
+++ b/compose/foundation/foundation/src/uikitTest/kotlin/androidx.compose.foundation/text/selection/TextFieldSelectionManagerTest.uikit.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.test.Test
+
+class TextFieldSelectionManagerTest {
+    private val selectionManager = TextFieldSelectionManager()
+    @Test
+    fun selectionHandlesInLtrTextSingleLineAreVisible() {
+        val a = selectionManager.isSelectionHandleInVisibleBound(true)
+    }
+
+    @Test
+    fun selectionHandlesInRtlTextSingleLineAreVisible() {
+
+    }
+
+    @Test
+    fun selectionHandlesInBiDiTextSingleLineAreVisible() {
+
+    }
+
+    /*
+    1. TextFieldState
+    2.
+     */
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/RtlAndBidiTextfieldExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/RtlAndBidiTextfieldExample.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.textfield
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun RtlAndBidiTextfieldExample() {
+    val ltrTextValue = remember { mutableStateOf("Text example") }
+    val rtlTextValue = remember { mutableStateOf("مثال نصي") }
+    val bidiTextValue = remember { mutableStateOf("Bidi text example مثال نص بيدي") }
+
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Column {
+            BasicText("BasicTextField, LTR Text")
+            OutlinedTextField(
+                value = ltrTextValue.value,
+                onValueChange = { ltrTextValue.value = it })
+        }
+        Column {
+            BasicText("BasicTextField, RTL Text")
+            OutlinedTextField(
+                value = rtlTextValue.value,
+                onValueChange = { ltrTextValue.value = it })
+        }
+        Column {
+            BasicText("BasicTextField, BiDi Text")
+            OutlinedTextField(
+                value = bidiTextValue.value,
+                onValueChange = { ltrTextValue.value = it })
+        }
+    }
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/RtlAndBidiTextfieldExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/RtlAndBidiTextfieldExample.kt
@@ -39,19 +39,19 @@ fun RtlAndBidiTextfieldExample() {
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         Column {
-            BasicText("BasicTextField, LTR Text")
+            BasicText("OutlinedTextField, LTR Text")
             OutlinedTextField(
                 value = ltrTextValue.value,
                 onValueChange = { ltrTextValue.value = it })
         }
         Column {
-            BasicText("BasicTextField, RTL Text")
+            BasicText("OutlinedTextField, RTL Text")
             OutlinedTextField(
                 value = rtlTextValue.value,
                 onValueChange = { ltrTextValue.value = it })
         }
         Column {
-            BasicText("BasicTextField, BiDi Text")
+            BasicText("OutlinedTextField, BiDi Text")
             OutlinedTextField(
                 value = bidiTextValue.value,
                 onValueChange = { ltrTextValue.value = it })

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -72,6 +72,10 @@ val TextFields = Screen.Selection(
     Screen.Example("BasicTextField") {
         var text by remember { mutableStateOf("usage of BasicTextField") }
         BasicTextField(text, { text = it })
+    },
+
+    Screen.Example("RTL and BiDi") {
+        ClearFocusBox { RtlAndBidiTextfieldExample() }
     }
 )
 


### PR DESCRIPTION
Adjusted check of visibility of selection handles in iOS - they won't be shown when they are visible less than 80% of their size.
This change is required for making selection handles visible when a single line textfield contains LTR + RTL text, before this fix selection handles weren't visible.
In addition, during scrolling the long textfield, selection handles will be hiding more smoothly than before.

<!-- Optional -->
Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-1359/iOS-Selection-Handles-work-weirdly-when-text-is-RTL-LTR

## Testing
<!-- Optional -->
Open the test app, go Android TextField Samples -> Basic input fields, write some LTR text in any textfield with RTL text, then try to select text. Selection Handles should be visible

## Release Notes
### Fixes - iOS
- visibility of selection handles in single-line textfields with LTR + RTL text in iOS

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
