### PR TITLE
Opt-out of new touches strategy on iOS

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosSpecificFeaturesExample.kt
@@ -54,5 +54,6 @@ val IosSpecificFeatures = Screen.Selection(
     LazyColumnWithInteropViewsExample,
     AccessibilityLiveRegionExample,
     InteropViewAndSemanticsConfigMerge,
-    StatusBarStateExample
+    StatusBarStateExample,
+    UIKitInteropExample
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/UIKitInteropExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/UIKitInteropExample.kt
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package androidx.compose.mpp.demo.bugs
+package androidx.compose.mpp.demo
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
-import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,6 +28,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.interop.UIKitViewController
 import androidx.compose.ui.unit.dp
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.readValue
@@ -69,38 +69,76 @@ private class TouchReactingView: UIView(frame = CGRectZero.readValue()) {
     }
 }
 
-val UIKitRenderSync = Screen.Example("UIKitRenderSync") {
+val UIKitInteropExample = Screen.Example("UIKitInterop") {
     var text by remember { mutableStateOf("Type something") }
     LazyColumn(Modifier.fillMaxSize()) {
+        item {
+            UIKitView(
+                factory = {
+                    MKMapView()
+                },
+                modifier = Modifier.fillMaxWidth().height(200.dp),
+                areTouchesDelayed = false
+            )
+        }
+
+        item {
+            UIKitViewController(
+                factory = {
+                    object : UIViewController(nibName = null, bundle = null) {
+                        override fun viewDidLoad() {
+                            super.viewDidLoad()
+
+                            view.backgroundColor = UIColor.blueColor
+                        }
+
+                        override fun viewWillAppear(animated: Boolean) {
+                            super.viewWillAppear(animated)
+
+                            println("viewWillAppear animated=$animated")
+                        }
+
+                        override fun viewDidAppear(animated: Boolean) {
+                            super.viewDidAppear(animated)
+
+                            println("viewDidAppear animated=$animated")
+                        }
+
+                        override fun viewDidDisappear(animated: Boolean) {
+                            super.viewDidDisappear(animated)
+
+                            println("viewDidDisappear animated=$animated")
+                        }
+
+                        override fun viewWillDisappear(animated: Boolean) {
+                            super.viewWillDisappear(animated)
+
+                            println("viewWillDisappear animated=$animated")
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(100.dp),
+            )
+        }
         items(100) { index ->
-            if (index == 0) {
-                UIKitView(
+            when (index % 5) {
+                0 -> Text("material.Text $index", Modifier.fillMaxSize().height(40.dp))
+                1 -> UIKitView(
                     factory = {
-                        MKMapView()
+                        val label = UILabel(frame = CGRectZero.readValue())
+                        label.text = "UILabel $index"
+                        label.textColor = UIColor.blackColor
+                        label
                     },
-                    modifier = Modifier.fillMaxWidth().height(200.dp),
-                    areTouchesDelayed = false
+                    modifier = Modifier.fillMaxWidth().height(40.dp),
+                    interactive = false
                 )
-            } else {
-                when (index % 5) {
-                    0 -> Text("material.Text $index", Modifier.fillMaxSize().height(40.dp))
-                    1 -> UIKitView(
-                        factory = {
-                            val label = UILabel(frame = CGRectZero.readValue())
-                            label.text = "UILabel $index"
-                            label.textColor = UIColor.blackColor
-                            label
-                        },
-                        modifier = Modifier.fillMaxWidth().height(40.dp),
-                        interactive = false
-                    )
-                    2 -> TextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth())
-                    3 -> ComposeUITextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth().height(40.dp))
-                    4 -> UIKitView(
-                        factory = { TouchReactingView() },
-                        modifier = Modifier.fillMaxWidth().height(40.dp)
-                    )
-                }
+                2 -> TextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth())
+                3 -> ComposeUITextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth().height(40.dp))
+                4 -> UIKitView(
+                    factory = { TouchReactingView() },
+                    modifier = Modifier.fillMaxWidth().height(40.dp)
+                )
             }
         }
     }

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
@@ -27,7 +27,6 @@ val IosBugs = Screen.Selection(
     UIKitViewMatryoshka,
     KeyboardEmptyWhiteSpace,
     KeyboardPasswordType,
-    UIKitRenderSync,
     DispatchersMainDelayCheck,
     StartRecompositionCheck,
     BackspaceIssue,

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/UIKitRenderSync.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/UIKitRenderSync.kt
@@ -78,7 +78,8 @@ val UIKitRenderSync = Screen.Example("UIKitRenderSync") {
                     factory = {
                         MKMapView()
                     },
-                    modifier = Modifier.fillMaxWidth().height(200.dp)
+                    modifier = Modifier.fillMaxWidth().height(200.dp),
+                    areTouchesDelayed = false
                 )
             } else {
                 when (index % 5) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -282,7 +282,7 @@ private abstract class UIKitInteropViewHolder<T : Any>(
     val onResize: (T, rect: CValue<CGRect>) -> Unit,
     val onRelease: (T) -> Unit,
     areTouchesDelayed: Boolean
-) : InteropViewHolder(container, group = UIKitInteropViewGroup()) {
+) : InteropViewHolder(container, group = UIKitInteropViewGroup(areTouchesDelayed)) {
     private var currentUnclippedRect: IntRect? = null
     private var currentClippedRect: IntRect? = null
     lateinit var userComponent: T
@@ -382,8 +382,8 @@ private class UIKitViewHolder<T : UIView>(
     onResize: (T, rect: CValue<CGRect>) -> Unit,
     onRelease: (T) -> Unit,
     areTouchesDelayed: Boolean
-) : UIKitInteropViewHolder<T>(container, createView, onResize, onRelease) {
-    override fun getInteropView(): InteropView? =
+) : UIKitInteropViewHolder<T>(container, createView, onResize, onRelease, areTouchesDelayed) {
+    override fun getInteropView(): InteropView =
         userComponent
 
     override fun setupViewHierarchy() {
@@ -402,11 +402,12 @@ private class UIKitViewControllerHolder<T : UIViewController>(
     onRelease: (T) -> Unit,
     areTouchesDelayed: Boolean
 ) : UIKitInteropViewHolder<T>(container, createViewController, onResize, onRelease, areTouchesDelayed) {
-    override fun getInteropView(): InteropView? =
+    override fun getInteropView(): InteropView =
         userComponent.view
 
     override fun setupViewHierarchy() {
         rootViewController.addChildViewController(userComponent)
+        //userComponent.wil
         group.addSubview(userComponent.view)
         userComponent.didMoveToParentViewController(rootViewController)
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -147,10 +147,6 @@ private fun <T : Any> UIKitInteropLayout(
  * @param onResize May be used to custom resize logic.
  * @param interactive If true, then user touches will be passed to this UIView
  * @param accessibilityEnabled If `true`, then the view will be visible to accessibility services.
- * @param areTouchesDelayed If `true`, then the touches reception will be delayed
- * for a while until a user holds a pointer down for a certain amount of time to give Compose a chance
- * to process and intercept the touches. If `false`, the view will receive touches immediately and
- * Compose will not be able to handle them. Default is `true`.
  *
  * If this Composable is within a modifier chain that merges
  * the semantics of its children (such as `Modifier.clickable`), the merged subtree data will be ignored in favor of
@@ -176,8 +172,7 @@ fun <T : UIView> UIKitView(
     onRelease: (T) -> Unit = STUB_CALLBACK_WITH_RECEIVER,
     onResize: (view: T, rect: CValue<CGRect>) -> Unit = DefaultViewResize,
     interactive: Boolean = true,
-    accessibilityEnabled: Boolean = true,
-    areTouchesDelayed: Boolean = true
+    accessibilityEnabled: Boolean = true
 ) {
     val interopContainer = LocalInteropContainer.current
     val interopViewHolder = remember {
@@ -186,7 +181,7 @@ fun <T : UIView> UIKitView(
             createView = factory,
             onResize = onResize,
             onRelease = onRelease,
-            areTouchesDelayed = areTouchesDelayed
+            areTouchesDelayed = true
         )
     }
 
@@ -212,10 +207,6 @@ fun <T : UIView> UIKitView(
  * @param onResize May be used to custom resize logic.
  * @param interactive If true, then user touches will be passed to this UIViewController
  * @param accessibilityEnabled If `true`, then the [UIViewController.view] will be visible to accessibility services.
- * @param areTouchesDelayed If `true`, then the touches reception will be delayed
- * for a while until a user holds a pointer down for a certain amount of time to give Compose a chance
- * to process and intercept the touches. If `false`, the view will receive touches immediately and
- * Compose will not be able to handle them. Default is `true`.
  *
  * If this Composable is within a modifier chain that merges the semantics of its children (such as `Modifier.clickable`),
  * the merged subtree data will be ignored in favor of
@@ -243,8 +234,7 @@ fun <T : UIViewController> UIKitViewController(
     onRelease: (T) -> Unit = STUB_CALLBACK_WITH_RECEIVER,
     onResize: (viewController: T, rect: CValue<CGRect>) -> Unit = DefaultViewControllerResize,
     interactive: Boolean = true,
-    accessibilityEnabled: Boolean = true,
-    areTouchesDelayed: Boolean = true
+    accessibilityEnabled: Boolean = true
 ) {
     val interopContainer = LocalInteropContainer.current
     val rootViewController = LocalUIViewController.current
@@ -255,7 +245,7 @@ fun <T : UIViewController> UIKitViewController(
             rootViewController = rootViewController,
             onResize = onResize,
             onRelease = onRelease,
-            areTouchesDelayed = areTouchesDelayed
+            areTouchesDelayed = true
         )
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/interop/UIKitView.uikit.kt
@@ -407,7 +407,6 @@ private class UIKitViewControllerHolder<T : UIViewController>(
 
     override fun setupViewHierarchy() {
         rootViewController.addChildViewController(userComponent)
-        //userComponent.wil
         group.addSubview(userComponent.view)
         userComponent.didMoveToParentViewController(rootViewController)
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/InteropView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/InteropView.uikit.kt
@@ -38,8 +38,14 @@ internal actual typealias InteropViewGroup = UIView
 /**
  * A [UIView] that contains underlying interop element, such as an independent [UIView]
  * or [UIViewController]'s root [UIView].
+ *
+ * @param areTouchesDelayed indicates whether the touches are allowed to be delayed by Compose
+ * in attempt to intercept touches, or should get delivered to the interop view immediately without
+ * Compose being aware of them.
  */
-internal class UIKitInteropViewGroup : CMPInteropWrappingView(frame = CGRectZero.readValue()) {
+internal class UIKitInteropViewGroup(
+    val areTouchesDelayed: Boolean
+) : CMPInteropWrappingView(frame = CGRectZero.readValue()) {
     var actualAccessibilityContainer: Any? = null
 
     init {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.interop.InteropWrappingView
 import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizerHandlerProtocol
@@ -59,6 +60,25 @@ private val UIGestureRecognizerState.isOngoing: Boolean
         }
 
 /**
+ * Enum class representing the possible hit test result of [InteractionUIViewHitTestResult].
+ * This enum is used solely to determine the strategy of touch event delivery and
+ * doesn't require any additional information about the hit-tested view.
+ *
+ * [SELF] - Hit-tested Compose view.
+ * [COOPERATIVE_CHILD_VIEW] - Hit-tested child view that is okay with Compose receiving touches and
+ * delaying them for the child view.
+ * [UNCOOPERATIVE_CHILD_VIEW] - Hit-tested child view that doesn't want to cooperate with
+ * Compose and receives touches immediately.
+ * [NONE] - Hit test didn't yield any result.
+ */
+private enum class InteractionUIViewHitTestResult {
+    SELF,
+    COOPERATIVE_CHILD_VIEW,
+    UNCOOPERATIVE_CHILD_VIEW,
+    NONE
+}
+
+/**
  * Implementation of [CMPGestureRecognizerHandlerProtocol] that handles touch events and forwards
  * them. The main difference from the original [UIView] touches based is that it's built on top of
  * [CMPGestureRecognizer], which play differently with UIKit touches processing and are required
@@ -70,12 +90,12 @@ private class GestureRecognizerHandlerImpl(
     private var onTouchesEvent: (view: UIView, touches: Set<*>, event: UIEvent?, phase: CupertinoTouchesPhase) -> Unit,
     private var view: UIView?,
     private val onTouchesCountChanged: (by: Int) -> Unit,
-): NSObject(), CMPGestureRecognizerHandlerProtocol {
+) : NSObject(), CMPGestureRecognizerHandlerProtocol {
     /**
      * The actual view that was hit-tested by the first touch in the sequence.
-     * It could be interop view, for example. If there are tracked touches assignment is ignored.
+     * It could be interop view, for example. If there are tracked touches, assignment is ignored.
      */
-    var hitTestView: UIView? = null
+    var hitTestResult = InteractionUIViewHitTestResult.NONE
         set(value) {
             /**
              * Only remember the first hit-tested view in the sequence.
@@ -182,11 +202,20 @@ private class GestureRecognizerHandlerImpl(
      *
      */
     override fun touchesBegan(touches: Set<*>, withEvent: UIEvent?) {
+        if (hitTestResult == InteractionUIViewHitTestResult.UNCOOPERATIVE_CHILD_VIEW) {
+            // If child view doesn't want delay logic applied, we should immediately fail the gesture
+            // and allow touches to go through directly to that view, gesture recognizer should
+            // fail immediately, no touches will be received by Compose and the gesture recognizer after
+            // this point until all fingers are lifted.
+            gestureRecognizerState = UIGestureRecognizerStateFailed
+            return
+        }
+
         val areTouchesInitial = startTrackingTouches(touches)
 
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.BEGAN)
 
-        if (gestureRecognizerState.isOngoing || hitTestView == view) {
+        if (gestureRecognizerState.isOngoing || hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, immediately start/continue the gesture recognizer if possible and pass touches.
             when (gestureRecognizerState) {
                 UIGestureRecognizerStatePossible -> {
@@ -222,7 +251,7 @@ private class GestureRecognizerHandlerImpl(
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent?) {
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.MOVED)
 
-        if (gestureRecognizerState.isOngoing || hitTestView == view) {
+        if (gestureRecognizerState.isOngoing || hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, just update the gesture recognizer state and pass touches to
             // the Compose runtime.
 
@@ -252,17 +281,15 @@ private class GestureRecognizerHandlerImpl(
 
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.ENDED)
 
-        if (gestureRecognizerState.isOngoing || hitTestView == view) {
+        if (gestureRecognizerState.isOngoing || hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, just update the gesture recognizer state and pass touches to
             // the Compose runtime.
 
-            when (gestureRecognizerState) {
-                UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    gestureRecognizerState = if (trackedTouches.isEmpty()) {
-                        UIGestureRecognizerStateEnded
-                    } else {
-                        UIGestureRecognizerStateChanged
-                    }
+            if (gestureRecognizerState.isOngoing) {
+                gestureRecognizerState = if (trackedTouches.isEmpty()) {
+                    UIGestureRecognizerStateEnded
+                } else {
+                    UIGestureRecognizerStateChanged
                 }
             }
         } else {
@@ -291,16 +318,14 @@ private class GestureRecognizerHandlerImpl(
 
         onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.CANCELLED)
 
-        if (hitTestView == view) {
+        if (hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, just update the gesture recognizer state.
 
-            when (gestureRecognizerState) {
-                UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    gestureRecognizerState = if (trackedTouches.isEmpty()) {
-                        UIGestureRecognizerStateCancelled
-                    } else {
-                        UIGestureRecognizerStateChanged
-                    }
+            if (gestureRecognizerState.isOngoing) {
+                gestureRecognizerState = if (trackedTouches.isEmpty()) {
+                    UIGestureRecognizerStateCancelled
+                } else {
+                    UIGestureRecognizerStateChanged
                 }
             }
         } else {
@@ -470,28 +495,29 @@ internal class InteractionUIView(
         super.pressesEnded(presses, withEvent)
     }
 
-    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? = savingHitTestResult {
-        if (!inInteractionBounds(point)) {
-            null
-        } else {
-            // Find if a scene contains a [InteropViewAnchorModifierNode] at the given point.
-            val interopView = hitTestInteropView(point, withEvent)
-
-            if (interopView == null) {
-                // Native [hitTest] happens after [pointInside] is checked. If hit testing
-                // inside ComposeScene didn't yield any interop view, then we should return [this]
-                this
+    override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? =
+        savingHitTestResult {
+            if (!inInteractionBounds(point)) {
+                null
             } else {
-                // Transform the point to the interop view's coordinate system.
-                // And perform native [hitTest] on the interop view.
-                // Return this view if the interop view doesn't handle the hit test.
-                interopView.hitTest(
-                    point = convertPoint(point, toView = interopView),
-                    withEvent = withEvent
-                ) ?: this
+                // Find if a scene contains a [InteropViewAnchorModifierNode] at the given point.
+                val interopView = hitTestInteropView(point, withEvent)
+
+                if (interopView == null) {
+                    // Native [hitTest] happens after [pointInside] is checked. If hit testing
+                    // inside ComposeScene didn't yield any interop view, then we should return [this]
+                    this
+                } else {
+                    // Transform the point to the interop view's coordinate system.
+                    // And perform native [hitTest] on the interop view.
+                    // Return this view if the interop view doesn't handle the hit test.
+                    interopView.hitTest(
+                        point = convertPoint(point, toView = interopView),
+                        withEvent = withEvent
+                    ) ?: this
+                }
             }
         }
-    }
 
     /**
      * Intentionally clean up all dependencies of InteractionUIView to prevent retain cycles that
@@ -516,7 +542,41 @@ internal class InteractionUIView(
      */
     private fun savingHitTestResult(hitTestBlock: () -> UIView?): UIView? {
         val result = hitTestBlock()
-        gestureRecognizerHandler.hitTestView = result
+        gestureRecognizerHandler.hitTestResult = if (result == null) {
+            InteractionUIViewHitTestResult.NONE
+        } else {
+            if (result == this) {
+                InteractionUIViewHitTestResult.SELF
+            } else {
+                // All views beneath are considered to be interop views.
+                // If the hit-tested view is not a descendant of [InteropWrappingView], then it
+                // should be considered as a view that doesn't want to cooperate with Compose.
+
+                val areTouchesDelayed = result.findInteropWrappingView()?.areTouchesDelayed ?: false
+
+                if (areTouchesDelayed) {
+                    InteractionUIViewHitTestResult.COOPERATIVE_CHILD_VIEW
+                } else {
+                    InteractionUIViewHitTestResult.UNCOOPERATIVE_CHILD_VIEW
+                }
+            }
+        }
         return result
     }
+}
+
+/**
+ * There is no way to associate [InteropWrappingView.areTouchesDelayed] with a given hitTest query.
+ * This extension function allows to find the nearest [InteropWrappingView] up the view hierarchy
+ * and request the value retroactively.
+ */
+private fun UIView.findInteropWrappingView(): InteropWrappingView? {
+    var view: UIView? = this
+    while (view != null) {
+        if (view is InteropWrappingView) {
+            return view
+        }
+        view = view.superview
+    }
+    return null
 }


### PR DESCRIPTION
Right now all touches are delayed until reception by interop views after changed introduced by https://github.com/JetBrains/compose-multiplatform-core/commit/a78dd417a3e1aec2aa2e009d46129551eb215a4e

Similar to interaction of `UIControl` and `UIScrollView`, sometimes [it's not a desirable behavior](https://youtrack.jetbrains.com/issue/CMP-5705) and touches should be processed exclusively by child views without any delay, as it was working before (without intending so).

~~The changes in this PR include new API allowing opt-out of new behavior and logic, that respect the values passed in the API.~~

~~Fixes~~ contains implementation required for fix of [CMP-5705](https://youtrack.jetbrains.com/issue/CMP-5705)

~~## Testing~~
~~First touch event in a sequence, being hit-tested against `UIKitView` with `areTouchesDelayed` set to `false` should be ignored by Compose and immediately dispatched.~~

~~See native `MKMapView` in `Demo/iOS-specific features/UIKitInterop`~~

~~This should be tested by QA~~

~~## Release Notes~~

~~### iOS - Features~~
~~- Allow to opt-out of newly introduced touches processing strategy in interop views, see new `areTouchesDelayed` argument in `UIKitView` and `UIKitViewController` API.~~  _(API change moved out of scope of this PR, it contains implementation)_
