### PR TITLE
Refactor JsPlatformLocale

### DIFF
--- a/compose/ui/ui-text/src/webCommonW3C/kotlin/androidx/compose/ui/text/intl/JsPlatformLocale.web.kt
+++ b/compose/ui/ui-text/src/webCommonW3C/kotlin/androidx/compose/ui/text/intl/JsPlatformLocale.web.kt
@@ -16,8 +16,6 @@
 
 package androidx.compose.ui.text.intl
 
-actual typealias PlatformLocale = IntlLocale
-
 internal actual val PlatformLocale.language: String
     get() = _language
 
@@ -56,19 +54,20 @@ internal actual fun PlatformLocale.isRtl(): Boolean = this.language in rtlLangua
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale
 // Note: Since Compose common code introduced PlatformLocale with extension properties with the same names,
 // we had to change the names of the properties in kotlin to avoid the name shadowing.
-external class IntlLocale {
+actual external class PlatformLocale {
     @JsName("language")
-    val _language: String
+    internal val _language: String
     @JsName("script")
-    val _script: String?
+    internal val _script: String?
     @JsName("region")
-    val _region: String?
+    internal val _region: String?
     @JsName("baseName")
-    val _baseName: String
+    internal val _baseName: String
 }
 
-internal fun parseLanguageTagToIntlLocale(languageTag: String): IntlLocale = js("new Intl.Locale(languageTag)")
+internal fun parseLanguageTagToIntlLocale(languageTag: String): PlatformLocale =
+    js("new Intl.Locale(languageTag)")
 
 internal expect fun userPreferredLanguages(): List<String>
 
-private fun String.toIntlLocale(): IntlLocale = parseLanguageTagToIntlLocale(this)
+private fun String.toIntlLocale(): PlatformLocale = parseLanguageTagToIntlLocale(this)


### PR DESCRIPTION
CMP-1256 (https://youtrack.jetbrains.com/issue/CMP-1256)

**NEW description**:

Provide no new public class except the common `expect class PlatformLocale` which is "empty" from user perspective. Only extension properties are exposed.

____

**OLD description:**

IMO, this is just an alternative to the current implementation. 

In both cases we expose some new public type:
- either JsPlatformLocale
- or IntLocale - external class (in this PR)

It's unavoidable. K/Js and K/Wasm stdlibs don't have such a type.

The current implementaion (not in this PR) is a bit better in my opinion, because in this PR:
- I don't like that we expose a public external class `IntlLocale` with modified names. Ideally it would be available in the stdlib. 
- with public JsPlatformLocale - it's a black box, so users can't expect much from it. 

WDYT?

