### PR TITLE
Turn off all flaky web tests

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -62,6 +62,7 @@ class SelectionContainerTests : OnCanvasTests {
 
     @Test
     @Ignore
+    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     fun canSelectOneWordUsingDoubleClick() = runTest {
         createCanvasAndAttach()
         val syncChannel = Channel<Selection?>(
@@ -179,6 +180,7 @@ class SelectionContainerTests : OnCanvasTests {
 
     @Test
     @Ignore
+    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     fun twoSingleClicksDoNotTriggerSelection() = runTest {
         createCanvasAndAttach()
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -60,6 +61,7 @@ class SelectionContainerTests : OnCanvasTests {
     }
 
     @Test
+    @Ignore
     fun canSelectOneWordUsingDoubleClick() = runTest {
         createCanvasAndAttach()
         val syncChannel = Channel<Selection?>(
@@ -176,6 +178,7 @@ class SelectionContainerTests : OnCanvasTests {
     }
 
     @Test
+    @Ignore
     fun twoSingleClicksDoNotTriggerSelection() = runTest {
         createCanvasAndAttach()
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.AfterTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -38,6 +39,7 @@ class TextTests : OnCanvasTests {
     }
 
     @Test
+    @Ignore
     // https://github.com/JetBrains/compose-multiplatform/issues/4078
     fun baselineShouldBeNotZero() = runTest {
         val canvas = createCanvasAndAttach()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
@@ -40,6 +40,7 @@ class TextTests : OnCanvasTests {
 
     @Test
     @Ignore
+    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     // https://github.com/JetBrains/compose-multiplatform/issues/4078
     fun baselineShouldBeNotZero() = runTest {
         val canvas = createCanvasAndAttach()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -52,6 +53,7 @@ class TextInputTests : OnCanvasTests  {
     }
 
     @Test
+    @Ignore
     fun keyboardEventPassedToTextField() = runTest {
 
         val textInputChannel = Channel<String>(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -54,6 +54,7 @@ class TextInputTests : OnCanvasTests  {
 
     @Test
     @Ignore
+    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     fun keyboardEventPassedToTextField() = runTest {
 
         val textInputChannel = Channel<String>(


### PR DESCRIPTION
I have to ignore flaky tests because investigation is still running but the team should not be blocked with flakiness of specific test set