### PR TITLE
Fix text brush animation

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/MainScreen.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/MainScreen.kt
@@ -19,6 +19,7 @@ package androidx.compose.mpp.demo
 import androidx.compose.mpp.demo.bug.BugReproducers
 import androidx.compose.mpp.demo.components.Components
 import androidx.compose.mpp.demo.textfield.android.AndroidTextFieldSamples
+import androidx.compose.mpp.demo.textfield.android.TextBrushDemo
 
 val MainScreen = Screen.Selection(
     "Demo",
@@ -35,4 +36,5 @@ val MainScreen = Screen.Selection(
     Screen.Example("FontRasterization") { FontRasterization() },
     Screen.Example("InteropOrder") { InteropOrder() },
     AndroidTextFieldSamples,
+    Screen.Example("Android TextBrushDemo") { TextBrushDemo() },
 )

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/android/BrushDemo.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/android/BrushDemo.kt
@@ -16,18 +16,236 @@
 
 package androidx.compose.mpp.demo.textfield.android
 
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Text
 import androidx.compose.material.TextField
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.center
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RadialGradientShader
+import androidx.compose.ui.graphics.Shader
+import androidx.compose.ui.graphics.ShaderBrush
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.TileMode
-import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.ParagraphStyle
+import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.sp
 
-@OptIn(ExperimentalTextApi::class)
+@Composable
+fun TextBrushDemo() {
+    LazyColumn {
+        item {
+            TagLine(tag = "Sample")
+            TextStyleBrushSample()
+        }
+        item {
+            TagLine(tag = "Brush")
+            BrushDemo()
+        }
+        item {
+            TagLine(tag = "Brush Emojis")
+            BrushGraphicalEmoji()
+        }
+        item {
+            TagLine(tag = "SingleLine Span Brush")
+            SingleLineSpanBrush()
+        }
+        item {
+            TagLine(tag = "MultiLine Span Brush")
+            MultiLineSpanBrush()
+        }
+        item {
+            TagLine(tag = "MultiParagraph Brush")
+            MultiParagraphBrush()
+        }
+        item {
+            TagLine(tag = "Animated Brush")
+            AnimatedBrush()
+        }
+        item {
+            TagLine(tag = "Shadow and Brush")
+            ShadowAndBrush()
+        }
+        item {
+            TagLine(tag = "TextField")
+            TextFieldBrush()
+        }
+    }
+}
+
+@Composable
+fun BrushDemo() {
+    Text(
+        "Brush is awesome\nBrush is awesome\nBrush is awesome",
+        style = TextStyle(
+            brush = Brush.linearGradient(
+                colors = RainbowColors,
+                tileMode = TileMode.Mirror
+            ),
+            fontSize = 30.sp
+        )
+    )
+}
+
+@Composable
+fun BrushGraphicalEmoji() {
+    Text(
+        "\uD83D\uDEF3\uD83D\uDD2E\uD83E\uDDED\uD83E\uDD5D\uD83E\uDD8C\uD83D\uDE0D",
+        style = TextStyle(
+            brush = Brush.linearGradient(
+                colors = RainbowColors,
+                tileMode = TileMode.Mirror
+            )
+        ),
+        fontSize = 30.sp
+    )
+}
+
+@Composable
+fun SingleLineSpanBrush() {
+    val infiniteTransition = rememberInfiniteTransition()
+    val start by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 4000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 2000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+    Text(
+        buildAnnotatedString {
+            append("Brush is awesome\n")
+            withStyle(
+                SpanStyle(
+                    brush = Brush.linearGradient(
+                        colors = RainbowColors,
+                        start = Offset(start, 0f),
+                        tileMode = TileMode.Mirror
+                    )
+                )
+            ) {
+                append("Brush is awesome")
+            }
+            append("\nBrush is awesome")
+        },
+        fontSize = 30.sp,
+    )
+}
+
+@Composable
+fun MultiLineSpanBrush() {
+    Text(
+        buildAnnotatedString {
+            append("Brush is aweso")
+            withStyle(
+                SpanStyle(
+                    brush = Brush.linearGradient(
+                        colors = RainbowColors,
+                        tileMode = TileMode.Mirror
+                    )
+                )
+            ) {
+                append("me\nBrush is awesome\nCo")
+            }
+            append("mpose is awesome")
+        },
+        fontSize = 30.sp,
+    )
+}
+
+@Composable
+fun MultiParagraphBrush() {
+    Text(
+        buildAnnotatedString {
+            withStyle(ParagraphStyle(textAlign = TextAlign.Right)) {
+                append(loremIpsum(wordCount = 29))
+            }
+
+            withStyle(ParagraphStyle(textAlign = TextAlign.Left)) {
+                append(loremIpsum(wordCount = 29))
+            }
+        },
+        style = TextStyle(
+            brush = Brush.radialGradient(
+                *RainbowStops.zip(RainbowColors).toTypedArray(),
+                radius = 600f,
+                tileMode = TileMode.Mirror
+            )
+        ),
+        fontSize = 30.sp
+    )
+}
+
+@Composable
+fun AnimatedBrush() {
+    val infiniteTransition = rememberInfiniteTransition()
+    val radius by infiniteTransition.animateFloat(
+        initialValue = 100f,
+        targetValue = 300f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Reverse
+        )
+    )
+    val brush = remember {
+        // postpone the state read to shader creation time which happens during draw.
+        ShaderBrush { size ->
+            RadialGradientShader(
+                center = size.center,
+                radius = radius,
+                colors = RainbowColors,
+                colorStops = RainbowStops,
+                tileMode = TileMode.Mirror
+            )
+        }
+    }
+    Text(
+        text = loremIpsum(wordCount = 29),
+        style = TextStyle(
+            brush = brush,
+            fontSize = 30.sp
+        )
+    )
+}
+
+@Composable
+fun ShadowAndBrush() {
+    Text(
+        "Brush is awesome",
+        style = TextStyle(
+            shadow = Shadow(
+                offset = Offset(8f, 8f),
+                blurRadius = 4f,
+                color = Color.Black
+            ),
+            brush = Brush.linearGradient(
+                colors = RainbowColors,
+                tileMode = TileMode.Mirror
+            )
+        ),
+        fontSize = 42.sp
+    )
+}
+
 @Composable
 fun TextFieldBrush() {
     var text by remember { mutableStateOf("Brush is awesome") }
@@ -45,7 +263,8 @@ fun TextFieldBrush() {
     )
 }
 
