### PR TITLE
Remove interop view during un-placement

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/LayoutAwareModifierNode.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/LayoutAwareModifierNode.kt
@@ -51,3 +51,7 @@ interface LayoutAwareModifierNode : DelegatableNode {
      */
     fun onRemeasured(size: IntSize) {}
 }
+
+internal interface OnUnplacedModifierNode : DelegatableNode {
+    fun onUnplaced()
+}

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/LayoutNodeLayoutDelegate.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/LayoutNodeLayoutDelegate.kt
@@ -499,6 +499,8 @@ internal class LayoutNodeLayoutDelegate(
             if (isPlaced) {
                 isPlaced = false
                 layoutNode.forEachCoordinatorIncludingInner {
+                    it.onUnplaced()
+
                     // nodes are not placed with a layer anymore, so the layers should be released
                     it.releaseLayer()
                 }

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/NodeCoordinator.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/NodeCoordinator.kt
@@ -317,6 +317,12 @@ internal abstract class NodeCoordinator(
         }
     }
 
+    fun onUnplaced() {
+        if (hasNode(Nodes.Unplaced)) {
+            visitNodes(Nodes.Unplaced) { it.onUnplaced() }
+        }
+    }
+
     /**
      * Places the modified child.
      */

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/NodeKind.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/NodeKind.kt
@@ -110,6 +110,10 @@ internal object Nodes {
         get() = NodeKind<SoftKeyboardInterceptionModifierNode>(0b1 shl 17)
     @JvmStatic
     inline val Traversable get() = NodeKind<TraversableNode>(0b1 shl 18)
+
+    @JvmStatic
+    inline val Unplaced
+        get() = NodeKind<OnUnplacedModifierNode>(0b1 shl 19)
     // ...
 }
 
@@ -215,6 +219,9 @@ internal fun calculateNodeKindSetFrom(node: Modifier.Node): Int {
         }
         if (node is TraversableNode) {
             mask = mask or Nodes.Traversable
+        }
+        if (node is OnUnplacedModifierNode) {
+            mask = mask or Nodes.Unplaced
         }
         mask
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingInteropContainer.desktop.kt
@@ -110,7 +110,7 @@ internal class SwingInteropContainer(
         container.repaint()
     }
 
-    fun removeInteropView(nativeView: InteropComponent) {
+    override fun unplaceInteropView(nativeView: InteropComponent) {
         val component = nativeView.container
         container.remove(component)
         interopComponents.remove(component)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -138,7 +138,6 @@ public fun <T : Component> SwingPanel(
         }
         interopContainer.container.addFocusListener(focusListener)
         onDispose {
-            interopContainer.removeInteropView(interopComponent)
             interopContainer.container.removeFocusListener(focusListener)
         }
     }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseApplicationTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.mouse
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.sendMouseEvent
+import androidx.compose.ui.sendMouseWheelEvent
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.rememberWindowState
+import androidx.compose.ui.window.runApplicationTest
+import com.google.common.truth.Truth.assertThat
+import java.awt.event.MouseEvent
+import javax.swing.JPanel
+import org.junit.Test
+
+class MouseApplicationTest {
+
+    @Test
+    fun `interop in lazy list`() = runApplicationTest {
+        lateinit var window: ComposeWindow
+
+        val currentlyVisible = mutableSetOf<Int>()
+        launchTestApplication {
+            Window(
+                onCloseRequest = ::exitApplication,
+                state = rememberWindowState(width = 250.dp, height = 250.dp)
+            ) {
+                window = this.window
+
+                LazyColumn(Modifier.fillMaxSize()) {
+                    items(1000) { index ->
+                        SwingPanel(
+                            factory = {
+                                object : JPanel() {
+                                    override fun addNotify() {
+                                        super.addNotify()
+                                        currentlyVisible += index
+                                    }
+
+                                    override fun removeNotify() {
+                                        super.removeNotify()
+                                        currentlyVisible -= index
+                                    }
+                                }
+                            },
+                            modifier = Modifier.size(100.dp)
+                        )
+                    }
+                }
+            }
+        }
+
+        awaitIdle()
+        assertThat(currentlyVisible).containsExactly(0, 1, 2)
+
+        window.sendMouseEvent(MouseEvent.MOUSE_ENTERED, 5, 5)
+        window.sendMouseWheelEvent(5, 5, wheelRotation = 1000.0)
+
+        awaitIdle()
+        assertThat(currentlyVisible).containsExactly(100, 101, 102)
+
+        window.sendMouseWheelEvent(5, 5, wheelRotation = -1000.0)
+
+        awaitIdle()
+        assertThat(currentlyVisible).containsExactly(0, 1, 2)
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -37,9 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.awaitEDT
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -64,7 +62,6 @@ import kotlin.random.Random
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
-import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Test
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/InteropContainer.skiko.kt
@@ -31,6 +31,7 @@ internal interface InteropContainer<T> {
     val interopViews: Set<T>
 
     fun placeInteropView(nativeView: T)
+    fun unplaceInteropView(nativeView: T)
 }
 
 /**
@@ -126,11 +127,21 @@ private const val TRAVERSAL_NODE_KEY =
 internal class TrackInteropModifierNode<T>(
     var container: InteropContainer<T>?,
     var nativeView: T?,
-) : Modifier.Node(), TraversableNode, LayoutAwareModifierNode {
+) : Modifier.Node(), TraversableNode, LayoutAwareModifierNode, OnUnplacedModifierNode {
     override val traverseKey = TRAVERSAL_NODE_KEY
 
     override fun onPlaced(coordinates: LayoutCoordinates) {
         val nativeView = nativeView ?: return
         container?.placeInteropView(nativeView)
+    }
+
+    override fun onUnplaced() {
+        val nativeView = nativeView ?: return
+        container?.unplaceInteropView(nativeView)
+    }
+
+    override fun onDetach() {
+        onUnplaced()
+        super.onDetach()
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitInteropContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitInteropContainer.uikit.kt
@@ -167,6 +167,12 @@ internal class UIKitInteropContainer(
         }
     }
 
+    override fun unplaceInteropView(nativeView: UIView) {
+        deferAction {
+            nativeView.removeFromSuperview()
+        }
+    }
+
     fun startTrackingInteropView(nativeView: UIView) {
         if (interopViews.isEmpty()) {
             transaction.state = UIKitInteropState.BEGAN

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -439,12 +439,10 @@ private class InteropViewHandler<T : UIView>(
     onRelease: (T) -> Unit
 ) : InteropComponentHandler<T>(createView, interopContainer, onResize, onRelease) {
     override fun setupViewHierarchy() {
-        interopContainer.containerView.addSubview(wrappingView)
         wrappingView.addSubview(component)
     }
 
     override fun destroyViewHierarchy() {
-        wrappingView.removeFromSuperview()
     }
 }
 
@@ -457,14 +455,12 @@ private class InteropViewControllerHandler<T : UIViewController>(
 ) : InteropComponentHandler<T>(createViewController, interopContainer, onResize, onRelease) {
     override fun setupViewHierarchy() {
         rootViewController.addChildViewController(component)
-        interopContainer.containerView.addSubview(wrappingView)
         wrappingView.addSubview(component.view)
         component.didMoveToParentViewController(rootViewController)
     }
 
     override fun destroyViewHierarchy() {
         component.willMoveToParentViewController(null)
-        wrappingView.removeFromSuperview()
         component.removeFromParentViewController()
     }
 }


### PR DESCRIPTION
Remove interop views on unplace instead of `onDestroy`

**Before**

https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/3dd315d7-107b-451d-9380-378c45fba231

**After**

https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/6ba20f9d-9e82-454b-9eab-c688aceed701

## Release Notes

### Fixes - iOS

- Fix hiding interop element during quick scroll

