### PR TITLE
Fix ui:ui:compileTestKotlinJs and make it part of testWeb 

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/InputEvent.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/InputEvent.kt
@@ -23,6 +23,6 @@ internal external interface InputEventInit {
     val inputType: String
 }
 
-internal fun InputEventInit(inputType: String, data: String): InputEventInit = js("({data, inputType})")
+internal fun InputEventInit(inputType: String, data: String): InputEventInit = js("({data: data, inputType: inputType})")
 
 internal external class InputEvent(type: String, options: InputEventInit) : Event

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -177,6 +177,7 @@ tasks.register("checkDesktop") {
 tasks.register("testWeb") {
     dependsOn(":compose:runtime:runtime:jsTest")
     dependsOn(":compose:runtime:runtime:wasmJsTest")
+    dependsOn(":compose:ui:ui:compileTestKotlinJs")
     // TODO: ideally we want to run all wasm tests that are possible but now we deal only with modules that have skikoTests
 
     dependsOn(":compose:foundation:foundation:wasmJsBrowserTest")


### PR DESCRIPTION
 Though tests are now not enabled in pipeline for the JS target, we should not break their compilation
