### PR TITLE
Update `WindowInfo.containerSize` on window resize to keep it correct when window is moved between displays

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -242,13 +242,13 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     override fun setComponentOrientation(o: ComponentOrientation?) {
         super.setComponentOrientation(o)
 
-        _composeContainer?.onChangeLayoutDirection(this)
+        _composeContainer?.onLayoutDirectionChanged(this)
     }
 
     override fun setLocale(l: Locale?) {
         super.setLocale(l)
 
-        _composeContainer?.onChangeLayoutDirection(this)
+        _composeContainer?.onLayoutDirectionChanged(this)
     }
 
     override fun addFocusListener(l: FocusListener?) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.scene.ComposeContainer
 import androidx.compose.ui.window.LocalWindow
-import java.awt.Color
 import java.awt.Component
 import java.awt.Container
 import java.awt.Dimension
@@ -34,10 +33,7 @@ import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelListener
 import javax.swing.JLayeredPane
-import org.jetbrains.skiko.GraphicsApi
-import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayerAnalytics
-import org.jetbrains.skiko.hostOs
 
 /**
  * A panel used as a main view in [ComposeWindow] and [ComposeDialog].
@@ -88,7 +84,7 @@ internal class ComposeWindowPanel(
                     "Cannot change transparency if window is already displayable."
                 }
                 field = value
-                composeContainer.onChangeWindowTransparency(value)
+                composeContainer.onWindowTransparencyChanged(value)
                 setTransparent(value)
                 window.background = getTransparentWindowBackground(value, renderApi)
             }
@@ -157,7 +153,7 @@ internal class ComposeWindowPanel(
     }
 
     fun onChangeLayoutDirection(component: Component) {
-        composeContainer.onChangeLayoutDirection(component)
+        composeContainer.onLayoutDirectionChanged(component)
     }
 
     fun onRenderApiChanged(action: () -> Unit) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -500,13 +500,13 @@ internal class ComposeSceneMediator(
         }
     }
 
-    fun onChangeComponentPosition() = catchExceptions {
+    fun onComponentPositionChanged() = catchExceptions {
         if (!container.isDisplayable) return
 
         offsetInWindow = windowContext.offsetInWindow(container)
     }
 
-    fun onChangeComponentSize() = catchExceptions {
+    fun onComponentSizeChanged() = catchExceptions {
         if (!container.isDisplayable) return
 
         val size = sceneBoundsInPx?.size ?: container.sizeInPx
@@ -520,15 +520,15 @@ internal class ComposeSceneMediator(
     fun onChangeDensity(density: Density = container.density) = catchExceptions {
         if (scene.density != density) {
             scene.density = density
-            onChangeComponentSize()
+            onComponentSizeChanged()
         }
     }
 
-    fun onChangeWindowTransparency(value: Boolean) {
+    fun onWindowTransparencyChanged(value: Boolean) {
         skiaLayerComponent.transparency = value || useInteropBlending
     }
 
-    fun onChangeLayoutDirection(layoutDirection: LayoutDirection) {
+    fun onLayoutDirectionChanged(layoutDirection: LayoutDirection) {
         scene.layoutDirection = layoutDirection
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -85,7 +85,7 @@ internal abstract class DesktopComposeSceneLayer(
     final override var layoutDirection: LayoutDirection = layoutDirection
         set(value) {
             field = value
-            mediator?.onChangeLayoutDirection(value)
+            mediator?.onLayoutDirectionChanged(value)
         }
 
     // It shouldn't be used for setting canvas size - it will crop drawings outside
@@ -144,19 +144,19 @@ internal abstract class DesktopComposeSceneLayer(
     /**
      * Called when the focus of the window containing main Compose view has changed.
      */
