### PR TITLE
Add the ability to publish libraries separately

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -68,7 +68,12 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 `-Pjetbrains.publication.version.NAVIGATION`,
 `-Pjetbrains.publication.version.SAVEDSTATE`
 
-Default value for the version is `0.0.0-SNAPSHOT`
+The default value for the version is `0.0.0-SNAPSHOT`
+
+And library groups:
+`-Pjetbrains.publication.libraries=CORE_BUNDLE,COMPOSE,LIFECYCLE,NAVIGATION,SAVEDSTATE`
+
+The default value includes all libraries.
 
 2. Publish core libraries
 ```bash

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -29,38 +29,19 @@ val composeProperties = ComposeProperties(project)
 // TODO: Align with other modules
 val viewModelPlatforms = ComposePlatforms.ALL_AOSP - ComposePlatforms.WINDOWS_NATIVE
 
-val mainComponents =
-    listOf(
-        ComposeComponent(":annotation:annotation", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
-        ComposeComponent(":collection:collection", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
-        ComposeComponent(
-            path = ":lifecycle:lifecycle-common",
-            // No android target here - jvm artefact will be used for android apps as well
-            supportedPlatforms = ComposePlatforms.ALL_AOSP - ComposePlatforms.ANDROID
-        ),
-        ComposeComponent(
-            path = ":lifecycle:lifecycle-runtime",
-            supportedPlatforms = ComposePlatforms.ALL_AOSP
-        ),
-        ComposeComponent(
-            path = ":lifecycle:lifecycle-viewmodel",
-            supportedPlatforms = viewModelPlatforms
-        ),
-
+val libraryToComponents = mapOf(
+    "CORE_BUNDLE" to listOf(
         ComposeComponent(
             path = ":core:core-bundle",
             supportedPlatforms = ComposePlatforms.ALL_AOSP,
             neverRedirect = true
         ),
-        ComposeComponent(":savedstate:savedstate", viewModelPlatforms),
-        ComposeComponent(":lifecycle:lifecycle-viewmodel-savedstate", viewModelPlatforms),
-
-        ComposeComponent(":navigation:navigation-common", viewModelPlatforms),
-        ComposeComponent(":navigation:navigation-runtime", viewModelPlatforms),
-
-        ComposeComponent(":lifecycle:lifecycle-runtime-compose", supportedPlatforms = ComposePlatforms.ALL),
-        ComposeComponent(":lifecycle:lifecycle-viewmodel-compose"),
-        ComposeComponent(":navigation:navigation-compose"),
+    ),
+    "COMPOSE" to listOf(
+        // TODO https://youtrack.jetbrains.com/issue/CMP-1604/Publish-public-collection-annotation-libraries-with-a-separate-version
+        // They are part of COMPOSE versioning
+        ComposeComponent(":annotation:annotation", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
+        ComposeComponent(":collection:collection", supportedPlatforms = ComposePlatforms.ALL - ComposePlatforms.ANDROID),
 
         ComposeComponent(":compose:animation:animation"),
         ComposeComponent(":compose:animation:animation-core"),
@@ -97,15 +78,37 @@ val mainComponents =
         ),
         ComposeComponent(":compose:ui:ui-unit"),
         ComposeComponent(":compose:ui:ui-util"),
-    )
+    ),
+    "LIFECYCLE" to listOf(
+        ComposeComponent(
+            path = ":lifecycle:lifecycle-common",
+            // No android target here - jvm artefact will be used for android apps as well
+            supportedPlatforms = ComposePlatforms.ALL_AOSP - ComposePlatforms.ANDROID
+        ),
+        ComposeComponent(
+            path = ":lifecycle:lifecycle-runtime",
+            supportedPlatforms = ComposePlatforms.ALL_AOSP
+        ),
+        ComposeComponent(
+            path = ":lifecycle:lifecycle-viewmodel",
+            supportedPlatforms = viewModelPlatforms
+        ),
+        ComposeComponent(":lifecycle:lifecycle-viewmodel-savedstate", viewModelPlatforms),
+        ComposeComponent(":lifecycle:lifecycle-runtime-compose", supportedPlatforms = ComposePlatforms.ALL),
+        ComposeComponent(":lifecycle:lifecycle-viewmodel-compose"),
+    ),
+    "NAVIGATION" to listOf(
+        ComposeComponent(":navigation:navigation-compose"),
+        ComposeComponent(":navigation:navigation-common", viewModelPlatforms),
+        ComposeComponent(":navigation:navigation-runtime", viewModelPlatforms),
+    ),
+    "SAVEDSTATE" to listOf(
+        ComposeComponent(":savedstate:savedstate", viewModelPlatforms),
+    ),
+)
 
-val iconsComponents =
-    listOf(
-        ComposeComponent(":compose:material:material-icons-extended"),
-    )
-
-fun ComposePublishingTask.mainPublications() {
-    publish(
+val libraryToTasks = mapOf(
+    "COMPOSE" to fun AbstractComposePublishingTask.() = publish(
         ":compose:desktop:desktop",
         onlyWithPlatforms = setOf(ComposePlatforms.Desktop),
         publications = listOf(
@@ -118,25 +121,40 @@ fun ComposePublishingTask.mainPublications() {
             "Jvmwindows-x64"
         )
     )
+)
 
-    mainComponents.forEach { publishMultiplatform(it) }
+tasks.register("publishComposeJb", ComposePublishingTask::class) {
+    repository = "MavenRepository"
+
+    libraries.forEach {
+        libraryToComponents[it]?.forEach(::publishMultiplatform)
+        libraryToTasks[it]?.invoke(this)
+    }
 }
+
+tasks.register("publishComposeJbToMavenLocal", ComposePublishingTask::class) {
+    repository = "MavenLocal"
+
+    libraries.forEach {
+        libraryToComponents[it]?.forEach(::publishMultiplatform)
+        libraryToTasks[it]?.invoke(this)
+    }
+}
+
+// isn't included in libraryToComponents for easy conflict resolution
+// (it is changed in integration and should be removed in 1.8)
+val iconsComponents =
+    listOf(
+        ComposeComponent(":compose:material:material-icons-extended"),
+    )
 
 fun ComposePublishingTask.iconsPublications() {
     iconsComponents.forEach { publishMultiplatform(it) }
 }
 
-// To show all projects which use `xxx` task, run:
-// ./gradlew -p frameworks/support help --task xxx
-tasks.register("publishComposeJb", ComposePublishingTask::class) {
-    repository = "MavenRepository"
-    mainPublications()
-}
-
-tasks.register("publishComposeJbToMavenLocal", ComposePublishingTask::class) {
-    repository = "MavenLocal"
-    mainPublications()
-}
+val libraries = project.findProperty("jetbrains.publication.libraries")
+    ?.toString()?.split(",")
+    ?: libraryToComponents.keys
 
 // separate task that cannot be built in parallel (because it requires too much RAM).
 // should be run with "--max-workers=1"
@@ -288,7 +306,7 @@ fun allTasksWith(name: String) =
 val printAllArtifactRedirectingVersions = tasks.register("printAllArtifactRedirectingVersions") {
     val filter = project.properties["filterProjectPath"] as? String ?: ""
     doLast {
-        val map = mainComponents.filter { it.path.contains(filter) }
+        val map = libraryToComponents.values.flatten().filter { it.path.contains(filter) }
             .joinToString("\n\n", prefix = "\n") {
             val p = rootProject.findProject(it.path)!!
             it.path + " --> \n" + p.artifactRedirecting().prettyText()


### PR DESCRIPTION
Adds a new property:
```
./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=CORE_BUNDLE,COMPOSE,LIFECYCLE,NAVIGATION,SAVEDSTATE
```

## Testing
- `./gradlew publishComposeJbToMavenLocal` publishes all libraries

- `./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=CORE_BUNDLE,LIFECYCLE,SAVEDSTATE` publishes 3 libraries