### PR TITLE
Revert "Don't show code completion for non-existenst API in `commonMain` that fails on Android with `NoSuchMethodException`"

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
@@ -110,7 +110,7 @@ internal fun Project.publishAndroidxReference(target: AbstractKotlinTarget, newR
                 // required for publication.
                 val configurationName = usage.name + "-published"
                 configurations.matching { it.name == configurationName }.all { conf ->
-                    newRootComponent.addUsageFromConfiguration(conf, usage)
+                    newRootComponent.addUsageFromConfiguration(conf)
                 }
             }
         }
@@ -130,14 +130,14 @@ internal class CustomRootComponent(
 
     private val extraUsages = mutableSetOf<UsageContext>()
 
-    fun addUsageFromConfiguration(configuration: Configuration, defaultUsage: KotlinUsageContext) {
+    fun addUsageFromConfiguration(configuration: Configuration) {
         val newDependency = customizeDependencyPerConfiguration(configuration)
 
         extraUsages.add(
             CustomUsage(
                 name = configuration.name,
                 attributes = configuration.attributes,
-                dependencies = setOf(newDependency) + defaultUsage.dependencies
+                dependencies = setOf(newDependency)
             )
         )
     }


### PR DESCRIPTION
Reverts JetBrains/compose-multiplatform-core#1328

Test fail:
![image](https://github.com/JetBrains/compose-multiplatform-core/assets/5963351/6308e35c-5905-47cb-ba20-b83709b86a71)
https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_AllPersonalBuild/4609532?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildTestsSection=true&expandBuildDeploymentsSection=false&expandBuildChangesSection=true&expandBuildProblemsSection=true

I will fix and will merge again

