### PR TITLE
Revert removing `material-icons-core` project dependency

### DIFF
--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -100,11 +100,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:animation:animation-core"))
 
                 api(project(":compose:foundation:foundation"))
-                api("org.jetbrains.compose.material:material-icons-core:1.6.11") {
-                    // exclude dependencies, because they override local projects when we build 0.0.0-* version
-                    // (see https://repo1.maven.org/maven2/org/jetbrains/compose/material/material-icons-core-desktop/1.6.11/material-icons-core-desktop-1.6.11.module)
-                    exclude group: "org.jetbrains.compose.ui"
-                }
+                // TODO: Remove material icons from compilation
+                api(project(":compose:material:material-icons-core"))
                 api(project(":compose:material:material-ripple"))
                 api(project(":compose:runtime:runtime"))
                 api(project(":compose:ui:ui-graphics"))


### PR DESCRIPTION
Revert of https://github.com/JetBrains/compose-multiplatform-core/commit/5df63ff653a058bb3c45fd75567539ef1a4a4536

It was only partially applied during material3 merge, so introduces version mixing without actual removal. It should be done separately and more careful