### PR TITLE
Better `ComposeScene` naming

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/OnClickTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/OnClickTest.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
-import androidx.compose.ui.ComposeScene
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -33,10 +32,11 @@ import androidx.compose.ui.input.pointer.isAltPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runSkikoComposeUiTest
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.use
 import kotlin.test.Test
@@ -82,9 +82,9 @@ class OnClickTest {
     @OptIn(ExperimentalFoundationApi::class, ExperimentalCoroutinesApi::class)
     @Test
     fun simpleClickWithoutMove() = runTest {
-        val scene = ComposeScene(coroutineContext = coroutineContext)
+        val scene = CanvasLayersComposeScene(coroutineContext = coroutineContext)
         try {
-            scene.constraints = Constraints.fixed(100, 100)
+            scene.size = IntSize(100, 100)
             scene.setContent {
                 Box(
                     Modifier

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneContext
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
@@ -218,7 +218,7 @@ class SkikoComposeUiTest @InternalTestApi constructor(
         }
     }
 
-    private fun createUi() = MultiLayerComposeScene(
+    private fun createUi() = CanvasLayersComposeScene(
         density = density,
         size = size,
         coroutineContext = coroutineContext,

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3475,6 +3475,11 @@ public final class androidx/compose/ui/res/Resources_desktopKt {
 	public static final fun useResource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
+public final class androidx/compose/ui/scene/CanvasLayersComposeScene_skikoKt {
+	public static final fun CanvasLayersComposeScene-3tKcejY (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
+	public static synthetic fun CanvasLayersComposeScene-3tKcejY$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
+}
+
 public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public abstract fun calculateContentSize-YbymL2g ()J
 	public abstract fun close ()V
@@ -3558,6 +3563,11 @@ public final class androidx/compose/ui/scene/ComposeScenePointer {
 public final class androidx/compose/ui/scene/MultiLayerComposeScene_skikoKt {
 	public static final fun MultiLayerComposeScene-3tKcejY (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
 	public static synthetic fun MultiLayerComposeScene-3tKcejY$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
+}
+
+public final class androidx/compose/ui/scene/PlatformLayersComposeScene_skikoKt {
+	public static final fun PlatformLayersComposeScene-3tKcejY (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;)Landroidx/compose/ui/scene/ComposeScene;
+	public static synthetic fun PlatformLayersComposeScene-3tKcejY$default (Landroidx/compose/ui/unit/Density;Landroidx/compose/ui/unit/LayoutDirection;Landroidx/compose/ui/unit/IntSize;Lkotlin/coroutines/CoroutineContext;Landroidx/compose/ui/scene/ComposeSceneContext;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Landroidx/compose/ui/scene/ComposeScene;
 }
 
 public final class androidx/compose/ui/scene/SingleLayerComposeScene_skikoKt {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -355,7 +355,7 @@ internal class ComposeContainer(
         val density = container.density
         return when (layerType) {
             LayerType.OnSameCanvas ->
-                MultiLayerComposeScene(
+                CanvasLayersComposeScene(
                     density = density,
                     layoutDirection = layoutDirection,
                     coroutineContext = mediator.coroutineContext,
@@ -364,7 +364,7 @@ internal class ComposeContainer(
                     ),
                     invalidate = mediator::onComposeInvalidation,
                 )
-            else -> SingleLayerComposeScene(
+            else -> PlatformLayersComposeScene(
                 density = density,
                 layoutDirection = layoutDirection,
                 coroutineContext = mediator.coroutineContext,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -159,7 +159,7 @@ internal class SwingComposeSceneLayer(
 
     private fun createComposeScene(mediator: ComposeSceneMediator): ComposeScene {
         val density = container.density
-        return SingleLayerComposeScene(
+        return PlatformLayersComposeScene(
             coroutineContext = mediator.coroutineContext,
             density = density,
             invalidate = mediator::onComposeInvalidation,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -203,7 +203,7 @@ internal class WindowComposeSceneLayer(
     private fun createComposeScene(mediator: ComposeSceneMediator): ComposeScene {
         val density = container.density
         val layoutDirection = layoutDirectionFor(container)
-        return SingleLayerComposeScene(
+        return PlatformLayersComposeScene(
             coroutineContext = mediator.coroutineContext,
             density = density,
             invalidate = mediator::onComposeInvalidation,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import kotlin.coroutines.CoroutineContext
@@ -59,7 +59,7 @@ internal class RenderingTestScope(
 
     val surface: Surface = Surface.makeRasterN32Premul(width, height)
     private val canvas = surface.canvas.asComposeCanvas()
-    val scene = MultiLayerComposeScene(
+    val scene = CanvasLayersComposeScene(
         coroutineContext = coroutineContext,
         invalidate = frameDispatcher::scheduleFrame
     ).apply {

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/native/ComposeLayer.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/native/ComposeLayer.js.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.ComposeSceneContext
 import androidx.compose.ui.scene.ComposeScenePointer
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.platformContext
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -55,7 +55,7 @@ internal class ComposeLayer(
         }
     }
 
-    private val scene = MultiLayerComposeScene(
+    private val scene = CanvasLayersComposeScene(
         coroutineContext = Dispatchers.Main,
         composeSceneContext = object : ComposeSceneContext {
             override val platformContext get() = platformContext

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.platform.MacosTextInputService
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.scene.ComposeSceneContext
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
@@ -96,7 +96,7 @@ private class ComposeWindow(
             override val textInputService get() = macosTextInputService
         }
     private val skiaLayer = SkiaLayer()
-    private val scene = MultiLayerComposeScene(
+    private val scene = CanvasLayersComposeScene(
         coroutineContext = Dispatchers.Main,
         composeSceneContext = object : ComposeSceneContext {
             override val platformContext get() = this@ComposeWindow.platformContext

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -49,7 +49,8 @@ import org.jetbrains.skiko.currentNanoTime
  */
 @Deprecated(
     "Replaced with interface in scene package",
-    replaceWith = ReplaceWith("androidx.compose.ui.scene.ComposeScene")
+    replaceWith = ReplaceWith("androidx.compose.ui.scene.ComposeScene"),
+    level = DeprecationLevel.ERROR
 )
 class ComposeScene internal constructor(
     coroutineContext: CoroutineContext,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeScene.skiko.kt
@@ -18,8 +18,6 @@ package androidx.compose.ui
 
 import org.jetbrains.skia.Canvas as SkCanvas
 import androidx.compose.runtime.*
-import androidx.compose.ui.focus.FocusDirection
-import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.key.KeyEvent
@@ -162,7 +160,7 @@ class ComposeScene internal constructor(
         invalidate = invalidate
     )
 
-    private val replacement = androidx.compose.ui.scene.MultiLayerComposeScene(
+    private val replacement = androidx.compose.ui.scene.CanvasLayersComposeScene(
         density = density,
         layoutDirection = layoutDirection,
         coroutineContext = coroutineContext,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skikoMain.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.scene.ComposeSceneContext
 import androidx.compose.ui.scene.ComposeScenePointer
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -153,7 +153,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
             get() = _platformContext
     }
 
-    private val scene = MultiLayerComposeScene(
+    private val scene = CanvasLayersComposeScene(
         density = density,
         layoutDirection = layoutDirection,
         size = imageSize,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.node.Owner
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.scene.ComposeScene
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.input.EditCommand
@@ -57,7 +57,7 @@ interface PlatformContext {
      * This is used when rendering the scrim of a dialog - if set to true, a special blending mode
      * will be used to take into account the existing alpha-channel values.
      *
-     * @see MultiLayerComposeScene
+     * @see CanvasLayersComposeScene
      */
     val isWindowTransparent: Boolean get() = false
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -86,6 +86,7 @@ fun CanvasLayersComposeScene(
     density: Density = Density(1f),
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
     size: IntSize? = null,
+    // TODO: Remove `Dispatchers.Unconfined` as a default
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
     invalidate: () -> Unit = {},

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -59,7 +59,7 @@ import kotlinx.coroutines.Dispatchers
 
 /**
  * Constructs a multi-layer [ComposeScene] using the specified parameters. Unlike
- * [SingleLayerComposeScene], this version doesn't employ [ComposeSceneContext.createPlatformLayer]
+ * [PlatformLayersComposeScene], this version doesn't employ [ComposeSceneContext.createPlatformLayer]
  * to position a new [LayoutNode] tree. Rather, it keeps track of the added layers on its own in
  * order to render (and also divide input among them) everything on a single canvas.
  *
@@ -82,14 +82,14 @@ import kotlinx.coroutines.Dispatchers
  * @see ComposeScene
  */
 @InternalComposeUiApi
-fun MultiLayerComposeScene(
+fun CanvasLayersComposeScene(
     density: Density = Density(1f),
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
     size: IntSize? = null,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
     invalidate: () -> Unit = {},
-): ComposeScene = MultiLayerComposeSceneImpl(
+): ComposeScene = CanvasLayersComposeSceneImpl(
     density = density,
     layoutDirection = layoutDirection,
     size = size,
@@ -98,7 +98,7 @@ fun MultiLayerComposeScene(
     invalidate = invalidate
 )
 
-private class MultiLayerComposeSceneImpl(
+private class CanvasLayersComposeSceneImpl(
     density: Density,
     layoutDirection: LayoutDirection,
     size: IntSize?,
@@ -456,7 +456,7 @@ private class MultiLayerComposeSceneImpl(
             density = density,
             layoutDirection = layoutDirection,
             coroutineContext = compositionContext.effectCoroutineContext,
-            size = this@MultiLayerComposeSceneImpl.size,
+            size = this@CanvasLayersComposeSceneImpl.size,
             platformContext = object : PlatformContext by composeSceneContext.platformContext {
 
                 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/MultiLayerComposeScene.skiko.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.scene
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+
+@Deprecated(
+    message = "Renamed to CanvasLayersComposeScene",
+    replaceWith = ReplaceWith(
+        expression = "CanvasLayersComposeScene(" +
+            "density, layoutDirection, size, coroutineContext, composeSceneContext, invalidate" +
+            ")",
+        imports = arrayOf(
+            "androidx.compose.ui.scene.CanvasLayersComposeScene"
+        )
+    ),
+    level = DeprecationLevel.WARNING
+)
+@InternalComposeUiApi
+fun MultiLayerComposeScene(
+    density: Density = Density(1f),
+    layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+    size: IntSize? = null,
+    coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+    composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
+    invalidate: () -> Unit = {},
+): ComposeScene = CanvasLayersComposeScene(
+    density = density,
+    layoutDirection = layoutDirection,
+    size = size,
+    coroutineContext = coroutineContext,
+    composeSceneContext = composeSceneContext,
+    invalidate = invalidate
+)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerInputEvent
+import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Constraints
@@ -39,7 +40,8 @@ import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 
 /**
- * Constructs a single-layer [ComposeScene] using the specified parameters.
+ * Constructs a single-layer [ComposeScene] using the specified parameters. It utilizes
+ * [ComposeSceneContext.createPlatformLayer] to position a new [LayoutNode] tree.
  *
  * After [ComposeScene] will no longer needed, you should call [ComposeScene.close] method, so
  * all resources and subscriptions will be properly closed. Otherwise, there can be a memory leak.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -60,14 +60,14 @@ import kotlinx.coroutines.Dispatchers
  * @see ComposeScene
  */
 @InternalComposeUiApi
-fun SingleLayerComposeScene(
+fun PlatformLayersComposeScene(
     density: Density = Density(1f),
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
     size: IntSize? = null,
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
     invalidate: () -> Unit = {},
-): ComposeScene = SingleLayerComposeSceneImpl(
+): ComposeScene = PlatformLayersComposeSceneImpl(
     density = density,
     layoutDirection = layoutDirection,
     size = size,
@@ -76,7 +76,7 @@ fun SingleLayerComposeScene(
     invalidate = invalidate
 )
 
-private class SingleLayerComposeSceneImpl(
+private class PlatformLayersComposeSceneImpl(
     density: Density,
     layoutDirection: LayoutDirection,
     size: IntSize?,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -66,6 +66,7 @@ fun PlatformLayersComposeScene(
     density: Density = Density(1f),
     layoutDirection: LayoutDirection = LayoutDirection.Ltr,
     size: IntSize? = null,
+    // TODO: Remove `Dispatchers.Unconfined` as a default
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
     invalidate: () -> Unit = {},

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/SingleLayerComposeScene.skiko.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.scene
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.Dispatchers
+
+@Deprecated(
+    message = "Renamed to PlatformLayersComposeScene",
+    replaceWith = ReplaceWith(
+        expression = "PlatformLayersComposeScene(" +
+            "density, layoutDirection, size, coroutineContext, composeSceneContext, invalidate" +
+            ")",
+        imports = arrayOf(
+            "androidx.compose.ui.scene.PlatformLayersComposeScenePlatformLayersComposeScene"
+        )
+    ),
+    level = DeprecationLevel.WARNING
+)
+@InternalComposeUiApi
+fun SingleLayerComposeScene(
+    density: Density = Density(1f),
+    layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+    size: IntSize? = null,
+    coroutineContext: CoroutineContext = Dispatchers.Unconfined,
+    composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
+    invalidate: () -> Unit = {},
+): ComposeScene = PlatformLayersComposeScene(
+    density = density,
+    layoutDirection = layoutDirection,
+    size = size,
+    coroutineContext = coroutineContext,
+    composeSceneContext = composeSceneContext,
+    invalidate = invalidate
+)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.platform.LocalPointerIconService
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneContext
-import androidx.compose.ui.scene.SingleLayerComposeScene
+import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.IntSize
@@ -346,7 +346,7 @@ private fun SingleLayerComposeScene(
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     platformContext: PlatformContext,
     invalidate: () -> Unit = {},
-) = SingleLayerComposeScene(
+) = PlatformLayersComposeScene(
     coroutineContext = coroutineContext,
     composeSceneContext = object : ComposeSceneContext {
         override val platformContext get() = platformContext

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
@@ -25,13 +25,14 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 
-class MultiLayerComposeSceneTest {
+class CanvasLayersComposeSceneTest {
 
     @Test
     fun sceneSizeChangeTriggersInvalidation() = runTest(StandardTestDispatcher()) {
         var invalidationCount = 0
         val scene = CanvasLayersComposeScene(
             size = IntSize(100, 100),
+            coroutineContext = coroutineContext,
             invalidate = { invalidationCount++ }
         )
         try {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/MultiLayerComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/MultiLayerComposeSceneTest.kt
@@ -30,7 +30,7 @@ class MultiLayerComposeSceneTest {
     @Test
     fun sceneSizeChangeTriggersInvalidation() = runTest(StandardTestDispatcher()) {
         var invalidationCount = 0
-        val scene = MultiLayerComposeScene(
+        val scene = CanvasLayersComposeScene(
             size = IntSize(100, 100),
             invalidate = { invalidationCount++ }
         )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -755,6 +755,7 @@ class PopupTest {
                 val windowInfo = it.platformContext.windowInfo as WindowInfoImpl
                 windowInfo.containerSize = IntSize(50, 50)
             },
+            coroutineContext = coroutineContext,
             invalidate = ::invalidate
         )
         try {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -52,7 +52,7 @@ import androidx.compose.ui.platform.ZeroInsetsConfig
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneContext
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
@@ -749,7 +749,7 @@ class PopupTest {
         fun invalidate() {
             scene.render(surface.canvas.asComposeCanvas(), 1)
         }
-        scene = MultiLayerComposeScene(
+        scene = CanvasLayersComposeScene(
             composeSceneContext = object : ComposeSceneContext {
             }.also {
                 val windowInfo = it.platformContext.windowInfo as WindowInfoImpl

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIViewComposeSceneLayer.uikit.kt
@@ -164,7 +164,7 @@ internal class UIViewComposeSceneLayer(
         platformContext: PlatformContext,
         coroutineContext: CoroutineContext,
     ): ComposeScene =
-        SingleLayerComposeScene(
+        PlatformLayersComposeScene(
             density = initDensity, // We should use the local density already set for the current layer.
             layoutDirection = initLayoutDirection,
             coroutineContext = coroutineContext,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -36,9 +36,9 @@ import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneContext
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.scene.ComposeSceneMediator
-import androidx.compose.ui.scene.MultiLayerComposeScene
+import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.SceneLayout
-import androidx.compose.ui.scene.SingleLayerComposeScene
+import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.scene.UIViewComposeSceneLayer
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
 import androidx.compose.ui.uikit.InterfaceOrientation
@@ -336,7 +336,7 @@ internal class ComposeContainer(
         platformContext: PlatformContext,
         coroutineContext: CoroutineContext,
     ): ComposeScene = if (configuration.platformLayers) {
-        SingleLayerComposeScene(
+        PlatformLayersComposeScene(
             density = systemDensity,
             layoutDirection = layoutDirection,
             coroutineContext = coroutineContext,
@@ -346,7 +346,7 @@ internal class ComposeContainer(
             invalidate = invalidate,
         )
     } else {
-        MultiLayerComposeScene(
+        CanvasLayersComposeScene(
             density = systemDensity,
             layoutDirection = layoutDirection,
             coroutineContext = coroutineContext,


### PR DESCRIPTION
- `MultiLayerComposeScene` -> `CanvasLayersComposeScene`
- `SingleLayerComposeScene` -> `PlatformLayersComposeScene`
- Change deprecation level to `ERROR` for old `ComposeScene`