### PR TITLE
Fix `ModalBottomSheet` safe area usage

### DIFF
--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
@@ -63,6 +63,7 @@ internal actual fun ModalBottomSheetDialog(
         properties = DialogProperties(
             dismissOnBackPress = properties.shouldDismissOnBackPress,
             usePlatformDefaultWidth = false,
+            usePlatformInsets = false,
             scrimColor = Color.Transparent,
         ),
         content = content


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/5089

![image](https://github.com/JetBrains/compose-multiplatform-core/assets/1836384/d943aa9d-b85b-4ddd-9f24-4432aa2eb179)

## Release Notes
### Fixes - iOS
- Fix `material3.ModalBottomSheet` safe area usage
