### PR TITLE
(Integration) Fixed tap behavior in iOS textfield, fixed double tap behavior

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -393,35 +393,15 @@ internal fun CoreTextField(
         }
     }
 
-    val pointerModifier = Modifier
-        .updateSelectionTouchMode { state.isInTouchMode = it }
-        .tapPressTextFieldModifier(interactionSource, enabled) { offset ->
-            requestFocusAndShowKeyboardIfNeeded(state, focusRequester, !readOnly)
-            if (state.hasFocus && enabled) {
-                if (state.handleState != HandleState.Selection) {
-                    state.layoutResult?.let { layoutResult ->
-                        TextFieldDelegate.setCursorOffset(
-                            offset,
-                            layoutResult,
-                            state.processor,
-                            offsetMapping,
-                            state.onValueChange
-                        )
-                        // Won't enter cursor state when text is empty.
-                        if (state.textDelegate.text.isNotEmpty()) {
-                            state.handleState = HandleState.Cursor
-                        }
-                    }
-                } else {
-                    manager.deselect(offset)
-                }
-            }
-        }
-        .selectionGestureInput(
-            mouseSelectionObserver = manager.mouseSelectionObserver,
-            textDragObserver = manager.touchSelectionObserver,
-        )
-        .pointerHoverIcon(textPointerIcon)
+    val pointerModifier = Modifier.textFieldPointer(
+        manager,
+        enabled,
+        interactionSource,
+        state,
+        focusRequester,
+        readOnly,
+        offsetMapping,
+    )
 
     val drawModifier = Modifier.drawBehind {
         state.layoutResult?.let { layoutResult ->

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldPointerModifier.common.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldPointerModifier.common.kt
@@ -50,7 +50,7 @@ internal fun Modifier.defaultTextFieldPointer(
     .updateSelectionTouchMode { state.isInTouchMode = it }
     .tapPressTextFieldModifier(interactionSource, enabled) { offset ->
         requestFocusAndShowKeyboardIfNeeded(state, focusRequester, !readOnly)
-        if (state.hasFocus) {
+        if (state.hasFocus && enabled) {
             if (state.handleState != HandleState.Selection) {
                 state.layoutResult?.let { layoutResult ->
                     TextFieldDelegate.setCursorOffset(


### PR DESCRIPTION
Fixed tap behavior in iOS textfield, fixed double tap behavior. It was broken after merge.

<!-- Optional -->
Fixes: https://youtrack.jetbrains.com/issue/COMPOSE-1484/Fix-textfield-tap-behavior-on-iOS-in-the-intergration-branch

## Testing
Manual: Open app, open any textfield with text, try to tap in the middle of the word in focused textfield, try to double tap the word