### PR TITLE
Improve interop touches by using UIScrollView-like strategy

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -24,6 +24,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (weak, nonatomic) id <CMPGestureRecognizerHandler> handler;
 
+- (void)cancelFailure;
+- (void)scheduleFailure;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -9,15 +9,14 @@
 #import <UIKit/UIGestureRecognizerSubclass.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
+ 
 @protocol CMPGestureRecognizerHandler <NSObject>
-
+ 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)onFailure;
-- (BOOL)shouldRecognizeSimultaneously:(UIGestureRecognizer *)first withOther:(UIGestureRecognizer *)second;
 
 @end
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
+- (void)onFailure;
 - (BOOL)shouldRecognizeSimultaneously:(UIGestureRecognizer *)first withOther:(UIGestureRecognizer *)second;
 
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -9,9 +9,9 @@
 #import <UIKit/UIGestureRecognizerSubclass.h>
 
 NS_ASSUME_NONNULL_BEGIN
- 
+
 @protocol CMPGestureRecognizerHandler <NSObject>
- 
+
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent * _Nullable)event;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -23,7 +23,7 @@
 }
 
 - (void)handleStateChange {
-    switch (self.state) {        
+    switch (self.state) {
         case UIGestureRecognizerStateEnded:
             [self cancelFailure];
             break;
@@ -81,9 +81,14 @@
         dispatch_block_cancel(_scheduledFailureBlock);
     }
     _scheduledFailureBlock = dispatchBlock;
+    
+    // 150ms is a timer delay for notifying a handler that the gesture was failed to recognize.
+    // `handler` implementtion is responsible for cancelling this via calling `cancelFailure` and transitioning
+    // this gesture recognizer to a proper state.
+    double failureInterval = 0.15;
 
     // Calculate the delay time in dispatch_time_t
-    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC));
+    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(failureInterval * NSEC_PER_SEC));
 
     // Schedule the block to be executed after the delay on the main queue
     dispatch_after(delay, dispatch_get_main_queue(), dispatchBlock);

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -39,7 +39,7 @@
 }
 
 - (void)fail {
-    self.state = UIGestureRecognizerStateFailed;
+    [self.handler onFailure];
 }
 
 - (void)scheduleFailure {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -82,13 +82,12 @@
     // 150ms is a timer delay for notifying a handler that the gesture was failed to recognize.
     // `handler` implementtion is responsible for cancelling this via calling `cancelFailure` and transitioning
     // this gesture recognizer to a proper state.
-    double failureInterval = 0.15;
+    double failureDelay = 0.15;
+    
+    dispatch_time_t dispatchTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(failureDelay * NSEC_PER_SEC));
 
