### PR TITLE
Fix WindowState and DialogState savers to not crash on unspecified window/dialog size.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DialogState.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DialogState.desktop.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.takeOrElse
 
 /**
  * Creates a [DialogState] that is remembered across compositions.
@@ -173,8 +175,9 @@ private class DialogStateImpl(
                     it.position.isSpecified,
                     it.position.x.value,
                     it.position.y.value,
-                    it.size.width.value,
-                    it.size.height.value,
+                    it.size.takeOrElse { DpSize.Zero }.width.value,
+                    it.size.takeOrElse { DpSize.Zero }.height.value,
+                    it.size.isSpecified,
                 )
             },
             restore = { state ->
@@ -184,7 +187,11 @@ private class DialogStateImpl(
                     } else {
                         unspecifiedPosition
                     },
-                    size = DpSize((state[3] as Float).dp, (state[4] as Float).dp),
+                    size = if (state.getOrNull(5) != false) {
+                        DpSize((state[3] as Float).dp, (state[4] as Float).dp)
+                    } else {
+                        DpSize.Unspecified
+                    },
                 )
             }
         )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowState.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/WindowState.desktop.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.unit.takeOrElse
 
 /**
  * Creates a [WindowState] that is remembered across compositions.
@@ -227,20 +229,25 @@ private class WindowStateImpl(
                     it.position.isSpecified,
                     it.position.x.value,
                     it.position.y.value,
-                    it.size.width.value,
-                    it.size.height.value,
+                    it.size.takeOrElse { DpSize.Zero }.width.value,
+                    it.size.takeOrElse { DpSize.Zero }.height.value,
+                    it.size.isSpecified,
                 )
             },
             restore = { state ->
                 WindowStateImpl(
-                    placement = WindowPlacement.values()[state[0] as Int],
+                    placement = WindowPlacement.entries[state[0] as Int],
                     isMinimized = state[1] as Boolean,
                     position = if (state[2] as Boolean) {
                         WindowPosition((state[3] as Float).dp, (state[4] as Float).dp)
                     } else {
                         unspecifiedPosition
                     },
-                    size = DpSize((state[5] as Float).dp, (state[6] as Float).dp),
+                    size = if (state.getOrNull(7) != false) {
+                        DpSize((state[5] as Float).dp, (state[6] as Float).dp)
+                    } else {
+                        DpSize.Unspecified
+                    },
                 )
             }
         )


### PR DESCRIPTION
Fix WindowState.Saver to correctly save/restore unspecified window size.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4945

## Testing
Manually with
```
fun main() = singleWindowApplication {
    LazyColumn {
        items(1000) { index ->
            val state = rememberWindowState(size = DpSize.Unspecified)
            Text("$index " + state.size.toString())
        }
    }
}

and also added unit tests for saving/restoring `WindowState` and `DialogState`.
```

## Release Notes
### Fixes - Desktop
- Correctly save `WindowState` with unspecified `size` instead of crashing.