### PR TITLE
Initial implementation of Drag and Drop for desktop.

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/draganddrop/DragAndDropSource.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/draganddrop/DragAndDropSource.kt
@@ -62,9 +62,6 @@ fun Modifier.dragAndDropSource(
     drawDragDecoration: DrawScope.() -> Unit,
     block: suspend DragAndDropSourceScope.() -> Unit
 ): Modifier {
-    // TODO https://youtrack.jetbrains.com/issue/COMPOSE-743/Implement-commonMain-Dragdrop-developed-in-AOSP
-    println("Compose Multiplatform doesn't support Modifier.dragAndDropSource yet. " +
-        "Follow https://github.com/JetBrains/compose-multiplatform/issues/4235")
     return this then DragAndDropSourceElement(
         drawDragDecoration = drawDragDecoration,
         dragAndDropSourceHandler = block,

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/draganddrop/DragAndDropTarget.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/draganddrop/DragAndDropTarget.kt
@@ -49,9 +49,6 @@ fun Modifier.dragAndDropTarget(
     shouldStartDragAndDrop: (startEvent: DragAndDropEvent) -> Boolean,
     target: DragAndDropTarget,
 ): Modifier {
-    // TODO https://youtrack.jetbrains.com/issue/COMPOSE-743/Implement-commonMain-Dragdrop-developed-in-AOSP
-    println("Compose Multiplatform doesn't support Modifier.dragAndDropTarget yet. " +
-        "Follow https://github.com/JetBrains/compose-multiplatform/issues/4235")
     return this then DropTargetElement(
         target = target,
         shouldStartDragAndDrop = shouldStartDragAndDrop,

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3293,7 +3293,7 @@ public abstract interface class androidx/compose/ui/platform/PlatformContext {
 	public fun convertLocalToWindowPosition-MK-Hz9U (J)J
 	public fun convertScreenToLocalPosition-MK-Hz9U (J)J
 	public fun convertWindowToLocalPosition-MK-Hz9U (J)J
-	public fun createPlatformDragAndDropManager ()Landroidx/compose/ui/platform/PlatformDragAndDropManager;
+	public fun createDragAndDropManager ()Landroidx/compose/ui/platform/PlatformDragAndDropManager;
 	public abstract fun getInputModeManager ()Landroidx/compose/ui/input/InputModeManager;
 	public fun getMeasureDrawLayerBounds ()Z
 	public fun getParentFocusManager ()Landroidx/compose/ui/focus/FocusManager;

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3293,10 +3293,10 @@ public abstract interface class androidx/compose/ui/platform/PlatformContext {
 	public fun convertLocalToWindowPosition-MK-Hz9U (J)J
 	public fun convertScreenToLocalPosition-MK-Hz9U (J)J
 	public fun convertWindowToLocalPosition-MK-Hz9U (J)J
+	public fun createPlatformDragAndDropManager ()Landroidx/compose/ui/platform/PlatformDragAndDropManager;
 	public abstract fun getInputModeManager ()Landroidx/compose/ui/input/InputModeManager;
 	public fun getMeasureDrawLayerBounds ()Z
 	public fun getParentFocusManager ()Landroidx/compose/ui/focus/FocusManager;
-	public fun getPlatformDragAndDropManager ()Landroidx/compose/ui/platform/PlatformDragAndDropManager;
 	public fun getRootForTestListener ()Landroidx/compose/ui/platform/PlatformContext$RootForTestListener;
 	public fun getSemanticsOwnerListener ()Landroidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener;
 	public fun getTextInputService ()Landroidx/compose/ui/text/input/PlatformTextInputService;

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -552,16 +552,11 @@ public final class androidx/compose/ui/awt/SwingPanel_desktopKt {
 	public static final fun getNoOpUpdate ()Lkotlin/jvm/functions/Function1;
 }
 
-public final class androidx/compose/ui/draganddrop/AwtDragAndDropTransferable : androidx/compose/ui/draganddrop/DragAndDropTransferable {
-	public static final field $stable I
-	public fun <init> (Ljava/awt/datatransfer/Transferable;)V
-	public fun toAwtTransferable ()Ljava/awt/datatransfer/Transferable;
-}
-
 public final class androidx/compose/ui/draganddrop/DragAndDropEvent {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/Object;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getNativeDropEvent ()Ljava/lang/Object;
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;Ljava/lang/Object;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAction ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
+	public final fun getNativeEvent ()Ljava/lang/Object;
 }
 
 public abstract interface class androidx/compose/ui/draganddrop/DragAndDropModifierNode : androidx/compose/ui/draganddrop/DragAndDropTarget, androidx/compose/ui/node/DelegatableNode {
@@ -587,6 +582,7 @@ public abstract interface class androidx/compose/ui/draganddrop/DragAndDropTarge
 public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction {
 	public static final field $stable I
 	public static final field Companion Landroidx/compose/ui/draganddrop/DragAndDropTransferAction$Companion;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction$Companion {
@@ -597,22 +593,19 @@ public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction$Com
 
 public final class androidx/compose/ui/draganddrop/DragAndDropTransferData {
 	public static final field $stable I
-	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getDragOffset-F1C5BW0 ()J
-	public final fun getInitialAction ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDragDecorationOffset-F1C5BW0 ()J
 	public final fun getOnTransferCompleted ()Lkotlin/jvm/functions/Function1;
 	public final fun getSupportedActions ()Ljava/lang/Iterable;
 	public final fun getTransferable ()Landroidx/compose/ui/draganddrop/DragAndDropTransferable;
 }
 
-public abstract class androidx/compose/ui/draganddrop/DragAndDropTransferable {
-	public static final field $stable I
-	public fun <init> ()V
-	public abstract fun toAwtTransferable ()Ljava/awt/datatransfer/Transferable;
+public abstract interface class androidx/compose/ui/draganddrop/DragAndDropTransferable {
 }
 
 public final class androidx/compose/ui/draganddrop/DragAndDrop_desktopKt {
+	public static final fun DragAndDropTransferable (Ljava/awt/datatransfer/Transferable;)Landroidx/compose/ui/draganddrop/DragAndDropTransferable;
 	public static final fun dragData (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Landroidx/compose/ui/DragData;
 	public static final fun getAwtTransferable (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Ljava/awt/datatransfer/Transferable;
 }

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -552,9 +552,16 @@ public final class androidx/compose/ui/awt/SwingPanel_desktopKt {
 	public static final fun getNoOpUpdate ()Lkotlin/jvm/functions/Function1;
 }
 
+public final class androidx/compose/ui/draganddrop/AwtDragAndDropTransferable : androidx/compose/ui/draganddrop/DragAndDropTransferable {
+	public static final field $stable I
+	public fun <init> (Ljava/awt/datatransfer/Transferable;)V
+	public fun toAwtTransferable ()Ljava/awt/datatransfer/Transferable;
+}
+
 public final class androidx/compose/ui/draganddrop/DragAndDropEvent {
 	public static final field $stable I
-	public fun <init> ()V
+	public synthetic fun <init> (Ljava/lang/Object;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getNativeDropEvent ()Ljava/lang/Object;
 }
 
 public abstract interface class androidx/compose/ui/draganddrop/DragAndDropModifierNode : androidx/compose/ui/draganddrop/DragAndDropTarget, androidx/compose/ui/node/DelegatableNode {
@@ -577,9 +584,37 @@ public abstract interface class androidx/compose/ui/draganddrop/DragAndDropTarge
 	public fun onStarted (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)V
 }
 
+public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction {
+	public static final field $stable I
+	public static final field Companion Landroidx/compose/ui/draganddrop/DragAndDropTransferAction$Companion;
+}
+
+public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction$Companion {
+	public final fun getCopy ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
+	public final fun getLink ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
+	public final fun getMove ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
+}
+
 public final class androidx/compose/ui/draganddrop/DragAndDropTransferData {
 	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDragOffset-F1C5BW0 ()J
+	public final fun getInitialAction ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
+	public final fun getOnTransferCompleted ()Lkotlin/jvm/functions/Function1;
+	public final fun getSupportedActions ()Ljava/lang/Iterable;
+	public final fun getTransferable ()Landroidx/compose/ui/draganddrop/DragAndDropTransferable;
+}
+
+public abstract class androidx/compose/ui/draganddrop/DragAndDropTransferable {
+	public static final field $stable I
 	public fun <init> ()V
+	public abstract fun toAwtTransferable ()Ljava/awt/datatransfer/Transferable;
+}
+
+public final class androidx/compose/ui/draganddrop/DragAndDrop_desktopKt {
+	public static final fun dragData (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Landroidx/compose/ui/DragData;
+	public static final fun getAwtTransferable (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Ljava/awt/datatransfer/Transferable;
 }
 
 public final class androidx/compose/ui/draw/AlphaKt {
@@ -3261,6 +3296,7 @@ public abstract interface class androidx/compose/ui/platform/PlatformContext {
 	public abstract fun getInputModeManager ()Landroidx/compose/ui/input/InputModeManager;
 	public fun getMeasureDrawLayerBounds ()Z
 	public fun getParentFocusManager ()Landroidx/compose/ui/focus/FocusManager;
+	public fun getPlatformDragAndDropManager ()Landroidx/compose/ui/platform/PlatformDragAndDropManager;
 	public fun getRootForTestListener ()Landroidx/compose/ui/platform/PlatformContext$RootForTestListener;
 	public fun getSemanticsOwnerListener ()Landroidx/compose/ui/platform/PlatformContext$SemanticsOwnerListener;
 	public fun getTextInputService ()Landroidx/compose/ui/text/input/PlatformTextInputService;
@@ -3286,6 +3322,13 @@ public abstract interface class androidx/compose/ui/platform/PlatformContext$Sem
 	public abstract fun onSemanticsChange (Landroidx/compose/ui/semantics/SemanticsOwner;)V
 	public abstract fun onSemanticsOwnerAppended (Landroidx/compose/ui/semantics/SemanticsOwner;)V
 	public abstract fun onSemanticsOwnerRemoved (Landroidx/compose/ui/semantics/SemanticsOwner;)V
+}
+
+public abstract interface class androidx/compose/ui/platform/PlatformDragAndDropManager {
+	public abstract fun drag-12SF9DM (Landroidx/compose/ui/draganddrop/DragAndDropTransferData;JLkotlin/jvm/functions/Function1;)Z
+	public abstract fun getModifier ()Landroidx/compose/ui/Modifier;
+	public abstract fun isInterestedNode (Landroidx/compose/ui/draganddrop/DragAndDropModifierNode;)Z
+	public abstract fun registerNodeInterest (Landroidx/compose/ui/draganddrop/DragAndDropModifierNode;)V
 }
 
 public final class androidx/compose/ui/platform/PlatformInsets {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -29,9 +29,16 @@ import java.awt.dnd.DropTargetDropEvent
  */
 @OptIn(ExperimentalComposeUiApi::class)
 actual class DragAndDropTransferData(
+    @property:ExperimentalComposeUiApi
     val transferable: DragAndDropTransferable,
+
+    @property:ExperimentalComposeUiApi
     val supportedActions: Iterable<DragAndDropTransferAction>,
+
+    @property:ExperimentalComposeUiApi
     val dragOffset: Offset = Offset.Zero,
+
+    @property:ExperimentalComposeUiApi
     val onTransferCompleted: ((userAction: DragAndDropTransferAction?) -> Unit)? = null,
 )
 
@@ -64,11 +71,13 @@ actual class DragAndDropEvent(
     /**
      * The action currently selected by the user.
      */
+    @property:ExperimentalComposeUiApi
     val action: DragAndDropTransferAction?,
 
     /**
      * The underlying native event.
      */
+    @property:ExperimentalComposeUiApi
     val nativeEvent: Any?,
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -27,7 +27,7 @@ import java.awt.dnd.DropTargetDropEvent
 /**
  * Encapsulates the information needed to start a drag-and-drop session from Compose on the desktop.
  */
-@ExperimentalComposeUiApi
+@OptIn(ExperimentalComposeUiApi::class)
 actual class DragAndDropTransferData(
     val transferable: DragAndDropTransferable,
     val supportedActions: Iterable<DragAndDropTransferAction>,
@@ -65,13 +65,12 @@ class DragAndDropTransferAction private constructor() {
 /**
  * The event dispatched to [DragAndDropTarget] implementations during a drag-and-drop session.
  */
-@ExperimentalComposeUiApi
 actual class DragAndDropEvent(
     /**
      * The underlying native event dispatched when the drag-and-drop gesture ends in a drop; only
      * available in [DragAndDropTarget.onDrop].
      *
-     * Use [DragAndDropEvent.awtTransferable] to access it..
+     * Use [DragAndDropEvent.awtTransferable] to access it.
      */
     val nativeDropEvent: Any?,
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.draganddrop
+
+import androidx.compose.ui.DragData
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.dragData
+import androidx.compose.ui.geometry.Offset
+import java.awt.datatransfer.Transferable
+import androidx.compose.ui.platform.PlatformDragAndDropManager
+import java.awt.dnd.DropTargetDropEvent
+
+/**
+ * Encapsulates the information needed to start a drag-and-drop session from Compose on the desktop.
+ */
+@ExperimentalComposeUiApi
+actual class DragAndDropTransferData(
+    val transferable: DragAndDropTransferable,
+    val supportedActions: Iterable<DragAndDropTransferAction>,
+    val initialAction: DragAndDropTransferAction,
+    val dragOffset: Offset = Offset.Zero,
+    val onTransferCompleted: ((userAction: DragAndDropTransferAction?) -> Unit)? = null,
+)
+
+/**
+ * Represents the actual object transferred during a drag-and-drop.
+ */
+@ExperimentalComposeUiApi
+abstract class DragAndDropTransferable {
+    /**
+     * Returns the AWT [Transferable] to pass to the AWT drag-and-drop system.
+     *
+     * This must return a non-null value in order to work with the AWT implementation of
+     * [PlatformDragAndDropManager].
+     */
+    abstract fun toAwtTransferable(): Transferable?
+}
+
+/**
+ * The possible actions on the transferred object in a drag-and-drop session.
+ */
+@ExperimentalComposeUiApi
+class DragAndDropTransferAction private constructor() {
+    companion object {
+        val Copy = DragAndDropTransferAction()
+        val Move = DragAndDropTransferAction()
+        val Link = DragAndDropTransferAction()
+    }
+}
+
+/**
+ * The event dispatched to [DragAndDropTarget] implementations during a drag-and-drop session.
+ */
+@ExperimentalComposeUiApi
+actual class DragAndDropEvent(
+    /**
+     * The underlying native event dispatched when the drag-and-drop gesture ends in a drop; only
+     * available in [DragAndDropTarget.onDrop].
+     *
+     * Use [DragAndDropEvent.awtTransferable] to access it..
+     */
+    val nativeDropEvent: Any?,
+
+    /**
+     * The position of the dragged object relative to the root Compose container.
+     */
+    internal val positionInRootImpl: Offset
+)
+
+/**
+ * A [DragAndDropTransferable] that simply wraps an AWT [Transferable] instance.
+ */
+@ExperimentalComposeUiApi
+class AwtDragAndDropTransferable(
+    private val transferable: Transferable
+) : DragAndDropTransferable() {
+    override fun toAwtTransferable(): Transferable = transferable
+}
+
+/**
+ * Returns the AWT [Transferable] associated with the [DragAndDropEvent].
+ *
+ * This may only be called on a [DragAndDropEvent] received in [DragAndDropTarget.onDrop].
+ */
+@ExperimentalComposeUiApi
+val DragAndDropEvent.awtTransferable: Transferable
+    get() = (nativeDropEvent as DropTargetDropEvent).transferable
+
+/**
+ * Returns the [DragData] associated with the given [DragAndDropEvent].
+ *
+ * This may only be called on a [DragAndDropEvent] received in [DragAndDropTarget.onDrop].
+ */
+@ExperimentalComposeUiApi
+fun DragAndDropEvent.dragData(): DragData = awtTransferable.dragData()
+
+internal actual val DragAndDropEvent.positionInRoot: Offset
+    get() = positionInRootImpl
+

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -54,11 +54,15 @@ abstract class DragAndDropTransferable {
  * The possible actions on the transferred object in a drag-and-drop session.
  */
 @ExperimentalComposeUiApi
-class DragAndDropTransferAction private constructor() {
+class DragAndDropTransferAction private constructor(private val name: String) {
+    override fun toString(): String {
+        return name
+    }
+
     companion object {
-        val Copy = DragAndDropTransferAction()
-        val Move = DragAndDropTransferAction()
-        val Link = DragAndDropTransferAction()
+        val Copy = DragAndDropTransferAction("Copy")
+        val Move = DragAndDropTransferAction("Move")
+        val Link = DragAndDropTransferAction("Link")
     }
 }
 
@@ -73,6 +77,11 @@ actual class DragAndDropEvent(
      * Use [DragAndDropEvent.awtTransferable] to access it.
      */
     val nativeDropEvent: Any?,
+
+    /**
+     * The action currently selected by the user.
+     */
+    val action: DragAndDropTransferAction?,
 
     /**
      * The position of the dragged object relative to the root Compose container.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -29,15 +29,30 @@ import java.awt.dnd.DropTargetDropEvent
  */
 @OptIn(ExperimentalComposeUiApi::class)
 actual class DragAndDropTransferData(
+    /**
+     * The object being transferred during a drag-and-drop gesture.
+     */
     @property:ExperimentalComposeUiApi
     val transferable: DragAndDropTransferable,
 
+    /**
+     * The transfer actions supported by the source of the drag-and-drop session.
+     */
     @property:ExperimentalComposeUiApi
     val supportedActions: Iterable<DragAndDropTransferAction>,
 
+    /**
+     * The offset of the pointer relative to the drag decoration.
+     */
     @property:ExperimentalComposeUiApi
-    val dragOffset: Offset = Offset.Zero,
+    val dragDecorationOffset: Offset = Offset.Zero,
 
+    /**
+     * Invoked when the drag-and-drop gesture completes.
+     *
+     * The argument to the callback specifies the transfer action with which the gesture completed,
+     * or `null` if the gesture did not complete successfully.
+     */
     @property:ExperimentalComposeUiApi
     val onTransferCompleted: ((userAction: DragAndDropTransferAction?) -> Unit)? = null,
 )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -31,7 +31,6 @@ import java.awt.dnd.DropTargetDropEvent
 actual class DragAndDropTransferData(
     val transferable: DragAndDropTransferable,
     val supportedActions: Iterable<DragAndDropTransferAction>,
-    val initialAction: DragAndDropTransferAction,
     val dragOffset: Offset = Offset.Zero,
     val onTransferCompleted: ((userAction: DragAndDropTransferAction?) -> Unit)? = null,
 )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.collection.ArraySet
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropEvent
+import androidx.compose.ui.draganddrop.DragAndDropModifierNode
+import androidx.compose.ui.draganddrop.DragAndDropNode
+import androidx.compose.ui.draganddrop.DragAndDropTransferAction
+import androidx.compose.ui.draganddrop.DragAndDropTransferAction.Companion.Copy
+import androidx.compose.ui.draganddrop.DragAndDropTransferAction.Companion.Link
+import androidx.compose.ui.draganddrop.DragAndDropTransferAction.Companion.Move
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.toAwtImage
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.window.density
+import androidx.compose.ui.window.layoutDirectionFor
+import java.awt.Image
+import java.awt.MouseInfo
+import java.awt.Point
+import java.awt.datatransfer.Transferable
+import java.awt.dnd.DnDConstants
+import java.awt.dnd.DropTarget
+import java.awt.dnd.DropTargetDragEvent
+import java.awt.dnd.DropTargetDropEvent
+import java.awt.dnd.DropTargetEvent
+import java.awt.dnd.DropTargetListener
+import java.awt.event.MouseEvent
+import javax.swing.JComponent
+import javax.swing.TransferHandler
+import kotlin.math.roundToInt
+
+/**
+ * Returns the AWT transfer action corresponding to the [DragAndDropTransferAction].
+ */
+private val DragAndDropTransferAction.awtAction: Int
+    get() = when (this) {
+        Copy -> TransferHandler.COPY
+        Move -> TransferHandler.MOVE
+        Link -> TransferHandler.LINK
+        else -> TransferHandler.NONE
+    }
+
+/**
+ * Returns the [DragAndDropTransferAction] corresponding to the given AWT transfer [action].
+ */
+internal fun DragAndDropTransferAction.Companion.fromAwtAction(
+    action: Int
+): DragAndDropTransferAction? = when (action) {
+    TransferHandler.COPY -> Copy
+    TransferHandler.MOVE -> Move
+    TransferHandler.LINK -> Link
+    else -> null
+}
+
+/**
+ * Implements [PlatformDragAndDropManager] via the AWT drag-and-drop system.
+ */
+internal class AwtDragAndDropManager(
+    private val rootContainer: JComponent
+): PlatformDragAndDropManager {
+
+    private val rootDragAndDropNode = DragAndDropNode { null }
+
+    private val transferHandler = ComposeTransferHandler()
+
+    private val dropTarget = ComposeDropTarget()
+
+    private val interestedNodes = ArraySet<DragAndDropModifierNode>()
+
+    private val density: Density
+        get() = rootContainer.density
+
+    private val scale: Float
+        get() = density.density
+
+    override val modifier: Modifier
+        get() = Modifier
+            .then(DragAndDropModifier(rootDragAndDropNode))
+            .onPlaced {
+                rootContainer.transferHandler = transferHandler
+                rootContainer.dropTarget = dropTarget
+            }
+
+    private fun Point.toOffset(): Offset {
+        val scale = this@AwtDragAndDropManager.scale
+        return Offset(
+            x = x * scale,
+            y = y * scale
+        )
+    }
+
+    private fun Offset.toPoint(): Point {
+        val scale = this@AwtDragAndDropManager.scale
+        return Point(
+            (x / scale).roundToInt(),
+            (y / scale).roundToInt()
+        )
+    }
+
+    override fun drag(
+        transferData: DragAndDropTransferData,
+        decorationSize: Size,
+        drawDragDecoration: DrawScope.() -> Unit
+    ): Boolean {
+        // These should actually be the values in the local composition where dragAndDropSource was
+        // used, but we don't currently have access to them, so we use the ones corresponding to
+        // the root container.
+        val density = this@AwtDragAndDropManager.density
+        val layoutDirection = layoutDirectionFor(rootContainer)
+
+        transferHandler.startOutgoingTransfer(
+            transferData = transferData,
+            dragImage = renderDragImage(
+                size = decorationSize,
+                density = density,
+                layoutDirection = layoutDirection,
+                drawDragDecoration = drawDragDecoration
+            ),
+            dragImageOffset = transferData.dragOffset.unaryMinus().toPoint()
+        )
+
+        return true
+    }
+
+    override fun registerNodeInterest(node: DragAndDropModifierNode) {
+        interestedNodes.add(node)
+    }
+
+    override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
+        return interestedNodes.contains(node)
+    }
+
+    /**
+     * Renders the image to represent the dragged object for AWT.
+     */
+    private fun renderDragImage(
+        size: Size,
+        density: Density,
+        layoutDirection: LayoutDirection,
+        drawDragDecoration: DrawScope.() -> Unit
+    ): Image {
+        val imageBitmap = ImageBitmap(
+            width = size.width.roundToInt(),
+            height = size.height.roundToInt()
+        )
+        // This results in blurry text for some reason.
+        val canvas = Canvas(imageBitmap)
+        val canvasScope = CanvasDrawScope()
+        canvasScope.draw(density, layoutDirection, canvas, size, drawDragDecoration)
+        return imageBitmap.toAwtImage().let {
+            it.getScaledInstance(
+                (it.width / density.density).roundToInt(),
+                (it.height / density.density).roundToInt(),
+                Image.SCALE_SMOOTH
+            )
+        }
+    }
+
+    private inner class ComposeTransferHandler : TransferHandler() {
+
+        private var outgoingTransfer: OutgoingTransfer? = null
+
+        fun startOutgoingTransfer(
+            transferData: DragAndDropTransferData,
+            dragImage: Image,
+            dragImageOffset: Point,
+        ) {
+            outgoingTransfer = OutgoingTransfer(
+                transferData = transferData,
+                dragImage = dragImage,
+                dragImageOffset = dragImageOffset
+            )
+
+            val rootContainerLocation = rootContainer.locationOnScreen
+            val mouseLocation = MouseInfo.getPointerInfo().location?.let {
+                IntOffset(
+                    x = it.x - rootContainerLocation.x,
+                    y = it.y - rootContainerLocation.y
+                )
+            } ?: rootContainerLocation.let { IntOffset(it.x, it.y) }
+            transferHandler.exportAsDrag(
+                rootContainer,
+                MouseEvent(
+                    rootContainer,
+                    MouseEvent.MOUSE_DRAGGED,
+                    System.currentTimeMillis(),
+                    0,
+                    mouseLocation.x,
+                    mouseLocation.y,
+                    0,
+                    false
+                ),
+                transferData.initialAction.awtAction
+            )
+        }
+
+        override fun createTransferable(c: JComponent?): Transferable? {
+            return outgoingTransfer?.transferData?.transferable?.toAwtTransferable()
+        }
+
+        override fun getSourceActions(c: JComponent?): Int {
+            val actions = outgoingTransfer?.transferData?.supportedActions ?: emptyList()
+            return actions.fold(
+                initial = NONE,
+                operation = { acc, action -> acc or action.awtAction },
+            )
+        }
+
+        override fun getDragImage() = outgoingTransfer?.dragImage
+
+        override fun getDragImageOffset() = outgoingTransfer?.dragImageOffset
+
+        override fun exportDone(source: JComponent?, data: Transferable?, action: Int) {
+            super.exportDone(source, data, action)
+
+            val transferAction = DragAndDropTransferAction.fromAwtAction(action)
+            outgoingTransfer?.transferData?.onTransferCompleted?.invoke(transferAction)
+            outgoingTransfer = null
+        }
+    }
+
+    private class OutgoingTransfer(
+        val transferData: DragAndDropTransferData,
+        val dragImage: Image,
+        val dragImageOffset: Point
+    )
+
+    private inner class ComposeDropTarget : DropTarget(
+        rootContainer,
+        DnDConstants.ACTION_MOVE or DnDConstants.ACTION_COPY or DnDConstants.ACTION_LINK,
+        object : DropTargetListener {
+            override fun dragEnter(dtde: DropTargetDragEvent) {
+                val event = DragAndDropEvent(dtde)
+
+                // There's no drag-start event in AWT, so start in dragEnter, and stop in dragExit
+                val accepted = rootDragAndDropNode.acceptDragAndDropTransfer(event)
+                interestedNodes.forEach { it.onStarted(event) }
+                rootDragAndDropNode.onEntered(event)
+                if (accepted) {
+                    dtde.acceptDrag(dtde.sourceActions)
+                }
+            }
+
+            override fun dragExit(dte: DropTargetEvent) {
+                val event = DragAndDropEvent(dte)
+                rootDragAndDropNode.onExited(event)
+                endDrag(event)
+            }
+
+            override fun dragOver(dtde: DropTargetDragEvent) {
+                rootDragAndDropNode.onMoved(DragAndDropEvent(dtde))
+                dtde.acceptDrag(dtde.sourceActions)
+            }
+
+            override fun dropActionChanged(dtde: DropTargetDragEvent) {
+                rootDragAndDropNode.onChanged(DragAndDropEvent(dtde))
+                dtde.acceptDrag(dtde.sourceActions)
+            }
+
+            override fun drop(dtde: DropTargetDropEvent) {
+                val event = DragAndDropEvent(dtde)
+                dtde.acceptDrop(dtde.dropAction)
+                dtde.dropComplete(rootDragAndDropNode.onDrop(event))
+                endDrag(event)
+            }
+
+            private fun endDrag(event: DragAndDropEvent) {
+                rootDragAndDropNode.onEnded(event)
+                interestedNodes.clear()
+            }
+
+            private fun DragAndDropEvent(dragEvent: DropTargetDragEvent) = DragAndDropEvent(
+                nativeDropEvent = dragEvent,
+                positionInRootImpl = dragEvent.location.toOffset()
+            )
+
+            private fun DragAndDropEvent(dropEvent: DropTargetDropEvent) = DragAndDropEvent(
+                nativeDropEvent = dropEvent,
+                positionInRootImpl = dropEvent.location.toOffset()
+            )
+
+            private fun DragAndDropEvent(dropEvent: DropTargetEvent) = DragAndDropEvent(
+                nativeDropEvent = dropEvent,
+                positionInRootImpl = Offset.Zero
+            )
+        },
+        true
+    )
+
+}
+
+private class DragAndDropModifier(
+    val dragAndDropNode: DragAndDropNode
+) : ModifierNodeElement<DragAndDropNode>() {
+
+    override fun create() = dragAndDropNode
+
+    override fun update(node: DragAndDropNode) = Unit
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "RootDragAndDropNode"
+    }
+
+    override fun hashCode(): Int = dragAndDropNode.hashCode()
+
+    override fun equals(other: Any?) = other === this
+
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -143,7 +143,7 @@ internal class AwtDragAndDropManager(
                 layoutDirection = layoutDirection,
                 drawDragDecoration = drawDragDecoration
             ),
-            dragImageOffset = transferData.dragOffset.toPoint()
+            dragImageOffset = transferData.dragDecorationOffset.toPoint()
         )
 
         return true

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -142,7 +142,7 @@ internal class AwtDragAndDropManager(
                 layoutDirection = layoutDirection,
                 drawDragDecoration = drawDragDecoration
             ),
-            dragImageOffset = transferData.dragOffset.unaryMinus().toPoint()
+            dragImageOffset = transferData.dragOffset.toPoint()
         )
 
         return true
@@ -248,8 +248,15 @@ internal class AwtDragAndDropManager(
     private class OutgoingTransfer(
         val transferData: DragAndDropTransferData,
         val dragImage: Image,
-        val dragImageOffset: Point
-    )
+        dragImageOffset: Point
+    ) {
+        val dragImageOffset: Point = dragImageOffset.let {
+            when (DesktopPlatform.Current) {
+                DesktopPlatform.MacOS -> Point(-it.x, -it.y)
+                else -> it
+            }
+        }
+    }
 
     private inner class ComposeDropTarget : DropTarget(
         rootContainer,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.platform
 
 import androidx.collection.ArraySet
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.AwtDragAndDropTransferable
 import androidx.compose.ui.draganddrop.DragAndDropEvent
 import androidx.compose.ui.draganddrop.DragAndDropModifierNode
 import androidx.compose.ui.draganddrop.DragAndDropNode
@@ -222,7 +223,8 @@ internal class AwtDragAndDropManager(
         }
 
         override fun createTransferable(c: JComponent?): Transferable? {
-            return outgoingTransfer?.transferData?.transferable?.toAwtTransferable()
+            return (outgoingTransfer?.transferData?.transferable as? AwtDragAndDropTransferable)
+                ?.toAwtTransferable()
         }
 
         override fun getSourceActions(c: JComponent?): Int {
@@ -302,19 +304,19 @@ internal class AwtDragAndDropManager(
             }
 
             private fun DragAndDropEvent(dragEvent: DropTargetDragEvent) = DragAndDropEvent(
-                nativeDropEvent = dragEvent,
+                nativeEvent = dragEvent,
                 action = DragAndDropTransferAction.fromAwtAction(dragEvent.dropAction),
                 positionInRootImpl = dragEvent.location.toOffset()
             )
 
             private fun DragAndDropEvent(dropEvent: DropTargetDropEvent) = DragAndDropEvent(
-                nativeDropEvent = dropEvent,
+                nativeEvent = dropEvent,
                 action = DragAndDropTransferAction.fromAwtAction(dropEvent.dropAction),
                 positionInRootImpl = dropEvent.location.toOffset()
             )
 
             private fun DragAndDropEvent(dropEvent: DropTargetEvent) = DragAndDropEvent(
-                nativeDropEvent = dropEvent,
+                nativeEvent = dropEvent,
                 action = null,
                 positionInRootImpl = Offset.Zero
             )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -269,8 +269,8 @@ internal class AwtDragAndDropManager(
                 val accepted = rootDragAndDropNode.acceptDragAndDropTransfer(event)
                 interestedNodes.forEach { it.onStarted(event) }
                 rootDragAndDropNode.onEntered(event)
-                if (accepted) {
-                    dtde.acceptDrag(dtde.sourceActions)
+                if (!accepted) {
+                    dtde.rejectDrag()
                 }
             }
 
@@ -282,12 +282,10 @@ internal class AwtDragAndDropManager(
 
             override fun dragOver(dtde: DropTargetDragEvent) {
                 rootDragAndDropNode.onMoved(DragAndDropEvent(dtde))
-                dtde.acceptDrag(dtde.sourceActions)
             }
 
             override fun dropActionChanged(dtde: DropTargetDragEvent) {
                 rootDragAndDropNode.onChanged(DragAndDropEvent(dtde))
-                dtde.acceptDrag(dtde.sourceActions)
             }
 
             override fun drop(dtde: DropTargetDropEvent) {
@@ -304,16 +302,19 @@ internal class AwtDragAndDropManager(
 
             private fun DragAndDropEvent(dragEvent: DropTargetDragEvent) = DragAndDropEvent(
                 nativeDropEvent = dragEvent,
+                action = DragAndDropTransferAction.fromAwtAction(dragEvent.dropAction),
                 positionInRootImpl = dragEvent.location.toOffset()
             )
 
             private fun DragAndDropEvent(dropEvent: DropTargetDropEvent) = DragAndDropEvent(
                 nativeDropEvent = dropEvent,
+                action = DragAndDropTransferAction.fromAwtAction(dropEvent.dropAction),
                 positionInRootImpl = dropEvent.location.toOffset()
             )
 
             private fun DragAndDropEvent(dropEvent: DropTargetEvent) = DragAndDropEvent(
                 nativeDropEvent = dropEvent,
+                action = null,
                 positionInRootImpl = Offset.Zero
             )
         },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -216,7 +216,8 @@ internal class AwtDragAndDropManager(
                     0,
                     false
                 ),
-                transferData.initialAction.awtAction
+                // This seems to be ignored, and the initial action is MOVE regardless
+                DnDConstants.ACTION_MOVE
             )
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -689,7 +689,7 @@ internal class ComposeSceneMediator(
         override val semanticsOwnerListener
             get() = this@ComposeSceneMediator.semanticsOwnerListener
 
-        override fun createPlatformDragAndDropManager() = AwtDragAndDropManager(container)
+        override fun createDragAndDropManager() = AwtDragAndDropManager(container)
     }
 
     private inner class DesktopPlatformComponent : PlatformComponent {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.platform.AwtDragAndDropManager
 import androidx.compose.ui.platform.DelegateRootForTestListener
 import androidx.compose.ui.platform.DesktopTextInputService
 import androidx.compose.ui.platform.EmptyViewConfiguration
@@ -61,7 +62,6 @@ import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.sizeInPx
 import java.awt.Component
-import java.awt.Container
 import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.Point
@@ -83,6 +83,7 @@ import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
 import java.awt.im.InputMethodRequests
 import javax.accessibility.Accessible
+import javax.swing.JComponent
 import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
@@ -104,7 +105,7 @@ import org.jetbrains.skiko.swing.SkiaSwingLayer
  * - for forcing refocus on input methods change
  */
 internal class ComposeSceneMediator(
-    private val container: Container,
+    private val container: JComponent,
     private val windowContext: PlatformWindowContext,
     private var exceptionHandler: WindowExceptionHandler?,
     eventListener: AwtEventListener? = null,
@@ -687,6 +688,8 @@ internal class ComposeSceneMediator(
             get() = this@ComposeSceneMediator.rootForTestListener
         override val semanticsOwnerListener
             get() = this@ComposeSceneMediator.semanticsOwnerListener
+
+        override val platformDragAndDropManager = AwtDragAndDropManager(container)
     }
 
     private inner class DesktopPlatformComponent : PlatformComponent {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -689,7 +689,7 @@ internal class ComposeSceneMediator(
         override val semanticsOwnerListener
             get() = this@ComposeSceneMediator.semanticsOwnerListener
 
-        override val platformDragAndDropManager = AwtDragAndDropManager(container)
+        override fun createPlatformDragAndDropManager() = AwtDragAndDropManager(container)
     }
 
     private inner class DesktopPlatformComponent : PlatformComponent {

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.jsNative.kt
@@ -18,8 +18,6 @@ package androidx.compose.ui.draganddrop
 
 import androidx.compose.ui.geometry.Offset
 
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-743/Implement-commonMain-Dragdrop-developed-in-AOSP
-
 actual class DragAndDropTransferData
 
 actual class DragAndDropEvent

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -123,7 +123,7 @@ internal class RootNodeOwner(
         },
     )
     private val dragAndDropManager: DragAndDropManager =
-        platformContext.createPlatformDragAndDropManager().asDragAndDropManager()
+        platformContext.createDragAndDropManager().asDragAndDropManager()
     private val rootSemanticsNode = EmptySemanticsModifier()
 
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -127,7 +127,7 @@ internal class RootNodeOwner(
         },
     )
     private val dragAndDropManager: DragAndDropManager =
-        PlatformDelegatingDragAndDropManager(platformContext.platformDragAndDropManager)
+        PlatformDelegatingDragAndDropManager(platformContext.createPlatformDragAndDropManager())
     private val rootSemanticsNode = EmptySemanticsModifier()
 
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.Autofill
 import androidx.compose.ui.autofill.AutofillTree
 import androidx.compose.ui.draganddrop.DragAndDropManager
+import androidx.compose.ui.draganddrop.DragAndDropModifierNode
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusOwner
 import androidx.compose.ui.focus.FocusOwnerImpl
@@ -34,9 +36,11 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
@@ -62,6 +66,7 @@ import androidx.compose.ui.platform.DefaultHapticFeedback
 import androidx.compose.ui.platform.DelegatingSoftwareKeyboardController
 import androidx.compose.ui.platform.PlatformClipboardManager
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformRootForTest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.platform.RenderNodeLayer
@@ -121,6 +126,8 @@ internal class RootNodeOwner(
             platformContext.parentFocusManager.clearFocus(true)
         },
     )
+    private val dragAndDropManager: DragAndDropManager =
+        PlatformDelegatingDragAndDropManager(platformContext.platformDragAndDropManager)
     private val rootSemanticsNode = EmptySemanticsModifier()
 
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)
@@ -136,6 +143,7 @@ internal class RootNodeOwner(
             }
         }
         .then(focusOwner.modifier)
+        .then(dragAndDropManager.modifier)
         .semantics {
             // This makes the reported role of the root node "PANEL", which is ignored by VoiceOver
             // (which is what we want).
@@ -324,8 +332,7 @@ internal class RootNodeOwner(
         ): Nothing {
             awaitCancellation()
         }
-        // TODO https://youtrack.jetbrains.com/issue/COMPOSE-743/Implement-commonMain-Dragdrop-developed-in-AOSP
-        override val dragAndDropManager: DragAndDropManager get() = TODO("Not yet implemented")
+        override val dragAndDropManager: DragAndDropManager = this@RootNodeOwner.dragAndDropManager
         override val pointerIconService = PointerIconServiceImpl()
         override val focusOwner get() = this@RootNodeOwner.focusOwner
         override val windowInfo get() = platformContext.windowInfo
@@ -609,6 +616,32 @@ internal class RootNodeOwner(
         override fun setIcon(value: PointerIcon?) {
             desiredPointerIcon = value
             platformContext.setPointerIcon(desiredPointerIcon ?: PointerIcon.Default)
+        }
+    }
+
+    /**
+     * Implements [DragAndDropManager] by delegating to [PlatformDragAndDropManager].
+     */
+    private class PlatformDelegatingDragAndDropManager(
+        val platformDragAndDropManager: PlatformDragAndDropManager
+    ): DragAndDropManager {
+        override val modifier: Modifier
+            get() = platformDragAndDropManager.modifier
+
+        override fun drag(
+            transferData: DragAndDropTransferData,
+            decorationSize: Size,
+            drawDragDecoration: DrawScope.() -> Unit
+        ): Boolean {
+            return platformDragAndDropManager.drag(transferData, decorationSize, drawDragDecoration)
+        }
+
+        override fun registerNodeInterest(node: DragAndDropModifierNode) {
+            platformDragAndDropManager.registerNodeInterest(node)
+        }
+
+        override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
+            return platformDragAndDropManager.isInterestedNode(node)
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -27,8 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.autofill.Autofill
 import androidx.compose.ui.autofill.AutofillTree
 import androidx.compose.ui.draganddrop.DragAndDropManager
-import androidx.compose.ui.draganddrop.DragAndDropModifierNode
-import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusOwner
 import androidx.compose.ui.focus.FocusOwnerImpl
@@ -36,11 +34,9 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.Matrix
-import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
@@ -66,10 +62,10 @@ import androidx.compose.ui.platform.DefaultHapticFeedback
 import androidx.compose.ui.platform.DelegatingSoftwareKeyboardController
 import androidx.compose.ui.platform.PlatformClipboardManager
 import androidx.compose.ui.platform.PlatformContext
-import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformRootForTest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.platform.RenderNodeLayer
+import androidx.compose.ui.platform.asDragAndDropManager
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeSceneInputHandler
 import androidx.compose.ui.scene.ComposeScenePointer
@@ -127,7 +123,7 @@ internal class RootNodeOwner(
         },
     )
     private val dragAndDropManager: DragAndDropManager =
-        PlatformDelegatingDragAndDropManager(platformContext.createPlatformDragAndDropManager())
+        platformContext.createPlatformDragAndDropManager().asDragAndDropManager()
     private val rootSemanticsNode = EmptySemanticsModifier()
 
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)
@@ -616,32 +612,6 @@ internal class RootNodeOwner(
         override fun setIcon(value: PointerIcon?) {
             desiredPointerIcon = value
             platformContext.setPointerIcon(desiredPointerIcon ?: PointerIcon.Default)
-        }
-    }
-
-    /**
-     * Implements [DragAndDropManager] by delegating to [PlatformDragAndDropManager].
-     */
-    private class PlatformDelegatingDragAndDropManager(
-        val platformDragAndDropManager: PlatformDragAndDropManager
-    ): DragAndDropManager {
-        override val modifier: Modifier
-            get() = platformDragAndDropManager.modifier
-
-        override fun drag(
-            transferData: DragAndDropTransferData,
-            decorationSize: Size,
-            drawDragDecoration: DrawScope.() -> Unit
-        ): Boolean {
-            return platformDragAndDropManager.drag(transferData, decorationSize, drawDragDecoration)
-        }
-
-        override fun registerNodeInterest(node: DragAndDropModifierNode) {
-            platformDragAndDropManager.registerNodeInterest(node)
-        }
-
-        override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
-            return platformDragAndDropManager.isInterestedNode(node)
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draganddrop.DragAndDropManager
 import androidx.compose.ui.draganddrop.DragAndDropModifierNode
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.focus.FocusDirection

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -116,7 +116,7 @@ interface PlatformContext {
     val parentFocusManager: FocusManager get() = EmptyFocusManager
     fun requestFocus(): Boolean = true
 
-    fun createPlatformDragAndDropManager(): PlatformDragAndDropManager = EmptyDragAndDropManager
+    fun createDragAndDropManager(): PlatformDragAndDropManager = EmptyDragAndDropManager
 
     /**
      * The listener to track [RootForTest]s.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -20,10 +20,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropModifierNode
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -109,6 +114,9 @@ interface PlatformContext {
 
     val parentFocusManager: FocusManager get() = EmptyFocusManager
     fun requestFocus(): Boolean = true
+
+    val platformDragAndDropManager: PlatformDragAndDropManager get() =
+        UnimplementedDragAndDropManager
 
     /**
      * The listener to track [RootForTest]s.
@@ -226,6 +234,27 @@ private object EmptyTextToolbar : TextToolbar {
 private object EmptyFocusManager : FocusManager {
     override fun clearFocus(force: Boolean) = Unit
     override fun moveFocus(focusDirection: FocusDirection) = false
+}
+
+private object UnimplementedDragAndDropManager : PlatformDragAndDropManager {
+    override val modifier: Modifier
+        get() = Modifier
+
+    override fun drag(
+        transferData: DragAndDropTransferData,
+        decorationSize: Size,
+        drawDragDecoration: DrawScope.() -> Unit
+    ): Boolean {
+        TODO("Drag&drop isn't implemented")
+    }
+
+    override fun registerNodeInterest(node: DragAndDropModifierNode) {
+        TODO("Drag&drop isn't implemented")
+    }
+
+    override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
+        TODO("Drag&drop isn't implemented")
+    }
 }
 
 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -115,8 +115,9 @@ interface PlatformContext {
     val parentFocusManager: FocusManager get() = EmptyFocusManager
     fun requestFocus(): Boolean = true
 
-    val platformDragAndDropManager: PlatformDragAndDropManager get() =
-        UnimplementedDragAndDropManager
+    fun createPlatformDragAndDropManager(): PlatformDragAndDropManager {
+        return UnimplementedDragAndDropManager
+    }
 
     /**
      * The listener to track [RootForTest]s.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropManager
 import androidx.compose.ui.draganddrop.DragAndDropModifierNode
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.focus.FocusDirection
@@ -115,9 +116,7 @@ interface PlatformContext {
     val parentFocusManager: FocusManager get() = EmptyFocusManager
     fun requestFocus(): Boolean = true
 
-    fun createPlatformDragAndDropManager(): PlatformDragAndDropManager {
-        return UnimplementedDragAndDropManager
-    }
+    fun createPlatformDragAndDropManager(): PlatformDragAndDropManager = EmptyDragAndDropManager
 
     /**
      * The listener to track [RootForTest]s.
@@ -237,7 +236,7 @@ private object EmptyFocusManager : FocusManager {
     override fun moveFocus(focusDirection: FocusDirection) = false
 }
 
-private object UnimplementedDragAndDropManager : PlatformDragAndDropManager {
+private object EmptyDragAndDropManager : PlatformDragAndDropManager {
     override val modifier: Modifier
         get() = Modifier
 
@@ -246,16 +245,12 @@ private object UnimplementedDragAndDropManager : PlatformDragAndDropManager {
         decorationSize: Size,
         drawDragDecoration: DrawScope.() -> Unit
     ): Boolean {
-        TODO("Drag&drop isn't implemented")
+        return false
     }
 
-    override fun registerNodeInterest(node: DragAndDropModifierNode) {
-        TODO("Drag&drop isn't implemented")
-    }
+    override fun registerNodeInterest(node: DragAndDropModifierNode) = Unit
 
-    override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
-        TODO("Drag&drop isn't implemented")
-    }
+    override fun isInterestedNode(node: DragAndDropModifierNode): Boolean = false
 }
 
 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropManager
+import androidx.compose.ui.draganddrop.DragAndDropModifierNode
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.node.RootNodeOwner
+
+/**
+ * The interface for platform implementations of [DragAndDropManager].
+ *
+ * This is needed because [DragAndDropManager] itself is `internal`, and therefore can't be
+ * implemented by 3rd-party code. The solution is for [RootNodeOwner] to implement the internal
+ * [DragAndDropManager] by delegating to a public [PlatformDragAndDropManager] provided by
+ * [PlatformContext].
+ *
+ * For documentation of the methods of this interface refer to [DragAndDropManager].
+ */
+@ExperimentalComposeUiApi
+interface PlatformDragAndDropManager {
+    val modifier: Modifier
+
+    fun drag(
+        transferData: DragAndDropTransferData,
+        decorationSize: Size,
+        drawDragDecoration: DrawScope.() -> Unit,
+    ): Boolean
+
+    fun registerNodeInterest(node: DragAndDropModifierNode)
+
+    fun isInterestedNode(node: DragAndDropModifierNode): Boolean
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.DragAndDropManager
 import androidx.compose.ui.draganddrop.DragAndDropModifierNode
@@ -35,7 +35,7 @@ import androidx.compose.ui.node.RootNodeOwner
  *
  * For documentation of the methods of this interface refer to [DragAndDropManager].
  */
-@ExperimentalComposeUiApi
+@InternalComposeUiApi
 interface PlatformDragAndDropManager {
     val modifier: Modifier
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.kt
@@ -49,3 +49,28 @@ interface PlatformDragAndDropManager {
 
     fun isInterestedNode(node: DragAndDropModifierNode): Boolean
 }
+
+
+/**
+ * Returns a [DragAndDropManager] that delegates to `this` [PlatformDragAndDropManager].
+ */
+internal fun PlatformDragAndDropManager.asDragAndDropManager() = object : DragAndDropManager {
+    override val modifier: Modifier
+        get() = this@asDragAndDropManager.modifier
+
+    override fun drag(
+        transferData: DragAndDropTransferData,
+        decorationSize: Size,
+        drawDragDecoration: DrawScope.() -> Unit
+    ): Boolean {
+        return this@asDragAndDropManager.drag(transferData, decorationSize, drawDragDecoration)
+    }
+
+    override fun registerNodeInterest(node: DragAndDropModifierNode) {
+        this@asDragAndDropManager.registerNodeInterest(node)
+    }
+
+    override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
+        return this@asDragAndDropManager.isInterestedNode(node)
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -21,9 +21,14 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropModifierNode
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -44,6 +49,7 @@ import androidx.compose.ui.platform.EmptyViewConfiguration
 import androidx.compose.ui.platform.LocalLayoutMargins
 import androidx.compose.ui.platform.LocalSafeArea
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.platform.UIKitTextInputService
@@ -697,6 +703,29 @@ internal class ComposeSceneMediator(
 
         override fun convertScreenToLocalPosition(positionOnScreen: Offset): Offset =
             windowContext.convertScreenToLocalPosition(viewForKeyboardOffsetTransform, positionOnScreen)
+
+        override fun createPlatformDragAndDropManager(): PlatformDragAndDropManager {
+            return object : PlatformDragAndDropManager {
+                override val modifier: Modifier
+                    get() = Modifier
+
+                override fun drag(
+                    transferData: DragAndDropTransferData,
+                    decorationSize: Size,
+                    drawDragDecoration: DrawScope.() -> Unit
+                ): Boolean {
+                    TODO("Drag&drop isn't implemented")
+                }
+
+                override fun registerNodeInterest(node: DragAndDropModifierNode) {
+                    TODO("Drag&drop isn't implemented")
+                }
+
+                override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
+                    TODO("Drag&drop isn't implemented")
+                }
+            }
+        }
 
         override val measureDrawLayerBounds get() = this@ComposeSceneMediator.measureDrawLayerBounds
         override val viewConfiguration get() = this@ComposeSceneMediator.viewConfiguration

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -704,7 +704,7 @@ internal class ComposeSceneMediator(
         override fun convertScreenToLocalPosition(positionOnScreen: Offset): Offset =
             windowContext.convertScreenToLocalPosition(viewForKeyboardOffsetTransform, positionOnScreen)
 
-        override fun createPlatformDragAndDropManager(): PlatformDragAndDropManager {
+        override fun createDragAndDropManager(): PlatformDragAndDropManager {
             return object : PlatformDragAndDropManager {
                 override val modifier: Modifier
                     get() = Modifier

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -22,9 +22,14 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropModifierNode
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.events.EventTargetListener
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.toComposeEvent
@@ -42,6 +47,7 @@ import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.scene.ComposeScenePointer
@@ -200,6 +206,28 @@ internal class ComposeWindow(
             }
         }
 
+        override fun createPlatformDragAndDropManager(): PlatformDragAndDropManager {
+            return object : PlatformDragAndDropManager {
+                override val modifier: Modifier
+                    get() = Modifier
+
+                override fun drag(
+                    transferData: DragAndDropTransferData,
+                    decorationSize: Size,
+                    drawDragDecoration: DrawScope.() -> Unit
+                ): Boolean {
+                    TODO("Drag&drop isn't implemented")
+                }
+
+                override fun registerNodeInterest(node: DragAndDropModifierNode) {
+                    TODO("Drag&drop isn't implemented")
+                }
+
+                override fun isInterestedNode(node: DragAndDropModifierNode): Boolean {
+                    TODO("Drag&drop isn't implemented")
+                }
+            }
+        }
     }
 
     private val layer = ComposeLayer(

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.input.InputModeManager
-import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.toComposeEvent
 import androidx.compose.ui.input.pointer.BrowserCursor
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -206,7 +205,7 @@ internal class ComposeWindow(
             }
         }
 
-        override fun createPlatformDragAndDropManager(): PlatformDragAndDropManager {
+        override fun createDragAndDropManager(): PlatformDragAndDropManager {
             return object : PlatformDragAndDropManager {
                 override val modifier: Modifier
                     get() = Modifier


### PR DESCRIPTION
Implemented the new AOSP Drag-and-Drop APIs for the desktop.

Note that there is currently no "common" API to either specify the transferred object when Compose is the source, or to handle the transferred object specified by the system when another application is the source. Currently it must be done via the underlying AWT types. We would like to add this for a few frequently used types (text, images, files), but this requires discussions with upstream first.

Fixes https://youtrack.jetbrains.com/issue/CMP-1585/Desktop-drag-and-drop
Partially addresses https://github.com/JetBrains/compose-multiplatform/issues/4235

https://github.com/JetBrains/compose-multiplatform-core/assets/5230206/5c46a35d-8154-4cb2-9a1a-2534a54c6435


## Testing
Will add unit tests later. In the meanwhile, can be tested manually with
```
@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
fun main() = singleWindowApplication {
    val exportedText = "Hello, DnD!"
    Row(
        horizontalArrangement = Arrangement.SpaceEvenly,
        verticalAlignment = Alignment.CenterVertically,
        modifier = Modifier.fillMaxSize()
    ) {
        val textMeasurer = rememberTextMeasurer()
        Box(Modifier
            .size(200.dp)
            .background(Color.LightGray)
            .dragAndDropSource(
                drawDragDecoration = {
                    drawRect(
                        color = Color.White,
                        topLeft = Offset(x = 0f, y = size.height/4),
                        size = Size(size.width, size.height/2)
                    )
                    val textLayoutResult = textMeasurer.measure(
                        text = AnnotatedString(exportedText),
                        layoutDirection = layoutDirection,
                        density = this
                    )
                    drawText(
                        textLayoutResult = textLayoutResult,
                        topLeft = Offset(
                            x = (size.width - textLayoutResult.size.width) / 2,
                            y = (size.height - textLayoutResult.size.height) / 2,
                        )
                    )
                }
            ) {
                detectDragGestures(
                    onDragStart = { offset ->
                        startTransfer(
                            DragAndDropTransferData(
                                transferable = AwtDragAndDropTransferable(
                                    StringSelection(exportedText)
                                ),
                                supportedActions = listOf(
                                    DragAndDropTransferAction.Copy,
                                    DragAndDropTransferAction.Move,
                                    DragAndDropTransferAction.Link,
                                ),
                                initialAction = DragAndDropTransferAction.Copy,
                                dragOffset = offset,
                                onTransferCompleted = { action ->
                                    when (action) {
                                        null -> println("Transfer aborted")
                                        DragAndDropTransferAction.Copy -> println("Copied")
                                        DragAndDropTransferAction.Move -> println("Moved")
                                        DragAndDropTransferAction.Link -> println("Linked")
                                    }
                                }
                            )
                        )
                    },
                    onDrag = { _, _ -> },
                )
            }
        ) {
            Text("Drag Me", Modifier.align(Alignment.Center))
        }

        var showTargetBorder by remember { mutableStateOf(false)}
        var targetText by remember { mutableStateOf("Drop Here") }
        val coroutineScope = rememberCoroutineScope()
        val dragAndDropTarget = remember {
            object: DragAndDropTarget {

                override fun onStarted(event: DragAndDropEvent) {
                    showTargetBorder = true
                }

                override fun onEnded(event: DragAndDropEvent) {
                    showTargetBorder = false
                }

                override fun onDrop(event: DragAndDropEvent): Boolean {
                    val result = targetText == "Drop Here"
                    targetText = event.awtTransferable.let {
                        if (it.isDataFlavorSupported(DataFlavor.stringFlavor))
                            it.getTransferData(DataFlavor.stringFlavor) as String
                        else
                            it.transferDataFlavors.first().humanPresentableName
                    }
                    coroutineScope.launch {
                        delay(2000)
                        targetText = "Drop Here"
                    }
                    return result
                }
            }
        }
        Box(Modifier
            .size(200.dp)
            .background(Color.LightGray)
            .then(
                if (showTargetBorder)
                    Modifier.border(BorderStroke(3.dp, Color.Black))
                else
                    Modifier
            )
            .dragAndDropTarget(
                shouldStartDragAndDrop = { true },
                target = dragAndDropTarget
            )
        ) {
            Text(targetText, Modifier.align(Alignment.Center))
        }
    }
}
```

This should be tested by QA

## Release Notes
### Features - Desktop
- Implemented Drag-and-Drop from AOSP: `Modifier.dragAndDropSource` and `Modifier.dragAndDropTarget`.
