### PR TITLE
Properly clip interop views whose clipped and unclipped bounding boxes don't match

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -60,8 +60,6 @@ import androidx.compose.ui.unit.toDpOffset
 import androidx.compose.ui.unit.toOffset
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGRectZero
-import platform.Foundation.NSNull
-import platform.QuartzCore.CALayer
 
 private val STUB_CALLBACK_WITH_RECEIVER: Any.() -> Unit = {}
 private val DefaultViewResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setFrame(rect) }
@@ -79,17 +77,6 @@ internal class InteropWrappingView : CMPInteropWrappingView(frame = CGRectZero.r
 
     override fun accessibilityContainer(): Any? {
         return actualAccessibilityContainer
-    }
-
-    /**
-     * CALayer have implicit animations enabled by default. This method disables them.
-     */
-    private fun CALayer.disableImplicitLayerAnimations() {
-        actions = mapOf(
-            "bounds" to NSNull.`null`(),
-            "position" to NSNull.`null`(),
-            "frame" to NSNull.`null`()
-        )
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -64,8 +64,9 @@ import platform.Foundation.NSNull
 import platform.QuartzCore.CALayer
 
 private val STUB_CALLBACK_WITH_RECEIVER: Any.() -> Unit = {}
-private val DefaultViewResize: UIView.(CValue<CGRect>) -> Unit = { }
-private val DefaultViewControllerResize: UIViewController.(CValue<CGRect>) -> Unit = { }
+private val DefaultViewResize: UIView.(CValue<CGRect>) -> Unit = { rect -> this.setFrame(rect) }
+private val DefaultViewControllerResize: UIViewController.(CValue<CGRect>) -> Unit =
+    { rect -> this.view.setFrame(rect) }
 
 internal class InteropWrappingView : CMPInteropWrappingView(frame = CGRectZero.readValue()) {
     var actualAccessibilityContainer: Any? = null

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -199,7 +199,6 @@ private fun <T : Any> UIKitInteropLayout(
         .onGloballyPositioned { coordinates ->
             val rootCoordinates = coordinates.findRootCoordinates()
 
-
             val bounds = rootCoordinates
                 .localBoundingBoxOf(
                     sourceCoordinates = coordinates,


### PR DESCRIPTION
Perform masking on interop views, whose clipped and unclipped bounding boxes don't match.

Before:

https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/68b1cecd-bb82-4eb3-9c06-6a3edb336551

After:

https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/3d57cfec-e0ec-497f-bd92-ecde145f4fb3

## Release Notes

### iOS - Fixes
- Interop views are now correctly clipped when their measured clipped and unclipped bounding boxes don't match
