### PR TITLE
Pop interactionView from focusStack.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -512,7 +512,7 @@ internal class ComposeSceneMediator(
     fun dispose() {
         uiKitTextInputService.stopInput()
         applicationForegroundStateListener.dispose()
-        focusStack?.popUntilNext(renderingView)
+        focusStack?.popUntilNext(interactionView)
         keyboardManager.dispose()
         renderingView.dispose()
         interactionView.dispose()


### PR DESCRIPTION
This should be a miss when refactoring renderingView and interactionView in this commit: [fix touch coordinates in layer with bounds](https://github.com/JetBrains/compose-multiplatform-core/commit/ba756a1f8567e0757146edac4c2603a4426c12eb#diff-10de9e10222563a6229c54f1f345e35fd1d03f14753d7189124115ad161ae56eR332)  in this issue #935.



