### PR TITLE
Fix ComposeAccessibleComponent.getAccessibleChild

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -332,9 +332,13 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleChild(i: Int): Accessible? {
-            return semanticsNode.replacedChildren.getOrNull(i)?.id?.let { id ->
-                controller.accessibleByNodeId(id)
-            } ?: auxiliaryChildren[i - semanticsNode.replacedChildren.size]
+            val replacedChildren = semanticsNode.replacedChildren
+            val replacedChildrenSize = replacedChildren.size
+            return if (i < replacedChildrenSize) {
+                controller.accessibleByNodeId(replacedChildren[i].id)
+            } else {
+                auxiliaryChildren[i - replacedChildrenSize]
+            }
         }
 
         override fun getLocale(): Locale = Locale.getDefault()


### PR DESCRIPTION
`ComposeAccessibleComponent.getAccessibleChild` was trying to incorrectly access `auxiliaryChildren` if `controller.accessibleByNodeId` returned `null`.

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4778

## Testing
1. Run the code below
2. Turn on VoiceOver
3. Scroll the list with the mouse wheel.
4. Press tab.
```
fun main() {
    application {
        Window(
            onCloseRequest = ::exitApplication
        ) {
            LazyColumn {
                items(100) {
                    Text("Item $it")
                }
            }
        }
    }
}
```
Note that this doesn't reproduce in latest jb-main, probably due to focus traversal changes.
