### PR TITLE
Fix StackOverflow when using navigation with type safe setPopUpTo

### DIFF
--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavOptions.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavOptions.jb.kt
@@ -236,7 +236,9 @@ public actual class NavOptions internal constructor(
             saveState: Boolean
         ): Builder {
             popUpToRouteObject = route
-            setPopUpTo(route::class.serializer().hashCode(), inclusive, saveState)
+            popUpToId = -1
+            popUpToInclusive = inclusive
+            popUpToSaveState = saveState
             return this
         }
 

--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavOptions.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavOptions.jb.kt
@@ -236,7 +236,7 @@ public actual class NavOptions internal constructor(
             saveState: Boolean
         ): Builder {
             popUpToRouteObject = route
-            popUpToId = -1
+            popUpToId = route::class.serializer().hashCode()
             popUpToInclusive = inclusive
             popUpToSaveState = saveState
             return this


### PR DESCRIPTION
The issue is that the call to setPopUpTo becomes recursive since the `hashCode` is treated as `route: T`. The fix is to duplicate what the other functions are doing, which isn't too bad because there isn't a lot happening.

Another option would be to extract everything into a separate private function and have all the overloads call that, but it seemed like overkill here.

## Testing
Describe how you tested your changes. If possible and needed:
- Test it on a sample project

## Google CLA
Signed
