### PR TITLE
Restore button filter for dialog closing

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3408,8 +3408,8 @@ public abstract interface class androidx/compose/ui/scene/ComposeSceneLayer {
 	public abstract fun setKeyEventListener (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun setKeyEventListener$default (Landroidx/compose/ui/scene/ComposeSceneLayer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public abstract fun setLayoutDirection (Landroidx/compose/ui/unit/LayoutDirection;)V
-	public abstract fun setOutsidePointerEventListener (Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun setOutsidePointerEventListener$default (Landroidx/compose/ui/scene/ComposeSceneLayer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public abstract fun setOutsidePointerEventListener (Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun setOutsidePointerEventListener$default (Landroidx/compose/ui/scene/ComposeSceneLayer;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public abstract fun setScrimColor-Y2TPw74 (Landroidx/compose/ui/graphics/Color;)V
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -714,11 +714,11 @@ private fun ComposeScene.onMouseEvent(
         buttons = event.buttons,
         keyboardModifiers = event.keyboardModifiers,
         nativeEvent = event,
-        button = event.getPointerButton()
+        button = event.composePointerButton
     )
 }
 
-private fun MouseEvent.getPointerButton(): PointerButton? {
+internal val MouseEvent.composePointerButton: PointerButton? get() {
     if (button == MouseEvent.NOBUTTON) return null
     return when (button) {
         MouseEvent.BUTTON2 -> PointerButton.Tertiary

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.awt.AwtEventFilter
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.awt.toAwtRectangle
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.skiko.RecordDrawRectRenderDecorator
 import androidx.compose.ui.unit.Density
@@ -73,7 +74,10 @@ internal abstract class DesktopComposeSceneLayer(
      */
     private var maxDrawInflate = IntRect.Zero
 
-    private var outsidePointerCallback: ((eventType: PointerEventType) -> Unit)? = null
+    private var outsidePointerCallback: ((
+        eventType: PointerEventType,
+        button: PointerButton?
+    ) -> Unit)? = null
     private var isClosed = false
 
     final override var density: Density = density
@@ -119,7 +123,7 @@ internal abstract class DesktopComposeSceneLayer(
     }
 
     final override fun setOutsidePointerEventListener(
-        onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)?
+        onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)?
     ) {
         outsidePointerCallback = onOutsidePointerEvent
     }
@@ -196,7 +200,7 @@ internal abstract class DesktopComposeSceneLayer(
             MouseEvent.MOUSE_RELEASED -> PointerEventType.Release
             else -> return
         }
-        outsidePointerCallback?.invoke(eventType)
+        outsidePointerCallback?.invoke(eventType, event.composePointerButton)
     }
 
     private fun inBounds(event: MouseEvent): Boolean {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.LocalDensity
@@ -145,7 +146,10 @@ interface ComposeSceneLayer {
      * gesture that started outside of [boundsInWindow].
      */
     fun setOutsidePointerEventListener(
-        onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null,
+        onOutsidePointerEvent: ((
+            eventType: PointerEventType,
+            button: PointerButton?
+        ) -> Unit)? = null,
     )
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -504,7 +504,10 @@ private class MultiLayerComposeSceneImpl(
             inputHandler = inputHandler,
         )
         private var composition: Composition? = null
-        private var outsidePointerCallback: ((eventType: PointerEventType) -> Unit)? = null
+        private var outsidePointerCallback: ((
+            eventType: PointerEventType,
+            button: PointerButton?
+        ) -> Unit)? = null
         private var isClosed = false
 
         override var density: Density by owner::density
@@ -577,7 +580,7 @@ private class MultiLayerComposeSceneImpl(
         }
 
         override fun setOutsidePointerEventListener(
-            onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)?,
+            onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)?,
         ) {
             outsidePointerCallback = onOutsidePointerEvent
         }
@@ -607,17 +610,17 @@ private class MultiLayerComposeSceneImpl(
         fun isInBounds(position: Offset) = boundsInWindow.contains(position.round())
 
         fun onOutsidePointerEvent(event: PointerInputEvent) {
-            if (!event.isMainAction()) {
+            if (!event.isMouseOrSingleTouch()) {
                 return
             }
-            outsidePointerCallback?.invoke(event.eventType)
+            outsidePointerCallback?.invoke(event.eventType, event.button)
         }
     }
 }
 
 private val PointerInputEvent.isGestureInProgress get() = pointers.fastAny { it.down }
 
-private fun PointerInputEvent.isMainAction() =
+private fun PointerInputEvent.isMouseOrSingleTouch() =
     button != null || pointers.size == 1
 
 private class CopiedList<T>(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalWindowInfo
@@ -159,8 +160,13 @@ actual fun Dialog(
         null
     }
     val onOutsidePointerEvent = if (properties.dismissOnClickOutside) {
-        { eventType: PointerEventType ->
-            if (eventType == PointerEventType.Release) {
+        { eventType: PointerEventType, button: PointerButton? ->
+            // Clicking outside dialog is clicking on scrim.
+            // So this behavior should match regular clicks or [detectTapGestures] that accepts
+            // only primary mouse button clicks.
+            if (eventType == PointerEventType.Release &&
+                (button == null || button == PointerButton.Primary)
+            ) {
                 currentOnDismissRequest()
             }
         }
@@ -182,7 +188,7 @@ private fun DialogLayout(
     modifier: Modifier = Modifier,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
-    onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null,
+    onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
     val currentContent by rememberUpdatedState(content)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.EmptyLayout
 import androidx.compose.ui.layout.Layout
@@ -410,7 +411,10 @@ fun Popup(
     }
     val onOutsidePointerEvent = if (properties.dismissOnClickOutside && onDismissRequest != null) {
         // No need to remember this lambda, as it doesn't capture any values that can change.
-        { eventType: PointerEventType ->
+        { eventType: PointerEventType, _: PointerButton? ->
+            // Popup should react on first event - [PointerEventType.Press],
+            // but at the same time trigger [onDismissRequest] only once per click.
+            // Any mouse buttons should be accepted to match regular dropdown behavior.
             if (eventType == PointerEventType.Press) {
                 currentOnDismissRequest?.invoke()
             }
@@ -436,7 +440,7 @@ private fun PopupLayout(
     modifier: Modifier,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean)? = null,
     onKeyEvent: ((KeyEvent) -> Boolean)? = null,
-    onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null,
+    onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
     val currentContent by rememberUpdatedState(content)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -197,23 +197,18 @@ class DialogTest {
     }
 
     @Test
-    fun secondaryButtonClickDismissDialog() = runSkikoComposeUiTest(
+    fun secondaryButtonClickDoesNotDismissDialog() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
     ) {
-        val openDialog = mutableStateOf(true)
         val background = FillBox()
         val dialog = DialogState(
             IntSize(40, 40),
-            onDismissRequest = {
-                openDialog.value = false
-            }
+            onDismissRequest = { fail() }
         )
 
         setContent {
             background.Content()
-            if (openDialog.value) {
-                dialog.Content()
-            }
+            dialog.Content()
         }
 
         val buttons = PointerButtons(
@@ -230,8 +225,6 @@ class DialogTest {
             position = Offset(10f, 10f),
             button = PointerButton.Secondary
         )
-
-        onNodeWithTag(dialog.tag).assertDoesNotExist()
     }
 
     @OptIn(InternalTestApi::class)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.interop.UIKitInteropContext
 import androidx.compose.ui.platform.PlatformContext
@@ -66,7 +67,10 @@ internal class UIViewComposeSceneLayer(
 ) : ComposeSceneLayer {
 
     override var focusable: Boolean = focusStack != null
-    private var onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)? = null
+    private var onOutsidePointerEvent: ((
+        eventType: PointerEventType,
+        button: PointerButton?
+    ) -> Unit)? = null
     private val rootView = composeContainer.view.window ?: composeContainer.view
     private val backgroundView: UIView = object : UIView(
         frame = CGRectZero.readValue()
@@ -77,7 +81,7 @@ internal class UIViewComposeSceneLayer(
             if (previousSuccessHitTestTimestamp != withEvent?.timestamp) {
                 // This workaround needs to send PointerEventType.Press just once
                 previousSuccessHitTestTimestamp = withEvent?.timestamp
-                onOutsidePointerEvent?.invoke(PointerEventType.Press)
+                onOutsidePointerEvent?.invoke(PointerEventType.Press, null)
             }
         }
 
@@ -91,7 +95,8 @@ internal class UIViewComposeSceneLayer(
                 // This view's coordinate space is equal to [ComposeScene]'s
                 val contains = boundsInWindow.contains(locationInView.toOffset(density).round())
                 if (!contains) {
-                    onOutsidePointerEvent?.invoke(PointerEventType.Release)
+                    // TODO: Send only for last pointer in case of multi-touch
+                    onOutsidePointerEvent?.invoke(PointerEventType.Release, null)
                 }
             }
             super.touchesEnded(touches, withEvent)
@@ -202,7 +207,7 @@ internal class UIViewComposeSceneLayer(
     }
 
     override fun setOutsidePointerEventListener(
-        onOutsidePointerEvent: ((eventType: PointerEventType) -> Unit)?
+        onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)?
     ) {
         this.onOutsidePointerEvent = onOutsidePointerEvent
     }


### PR DESCRIPTION
Fine tune #1280 change. The problem is some components like bottom sheet or navigation drawer define custom scrim and detect click on them via regular detection like `detectTapGestures` (that filters only primary mouse button). So to keep things consistent, we need to revert primary button filtering for `Dialog`, but keep it as-is for `Popup` to avoid breaking dropdowns,

## Testing

Unit test: `DialogTest`
Try to close `Popup` and `Dialog` by outside click via mouse buttons and touch.
This should be tested by QA

## Release Notes

### Fixes - Desktop
- _(prerelease fix)_ Fix inconsistency in closing `Dialog` by mouse clicking on scrim that was introduced by `1.6.10-beta02` 