-    open fun onChangeWindowFocus() {
+    open fun onWindowFocusChanged() {
     }
 
     /**
-     * Called when position of the window containing main Compose view has changed.
+     * Called when position of the window container, containing the main Compose view, has changed.
      */
-    open fun onChangeWindowPosition() {
+    open fun onWindowContainerPositionChanged() {
     }
 
     /**
-     * Called when size of the window containing main Compose view has changed.
+     * Called when size of the window container, containing the main Compose view, has changed.
      */
-    open fun onChangeWindowSize() {
+    open fun onWindowContainerSizeChanged() {
     }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -79,7 +79,7 @@ internal class SwingComposeSceneLayer(
                 field = value
                 container.setBounds(0, 0, value.width, value.height)
                 mediator?.contentComponent?.size = container.size
-                mediator?.onChangeComponentSize()
+                mediator?.onComponentSizeChanged()
             }
         }
 
@@ -113,7 +113,7 @@ internal class SwingComposeSceneLayer(
             skiaLayerComponentFactory = ::createSkiaLayerComponent,
             composeSceneFactory = ::createComposeScene,
         ).also {
-            it.onChangeWindowTransparency(true)
+            it.onWindowTransparencyChanged(true)
             it.contentComponent.size = container.size
         }
 
@@ -135,7 +135,7 @@ internal class SwingComposeSceneLayer(
         windowContainer.repaint()
     }
 
-    override fun onChangeWindowSize() {
+    override fun onWindowContainerSizeChanged() {
         containerSize = IntSize(windowContainer.width, windowContainer.height)
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -85,7 +85,7 @@ internal class WindowComposeSceneLayer(
 
     private val windowPositionListener = object : ComponentAdapter() {
         override fun componentMoved(e: ComponentEvent?) {
-            onChangeWindowPosition()
+            onWindowContainerPositionChanged()
         }
     }
 
@@ -114,7 +114,7 @@ internal class WindowComposeSceneLayer(
             skiaLayerComponentFactory = ::createSkiaLayerComponent,
             composeSceneFactory = ::createComposeScene,
         ).also {
-            it.onChangeWindowTransparency(true)
+            it.onWindowTransparencyChanged(true)
             it.sceneBoundsInPx = boundsInPx
             it.contentComponent.size = windowContainer.size
         }
@@ -140,12 +140,12 @@ internal class WindowComposeSceneLayer(
         dialog.dispose()
     }
 
-    override fun onChangeWindowPosition() {
+    override fun onWindowContainerPositionChanged() {
         val scaledRectangle = drawBounds.toAwtRectangle(density)
         setDialogLocation(scaledRectangle.x, scaledRectangle.y)
     }
 
-    override fun onChangeWindowSize() {
+    override fun onWindowContainerSizeChanged() {
         windowContext.setContainerSize(windowContainer.sizeInPx)
 
         // Update compose constrains based on main window size

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -57,7 +57,7 @@ internal class SwingSkiaLayerComponent(
 
             override fun doLayout() {
                 super.doLayout()
-                mediator.onChangeComponentSize()
+                mediator.onComponentSizeChanged()
             }
 
             override fun getPreferredSize(): Dimension = if (isPreferredSizeSet) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -58,7 +58,7 @@ internal class WindowSkiaLayerComponent(
 
         override fun doLayout() {
             super.doLayout()
-            mediator.onChangeComponentSize()
+            mediator.onComponentSizeChanged()
         }
 
         override fun getPreferredSize(): Dimension = if (isPreferredSizeSet) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -512,7 +512,10 @@ private fun rememberPopupMeasurePolicy(
                 -platformInsets.top.roundToPx()
             )
             val positionInWindow = popupPositionProvider.calculatePosition(
-                boundsWithoutInsets, sizeWithoutInsets, layoutDirection, contentSize
+                anchorBounds = boundsWithoutInsets,
+                windowSize = sizeWithoutInsets,
+                layoutDirection = layoutDirection,
+                popupContentSize = contentSize
             )
             if (properties.clippingEnabled) {
                 clipPosition(positionInWindow, contentSize, sizeWithoutInsets)


### PR DESCRIPTION
`ComposeContainter` currently registers the listener for window size and position on the `windowContainer`, which is a `JLayeredPane`. It ends up not being called at all when the window is resized or moved. According to @MatkovIvan, however, this is intentional and merely poorly named (e.g. `onChangeWindowPosition` is meant to be called when the `windowContainer`'s position changes, not the window's).

Because of this, when a window is moved to another screen with a different density, the size we store for it in `WindowInfo.containerSize` isn't updated. This, in turn, causes issues with popup positioning.

This PR registers an additional size listener on the window, in order to update `WindowInfo.containerSize` when the window size changes. It also renames all the related listener functions.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4697 
Possibly fixes additional issues where the window size was not being updated after moving it to a different screen.

## Testing
Tested manually with this code:
```
@Composable
fun TestButton(text: String) {
    val displayHover = remember { mutableStateOf(false) }

    Column(
        modifier = Modifier
    ) {
        Button(
            onClick = {
                displayHover.value = true
            },
            modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
        ) {
            Text(text)
        }
        DropdownMenu(
            displayHover.value,
            onDismissRequest = {
                displayHover.value = false
            },
            modifier = Modifier.background(MaterialTheme.colors.background),
        ) {
            Row(Modifier.width(200.dp), horizontalArrangement = Arrangement.SpaceBetween) {
                Text(
                    text = "My tooltip",
                )
                Text(
                    text = "2 tooltip",
                )
            }

        }
    }
}

fun main() = singleWindowApplication {
    MaterialTheme {
        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.TopEnd) {
            TestButton("Hello, World!")
        }
    }
}
```

To simulate a 2nd screen, I've used this app: https://github.com/Stengo/DeskPad and configured the 2nd screen to be of a very low resolution (such that the density is 1.0).

This could be tested by QA

## Release Notes

### Fixes - Desktop

- Fix dropdown/popup positioning when a window is moved to a screen with a different density

