### PR TITLE
Fix a crash when UIKitView is used inside LayoutNode that merges its semantics config

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropViewAndSemanticsConfigMerge.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropViewAndSemanticsConfigMerge.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.unit.dp
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRectZero
+import platform.UIKit.UILabel
+
+val InteropViewAndSemanticsConfigMerge = Screen.Example("InteropViewAndSemanticsConfigMerge") {
+    Button(onClick = {
+        println("Clicked")
+    }) {
+        UIKitView(
+            factory = {
+                val view = UILabel(frame = CGRectZero.readValue())
+                view.text = "UILabel"
+                view
+            },
+            modifier = Modifier.size(80.dp, 40.dp)
+        )
+    }
+}

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropViewAndSemanticsConfigMerge.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropViewAndSemanticsConfigMerge.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
@@ -27,40 +28,42 @@ import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UILabel
 
 val InteropViewAndSemanticsConfigMerge = Screen.Example("InteropViewAndSemanticsConfigMerge") {
-    Button(onClick = {
-        println("Clicked")
-    }) {
-        UIKitView(
-            factory = {
-                val view = UILabel(frame = CGRectZero.readValue())
-                view.text = "UILabel"
-                view
-            },
-            modifier = Modifier.size(80.dp, 40.dp)
-        )
-    }
-
-    Button(onClick = {
-        println("Clicked")
-    }) {
-        Row {
+    Column {
+        Button(onClick = {
+            println("Clicked")
+        }) {
             UIKitView(
                 factory = {
                     val view = UILabel(frame = CGRectZero.readValue())
-                    view.text = "Illegal"
+                    view.text = "UILabel"
                     view
                 },
                 modifier = Modifier.size(80.dp, 40.dp)
             )
+        }
 
-            UIKitView(
-                factory = {
-                    val view = UILabel(frame = CGRectZero.readValue())
-                    view.text = "Merge"
-                    view
-                },
-                modifier = Modifier.size(80.dp, 40.dp)
-            )
+        Button(onClick = {
+            println("Clicked")
+        }) {
+            Row {
+                UIKitView(
+                    factory = {
+                        val view = UILabel(frame = CGRectZero.readValue())
+                        view.text = "Illegal"
+                        view
+                    },
+                    modifier = Modifier.size(80.dp, 40.dp)
+                )
+
+                UIKitView(
+                    factory = {
+                        val view = UILabel(frame = CGRectZero.readValue())
+                        view.text = "Merge"
+                        view
+                    },
+                    modifier = Modifier.size(80.dp, 40.dp)
+                )
+            }
         }
     }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropViewAndSemanticsConfigMerge.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropViewAndSemanticsConfigMerge.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.ui.Modifier
@@ -37,5 +38,29 @@ val InteropViewAndSemanticsConfigMerge = Screen.Example("InteropViewAndSemantics
             },
             modifier = Modifier.size(80.dp, 40.dp)
         )
+    }
+
+    Button(onClick = {
+        println("Clicked")
+    }) {
+        Row {
+            UIKitView(
+                factory = {
+                    val view = UILabel(frame = CGRectZero.readValue())
+                    view.text = "Illegal"
+                    view
+                },
+                modifier = Modifier.size(80.dp, 40.dp)
+            )
+
+            UIKitView(
+                factory = {
+                    val view = UILabel(frame = CGRectZero.readValue())
+                    view.text = "Merge"
+                    view
+                },
+                modifier = Modifier.size(80.dp, 40.dp)
+            )
+        }
     }
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
@@ -52,5 +52,6 @@ val IosSpecificFeatures = Screen.Selection(
     NativeModalWithNaviationExample,
     HapticFeedbackExample,
     LazyColumnWithInteropViewsExample,
-    AccessibilityLiveRegionExample
+    AccessibilityLiveRegionExample,
+    InteropViewAndSemanticsConfigMerge
 )

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -73,26 +73,23 @@ internal class InteropWrappingView: CMPInteropWrappingView(frame = CGRectZero.re
     }
 }
 
