### PR TITLE
Typo fix.

### DIFF
--- a/compose/material3/material3-common/src/commonMain/kotlin/androidx/compose/material3/common/InteractiveComponentSize.kt
+++ b/compose/material3/material3-common/src/commonMain/kotlin/androidx/compose/material3/common/InteractiveComponentSize.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.material3.common
 
-import androidx.compose.material3.common.interal.identityHashCode
+import androidx.compose.material3.common.internal.identityHashCode
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.staticCompositionLocalOf

--- a/compose/material3/material3-common/src/commonMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.kt
+++ b/compose/material3/material3-common/src/commonMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.kt
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-package androidx.compose.material3.common.interal
+package androidx.compose.material3.common.internal
 
 internal expect fun identityHashCode(instance: Any?): Int

--- a/compose/material3/material3-common/src/jsMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.js.kt
+++ b/compose/material3/material3-common/src/jsMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.js.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.compose.material3.common.interal
+package androidx.compose.material3.common.internal
 
 import androidx.compose.runtime.NoLiveLiterals
 

--- a/compose/material3/material3-common/src/jvmMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.jvm.kt
+++ b/compose/material3/material3-common/src/jvmMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.jvm.kt
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-package androidx.compose.material3.common.interal
+package androidx.compose.material3.common.internal
 
-internal actual fun identityHashCode(instance: Any?): Int {
-    if (instance == null) {
-        return 0
-    }
-    return instance.hashCode()
-}
+internal actual fun identityHashCode(instance: Any?): Int = System.identityHashCode(instance)

--- a/compose/material3/material3-common/src/nativeMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.native.kt
+++ b/compose/material3/material3-common/src/nativeMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.native.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.compose.material3.common.interal
+package androidx.compose.material3.common.internal
 
 import kotlin.native.identityHashCode
 

--- a/compose/material3/material3-common/src/wasmJsMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.wasmJs.kt
+++ b/compose/material3/material3-common/src/wasmJsMain/kotlin/androidx/compose/material3/common/internal/IdentityHashCode.wasmJs.kt
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
-package androidx.compose.material3.common.interal
+package androidx.compose.material3.common.internal
 
-internal actual fun identityHashCode(instance: Any?): Int = System.identityHashCode(instance)
+internal actual fun identityHashCode(instance: Any?): Int {
+    if (instance == null) {
+        return 0
+    }
+    return instance.hashCode()
+}


### PR DESCRIPTION
`interal` -> `internal`