### PR TITLE
Respect type of event copied in SuspendingPointerInputModifierNodeImpl::onCancelPointerInput

### DIFF
--- a/compose/ui/ui/src/androidInstrumentedTest/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilterTest.kt
+++ b/compose/ui/ui/src/androidInstrumentedTest/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilterTest.kt
@@ -302,6 +302,142 @@ class SuspendingPointerInputFilterTest {
     }
 
     @Test
+    @MediumTest
+    fun testSyntheticMouseCancelEvent() {
+        var currentEventAtEnd: PointerEvent? = null
+        val latch = CountDownLatch(3)
+        val results = Channel<PointerEvent>(Channel.UNLIMITED)
+
+        // Used to manually trigger a PointerEvent(s) created from our PointerInputChange(s).
+        val suspendingPointerInputModifierNode = SuspendingPointerInputModifierNode {
+            awaitPointerEventScope {
+                try {
+                    repeat(3) {
+                        results.trySend(awaitPointerEvent())
+                        latch.countDown()
+                    }
+                    results.close()
+                } finally {
+                    currentEventAtEnd = currentEvent
+                }
+            }
+        }
+
+        rule.setContent {
+            Box(
+                modifier =
+                    elementFor(
+                        key1 = Unit,
+                        instance = suspendingPointerInputModifierNode as Modifier.Node
+                    )
+            )
+        }
+
+        val bounds = IntSize(50, 50)
+        val emitter1 = PointerInputChangeEmitter(0)
+        val emitter2 = PointerInputChangeEmitter(1)
+        val expectedEvents =
+            listOf(
+                PointerEvent(
+                    listOf(
+                        emitter1.nextChange(Offset(5f, 5f), pointerType = PointerType.Mouse),
+                        emitter2.nextChange(Offset(10f, 10f), pointerType = PointerType.Mouse)
+                    )
+                ),
+                PointerEvent(
+                    listOf(
+                        emitter1.nextChange(Offset(6f, 6f), pointerType = PointerType.Mouse),
+                        emitter2.nextChange(
+                            Offset(10f, 10f),
+                            down = false,
+                            pointerType = PointerType.Mouse
+                        )
+                    )
+                ),
+                // Synthetic cancel should look like this (Note: this specific event isn't ever
+                // triggered directly, it's just for reference so you know what
+                // onCancelPointerInput()
+                // triggers).
+                // Both pointers are there, but only the with the pressed = true is changed to
+                // false,
+                // and the down change is consumed.
+                PointerEvent(
+                    listOf(
+                        PointerInputChange(
+                            PointerId(0),
+                            0,
+                            Offset(6f, 6f),
+                            false,
+                            0,
+                            Offset(6f, 6f),
+                            true,
+                            isInitiallyConsumed = true,
+                            PointerType.Mouse
+                        ),
+                        PointerInputChange(
+                            PointerId(1),
+                            0,
+                            Offset(10f, 10f),
+                            false,
+                            0,
+                            Offset(10f, 10f),
+                            false,
+                            isInitiallyConsumed = false,
+                            PointerType.Mouse
+                        )
+                    )
+                )
+            )
+
+        rule.runOnIdle {
+            expectedEvents.take(expectedEvents.size - 1).forEach { pointerEvent ->
+                // Initial
+                suspendingPointerInputModifierNode.onPointerEvent(
+                    pointerEvent,
+                    PointerEventPass.Initial,
+                    bounds
+                )
+
+                // Main
+                suspendingPointerInputModifierNode.onPointerEvent(
+                    pointerEvent,
+                    PointerEventPass.Main,
+                    bounds
+                )
+
+                // Final
+                suspendingPointerInputModifierNode.onPointerEvent(
+                    pointerEvent,
+                    PointerEventPass.Final,
+                    bounds
+                )
+            }
+
+            // Manually cancels the current pointer input event.
+            suspendingPointerInputModifierNode.onCancelPointerInput()
+        }
+
+        // Checks events triggered are the correct ones
+        rule.runOnIdle {
+            assertTrue("Waiting for relaunch timed out", latch.await(200, TimeUnit.MILLISECONDS))
+
+            runTest {
+                val received = withTimeout(200) { results.receiveAsFlow().toList() }
+
+                assertThat(expectedEvents).hasSize(received.size)
+
+                expectedEvents.forEachIndexed { index, expectedEvent ->
+                    val actualEvent = received[index]
+                    PointerEventSubject.assertThat(actualEvent).isStructurallyEqualTo(expectedEvent)
+                }
+                assertThat(currentEventAtEnd).isNotNull()
+                PointerEventSubject.assertThat(currentEventAtEnd!!)
+                    .isStructurallyEqualTo(expectedEvents.last())
+            }
+        }
+    }
+
+    @Test
     @LargeTest
     fun testNoSyntheticCancelEventWhenPressIsFalse() {
         var currentEventAtEnd: PointerEvent? = null

--- a/compose/ui/ui/src/androidInstrumentedTest/kotlin/androidx/compose/ui/input/pointer/TestUtils.kt
+++ b/compose/ui/ui/src/androidInstrumentedTest/kotlin/androidx/compose/ui/input/pointer/TestUtils.kt
@@ -507,6 +507,7 @@ internal class PointerEventSubject(
             check("consumed")
                 .that(actualChanges[i].isConsumed)
                 .isEqualTo(expectedChanges[i].isConsumed)
+            check("type").that(actualChanges[i].type).isEqualTo(expectedChanges[i].type)
         }
     }
 }
