### PR TITLE
In tests, don't attempt to close the `ComposeScene` if it failed to create

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -191,8 +191,8 @@ class SkikoComposeUiTest @InternalTestApi constructor(
     }
 
     private fun <R> withScene(block: () -> R): R {
+        scene = runOnUiThread(::createUi)
         try {
-            scene = runOnUiThread(::createUi)
             return block()
         } finally {
             // Close the scene before calling testScope.runTest so that all the coroutines are


### PR DESCRIPTION
When `ComposeUiTest.createUi` throws an exception (from `withScene`) it does not currently propagate to the test runner, because in the `finally` block we throw a NPE attempting to close the scene.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4757

## Testing
- Tested by throwing an exception in `createUi` and verifying that the test fails with that exception.
