### PR TITLE
Adapt focus interop code to Compose 1.7 changes

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3496,9 +3496,12 @@ public final class androidx/compose/ui/scene/ComposeSceneContext$Companion {
 	public final fun getEmpty ()Landroidx/compose/ui/scene/ComposeSceneContext;
 }
 
-public abstract interface class androidx/compose/ui/scene/ComposeSceneFocusManager : androidx/compose/ui/focus/FocusManager {
-	public abstract fun getFocusRect ()Landroidx/compose/ui/geometry/Rect;
-	public abstract fun getHasFocus ()Z
+public final class androidx/compose/ui/scene/ComposeSceneFocusManager {
+	public static final field $stable I
+	public final fun getFocusRect ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getHasFocus ()Z
+	public final fun releaseFocus ()V
+	public final fun takeFocus-3ESFkO8 (I)Z
 }
 
 public abstract interface class androidx/compose/ui/scene/ComposeSceneLayer {

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -151,10 +151,7 @@ public final class androidx/compose/ui/ComposeScene {
 	public final fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
 	public final fun getRoots ()Ljava/util/Set;
 	public final fun hasInvalidations ()Z
-	public final fun moveFocus-3ESFkO8 (I)Z
-	public final fun releaseFocus ()V
 	public final fun render (Lorg/jetbrains/skia/Canvas;J)V
-	public final fun requestFocus ()V
 	public final fun sendKeyEvent-ZmokQxo (Ljava/lang/Object;)Z
 	public final fun sendPointerEvent-BGSDPeU (IJJJILandroidx/compose/ui/input/pointer/PointerButtons;Landroidx/compose/ui/input/pointer/PointerKeyboardModifiers;Ljava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;)V
 	public static synthetic fun sendPointerEvent-BGSDPeU$default (Landroidx/compose/ui/ComposeScene;IJJJILandroidx/compose/ui/input/pointer/PointerButtons;Landroidx/compose/ui/input/pointer/PointerKeyboardModifiers;Ljava/lang/Object;Landroidx/compose/ui/input/pointer/PointerButton;ILjava/lang/Object;)V
@@ -3501,8 +3498,7 @@ public final class androidx/compose/ui/scene/ComposeSceneContext$Companion {
 
 public abstract interface class androidx/compose/ui/scene/ComposeSceneFocusManager : androidx/compose/ui/focus/FocusManager {
 	public abstract fun getFocusRect ()Landroidx/compose/ui/geometry/Rect;
-	public abstract fun releaseFocus ()V
-	public abstract fun requestFocus ()V
+	public abstract fun getHasFocus ()Z
 }
 
 public abstract interface class androidx/compose/ui/scene/ComposeSceneLayer {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -198,7 +198,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             skiaLayerAnalytics = skiaLayerAnalytics,
             windowContainer = windowContainer
         ).apply {
-            focusManager.releaseFocus()
             setBounds(0, 0, width, height)
             contentComponent.isFocusable = isFocusable
             contentComponent.isRequestFocusEnabled = isRequestFocusEnabled
@@ -207,19 +206,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             _focusListeners.forEach(contentComponent::addFocusListener)
             contentComponent.addFocusListener(object : FocusListener {
                 override fun focusGained(e: FocusEvent) {
-                    // The focus can be switched from the child component inside SwingPanel.
-                    // In that case, SwingPanel will take care of it.
-                    if (!isParentOf(e.oppositeComponent)) {
-                        focusManager.requestFocus()
+                    if (!e.isTemporary && !e.isFocusGainedHandledBySwingPanel(this@ComposePanel)) {
                         when (e.cause) {
-                            FocusEvent.Cause.TRAVERSAL_FORWARD -> {
-                                focusManager.moveFocus(FocusDirection.Next)
-                            }
-                            FocusEvent.Cause.TRAVERSAL_BACKWARD -> {
-                                focusManager.moveFocus(FocusDirection.Previous)
-                            }
                             FocusEvent.Cause.UNKNOWN, FocusEvent.Cause.ACTIVATION -> {
-                                focusManager.moveFocus(FocusDirection.Enter)
+                                if (!focusManager.hasFocus) {
+                                    focusManager.takeFocus(FocusDirection.Next)
+                                }
                             }
                             else -> Unit
                         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -125,7 +125,7 @@ public fun <T : Component> SwingPanel(
     DisposableEffect(Unit) {
         val focusListener = object : FocusListener {
             override fun focusGained(e: FocusEvent) {
-                if (interopComponent.container.isParentOf(e.oppositeComponent)) {
+                if (e.isFocusGainedHandledBySwingPanel(interopComponent.container)) {
                     when (e.cause) {
                         FocusEvent.Cause.TRAVERSAL_FORWARD -> focusSwitcher.moveForward()
                         FocusEvent.Cause.TRAVERSAL_BACKWARD -> focusSwitcher.moveBackward()
@@ -155,6 +155,19 @@ public fun <T : Component> SwingPanel(
         interopComponent.update = update
     }
 }
+
+/**
+ * true, if the event is handled by SwingPanel.
+ *
+ * The focus can be switched from the child component inside SwingPanel.
+ * In that case, SwingPanel will take care of it.
+ *
+ * The alternative that needs more investigation is to
+ * not use ComposePanel as next/previous focus element for SwingPanel children
+ * (see [SwingPanelContainer.focusComponent])
+ */
+internal fun FocusEvent.isFocusGainedHandledBySwingPanel(container: Container) =
+    container.isParentOf(oppositeComponent)
 
 /**
  * A container for [SwingPanel]'s component. Takes care about focus and clipping.
@@ -194,67 +207,77 @@ private class FocusSwitcher<T : Component>(
     private val interopComponent: SwingInteropComponent<T>,
     private val focusManager: FocusManager,
 ) {
-    private val backwardRequester = FocusRequester()
-    private val forwardRequester = FocusRequester()
-    private var isRequesting = false
+    private val backwardTracker = FocusTracker {
+        val container = interopComponent.container
+        val component = container.focusTraversalPolicy.getFirstComponent(container)
+        if (component != null) {
+            component.requestFocus(FocusEvent.Cause.TRAVERSAL_FORWARD)
+        } else {
+            moveForward()
+        }
+    }
+
+    private val forwardTracker = FocusTracker {
+        val component = interopComponent.container.focusTraversalPolicy.getLastComponent(interopComponent.container)
+        if (component != null) {
+            component.requestFocus(FocusEvent.Cause.TRAVERSAL_BACKWARD)
+        } else {
+            moveBackward()
+        }
+    }
 
     fun moveBackward() {
-        try {
-            isRequesting = true
-            backwardRequester.requestFocus()
-        } finally {
-            isRequesting = false
-        }
+        backwardTracker.requestFocusWithoutEvent()
         focusManager.moveFocus(FocusDirection.Previous)
     }
 
     fun moveForward() {
-        try {
-            isRequesting = true
-            forwardRequester.requestFocus()
-        } finally {
-            isRequesting = false
-        }
+        forwardTracker.requestFocusWithoutEvent()
         focusManager.moveFocus(FocusDirection.Next)
     }
 
     @Composable
     fun Content() {
-        EmptyLayout(
-            Modifier
-                .focusRequester(backwardRequester)
-                .onFocusEvent {
-                    if (it.isFocused && !isRequesting) {
-                        focusManager.clearFocus(force = true)
+        EmptyLayout(backwardTracker.modifier)
+        EmptyLayout(forwardTracker.modifier)
+    }
 
-                        val container = interopComponent.container
-                        val component = container.focusTraversalPolicy.getFirstComponent(container)
-                        if (component != null) {
-                            component.requestFocus(FocusEvent.Cause.TRAVERSAL_FORWARD)
-                        } else {
-                            moveForward()
-                        }
+    /**
+     * A helper class that can help:
+     * - to prevent recursive focus events
+     *   (a case when we focus the same element inside `onFocusEvent`)
+     * - to prevent triggering `onFocusEvent` while requesting focus somewhere else
+     */
+    private class FocusTracker(
+        private val onNonRecursiveFocused: () -> Unit
+    ) {
+        private val requester = FocusRequester()
+
+        private var isRequestingFocus = false
+        private var isHandlingFocus = false
+
+        fun requestFocusWithoutEvent() {
+            try {
+                isRequestingFocus = true
+                requester.requestFocus()
+            } finally {
+                isRequestingFocus = false
+            }
+        }
+
+        val modifier = Modifier
+            .focusRequester(requester)
+            .onFocusEvent {
+                if (!isRequestingFocus && !isHandlingFocus && it.isFocused) {
+                    try {
+                        isHandlingFocus = true
+                        onNonRecursiveFocused()
+                    } finally {
+                        isHandlingFocus = false
                     }
                 }
-                .focusTarget()
-        )
-        EmptyLayout(
-            Modifier
-                .focusRequester(forwardRequester)
-                .onFocusEvent {
-                    if (it.isFocused && !isRequesting) {
-                        focusManager.clearFocus(force = true)
-
-                        val component = interopComponent.container.focusTraversalPolicy.getLastComponent(interopComponent.container)
-                        if (component != null) {
-                            component.requestFocus(FocusEvent.Cause.TRAVERSAL_BACKWARD)
-                        } else {
-                            moveBackward()
-                        }
-                    }
-                }
-                .focusTarget()
-        )
+            }
+            .focusTarget()
     }
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -157,7 +157,7 @@ public fun <T : Component> SwingPanel(
 }
 
 /**
- * true, if the event is handled by SwingPanel.
+ * Returns whether the event is handled by SwingPanel.
  *
  * The focus can be switched from the child component inside SwingPanel.
  * In that case, SwingPanel will take care of it.

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -16,35 +16,47 @@
 
 package androidx.compose.ui.awt
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awaitEDT
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.performClick
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import com.google.common.truth.Truth.assertThat
+import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.KeyboardFocusManager
 import java.awt.Window
+import java.awt.event.FocusEvent
+import java.awt.event.FocusEvent.Cause
 import java.awt.event.KeyEvent
 import javax.swing.JButton
 import javax.swing.JFrame
+import javax.swing.JPanel
 import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.MainUIDispatcher
-import org.junit.Assume
-import org.junit.Test
+import org.junit.Assume.assumeFalse
 
 class ComposeFocusTest {
 
@@ -56,10 +68,10 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton1.Content()
-                    composeButton2.Content()
-                    composeButton3.Content()
-                    composeButton4.Content()
+                    composeButton1.Button()
+                    composeButton2.Button()
+                    composeButton3.Button()
+                    composeButton4.Button()
                 }
             }
         }
@@ -81,10 +93,10 @@ class ComposeFocusTest {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton1.Content()
-                            composeButton2.Content()
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton1.Button()
+                            composeButton2.Button()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
                 }
@@ -111,10 +123,10 @@ class ComposeFocusTest {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton1.Content()
-                            composeButton2.Content()
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton1.Button()
+                            composeButton2.Button()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
                 }
@@ -138,10 +150,10 @@ class ComposeFocusTest {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton1.Content()
-                            composeButton2.Content()
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton1.Button()
+                            composeButton2.Button()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
                 }
@@ -167,7 +179,7 @@ class ComposeFocusTest {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton3.Content()
+                            composeButton3.Button()
                             SwingPanel(
                                 modifier = Modifier.size(100.dp),
                                 factory = {
@@ -176,7 +188,7 @@ class ComposeFocusTest {
                                     }
                                 }
                             )
-                            composeButton4.Content()
+                            composeButton4.Button()
                         }
                     }
                 }
@@ -198,7 +210,7 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton3.Content()
+                    composeButton3.Button()
                     SwingPanel(
                         modifier = Modifier.size(100.dp),
                         factory = {
@@ -207,7 +219,7 @@ class ComposeFocusTest {
                             }
                         }
                     )
-                    composeButton4.Content()
+                    composeButton4.Button()
                 }
             }
         }
@@ -232,8 +244,8 @@ class ComposeFocusTest {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton1.Content()
-                            composeButton2.Content()
+                            composeButton1.Button()
+                            composeButton2.Button()
                             SwingPanel(
                                 modifier = Modifier.size(100.dp),
                                 factory = {
@@ -278,8 +290,8 @@ class ComposeFocusTest {
                                     }
                                 }
                             )
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
                 }
@@ -356,14 +368,14 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton3.Content()
+                    composeButton3.Button()
                     SwingPanel(
                         modifier = Modifier.size(100.dp),
                         factory = {
                             javax.swing.Box.createVerticalBox()
                         }
                     )
-                    composeButton4.Content()
+                    composeButton4.Button()
                 }
             }
         }
@@ -376,6 +388,46 @@ class ComposeFocusTest {
     }
 
     @Test
+    fun `only empty swing panel in a compose window`() = runFocusTest {
+        val window = ComposeWindow().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.setContent {
+            SwingPanel(
+                modifier = Modifier.size(100.dp).offset(50.dp, 50.dp),
+                factory = { JPanel() }
+            )
+        }
+        //window.pack()
+        window.isVisible = true
+
+        // no assert, just check that there is no crash or StackOverflow
+    }
+
+    @Test
+    fun `only empty swing panel in a compose panel`() = runFocusTest {
+        val window = JFrame().disposeOnEnd()
+        window.preferredSize = Dimension(500, 500)
+
+        window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
+            add(ComposePanel().apply {
+                setContent {
+                    SwingPanel(
+                        modifier = Modifier.size(100.dp),
+                        factory = {
+                            javax.swing.Box.createVerticalBox()
+                        }
+                    )
+                }
+            })
+        })
+        window.pack()
+        window.isVisible = true
+
+        // no assert, just check that there is no crash or StackOverflow
+    }
+
+    @Test
     fun `popup inside window`() = runFocusTest {
         val window = ComposeWindow().disposeOnEnd()
         window.preferredSize = Dimension(500, 500)
@@ -383,14 +435,14 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton1.Content()
-                    composeButton2.Content()
+                    composeButton1.Button()
+                    composeButton2.Button()
                     Popup(focusable = true) {
-                        composeButton3.Content()
-                        composeButton4.Content()
+                        composeButton3.Button()
+                        composeButton4.Button()
                     }
-                    composeButton5.Content()
-                    composeButton6.Content()
+                    composeButton5.Button()
+                    composeButton6.Button()
                 }
             }
         }
@@ -415,14 +467,14 @@ class ComposeFocusTest {
                 setContent {
                     MaterialTheme {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton1.Content()
-                            composeButton2.Content()
+                            composeButton1.Button()
+                            composeButton2.Button()
                             Popup(focusable = true) {
-                                composeButton3.Content()
-                                composeButton4.Content()
+                                composeButton3.Button()
+                                composeButton4.Button()
                             }
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
                 }
@@ -447,11 +499,11 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton1.Content()
-                    composeButton2.Content()
+                    composeButton1.Button()
+                    composeButton2.Button()
                     Popup(focusable = true) {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton3.Content()
+                            composeButton3.Button()
                             SwingPanel(
                                 modifier = Modifier.size(100.dp),
                                 factory = {
@@ -460,11 +512,11 @@ class ComposeFocusTest {
                                     }
                                 }
                             )
-                            composeButton4.Content()
+                            composeButton4.Button()
                         }
                     }
-                    composeButton5.Content()
-                    composeButton6.Content()
+                    composeButton5.Button()
+                    composeButton6.Button()
                 }
             }
         }
@@ -484,8 +536,8 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton1.Content()
-                    composeButton2.Content()
+                    composeButton1.Button()
+                    composeButton2.Button()
                     SwingPanel(
                         modifier = Modifier.size(100.dp),
                         factory = {
@@ -496,12 +548,12 @@ class ComposeFocusTest {
                     )
                     Popup(focusable = true) {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
-                    composeButton5.Content()
-                    composeButton6.Content()
+                    composeButton5.Button()
+                    composeButton6.Button()
                 }
             }
         }
@@ -521,12 +573,12 @@ class ComposeFocusTest {
         window.setContent {
             MaterialTheme {
                 Column(Modifier.fillMaxSize()) {
-                    composeButton1.Content()
-                    composeButton2.Content()
+                    composeButton1.Button()
+                    composeButton2.Button()
                     Popup(focusable = true) {
                         Column(Modifier.fillMaxSize()) {
-                            composeButton3.Content()
-                            composeButton4.Content()
+                            composeButton3.Button()
+                            composeButton4.Button()
                         }
                     }
                     SwingPanel(
@@ -537,8 +589,8 @@ class ComposeFocusTest {
                             }
                         }
                     )
-                    composeButton5.Content()
-                    composeButton6.Content()
+                    composeButton5.Button()
+                    composeButton6.Button()
                 }
             }
         }
@@ -556,7 +608,7 @@ class ComposeFocusTest {
         window.preferredSize = Dimension(500, 500)
 
         window.setContent {
-            composeButton1.Content()
+            composeButton1.Button()
         }
         window.pack()
         window.isVisible = true
@@ -577,7 +629,7 @@ class ComposeFocusTest {
         window.contentPane.add(javax.swing.Box.createVerticalBox().apply {
             add(ComposePanel().apply {
                 setContent {
-                    composeButton1.Content()
+                    composeButton1.Button()
                 }
             })
         })
@@ -621,51 +673,209 @@ class ComposeFocusTest {
         pressNextFocusKey()
     }
 
-    private val outerButton1 = TestJButton("outerButton1")
-    private val outerButton2 = TestJButton("outerButton2")
-    private val outerButton3 = TestJButton("outerButton3")
-    private val outerButton4 = TestJButton("outerButton4")
-    private val innerButton1 = TestJButton("innerButton1")
-    private val innerButton2 = TestJButton("innerButton2")
-    private val innerButton3 = TestJButton("innerButton3")
-    private val composeButton1 = ComposeButton("composeButton1")
-    private val composeButton2 = ComposeButton("composeButton2")
-    private val composeButton3 = ComposeButton("composeButton3")
-    private val composeButton4 = ComposeButton("composeButton4")
-    private val composeButton5 = ComposeButton("composeButton5")
-    private val composeButton6 = ComposeButton("composeButton6")
+    // Feature https://github.com/JetBrains/compose-multiplatform/issues/3888
+    @Test
+    fun `requestFocus assigns focus to first focusable element in ComposePanel`() = runFocusTest {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
 
-    private suspend fun FocusTestScope.testRandomFocus(vararg buttons: Any) {
-        fun Any.validateIsFocused() {
-            assertThat(
-                buttons.filter { it.isFocused() }
-            ).containsExactly(this)
+        val composePanel = ComposePanel()
+        composePanel.setBounds(0, 25, 100, 100)
+        composePanel.setContent {
+            Column {
+                composeButton1.Button()
+                composeButton2.Button()
+            }
         }
 
+        val frame = JFrame().disposeOnEnd()
+        frame.size = Dimension(500, 500)
+        frame.contentPane.add(outerButton1, BorderLayout.NORTH)
+        frame.contentPane.add(composePanel, BorderLayout.CENTER)
+        frame.isVisible = true
+
+        awaitEdtAfterDelay()
+        assertEquals(outerButton1, focusedComponent)
+
+        // The first requestFocus sends a focusGained(Cause.ACTIVATION) event
+        composePanel.requestFocus()
+        awaitEdtAfterDelay()
+        assertEquals(composeButton1, focusedComponent)
+
+        // Switch focus back to Swing
+        outerButton1.requestFocus()
+        awaitEdtAfterDelay()
+        assertEquals(outerButton1, focusedComponent)
+
+        // The 2nd requestFocus sends a focusGained(Cause.UNKNOWN) event; we want to test both
+        composePanel.requestFocus()
+        awaitEdtAfterDelay()
+        assertEquals(composeButton1, focusedComponent)
+    }
+
+    // Feature for changing the current behavior https://github.com/JetBrains/compose-multiplatform/issues/4917
+    @Test
+    fun `requestFocus doesn't assign focus to first focusable element in ComposeWindow`() = runFocusTest {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        val frame = ComposeWindow().disposeOnEnd()
+        frame.size = Dimension(500, 500)
+        frame.setContent {
+            Column {
+                composeButton1.Button()
+                composeButton2.Button()
+            }
+        }
+        frame.isVisible = true
+
+        awaitEdtAfterDelay()
+        assertEquals(null, focusedComponent)
+    }
+
+    @Test
+    fun `requestFocus shouldn't change already focused element`() = runFocusTest {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        val composePanel = ComposePanel()
+        composePanel.setBounds(0, 25, 100, 100)
+        composePanel.setContent {
+            composeButton1.Button()
+            composeBox1.Box {
+                composeButton2.Button()
+            }
+        }
+
+        val frame = JFrame().disposeOnEnd()
+        frame.size = Dimension(500, 500)
+        frame.contentPane.add(composePanel, BorderLayout.CENTER)
+        frame.isVisible = true
+
+        composeBox1.requestFocus()
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+
+        composePanel.requestFocus(Cause.UNKNOWN)
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+
+        composePanel.requestFocus(Cause.ACTIVATION)
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+
+        composePanel.requestFocus(Cause.TRAVERSAL_FORWARD)
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+
+        composePanel.requestFocus(Cause.TRAVERSAL_BACKWARD)
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+    }
+
+    // Bug https://github.com/JetBrains/compose-multiplatform/issues/4919
+    @Test
+    fun `temporary deactivation shouldn't reset focus`() = runFocusTest {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        val composePanel = ComposePanel()
+        composePanel.setBounds(0, 25, 100, 100)
+        composePanel.setContent {
+            composeButton1.Button()
+            composeBox1.Box {
+                composeButton2.Button()
+            }
+        }
+
+        val frame = JFrame().disposeOnEnd()
+        frame.size = Dimension(500, 500)
+        frame.contentPane.add(composePanel, BorderLayout.CENTER)
+        frame.isVisible = true
+
+        composeBox1.requestFocus()
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+
+        // show a second window, so the first loses focus with "event.isTemporary = true"
+        val temporaryFrame = JFrame().disposeOnEnd()
+        temporaryFrame.size = Dimension(500, 500)
+        temporaryFrame.isVisible = true
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+
+        temporaryFrame.dispose()
+        awaitEdtAfterDelay()
+        assertEquals(composeBox1, focusedComponent)
+    }
+
+    @Test
+    fun `custom focused component at start`() = runFocusTest {
+        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+
+        val frame = ComposeWindow().disposeOnEnd()
+        frame.setContent {
+            composeButton1.Button()
+            composeButton2.Button()
+            composeButton3.Button()
+
+            LaunchedEffect(Unit) {
+                composeButton2.requestFocus()
+            }
+        }
+        frame.size = Dimension(500, 500)
+        frame.isVisible = true
+
+        awaitEdtAfterDelay()
+        assertEquals(composeButton2, focusedComponent)
+    }
+
+    private val components = mutableListOf<TestComponent>()
+    private val focusedComponent: TestComponent?
+        get() {
+            val focused = components.filter { it.isFocused }
+            check(focused.size <= 1) {
+                "Too many components are focused: $focused"
+            }
+            return focused.firstOrNull()
+        }
+
+    private val outerButton1 = TestJButton("outerButton1").also(components::add)
+    private val outerButton2 = TestJButton("outerButton2").also(components::add)
+    private val outerButton3 = TestJButton("outerButton3").also(components::add)
+    private val outerButton4 = TestJButton("outerButton4").also(components::add)
+    private val innerButton1 = TestJButton("innerButton1").also(components::add)
+    private val innerButton2 = TestJButton("innerButton2").also(components::add)
+    private val innerButton3 = TestJButton("innerButton3").also(components::add)
+    private val composeButton1 = ComposeComponent("composeButton1").also(components::add)
+    private val composeButton2 = ComposeComponent("composeButton2").also(components::add)
+    private val composeButton3 = ComposeComponent("composeButton3").also(components::add)
+    private val composeButton4 = ComposeComponent("composeButton4").also(components::add)
+    private val composeButton5 = ComposeComponent("composeButton5").also(components::add)
+    private val composeButton6 = ComposeComponent("composeButton6").also(components::add)
+    private val composeBox1 = ComposeComponent("composeBox1").also(components::add)
+
+    private suspend fun FocusTestScope.testRandomFocus(vararg buttons: TestComponent) {
         suspend fun cycleForward() {
-            var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            var focusedIndex = buttons.indexOfFirst { it.isFocused }
             println("cycleForward from ${buttons[focusedIndex]}")
 
             repeat(2 * buttons.size) {
                 pressNextFocusKey()
                 focusedIndex = (focusedIndex + 1).mod(buttons.size)
-                buttons[focusedIndex].validateIsFocused()
+                assertEquals(buttons[focusedIndex], focusedComponent)
             }
         }
 
         suspend fun cycleBackward() {
-            var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            var focusedIndex = buttons.indexOfFirst { it.isFocused }
             println("cycleBackward from ${buttons[focusedIndex]}")
 
             repeat(2 * buttons.size) {
                 pressPreviousFocusKey()
                 focusedIndex = (focusedIndex - 1).mod(buttons.size)
-                buttons[focusedIndex].validateIsFocused()
+                assertEquals(buttons[focusedIndex], focusedComponent)
             }
         }
 
         suspend fun cycleRandom() {
-            var focusedIndex = buttons.indexOfFirst { it.isFocused() }
+            var focusedIndex = buttons.indexOfFirst { it.isFocused }
             println("cycleRandom from ${buttons[focusedIndex]}")
 
             repeat(4 * buttons.size) {
@@ -677,7 +887,7 @@ class ComposeFocusTest {
                     pressPreviousFocusKey()
                     focusedIndex = (focusedIndex - 1).mod(buttons.size)
                 }
-                buttons[focusedIndex].validateIsFocused()
+                assertEquals(buttons[focusedIndex], focusedComponent)
             }
         }
 
@@ -687,23 +897,25 @@ class ComposeFocusTest {
             val button = buttons.toList().random()
             button.requestFocus()
             awaitEdtAfterDelay()
-            button.validateIsFocused()
+            assertEquals(button, focusedComponent)
         }
 
         suspend fun randomPress() {
             println("randomPress")
 
-            val button = buttons.filterIsInstance<Component>().randomOrNull()
-            button?.performClick()
-            awaitEdtAfterDelay()
-            button?.validateIsFocused()
+            val button = buttons.filterIsInstance<TestJButton>().randomOrNull()
+            if (button != null) {
+                button.performClick()
+                awaitEdtAfterDelay()
+                assertEquals(button, focusedComponent)
+            }
         }
 
         awaitEdtAfterDelay()
         println("firstButton")
         buttons.first().requestFocus()
         awaitEdtAfterDelay()
-        buttons.first().validateIsFocused()
+        assertEquals(buttons.first(), focusedComponent)
 
         repeat(10) {
             when (Random.nextInt(5)) {
@@ -718,7 +930,7 @@ class ComposeFocusTest {
 }
 
 fun runFocusTest(action: suspend FocusTestScope.() -> Unit) {
-    Assume.assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
+    assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
     runBlocking(MainUIDispatcher) {
         val scope = FocusTestScope()
         try {
@@ -757,35 +969,34 @@ class FocusTestScope {
     }
 }
 
-private fun Any.requestFocus() {
-    when (this) {
-        is ComposeButton -> requestFocus()
-        is Component -> requestFocusInWindow()
-        else -> error("Unknown component")
-    }
+interface TestComponent {
+    fun requestFocus()
+    val isFocused: Boolean
 }
 
-private fun Any.isFocused() = when (this) {
-    is ComposeButton -> isFocused
-    is Component -> hasFocus()
-    else -> error("Unknown component")
-}
-
-private class ComposeButton(val name: String) {
-    var isFocused = false
-        private set
+private class ComposeComponent(val name: String): TestComponent {
+    override var isFocused = false
     private val focusRequester = FocusRequester()
-
-    @Composable
-    fun Content() {
-        Button({}, modifier = Modifier.onFocusChanged { isFocused = it.isFocused }.focusRequester(focusRequester)) {}
-    }
-
-    fun requestFocus() = focusRequester.requestFocus()
-
+    override fun requestFocus() = focusRequester.requestFocus()
     override fun toString() = name
+
+    val modifier = Modifier
+        .onFocusChanged { isFocused = it.isFocused }
+        .focusRequester(focusRequester)
 }
-private class TestJButton(name: String) : JButton(name) {
+
+@Composable
+private fun ComposeComponent.Button() {
+    Button({}, modifier = modifier) {}
+}
+
+@Composable
+private fun ComposeComponent.Box(content: @Composable BoxScope.() -> Unit) {
+    Box(modifier = modifier.focusTarget(), content = content)
+}
+
+private class TestJButton(name: String) : JButton(name), TestComponent {
+    override val isFocused: Boolean get() = hasFocus()
     override fun toString(): String = text
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -15,6 +15,7 @@
  */
 package androidx.compose.ui.awt
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -31,8 +33,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.layout
@@ -48,6 +52,7 @@ import com.google.common.truth.Truth.assertThat
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
+import java.awt.event.FocusEvent
 import java.awt.event.MouseEvent
 import javax.swing.JButton
 import javax.swing.JFrame
@@ -460,61 +465,6 @@ class ComposePanelTest {
             assertEquals(1, exitEvents)
         } finally {
             window.dispose()
-        }
-    }
-
-    @Test
-    fun `requestFocus assigns focus to first focusable element`() = runApplicationTest {
-        assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
-
-        var focusedElement: String? = null
-        val composePanel = ComposePanel()
-        composePanel.setBounds(0, 25, 100, 100)
-        composePanel.setContent {
-            Column {
-                Box(Modifier
-                    .size(10.dp)
-                    .onFocusChanged {
-                        focusedElement = if (it.isFocused) "first" else null
-                    }
-                    .focusable()
-                )
-                Box(Modifier
-                    .size(10.dp)
-                    .onFocusChanged {
-                        focusedElement = if (it.isFocused) "second" else null
-                    }
-                    .focusable()
-                )
-            }
-        }
-
-        val frame = JFrame()
-        try {
-            val button = JButton("Button")
-            frame.size = Dimension(500, 500)
-            frame.contentPane.add(button, BorderLayout.NORTH)
-            frame.contentPane.add(composePanel, BorderLayout.CENTER)
-            frame.isVisible = true
-
-            assertEquals(null, focusedElement)
-
-            // The first requestFocus sends a focusGained(Cause.ACTIVATION) event
-            composePanel.requestFocus()
-            awaitIdle()
-            assertEquals("first", focusedElement)
-
-            // Switch focus back to Swing
-            button.requestFocus()
-            awaitIdle()
-            assertEquals(null, focusedElement)
-
-            // The 2nd requestFocus sends a focusGained(Cause.UNKNOWN) event; we want to test both
-            composePanel.requestFocus()
-            awaitIdle()
-            assertEquals("first", focusedElement)
-        } finally {
-            frame.dispose()
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -338,33 +338,6 @@ class ComposeScene internal constructor(
     fun sendKeyEvent(event: KeyEvent): Boolean {
         return replacement.sendKeyEvent(event)
     }
-
-    /**
-     * Call this function to clear focus from the currently focused component, and set the focus to
-     * the root focus modifier.
-     */
-    @ExperimentalComposeUiApi
-    fun releaseFocus() {
-        replacement.focusManager.releaseFocus()
-    }
-
-    @ExperimentalComposeUiApi
-    fun requestFocus() {
-        replacement.focusManager.requestFocus()
-    }
-
-    /**
-     * Moves focus in the specified [direction][FocusDirection].
-     *
-     * If you are not satisfied with the default focus order, consider setting a custom order using
-     * [Modifier.focusProperties()][focusProperties].
-     *
-     * @return true if focus was moved successfully. false if the focused item is unchanged.
-     */
-    @ExperimentalComposeUiApi
-    fun moveFocus(focusDirection: FocusDirection): Boolean {
-        return replacement.focusManager.moveFocus(focusDirection)
-    }
 }
 
 private fun Constraints.toIntSize() =

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -29,6 +29,9 @@ import androidx.compose.ui.draganddrop.DragAndDropManager
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusOwner
 import androidx.compose.ui.focus.FocusOwnerImpl
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Canvas
@@ -104,35 +107,36 @@ internal class RootNodeOwner(
     private val snapshotInvalidationTracker: SnapshotInvalidationTracker,
     private val inputHandler: ComposeSceneInputHandler,
 ) {
-    // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-1257/Implement-new-FocusOwnerImpl-from-08.04.2024)
-    //  implement new changes from upstream
-    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2944)
-    //  Check if ComposePanel/SwingPanel focus interop work correctly with new features of
-    //  the focus system (it works with the old features like moveFocus/clearFocus)
     val focusOwner: FocusOwner = FocusOwnerImpl(
-        onRequestFocusForOwner = { focusDirection, _ ->
-            var result = platformContext.requestFocus()
-            if (result && focusDirection != null) {
-                result = platformContext.parentFocusManager.moveFocus(focusDirection)
-            }
-            return@FocusOwnerImpl result
+        onRequestFocusForOwner = { _, _ ->
+            platformContext.requestFocus()
         },
         onRequestApplyChangesListener = {
             owner.registerOnEndApplyChangesListener(it)
         },
-        onMoveFocusInterop = {
-            platformContext.parentFocusManager.moveFocus(it)
-        },
-        onFocusRectInterop = {
-            null
-        },
+        // onMoveFocusInterop's purpose is to move focus inside embed interop views.
+        // We use another logic inside SwingPanel
+        onMoveFocusInterop = { false },
+        onFocusRectInterop = { null },
         onLayoutDirection = { _layoutDirection },
         onClearFocusForOwner = {
             platformContext.parentFocusManager.clearFocus(true)
         },
     )
     private val rootSemanticsNode = EmptySemanticsModifier()
+
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)
+        .then(Modifier.focusProperties {
+            exit = {
+                // if focusDirection is forward/backward,
+                // it will move the focus after/before ComposePanel
+                if (platformContext.parentFocusManager.moveFocus(it)) {
+                    FocusRequester.Cancel
+                } else {
+                    FocusRequester.Default
+                }
+            }
+        })
         .then(focusOwner.modifier)
         .semantics {
             // This makes the reported role of the root node "PANEL", which is ignored by VoiceOver

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -126,7 +126,7 @@ internal class RootNodeOwner(
     private val rootSemanticsNode = EmptySemanticsModifier()
 
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)
-        .then(Modifier.focusProperties {
+        .focusProperties {
             exit = {
                 // if focusDirection is forward/backward,
                 // it will move the focus after/before ComposePanel
@@ -136,7 +136,7 @@ internal class RootNodeOwner(
                     FocusRequester.Default
                 }
             }
-        })
+        }
         .then(focusOwner.modifier)
         .semantics {
             // This makes the reported role of the root node "PANEL", which is ignored by VoiceOver

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -115,7 +115,7 @@ internal class RootNodeOwner(
             owner.registerOnEndApplyChangesListener(it)
         },
         // onMoveFocusInterop's purpose is to move focus inside embed interop views.
-        // We use another logic inside SwingPanel
+        // Another logic is used in our child-interop views (SwingPanel, etc)
         onMoveFocusInterop = { false },
         onFocusRectInterop = { null },
         onLayoutDirection = { _layoutDirection },

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
@@ -17,28 +17,44 @@
 package androidx.compose.ui.scene
 
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.FocusOwner
 import androidx.compose.ui.geometry.Rect
 
 /**
  * The extension of [FocusManager] to manage focus within a [ComposeScene].
  */
 @InternalComposeUiApi
-interface ComposeSceneFocusManager : FocusManager {
+class ComposeSceneFocusManager internal constructor(
+    private val focusOwner: () -> FocusOwner
+) {
     /**
-     * Call this function to propagate focus to one of the focus modifiers
-     * in the component hierarchy.
+     * `true` if any child has focus
      */
-    fun requestFocus()
-
-    /**
-     * Call this function to clear focus from the currently focused component, and set the focus to
-     * the root focus modifier.
-     */
-    fun releaseFocus()
+    val hasFocus: Boolean get() = focusOwner().rootState.hasFocus
 
     /**
      * Searches for the currently focused item, and returns its coordinates as a rect.
      */
-    fun getFocusRect(): Rect?
+    fun getFocusRect(): Rect? = focusOwner().getFocusRect()
+
+    /**
+     * Take focus to ComposeScene in specified [focusDirection].
+     *
+     * Returns false if there are no focusable elements in this direction:
+     * - the scene is empty
+     * - we are in the end of the scene and move forward
+     * - we are in the beginning of the scene and move backward
+     */
+    fun takeFocus(focusDirection: FocusDirection): Boolean {
+        return focusOwner().takeFocus(focusDirection, previouslyFocusedRect = null)
+    }
+
+    /**
+     * Release focus from ComposeScene
+     */
+    fun releaseFocus() {
+        focusOwner().releaseFocus()
+    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
@@ -22,9 +22,7 @@ import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerInputEvent
@@ -124,8 +122,9 @@ private class SingleLayerComposeSceneImpl(
             mainOwner.size = value
         }
 
-    override val focusManager: ComposeSceneFocusManager =
-        ComposeSceneFocusManagerImpl()
+    override val focusManager: ComposeSceneFocusManager = ComposeSceneFocusManager(
+        focusOwner = { mainOwner.focusOwner }
+    )
 
     init {
         onOwnerAppended(mainOwner)
@@ -188,23 +187,10 @@ private class SingleLayerComposeSceneImpl(
     )
 
     private fun onOwnerAppended(owner: RootNodeOwner) {
-        owner.focusOwner.takeFocus(FocusDirection.Enter, previouslyFocusedRect = null)
         semanticsOwnerListener?.onSemanticsOwnerAppended(owner.semanticsOwner)
     }
 
     private fun onOwnerRemoved(owner: RootNodeOwner) {
         semanticsOwnerListener?.onSemanticsOwnerRemoved(owner.semanticsOwner)
-    }
-
-    private inner class ComposeSceneFocusManagerImpl : ComposeSceneFocusManager {
-        private val focusOwner get() = mainOwner.focusOwner
-        override fun requestFocus() {
-            focusOwner.takeFocus(FocusDirection.Enter, previouslyFocusedRect = null)
-        }
-        override fun releaseFocus() = focusOwner.releaseFocus()
-        override fun getFocusRect(): Rect? = focusOwner.getFocusRect()
-        override fun clearFocus(force: Boolean) = focusOwner.clearFocus(force)
-        override fun moveFocus(focusDirection: FocusDirection): Boolean =
-            focusOwner.moveFocus(focusDirection)
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/JetBrains/compose-multiplatform/issues/2944

- Fixes https://github.com/JetBrains/compose-multiplatform/issues/4919

- Fixes https://youtrack.jetbrains.com/issue/COMPOSE-1212/Integration.-Check-changes-in-FocusOwnerImpl

After https://android-review.googlesource.com/c/platform/frameworks/support/+/2813125, there are some changes that affected our code for focus interop with ComposePanel/SwingPanel:
- the root node no longer focusable
- FocusOwnerImpl now has iterop callbacks and our own modifications of this class (in jb-main, integration was reset) doesn't work anymore

## Testing
- added new tests
- ComposeFocusTest now pass

## Release notes
### Fixes - Multiple platforms
- Fix "ComposePanel. Focus moves to child after focusing/unfocusing the main window"