### PR TITLE
Fix running tests via IDEA configuration desktop/test.run.xml

### DIFF
--- a/.run/desktop/test.run.xml
+++ b/.run/desktop/test.run.xml
@@ -18,6 +18,7 @@
     <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
     <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
     <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>true</RunAsTest>
     <method v="2" />
   </configuration>
 </component>

--- a/.run/desktop/test.run.xml
+++ b/.run/desktop/test.run.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="desktopTest" />
+          <option value="cleanDesktopTest desktopTest -Pandroidx.ignoreTestFailures" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.run/desktop/test.run.xml
+++ b/.run/desktop/test.run.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="cleanDesktopTest desktopTest -Pandroidx.ignoreTestFailures" />
+          <option value="desktopTest -Pandroidx.ignoreTestFailures" />
         </list>
       </option>
       <option name="vmOptions" />


### PR DESCRIPTION
Tests don't start after the first failure at the moment.

Note, that this option makes the Gradle task itself always successful, even if there are failed tests, so it shouldn't be used in Terminal. It is okay if we run it from IDEA - it doesn't look at the task result.