### PR TITLE
Common method to decode a ByteArray to the ImageBitmap

### DIFF
--- a/compose/ui/ui-graphics/src/androidMain/kotlin/androidx/compose/ui/graphics/AndroidImageBitmap.android.kt
+++ b/compose/ui/ui-graphics/src/androidMain/kotlin/androidx/compose/ui/graphics/AndroidImageBitmap.android.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.graphics
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
 import android.os.Build
 import android.util.DisplayMetrics
 import androidx.annotation.DoNotInline
@@ -30,6 +31,10 @@ import androidx.compose.ui.graphics.colorspace.ColorSpaces
  * will modify the returned [ImageBitmap]
  */
 fun Bitmap.asImageBitmap(): ImageBitmap = AndroidImageBitmap(this)
+
+internal actual fun createImageBitmap(bytes: ByteArray): ImageBitmap {
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size).asImageBitmap()
+}
 
 internal actual fun ActualImageBitmap(
     width: Int,

--- a/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/ImageBitmap.kt
+++ b/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/ImageBitmap.kt
@@ -259,3 +259,12 @@ fun ImageBitmap(
     hasAlpha,
     colorSpace
 )
+
+/**
+ * Decodes a byte array of a Bitmap to an ImageBitmap.
+ *
+ * @return The converted ImageBitmap.
+ */
+fun ByteArray.decodeToImageBitmap(): ImageBitmap = createImageBitmap(this)
+
+internal expect fun createImageBitmap(bytes: ByteArray): ImageBitmap

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaImageAsset.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaImageAsset.skiko.kt
@@ -38,6 +38,10 @@ fun Bitmap.asComposeImageBitmap(): ImageBitmap = SkiaBackedImageBitmap(this)
  */
 fun Image.toComposeImageBitmap(): ImageBitmap = SkiaBackedImageBitmap(toBitmap())
 
+internal actual fun createImageBitmap(bytes: ByteArray): ImageBitmap {
+    return Image.makeFromEncoded(bytes).toComposeImageBitmap()
+}
+
 // Split into expect/actual to use a faster implementation for web
 // See web implementation for details and the reason.
 internal expect fun Image.toBitmap(): Bitmap


### PR DESCRIPTION
## Proposed Changes
Android API has `Bitmap.asImageBitmap()` method and Skiko API has own `Image.makeFromEncoded(bytes)` method. The PR commonized both of them for the common source set.

## Testing

Test: I checked the method manually.