### PR TITLE
Avoid double `then` on applying modifier

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -98,7 +98,7 @@ private var SemanticsPropertyReceiver.interopView by InteropViewSemanticsKey
  */
 private fun Modifier.interopSemantics(enabled: Boolean, wrappingView: InteropWrappingView): Modifier =
     if (enabled) {
-        this then semantics {
+        this.semantics {
             interopView = wrappingView
         }
     } else {


### PR DESCRIPTION
Fix regression after #1350

Before | After
---|---
![Simulator Screenshot - iPhone 15 Plus - 2024-05-22 at 13 03 14](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/533b0841-1518-4b34-8427-56bdf9fff3b8) | ![Simulator Screenshot - iPhone 15 Plus - 2024-05-22 at 12 58 33](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/6a5d554f-d132-4c30-9488-8b027549b15b)