-    // Calculate the delay time in dispatch_time_t
-    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(failureInterval * NSEC_PER_SEC));
-
-    // Schedule the block to be executed after the delay on the main queue
-    dispatch_after(delay, dispatch_get_main_queue(), dispatchBlock);
+    // Schedule the block to be executed at `dispatchTime`
+    dispatch_after(dispatchTime, dispatch_get_main_queue(), dispatchBlock);
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -25,9 +25,6 @@
 - (void)handleStateChange {
     switch (self.state) {
         case UIGestureRecognizerStateEnded:
-            [self cancelFailure];
-            break;
-            
         case UIGestureRecognizerStateCancelled:
             [self cancelFailure];
             break;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -23,15 +23,7 @@
 }
 
 - (void)handleStateChange {
-    switch (self.state) {
-        case UIGestureRecognizerStateBegan:
-            NSLog(@"state = Began");
-            break;
-            
-        case UIGestureRecognizerStateChanged:
-            NSLog(@"state = Changed");
-            break;
-            
+    switch (self.state) {        
         case UIGestureRecognizerStateEnded:
             [self cancelFailure];
             break;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -42,11 +42,8 @@
         return NO;
     }
     
-    if ([otherView isDescendantOfView:view]) {
-        return NO;
-    } else {
-        return YES;
-    }
+    // Allow simultaneous recognition only if otherGestureRecognizer is attached to the view up in the hierarchy
+    return ![otherView isDescendantOfView:view];
 }
 
 - (BOOL)shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -12,8 +12,7 @@
 - (instancetype)init {
     self = [super init];
     
-    if (self) {
-        self.cancelsTouchesInView = false;
+    if (self) {        
         self.delegate = self;
     }
     
@@ -32,57 +31,18 @@
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [self.handler touchesBegan:touches withEvent:event];
-    
-    if (self.state == UIGestureRecognizerStatePossible) {
-        self.state = UIGestureRecognizerStateBegan;
-    }
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [self.handler touchesMoved:touches withEvent:event];
-    
-    switch (self.state) {
-        case UIGestureRecognizerStateBegan:
-        case UIGestureRecognizerStateChanged:
-            self.state = UIGestureRecognizerStateChanged;
-            break;
-        default:
-            break;
-    }
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [self.handler touchesEnded:touches withEvent:event];
-    
-    switch (self.state) {
-        case UIGestureRecognizerStateBegan:
-        case UIGestureRecognizerStateChanged:
-            if (self.numberOfTouches == 0) {
-                self.state = UIGestureRecognizerStateEnded;
-            } else {
-                self.state = UIGestureRecognizerStateChanged;
-            }
-            break;
-        default:
-            break;
-    }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [self.handler touchesCancelled:touches withEvent:event];
-    
-    switch (self.state) {
-        case UIGestureRecognizerStateBegan:
-        case UIGestureRecognizerStateChanged:
-            if (self.numberOfTouches == 0) {
-                self.state = UIGestureRecognizerStateCancelled;
-            } else {
-                self.state = UIGestureRecognizerStateChanged;
-            }
-            break;
-        default:
-            break;
-    }
 }
 
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -7,7 +7,9 @@
 
 #import "CMPGestureRecognizer.h"
 
-@implementation CMPGestureRecognizer
+@implementation CMPGestureRecognizer {
+    dispatch_block_t _scheduledFailureBlock;
+}
 
 - (instancetype)init {
     self = [super init];
@@ -27,6 +29,35 @@
     } else {
         return NO;
     }
+}
+
+- (void)cancelFailure {
+    if (_scheduledFailureBlock) {
+        dispatch_block_cancel(_scheduledFailureBlock);
+        _scheduledFailureBlock = NULL;
+    }
+}
+
+- (void)fail {
+    self.state = UIGestureRecognizerStateFailed;
+}
+
+- (void)scheduleFailure {
+    __weak typeof(self) weakSelf = self;
+    dispatch_block_t dispatchBlock = dispatch_block_create(0, ^{
+        [weakSelf fail];
+    });
+    
+    if (_scheduledFailureBlock) {
+        dispatch_block_cancel(_scheduledFailureBlock);
+    }
+    _scheduledFailureBlock = dispatchBlock;
+
+    // Calculate the delay time in dispatch_time_t
+    dispatch_time_t delay = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.15 * NSEC_PER_SEC));
+
+    // Schedule the block to be executed after the delay on the main queue
+    dispatch_after(delay, dispatch_get_main_queue(), dispatchBlock);
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -16,19 +16,56 @@
     
     if (self) {        
         self.delegate = self;
+        [self addTarget:self action:@selector(handleStateChange)];
     }
     
     return self;
 }
 
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    id <CMPGestureRecognizerHandler> handler = self.handler;
+- (void)handleStateChange {
+    switch (self.state) {
+        case UIGestureRecognizerStateBegan:
+            NSLog(@"state = Began");
+            break;
+            
+        case UIGestureRecognizerStateChanged:
+            NSLog(@"state = Changed");
+            break;
+            
+        case UIGestureRecognizerStateEnded:
+            [self cancelFailure];
+            break;
+            
+        case UIGestureRecognizerStateCancelled:
+            [self cancelFailure];
+            break;
+
+        default:
+            break;
+    }
+}
+
+- (BOOL)shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    UIView *view = self.view;
+    UIView *otherView = otherGestureRecognizer.view;
     
