### PR TITLE
Use z-sorted traverse in `InteropContainer`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
@@ -71,14 +71,16 @@ internal class SwingInteropContainer(
         val component = nativeView.container
         val nonInteropComponents = container.componentCount - interopComponents.size
         // AWT uses the reverse order for drawing and events, so index = size - count
-        val index = interopComponents.size - countInteropComponentsBefore(nativeView)
-        interopComponents[component] = nativeView
-        container.remove(component)
-        container.add(component, if (placeInteropAbove) {
-            index
+        var index = interopComponents.size - countInteropComponentsBefore(nativeView)
+        if (!placeInteropAbove) {
+            index += nonInteropComponents
+        }
+        if (component in interopComponents) {
+            container.setComponentZOrder(component, index)
         } else {
-            index + nonInteropComponents
-        })
+            interopComponents[component] = nativeView
+            container.add(component, index)
+        }
 
         // Sometimes Swing displays the rest of interop views in incorrect order after adding,
         // so we need to force re-validate it.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
@@ -67,7 +67,7 @@ internal class SwingInteropContainer(
     override val interopViews: Set<InteropComponent>
         get() = interopComponents.values.toSet()
 
-    override fun placeInteropView(nativeView: InteropComponent) = SwingUtilities.invokeLater {
+    override fun placeInteropView(nativeView: InteropComponent) {
         val component = nativeView.container
         val nonInteropComponents = container.componentCount - interopComponents.size
         // AWT uses the reverse order for drawing and events, so index = size - count
@@ -86,7 +86,7 @@ internal class SwingInteropContainer(
         container.repaint()
     }
 
-    override fun removeInteropView(nativeView: InteropComponent) = SwingUtilities.invokeLater {
+    override fun removeInteropView(nativeView: InteropComponent) {
         val component = nativeView.container
         container.remove(component)
         interopComponents.remove(component)
@@ -97,7 +97,7 @@ internal class SwingInteropContainer(
         container.repaint()
     }
 
-    fun validateComponentsOrder() = SwingUtilities.invokeLater {
+    fun validateComponentsOrder() {
         container.validate()
         container.repaint()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.node
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.areObjectsOfSameType
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.OverlayLayout
 
 /**
@@ -30,7 +31,7 @@ internal interface InteropContainer<T> {
     var rootModifier: TrackInteropModifierNode<T>?
     val interopViews: Set<T>
 
-    fun addInteropView(nativeView: T)
+    fun placeInteropView(nativeView: T)
     fun removeInteropView(nativeView: T)
 }
 
@@ -42,57 +43,83 @@ internal interface InteropContainer<T> {
  */
 internal fun <T> InteropContainer<T>.countInteropComponentsBefore(nativeView: T): Int {
     var componentsBefore = 0
-    rootModifier?.visitSubtreeIf(Nodes.Traversable, zOrder = true) {
-        if (TRAVERSAL_NODE_KEY == it.traverseKey && areObjectsOfSameType(this, it)) {
-            @Suppress("UNCHECKED_CAST")
-            val interopModifierNode = it as TrackInteropModifierNode<T>
-            if (interopModifierNode.nativeView == nativeView) return componentsBefore
-
+    rootModifier?.traverseDescendantsInDrawOrder {
+        if (it.nativeView != nativeView) {
             // It might be inside Compose tree before adding in InteropContainer in case
             // if it was initiated out of scroll visible bounds for example.
             if (it.nativeView in interopViews) {
                 componentsBefore++
             }
+            true
+        } else {
+            false
         }
-        true
     }
     return componentsBefore
 }
 
+private fun <T> T.traverseDescendantsInDrawOrder(block: (T) -> Boolean) where T : TraversableNode {
+    visitSubtreeIf(Nodes.Traversable, zOrder = true) {
+        if (this.traverseKey == it.traverseKey && areObjectsOfSameType(this, it)) {
+            @Suppress("UNCHECKED_CAST")
+            if (!block(it as T)) return
+        }
+        true
+    }
+}
+
 /**
  * Wrapper of Compose content that might contain interop views. It adds a helper modifier to root
- * that allows to traverse interop views in the tree with the right order.
+ * that allows traversing interop views in the tree with the right order.
  */
 @Composable
 internal fun <T> InteropContainer<T>.TrackInteropContainer(content: @Composable () -> Unit) {
     OverlayLayout(
-        modifier = TrackInteropModifierElement { rootModifier = it },
+        modifier = RootTrackInteropModifierElement { rootModifier = it },
         content = content
     )
+}
+
+/**
+ * A helper modifier element to track interop views inside a [LayoutNode] hierarchy.
+ *
+ * @property onModifierNodeCreated An optional block of code that to receive the reference to
+ * [TrackInteropModifierNode].
+ */
+private data class RootTrackInteropModifierElement<T>(
+    val onModifierNodeCreated: (TrackInteropModifierNode<T>) -> Unit
+) : ModifierNodeElement<TrackInteropModifierNode<T>>() {
+    override fun create() = TrackInteropModifierNode<T>(
+        container = null,
+        nativeView = null
+    ).also {
+        onModifierNodeCreated.invoke(it)
+    }
+
+    override fun update(node: TrackInteropModifierNode<T>) {
+    }
 }
 
 /**
  * A helper modifier element that tracks an interop view inside a [LayoutNode] hierarchy.
  *
  * @property nativeView The native view associated with this modifier element.
- * @property onModifierNodeCreated An optional block of code that to receive the reference to
- * [TrackInteropModifierNode].
  * @param T The type of the native view.
  *
  * @see TrackInteropModifierNode
  * @see ModifierNodeElement
  */
 internal data class TrackInteropModifierElement<T>(
-    var nativeView: T? = null,
-    val onModifierNodeCreated: ((TrackInteropModifierNode<T>) -> Unit)? = null
+    var container: InteropContainer<T>,
+    var nativeView: T,
 ) : ModifierNodeElement<TrackInteropModifierNode<T>>() {
     override fun create() = TrackInteropModifierNode(
+        container = container,
         nativeView = nativeView
-    ).also {
-        onModifierNodeCreated?.invoke(it)
-    }
+    )
 
     override fun update(node: TrackInteropModifierNode<T>) {
+        node.container = container
         node.nativeView = nativeView
     }
 }
@@ -109,7 +136,13 @@ private const val TRAVERSAL_NODE_KEY =
  * @see TraversableNode
  */
 internal class TrackInteropModifierNode<T>(
-    var nativeView: T?
-) : Modifier.Node(), TraversableNode {
+    var container: InteropContainer<T>?,
+    var nativeView: T?,
+) : Modifier.Node(), TraversableNode, LayoutAwareModifierNode {
     override val traverseKey = TRAVERSAL_NODE_KEY
+
+    override fun onPlaced(coordinates: LayoutCoordinates) {
+        val nativeView = nativeView ?: return
+        container?.placeInteropView(nativeView)
+    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.skiko.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.node
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.areObjectsOfSameType
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.OverlayLayout
 
@@ -56,16 +55,6 @@ internal fun <T> InteropContainer<T>.countInteropComponentsBefore(nativeView: T)
         }
     }
     return componentsBefore
-}
-
-private fun <T> T.traverseDescendantsInDrawOrder(block: (T) -> Boolean) where T : TraversableNode {
-    visitSubtreeIf(Nodes.Traversable, zOrder = true) {
-        if (this.traverseKey == it.traverseKey && areObjectsOfSameType(this, it)) {
-            @Suppress("UNCHECKED_CAST")
-            if (!block(it as T)) return
-        }
-        true
-    }
 }
 
 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.skiko.kt
@@ -40,11 +40,11 @@ internal interface InteropContainer<T> {
  * @param nativeView The native view to count interop components before.
  * @return The number of interop components before the given native view.
  */
-internal fun <T> InteropContainer<T>.countInteropComponentsBefore(nativeView: T): Int {
+internal fun <T> InteropContainer<T>.countInteropComponentsBelow(nativeView: T): Int {
     var componentsBefore = 0
     rootModifier?.traverseDescendantsInDrawOrder {
         if (it.nativeView != nativeView) {
-            // It might be inside Compose tree before adding in InteropContainer in case
+            // It might be inside a Compose tree before adding in InteropContainer in case
             // if it was initiated out of scroll visible bounds for example.
             if (it.nativeView in interopViews) {
                 componentsBefore++

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/TraversableNodeInDrawOrder.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/TraversableNodeInDrawOrder.skiko.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.node
+
+import androidx.compose.runtime.collection.MutableVector
+import androidx.compose.runtime.collection.mutableVectorOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.areObjectsOfSameType
+
+internal fun <T> T.traverseDescendantsInDrawOrder(block: (T) -> Boolean) where T : TraversableNode {
+    visitSubtreeIf(Nodes.Traversable, zOrder = true) {
+        if (this.traverseKey == it.traverseKey && areObjectsOfSameType(this, it)) {
+            @Suppress("UNCHECKED_CAST")
+            if (!block(it as T)) return
+        }
+        true
+    }
+}
+
+// TODO: Remove a copy once aosp/3045224 merged
+
+private inline fun <reified T> DelegatableNode.visitSubtreeIf(
+    type: NodeKind<T>,
+    zOrder: Boolean = false,
+    block: (T) -> Boolean
+) = visitSubtreeIf(type.mask, zOrder) foo@{ node ->
+    node.dispatchForKind(type) {
+        if (!block(it)) return@foo false
+    }
+    true
+}
+
+private fun LayoutNode.getChildren(zOrder: Boolean) =
+    if (zOrder) {
+        zSortedChildren
+    } else {
+        _children
+    }
+
+private fun MutableVector<Modifier.Node>.addLayoutNodeChildren(
+    node: Modifier.Node,
+    zOrder: Boolean,
+) {
+    node.requireLayoutNode().getChildren(zOrder).forEachReversed {
+        add(it.nodes.head)
+    }
+}
+
+private inline fun DelegatableNode.visitSubtreeIf(
+    mask: Int,
+    zOrder: Boolean,
+    block: (Modifier.Node) -> Boolean
+) {
+    check(node.isAttached) { "visitSubtreeIf called on an unattached node" }
+    val branches = mutableVectorOf<Modifier.Node>()
+    val child = node.child
+    if (child == null)
+        branches.addLayoutNodeChildren(node, zOrder)
+    else
+        branches.add(child)
+    outer@ while (branches.isNotEmpty()) {
+        val branch = branches.removeAt(branches.size - 1)
+        if (branch.aggregateChildKindSet and mask != 0) {
+            var node: Modifier.Node? = branch
+            while (node != null) {
+                if (node.kindSet and mask != 0) {
+                    val diveDeeper = block(node)
+                    if (!diveDeeper) continue@outer
+                }
+                node = node.child
+            }
+        }
+        branches.addLayoutNodeChildren(branch, zOrder)
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitInteropContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitInteropContainer.uikit.kt
@@ -41,15 +41,22 @@ internal val LocalUIKitInteropContainer = staticCompositionLocalOf<UIKitInteropC
 /**
  * A container that controls interop views/components.
  */
-internal class UIKitInteropContainer: InteropContainer<UIView> {
+internal class UIKitInteropContainer(
+    private val interopContext: UIKitInteropContext
+): InteropContainer<UIView> {
     val containerView: UIView = UIKitInteropContainerView()
     override var rootModifier: TrackInteropModifierNode<UIView>? = null
     override var interopViews = mutableSetOf<UIView>()
         private set
 
-    override fun addInteropView(nativeView: UIView) {
+    override fun placeInteropView(nativeView: UIView) = interopContext.deferAction {
         val index = countInteropComponentsBefore(nativeView)
-        interopViews.add(nativeView)
+        if (nativeView in interopViews) {
+            // Place might be called multiple times
+            nativeView.removeFromSuperview()
+        } else {
+            interopViews.add(nativeView)
+        }
         containerView.insertSubview(nativeView, index.toLong())
     }
 
@@ -61,8 +68,8 @@ internal class UIKitInteropContainer: InteropContainer<UIView> {
 
 private class UIKitInteropContainerView: UIView(CGRectZero.readValue()) {
     /**
-     * We used simple solution to make only this view not touchable.
-     * Other view added to this container will be touchable.
+     * We used a simple solution to make only this view not touchable.
+     * Another view added to this container will be touchable.
      */
     override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? =
         super.hitTest(point, withEvent).takeIf {
@@ -76,7 +83,9 @@ private class UIKitInteropContainerView: UIView(CGRectZero.readValue()) {
  * @param view The [UIView] that matches the current node.
  */
 internal fun Modifier.trackUIKitInterop(
+    container: UIKitInteropContainer,
     view: UIView
 ): Modifier = this then TrackInteropModifierElement(
+    container = container,
     nativeView = view
 )

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitInteropContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitInteropContainer.uikit.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.node.InteropContainer
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.TrackInteropModifierElement
 import androidx.compose.ui.node.TrackInteropModifierNode
-import androidx.compose.ui.node.countInteropComponentsBefore
+import androidx.compose.ui.node.countInteropComponentsBelow
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGPoint
@@ -50,7 +50,7 @@ internal class UIKitInteropContainer(
         private set
 
     override fun placeInteropView(nativeView: UIView) = interopContext.deferAction {
-        val index = countInteropComponentsBefore(nativeView)
+        val index = countInteropComponentsBelow(nativeView)
         if (nativeView in interopViews) {
             // Place might be called multiple times
             nativeView.removeFromSuperview()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -182,7 +182,7 @@ fun <T : UIView> UIKitView(
         }.drawBehind {
             // Clear interop area to make visible the component under our canvas.
             drawRect(Color.Transparent, blendMode = BlendMode.Clear)
-        }.trackUIKitInterop(embeddedInteropComponent.wrappingView).let {
+        }.trackUIKitInterop(interopContainer, embeddedInteropComponent.wrappingView).let {
             if (interactive) {
                 it.then(InteropViewCatchPointerModifier())
             } else {
@@ -301,7 +301,7 @@ fun <T : UIViewController> UIKitViewController(
         }.drawBehind {
             // Clear interop area to make visible the component under our canvas.
             drawRect(Color.Transparent, blendMode = BlendMode.Clear)
-        }.trackUIKitInterop(embeddedInteropComponent.wrappingView).let {
+        }.trackUIKitInterop(interopContainer, embeddedInteropComponent.wrappingView).let {
             if (interactive) {
                 it.then(InteropViewCatchPointerModifier())
             } else {
@@ -359,7 +359,7 @@ private abstract class EmbeddedInteropComponent<T : Any>(
 
     protected fun addViewToHierarchy(view: UIView) {
         wrappingView.addSubview(view)
-        interopContainer.addInteropView(wrappingView)
+        // wrappingView will be added to the container from [onPlaced]
     }
 
     protected fun removeViewFromHierarchy(view: UIView) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -266,10 +266,15 @@ internal class ComposeSceneMediator(
      */
     private val rootView = ComposeSceneMediatorRootUIView()
 
+
+    private val interopContext = UIKitInteropContext(
+        requestRedraw = ::onComposeSceneInvalidate
+    )
+    
     /**
      * Container for UIKitView and UIKitViewController
      */
-    private val interopViewContainer = UIKitInteropContainer()
+    private val interopViewContainer = UIKitInteropContainer(interopContext)
 
     private val interactionBounds: IntRect get() {
         val boundsLayout = _layout as? SceneLayout.Bounds
@@ -290,12 +295,6 @@ internal class ComposeSceneMediator(
                 }
                 interactionBounds.contains(positionInContainer)
             }
-        )
-    }
-
-    private val interopContext: UIKitInteropContext by lazy {
-        UIKitInteropContext(
-            requestRedraw = ::onComposeSceneInvalidate
         )
     }
 


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/4485

## Testing

Use reproduction from the issue
This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Fix order of interop elements in some cases
