### PR TITLE
Fix clickable in a scroll container

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Draggable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Draggable.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.Velocity
+import androidx.compose.ui.util.fastAny
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.sign
 import kotlinx.coroutines.CoroutineScope
@@ -466,7 +467,9 @@ internal abstract class DragGestureNode(
         if (enabled && pointerInputNode == null) {
             pointerInputNode = delegate(initializePointerInputNode())
         }
-        pointerInputNode?.onPointerEvent(pointerEvent, pass, bounds)
+        if (pointerEvent.changes.fastAny { canDrag.invoke(it) }) {
+            pointerInputNode?.onPointerEvent(pointerEvent, pass, bounds)
+        }
     }
 
     private fun initializePointerInputNode(): SuspendingPointerInputModifierNode {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
@@ -16,8 +16,10 @@
 
 package androidx.compose.foundation.gestures
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -151,5 +153,29 @@ class SkikoScrollableTest {
          * it doesn't freeze. This was an issue previously, as inside the scroll animation, there
          * was a handler for the CancellationException that used to stop the scene from closing.
          */
+    }
+
+    @Test
+    fun clickableInScrollContainer() = runSkikoComposeUiTest {
+        var isClicked = false
+        setContent {
+            Row(modifier = Modifier.testTag("container")) {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    Box(modifier = Modifier.size(100.dp).clickable {
+                       isClicked = true
+                    })
+                }
+            }
+        }
+
+        onNodeWithTag("container").performMouseInput {
+            moveBy(Offset(10f, 10f))
+            press()
+            moveBy(Offset(50f, 50f))
+            release()
+        }
+
+        runOnIdle { assertTrue(isClicked, "The Box is expected to receive a Click") }
+
     }
 }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
@@ -199,6 +199,7 @@ class SkikoScrollableTest {
 
         onNodeWithTag("container").performTouchInput {
             down(Offset(10f, 10f))
+            // drag a bit
             moveBy(Offset(50f, 50f))
             up()
         }
@@ -207,6 +208,19 @@ class SkikoScrollableTest {
             assertFalse(
                 isClicked,
                 "The Box is NOT expected to receive a Click while dragging using touch"
+            )
+        }
+
+        onNodeWithTag("container").performTouchInput {
+            down(Offset(50f, 50f))
+            // no drag
+            up()
+        }
+
+        runOnIdle {
+            assertTrue(
+                isClicked,
+                "The Box is expected to receive a Click, because there was no dragging using touch"
             )
         }
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/gestures/SkikoScrollableTest.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.test.swipe
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
@@ -155,8 +156,8 @@ class SkikoScrollableTest {
          */
     }
 
-    @Test
-    fun clickableInScrollContainer() = runSkikoComposeUiTest {
+    @Test // https://youtrack.jetbrains.com/issue/CMP-5069
+    fun clickableInScrollContainerWithMouse() = runSkikoComposeUiTest {
         var isClicked = false
         setContent {
             Row(modifier = Modifier.testTag("container")) {
@@ -175,7 +176,38 @@ class SkikoScrollableTest {
             release()
         }
 
-        runOnIdle { assertTrue(isClicked, "The Box is expected to receive a Click") }
+        runOnIdle {
+            assertTrue(
+                isClicked,
+                "The Box is expected to receive a Click using Mouse"
+            )
+        }
+    }
 
+    @Test // https://youtrack.jetbrains.com/issue/CMP-5069
+    fun clickableInScrollContainerWithTouch() = runSkikoComposeUiTest {
+        var isClicked = false
+        setContent {
+            Row(modifier = Modifier.testTag("container")) {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    Box(modifier = Modifier.size(100.dp).clickable {
+                        isClicked = true
+                    })
+                }
+            }
+        }
+
+        onNodeWithTag("container").performTouchInput {
+            down(Offset(10f, 10f))
+            moveBy(Offset(50f, 50f))
+            up()
+        }
+
+        runOnIdle {
+            assertFalse(
+                isClicked,
+                "The Box is NOT expected to receive a Click while dragging using touch"
+            )
+        }
     }
 }


### PR DESCRIPTION
Since new scroll implementation involves detecting drag gestures, the pointer events are consumed by it. Therefore the clicks do not work when the pointer is moved. 

This change check the pointer input event using the existing CanDrag lambda, which returns false for Scrollable container when the pointer type is Mouse.

Fixes https://youtrack.jetbrains.com/issue/CMP-5069

## Testing
- Added a test
This should be tested by QA

## Release Notes

### Fixes - Multiple Platforms
- Fix missed clicks after mouse is moved in Scrollable containers 



