### PR TITLE
iOS fix keyboard crash

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
@@ -41,6 +41,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
     }
 
     // UIPress has special types for arrow keys and page up/down and has null `key`
+    // For other keys the `type` returns an int value that doesn't match any UIPressType enum case.
     val specialTypeKey = when (type) {
         UIPressTypeUpArrow -> Key.DirectionUp
         UIPressTypeDownArrow -> Key.DirectionDown

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
@@ -51,6 +51,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
     }
 
     val internalKey = specialTypeKey ?: key?.keyCode?.let { Key(it) } ?: Key.Unknown
+    // TODO: review correctness of this code
     val codePoint = key?.characters?.firstOrNull()?.code ?: 0
 
     val modifierFlags = key?.modifierFlags ?: 0L

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
@@ -41,7 +41,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
     }
 
     // UIPress has special types for arrow keys and page up/down and has null `key`
-    // For other keys the `type` returns an int value that doesn't match any UIPressType enum case.
+    // In other cases the `type` returns an int value that doesn't match any UIPressType.
     val specialTypeKey = when (type) {
         UIPressTypeUpArrow -> Key.DirectionUp
         UIPressTypeDownArrow -> Key.DirectionDown

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
@@ -55,14 +55,13 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
     val key = specialTypeKey ?: pressKey?.keyCode?.let { Key(it) } ?: Key.Unknown
     val codePoint = pressKey?.characters?.firstOrNull()?.code ?: 0
 
-    val modifiers = pressKey?.let {
-        PointerKeyboardModifiers(
-            isCtrlPressed = it.modifierFlags and UIKeyModifierControl != 0L,
-            isMetaPressed = it.modifierFlags and UIKeyModifierCommand != 0L,
-            isAltPressed = it.modifierFlags and UIKeyModifierAlternate != 0L,
-            isShiftPressed = it.modifierFlags and UIKeyModifierShift != 0L,
-        )
-    } ?: PointerKeyboardModifiers()
+    val modifierFlags = pressKey?.modifierFlags ?: 0L
+    val modifiers = PointerKeyboardModifiers(
+        isCtrlPressed = modifierFlags and UIKeyModifierControl != 0L,
+        isMetaPressed = modifierFlags and UIKeyModifierCommand != 0L,
+        isAltPressed = modifierFlags and UIKeyModifierAlternate != 0L,
+        isShiftPressed = modifierFlags and UIKeyModifierShift != 0L,
+    )
 
     return KeyEvent(
         nativeKeyEvent = InternalKeyEvent(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
@@ -32,8 +32,6 @@ import platform.UIKit.UIPressTypeRightArrow
 import platform.UIKit.UIPressTypeUpArrow
 
 internal fun UIPress.toComposeEvent(): KeyEvent {
-    val pressKey = key
-
     val keyEventType = when (phase) {
         UIPressPhaseBegan -> KeyEventType.KeyDown
         UIPressPhaseEnded -> KeyEventType.KeyUp
@@ -52,10 +50,10 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
         else -> null
     }
 
-    val key = specialTypeKey ?: pressKey?.keyCode?.let { Key(it) } ?: Key.Unknown
-    val codePoint = pressKey?.characters?.firstOrNull()?.code ?: 0
+    val internalKey = specialTypeKey ?: key?.keyCode?.let { Key(it) } ?: Key.Unknown
+    val codePoint = key?.characters?.firstOrNull()?.code ?: 0
 
-    val modifierFlags = pressKey?.modifierFlags ?: 0L
+    val modifierFlags = key?.modifierFlags ?: 0L
     val modifiers = PointerKeyboardModifiers(
         isCtrlPressed = modifierFlags and UIKeyModifierControl != 0L,
         isMetaPressed = modifierFlags and UIKeyModifierCommand != 0L,
@@ -65,7 +63,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
 
     return KeyEvent(
         nativeKeyEvent = InternalKeyEvent(
-            key = key,
+            key = internalKey,
             type = keyEventType,
             codePoint = codePoint,
             modifiers = modifiers,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/key/KeyEvent.uikit.kt
@@ -51,7 +51,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
     }
 
     val internalKey = specialTypeKey ?: key?.keyCode?.let { Key(it) } ?: Key.Unknown
-    // TODO: review correctness of this code
+    // TODO: Reuse `String.codePointAt` helper to support multi-char code points
     val codePoint = key?.characters?.firstOrNull()?.code ?: 0
 
     val modifierFlags = key?.modifierFlags ?: 0L


### PR DESCRIPTION
Properly handle UIPress with `key == nil`

Fixes a crash https://github.com/JetBrains/compose-multiplatform/issues/4911

## Testing
The reported issue doesn't reproduce anymore.

## Release Notes

### Fixes - iOS
- Pressing directional keys on a physical keyboard connected to iOS device doesn't cause a crash.