### PR TITLE
Replace TODO() to comments in `IntermediateTextInputUIView`

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -332,14 +332,12 @@ internal class IntermediateTextInputUIView(
     override fun positionWithinRange(
         range: UITextRange,
         atCharacterOffset: NSInteger
-    ): UITextPosition? =
-        TODO("positionWithinRange range: $range, atCharacterOffset: $atCharacterOffset")
+    ): UITextPosition? = null // TODO positionWithinRange
 
     override fun positionWithinRange(
         range: UITextRange,
         farthestInDirection: UITextLayoutDirection
-    ): UITextPosition? =
-        TODO("positionWithinRange, farthestInDirection: ${farthestInDirection.directionToStr()}")
+    ): UITextPosition? = null // TODO positionWithinRange
 
     override fun characterRangeByExtendingPosition(
         position: UITextPosition,
@@ -348,7 +346,7 @@ internal class IntermediateTextInputUIView(
         if (position !is IntermediateTextPosition) {
             error("position !is IntermediateTextPosition")
         }
-        TODO("characterRangeByExtendingPosition, inDirection: ${inDirection.directionToStr()}")
+        return null // TODO characterRangeByExtendingPosition
     }
 
     override fun baseWritingDirectionForPosition(
@@ -356,9 +354,6 @@ internal class IntermediateTextInputUIView(
         inDirection: UITextStorageDirection
     ): NSWritingDirection {
         return NSWritingDirectionLeftToRight // TODO support RTL text direction
-        if (position !is IntermediateTextPosition) {
-            error("position !is IntermediateTextPosition")
-        }
     }
 
     override fun setBaseWritingDirection(
@@ -377,9 +372,6 @@ internal class IntermediateTextInputUIView(
             Ideally, here should be correct rect for caret from Compose.
          */
         return CGRectMake(x = 1.0, y = 1.0, width = 1.0, height = 1.0)
-        if (position !is IntermediateTextPosition) {
-            error("position !is IntermediateTextPosition")
-        }
     }
 
     override fun selectionRectsForRange(range: UITextRange): List<*> = listOf<UITextSelectionRect>()
@@ -397,9 +389,6 @@ internal class IntermediateTextInputUIView(
     ): Map<Any?, *>? {
         return NSDictionary.dictionary()
         //TODO: Need to implement
-        if (position !is IntermediateTextPosition) {
-            error("position !is IntermediateTextPosition")
-        }
     }
 
     override fun characterOffsetOfPosition(
@@ -409,7 +398,7 @@ internal class IntermediateTextInputUIView(
         if (position !is IntermediateTextPosition) {
             error("position !is IntermediateTextPosition")
         }
-        TODO("characterOffsetOfPosition")
+        return 0 // TODO: characterOffsetOfPosition
     }
 
     override fun shouldChangeTextInRange(range: UITextRange, replacementText: String): Boolean {


### PR DESCRIPTION
Change TODO throw to comment. Fixes crashes like:
```

Uncaught Kotlin exception: kotlin.NotImplementedError: An operation is not implemented: positionWithinRange, farthestInDirection: Right
    at 0   ComposeDemo                         0x1020baceb        kfun:kotlin.Throwable#<init>(kotlin.String?){} + 119 (/opt/buildAgent/work/2fed3917837e7e79/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Throwable.kt:28:37)
    at 1   ComposeDemo                         0x1020b4147        kfun:kotlin.Error#<init>(kotlin.String?){} + 115 (/opt/buildAgent/work/2fed3917837e7e79/kotlin/kotlin-native/runtime/src/main/kotlin/kotlin/Exceptions.kt:12:44)
    at 2   ComposeDemo                         0x1021cdf1f        kfun:kotlin.NotImplementedError#<init>(kotlin.String){} + 115 (/opt/buildAgent/work/2fed3917837e7e79/kotlin/libraries/stdlib/src/kotlin/util/Standard.kt:15:90)
    at 3   ComposeDemo                         0x1014e51e7        kfun:androidx.compose.ui.window.IntermediateTextInputUIView#objc:positionWithinRange:farthestInDirection: + 287 
    at 4   ComposeDemo                         0x1014eae6f        _6f72672e6a6574627261696e732e636f6d706f73652e75693a75692f55736572732f566c61642e4b6f6e7374616e74696e6f762f53747564696f50726f6a656374732f636f6d706f73652d6d756c7469706c6174666f726d2d636f72652d6d61696e2f636f6d706f73652f75692f75692f7372632f75696b69744d61696e2f6b6f746c696e2f616e64726f6964782f636f6d706f73652f75692f77696e646f772f496e7465726d65646961746554657874496e7075745549566965772e75696b69742e6b74_knbridge112 + 219 
    at 5   UIKitCore                           0x185179e7b        -[_UIKeyboardTextSelectionController caretRectForRightmostSelectedPosition] + 87 
    at 6   UIKitCore                           0x185180103        -[_UIKeyboardTextSelectionInteraction beginTwoFingerPanWithTranslation:isShiftKeyBeingHeld:executionContext:] + 347 
    at 7   UIKitCore                           0x1851817db        __122-[_UIKeyboardTextSelectionInteraction indirectPanGestureWithState:withTranslation:withFlickDirection:isShiftKeyBeingHeld:]_block_invoke + 131 
    at 8   UIKitCore                           0x18510b26b        -[UIKeyboardTaskEntry execute:] + 199 
    at 9   UIKitCore                           0x185109f17        -[UIKeyboardTaskQueue continueExecutionOnMainThread] + 303 
    at 10  UIKitCore                           0x18510a37f        -[UIKeyboardTaskQueue addTask:] + 91 
```