### PR TITLE
Add predictive back support for iOS

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/BackEventCompat.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/window/BackEventCompat.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.annotation.FloatRange
+import androidx.annotation.IntRange
+import androidx.annotation.VisibleForTesting
+
+/**
+ * Compat around the BackEvent class
+ */
+class BackEventCompat @VisibleForTesting constructor(
+    /**
+     * Absolute X location of the touch point of this event in the coordinate space of the view that
+     *      * received this back event.
+     */
+    val touchX: Float,
+    /**
+     * Absolute Y location of the touch point of this event in the coordinate space of the view that
+     * received this back event.
+     */
+    val touchY: Float,
+    /**
+     * Value between 0 and 1 on how far along the back gesture is.
+     */
+    @FloatRange(from = 0.0, to = 1.0)
+    val progress: Float,
+    /**
+     * Indicates which edge the swipe starts from.
+     */
+    @IntRange(from = 0L, to = 1L)
+    val swipeEdge: Int
+)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/BackEventHandler.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/BackEventHandler.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow.SUSPEND
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+
+val LocalBackEventHandler = staticCompositionLocalOf<BackEventHandler> {
+    error("BackEventHandler not provided")
+}
+
+
+class BackEventHandler {
+    private val scope = CoroutineScope(Dispatchers.Main)
+    private lateinit var channel: Channel<BackEventCompat>
+    private lateinit var job: Job
+
+    var onBack: (suspend (progress: Flow<BackEventCompat>) -> Unit)? = null
+    var isEnabled: Boolean = true
+
+    fun handleOnBackProgressed(touchX: Double, touchY: Double, progress: Double) {
+        if (isEnabled) {
+            scope.launch {
+                runCatching {
+                    channel.send(
+                        BackEventCompat(
+                            touchX.toFloat(),
+                            touchY.toFloat(),
+                            progress.toFloat().coerceIn(0f, 1f),
+                            0
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    fun recreate() {
+        if (isEnabled) {
+            channel = Channel(capacity = BUFFERED, onBufferOverflow = SUSPEND)
+            job = createJob()
+        }
+    }
+
+    fun close() {
+        if (this::channel.isInitialized) {
+            channel.close()
+        }
+    }
+
+    fun cancel() {
+        channel.cancel()
+        job.cancel()
+    }
+
+    private fun createJob(): Job = scope.launch {
+        var completed = false
+        onBack?.invoke(channel.consumeAsFlow().onCompletion {
+            completed = true
+        })
+        check(completed) {
+            "You must collect the progress flow"
+        }
+    }
+}

--- a/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.android.kt
+++ b/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.android.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.BackEventCompat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@Composable
+actual fun PredictiveBackHandler(
+    enabled: Boolean,
+    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
+) {
+    androidx.activity.compose.PredictiveBackHandler(enabled) {
+        onBack(it.map { BackEventCompat(it.touchX, it.touchY, it.progress, it.swipeEdge) })
+    }
+}

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -55,13 +55,16 @@ import androidx.navigation.NavType
 import androidx.navigation.Navigator
 import androidx.navigation.createGraph
 import androidx.navigation.get
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.jvm.JvmSuppressWildcards
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
-private class ComposeViewModelStoreOwner: ViewModelStoreOwner {
+private class ComposeViewModelStoreOwner : ViewModelStoreOwner {
     override val viewModelStore: ViewModelStore = ViewModelStore()
-    fun dispose() { viewModelStore.clear() }
+    fun dispose() {
+        viewModelStore.clear()
+    }
 }
 
 /**
@@ -202,28 +205,28 @@ public fun NavHost(
     contentAlignment: Alignment = Alignment.TopStart,
     route: String? = null,
     enterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         {
             fadeIn(animationSpec = tween(700))
         },
     exitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         {
             fadeOut(animationSpec = tween(700))
         },
     popEnterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         enterTransition,
     popExitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         exitTransition,
     sizeTransform:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
         null,
     builder: NavGraphBuilder.() -> Unit
 ) {
@@ -274,28 +277,28 @@ public fun NavHost(
     route: KClass<*>? = null,
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     enterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         {
             fadeIn(animationSpec = tween(700))
         },
     exitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         {
             fadeOut(animationSpec = tween(700))
         },
     popEnterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         enterTransition,
     popExitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         exitTransition,
     sizeTransform:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
         null,
     builder: NavGraphBuilder.() -> Unit
 ) {
@@ -346,28 +349,28 @@ public fun NavHost(
     route: KClass<*>? = null,
     typeMap: Map<KType, NavType<*>> = emptyMap(),
     enterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         {
             fadeIn(animationSpec = tween(700))
         },
     exitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         {
             fadeOut(animationSpec = tween(700))
         },
     popEnterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         enterTransition,
     popExitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         exitTransition,
     sizeTransform:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
         null,
     builder: NavGraphBuilder.() -> Unit
 ) {
@@ -481,28 +484,28 @@ public fun NavHost(
     modifier: Modifier = Modifier,
     contentAlignment: Alignment = Alignment.TopStart,
     enterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         {
             fadeIn(animationSpec = tween(700))
         },
     exitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         {
             fadeOut(animationSpec = tween(700))
         },
     popEnterTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
         enterTransition,
     popExitTransition:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         exitTransition,
     sizeTransform:
-        (@JvmSuppressWildcards
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
+    (@JvmSuppressWildcards
+    AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
         null
 ) {
 
@@ -524,7 +527,6 @@ public fun NavHost(
 
     var progress by remember { mutableFloatStateOf(0f) }
     var inPredictiveBack by remember { mutableStateOf(false) }
-    /* TODO: Support PredictiveBackHandler on multiplatform
     PredictiveBackHandler(currentBackStack.size > 1) { backEvent ->
         progress = 0f
         val currentBackStackEntry = currentBackStack.lastOrNull()
@@ -539,10 +541,10 @@ public fun NavHost(
             inPredictiveBack = false
             composeNavigator.popBackStack(currentBackStackEntry, false)
         } catch (e: CancellationException) {
-            inPredictiveBack = false
+            // Reset progress instead of the `inPredictiveBack` since we want to animate back on iOS
+            progress = 0f
         }
     }
-    */
 
     DisposableEffect(lifecycleOwner) {
         // Setup the navController with proper owners
@@ -623,6 +625,9 @@ public fun NavHost(
             LaunchedEffect(progress) {
                 val previousEntry = currentBackStack[currentBackStack.size - 2]
                 transitionState.seekTo(progress, previousEntry)
+                if (progress == 0f) {
+                    inPredictiveBack = false
+                }
             }
         } else {
             LaunchedEffect(backStackEntry) {

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.BackEventCompat
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+expect fun PredictiveBackHandler(
+    enabled: Boolean = true,
+    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
+)

--- a/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.desktop.kt
+++ b/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.desktop.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.BackEventCompat
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+actual fun PredictiveBackHandler(
+    enabled: Boolean,
+    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
+) {
+}

--- a/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.macos.kt
+++ b/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.macos.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.BackEventCompat
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+actual fun PredictiveBackHandler(
+    enabled: Boolean,
+    onBack: suspend (progress:  Flow<BackEventCompat>) -> Unit
+) {
+}

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.uikit.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.window.BackEventCompat
+import androidx.compose.ui.window.LocalBackEventHandler
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+
+@Composable
+actual fun PredictiveBackHandler(
+    enabled: Boolean,
+    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
+) {
+    val backHandler = LocalBackEventHandler.current
+    backHandler.isEnabled = enabled
+    backHandler.onBack = onBack
+}

--- a/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.web.kt
+++ b/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/PredictiveBackHandler.web.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.BackEventCompat
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+actual fun PredictiveBackHandler(
+    enabled: Boolean,
+    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
+) {
+}


### PR DESCRIPTION
Added predictive back support for iOS which in turn allows it to work in navigation

## Testing
I tested thoroughly on a sample project on both iOS and Android

This should be tested by QA

## Release Notes
### Feature - iOS
- Added support for Predictive back, now swiping back on iOS correctly shows progress to the previous screen

## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
