### PR TITLE
Fixed keyboard appearing in SelectionContainer in iOS

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -306,7 +306,6 @@ internal class UIKitTextInputService(
             // then it means that showMenu() called in SelectionContainer without any textfields,
             // and IntermediateTextInputView must be created to show an editing menu
             attachIntermediateTextInputView()
-            textUIView?.becomeFirstResponder()
             updateView()
         }
         textUIView?.showTextMenu(


### PR DESCRIPTION
Fixed the keyboard appearing in SelectionContainer in iOS

<!-- Optional -->
Fixes: https://github.com/JetBrains/compose-multiplatform/issues/4986
https://youtrack.jetbrains.com/issue/CMP-1554/iOS-Selection-Container-shows-keyboard-while-selecting-text
https://github.com/JetBrains/compose-multiplatform/issues/5088

## Testing
Manual. Open Test App, go Components -> Selection, double tap any selectable text, on-screen keyboard shouldn't appear.

## Release Notes
<!--
Optional, if omitted - won't be included in the changelog

Sections:
- Highlights
- Known issues
- Breaking changes
- Features
- Fixes

Subsections:
- Multiple Platforms
- iOS
- Desktop
- Web
- Resources
- Gradle Plugin
-->
### Fixes - iOS
- Fixed the keyboard appearing when selecting from SelectionContainer


## Google CLA
You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.
This is needed since we synchronise most of the code with Google’s AOSP repository. Signing this agreement allows us to synchronise code from your Pull Requests as well.
