### PR TITLE
Workaround IndexOutOfBounds when sorting an empty collection

### DIFF
--- a/collection/collection/src/commonMain/kotlin/androidx/collection/FloatList.kt
+++ b/collection/collection/src/commonMain/kotlin/androidx/collection/FloatList.kt
@@ -878,6 +878,7 @@ public class MutableFloatList(
      * Sorts the [MutableFloatList] elements in ascending order.
      */
     public fun sort() {
+        if (_size == 0) return // TODO: remove after fix https://youtrack.jetbrains.com/issue/KT-70005
         content.sort(fromIndex = 0, toIndex = _size)
     }
 
@@ -885,6 +886,7 @@ public class MutableFloatList(
      * Sorts the [MutableFloatList] elements in descending order.
      */
     public fun sortDescending() {
+        if (_size == 0) return // TODO: remove after fix https://youtrack.jetbrains.com/issue/KT-70005
         content.sortDescending(fromIndex = 0, toIndex = _size)
     }
 }

--- a/collection/collection/src/commonMain/kotlin/androidx/collection/IntList.kt
+++ b/collection/collection/src/commonMain/kotlin/androidx/collection/IntList.kt
@@ -878,6 +878,7 @@ public class MutableIntList(
      * Sorts the [MutableIntList] elements in ascending order.
      */
     public fun sort() {
+        if (_size == 0) return // TODO: remove after fix https://youtrack.jetbrains.com/issue/KT-70005
         content.sort(fromIndex = 0, toIndex = _size)
     }
 
@@ -885,6 +886,7 @@ public class MutableIntList(
      * Sorts the [MutableIntList] elements in descending order.
      */
     public fun sortDescending() {
+        if (_size == 0) return // TODO: remove after fix https://youtrack.jetbrains.com/issue/KT-70005
         content.sortDescending(fromIndex = 0, toIndex = _size)
     }
 }

--- a/collection/collection/src/commonTest/kotlin/androidx/collection/FloatListTest.kt
+++ b/collection/collection/src/commonTest/kotlin/androidx/collection/FloatListTest.kt
@@ -657,6 +657,14 @@ internal class FloatListTest {
         assertEquals(mutableFloatListOf(5f, 4f, 3f, 2f, 1f), l)
     }
 
+    @Test // https://youtrack.jetbrains.com/issue/CMP-5698
+    fun sortEmpty() {
+        val l = MutableFloatList(0)
+        l.sort()
+        l.sortDescending()
+        assertEquals(MutableFloatList(0), l)
+    }
+
     @Test
     fun testEmptyFloatList() {
         val l = emptyFloatList()

--- a/collection/collection/src/commonTest/kotlin/androidx/collection/IntListTest.kt
+++ b/collection/collection/src/commonTest/kotlin/androidx/collection/IntListTest.kt
@@ -651,6 +651,14 @@ internal class IntListTest {
         assertEquals(list, l)
     }
 
+    @Test // https://youtrack.jetbrains.com/issue/CMP-5698
+    fun sortEmpty() {
+        val l = MutableIntList(0)
+        l.sort()
+        l.sortDescending()
+        assertEquals(MutableIntList(0), l)
+    }
+
     @Test
     fun sortDescending() {
         val l = mutableIntListOf(1, 4, 2, 5, 3)

--- a/collection/collection/src/commonTest/kotlin/androidx/collection/LongListTest.kt
+++ b/collection/collection/src/commonTest/kotlin/androidx/collection/LongListTest.kt
@@ -658,6 +658,14 @@ internal class LongListTest {
         assertEquals(mutableLongListOf(5L, 4L, 3L, 2L, 1L), l)
     }
 
+    @Test // https://youtrack.jetbrains.com/issue/CMP-5698
+    fun sortEmpty() {
+        val l = MutableLongList()
+        l.sort()
+        l.sortDescending()
+        assertEquals(MutableLongList(), l)
+    }
+
     @Test
     fun testEmptyLongList() {
         val l = emptyLongList()


### PR DESCRIPTION
Workaround for: https://youtrack.jetbrains.com/issue/CMP-5698 (affects K/Wasm and K/Native. Other targets are not affected)

The root cause issue was reported to Kotlin: https://youtrack.jetbrains.com/issue/KT-70005