-private var hasIssuedInteropViewMergingWarning = false
 internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
     name = "InteropView",
     mergePolicy = { parentValue, childValue ->
         if (parentValue == null) {
             childValue
         } else {
-            if (!hasIssuedInteropViewMergingWarning) {
-                hasIssuedInteropViewMergingWarning = true
-                println(
-                    """
-                    Warning: multiple interop views are in the subtree of [SemanticsNode] that requires merging.
-                    Only the first found one can be seen by the accessibility system.
-                    It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true.
-                    It's needed to represent a group of elements (e.g. content of a button) as a single element.
-                    Merging multiple interop views is not supported.
-                    If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].
+            println(
+                """
+                    Warning: 
+                        Multiple interop views are in the subtree of [SemanticsNode] that requires merging.
+                        Only the first found one can be seen by the accessibility system.
+                        It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true.
+                        It's needed to represent a group of elements (e.g. content of a button) as a single element.
+                        Merging multiple interop views is not supported.
+                        If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].
                 """.trimIndent()
-                )
-            }
+            )
 
             parentValue
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -79,7 +79,10 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
         if (parentValue == null) {
             childValue
         } else {
-            println("Warning:  Multiple interop views are in the subtree of [SemanticsNode] that requires merging. It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true. Only the first found one can be seen by the accessibility system. It's needed to represent a group of elements (e.g. content of a button) as a single element. Merging multiple interop views is not supported. If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].")
+            println("Warning: Merging accessibility for multiple interop views is not supported. " +
+                "Multiple [UIKitView] are grouped under one node that should be represented as a single accessibility element." +
+                "It isn't recommended because the accessibility system can only recognize the first one. " +
+                "If you need multiple native views for accessibility, make sure to place them inside a single [UIKitView].")
 
             parentValue
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -79,7 +79,7 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
         if (parentValue == null) {
             childValue
         } else {
-            println("Warning: It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true. Multiple interop views are in the subtree of [SemanticsNode] that requires merging. Only the first found one can be seen by the accessibility system. It's needed to represent a group of elements (e.g. content of a button) as a single element. Merging multiple interop views is not supported. If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].")
+            println("Warning:  Multiple interop views are in the subtree of [SemanticsNode] that requires merging. It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true. Only the first found one can be seen by the accessibility system. It's needed to represent a group of elements (e.g. content of a button) as a single element. Merging multiple interop views is not supported. If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].")
 
             parentValue
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -79,22 +79,7 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
         if (parentValue == null) {
             childValue
         } else {
-            println(
-                """
-                +----------------------------------------------------------------------------------------------+
-                | WARNING                                                                                      |
-                |                                                                                              |  
-                | Multiple interop views are in the subtree of [SemanticsNode] that requires merging.          |
-                | It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set   |
-                | to true.                                                                                     |
-                | Only the first found one can be seen by the accessibility services.                          |
-                | It's needed to represent a group of elements (e.g. content of a button) as a single element. |
-                | Merging multiple interop views is not supported.                                             |
-                | If you still need multiple interop views for accessibility, consider constructing the        |
-                | hierarchy natively inside a single [UIKitView].                                              |
-                +----------------------------------------------------------------------------------------------+
-                """.trimIndent()
-            )
+            println("Warning: It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true. Multiple interop views are in the subtree of [SemanticsNode] that requires merging. Only the first found one can be seen by the accessibility system. It's needed to represent a group of elements (e.g. content of a button) as a single element. Merging multiple interop views is not supported. If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].")
 
             parentValue
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -85,9 +85,9 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
                 | WARNING                                                                                      |
                 |                                                                                              |  
                 | Multiple interop views are in the subtree of [SemanticsNode] that requires merging.          |
-                | Only the first found one can be seen by the accessibility system.                            |
                 | It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set   |
                 | to true.                                                                                     |
+                | Only the first found one can be seen by the accessibility services.                          |
                 | It's needed to represent a group of elements (e.g. content of a button) as a single element. |
                 | Merging multiple interop views is not supported.                                             |
                 | If you still need multiple interop views for accessibility, consider constructing the        |

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -81,18 +81,18 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
         } else {
             println(
                 """
-                +-------------------------------------------------------------------------------------------------+
-                |     WARNING                                                                                     |
-                |                                                                                                 |  
-                |     Multiple interop views are in the subtree of [SemanticsNode] that requires merging.         |
-                |     Only the first found one can be seen by the accessibility system.                           |
-                |     It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set  |
-                |     to true.                                                                                    |
-                |     It's needed to represent a group of elements (e.g. content of a button) as a single element.|
-                |     Merging multiple interop views is not supported.                                            |
-                |     If you still need multiple interop views for accessibility, consider constructing the       |
-                |     hierarchy natively inside a single [UIKitView].                                             |
-                +-------------------------------------------------------------------------------------------------+
+                +----------------------------------------------------------------------------------------------+
+                | WARNING                                                                                      |
+                |                                                                                              |  
+                | Multiple interop views are in the subtree of [SemanticsNode] that requires merging.          |
+                | Only the first found one can be seen by the accessibility system.                            |
+                | It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set   |
+                | to true.                                                                                     |
+                | It's needed to represent a group of elements (e.g. content of a button) as a single element. |
+                | Merging multiple interop views is not supported.                                             |
+                | If you still need multiple interop views for accessibility, consider constructing the        |
+                | hierarchy natively inside a single [UIKitView].                                              |
+                +----------------------------------------------------------------------------------------------+
                 """.trimIndent()
             )
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -86,9 +86,10 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
                     """
                     Warning: multiple interop views are in the subtree of [SemanticsNode] that requires merging.
                     Only the first found one can be seen by the accessibility system.
-                    It means that it's contained in a widget that has [shouldMergeDescendantSemantics] set to true.
+                    It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true.
                     It's needed to represent a group of elements (e.g. content of a button) as a single element.
                     Merging multiple interop views is not supported.
+                    If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].
                 """.trimIndent()
                 )
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -81,13 +81,18 @@ internal val InteropViewSemanticsKey = AccessibilityKey<InteropWrappingView>(
         } else {
             println(
                 """
-                    Warning: 
-                        Multiple interop views are in the subtree of [SemanticsNode] that requires merging.
-                        Only the first found one can be seen by the accessibility system.
-                        It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set to true.
-                        It's needed to represent a group of elements (e.g. content of a button) as a single element.
-                        Merging multiple interop views is not supported.
-                        If you still need multiple interop views for accessibility, consider constructing the hierarchy natively inside a single [UIKitView].
+                +-------------------------------------------------------------------------------------------------+
+                |     WARNING                                                                                     |
+                |                                                                                                 |  
+                |     Multiple interop views are in the subtree of [SemanticsNode] that requires merging.         |
+                |     Only the first found one can be seen by the accessibility system.                           |
+                |     It means that they are contained in a widget that has [shouldMergeDescendantSemantics] set  |
+                |     to true.                                                                                    |
+                |     It's needed to represent a group of elements (e.g. content of a button) as a single element.|
+                |     Merging multiple interop views is not supported.                                            |
+                |     If you still need multiple interop views for accessibility, consider constructing the       |
+                |     hierarchy natively inside a single [UIKitView].                                             |
+                +-------------------------------------------------------------------------------------------------+
                 """.trimIndent()
             )
 


### PR DESCRIPTION
Don't throw an exception on `InteropViewSemanticsKey.mergePolicy` invocation.
Issue a warning if `mergePolicy` is executed on two non-null properties with `InteropViewSemanticsKey`.
Proceed as usual, if `parent` property with `InteropViewSemanticsKey` is null.

Fixes [a crash](https://kotlinlang.slack.com/archives/C0346LWVBJ4/p1715002727858119) when UIKitView[Controller] API is used in LayoutNode that merges its semantics config and Accessibility sync is on.

## Testing

iOS demo app screen `LazyColumnWithInteropViewsExample` doesn't crash.

## Release Notes

### Fixes - iOS
- _(prerelease fix)_ Fixes a crash when `UIKitView` or `UIKitViewController` is inside a tree with `SemanticsModifierNode` having `shouldMergeDescendantSemantics = true` and Accessibility sync is on.
