### PR TITLE
CfW: temporary disable one lifecycle test which opens a new browser window

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlin.test.AfterTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -43,6 +44,7 @@ class ComposeWindowLifecycleTest {
     }
 
     @Test
+    @Ignore
     fun allEvents() = runTest {
         if (isHeadlessBrowser()) return@runTest
         val canvas = document.createElement("canvas") as HTMLCanvasElement

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -44,7 +44,7 @@ class ComposeWindowLifecycleTest {
     }
 
     @Test
-    @Ignore
+    @Ignore // ignored while investigating CI issues: this test opens a new browser window which can be the cause
     fun allEvents() = runTest {
         if (isHeadlessBrowser()) return@runTest
         val canvas = document.createElement("canvas") as HTMLCanvasElement


### PR DESCRIPTION
It seems that test makes our CI hang sometimes (because the test opens another browser window) 