### PR TITLE
Fix `:compose:ui:ui-test` redirect dependency on `androidx.test:monitor` version

### DIFF
--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -120,7 +120,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation("androidx.annotation:annotation:1.1.0")
                 implementation("androidx.core:core-ktx:1.2.0")
                 implementation("androidx.test.espresso:espresso-core:3.3.0")
-                implementation(libs.testMonitor)
+                implementation("androidx.test:monitor:1.6.1")
             }
 
             androidCommonTest.dependencies {


### PR DESCRIPTION
The PR fixes the android instrumented tests error:
```
java.lang.NoSuchMethodError: No static method forceEnableAppTracing()V in class Landroidx/tracing/Trace; or its super classes (declaration of 'androidx.tracing.Trace' appears in /data/app/~~s26c1oIVvuiT-6A9Xs0BMw==/com.example.myapplication-IKiXmDMQhaHbuYuDnhHIDA==/base.apk!classes4.dex)
at androidx.test.platform.tracing.AndroidXTracer.enableTracing(AndroidXTracer.java:57)
```