### PR TITLE
Call measureAndLayout again before draw

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
@@ -166,7 +167,18 @@ internal abstract class BaseComposeScene(
                 recomposer.scheduleAsEffect(updatePointerPosition)
             }
 
-            // Draw
+            // Between layout and draw, Android's Choreographer flushes the main dispatcher.
+            // We can't do quite that, but an important side effect of that is that the
+            // GlobalSnapshotManager gets to run and call `Snapshot.sendApplyNotifications()`, which
+            // we can (and must) do.
+            Snapshot.sendApplyNotifications()
+
+            // The drawing phase.
+            // Android calls these two before drawing (AndroidComposeView.dispatchDraw)
+            doMeasureAndLayout()
+            Snapshot.sendApplyNotifications()
+
+            // Actually draw
             snapshotInvalidationTracker.onDraw()
             draw(canvas)
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -429,7 +429,7 @@ private class MultiLayerComposeSceneImpl(
         onOwnerAppended(layer.owner)
 
         inputHandler.onPointerUpdate()
-        invalidateIfNeeded()
+        updateInvalidations()
     }
 
     private fun detachLayer(layer: AttachedComposeSceneLayer) {
@@ -440,7 +440,7 @@ private class MultiLayerComposeSceneImpl(
         onOwnerRemoved(layer.owner)
 
         inputHandler.onPointerUpdate()
-        invalidateIfNeeded()
+        updateInvalidations()
     }
 
     private fun requestFocus(layer: AttachedComposeSceneLayer) {
@@ -536,7 +536,7 @@ private class MultiLayerComposeSceneImpl(
                     releaseFocus(this)
                 }
                 inputHandler.onPointerUpdate()
-                invalidateIfNeeded()
+                updateInvalidations()
             }
 
         private val background: Modifier


### PR DESCRIPTION
Android currently does two things differently from CMP:
1. Between layout and draw, Android's Choreographer flushes the main dispatcher. We can't do quite that, but an important side effect of that is that the GlobalSnapshotManager gets to run and call `Snapshot.sendApplyNotifications()`, which we can do.
2. Right before drawing, `AndroidComposeView.dispatchDraw` calls `measureAndLayout` again, followed by `Snapshot.sendApplyNotifications()`.

This PR aligns the behavior of CMP with that of Android. 

## Testing
- Added a unit test that verifies measure and layout are being called again before drawing.