### PR TITLE
Fix touch processing regression on iOS

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
@@ -38,5 +38,6 @@ val IosBugs = Screen.Selection(
     AnimationFreezeBug,
     ModalMemoryLeak,
     ModalCrash,
-    PopupStretching
+    PopupStretching,
+    TransformGesturesBug
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/TransformGestures.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/TransformGestures.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+
+val TransformGesturesBug = Screen.Example("TransformGestures") {
+    TransformGestures()
+}
+
+@Composable
+fun TransformGestures() {
+    var lastCentroid by remember { mutableStateOf(null as Offset?) }
+    var lastPan by remember { mutableStateOf(null as Offset?) }
+    var lastZoom by remember { mutableStateOf(null as Float?) }
+    var lastRotation by remember { mutableStateOf(null as Float?) }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectTransformGestures { centroid, pan, zoom, rotation ->
+                    lastCentroid = centroid
+                    lastPan = pan
+                    lastZoom = zoom
+                    lastRotation = rotation
+                }
+            },
+        verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically)
+    ) {
+        Text("Centroid: $lastCentroid")
+        Text("Pan: $lastPan")
+        Text("Zoom: $lastZoom")
+        Text("Rotation: $lastRotation")
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/InteractionUIView.uikit.kt
@@ -213,7 +213,7 @@ private class GestureRecognizerHandlerImpl(
 
         val areTouchesInitial = startTrackingTouches(touches)
 
-        onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.BEGAN)
+        onTouchesEvent(trackedTouches, withEvent, CupertinoTouchesPhase.BEGAN)
 
         if (gestureRecognizerState.isOngoing || hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, immediately start/continue the gesture recognizer if possible and pass touches.
@@ -249,7 +249,7 @@ private class GestureRecognizerHandlerImpl(
      * 2. An interop view is hit-tested. In this case we should check if the pan intent is met.
      */
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent?) {
-        onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.MOVED)
+        onTouchesEvent(trackedTouches, withEvent, CupertinoTouchesPhase.MOVED)
 
         if (gestureRecognizerState.isOngoing || hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, just update the gesture recognizer state and pass touches to
@@ -277,9 +277,9 @@ private class GestureRecognizerHandlerImpl(
      * we need to allow all the touches to be passed to the interop view by failing explicitly.
      */
     override fun touchesEnded(touches: Set<*>, withEvent: UIEvent?) {
-        stopTrackingTouches(touches)
+        onTouchesEvent(trackedTouches, withEvent, CupertinoTouchesPhase.ENDED)
 
-        onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.ENDED)
+        stopTrackingTouches(touches)
 
         if (gestureRecognizerState.isOngoing || hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, just update the gesture recognizer state and pass touches to
@@ -314,9 +314,9 @@ private class GestureRecognizerHandlerImpl(
      * we need to allow all the touches to be passed to the interop view by failing explicitly.
      */
     override fun touchesCancelled(touches: Set<*>, withEvent: UIEvent?) {
+        onTouchesEvent(trackedTouches, withEvent, CupertinoTouchesPhase.CANCELLED)
+        
         stopTrackingTouches(touches)
-
-        onTouchesEvent(touches, withEvent, CupertinoTouchesPhase.CANCELLED)
 
         if (hitTestResult == InteractionUIViewHitTestResult.SELF) {
             // Golden path, just update the gesture recognizer state.


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5879/detectTransformGestures-doesnt-work-properly-on-iOS-with-Compose-Multiplatform-1.7.0-alpha02

## Release Notes

### iOS - Fixes
- _(prerelease fix)_  Fix the bug where only the changed touches were sent Compose, while all tracked touches were expected.

