### PR TITLE
PlatformContext.requestFocus - return true by default

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -92,7 +92,7 @@ interface PlatformContext {
     fun setPointerIcon(pointerIcon: PointerIcon) = Unit
 
     val parentFocusManager: FocusManager get() = EmptyFocusManager
-    fun requestFocus(): Boolean = false
+    fun requestFocus(): Boolean = true
 
     /**
      * The listener to track [RootForTest]s.


### PR DESCRIPTION
If someone calls `node.requestFocus`, Compose tries to call `requestFocus` of all parents. If the root denies requesting focus, the node won't be focused. 

Now the default implementation (that is used by standalone ComposeScene's) always allows focus requesting.

## Testing

Focus tests based on `ImageComposeScene` and use `requestFocus` now pass.