### PR TITLE
Report the role of `ComposeSceneAccessible` on macOS as PANEL

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -55,7 +55,7 @@ internal class ComposeWindowPanel(
         window = window,
         useSwingGraphics = false,
         layerType = ComposeFeatureFlags.layerType.let {
-            // LayerType.OnComponent might be used only with rendering to Swing graphics,
+            // LayerType.OnComponent may can only be used with rendering via Swing graphics,
             // but it's always disabled here. Using fallback instead of [check] to support
             // opening separate windows from [ComposePanel] with such layer type.
             if (it == LayerType.OnComponent) LayerType.OnSameCanvas else it

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -21,6 +21,8 @@ import java.awt.*
 import java.awt.event.FocusListener
 import java.util.*
 import javax.accessibility.*
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
 
 /**
  * This is a root [Accessible] for a [androidx.compose.ui.ComposeScene]
@@ -153,7 +155,16 @@ internal class ComposeSceneAccessible(
         }
 
         override fun getAccessibleRole(): AccessibleRole {
-            return AccessibleRole.UNKNOWN
+            // We want to return a role that makes the ComposeScene container "transparent" to
+            // accessibility, as if its contents are inside the parent directly.
+            // On macOS, PANEL is ignored by Java's a11y (see CAccessibility.ignoredRoles), but on
+            // Windows, it makes NVDA read it as "panel".
+            // On Windows, NVDA ignores UNKNOWN, but on macOS UNKNOWN causes VoiceOver to highlight
+            // the entire component when traversing via VoiceOver shortcuts.
+            return when (hostOs) {
+                OS.MacOS -> AccessibleRole.PANEL
+                else -> AccessibleRole.UNKNOWN
+            }
         }
 
         override fun getAccessibleStateSet(): AccessibleStateSet {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -183,7 +183,7 @@ internal class ComposeContainer(
         this.windowContainer = windowContainer
 
         if (layerType == LayerType.OnComponent && !useSwingGraphics) {
-            error("Unsupported LayerType.OnComponent might be used only with rendering to Swing graphics")
+            error("LayerType.OnComponent can only be used with rendering via Swing graphics")
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -66,6 +66,8 @@ import androidx.compose.ui.scene.ComposeSceneInputHandler
 import androidx.compose.ui.scene.ComposeScenePointer
 import androidx.compose.ui.semantics.EmptySemanticsElement
 import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.text.input.TextInputService
 import androidx.compose.ui.unit.Constraints
@@ -117,6 +119,11 @@ internal class RootNodeOwner(
             platformContext.inputModeManager.requestInputMode(InputMode.Keyboard)
             // Consume the key event if we moved focus.
             focusOwner.moveFocus(focusDirection)
+        }
+        .semantics {
+            // This makes the reported role of the root node "PANEL", which is ignored by VoiceOver
+            // (which is what we want).
+            isTraversalGroup = true
         }
     val owner: Owner = OwnerImpl(layoutDirection, coroutineContext)
     val semanticsOwner = SemanticsOwner(owner.root)


### PR DESCRIPTION
Report the role of `ComposeSceneAccessible` (only on macOS) and the root `LayoutNode` as PANEL, allowing them to be ignored when accessible elements are presented to the user.

Fixes https://youtrack.jetbrains.com/issue/COMPOSE-1398/Make-ComposePanel-transparent-to-accessibility

## Testing
Run the app below on macOS, turn on VoiceOver and traverse the accessible elements via VoiceOver shortcuts (ctrl-opt-right/left). The selection should move correctly inside the ComposePanel into the Compose button.
```
fun main() {
    SwingUtilities.invokeLater {
        val frame = JFrame()
        val panel = JPanel(GridLayout(3, 1))
        frame.contentPane.add(panel)

        panel.add(JPanel().apply {
            add(JButton("Swing Button 1"))
        })
        panel.add(ComposePanel().apply {
            setContent {
                Column {
                    Button(onClick = {}) { Text("Compose Button") }
                }
            }
        })
        panel.add(JPanel(GridLayout(2, 1)).apply {
            add(JButton("Swing Button 2"))
        })
        frame.size = Dimension(400, 500)
        frame.isVisible = true
    }
}
```

This could be tested by QA

## Release Notes
### Fixes - Desktop
- When using `ComposePanel` inside a Swing application on macOS, VoiceOver will now correctly go into the `ComposePanel` when traversing accessible elements.
