### PR TITLE
Use only suspendable send/recieve channel methods in tests

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -18,6 +18,11 @@ package androidx.compose.ui
 
 import kotlin.math.abs
 import kotlinx.browser.document
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.asList
 
@@ -47,4 +52,8 @@ internal interface OnCanvasTests {
             throw AssertionError("Expected $expected but got $actual. Difference is more than the allowed delta $tolerance")
         }
     }
+}
+
+internal fun <T> Channel<T>.sendFromScope(value: T, scope: CoroutineScope = GlobalScope) {
+    scope.launch(Dispatchers.Unconfined) { send(value) }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -61,8 +60,6 @@ class SelectionContainerTests : OnCanvasTests {
     }
 
     @Test
-    @Ignore
-    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     fun canSelectOneWordUsingDoubleClick() = runTest {
         createCanvasAndAttach()
         val syncChannel = Channel<Selection?>(
@@ -79,7 +76,7 @@ class SelectionContainerTests : OnCanvasTests {
                 selection = selection,
                 onSelectionChange = {
                     selection = it
-                    syncChannel.trySend(it)
+                    syncChannel.sendFromScope(it)
                 },
                 children = {
                     Column {
@@ -143,7 +140,7 @@ class SelectionContainerTests : OnCanvasTests {
                 selection = selection,
                 onSelectionChange = {
                     selection = it
-                    syncChannel.trySend(it)
+                    syncChannel.sendFromScope(it)
                 },
                 children = {
                     Column {
@@ -179,8 +176,6 @@ class SelectionContainerTests : OnCanvasTests {
     }
 
     @Test
-    @Ignore
-    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     fun twoSingleClicksDoNotTriggerSelection() = runTest {
         createCanvasAndAttach()
 
@@ -199,7 +194,7 @@ class SelectionContainerTests : OnCanvasTests {
                 selection = selection,
                 onSelectionChange = {
                     selection = it
-                    syncChannel.trySend(it)
+                    syncChannel.sendFromScope(it)
                     selectionCallbackCounter++
                 },
                 children = {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.AfterTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -39,8 +38,6 @@ class TextTests : OnCanvasTests {
     }
 
     @Test
-    @Ignore
-    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     // https://github.com/JetBrains/compose-multiplatform/issues/4078
     fun baselineShouldBeNotZero() = runTest {
         val canvas = createCanvasAndAttach()
@@ -56,7 +53,7 @@ class TextTests : OnCanvasTests {
                         "Heading",
                         modifier = Modifier.alignByBaseline()
                             .onGloballyPositioned {
-                                headingOnPositioned.trySend(it[FirstBaseline] / density)
+                                headingOnPositioned.sendFromScope(it[FirstBaseline] / density)
                             },
                         style = MaterialTheme.typography.h4
                     )
@@ -64,7 +61,7 @@ class TextTests : OnCanvasTests {
                         " — Subtitle",
                         modifier = Modifier.alignByBaseline()
                             .onGloballyPositioned {
-                                subtitleOnPositioned.trySend(it[FirstBaseline] / density)
+                                subtitleOnPositioned.sendFromScope(it[FirstBaseline] / density)
                             },
                         style = MaterialTheme.typography.subtitle1
                     )

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -29,9 +29,9 @@ import androidx.compose.ui.events.createTouchEvent
 import androidx.compose.ui.events.keyDownEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.sendFromScope
 import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.BeforeTest
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -53,8 +53,6 @@ class TextInputTests : OnCanvasTests  {
     }
 
     @Test
-    @Ignore
-    // TODO: Activate after fixing https://youtrack.jetbrains.com/issue/CMP-1580/Fix-flaky-tests
     fun keyboardEventPassedToTextField() = runTest {
 
         val textInputChannel = Channel<String>(
@@ -70,7 +68,7 @@ class TextInputTests : OnCanvasTests  {
             TextField(
                 value = "",
                 onValueChange = { value ->
-                    textInputChannel.trySend(value)
+                    textInputChannel.sendFromScope(value)
                 },
                 modifier = Modifier.focusRequester(firstFocusRequester)
             )
@@ -78,7 +76,7 @@ class TextInputTests : OnCanvasTests  {
             TextField(
                 value = "",
                 onValueChange = { value ->
-                    textInputChannel.trySend(value)
+                    textInputChannel.sendFromScope(value)
                 },
                 modifier = Modifier.focusRequester(secondFocusRequester)
             )

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.sendFromScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
@@ -63,7 +64,7 @@ class ComposeWindowLifecycleTest {
 
         lifecycleOwner.lifecycle.addObserver(object : LifecycleEventObserver {
             override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                eventsChannel.trySend(event)
+                eventsChannel.sendFromScope(event)
             }
         })
 


### PR DESCRIPTION
Flakiness was caused by (at least this was the major contributing factor) intermixing suspendable and non-suspendable channel methods

This is presumably the ultimate fix for https://youtrack.jetbrains.com/issue/CMP-1580
