### PR TITLE
CMP-1108: Deprecate resources in `compose.ui` in favour of the new resource library

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3466,12 +3466,6 @@ public final class androidx/compose/ui/platform/WindowInfo$DefaultImpls {
 	public static fun getKeyboardModifiers-k7X9c1A (Landroidx/compose/ui/platform/WindowInfo;)I
 }
 
-public final class androidx/compose/ui/res/ClassLoaderResourceLoader : androidx/compose/ui/res/ResourceLoader {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun load (Ljava/lang/String;)Ljava/io/InputStream;
-}
-
 public final class androidx/compose/ui/res/DesktopSvgResources_desktopKt {
 	public static final fun loadSvgPainter (Ljava/io/InputStream;Landroidx/compose/ui/unit/Density;)Landroidx/compose/ui/graphics/painter/Painter;
 }
@@ -3480,34 +3474,16 @@ public final class androidx/compose/ui/res/DesktopXmlVectorResources_desktopKt {
 	public static final fun loadXmlImageVector (Lorg/xml/sax/InputSource;Landroidx/compose/ui/unit/Density;)Landroidx/compose/ui/graphics/vector/ImageVector;
 }
 
-public final class androidx/compose/ui/res/FileResourceLoader : androidx/compose/ui/res/ResourceLoader {
-	public static final field $stable I
-	public fun <init> (Ljava/io/File;)V
-	public final fun getRoot ()Ljava/io/File;
-	public fun load (Ljava/lang/String;)Ljava/io/InputStream;
-}
-
 public final class androidx/compose/ui/res/ImageResources_desktopKt {
 	public static final fun loadImageBitmap (Ljava/io/InputStream;)Landroidx/compose/ui/graphics/ImageBitmap;
 }
 
 public final class androidx/compose/ui/res/PainterResources_desktopKt {
 	public static final fun painterResource (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
-	public static final fun painterResource (Ljava/lang/String;Landroidx/compose/ui/res/ResourceLoader;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
-}
-
-public abstract interface class androidx/compose/ui/res/ResourceLoader {
-	public static final field Companion Landroidx/compose/ui/res/ResourceLoader$Companion;
-	public abstract fun load (Ljava/lang/String;)Ljava/io/InputStream;
-}
-
-public final class androidx/compose/ui/res/ResourceLoader$Companion {
-	public final fun getDefault ()Landroidx/compose/ui/res/ClassLoaderResourceLoader;
 }
 
 public final class androidx/compose/ui/res/Resources_desktopKt {
 	public static final fun openResource (Ljava/lang/String;)Ljava/io/InputStream;
-	public static final fun openResource (Ljava/lang/String;Landroidx/compose/ui/res/ResourceLoader;)Ljava/io/InputStream;
 	public static final fun useResource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
@@ -49,6 +49,7 @@ import org.jetbrains.skia.svg.SVGPreserveAspectRatioAlign
  * will be drawn with the specified size, density will have no effect.
  * @return the decoded SVG image associated with the resource
  */
+@Deprecated("Migrate to the compose resources library")
 fun loadSvgPainter(
     inputStream: InputStream,
     density: Density

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
@@ -49,7 +49,7 @@ import org.jetbrains.skia.svg.SVGPreserveAspectRatioAlign
  * will be drawn with the specified size, density will have no effect.
  * @return the decoded SVG image associated with the resource
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 fun loadSvgPainter(
     inputStream: InputStream,
     density: Density

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
@@ -49,7 +49,14 @@ import org.jetbrains.skia.svg.SVGPreserveAspectRatioAlign
  * will be drawn with the specified size, density will have no effect.
  * @return the decoded SVG image associated with the resource
  */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
+@Deprecated(
+    "Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html",
+    replaceWith = ReplaceWith(
+        "inputStream.readAllBytes().decodeToSvgPainter(density)",
+        "org.jetbrains.compose.resources.decodeToSvgPainter",
+        "java.io.InputStream"
+    )
+)
 fun loadSvgPainter(
     inputStream: InputStream,
     density: Density

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopXmlVectorResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopXmlVectorResources.desktop.kt
@@ -36,6 +36,7 @@ import org.xml.sax.InputSource
  * will be drawn with the specified size, density will have no effect.
  * @return the decoded vector image associated with the image
  */
+@Deprecated("Migrate to the compose resources library")
 fun loadXmlImageVector(
     inputSource: InputSource,
     density: Density

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopXmlVectorResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopXmlVectorResources.desktop.kt
@@ -36,7 +36,7 @@ import org.xml.sax.InputSource
  * will be drawn with the specified size, density will have no effect.
  * @return the decoded vector image associated with the image
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 fun loadXmlImageVector(
     inputSource: InputSource,
     density: Density

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopXmlVectorResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopXmlVectorResources.desktop.kt
@@ -36,7 +36,13 @@ import org.xml.sax.InputSource
  * will be drawn with the specified size, density will have no effect.
  * @return the decoded vector image associated with the image
  */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html",
+    replaceWith = ReplaceWith(
+        "inputStream.readAllBytes().decodeToImageVector(density)",
+        "org.jetbrains.compose.resources.decodeToImageVector",
+        "java.io.InputStream"
+    )
+)
 fun loadXmlImageVector(
     inputSource: InputSource,
     density: Density

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
@@ -29,5 +29,6 @@ import org.jetbrains.skia.Image
  * stream, but stream will not be closed after this method.
  * @return the decoded SVG image associated with the resource
  */
+@Deprecated("Migrate to the compose resources library")
 fun loadImageBitmap(inputStream: InputStream): ImageBitmap =
     Image.makeFromEncoded(inputStream.readAllBytes()).toComposeImageBitmap()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
@@ -29,6 +29,6 @@ import org.jetbrains.skia.Image
  * stream, but stream will not be closed after this method.
  * @return the decoded SVG image associated with the resource
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 fun loadImageBitmap(inputStream: InputStream): ImageBitmap =
     Image.makeFromEncoded(inputStream.readAllBytes()).toComposeImageBitmap()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/ImageResources.desktop.kt
@@ -29,6 +29,12 @@ import org.jetbrains.skia.Image
  * stream, but stream will not be closed after this method.
  * @return the decoded SVG image associated with the resource
  */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html",
+    replaceWith = ReplaceWith(
+        "inputStream.readAllBytes().decodeToImageBitmap()",
+        "org.jetbrains.compose.resources.decodeToImageBitmap",
+        "java.io.InputStream"
+    )
+)
 fun loadImageBitmap(inputStream: InputStream): ImageBitmap =
     Image.makeFromEncoded(inputStream.readAllBytes()).toComposeImageBitmap()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
@@ -50,7 +50,7 @@ import org.xml.sax.InputSource
  * @param loader  resources loader
  * @return [Painter] used for drawing the loaded resource
  */
-@OptIn(ExperimentalComposeUiApi::class)
+@Deprecated("Migrate to the compose resources library")
 @Composable
 fun painterResource(
     resourcePath: String
@@ -59,7 +59,7 @@ fun painterResource(
     ResourceLoader.Default
 )
 
-@ExperimentalComposeUiApi
+@Deprecated("Migrate to the compose resources library")
 @Composable
 fun painterResource(
     resourcePath: String,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
@@ -50,7 +50,7 @@ import org.xml.sax.InputSource
  * @param loader  resources loader
  * @return [Painter] used for drawing the loaded resource
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 @Composable
 fun painterResource(
     resourcePath: String
@@ -59,7 +59,7 @@ fun painterResource(
     ResourceLoader.Default
 )
 
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 @Composable
 fun painterResource(
     resourcePath: String,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
@@ -71,7 +71,6 @@ fun painterResource(
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun rememberSvgResource(
     resourcePath: String,
     loader: ResourceLoader = ResourceLoader.Default
@@ -85,7 +84,6 @@ private fun rememberSvgResource(
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun rememberVectorXmlResource(
     resourcePath: String,
     loader: ResourceLoader = ResourceLoader.Default
@@ -100,7 +98,6 @@ private fun rememberVectorXmlResource(
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun rememberBitmapResource(
     resourcePath: String,
     loader: ResourceLoader = ResourceLoader.Default

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
@@ -47,7 +47,6 @@ import org.xml.sax.InputSource
  * [loadXmlImageVector]
  *
  * @param resourcePath  path to the resource
- * @param loader  resources loader
  * @return [Painter] used for drawing the loaded resource
  */
 @Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html " +
@@ -55,44 +54,27 @@ import org.xml.sax.InputSource
 @Composable
 fun painterResource(
     resourcePath: String
-): Painter = painterResource(
-    resourcePath,
-    ResourceLoader.Default
-)
-
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html " +
-    "If you need to load resources specificly from Java classpath, you should still use the new resource library and use a snippet from https://github.com/JetBrains/compose-multiplatform-core/pull/1457")
-@Composable
-fun painterResource(
-    resourcePath: String,
-    loader: ResourceLoader
-): Painter = when (resourcePath.substringAfterLast(".")) {
-    "svg" -> rememberSvgResource(resourcePath, loader)
-    "xml" -> rememberVectorXmlResource(resourcePath, loader)
-    else -> rememberBitmapResource(resourcePath, loader)
+): Painter  = when (resourcePath.substringAfterLast(".")) {
+    "svg" -> rememberSvgResource(resourcePath)
+    "xml" -> rememberVectorXmlResource(resourcePath)
+    else -> rememberBitmapResource(resourcePath)
 }
 
 @Composable
-private fun rememberSvgResource(
-    resourcePath: String,
-    loader: ResourceLoader = ResourceLoader.Default
-): Painter {
+private fun rememberSvgResource(resourcePath: String): Painter {
     val density = LocalDensity.current
     return remember(resourcePath, density) {
-        useResource(resourcePath, loader) {
+        useResource(resourcePath) {
             loadSvgPainter(it, density)
         }
     }
 }
 
 @Composable
-private fun rememberVectorXmlResource(
-    resourcePath: String,
-    loader: ResourceLoader = ResourceLoader.Default
-): Painter {
+private fun rememberVectorXmlResource(resourcePath: String): Painter {
     val density = LocalDensity.current
     val image = remember(resourcePath, density) {
-        useResource(resourcePath, loader) {
+        useResource(resourcePath) {
             loadXmlImageVector(InputSource(it), density)
         }
     }
@@ -100,12 +82,9 @@ private fun rememberVectorXmlResource(
 }
 
 @Composable
-private fun rememberBitmapResource(
-    resourcePath: String,
-    loader: ResourceLoader = ResourceLoader.Default
-): Painter {
+private fun rememberBitmapResource(resourcePath: String): Painter {
     val image = remember(resourcePath) {
-        useResource(resourcePath, loader, ::loadImageBitmap)
+        useResource(resourcePath, ::loadImageBitmap)
     }
     return BitmapPainter(image)
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/PainterResources.desktop.kt
@@ -50,7 +50,8 @@ import org.xml.sax.InputSource
  * @param loader  resources loader
  * @return [Painter] used for drawing the loaded resource
  */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html " +
+    "If you need to load resources specificly from Java classpath, you should still use the new resource library and use a snippet from https://github.com/JetBrains/compose-multiplatform-core/pull/1457")
 @Composable
 fun painterResource(
     resourcePath: String
@@ -59,7 +60,8 @@ fun painterResource(
     ResourceLoader.Default
 )
 
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html " +
+    "If you need to load resources specificly from Java classpath, you should still use the new resource library and use a snippet from https://github.com/JetBrains/compose-multiplatform-core/pull/1457")
 @Composable
 fun painterResource(
     resourcePath: String,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -33,7 +33,7 @@ import java.io.FileInputStream
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
 @ExperimentalComposeUiApi
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 internal inline fun <T> useResource(
     resourcePath: String,
     loader: ResourceLoader,
@@ -50,7 +50,7 @@ internal inline fun <T> useResource(
  *
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 inline fun <T> useResource(
     resourcePath: String,
     block: (InputStream) -> T
@@ -66,7 +66,7 @@ inline fun <T> useResource(
  */
 @PublishedApi
 @ExperimentalComposeUiApi
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 internal fun openResource(
     resourcePath: String,
     loader: ResourceLoader
@@ -82,7 +82,7 @@ internal fun openResource(
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
 @PublishedApi
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 internal fun openResource(
     resourcePath: String,
 ): InputStream {
@@ -97,7 +97,7 @@ internal fun openResource(
  * Also the resource should be always available to load, and if you need to handle exceptions,
  * it is better to use these functions as well.
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 interface ResourceLoader {
     companion object {
         /**
@@ -114,7 +114,7 @@ interface ResourceLoader {
 /**
  * Resource loader based on JVM current context class loader.
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 class ClassLoaderResourceLoader : ResourceLoader {
     override fun load(resourcePath: String): InputStream {
         // TODO(https://github.com/JetBrains/compose-jb/issues/618): probably we shouldn't use
@@ -129,7 +129,7 @@ class ClassLoaderResourceLoader : ResourceLoader {
 /**
  * Resource loader from the file system relative to a certain root location.
  */
-@Deprecated("Migrate to the compose resources library")
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 class FileResourceLoader(val root: File) : ResourceLoader {
     override fun load(resourcePath: String): InputStream {
         return FileInputStream(File(root, resourcePath))

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -33,6 +33,7 @@ import java.io.FileInputStream
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
 @ExperimentalComposeUiApi
+@Deprecated("Migrate to the compose resources library")
 internal inline fun <T> useResource(
     resourcePath: String,
     loader: ResourceLoader,
@@ -49,6 +50,7 @@ internal inline fun <T> useResource(
  *
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
+@Deprecated("Migrate to the compose resources library")
 inline fun <T> useResource(
     resourcePath: String,
     block: (InputStream) -> T
@@ -64,6 +66,7 @@ inline fun <T> useResource(
  */
 @PublishedApi
 @ExperimentalComposeUiApi
+@Deprecated("Migrate to the compose resources library")
 internal fun openResource(
     resourcePath: String,
     loader: ResourceLoader
@@ -79,7 +82,7 @@ internal fun openResource(
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
 @PublishedApi
-@OptIn(ExperimentalComposeUiApi::class)
+@Deprecated("Migrate to the compose resources library")
 internal fun openResource(
     resourcePath: String,
 ): InputStream {
@@ -94,7 +97,7 @@ internal fun openResource(
  * Also the resource should be always available to load, and if you need to handle exceptions,
  * it is better to use these functions as well.
  */
-@ExperimentalComposeUiApi
+@Deprecated("Migrate to the compose resources library")
 interface ResourceLoader {
     companion object {
         /**
@@ -111,7 +114,7 @@ interface ResourceLoader {
 /**
  * Resource loader based on JVM current context class loader.
  */
-@ExperimentalComposeUiApi
+@Deprecated("Migrate to the compose resources library")
 class ClassLoaderResourceLoader : ResourceLoader {
     override fun load(resourcePath: String): InputStream {
         // TODO(https://github.com/JetBrains/compose-jb/issues/618): probably we shouldn't use
@@ -126,7 +129,7 @@ class ClassLoaderResourceLoader : ResourceLoader {
 /**
  * Resource loader from the file system relative to a certain root location.
  */
-@ExperimentalComposeUiApi
+@Deprecated("Migrate to the compose resources library")
 class FileResourceLoader(val root: File) : ResourceLoader {
     override fun load(resourcePath: String): InputStream {
         return FileInputStream(File(root, resourcePath))

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -32,7 +32,6 @@ import java.io.FileInputStream
  *
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
-@ExperimentalComposeUiApi
 @Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 internal inline fun <T> useResource(
     resourcePath: String,
@@ -65,7 +64,6 @@ inline fun <T> useResource(
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
  */
 @PublishedApi
-@ExperimentalComposeUiApi
 @Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 internal fun openResource(
     resourcePath: String,
@@ -105,7 +103,6 @@ interface ResourceLoader {
          * project. Ability to load from dependent modules resources is not guaranteed in the future.
          * Use explicit `ClassLoaderResourceLoader` instance if such guarantee is needed.
          */
-        @ExperimentalComposeUiApi
         val Default = ClassLoaderResourceLoader()
     }
     fun load(resourcePath: String): InputStream

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -16,10 +16,7 @@
 
 package androidx.compose.ui.res
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import java.io.InputStream
-import java.io.File
-import java.io.FileInputStream
 
 /**
  * Open [InputStream] from a resource stored in resources for the application, calls the [block]

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -103,7 +103,7 @@ interface ResourceLoader {
          * project. Ability to load from dependent modules resources is not guaranteed in the future.
          * Use explicit `ClassLoaderResourceLoader` instance if such guarantee is needed.
          */
-        val Default = ClassLoaderResourceLoader()
+        val Default: ResourceLoader = ClassLoaderResourceLoader()
     }
     fun load(resourcePath: String): InputStream
 }
@@ -111,8 +111,7 @@ interface ResourceLoader {
 /**
  * Resource loader based on JVM current context class loader.
  */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
-class ClassLoaderResourceLoader : ResourceLoader {
+private class ClassLoaderResourceLoader : ResourceLoader {
     override fun load(resourcePath: String): InputStream {
         // TODO(https://github.com/JetBrains/compose-jb/issues/618): probably we shouldn't use
         //  contextClassLoader here, as it is not defined in threads created by non-JVM
@@ -120,15 +119,5 @@ class ClassLoaderResourceLoader : ResourceLoader {
         val resource = contextClassLoader.getResourceAsStream(resourcePath)
             ?: (::ClassLoaderResourceLoader.javaClass).getResourceAsStream(resourcePath)
         return requireNotNull(resource) { "Resource $resourcePath not found" }
-    }
-}
-
-/**
- * Resource loader from the file system relative to a certain root location.
- */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
-class FileResourceLoader(val root: File) : ResourceLoader {
-    override fun load(resourcePath: String): InputStream {
-        return FileInputStream(File(root, resourcePath))
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -23,24 +23,6 @@ import java.io.InputStream
  * callback giving it a InputStream and closes stream once the processing is
  * complete.
  *
- * @param resourcePath  path of resource in loader
- * @param loader  resource loader
- * @return object that was returned by [block]
- *
- * @throws IllegalArgumentException if there is no [resourcePath] in resources
- */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
-internal inline fun <T> useResource(
-    resourcePath: String,
-    loader: ResourceLoader,
-    block: (InputStream) -> T
-): T = openResource(resourcePath, loader).use(block)
-
-/**
- * Open [InputStream] from a resource stored in resources for the application, calls the [block]
- * callback giving it a InputStream and closes stream once the processing is
- * complete.
- *
  * @param resourcePath  path of resource
  * @return object that was returned by [block]
  *
@@ -55,23 +37,6 @@ inline fun <T> useResource(
 /**
  * Open [InputStream] from a resource stored in resources for the application.
  *
- * @param resourcePath  path of resource in loader
- * @param loader  resource loader
- *
- * @throws IllegalArgumentException if there is no [resourcePath] in resources
- */
-@PublishedApi
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
-internal fun openResource(
-    resourcePath: String,
-    loader: ResourceLoader
-): InputStream {
-    return loader.load(resourcePath)
-}
-
-/**
- * Open [InputStream] from a resource stored in resources for the application.
- *
  * @param resourcePath  path of resource
  *
  * @throws IllegalArgumentException if there is no [resourcePath] in resources
@@ -80,41 +45,19 @@ internal fun openResource(
 @Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 internal fun openResource(
     resourcePath: String,
-): InputStream {
-    return ResourceLoader.Default.load(resourcePath)
-}
-
-/**
- * Abstraction for loading resources. This API is intended for use in synchronous cases,
- * where resource is expected to be loaded quick during the first composition, and so potentially
- * slow operations like network access is not recommended. For such scenarious use functions
- * [loadSvgPainter] and [loadXmlImageVector] instead on IO dispatcher.
- * Also the resource should be always available to load, and if you need to handle exceptions,
- * it is better to use these functions as well.
- */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
-interface ResourceLoader {
-    companion object {
-        /**
-         * Resource loader which is capable to load resources from `resources` folder in an application's
-         * project. Ability to load from dependent modules resources is not guaranteed in the future.
-         * Use explicit `ClassLoaderResourceLoader` instance if such guarantee is needed.
-         */
-        val Default: ResourceLoader = ClassLoaderResourceLoader()
-    }
-    fun load(resourcePath: String): InputStream
-}
+): InputStream = ClassLoaderResourceLoader.load(resourcePath)
 
 /**
  * Resource loader based on JVM current context class loader.
  */
-private class ClassLoaderResourceLoader : ResourceLoader {
-    override fun load(resourcePath: String): InputStream {
+@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
+private object ClassLoaderResourceLoader {
+    fun load(resourcePath: String): InputStream {
         // TODO(https://github.com/JetBrains/compose-jb/issues/618): probably we shouldn't use
         //  contextClassLoader here, as it is not defined in threads created by non-JVM
         val contextClassLoader = Thread.currentThread().contextClassLoader!!
         val resource = contextClassLoader.getResourceAsStream(resourcePath)
-            ?: (::ClassLoaderResourceLoader.javaClass).getResourceAsStream(resourcePath)
+            ?: this::class.java.getResourceAsStream(resourcePath)
         return requireNotNull(resource) { "Resource $resourcePath not found" }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/Resources.desktop.kt
@@ -50,7 +50,6 @@ internal fun openResource(
 /**
  * Resource loader based on JVM current context class loader.
  */
-@Deprecated("Migrate to the Compose resources library. See https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-images-resources.html")
 private object ClassLoaderResourceLoader {
     fun load(resourcePath: String): InputStream {
         // TODO(https://github.com/JetBrains/compose-jb/issues/618): probably we shouldn't use


### PR DESCRIPTION
To work with resources in the desktop compose the recommended way is to use the special resources library.

Fixes https://youtrack.jetbrains.com/issue/CMP-1108

### Migration snippet
To read java resources by path as Painters you may use:
```kotlin
@Composable
internal fun painterResource(
    resourcePath: String
): Painter = when (resourcePath.substringAfterLast(".")) {
    "svg" -> rememberSvgResource(resourcePath)
    "xml" -> rememberVectorXmlResource(resourcePath)
    else -> rememberBitmapResource(resourcePath)
}

@Composable
internal fun rememberBitmapResource(path: String): Painter {
    return remember(path) { BitmapPainter(readResourceBytes(path).decodeToImageBitmap()) }
}

@Composable
internal fun rememberVectorXmlResource(path: String): Painter {
    val density = LocalDensity.current
    val imageVector = remember(density, path) { readResourceBytes(path).decodeToImageVector(density) }
    return rememberVectorPainter(imageVector)
}

@Composable
internal fun rememberSvgResource(path: String): Painter {
    val density = LocalDensity.current
    return remember(density, path) { readResourceBytes(path).decodeToSvgPainter(density) }
}

private object ResourceLoader
private fun readResourceBytes(resourcePath: String) =
    ResourceLoader.javaClass.classLoader.getResourceAsStream(resourcePath).readAllBytes()
```

## Release Notes
### Breaking changes - Resources
- Deprecate resources in `compose.ui` in favour of the new resource library