-private val RainbowColors = listOf(
+@Suppress("PrimitiveInCollection")
+internal val RainbowColors = listOf(
     Color(0xff9c4f96),
     Color(0xffff6355),
     Color(0xfffba949),
@@ -53,3 +272,12 @@ private val RainbowColors = listOf(
     Color(0xff8bd448),
     Color(0xff2aa8f2)
 )
+
+@Suppress("PrimitiveInCollection")
+internal val RainbowStops = listOf(0f, 0.2f, 0.4f, 0.6f, 0.8f, 1f)
+
+private fun ShaderBrush(block: (Size) -> Shader): ShaderBrush {
+    return object : ShaderBrush() {
+        override fun createShader(size: Size): Shader = block(size)
+    }
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/android/TextStyleSamples.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/android/TextStyleSamples.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.textfield.android
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun TextStyleSample() {
+    Text(
+        text = "Demo Text",
+        style = TextStyle(
+            color = Color.Red,
+            fontSize = 16.sp,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.W800,
+            fontStyle = FontStyle.Italic,
+            letterSpacing = 0.5.em,
+            background = Color.LightGray,
+            textDecoration = TextDecoration.Underline
+        )
+    )
+}
+
+@Composable
+fun TextStyleBrushSample() {
+    Text(
+        text = "Demo Text",
+        style = TextStyle(
+            brush = Brush.linearGradient(listOf(Color.Red, Color.Blue, Color.Green)),
+            alpha = 0.8f,
+            fontSize = 16.sp,
+            fontFamily = FontFamily.Monospace,
+            fontWeight = FontWeight.W800,
+            fontStyle = FontStyle.Italic,
+            letterSpacing = 0.5.em,
+            textDecoration = TextDecoration.Underline
+        )
+    )
+}

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -20,9 +20,16 @@ import org.jetbrains.skia.Rect as SkRect
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.drawscope.DrawStyle
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toComposeRect
 import androidx.compose.ui.text.platform.SkiaParagraphIntrinsics
 import androidx.compose.ui.text.platform.cursorHorizontalPosition
 import androidx.compose.ui.text.style.LineHeightStyle
@@ -34,7 +41,11 @@ import kotlin.math.floor
 import kotlin.math.roundToInt
 import org.jetbrains.skia.FontMetrics
 import org.jetbrains.skia.IRange
-import org.jetbrains.skia.paragraph.*
+import org.jetbrains.skia.paragraph.Direction
+import org.jetbrains.skia.paragraph.LineMetrics
+import org.jetbrains.skia.paragraph.RectHeightMode
+import org.jetbrains.skia.paragraph.RectWidthMode
+import org.jetbrains.skia.paragraph.TextBox
 
 internal class SkiaParagraph(
     intrinsics: ParagraphIntrinsics,
@@ -482,8 +493,8 @@ internal class SkiaParagraph(
         textDecoration: TextDecoration?
     ) {
         paragraph = with(layouter) {
+            setColor(color)
             setTextStyle(
-                color = color,
                 shadow = shadow,
                 textDecoration = textDecoration
             )
@@ -504,8 +515,8 @@ internal class SkiaParagraph(
         blendMode: BlendMode
     ) {
         paragraph = with(layouter) {
+            setColor(color)
             setTextStyle(
-                color = color,
                 shadow = shadow,
                 textDecoration = textDecoration
             )
@@ -529,12 +540,14 @@ internal class SkiaParagraph(
         blendMode: BlendMode
     ) {
         paragraph = with(layouter) {
-            setTextStyle(
+            setBrush(
                 brush = brush,
                 brushSize = Size(width, height),
                 alpha = alpha,
+            )
+            setTextStyle(
                 shadow = shadow,
-                textDecoration = textDecoration
+                textDecoration = textDecoration,
             )
             setDrawStyle(drawStyle)
             setBlendMode(blendMode)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -48,15 +48,13 @@ import org.jetbrains.skia.paragraph.RectWidthMode
 import org.jetbrains.skia.paragraph.TextBox
 
 internal class SkiaParagraph(
-    intrinsics: ParagraphIntrinsics,
+    private val paragraphIntrinsics: SkiaParagraphIntrinsics,
     val maxLines: Int,
     val ellipsis: Boolean,
     val constraints: Constraints
 ) : Paragraph {
 
     private val ellipsisChar = if (ellipsis) "\u2026" else ""
-
-    private val paragraphIntrinsics = intrinsics as SkiaParagraphIntrinsics
 
     private val layouter = paragraphIntrinsics.layouter().apply {
         setParagraphStyle(

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ActualParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ActualParagraph.skiko.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("SkiaParagraph_skikoKt")
+@file:JvmMultifileClass
+
+package androidx.compose.ui.text.platform
+
+import androidx.compose.ui.text.AnnotatedString.Range
+import androidx.compose.ui.text.Paragraph
+import androidx.compose.ui.text.ParagraphIntrinsics
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.SkiaParagraph
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.ceilToInt
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
+
+@Suppress("DEPRECATION")
+@Deprecated(
+    "Font.ResourceLoader is deprecated, instead pass FontFamily.Resolver",
+    replaceWith = ReplaceWith("ActualParagraph(text, style, spanStyles, placeholders, " +
+        "maxLines, ellipsis, width, density, fontFamilyResolver)"),
+)
+internal actual fun ActualParagraph(
+    text: String,
+    style: TextStyle,
+    spanStyles: List<Range<SpanStyle>>,
+    placeholders: List<Range<Placeholder>>,
+    maxLines: Int,
+    ellipsis: Boolean,
+    width: Float,
+    density: Density,
+    @Suppress("DEPRECATION") resourceLoader: Font.ResourceLoader
+): Paragraph = SkiaParagraph(
+    SkiaParagraphIntrinsics(
+        text,
+        style,
+        spanStyles,
+        placeholders,
+        density,
+        createFontFamilyResolver(resourceLoader)
+    ),
+    maxLines,
+    ellipsis,
+    Constraints(maxWidth = width.ceilToInt())
+)
+
+internal actual fun ActualParagraph(
+    text: String,
+    style: TextStyle,
+    spanStyles: List<Range<SpanStyle>>,
+    placeholders: List<Range<Placeholder>>,
+    maxLines: Int,
+    ellipsis: Boolean,
+    constraints: Constraints,
+    density: Density,
+    fontFamilyResolver: FontFamily.Resolver
+): Paragraph = SkiaParagraph(
+    SkiaParagraphIntrinsics(
+        text,
+        style,
+        spanStyles,
+        placeholders,
+        density,
+        fontFamilyResolver
+    ),
+    maxLines,
+    ellipsis,
+    constraints
+)
+
+internal actual fun ActualParagraph(
+    paragraphIntrinsics: ParagraphIntrinsics,
+    maxLines: Int,
+    ellipsis: Boolean,
+    constraints: Constraints
+): Paragraph = SkiaParagraph(
+    paragraphIntrinsics as SkiaParagraphIntrinsics,
+    maxLines,
+    ellipsis,
+    constraints
+)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+@file:JvmName("SkiaParagraph_skikoKt")
+@file:JvmMultifileClass
+
 package androidx.compose.ui.text.platform
 
 import org.jetbrains.skia.Font as SkFont
@@ -34,24 +38,18 @@ import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.text.AnnotatedString.Range
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.FontRasterizationSettings
-import androidx.compose.ui.text.Paragraph
-import androidx.compose.ui.text.ParagraphIntrinsics
 import androidx.compose.ui.text.Placeholder
 import androidx.compose.ui.text.PlaceholderVerticalAlign
-import androidx.compose.ui.text.SkiaParagraph
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextDecorationLineStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.WeakKeysCache
-import androidx.compose.ui.text.ceilToInt
-import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontFamilyResolverImpl
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontSynthesis
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.font.SkiaFontLoader
-import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.text.intl.LocaleList
 import androidx.compose.ui.text.style.BaselineShift
 import androidx.compose.ui.text.style.LineHeightStyle
@@ -61,12 +59,13 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextForegroundStyle
 import androidx.compose.ui.text.style.TextGeometricTransform
 import androidx.compose.ui.text.toSkFontRastrSettings
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.isUnspecified
 import androidx.compose.ui.unit.sp
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
 import org.jetbrains.skia.FontFeature
 import org.jetbrains.skia.Paint
 import org.jetbrains.skia.PaintMode
@@ -79,72 +78,6 @@ import org.jetbrains.skia.paragraph.PlaceholderStyle
 import org.jetbrains.skia.paragraph.TextBox
 
 private val DefaultFontSize = 16.sp
-
-@Suppress("DEPRECATION")
-@Deprecated(
-    "Font.ResourceLoader is deprecated, instead pass FontFamily.Resolver",
-    replaceWith = ReplaceWith("ActualParagraph(text, style, spanStyles, placeholders, " +
-        "maxLines, ellipsis, width, density, fontFamilyResolver)"),
-)
-internal actual fun ActualParagraph(
-    text: String,
-    style: TextStyle,
-    spanStyles: List<Range<SpanStyle>>,
-    placeholders: List<Range<Placeholder>>,
-    maxLines: Int,
-    ellipsis: Boolean,
-    width: Float,
-    density: Density,
-    @Suppress("DEPRECATION") resourceLoader: Font.ResourceLoader
-): Paragraph = SkiaParagraph(
-    SkiaParagraphIntrinsics(
-        text,
-        style,
-        spanStyles,
-        placeholders,
-        density,
-        createFontFamilyResolver(resourceLoader)
-    ),
-    maxLines,
-    ellipsis,
-    Constraints(maxWidth = width.ceilToInt())
-)
-
-internal actual fun ActualParagraph(
-    text: String,
-    style: TextStyle,
-    spanStyles: List<Range<SpanStyle>>,
-    placeholders: List<Range<Placeholder>>,
-    maxLines: Int,
-    ellipsis: Boolean,
-    constraints: Constraints,
-    density: Density,
-    fontFamilyResolver: FontFamily.Resolver
-): Paragraph = SkiaParagraph(
-    SkiaParagraphIntrinsics(
-        text,
-        style,
-        spanStyles,
-        placeholders,
-        density,
-        fontFamilyResolver
-    ),
-    maxLines,
-    ellipsis,
-    constraints
-)
-
-internal actual fun ActualParagraph(
-    paragraphIntrinsics: ParagraphIntrinsics,
-    maxLines: Int,
-    ellipsis: Boolean,
-    constraints: Constraints
-): Paragraph = SkiaParagraph(
-    paragraphIntrinsics as SkiaParagraphIntrinsics,
-    maxLines,
-    ellipsis,
-    constraints
-)
 
 // Computed ComputedStyles always have font/letter size in pixels for particular `density`.
 // It's important because density could be changed in runtime, and it should force

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -152,6 +152,7 @@ private data class ComputedStyle(
         // so all the changes will be applied to skia paint.
         val paint = _foregroundPaint.asFrameworkPaint()
         paint.reset()
+        _foregroundPaint.color = textForegroundStyle.color
         _foregroundPaint.setBrush(textForegroundStyle.brush, brushSize, textForegroundStyle.alpha)
         _foregroundPaint.setDrawStyle(drawStyle)
         _foregroundPaint.blendMode = blendMode

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -189,13 +189,22 @@ internal class ParagraphLayouter(
     fun layoutParagraph(width: Float): Paragraph {
         var paragraph = paragraphCache
         return if (paragraph != null) {
-            if (!this.width.sameValueAs(width)) {
-                this.width = width
-                paragraph.layout(width)
-            }
+            var layoutRequired = false
             if (updateForeground) {
                 builder.updateForegroundPaint(paragraph)
                 updateForeground = false
+
+                // Skia caches everything internally, so to actually apply it
+                // markDirty + layout is required.
+                paragraph.markDirty()
+                layoutRequired = true
+            }
+            if (!this.width.sameValueAs(width)) {
+                this.width = width
+                layoutRequired = true
+            }
+            if (layoutRequired) {
+                paragraph.layout(width)
             }
             paragraph
         } else {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -76,10 +76,21 @@ internal class ParagraphLayouter(
         textDirection = textDirection
     )
     private var paragraphCache: Paragraph? = null
+    private var updateForeground = false
     private var width: Float = Float.NaN
 
     val defaultFont get() = builder.defaultFont
     val textStyle get() = builder.textStyle
+
+    private fun invalidateParagraph(onlyForeground: Boolean = false) {
+        // skia's updateForegroundPaint applies the same style to every span,
+        // so if we have any, we need to rebuild the entire paragraph :'(
+        if (onlyForeground && builder.spanStyles.isEmpty()) {
+            updateForeground = true
+        } else {
+            paragraphCache = null
+        }
+    }
 
     internal fun emptyLineMetrics(paragraph: Paragraph): Array<LineMetrics> =
         builder.emptyLineMetrics(paragraph)
@@ -93,7 +104,40 @@ internal class ParagraphLayouter(
         ) {
             builder.maxLines = maxLines
             builder.ellipsis = ellipsis
-            paragraphCache = null
+            invalidateParagraph()
+        }
+    }
+
+    fun setColor(
+        color: Color,
+    ) {
+        val actualColor = color.takeOrElse { builder.textStyle.color }
+        if (builder.textStyle.color != actualColor) {
+            builder.textStyle = builder.textStyle.copy(
+                color = actualColor,
+            )
+            invalidateParagraph(onlyForeground = true)
+        }
+    }
+
+    fun setBrush(
+        brush: Brush?,
+        brushSize: Size,
+        alpha: Float,
+    ) {
+        val actualSize = builder.brushSize
+        if (builder.textStyle.brush != brush ||
+            actualSize.isUnspecified ||
+            !actualSize.width.sameValueAs(brushSize.width) ||
+            !actualSize.height.sameValueAs(brushSize.height) ||
+            !builder.textStyle.alpha.sameValueAs(alpha)
+        ) {
+            builder.textStyle = builder.textStyle.copy(
+                brush = brush,
+                alpha = alpha,
+            )
+            builder.brushSize = brushSize
+            invalidateParagraph(onlyForeground = true)
         }
     }
 
@@ -108,85 +152,58 @@ internal class ParagraphLayouter(
             // Since it affects only [ShaderBrush] we can keep the cache if it's not used.
             if (builder.textStyle.brush is ShaderBrush ||
                 builder.spanStyles.any { it.item.brush is ShaderBrush }) {
-                paragraphCache = null
+                invalidateParagraph(onlyForeground = true)
             }
         }
     }
 
     fun setTextStyle(
-        color: Color,
         shadow: Shadow?,
-        textDecoration: TextDecoration?
+        textDecoration: TextDecoration?,
     ) {
-        val actualColor = color.takeOrElse { builder.textStyle.color }
-        if (builder.textStyle.color != actualColor ||
-            builder.textStyle.shadow != shadow ||
+        if (builder.textStyle.shadow != shadow ||
             builder.textStyle.textDecoration != textDecoration
         ) {
             builder.textStyle = builder.textStyle.copy(
-                color = actualColor,
                 shadow = shadow,
-                textDecoration = textDecoration
+                textDecoration = textDecoration,
             )
-            paragraphCache = null
-        }
-    }
-
-    @ExperimentalTextApi
-    fun setTextStyle(
-        brush: Brush?,
-        brushSize: Size,
-        alpha: Float,
-        shadow: Shadow?,
-        textDecoration: TextDecoration?
-    ) {
-        val actualSize = builder.brushSize
-        if (builder.textStyle.brush != brush ||
-            actualSize.isUnspecified ||
-            !actualSize.width.sameValueAs(brushSize.width) ||
-            !actualSize.height.sameValueAs(brushSize.height) ||
-            !builder.textStyle.alpha.sameValueAs(alpha) ||
-            builder.textStyle.shadow != shadow ||
-            builder.textStyle.textDecoration != textDecoration
-        ) {
-            builder.textStyle = builder.textStyle.copy(
-                brush = brush,
-                alpha = alpha,
-                shadow = shadow,
-                textDecoration = textDecoration
-            )
-            builder.brushSize = brushSize
-            paragraphCache = null
+            invalidateParagraph()
         }
     }
 
     fun setDrawStyle(drawStyle: DrawStyle?) {
         if (builder.drawStyle != drawStyle) {
             builder.drawStyle = drawStyle
-            paragraphCache = null
+            invalidateParagraph(onlyForeground = true)
         }
     }
 
     fun setBlendMode(blendMode: BlendMode) {
         if (builder.blendMode != blendMode) {
             builder.blendMode = blendMode
-            paragraphCache = null
+            invalidateParagraph()
         }
     }
 
     fun layoutParagraph(width: Float): Paragraph {
-        val paragraph = paragraphCache
+        var paragraph = paragraphCache
         return if (paragraph != null) {
             if (!this.width.sameValueAs(width)) {
                 this.width = width
                 paragraph.layout(width)
             }
+            if (updateForeground) {
+                builder.updateForegroundPaint(paragraph)
+                updateForeground = false
+            }
             paragraph
         } else {
-            builder.build().apply {
-                paragraphCache = this
-                layout(width)
-            }
+            paragraph = builder.build()
+            paragraph.layout(width)
+            paragraphCache = paragraph
+            updateForeground = false
+            return paragraph
         }
     }
 }


### PR DESCRIPTION
- Adopt https://github.com/androidx/androidx/commit/16311966039d5d0cd98652b333059f1741bed564 change
- Use `paragraph.updateForegroundPaint` instead of full rebuild where possible

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4903

## Testing

Added `Android TextBrushDemo` in mpp demo

<img width="1029" alt="Screenshot 2024-06-07 at 19 21 39" src="https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/97d17949-e743-4774-ae55-cab664412091">

This should be tested by QA

## Release Notes

### Fixes - Multiple Platforms

- Fix text `brush` animation and optimized updating some visual text properties (applying time is reduced up to 40%)