### PR TITLE
Fix `ComposePanel` focus traversal on windows with nvda (Windows)

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -470,8 +470,6 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public fun hasFocus ()Z
 	public final fun isDisposeOnRemove ()Z
 	public fun isFocusOwner ()Z
-	public fun isFocusable ()Z
-	public fun isRequestFocusEnabled ()Z
 	public fun remove (Ljava/awt/Component;)V
 	public fun removeFocusListener (Ljava/awt/event/FocusListener;)V
 	public fun removeNotify ()V

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -80,11 +80,10 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             override fun getDefaultComponent(aContainer: Container?) = null
         }
         isFocusCycleRoot = true
+        isFocusable = true
     }
 
     private val _focusListeners = mutableSetOf<FocusListener?>()
-    private var _isFocusable = true
-    private var _isRequestFocusEnabled = false
 
     private var _composeContainer: ComposeContainer? = null
     private var _composeContent: (@Composable () -> Unit)? = null
@@ -201,8 +200,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         ).apply {
             focusManager.releaseFocus()
             setBounds(0, 0, width, height)
-            contentComponent.isFocusable = _isFocusable
-            contentComponent.isRequestFocusEnabled = _isRequestFocusEnabled
+            contentComponent.isFocusable = isFocusable
+            contentComponent.isRequestFocusEnabled = isRequestFocusEnabled
             exceptionHandler = this@ComposePanel.exceptionHandler
 
             _focusListeners.forEach(contentComponent::addFocusListener)
@@ -262,17 +261,13 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         _focusListeners.remove(l)
     }
 
-    override fun isFocusable() = _isFocusable
-
     override fun setFocusable(focusable: Boolean) {
-        _isFocusable = focusable
+        super.setFocusable(focusable)
         _composeContainer?.contentComponent?.isFocusable = focusable
     }
 
-    override fun isRequestFocusEnabled(): Boolean = _isRequestFocusEnabled
-
     override fun setRequestFocusEnabled(requestFocusEnabled: Boolean) {
-        _isRequestFocusEnabled = requestFocusEnabled
+        super.setRequestFocusEnabled(requestFocusEnabled)
         _composeContainer?.contentComponent?.isRequestFocusEnabled = requestFocusEnabled
     }
 


### PR DESCRIPTION
`ComposePanel` keeps its own `_isFocusable` and `_isRequestFocusEnabled` flags, and doesn't call the superclass' methods on `setFocusable` and `setRequestFocusEnabled`. Unfortunately Swing is not a well-behaved object-oriented library, and calling the superclass' methods has side effects which are needed.

`Component.setFocusable` sets an `isFocusTraversableOverridden` flag which is consulted when determining the "next" focusable component (see `DefaultFocusTraversalPolicy.accept()`).  This flag's value is, by default, `FOCUS_TRAVERSABLE_UNKNOWN`, causing `isFocusTraversableOverridden()` to return `true`, which causes the `ComposePanel` to be accepted by `DefaultFocusTraversalPolicy.accept()`.

_**When NVDA is turned on, however, the accessibility system calls `ComposePanel.isFocusTraversable`, which sets this flag to `FOCUS_TRAVERSABLE_DEFAULT`, causing `isFocusTraversableOverridden()` to return `false`, which causes `DefaultFocusTraversalPolicy.accept()` to reject the `ComposePanel`.**_ If `Component.setFocusable` has been called before that, this doesn't happen because the flag is set with:
```
        if (isFocusTraversableOverridden == FOCUS_TRAVERSABLE_UNKNOWN) {
            isFocusTraversableOverridden = FOCUS_TRAVERSABLE_DEFAULT;
        }
```

An alternative solution here would be for `ComposePanel` to override `isFocusTraversable` in addition to `isFocusable`, thus preventing the `isFocusTraversableOverridden` from being set. This would be a less disruptive change, but I think the more correct way is to call the superclass' methods, as they have additional side effects (`setFocusable` fires a property change, for example).

Fixes https://youtrack.jetbrains.com/issue/COMPOSE-1398/Make-ComposePanel-transparent-to-accessibility

## Testing
Run the app below on Windows, with NVDA turned on, and try traversing the buttons using (ctrl)-shift-tab.
Before this PR, the focus would jump only between the Swing buttons. After it, it will correctly go onto the Compose Button.
```
fun main() {
    SwingUtilities.invokeLater {
        val frame = JFrame()
        val panel = JPanel(GridLayout(3, 1))
        frame.contentPane.add(panel)

        panel.add(JPanel().apply {
            add(JButton("Swing Button 1"))
        })
        panel.add(ComposePanel().apply {
            setContent {
                Column {
                    Button(onClick = {}) { Text("Compose Button") }
                }
            }
        })
        panel.add(JPanel(GridLayout(2, 1)).apply {
            add(JButton("Swing Button 2"))
        })
        frame.size = Dimension(400, 500)
        frame.isVisible = true
    }
}
```
This could be tested by QA

## Release Notes
### Fixes - Desktop
- When using `ComposePanel` inside a Swing application on Windows with NVDA turned on, focus will now correctly go into the `ComposePanel` when traversing with (ctrl)-shift-tab.
