### PR TITLE
FlushCoroutineDispatcher fixes

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -49,6 +49,7 @@ internal class FlushCoroutineDispatcher(
     @Volatile
     private var isPerformingRun = false
     private val runLock = createSynchronizedObject()
+    
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         synchronized(tasksLock) {
             tasks.add(block)
@@ -64,12 +65,13 @@ internal class FlushCoroutineDispatcher(
             }
         }
     }
+
     /**
-     * Does the dispatcher have any tasks scheduled or currently in progress
+     * Whether the dispatcher has any tasks scheduled or currently running.
      */
     fun hasTasks() = synchronized(tasksLock) {
         tasks.isNotEmpty() || delayedTasks.isNotEmpty()
-    } && !isPerformingRun
+    } || isPerformingRun
 
     /**
      * Perform all scheduled tasks and wait for the tasks which are already

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -42,10 +42,10 @@ internal class FlushCoroutineDispatcher(
     // use this dispatcher won't be properly cancelled.
     // TODO replace it by scope.coroutineContext[CoroutineDispatcher] when it will be no longer experimental
     private val scope = CoroutineScope(scope.coroutineContext.minusKey(Job))
-    private var immediateTasks = mutableSetOf<Runnable>()
-    private val delayedTasks = mutableSetOf<Runnable>()
+    private var immediateTasks = ArrayDeque<Runnable>()
+    private val delayedTasks = ArrayDeque<Runnable>()
     private val tasksLock = createSynchronizedObject()
-    private var immediateTasksSwap = mutableSetOf<Runnable>()
+    private var immediateTasksSwap = ArrayDeque<Runnable>()
     @Volatile
     private var isPerformingRun = false
     private val runLock = createSynchronizedObject()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -111,21 +111,21 @@ internal class FlushCoroutineDispatcher(
             delayedTasks.add(block)
         }
         val job = scope.launch {
-            try{
-                kotlinx.coroutines.delay(timeMillis)
-            } finally {
-                performRun {
-                    val isTaskAlive = synchronized(tasksLock) {
-                        delayedTasks.remove(block)
-                    }
-                    if (isTaskAlive) {
-                        block.run()
-                    }
+            kotlinx.coroutines.delay(timeMillis)
+            performRun {
+                val isTaskAlive = synchronized(tasksLock) {
+                    delayedTasks.remove(block)
+                }
+                if (isTaskAlive) {
+                    block.run()
                 }
             }
         }
         continuation.invokeOnCancellation {
             job.cancel()
+            synchronized(tasksLock) {
+                delayedTasks.remove(block)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR includes several small fixes/changes of `FlushCoroutineDispatcher`:
- Fix `hasTasks()` to return `true` while tasks are being performed, as documented.
- Fix a potential memory leak when a task is not removed from `delayedTasks` if the job is cancelled before the delaying coroutine is actually run.
- Swap between the two task lists instead of copying the tasks from one list to the other.
- Rename `tasks` to `immediateTasks`. This makes it more coherent with `delayedTasks`, and will also be useful in the future when we need to distinguish between immediate and delayed tasks for (this ticket)[https://youtrack.jetbrains.com/issue/COMPOSE-965/Tests-hang-if-theres-an-infinite-loop-in-LaunchedEffect].
- Use `ArrayDeque` instead of set to hold the tasks. With a set we could fail to correctly run a task if we are asked to dispatch the same `Runnable` twice. It should also be faster, and make less allocations in the common case when tasks are appended to the end and removed from the beginning of the list.

I intend to merge these without squashing, to preserve the individual commits in case something needs to be reverted later, and for separation of changes.

## Testing
- Added unit tests for the fixes.
