### PR TITLE
Fix floating cursor broken after 1.7 merge

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -60,7 +60,6 @@ internal actual fun legacyPlatformTextInputServiceAdapter(): LegacyPlatformTextI
                 session?.updateState(oldValue, newValue)
             }
 
-
             override fun updateTextLayoutResult(
                 textFieldValue: TextFieldValue,
                 offsetMapping: OffsetMapping,

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -18,11 +18,15 @@ package androidx.compose.foundation.text.input.internal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.platform.LocalTextInputService
 import androidx.compose.ui.text.InternalTextApi
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TextInputSession
 
@@ -54,6 +58,25 @@ internal actual fun legacyPlatformTextInputServiceAdapter(): LegacyPlatformTextI
 
             override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) {
                 session?.updateState(oldValue, newValue)
+            }
+
+
+            override fun updateTextLayoutResult(
+                textFieldValue: TextFieldValue,
+                offsetMapping: OffsetMapping,
+                textLayoutResult: TextLayoutResult,
+                textFieldToRootTransform: (Matrix) -> Unit,
+                innerTextFieldBounds: Rect,
+                decorationBoxBounds: Rect
+            ) {
+                session?.updateTextLayoutResult(
+                    textFieldValue,
+                    offsetMapping,
+                    textLayoutResult,
+                    textFieldToRootTransform,
+                    innerTextFieldBounds,
+                    decorationBoxBounds
+                )
             }
         }
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isTrue
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.platform.LocalTextInputService
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.PlatformTextInputService
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TextInputService
+import kotlin.test.Test
+
+class LegacyPlatformTextInputServiceAdapterTest {
+
+    @Suppress("DEPRECATION")
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun textLayoutResultIsProvided() = runComposeUiTest {
+
+        var isProvided = false
+
+        val platformTextInputService = object : PlatformTextInputService {
+
+            override fun startInput(
+                value: TextFieldValue,
+                imeOptions: ImeOptions,
+                onEditCommand: (List<EditCommand>) -> Unit,
+                onImeActionPerformed: (ImeAction) -> Unit
+            ) {}
+
+            override fun stopInput() {}
+
+            override fun showSoftwareKeyboard() {}
+
+            override fun hideSoftwareKeyboard() {}
+
+            override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) {}
+
+            override fun updateTextLayoutResult(
+                textFieldValue: TextFieldValue,
+                offsetMapping: OffsetMapping,
+                textLayoutResult: TextLayoutResult,
+                textFieldToRootTransform: (Matrix) -> Unit,
+                innerTextFieldBounds: Rect,
+                decorationBoxBounds: Rect
+            ) {
+                isProvided = true
+            }
+        }
+        val textInputService = TextInputService(platformTextInputService)
+
+        setContent {
+            CompositionLocalProvider(LocalTextInputService provides textInputService) {
+                BasicTextField(
+                    modifier = Modifier.testTag("input"),
+                    value = "",
+                    onValueChange = {}
+                )
+            }
+        }
+
+        waitForIdle()
+
+        onNodeWithTag("input").performTextInput("abc")
+
+        waitForIdle()
+
+        assertThat(isProvided).isTrue()
+    }
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
@@ -17,8 +17,13 @@
 package androidx.compose.foundation.text
 
 import androidx.compose.foundation.assertThat
-import androidx.compose.foundation.isTrue
+import androidx.compose.foundation.isEqualTo
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Matrix
@@ -37,6 +42,7 @@ import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TextInputService
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 class LegacyPlatformTextInputServiceAdapterTest {
 
@@ -45,7 +51,7 @@ class LegacyPlatformTextInputServiceAdapterTest {
     @Test
     fun textLayoutResultIsProvided() = runComposeUiTest {
 
-        var isProvided = false
+        var textFromUpdateTextLayoutResult = ""
 
         val platformTextInputService = object : PlatformTextInputService {
 
@@ -72,17 +78,20 @@ class LegacyPlatformTextInputServiceAdapterTest {
                 innerTextFieldBounds: Rect,
                 decorationBoxBounds: Rect
             ) {
-                isProvided = true
+                textFromUpdateTextLayoutResult = textFieldValue.text
             }
         }
         val textInputService = TextInputService(platformTextInputService)
 
         setContent {
             CompositionLocalProvider(LocalTextInputService provides textInputService) {
+                var text by remember { mutableStateOf("") }
                 BasicTextField(
                     modifier = Modifier.testTag("input"),
-                    value = "",
-                    onValueChange = {}
+                    value = text,
+                    onValueChange = {
+                        text = it
+                    }
                 )
             }
         }
@@ -93,6 +102,6 @@ class LegacyPlatformTextInputServiceAdapterTest {
 
         waitForIdle()
 
-        assertThat(isProvided).isTrue()
+        assertThat(textFromUpdateTextLayoutResult).isEqualTo("abc")
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.uikit.kt
@@ -21,11 +21,11 @@ import androidx.compose.ui.unit.DpOffset
 
 internal interface IOSSkikoInput {
 
-    fun beginFloatingCursor(offset: DpOffset) {}
+    fun beginFloatingCursor(offset: DpOffset)
 
-    fun updateFloatingCursor(offset: DpOffset) {}
+    fun updateFloatingCursor(offset: DpOffset)
 
-    fun endFloatingCursor() {}
+    fun endFloatingCursor()
 
     /**
      * A Boolean value that indicates whether the text-entry object has any text.
@@ -118,6 +118,9 @@ internal interface IOSSkikoInput {
     fun positionFromPosition(position: Long, offset: Long): Long
 
     object Empty : IOSSkikoInput {
+        override fun beginFloatingCursor(offset: DpOffset) = Unit
+        override fun updateFloatingCursor(offset: DpOffset)  = Unit
+        override fun endFloatingCursor()  = Unit
         override fun hasText(): Boolean = false
         override fun insertText(text: String) = Unit
         override fun deleteBackward() = Unit


### PR DESCRIPTION
Floating cursor was broken after 1.7 merge.
Fixes https://youtrack.jetbrains.com/issue/CMP-1626

## Testing

Manually + new unit test

## Release Notes

### Fixes - iOS
- (prerelease fix) Fixed floating cursor isn't working
