### PR TITLE
Use `InternalComposeUiApi` for APIs in UI module

### DIFF
--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -17,8 +17,8 @@
 package androidx.compose.foundation.layout
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.LocalLayoutMargins
 import androidx.compose.ui.platform.LocalSafeArea
 import androidx.compose.ui.platform.PlatformInsets
@@ -41,7 +41,7 @@ private fun PlatformInsets.toWindowInsets() = WindowInsets(
  */
 private val WindowInsets.Companion.iosSafeArea: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class, ExperimentalComposeUiApi::class)
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
     get() = LocalSafeArea.current.toWindowInsets()
 
 /**
@@ -49,7 +49,7 @@ private val WindowInsets.Companion.iosSafeArea: WindowInsets
  */
 private val WindowInsets.Companion.layoutMargins: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class, ExperimentalComposeUiApi::class)
+    @OptIn(InternalComposeUiApi::class, ExperimentalComposeUiApi::class)
     get() = LocalLayoutMargins.current.toWindowInsets()
 
 /**
@@ -64,7 +64,7 @@ actual val WindowInsets.Companion.captionBar: WindowInsets
  */
 actual val WindowInsets.Companion.displayCutout: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class)
+    @OptIn(InternalComposeUiApi::class)
     get() = when (LocalInterfaceOrientation.current) {
         InterfaceOrientation.Portrait -> iosSafeArea.only(WindowInsetsSides.Top)
         InterfaceOrientation.PortraitUpsideDown -> iosSafeArea.only(WindowInsetsSides.Bottom)
@@ -78,7 +78,7 @@ actual val WindowInsets.Companion.displayCutout: WindowInsets
  */
 actual val WindowInsets.Companion.ime: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class)
+    @OptIn(InternalComposeUiApi::class)
     get() = WindowInsets(bottom = LocalKeyboardOverlapHeight.current)
 
 /**
@@ -101,7 +101,7 @@ actual val WindowInsets.Companion.navigationBars: WindowInsets
  */
 actual val WindowInsets.Companion.statusBars: WindowInsets
     @Composable
-    @OptIn(InternalComposeApi::class)
+    @OptIn(InternalComposeUiApi::class)
     get() = when (LocalInterfaceOrientation.current) {
         InterfaceOrientation.Portrait -> iosSafeArea.only(WindowInsetsSides.Top)
         else -> ZeroInsets

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/DarkTheme.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/DarkTheme.skiko.kt
@@ -17,8 +17,8 @@
 package androidx.compose.foundation
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.SystemTheme
 
@@ -43,7 +43,7 @@ import androidx.compose.ui.SystemTheme
  *
  * @return `true` if the system is considered to be in 'dark theme'.
  */
-@OptIn(InternalComposeApi::class)
+@OptIn(InternalComposeUiApi::class)
 @Composable
 @ReadOnlyComposable
 internal actual fun _isSystemInDarkTheme(): Boolean {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/SystemTheme.kt
@@ -18,14 +18,13 @@ package androidx.compose.ui
 
 import androidx.compose.runtime.staticCompositionLocalOf
 import org.jetbrains.skiko.SystemTheme as SkikoSystemTheme
-import androidx.compose.runtime.InternalComposeApi
 import org.jetbrains.skiko.currentSystemTheme
 
 enum class SystemTheme {
     Dark, Light, Unknown
 }
 
-@InternalComposeApi
+@InternalComposeUiApi
 val LocalSystemTheme = staticCompositionLocalOf {
     currentSystemTheme.asComposeSystemTheme()
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformInsets.uikit.kt
@@ -18,24 +18,23 @@ package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.uikit.LocalKeyboardOverlapHeight
 import androidx.compose.ui.unit.dp
 
 /**
  * Composition local for SafeArea of ComposeUIViewController
  */
-@InternalComposeApi
+@InternalComposeUiApi
 val LocalSafeArea = staticCompositionLocalOf { PlatformInsets.Zero }
 
 /**
  * Composition local for layoutMargins of ComposeUIViewController
  */
-@InternalComposeApi
+@InternalComposeUiApi
 val LocalLayoutMargins = staticCompositionLocalOf { PlatformInsets.Zero }
 
-@OptIn(InternalComposeApi::class)
 private object SafeAreaInsetsConfig : InsetsConfig {
     override val safeInsets: PlatformInsets
         @Composable get() = LocalSafeArea.current

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -19,7 +19,6 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ExperimentalComposeApi
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Offset
@@ -485,7 +484,6 @@ internal class ComposeSceneMediator(
         layoutMarginsState.value = calcLayoutMargin()
     }
 
-    @OptIn(InternalComposeApi::class)
     @Composable
     private fun ProvideComposeSceneMediatorCompositionLocals(content: @Composable () -> Unit) =
         CompositionLocalProvider(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
@@ -17,14 +17,14 @@
 package androidx.compose.ui.uikit
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.InternalComposeUiApi
 import platform.UIKit.*
 
 /**
  * Wraps valid layout values for iOS UIInterfaceOrientation
  */
-@InternalComposeApi
+@InternalComposeUiApi
 @Immutable
 enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
     Portrait(UIInterfaceOrientationPortrait),
@@ -44,5 +44,5 @@ enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
 /**
  * Composition local for [InterfaceOrientation]
  */
-@InternalComposeApi
+@InternalComposeUiApi
 val LocalInterfaceOrientation = staticCompositionLocalOf { InterfaceOrientation.Portrait }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/KeyboardOverlapHeight.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/KeyboardOverlapHeight.uikit.kt
@@ -16,13 +16,13 @@
 
 package androidx.compose.ui.uikit
 
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.unit.dp
 
 
 /**
  * Composition local for height that is overlapped with keyboard over Compose view.
  */
-@InternalComposeApi
+@InternalComposeUiApi
 val LocalKeyboardOverlapHeight = compositionLocalOf { 0.dp }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ExperimentalComposeApi
-import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.LocalSystemTheme
@@ -93,7 +92,6 @@ import platform.darwin.dispatch_get_main_queue
 private val coroutineDispatcher = Dispatchers.Main
 
 // TODO: Move to androidx.compose.ui.scene
-@OptIn(InternalComposeApi::class)
 @ExportObjCClass
 internal class ComposeContainer(
     private val configuration: ComposeUIViewControllerConfiguration,
@@ -432,7 +430,6 @@ private fun getLayoutDirection() =
         else -> LayoutDirection.Ltr
     }
 
-@OptIn(InternalComposeApi::class)
 @Composable
 internal fun ProvideContainerCompositionLocals(
     composeContainer: ComposeContainer,


### PR DESCRIPTION
`InternalComposeApi` is for the runtime.

Test: `gw :compose:ui:ui:cKUA :compose:foundation:foundation:cKUA`
