### PR TITLE
Hide Metal drawables from Kotlin runtime

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
@@ -38,5 +38,6 @@ val IosBugs = Screen.Selection(
     MeasureAndLayoutCrash,
     AnimationFreezeBug,
     ModalMemoryLeak,
-    ModalCrash
+    ModalCrash,
+    PopupStretching
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/PopupStretching.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/PopupStretching.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.material3.Button
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.interop.LocalUIViewController
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.ComposeUIViewController
+import platform.UIKit.UIModalPresentationFormSheet
+import platform.UIKit.UISheetPresentationControllerDetent
+import platform.UIKit.sheetPresentationController
+
+//val bottomSheetUIViewController =
+//    ComposeUIViewController {
+//        VerticalScrollWithIndependentHorizontalRows()
+//    }
+//bottomSheetUIViewController.modalPresentationStyle = UIModalPresentationFormSheet
+//bottomSheetUIViewController.sheetPresentationController?.setDetents(
+//listOf(
+//UISheetPresentationControllerDetent.mediumDetent(),
+//UISheetPresentationControllerDetent.largeDetent(),
+//)
+//)
+//
+//UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
+//viewControllerToPresent = bottomSheetUIViewController,
+//animated = true,
+//completion = {},
+//)
+
+val PopupStretching = Screen.Example("Popup stretching") {
+    val viewController = LocalUIViewController.current
+
+    Button(onClick = {
+        val bottomSheetController = ComposeUIViewController {
+            VerticalScrollWithIndependentHorizontalRows()
+        }
+
+        bottomSheetController.modalPresentationStyle = UIModalPresentationFormSheet
+        bottomSheetController.sheetPresentationController?.setDetents(
+            listOf(
+                UISheetPresentationControllerDetent.mediumDetent(),
+                UISheetPresentationControllerDetent.largeDetent(),
+            )
+        )
+
+        viewController.presentViewController(bottomSheetController, animated = true, completion = {})
+    }) {
+        Text("Show popup")
+    }
+}
+
+
+@Composable
+fun VerticalScrollWithIndependentHorizontalRows() {
+    Column(
+        modifier =
+        Modifier.fillMaxSize().verticalScroll(rememberScrollState(), enabled = true),
+    ) {
+        repeat(10) { rowIndex ->
+            val horizontalScrollState = rememberScrollState()
+
+            Spacer(Modifier.height(30.dp).background(Color.DarkGray))
+            Row(
+                modifier =
+                Modifier
+                    .padding(start = 16.dp, end = 16.dp)
+                    .horizontalScroll(horizontalScrollState),
+            ) {
+                repeat(5) {
+                    Box(
+                        modifier =
+                        Modifier
+                            .size(100.dp)
+                            .background(Color.Gray),
+                    ) {
+                        Text("Item $it in row $rowIndex")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/PopupStretching.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/PopupStretching.kt
@@ -41,24 +41,6 @@ import platform.UIKit.UIModalPresentationFormSheet
 import platform.UIKit.UISheetPresentationControllerDetent
 import platform.UIKit.sheetPresentationController
 
-//val bottomSheetUIViewController =
-//    ComposeUIViewController {
-//        VerticalScrollWithIndependentHorizontalRows()
-//    }
-//bottomSheetUIViewController.modalPresentationStyle = UIModalPresentationFormSheet
-//bottomSheetUIViewController.sheetPresentationController?.setDetents(
-//listOf(
-//UISheetPresentationControllerDetent.mediumDetent(),
-//UISheetPresentationControllerDetent.largeDetent(),
-//)
-//)
-//
-//UIApplication.sharedApplication.keyWindow?.rootViewController?.presentViewController(
-//viewControllerToPresent = bottomSheetUIViewController,
-//animated = true,
-//completion = {},
-//)
-
 val PopupStretching = Screen.Example("Popup stretching") {
     val viewController = LocalUIViewController.current
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E92B27106100300068 /* CMPAccessibilityContainer.m */; };
 		EA82F4F92B86144E00465418 /* CMPOSLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4F82B86144E00465418 /* CMPOSLogger.m */; };
 		EA82F4FC2B86184F00465418 /* CMPOSLoggerInterval.m in Sources */ = {isa = PBXBuildFile; fileRef = EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */; };
+		EAB33E182C12E746002CFF44 /* CMPMetalDrawablesHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = EAB33E172C12E746002CFF44 /* CMPMetalDrawablesHandler.m */; };
 		EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */ = {isa = PBXBuildFile; fileRef = EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */; };
 		EAC703E32B8C826E001ECDA6 /* CMPAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */; };
 		EAC703E42B8C826E001ECDA6 /* CMPViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCDD2B18D135000B56B5 /* CMPViewController.m */; };
@@ -82,6 +83,8 @@
 		EA82F4F82B86144E00465418 /* CMPOSLogger.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPOSLogger.m; sourceTree = "<group>"; };
 		EA82F4FA2B86184F00465418 /* CMPOSLoggerInterval.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPOSLoggerInterval.h; sourceTree = "<group>"; };
 		EA82F4FB2B86184F00465418 /* CMPOSLoggerInterval.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPOSLoggerInterval.m; sourceTree = "<group>"; };
+		EAB33E162C12E746002CFF44 /* CMPMetalDrawablesHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPMetalDrawablesHandler.h; sourceTree = "<group>"; };
+		EAB33E172C12E746002CFF44 /* CMPMetalDrawablesHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPMetalDrawablesHandler.m; sourceTree = "<group>"; };
 		EABD91292BC02B5F00455279 /* CMPInteropWrappingView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPInteropWrappingView.h; sourceTree = "<group>"; };
 		EABD912A2BC02B5F00455279 /* CMPInteropWrappingView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPInteropWrappingView.m; sourceTree = "<group>"; };
 		EAC703DF2B8C8154001ECDA6 /* CMPUIKitUtilsTestApp-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CMPUIKitUtilsTestApp-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -134,6 +137,8 @@
 				99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */,
 				99D97A862BF73A9B0035552B /* CMPEditMenuView.h */,
 				99D97A872BF73A9B0035552B /* CMPEditMenuView.m */,
+				EAB33E162C12E746002CFF44 /* CMPMetalDrawablesHandler.h */,
+				EAB33E172C12E746002CFF44 /* CMPMetalDrawablesHandler.m */,
 			);
 			path = CMPUIKitUtils;
 			sourceTree = "<group>";
@@ -308,6 +313,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				997DFCDE2B18D135000B56B5 /* CMPViewController.m in Sources */,
+				EAB33E182C12E746002CFF44 /* CMPMetalDrawablesHandler.m in Sources */,
 				99D97A882BF73A9B0035552B /* CMPEditMenuView.m in Sources */,
 				EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */,
 				EA70A7EC2B27106100300068 /* CMPAccessibilityContainer.m in Sources */,

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMacros.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMacros.h
@@ -18,3 +18,12 @@
 
 #define CMP_MUST_BE_OVERRIDED
 #define CMP_MUST_BE_OVERRIDED_INVARIANT_VIOLATION assert(false && "MUST_OVERRIDE");
+
+// Marker for indicating that raw pointer returned from a function is owned by the caller
+#define CMP_OWNED
+
+// Marker for indicating that raw pointer is consumed when passed as an argument
+#define CMP_CONSUMED
+
+// Marker for indicating that raw pointer is implied as borrowed when returned from a function or passed as an argument
+#define CMP_BORROWED

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  A handler class for managing Metal drawables explicitly using raw pointers.
  This class encapsulates the lifecycle management of drawable objects,
  facilitating the use in environments where automatic reference counting (ARC)
- mixed with Kotlin/Native memory model that  leads to violation of practices enstated by Apple, which lead to inadequate memory spikes during drawable size updates across consequent frames.
+ mixed with Kotlin/Native memory model that  leads to violation of practices enstated by Apple (namely, not releasing drawables as soon as possible), which lead to inadequate memory spikes during drawable size updates across consequent frames.
  @see https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/Drawables.html
 
  The class methods handle the acquisition, release, and presentation of

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
@@ -22,16 +22,44 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ A handler class for managing Metal drawables explicitly using raw pointers.
+ This class encapsulates the lifecycle management of drawable objects,
+ facilitating the use in environments where automatic reference counting (ARC)
+ mixed with Kotlin/Native memory model that  leads to violation of practices enstated by Apple, which lead to inadequate memory spikes during drawable size updates across consequent frames.
+ @see https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/MTLBestPracticesGuide/Drawables.html
+
+ The class methods handle the acquisition, release, and presentation of
+ drawable objects associated with a given CAMetalLayer. Usage of raw pointers
+ helps in explicitly controlling the drawable lifecycle, preventing application from keeping drawables and their pools alive longer, than needed, due to awaiting deallocation by GC.
+ */
 @interface CMPMetalDrawablesHandler : NSObject
 
+/// Initializes the handler with a given Metal layer.
+/// @param metalLayer The CAMetalLayer instance to be associated with this handler.
 - (instancetype)initWithMetalLayer:(CAMetalLayer *)metalLayer;
 
+/// Retrieves the next drawable object from the associated Metal layer.
+/// @return A raw pointer to the next drawable object, ownership is transferred to the caller.
 - (void * CMP_OWNED)nextDrawable;
-- (void)releaseDrawable:(void * CMP_CONSUMED)drawablePtr;
-- (void * CMP_BORROWED)drawableTexture:(void * CMP_BORROWED)drawablePtr;
-- (void)presentDrawable:(void * CMP_CONSUMED)drawablePtr;
-- (void)scheduleDrawablePresentation:(void * CMP_CONSUMED)drawablePtr onCommandBuffer:(id <MTLCommandBuffer>)commandBuffer;
 
+/// Releases a drawable object, indicating that it is no longer in use by the caller.
+/// @param drawablePtr A raw pointer to the drawable to be released, indicating transfer of ownership back to the handler.
+- (void)releaseDrawable:(void * CMP_CONSUMED)drawablePtr;
+
+/// Retrieves the texture of a drawable without transferring ownership.
+/// @param drawablePtr A raw pointer to the drawable from which to get the texture.
+/// @return A raw pointer to the texture of the drawable, ownership is not transferred.
+- (void * CMP_BORROWED)drawableTexture:(void * CMP_BORROWED)drawablePtr;
+
+/// Presents a drawable to the screen immediately.
+/// @param drawablePtr A raw pointer to the drawable to be presented, indicating transfer of ownership.
+- (void)presentDrawable:(void * CMP_CONSUMED)drawablePtr;
+
+/// Schedules the presentation of a drawable on a specific command buffer.
+/// @param drawablePtr A raw pointer to the drawable to be presented, indicating transfer of ownership.
+/// @param commandBuffer The command buffer on which the drawable will be scheduled for presentation.
+- (void)scheduleDrawablePresentation:(void * CMP_CONSUMED)drawablePtr onCommandBuffer:(id <MTLCommandBuffer>)commandBuffer;
 
 @end
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithMetalLayer:(CAMetalLayer *)metalLayer;
 
-- (void * __nullable CMP_OWNED)nextDrawable;
+- (void * CMP_OWNED)nextDrawable;
 - (void)releaseDrawable:(void * CMP_CONSUMED)drawablePtr;
 - (void * CMP_BORROWED)drawableTexture:(void * CMP_BORROWED)drawablePtr;
 - (void)presentDrawable:(void * CMP_CONSUMED)drawablePtr;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
@@ -1,9 +1,18 @@
-//
-//  CMPMetalDrawablesHandler.h
-//  CMPUIKitUtils
-//
-//  Created by Ilia.Semenov on 07/06/2024.
-//
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import <Foundation/Foundation.h>
 #import <QuartzCore/QuartzCore.h>

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.h
@@ -1,0 +1,29 @@
+//
+//  CMPMetalDrawablesHandler.h
+//  CMPUIKitUtils
+//
+//  Created by Ilia.Semenov on 07/06/2024.
+//
+
+#import <Foundation/Foundation.h>
+#import <QuartzCore/QuartzCore.h>
+#import <Metal/Metal.h>
+
+#import "CMPMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CMPMetalDrawablesHandler : NSObject
+
+- (instancetype)initWithMetalLayer:(CAMetalLayer *)metalLayer;
+
+- (void * __nullable CMP_OWNED)nextDrawable;
+- (void)releaseDrawable:(void * CMP_CONSUMED)drawablePtr;
+- (void * CMP_BORROWED)drawableTexture:(void * CMP_BORROWED)drawablePtr;
+- (void)presentDrawable:(void * CMP_CONSUMED)drawablePtr;
+- (void)scheduleDrawablePresentation:(void * CMP_CONSUMED)drawablePtr onCommandBuffer:(id <MTLCommandBuffer>)commandBuffer;
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
@@ -19,7 +19,7 @@
     return self;
 }
 
-- (void * __nullable CMP_OWNED)nextDrawable {
+- (void * CMP_OWNED)nextDrawable {
     id <CAMetalDrawable> drawable = [_metalLayer nextDrawable];
     
     if (drawable) {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
@@ -49,14 +49,14 @@
 - (void)presentDrawable:(void * CMP_CONSUMED)drawablePtr {
     assert(drawablePtr != NULL);
     
-    id <CAMetalDrawable> drawable __unused = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
+    id <CAMetalDrawable> drawable = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
     [drawable present];
 }
 
 - (void)scheduleDrawablePresentation:(void * CMP_CONSUMED)drawablePtr onCommandBuffer:(id <MTLCommandBuffer>)commandBuffer {
     assert(drawablePtr != NULL);
     
-    id <CAMetalDrawable> drawable __unused = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
+    id <CAMetalDrawable> drawable = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
     [commandBuffer presentDrawable:drawable];
 }
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
@@ -1,9 +1,18 @@
-//
-//  CMPMetalDrawablesHandler.m
-//  CMPUIKitUtils
-//
-//  Created by Ilia.Semenov on 07/06/2024.
-//
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #import "CMPMetalDrawablesHandler.h"
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalDrawablesHandler.m
@@ -1,0 +1,63 @@
+//
+//  CMPMetalDrawablesHandler.m
+//  CMPUIKitUtils
+//
+//  Created by Ilia.Semenov on 07/06/2024.
+//
+
+#import "CMPMetalDrawablesHandler.h"
+
+@implementation CMPMetalDrawablesHandler {
+    CAMetalLayer *_metalLayer;
+}
+
+- (instancetype)initWithMetalLayer:(CAMetalLayer *)metalLayer {
+    self = [super init];
+    if (self) {
+        _metalLayer = metalLayer;
+    }
+    return self;
+}
+
+- (void * __nullable CMP_OWNED)nextDrawable {
+    id <CAMetalDrawable> drawable = [_metalLayer nextDrawable];
+    
+    if (drawable) {
+        void *ptr = (__bridge_retained void *)drawable;
+        return ptr;
+    } else {
+        return NULL;
+    }
+}
+
+- (void)releaseDrawable:(void * CMP_CONSUMED)drawablePtr {
+    assert(drawablePtr != NULL);
+    
+    id <CAMetalDrawable> drawable __unused = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
+    // drawable will be released by ARC
+}
+
+- (void * CMP_BORROWED)drawableTexture:(void * CMP_BORROWED)drawablePtr {
+    assert(drawablePtr != NULL);
+    
+    id <CAMetalDrawable> drawable = (__bridge id <CAMetalDrawable>)drawablePtr;
+    id <MTLTexture> texture = drawable.texture;    
+    void *texturePtr = (__bridge void *)texture;
+    return texturePtr;
+}
+
+- (void)presentDrawable:(void * CMP_CONSUMED)drawablePtr {
+    assert(drawablePtr != NULL);
+    
+    id <CAMetalDrawable> drawable __unused = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
+    [drawable present];
+}
+
+- (void)scheduleDrawablePresentation:(void * CMP_CONSUMED)drawablePtr onCommandBuffer:(id <MTLCommandBuffer>)commandBuffer {
+    assert(drawablePtr != NULL);
+    
+    id <CAMetalDrawable> drawable __unused = (__bridge_transfer id <CAMetalDrawable>)drawablePtr;
+    [commandBuffer presentDrawable:drawable];
+}
+
+@end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
@@ -27,3 +27,4 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 #import "CMPAccessibilityContainer.h"
 #import "CMPOSLogger.h"
 #import "CMPTextLoupeSession.h"
+#import "CMPMetalDrawablesHandler.h"

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.interop.UIKitInteropState
 import androidx.compose.ui.interop.UIKitInteropTransaction
 import androidx.compose.ui.interop.doLocked
 import androidx.compose.ui.interop.isNotEmpty
+import androidx.compose.ui.uikit.utils.CMPMetalDrawablesHandler
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
 import kotlin.math.roundToInt
@@ -145,6 +146,7 @@ internal class MetalRedrawer(
     private val metalLayer: CAMetalLayer,
     private val callbacks: MetalRedrawerCallbacks
 ) {
+    private val metalDrawableHandler = CMPMetalDrawablesHandler(metalLayer)
     // Workaround for KN compiler bug
     // Type mismatch: inferred type is objcnames.protocols.MTLDeviceProtocol but platform.Metal.MTLDeviceProtocol was expected
     @Suppress("USELESS_CAST")
@@ -316,7 +318,7 @@ internal class MetalRedrawer(
             }
 
             val metalDrawable = trace("MetalRedrawer:draw:nextDrawable") {
-                metalLayer.nextDrawable()
+                metalDrawableHandler.nextDrawable()
             }
 
             if (metalDrawable == null) {
@@ -328,7 +330,7 @@ internal class MetalRedrawer(
             }
 
             val renderTarget =
-                BackendRenderTarget.makeMetal(width, height, metalDrawable.texture.objcPtr())
+                BackendRenderTarget.makeMetal(width, height, metalDrawableHandler.drawableTexture(metalDrawable).rawValue)
 
             val surface = Surface.makeFromBackendRenderTarget(
                 context,
@@ -344,6 +346,7 @@ internal class MetalRedrawer(
                 // Logger.warn { "'Surface.makeFromBackendRenderTarget' returned null. Skipping the frame." }
                 picture.close()
                 renderTarget.close()
+                metalDrawableHandler.releaseDrawable(metalDrawable)
                 dispatch_semaphore_signal(inflightSemaphore)
                 return@autoreleasepool
             }
@@ -372,7 +375,9 @@ internal class MetalRedrawer(
                     commandBuffer.label = "Present"
 
                     if (!presentsWithTransaction) {
-                        commandBuffer.presentDrawable(metalDrawable)
+                        // scheduleDrawablePresentation consumes metalDrawable
+                        // don't use metalDrawable after this call
+                        metalDrawableHandler.scheduleDrawablePresentation(metalDrawable, commandBuffer)
                     }
 
                     commandBuffer.addCompletedHandler {
@@ -388,7 +393,9 @@ internal class MetalRedrawer(
                             commandBuffer.waitUntilScheduled()
                         }
 
-                        metalDrawable.present()
+                        // presentDrawable consumes metalDrawable
+                        // don't use metalDrawable after this call
+                        metalDrawableHandler.presentDrawable(metalDrawable)
 
                         interopTransaction.actions.fastForEach {
                             it.invoke()


### PR DESCRIPTION
Explicitly manage lifetime of metal drawables by hiding them from Kotlin runtime.

Fixes a memory spike when quickly resizing metal layer as in a scenario reported in [the issue](https://github.com/JetBrains/compose-multiplatform/issues/4850)

Otherwise associated drawable pools are retained until next GC, which can happen after inadequate amount of drawables with new sizes are allocated

###
Before:
<img width="414" alt="Screenshot 2024-06-06 at 13 33 46" src="https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/81d74dfe-91c0-4362-ad71-93416dbe172f">
###
After:
<img width="574" alt="Screenshot 2024-06-07 at 10 04 18" src="https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/6574b297-1e81-48db-9aee-d31c2425267c">


## Testing

Resize the popup with `ComposeUIViewController` to different detents inside Demo `IosBugs/PopupStretching`
Requires either patch:
```
Index: compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt	(revision 39d436a845d0cbe9526a6c24933268aacf83b2eb)
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt	(date 1717747754590)
@@ -558,6 +558,7 @@
                 asDpRect().toRect()
             }
         }
+        onComposeSceneInvalidate()
         scene.size = IntSize(
             width = boundsInPx.width.roundToInt(),
             height = boundsInPx.height.roundToInt()
```
Or https://github.com/JetBrains/compose-multiplatform-core/pull/1387

## Release Notes

### Fixes - iOS
- Fixed a memory spike when continuously resizing the `ComposeUIViewController` (such as when used in modal sheet presentation context with different detents)