-    if (handler) {
-        return [handler shouldRecognizeSimultaneously:gestureRecognizer withOther:otherGestureRecognizer];
-    } else {
+    if (view == nil || otherView == nil) {
         return NO;
     }
+    
+    if ([otherView isDescendantOfView:view]) {
+        return NO;
+    } else {
+        return YES;
+    }
+}
+
+- (BOOL)shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return NO;
+}
+
+- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return YES;
 }
 
 - (void)cancelFailure {

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEventProcessor.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEventProcessor.kt
@@ -135,10 +135,6 @@ internal class PointerInputEventProcessor(val root: LayoutNode) {
                 result
             }
 
-            internalPointerEvent.changes.forEach { key, value ->
-                println(value.toString())
-            }
-
             return ProcessResult(dispatchedToSomething, anyMovementConsumed)
         } finally {
             isProcessing = false

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEventProcessor.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEventProcessor.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.input.pointer
 
 import androidx.collection.LongSparseArray
-import androidx.collection.forEach
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Matrix

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEventProcessor.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/PointerInputEventProcessor.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.input.pointer
 
 import androidx.collection.LongSparseArray
+import androidx.collection.forEach
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Matrix
@@ -132,6 +133,10 @@ internal class PointerInputEventProcessor(val root: LayoutNode) {
                     }
                 }
                 result
+            }
+
+            internalPointerEvent.changes.forEach { key, value ->
+                println(value.toString())
             }
 
             return ProcessResult(dispatchedToSomething, anyMovementConsumed)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Constants.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Constants.uikit.kt
@@ -17,6 +17,6 @@
 package androidx.compose.ui.platform
 
 /**
- * iOS default value in scale-independent points for the pan gesture slop.
+ * iOS default value in scale-independent points for touch slop that recognizes as scroll/pan gesture.
  */
-internal const val CUPERTINO_PAN_GESTURE_SLOP_VALUE = 10
+internal const val CUPERTINO_TOUCH_SLOP = 10

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Constants.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Constants.uikit.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+/**
+ * iOS default value in scale-independent points for the pan gesture slop.
+ */
+internal const val CUPERTINO_PAN_GESTURE_SLOP_VALUE = 10

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.interop.UIKitInteropContainer
 import androidx.compose.ui.node.TrackInteropContainer
 import androidx.compose.ui.platform.AccessibilityMediator
 import androidx.compose.ui.platform.AccessibilitySyncOptions
+import androidx.compose.ui.platform.CUPERTINO_PAN_GESTURE_SLOP_VALUE
 import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.EmptyViewConfiguration
 import androidx.compose.ui.platform.LocalLayoutMargins
@@ -230,7 +231,7 @@ internal class ComposeSceneMediator(
             override val touchSlop: Float
                 get() = with(density) {
                     // this value is originating from iOS 16 drag behavior reverse engineering
-                    10.dp.toPx()
+                    CUPERTINO_PAN_GESTURE_SLOP_VALUE.dp.toPx()
                 }
         }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.interop.UIKitInteropContainer
 import androidx.compose.ui.node.TrackInteropContainer
 import androidx.compose.ui.platform.AccessibilityMediator
 import androidx.compose.ui.platform.AccessibilitySyncOptions
-import androidx.compose.ui.platform.CUPERTINO_PAN_GESTURE_SLOP_VALUE
+import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.EmptyViewConfiguration
 import androidx.compose.ui.platform.LocalLayoutMargins
@@ -231,7 +231,7 @@ internal class ComposeSceneMediator(
             override val touchSlop: Float
                 get() = with(density) {
                     // this value is originating from iOS 16 drag behavior reverse engineering
-                    CUPERTINO_PAN_GESTURE_SLOP_VALUE.dp.toPx()
+                    CUPERTINO_TOUCH_SLOP.dp.toPx()
                 }
         }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -87,6 +87,7 @@ import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSize
+import platform.QuartzCore.CACurrentMediaTime
 import platform.QuartzCore.CATransaction
 import platform.UIKit.NSLayoutConstraint
 import platform.UIKit.UIEvent
