### PR TITLE
Text size in iOS is changing with delay after being changed in settings

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -190,6 +190,7 @@ internal class ComposeContainer(
     override fun traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         systemThemeState.value = traitCollection.userInterfaceStyle.asComposeSystemTheme()
+        view.setNeedsLayout()
     }
 
     override fun viewWillLayoutSubviews() {


### PR DESCRIPTION
Added calling setNeedsLayout() in traitCollectionDidChange() on purpose to update the scene with new fontScale.

<!-- Optional -->
https://youtrack.jetbrains.com/issue/CMP-1514/iOS-Font-size-in-app-is-changing-with-delay-after-being-changed-in-settings

probably, may fix https://github.com/JetBrains/compose-multiplatform/issues/4923

## Testing
Manual testing: Open App, then switch to Settings application, go Accessibility -> Display & Text Size -> Larger Text, change preferred text size and go back to testing App. The text size should be changed after changing text size in Settings.


## Release Notes
<!--
Optional, if omitted - won't be included in the changelog

Sections:
- Highlights
- Known issues
- Breaking changes
- Features
- Fixes

Subsections:
- Multiple Platforms
- iOS
- Desktop
- Web
- Resources
- Gradle Plugin
-->
### Fixes - iOS
- Fixed delaying in changing text size in Compose iOS Application after changing text size in Accessibility settings

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
