### PR TITLE
Simplify SelectionManager.onClearSelectionRequested

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/ForEachGesture.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/ForEachGesture.kt
@@ -80,10 +80,12 @@ internal suspend fun PointerInputScope.awaitAllPointersUp() {
 /**
  * Waits for all pointers to be up before returning.
  */
-internal suspend fun AwaitPointerEventScope.awaitAllPointersUp() {
+internal suspend fun AwaitPointerEventScope.awaitAllPointersUp(
+    pass: PointerEventPass = PointerEventPass.Final
+) {
     if (!allPointersUp()) {
         do {
-            val events = awaitPointerEvent(PointerEventPass.Final)
+            val events = awaitPointerEvent(pass)
         } while (events.changes.fastAny { it.pressed })
     }
 }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
@@ -156,7 +156,7 @@ internal fun SelectionContainer(
     DisposableEffect(manager) {
         onDispose {
             manager.onRelease()
-            manager.focusState = null
+            manager.hasFocus = false
         }
     }
 }


### PR DESCRIPTION
Simplify `SelectionManager.onClearSelectionRequested` to more clearly detect clicks that aren't a drag.

## Testing
Manually with
```
fun main() = singleWindowApplication {
    SelectionContainer {
        Column {
            Text("Hello world! Lorem lorem ipsum ipsum")
            DisableSelection {
                Text("Disabled selection: Hello world! Lorem lorem ipsum ipsum")
            }
            Text("Hello world! Lorem lorem ipsum ipsum")
            DisableSelection {
                Button(
                    onClick = {},
                    colors = ButtonDefaults.textButtonColors(
                        backgroundColor = Color.LightGray,
                    )
                ) {
                    Text("I'm a button inside DisableSelection")
                }
            }
            Button(
                onClick = {},
                colors = ButtonDefaults.textButtonColors(
                    backgroundColor = Color.LightGray,
                )
            ) {
                Text("I'm a button")
            }
        }
    }
}
```

This could be tested by QA (to make sure the functionality didn't break in edge cases).