@@ -367,7 +368,7 @@ internal class ComposeSceneMediator(
      * @param event the [UIEvent] associated with the touches
      * @param phase the [CupertinoTouchesPhase] of the touches
      */
-    private fun onTouchesEvent(view: UIView, touches: Set<*>, event: UIEvent, phase: CupertinoTouchesPhase) {
+    private fun onTouchesEvent(view: UIView, touches: Set<*>, event: UIEvent?, phase: CupertinoTouchesPhase) {
         val pointers = touches.map {
             val touch = it as UITouch
             val id = touch.hashCode().toLong()
@@ -378,18 +379,20 @@ internal class ComposeSceneMediator(
                 pressed = touch.isPressed,
                 type = PointerType.Touch,
                 pressure = touch.force.toFloat(),
-                historical = event.historicalChangesForTouch(
+                historical = event?.historicalChangesForTouch(
                     touch,
                     view,
                     density.density
-                )
+                ) ?: emptyList()
             )
-        } ?: emptyList()
+        }
+
+        val timestamp = event?.timestamp ?: CACurrentMediaTime()
 
         scene.sendPointerEvent(
             eventType = phase.toPointerEventType(),
             pointers = pointers,
-            timeMillis = (event.timestamp * 1e3).toLong(),
+            timeMillis = (timestamp * 1e3).toLong(),
             nativeEvent = event
         )
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -394,7 +394,9 @@ internal class ComposeSceneMediator(
             )
         }
 
-        println("${pointers.size} $phase")
+        // If the touches were cancelled due to gesture failure, the timestamp is not available,
+        // because no actual event with touch updates happened. We just use the current time in
+        // this case.
         val timestamp = event?.timestamp ?: CACurrentMediaTime()
 
         scene.sendPointerEvent(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -376,7 +376,14 @@ internal class ComposeSceneMediator(
             ComposeScenePointer(
                 id = PointerId(id),
                 position = position,
-                pressed = touch.isPressed,
+                pressed = when (phase) {
+                    // When CMPGestureRecognizer is failed, all tracked touches are sent immediately
+                    // as CANCELLED. In this case, we should not consider the touch as pressed
+                    // despite them being on the screen. This is the last event for Compose in a
+                    // given gesture sequence and should be treated as such.
+                    CupertinoTouchesPhase.CANCELLED -> false
+                    else -> touch.isPressed
+                },
                 type = PointerType.Touch,
                 pressure = touch.force.toFloat(),
                 historical = event?.historicalChangesForTouch(
@@ -387,6 +394,7 @@ internal class ComposeSceneMediator(
             )
         }
 
+        println("${pointers.size} $phase")
         val timestamp = event?.timestamp ?: CACurrentMediaTime()
 
         scene.sendPointerEvent(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.ui.platform.CUPERTINO_PAN_GESTURE_SLOP_VALUE
+import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizerHandlerProtocol
 import androidx.compose.ui.viewinterop.InteropView
@@ -116,7 +116,7 @@ private class GestureRecognizerHandlerImpl(
             val initialLocation = initialLocation ?: return false
             val centroidLocation = trackedTouchesCentroidLocation ?: return false
 
-            val slop = CUPERTINO_PAN_GESTURE_SLOP_VALUE.toDouble()
+            val slop = CUPERTINO_TOUCH_SLOP.toDouble()
 
             val dx = centroidLocation.useContents { x - initialLocation.useContents { x } }
             val dy = centroidLocation.useContents { y - initialLocation.useContents { y } }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -89,7 +89,7 @@ private class GestureRecognizerHandlerImpl(
      */
     var gestureRecognizer: CMPGestureRecognizer? = null
 
-    private var state: UIGestureRecognizerState
+    private var gestureRecognizerState: UIGestureRecognizerState
         get() = gestureRecognizer?.state ?: UIGestureRecognizerStateFailed
         set(value) {
             gestureRecognizer?.setState(value)
@@ -185,15 +185,15 @@ private class GestureRecognizerHandlerImpl(
 
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.BEGAN)
 
-        if (state.isOngoing || hitTestView == view) {
+        if (gestureRecognizerState.isOngoing || hitTestView == view) {
             // Golden path, immediately start/continue the gesture recognizer if possible and pass touches.
-            when (state) {
+            when (gestureRecognizerState) {
                 UIGestureRecognizerStatePossible -> {
-                    state = UIGestureRecognizerStateBegan
+                    gestureRecognizerState = UIGestureRecognizerStateBegan
                 }
 
                 UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    state = UIGestureRecognizerStateChanged
+                    gestureRecognizerState = UIGestureRecognizerStateChanged
                 }
             }
         } else {
@@ -221,13 +221,13 @@ private class GestureRecognizerHandlerImpl(
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent?) {
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.MOVED)
 
-        if (state.isOngoing || hitTestView == view) {
+        if (gestureRecognizerState.isOngoing || hitTestView == view) {
             // Golden path, just update the gesture recognizer state and pass touches to
             // the Compose runtime.
 
-            when (state) {
+            when (gestureRecognizerState) {
                 UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    state = UIGestureRecognizerStateChanged
+                    gestureRecognizerState = UIGestureRecognizerStateChanged
                 }
             }
         } else {
@@ -251,16 +251,16 @@ private class GestureRecognizerHandlerImpl(
 
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.ENDED)
 
-        if (state.isOngoing || hitTestView == view) {
+        if (gestureRecognizerState.isOngoing || hitTestView == view) {
             // Golden path, just update the gesture recognizer state and pass touches to
             // the Compose runtime.
 
-            when (state) {
+            when (gestureRecognizerState) {
                 UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
                     if (trackedTouches.isEmpty()) {
-                        state = UIGestureRecognizerStateEnded
+                        gestureRecognizerState = UIGestureRecognizerStateEnded
                     } else {
-                        state = UIGestureRecognizerStateChanged
+                        gestureRecognizerState = UIGestureRecognizerStateChanged
                     }
                 }
             }
@@ -269,7 +269,7 @@ private class GestureRecognizerHandlerImpl(
                 // Explicitly fail the gesture, cancelling a scheduled failure
                 gestureRecognizer?.cancelFailure()
 
-                state = UIGestureRecognizerStateFailed
+                gestureRecognizerState = UIGestureRecognizerStateFailed
             }
         }
     }
@@ -293,12 +293,12 @@ private class GestureRecognizerHandlerImpl(
         if (hitTestView == view) {
             // Golden path, just update the gesture recognizer state.
 
-            when (state) {
+            when (gestureRecognizerState) {
                 UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
                     if (trackedTouches.isEmpty()) {
-                        state = UIGestureRecognizerStateCancelled
+                        gestureRecognizerState = UIGestureRecognizerStateCancelled
                     } else {
-                        state = UIGestureRecognizerStateChanged
+                        gestureRecognizerState = UIGestureRecognizerStateChanged
                     }
                 }
             }
@@ -308,7 +308,7 @@ private class GestureRecognizerHandlerImpl(
                 // Explicitly fail the gesture, cancelling a scheduled failure
                 gestureRecognizer?.cancelFailure()
 
-                state = UIGestureRecognizerStateFailed
+                gestureRecognizerState = UIGestureRecognizerStateFailed
             }
         }
     }
@@ -324,7 +324,7 @@ private class GestureRecognizerHandlerImpl(
      * [UIGestureRecognizer.delaysTouchesBegan]
      */
     override fun onFailure() {
-        state = UIGestureRecognizerStateFailed
+        gestureRecognizerState = UIGestureRecognizerStateFailed
 
         // We won't receive other touches events until all fingers are lifted, so we can't rely
         // on touchesEnded/touchesCancelled to reset the state.  We need to immediately notify
@@ -370,7 +370,7 @@ private class GestureRecognizerHandlerImpl(
     private fun checkPanIntent() {
         if (isLocationDeltaAboveSlope) {
             gestureRecognizer?.cancelFailure()
-            state = UIGestureRecognizerStateBegan
+            gestureRecognizerState = UIGestureRecognizerStateBegan
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -50,10 +50,6 @@ internal enum class CupertinoTouchesPhase {
     BEGAN, MOVED, ENDED, CANCELLED
 }
 
-fun dbgLog(msg: String) {
-    println("DBG: $msg")
-}
-
 private val UIGestureRecognizerState.isOngoing: Boolean
     get() =
         when (this) {
@@ -84,7 +80,6 @@ private class GestureRecognizerHandlerImpl(
              * Only remember the first hit-tested view in the sequence.
              */
             if (initialLocation == null) {
-                dbgLog("hitTestView: $value")
                 field = value
             }
         }
@@ -191,8 +186,6 @@ private class GestureRecognizerHandlerImpl(
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.BEGAN)
 
         if (state.isOngoing || hitTestView == view) {
-            dbgLog("touchesBegan golden")
-
             // Golden path, immediately start/continue the gesture recognizer if possible and pass touches.
             when (state) {
                 UIGestureRecognizerStatePossible -> {
@@ -205,12 +198,10 @@ private class GestureRecognizerHandlerImpl(
             }
         } else {
             if (areTouchesInitial) {
-                dbgLog("touchesBegan initial")
                 // We are in the scenario (2), we should schedule failure and pass touches to the
                 // interop view.
                 gestureRecognizer?.scheduleFailure()
             } else {
-                dbgLog("touchesBegan not initial")
                 // We are in the scenario (4), check if the gesture recognizer should be recognized.
                 checkPanIntent()
             }
@@ -231,7 +222,6 @@ private class GestureRecognizerHandlerImpl(
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.MOVED)
 
         if (state.isOngoing || hitTestView == view) {
-            dbgLog("touchesMoved golden")
             // Golden path, just update the gesture recognizer state and pass touches to
             // the Compose runtime.
 
@@ -241,7 +231,6 @@ private class GestureRecognizerHandlerImpl(
                 }
             }
         } else {
-            dbgLog("touchesMoved not golden")
             checkPanIntent()
         }
     }
@@ -263,7 +252,6 @@ private class GestureRecognizerHandlerImpl(
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.ENDED)
 
         if (state.isOngoing || hitTestView == view) {
-            dbgLog("touchesEnded golden")
             // Golden path, just update the gesture recognizer state and pass touches to
             // the Compose runtime.
 
@@ -272,13 +260,11 @@ private class GestureRecognizerHandlerImpl(
                     if (trackedTouches.isEmpty()) {
                         state = UIGestureRecognizerStateEnded
                     } else {
-                        dbgLog("touchesEnded, trackedTouches.size: ${trackedTouches.size}")
                         state = UIGestureRecognizerStateChanged
                     }
                 }
             }
         } else {
-            dbgLog("touchesEnded not golden")
             if (trackedTouches.isEmpty()) {
                 // Explicitly fail the gesture, cancelling a scheduled failure
                 gestureRecognizer?.cancelFailure()
@@ -305,7 +291,6 @@ private class GestureRecognizerHandlerImpl(
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.CANCELLED)
 
         if (hitTestView == view) {
-            dbgLog("touchesCancelled golden")
             // Golden path, just update the gesture recognizer state.
 
             when (state) {
@@ -313,13 +298,11 @@ private class GestureRecognizerHandlerImpl(
                     if (trackedTouches.isEmpty()) {
                         state = UIGestureRecognizerStateCancelled
                     } else {
-                        dbgLog("touchesCancelled, trackedTouches.size: ${trackedTouches.size}")
                         state = UIGestureRecognizerStateChanged
                     }
                 }
             }
         } else {
-            dbgLog("touchesCancelled not golden")
             if (trackedTouches.isEmpty()) {
                 // Those were the last touches in the sequence
                 // Explicitly fail the gesture, cancelling a scheduled failure
@@ -348,8 +331,6 @@ private class GestureRecognizerHandlerImpl(
         // the runtime about the cancelled touches and reset the state manually
         onTouchesEvent(trackedTouches, null, CupertinoTouchesPhase.CANCELLED)
         stopTrackingTouches(trackedTouches)
-
-        dbgLog("onFailure, trackedTouches.size: ${trackedTouches.size}")
     }
 
     /**
@@ -388,7 +369,6 @@ private class GestureRecognizerHandlerImpl(
      */
     private fun checkPanIntent() {
         if (isLocationDeltaAboveSlope) {
-            dbgLog("checkPanIntent success")
             gestureRecognizer?.cancelFailure()
             state = UIGestureRecognizerStateBegan
         }
@@ -539,8 +519,6 @@ internal class InteractionUIView(
     private fun rememberHitTestResult(hitTestBlock: () -> UIView?): UIView? {
         val result = hitTestBlock()
         gestureRecognizerHandler.hitTestView = result
-
-        dbgLog("rememberHitTestResult: $result")
         return result
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -217,7 +217,12 @@ private class GestureRecognizerHandlerImpl(
      */
     override fun onFailure() {
         state = UIGestureRecognizerStateFailed
+
         onTouchesEventCallbackForPhase(trackedTouches, null, CupertinoTouchesPhase.CANCELLED).invoke()
+
+        // We won't receive other touches until all fingers are lifted, so we can't rely
+        // on touchesEnded/touchesCancelled to reset the state.
+        stopTrackingTouches(trackedTouches)
     }
 
     override fun shouldRecognizeSimultaneously(first: UIGestureRecognizer, withOther: UIGestureRecognizer): Boolean {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -414,7 +414,7 @@ internal class InteractionUIView(
         super.touchesCancelled(touches, withEvent)
     }
 
-    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? = rememberingHitTestResult {
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? = rememberHitTestResult {
         if (!inInteractionBounds(point)) {
             null
         } else {
@@ -454,9 +454,11 @@ internal class InteractionUIView(
     }
 
     /**
-     * Execute the given [hitTestBlock] and save the result to the gesture recognizer handler.
+     * Execute the given [hitTestBlock] and save the result to the gesture recognizer handler, so
+     * that it can be used later to determine if the gesture recognizer should be recognized
+     * or failed.
      */
-    private fun rememberingHitTestResult(hitTestBlock: () -> UIView?): UIView? {
+    private fun rememberHitTestResult(hitTestBlock: () -> UIView?): UIView? {
         val result = hitTestBlock()
         gestureRecognizerHandler.hitTestView = result
         return result

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -164,7 +164,7 @@ private class GestureRecognizerHandlerImpl(
      * [CMPGestureRecognizer.scheduleFailure], which will pass intercepted touches to the interop
      * views if the gesture recognizer is not recognized within a certain time frame
      * (UIScrollView reverse-engineered 150ms is used).
-     * The similar approach is used by [UIScrollView](https://developer.apple.com/documentation/uikit/uiscrollview?language=objc)
+     * The similar approach is used by [UIScrollView](https://developer.apple.com/documentation/uikit/uiscrollview)
      *
      * 3. Those are not the first touches in the sequence. A gesture is recognized.
      * We should continue with scenario (1), we don't yet support multitouch sequence in

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -288,6 +288,17 @@ private class GestureRecognizerHandlerImpl(
         }
     }
 
+    /**
+     * Implementation of [CMPGestureRecognizerHandlerProtocol] that handles touchesCancelled event and
+     * forwards it here.
+     *
+     * There are following scenarios:
+     * 1. The interaction view is hit-tested, or a gesture is recognized. Just update the gesture
+     * recognizer state and pass touches to the Compose runtime.
+     *
+     * 2. An interop view is hit-tested. In this case if there are no tracked touches left -
+     * we need to allow all the touches to be passed to the interop view by failing explicitly.
+     */
     override fun touchesCancelled(touches: Set<*>, withEvent: UIEvent?) {
         stopTrackingTouches(touches)
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -349,13 +349,13 @@ private class GestureRecognizerHandlerImpl(
      * @return `true` if the touches are initial, `false` otherwise.
      */
     private fun startTrackingTouches(touches: Set<*>): Boolean {
-        onTouchesCountChanged(touches.size)
-
         val areTouchesInitial = trackedTouches.isEmpty()
 
         for (touch in touches) {
             trackedTouches.add(touch as UITouch)
         }
+
+        onTouchesCountChanged(touches.size)
 
         if (areTouchesInitial) {
             initialLocation = trackedTouchesCentroidLocation
@@ -379,11 +379,11 @@ private class GestureRecognizerHandlerImpl(
      * location to null.
      */
     private fun stopTrackingTouches(touches: Set<*>) {
-        onTouchesCountChanged(-touches.size)
-
         for (touch in touches) {
             trackedTouches.remove(touch as UITouch)
         }
+
+        onTouchesCountChanged(-touches.size)
 
         if (trackedTouches.isEmpty()) {
             initialLocation = null

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -111,7 +111,7 @@ private class GestureRecognizerHandlerImpl(
      * Checks whether the centroid location of [trackedTouches] has exceeded the scrolling slop
      * relative to [initialLocation]
      */
-    private val isLocationDeltaAboveSlope: Boolean
+    private val isLocationDeltaAboveSlop: Boolean
         get() {
             val initialLocation = initialLocation ?: return false
             val centroidLocation = trackedTouchesCentroidLocation ?: return false
@@ -369,7 +369,7 @@ private class GestureRecognizerHandlerImpl(
      * Check if the tracked touches have moved enough to recognize the gesture.
      */
     private fun checkPanIntent() {
-        if (isLocationDeltaAboveSlope) {
+        if (isLocationDeltaAboveSlop) {
             gestureRecognizer?.cancelFailure()
             gestureRecognizerState = UIGestureRecognizerStateBegan
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -296,10 +296,10 @@ private class GestureRecognizerHandlerImpl(
 
             when (gestureRecognizerState) {
                 UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    if (trackedTouches.isEmpty()) {
-                        gestureRecognizerState = UIGestureRecognizerStateCancelled
+                    gestureRecognizerState = if (trackedTouches.isEmpty()) {
+                        UIGestureRecognizerStateCancelled
                     } else {
-                        gestureRecognizerState = UIGestureRecognizerStateChanged
+                        UIGestureRecognizerStateChanged
                     }
                 }
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -155,7 +155,7 @@ private class GestureRecognizerHandlerImpl(
      * runtime.
      *
      * 2. Those are first touches in the sequence, an interop view is hit-tested. In this case we
-     * intecept touches from interop views until the gesture recognizer is explicitly failed.
+     * intercept touches from interop views until the gesture recognizer is explicitly failed.
      * See [UIGestureRecognizer.delaysTouchesBegan]. In the same time we schedule a failure in
      * [CMPGestureRecognizer.scheduleFailure], which will pass intercepted touches to the interop
      * views if the gesture recognizer is not recognized within a certain time frame
@@ -192,17 +192,15 @@ private class GestureRecognizerHandlerImpl(
                 }
             }
         } else {
+            onTouchesEvent()
+
             if (areTouchesInitial) {
                 // We are in the scenario (2), we should schedule failure and pass touches to the
                 // interop view.
                 gestureRecognizer?.scheduleFailure()
-
-                onTouchesEvent()
             } else {
                 // We are in the scenario (4), check if the gesture recognizer should be recognized.
                 checkPanIntent()
-
-                onTouchesEvent()
             }
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -470,7 +470,7 @@ internal class InteractionUIView(
         super.pressesEnded(presses, withEvent)
     }
 
-    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? = rememberHitTestResult {
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? = savingHitTestResult {
         if (!inInteractionBounds(point)) {
             null
         } else {
@@ -514,7 +514,7 @@ internal class InteractionUIView(
      * that it can be used later to determine if the gesture recognizer should be recognized
      * or failed.
      */
-    private fun rememberHitTestResult(hitTestBlock: () -> UIView?): UIView? {
+    private fun savingHitTestResult(hitTestBlock: () -> UIView?): UIView? {
         val result = hitTestBlock()
         gestureRecognizerHandler.hitTestView = result
         return result

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -390,9 +390,6 @@ private class GestureRecognizerHandlerImpl(
         }
     }
 
-    /**
-     * Curry the [onTouchesEvent] callback with the given [touches], [event], and [phase].
-     */
     private fun onTouchesEvent(
         touches: Set<*>,
         event: UIEvent?,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.platform.CUPERTINO_PAN_GESTURE_SLOP_VALUE
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizerHandlerProtocol
 import androidx.compose.ui.viewinterop.InteropView
@@ -115,7 +116,7 @@ private class GestureRecognizerHandlerImpl(
             val initialLocation = initialLocation ?: return false
             val centroidLocation = trackedTouchesCentroidLocation ?: return false
 
-            val slop = 10.0
+            val slop = CUPERTINO_PAN_GESTURE_SLOP_VALUE.toDouble()
 
             val dx = centroidLocation.useContents { x - initialLocation.useContents { x } }
             val dy = centroidLocation.useContents { y - initialLocation.useContents { y } }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -258,10 +258,10 @@ private class GestureRecognizerHandlerImpl(
 
             when (gestureRecognizerState) {
                 UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    if (trackedTouches.isEmpty()) {
-                        gestureRecognizerState = UIGestureRecognizerStateEnded
+                    gestureRecognizerState = if (trackedTouches.isEmpty()) {
+                        UIGestureRecognizerStateEnded
                     } else {
-                        gestureRecognizerState = UIGestureRecognizerStateChanged
+                        UIGestureRecognizerStateChanged
                     }
                 }
             }


### PR DESCRIPTION
## Description
In this approach `CMPGestureRecognizer` delays `touchesBegan` until explicitly failed, and is required to fail by `UIGestureRecognizer` of children views (aka interop views). Failure happens after the first touch started and no motion above scroll slop happens within 150ms. If this happens, intercepted touches are delivered to children views (and their gesture recognisers), Compose itself gets all tracked touches as cancelled and ignores them until the touch sequence ends (imposed by UIKit).
This behavior is inspired by `UIScrollView` implementation.

https://github.com/JetBrains/compose-multiplatform-core/assets/4167681/1245b986-1f11-4f02-a939-c069a7797e3a

### Fixes
Improves behavior of touches in [certain scenarios](https://github.com/JetBrains/compose-multiplatform/issues/4818)

## Testing
This should be tested by QA

## Release Notes

### iOS - Features
- Improvements in touches processing to detect if touches were meant to be delivered to interop views, or should be processed by Compose.