### PR TITLE
[web] KeyEvent resolved via code rather than keyCode

### DIFF
--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/input/key/Key.jsWasm.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/input/key/Key.jsWasm.kt
@@ -95,10 +95,10 @@ actual value class Key(val keyCode: Long) {
         actual val Nine = Key(57)
 
         /** '-' key. */
-        actual val Minus = Key(173)
+        actual val Minus = Key(189)
 
         /** '=' key. */
-        actual val Equals = Key(61)
+        actual val Equals = Key(187)
 
         /** 'A' key. */
         actual val A = Key(65)

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/input/key/KeyEvent.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/input/key/KeyEvent.web.kt
@@ -19,18 +19,6 @@ package androidx.compose.ui.input.key
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import org.w3c.dom.events.KeyboardEvent
 
-private fun Key(keyCode: Long, location: Int) = Key(
-    keyCode = if (location == KeyboardEvent.DOM_KEY_LOCATION_RIGHT) {
-        when (keyCode) {
-            Key.CtrlLeft.keyCode,
-            Key.ShiftLeft.keyCode,
-            Key.MetaLeft.keyCode -> keyCode or 0x80000000
-            else -> keyCode
-        }
-    } else {
-        keyCode
-    }
-)
 
 private fun KeyboardEvent.toInputModifiers(): PointerKeyboardModifiers {
     return PointerKeyboardModifiers(
@@ -41,16 +29,26 @@ private fun KeyboardEvent.toInputModifiers(): PointerKeyboardModifiers {
     )
 }
 
+private fun KeyboardEvent.resolveCodePoint(composeKey: Key): Int {
+    val isMeta = when (composeKey) {
+        Key.MetaLeft, Key.MetaRight, Key.AltLeft, Key.AltRight, Key.CtrlLeft, Key.CtrlRight -> true
+        else -> false
+    }
+
+    return if (key == code || isMeta) composeKey.keyCode.toInt() else key.codePointAt(0)
+}
+
 internal fun KeyboardEvent.toComposeEvent(): KeyEvent {
+    val composeKey = toKey()
     return KeyEvent(
         nativeKeyEvent = InternalKeyEvent(
-            key = Key(keyCode.toLong(), location),
+            key = composeKey,
             type = when (type) {
                 "keydown" -> KeyEventType.KeyDown
                 "keyup" -> KeyEventType.KeyUp
                 else -> KeyEventType.Unknown
             },
-            codePoint = key.codePointAt(0),
+            codePoint = resolveCodePoint(composeKey),
             modifiers = toInputModifiers(),
             nativeEvent = this
         )
@@ -79,4 +77,122 @@ internal fun String.codePointAt(index: Int): CodePoint {
         }
     }
     return high.code
+}
+
+private fun KeyboardEvent.toKey(): Key {
+    return when(code) {
+        "KeyA" -> Key.A
+        "KeyB" -> Key.B
+        "KeyC" -> Key.C
+        "KeyD" -> Key.D
+        "KeyE" -> Key.E
+        "KeyF" -> Key.F
+        "KeyG" -> Key.G
+        "KeyH" -> Key.H
+        "KeyI" -> Key.I
+        "KeyJ" -> Key.J
+        "KeyK" -> Key.K
+        "KeyL" -> Key.L
+        "KeyM" -> Key.M
+        "KeyN" -> Key.N
+        "KeyO" -> Key.O
+        "KeyP" -> Key.P
+        "KeyQ" -> Key.Q
+        "KeyR" -> Key.R
+        "KeyS" -> Key.S
+        "KeyT" -> Key.T
+        "KeyU" -> Key.U
+        "KeyV" -> Key.V
+        "KeyW" -> Key.W
+        "KeyX" -> Key.X
+        "KeyY" -> Key.Y
+        "KeyZ" -> Key.Z
+
+        "Digit0" -> Key.Zero
+        "Digit1" -> Key.One
+        "Digit2" -> Key.Two
+        "Digit3" -> Key.Three
+        "Digit4" -> Key.Four
+        "Digit5" -> Key.Five
+        "Digit6" -> Key.Six
+        "Digit7" -> Key.Seven
+        "Digit8" -> Key.Eight
+        "Digit9" -> Key.Nine
+
+        "Numpad0" -> Key.NumPad0
+        "Numpad1" -> Key.NumPad1
+        "Numpad2" -> Key.NumPad2
+        "Numpad3" -> Key.NumPad3
+        "Numpad4" -> Key.NumPad4
+        "Numpad5" -> Key.NumPad5
+        "Numpad6" -> Key.NumPad6
+        "Numpad7" -> Key.NumPad7
+        "Numpad8" -> Key.NumPad8
+        "Numpad9" -> Key.NumPad9
+
+        "NumpadDivide" -> Key.NumPadDivide
+        "NumpadMultiply" -> Key.NumPadMultiply
+        "NumpadSubtract" -> Key.NumPadSubtract
+        "NumpadAdd" -> Key.NumPadAdd
+        "NumpadEnter" -> Key.NumPadEnter
+        "NumpadEqual" -> Key.NumPadEquals
+        "NumpadDecimal" -> Key.NumPadDot
+
+        "NumLock" -> Key.NumLock
+
+        "Minus" -> Key.Minus
+        "Equal" -> Key.Equals
+        "Backspace" -> Key.Backspace
+        "BracketLeft" -> Key.LeftBracket
+        "BracketRight" -> Key.RightBracket
+        "Backslash" -> Key.Backslash
+        "Semicolon" -> Key.Semicolon
+        "Enter" -> Key.Enter
+        "Comma" -> Key.Comma
+        "Period" -> Key.Period
+        "Slash" -> Key.Slash
+
+        "ArrowLeft" -> Key.DirectionLeft
+        "ArrowUp" -> Key.DirectionUp
+        "ArrowRight" -> Key.DirectionRight
+        "ArrowDown" -> Key.DirectionDown
+
+        "Home" -> Key.MoveHome
+        "PageUp" -> Key.PageUp
+        "PageDown" -> Key.PageDown
+        "Delete" -> Key.Delete
+        "End" -> Key.MoveEnd
+
+        "Escape" -> Key.Escape
+
+        "Backquote" -> Key.Grave
+        "Tab" -> Key.Tab
+        "CapsLock" -> Key.CapsLock
+
+        "ShiftLeft" -> Key.ShiftLeft
+        "ControlLeft" -> Key.CtrlLeft
+        "AltLeft" -> Key.AltLeft
+        "MetaLeft" -> Key.MetaLeft
+
+        "ShiftRight" -> Key.ShiftRight
+        "ControlRight" -> Key.CtrlRight
+        "AltRight" -> Key.AltRight
+        "MetaRight" -> Key.MetaRight
+        "Insert" -> Key.Insert
+
+        "F1" -> Key.F1
+        "F2" -> Key.F2
+        "F3" -> Key.F3
+        "F4" -> Key.F4
+        "F5" -> Key.F5
+        "F6" -> Key.F6
+        "F7" -> Key.F7
+        "F8" -> Key.F8
+        "F9" -> Key.F9
+        "F10" -> Key.F10
+        "F11" -> Key.F11
+        "F12" -> Key.F12
+
+        else -> Key.Unknown
+    }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/KeyEventConversionTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/KeyEventConversionTests.kt
@@ -34,6 +34,8 @@ class KeyEventConversionTests {
 
     @Test
     fun standardKeyboardLayout() {
+        keyDownEvent("Escape", code = "Escape").assertEquivalence(key = Key.Escape)
+
         keyDownEvent("CapsLock", code = "CapsLock").assertEquivalence(key = Key.CapsLock)
         keyDownEvent("Tab", code = "Tab").assertEquivalence(key = Key.Tab)
         keyDownEvent("Enter", code = "Enter").assertEquivalence(key = Key.Enter)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/KeyEventConversionTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/KeyEventConversionTests.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.toComposeEvent
+import androidx.compose.ui.input.key.utf16CodePoint
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import org.w3c.dom.events.KeyboardEvent
+
+private fun KeyboardEvent.assertEquivalence(key: Key, codePoint: Int = key.keyCode.toInt()) {
+    val keyEvent = toComposeEvent()
+    assertEquals(actual = keyEvent.key, expected = key)
+    assertEquals(actual = keyEvent.utf16CodePoint, expected = codePoint)
+}
+
+class KeyEventConversionTests {
+
+    @Test
+    fun standardKeyboardConversionTest() {
+        keyDownEvent("CapsLock", code = "CapsLock").assertEquivalence(key = Key.CapsLock)
+        keyDownEvent("Tab", code = "Tab").assertEquivalence(key = Key.Tab)
+        keyDownEvent("Enter", code = "Enter").assertEquivalence(key = Key.Enter)
+
+        keyDownEvent("a", code = "KeyA").assertEquivalence(key = Key.A, codePoint = 97)
+        keyDownEvent("b", code = "KeyB").assertEquivalence(key = Key.B, codePoint = 98)
+        keyDownEvent("c", code = "KeyC").assertEquivalence(key = Key.C, codePoint = 99)
+        keyDownEvent("d", code = "KeyD").assertEquivalence(key = Key.D, codePoint = 100)
+        keyDownEvent("e", code = "KeyE").assertEquivalence(key = Key.E, codePoint = 101)
+        keyDownEvent("f", code = "KeyF").assertEquivalence(key = Key.F, codePoint = 102)
+        keyDownEvent("g", code = "KeyG").assertEquivalence(key = Key.G, codePoint = 103)
+        keyDownEvent("h", code = "KeyH").assertEquivalence(key = Key.H, codePoint = 104)
+        keyDownEvent("i", code = "KeyI").assertEquivalence(key = Key.I, codePoint = 105)
+        keyDownEvent("j", code = "KeyJ").assertEquivalence(key = Key.J, codePoint = 106)
+        keyDownEvent("k", code = "KeyK").assertEquivalence(key = Key.K, codePoint = 107)
+        keyDownEvent("l", code = "KeyL").assertEquivalence(key = Key.L, codePoint = 108)
+        keyDownEvent("m", code = "KeyM").assertEquivalence(key = Key.M, codePoint = 109)
+        keyDownEvent("n", code = "KeyN").assertEquivalence(key = Key.N, codePoint = 110)
+        keyDownEvent("o", code = "KeyO").assertEquivalence(key = Key.O, codePoint = 111)
+        keyDownEvent("p", code = "KeyP").assertEquivalence(key = Key.P, codePoint = 112)
+        keyDownEvent("q", code = "KeyQ").assertEquivalence(key = Key.Q, codePoint = 113)
+        keyDownEvent("r", code = "KeyR").assertEquivalence(key = Key.R, codePoint = 114)
+        keyDownEvent("s", code = "KeyS").assertEquivalence(key = Key.S, codePoint = 115)
+        keyDownEvent("t", code = "KeyT").assertEquivalence(key = Key.T, codePoint = 116)
+        keyDownEvent("u", code = "KeyU").assertEquivalence(key = Key.U, codePoint = 117)
+        keyDownEvent("v", code = "KeyV").assertEquivalence(key = Key.V, codePoint = 118)
+        keyDownEvent("w", code = "KeyW").assertEquivalence(key = Key.W, codePoint = 119)
+        keyDownEvent("x", code = "KeyX").assertEquivalence(key = Key.X, codePoint = 120)
+        keyDownEvent("y", code = "KeyY").assertEquivalence(key = Key.Y, codePoint = 121)
+        keyDownEvent("z", code = "KeyZ").assertEquivalence(key = Key.Z, codePoint = 122)
+
+        keyDownEvent("`", code = "Backquote").assertEquivalence(key = Key.Grave, codePoint = 96)
+        keyDownEvent("0", code = "Digit0").assertEquivalence(key = Key.Zero)
+        keyDownEvent("1", code = "Digit1").assertEquivalence(key = Key.One)
+        keyDownEvent("2", code = "Digit2").assertEquivalence(key = Key.Two)
+        keyDownEvent("3", code = "Digit3").assertEquivalence(key = Key.Three)
+        keyDownEvent("4", code = "Digit4").assertEquivalence(key = Key.Four)
+        keyDownEvent("5", code = "Digit5").assertEquivalence(key = Key.Five)
+        keyDownEvent("6", code = "Digit6").assertEquivalence(key = Key.Six)
+        keyDownEvent("7", code = "Digit7").assertEquivalence(key = Key.Seven)
+        keyDownEvent("8", code = "Digit8").assertEquivalence(key = Key.Eight)
+        keyDownEvent("9", code = "Digit9").assertEquivalence(key = Key.Nine)
+
+        keyDownEvent("0", code = "Digit0").assertEquivalence(key = Key.Zero)
+        keyDownEvent("1", code = "Digit1").assertEquivalence(key = Key.One)
+        keyDownEvent("2", code = "Digit2").assertEquivalence(key = Key.Two)
+        keyDownEvent("3", code = "Digit3").assertEquivalence(key = Key.Three)
+        keyDownEvent("4", code = "Digit4").assertEquivalence(key = Key.Four)
+        keyDownEvent("5", code = "Digit5").assertEquivalence(key = Key.Five)
+        keyDownEvent("6", code = "Digit6").assertEquivalence(key = Key.Six)
+        keyDownEvent("7", code = "Digit7").assertEquivalence(key = Key.Seven)
+        keyDownEvent("8", code = "Digit8").assertEquivalence(key = Key.Eight)
+        keyDownEvent("9", code = "Digit9").assertEquivalence(key = Key.Nine)
+
+        keyDownEvent("0", code = "Numpad0").assertEquivalence(key = Key.NumPad0, codePoint = 48)
+        keyDownEvent("1", code = "Numpad1").assertEquivalence(key = Key.NumPad1, codePoint = 49)
+        keyDownEvent("2", code = "Numpad2").assertEquivalence(key = Key.NumPad2, codePoint = 50)
+        keyDownEvent("3", code = "Numpad3").assertEquivalence(key = Key.NumPad3, codePoint = 51)
+        keyDownEvent("4", code = "Numpad4").assertEquivalence(key = Key.NumPad4, codePoint = 52)
+        keyDownEvent("5", code = "Numpad5").assertEquivalence(key = Key.NumPad5, codePoint = 53)
+        keyDownEvent("6", code = "Numpad6").assertEquivalence(key = Key.NumPad6, codePoint = 54)
+        keyDownEvent("7", code = "Numpad7").assertEquivalence(key = Key.NumPad7, codePoint = 55)
+        keyDownEvent("8", code = "Numpad8").assertEquivalence(key = Key.NumPad8, codePoint = 56)
+        keyDownEvent("9", code = "Numpad9").assertEquivalence(key = Key.NumPad9, codePoint = 57)
+
+        keyDownEvent("=", code = "NumpadEqual").assertEquivalence(key = Key.NumPadEquals, codePoint = 61)
+        keyDownEvent("/", code = "NumpadDivide").assertEquivalence(key = Key.NumPadDivide, codePoint = 47)
+        keyDownEvent("*", code = "NumpadMultiply").assertEquivalence(key = Key.NumPadMultiply, codePoint = 42)
+        keyDownEvent("-", code = "NumpadSubtract").assertEquivalence(key = Key.NumPadSubtract, codePoint = 45)
+        keyDownEvent("+", code = "NumpadAdd").assertEquivalence(key = Key.NumPadAdd, codePoint = 43)
+        //keyDownEvent("Enter", code = "NumpadEnter").assertEquivalence(key = Key.NumPadEnter, codePoint = 13)
+        keyDownEvent(".", code = "NumpadDecimal").assertEquivalence(key = Key.NumPadDot, codePoint = 46)
+
+        keyDownEvent("Backspace", code = "Backspace").assertEquivalence(key = Key.Backspace)
+        keyDownEvent("Delete", code = "Delete").assertEquivalence(key = Key.Delete)
+
+        keyDownEvent("[", code = "BracketLeft").assertEquivalence(key = Key.LeftBracket, codePoint = 91)
+        keyDownEvent("]", code = "BracketRight").assertEquivalence(key = Key.RightBracket, codePoint = 93)
+        keyDownEvent("\\", code = "Backslash").assertEquivalence(key = Key.Backslash, codePoint = 92)
+
+        keyDownEvent("Home", code = "Home").assertEquivalence(key = Key.MoveHome)
+        keyDownEvent("End", code = "End").assertEquivalence(key = Key.MoveEnd)
+        keyDownEvent("PageUp", code = "PageUp").assertEquivalence(key = Key.PageUp)
+        keyDownEvent("PageDown", code = "PageDown").assertEquivalence(key = Key.PageDown)
+
+
+        keyDownEvent("ShiftLeft", code = "ShiftLeft").assertEquivalence(key = Key.ShiftLeft)
+        keyDownEvent("ShiftRight", code = "ShiftRight").assertEquivalence(key = Key.ShiftRight)
+
+        keyDownEvent("Control", code = "ControlLeft").assertEquivalence(key = Key.CtrlLeft)
+        keyDownEvent("Control", code = "ControlRight").assertEquivalence(key = Key.CtrlRight)
+
+        keyDownEvent("Meta", code = "MetaLeft").assertEquivalence(key = Key.MetaLeft)
+        keyDownEvent("Meta", code = "MetaRight").assertEquivalence(key = Key.MetaRight)
+        keyDownEvent("-", code = "Minus").assertEquivalence(key = Key.Minus, codePoint = 45)
+        keyDownEvent("=", code = "Equal").assertEquivalence(key = Key.Equals, codePoint = 61)
+        keyDownEvent(";", code = "Semicolon").assertEquivalence(key = Key.Semicolon, codePoint = 59)
+
+        keyDownEvent(",", code = "Comma").assertEquivalence(key = Key.Comma, codePoint = 44)
+        keyDownEvent(".", code = "Period").assertEquivalence(key = Key.Period, codePoint = 46)
+        keyDownEvent("/", code = "Slash").assertEquivalence(key = Key.Slash, codePoint = 47)
+
+        keyDownEvent("/", code = "Slash").assertEquivalence(key = Key.Slash, codePoint = 47)
+
+        keyDownEvent("Alt", code = "AltLeft").assertEquivalence(key = Key.AltLeft)
+        keyDownEvent("Alt", code = "AltRight").assertEquivalence(key = Key.AltRight)
+
+        keyDownEvent("ArrowUp", code = "ArrowUp").assertEquivalence(key = Key.DirectionUp)
+        keyDownEvent("ArrowRight", code = "ArrowRight").assertEquivalence(key = Key.DirectionRight)
+        keyDownEvent("ArrowDown", code = "ArrowDown").assertEquivalence(key = Key.DirectionDown)
+        keyDownEvent("ArrowLeft", code = "ArrowLeft").assertEquivalence(key = Key.DirectionLeft)
+
+        keyDownEvent("CapsLock", code = "CapsLock").assertEquivalence(key = Key.CapsLock)
+
+        keyDownEvent("F1", code = "F1").assertEquivalence(key = Key.F1)
+        keyDownEvent("F2", code = "F2").assertEquivalence(key = Key.F2)
+        keyDownEvent("F3", code = "F3").assertEquivalence(key = Key.F3)
+        keyDownEvent("F4", code = "F4").assertEquivalence(key = Key.F4)
+        keyDownEvent("F5", code = "F5").assertEquivalence(key = Key.F5)
+        keyDownEvent("F6", code = "F6").assertEquivalence(key = Key.F6)
+        keyDownEvent("F7", code = "F7").assertEquivalence(key = Key.F7)
+        keyDownEvent("F8", code = "F8").assertEquivalence(key = Key.F8)
+        keyDownEvent("F9", code = "F9").assertEquivalence(key = Key.F9)
+        keyDownEvent("F10", code = "F10").assertEquivalence(key = Key.F10)
+        keyDownEvent("F11", code = "F11").assertEquivalence(key = Key.F11)
+        keyDownEvent("F12", code = "F12").assertEquivalence(key = Key.F12)
+    }
+
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/KeyEventConversionTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/KeyEventConversionTests.kt
@@ -33,7 +33,7 @@ private fun KeyboardEvent.assertEquivalence(key: Key, codePoint: Int = key.keyCo
 class KeyEventConversionTests {
 
     @Test
-    fun standardKeyboardConversionTest() {
+    fun standardKeyboardLayout() {
         keyDownEvent("CapsLock", code = "CapsLock").assertEquivalence(key = Key.CapsLock)
         keyDownEvent("Tab", code = "Tab").assertEquivalence(key = Key.Tab)
         keyDownEvent("Enter", code = "Enter").assertEquivalence(key = Key.Enter)
@@ -161,5 +161,51 @@ class KeyEventConversionTests {
         keyDownEvent("F11", code = "F11").assertEquivalence(key = Key.F11)
         keyDownEvent("F12", code = "F12").assertEquivalence(key = Key.F12)
     }
+
+    @Test
+    fun standardKeyboardLayoutUpper() {
+
+        keyDownEvent("A", code = "KeyA").assertEquivalence(key = Key.A)
+        keyDownEvent("B", code = "KeyB").assertEquivalence(key = Key.B)
+        keyDownEvent("C", code = "KeyC").assertEquivalence(key = Key.C)
+        keyDownEvent("D", code = "KeyD").assertEquivalence(key = Key.D)
+        keyDownEvent("E", code = "KeyE").assertEquivalence(key = Key.E)
+        keyDownEvent("F", code = "KeyF").assertEquivalence(key = Key.F)
+        keyDownEvent("G", code = "KeyG").assertEquivalence(key = Key.G)
+        keyDownEvent("H", code = "KeyH").assertEquivalence(key = Key.H)
+        keyDownEvent("I", code = "KeyI").assertEquivalence(key = Key.I)
+        keyDownEvent("J", code = "KeyJ").assertEquivalence(key = Key.J)
+        keyDownEvent("K", code = "KeyK").assertEquivalence(key = Key.K)
+        keyDownEvent("L", code = "KeyL").assertEquivalence(key = Key.L)
+        keyDownEvent("M", code = "KeyM").assertEquivalence(key = Key.M)
+        keyDownEvent("N", code = "KeyN").assertEquivalence(key = Key.N)
+        keyDownEvent("O", code = "KeyO").assertEquivalence(key = Key.O)
+        keyDownEvent("P", code = "KeyP").assertEquivalence(key = Key.P)
+        keyDownEvent("Q", code = "KeyQ").assertEquivalence(key = Key.Q)
+        keyDownEvent("R", code = "KeyR").assertEquivalence(key = Key.R)
+        keyDownEvent("S", code = "KeyS").assertEquivalence(key = Key.S)
+        keyDownEvent("T", code = "KeyT").assertEquivalence(key = Key.T)
+        keyDownEvent("U", code = "KeyU").assertEquivalence(key = Key.U)
+        keyDownEvent("V", code = "KeyV").assertEquivalence(key = Key.V)
+        keyDownEvent("W", code = "KeyW").assertEquivalence(key = Key.W)
+        keyDownEvent("X", code = "KeyX").assertEquivalence(key = Key.X)
+        keyDownEvent("Y", code = "KeyY").assertEquivalence(key = Key.Y)
+        keyDownEvent("Z", code = "KeyZ").assertEquivalence(key = Key.Z)
+
+        keyDownEvent("~", code = "Backquote").assertEquivalence(key = Key.Grave, codePoint = 126)
+        keyDownEvent(")", code = "Digit0").assertEquivalence(key = Key.Zero, codePoint = 41)
+        keyDownEvent("!", code = "Digit1").assertEquivalence(key = Key.One, codePoint = 33)
+        keyDownEvent("@", code = "Digit2").assertEquivalence(key = Key.Two, codePoint = 64)
+        keyDownEvent("#", code = "Digit3").assertEquivalence(key = Key.Three, codePoint = 35)
+        keyDownEvent("$", code = "Digit4").assertEquivalence(key = Key.Four, codePoint = 36)
+        keyDownEvent("%", code = "Digit5").assertEquivalence(key = Key.Five, codePoint = 37)
+        keyDownEvent("^", code = "Digit6").assertEquivalence(key = Key.Six, codePoint = 94)
+        keyDownEvent("&", code = "Digit7").assertEquivalence(key = Key.Seven, codePoint = 38)
+        keyDownEvent("*", code = "Digit8").assertEquivalence(key = Key.Eight, codePoint = 42)
+        keyDownEvent("(", code = "Digit9").assertEquivalence(key = Key.Nine, codePoint = 40)
+        keyDownEvent("_", code = "Minus").assertEquivalence(key = Key.Minus, codePoint = 95)
+        keyDownEvent("+", code = "Equal").assertEquivalence(key = Key.Equals, codePoint = 43)
+    }
+
 
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/keydownEvent.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/keydownEvent.kt
@@ -29,8 +29,8 @@ private fun KeyboardEventInit.withKeyCode() = (this as KeyboardEventInitExtended
 }
 
 internal fun keyDownEvent(
-    c: String,
-    code: String = "Key${c.uppercase()}",
+    key: String,
+    code: String = "Key${key.uppercase()}",
     ctrlKey: Boolean = false,
     metaKey: Boolean = false,
     altKey: Boolean = false,
@@ -38,7 +38,7 @@ internal fun keyDownEvent(
     cancelable: Boolean = true
 ): KeyboardEvent =
     KeyboardEventInit(
-        key = c,
+        key = key,
         code = code,
         ctrlKey = ctrlKey,
         metaKey = metaKey,
@@ -51,14 +51,14 @@ internal fun keyDownEvent(
 
 
 internal fun keyDownEvent(
-    c: Char = 'c',
-    code: String = "Key${c.uppercase()}",
+    key: Char = 'c',
+    code: String = "Key${key.uppercase()}",
     ctrlKey: Boolean = false,
     metaKey: Boolean = false,
     altKey: Boolean = false,
     shiftKey: Boolean = false,
     cancelable: Boolean = true
-) = keyDownEvent("$c", code, ctrlKey, metaKey, altKey, shiftKey, cancelable)
+) = keyDownEvent("$key", code, ctrlKey, metaKey, altKey, shiftKey, cancelable)
 
 internal fun keyDownEventUnprevented(): KeyboardEvent =
     KeyboardEventInit(ctrlKey = true, cancelable = true, key = "Control")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/CanvasBasedWindowTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/CanvasBasedWindowTests.kt
@@ -44,7 +44,6 @@ import kotlin.test.AfterTest
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.assertFalse
-import kotlinx.browser.window
 
 class CanvasBasedWindowTests {
 
@@ -99,7 +98,7 @@ class CanvasBasedWindowTests {
         assertFalse(stack.last())
 
         // copy shortcut should not be prevented (we let browser create a corresponding event)
-        canvasElement.dispatchEvent(keyDownEvent(c = 'c', metaKey = true, ctrlKey = true))
+        canvasElement.dispatchEvent(keyDownEvent(key = 'c', metaKey = true, ctrlKey = true))
         assertEquals(3, stack.size)
         assertFalse(stack.last())
     }
@@ -147,7 +146,7 @@ class CanvasBasedWindowTests {
         )
 
         ('0'..'9').forEachIndexed { index, c ->
-            canvasElement.dispatchEvent(keyDownEvent(c))
+            canvasElement.dispatchEvent(keyDownEvent(c, "Digit${index}"))
             assertEquals(listOfNumbers[index], k)
         }
     }


### PR DESCRIPTION
This PR has two main goals:

* Don't use KeyboardEvent::keyCode for resolving compose Key (reason - keyCode is deprecated)
* Fix codePoint resolution (still non-ideal but fixes a lot of issues like resolving codePoint for Backspace as "B".toChar()