@@ -591,22 +592,25 @@ internal class PointerInputChangeEmitter(id: Int = 0) {
     fun nextChange(
         position: Offset = Offset.Zero,
         down: Boolean = true,
-        time: Long = 0
+        time: Long = 0,
+        pointerType: PointerType = PointerType.Touch
     ): PointerInputChange {
         return PointerInputChange(
-            id = pointerId,
-            time,
-            position,
-            down,
-            previousTime,
-            previousPosition,
-            previousPressed,
-            isInitiallyConsumed = false
-        ).also {
-            previousTime = time
-            previousPosition = position
-            previousPressed = down
-        }
+                id = pointerId,
+                time,
+                position,
+                down,
+                previousTime,
+                previousPosition,
+                previousPressed,
+                isInitiallyConsumed = false,
+                type = pointerType
+            )
+            .also {
+                previousTime = time
+                previousPosition = position
+                previousPressed = down
+            }
     }
 }
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -584,21 +584,21 @@ internal class SuspendingPointerInputModifierNodeImpl(
         if (lastEvent.changes.fastAll { !it.pressed }) {
             return // There aren't any pressed pointers, so we don't need to send any events.
         }
-        val newChanges = lastEvent.changes.fastMapNotNull { old ->
-            PointerInputChange(
-                id = old.id,
-                position = old.position,
-                uptimeMillis = old.uptimeMillis,
-                pressed = false,
-                pressure = old.pressure,
-                previousPosition = old.position,
-                previousUptimeMillis = old.uptimeMillis,
-                previousPressed = old.pressed,
-                isInitiallyConsumed = old.pressed
-            )
-        }
-
-        if (newChanges.isEmpty()) return
+        val newChanges =
+            lastEvent.changes.fastMapNotNull { old ->
+                PointerInputChange(
+                    id = old.id,
+                    position = old.position,
+                    uptimeMillis = old.uptimeMillis,
+                    pressed = false,
+                    pressure = old.pressure,
+                    previousPosition = old.position,
+                    previousUptimeMillis = old.uptimeMillis,
+                    previousPressed = old.pressed,
+                    isInitiallyConsumed = old.pressed,
+                    type = old.type
+                )
+            }
 
         val cancelEvent = PointerEvent(newChanges)
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -600,6 +600,8 @@ internal class SuspendingPointerInputModifierNodeImpl(
                 )
             }
 
+        if (newChanges.isEmpty()) return
+
         val cancelEvent = PointerEvent(newChanges)
 
         currentEvent = cancelEvent


### PR DESCRIPTION
    This is cherry-pick of c228104a190 from aosp/androidx-main
    This resolves https://youtrack.jetbrains.com/issue/CMP-1497/Selection-Handlers-seen-in-desktop-when-are-not-supposed-to