### PR TITLE
Add custom launcher so that we won't see "Choose your search engine" popup at every non-headless test run

### DIFF
--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -70,3 +70,13 @@ const KarmaWebpackOutputPlugin = {
 
 config.plugins.push(KarmaWebpackOutputPlugin);
 config.frameworks.push("webpack-output");
+
+
+config.customLaunchers = {
+    ChromeForComposeTests: {
+        base: "Chrome",
+        flags: ["--disable-search-engine-choice-screen"]
+    }
+}
+
+config.browsers = ["ChromeForComposeTests"]


### PR DESCRIPTION
In Chrome 127 a "Choose your search engine" screen [was introduced](https://support.google.com/chrome/a/answer/7679408?hl=eN).

This screen at first glance doesn't interfere with the tests themselves but make it harder to see the screen with actual tests running (see the screenshot). 

The purpose of this PR is to introduce command-line argument that turn this dialog off. 

![screen](https://github.com/user-attachments/assets/23edbfd9-b95d-4541-bacc-ecfb1764c627)
