### PR TITLE
All tests that work with canvas are implementing OnCanvasTests

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -35,25 +35,18 @@ private const val canvasId: String = "canvasApp"
 internal interface OnCanvasTests {
     fun getCanvas() = document.getElementById(canvasId) as HTMLCanvasElement
 
-    private fun createCanvasAndAttach(): HTMLCanvasElement {
+    fun resetCanvas(): HTMLCanvasElement {
+        /** TODO: [kotlin.test.AfterTest] is fixed only in kotlin 2.0
+        see https://youtrack.jetbrains.com/issue/KT-61888
+         */
+        document.getElementById(canvasId)?.remove()
+
         val canvas = document.createElement("canvas") as HTMLCanvasElement
         canvas.setAttribute("id", canvasId)
         canvas.setAttribute("tabindex", "0")
 
         document.body!!.appendChild(canvas)
         return canvas
-    }
-
-    private fun commonAfterTest() {
-        document.getElementById(canvasId)?.remove()
-    }
-
-    fun resetCanvas(): HTMLCanvasElement {
-        /** TODO: [kotlin.test.AfterTest] is fixed only in kotlin 2.0
-        see https://youtrack.jetbrains.com/issue/KT-61888
-         */
-        commonAfterTest()
-        return createCanvasAndAttach()
     }
 
     fun createComposeWindow(content: @Composable () -> Unit) {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -16,7 +16,8 @@
 
 package androidx.compose.ui
 
-import kotlin.math.abs
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.CanvasBasedWindow
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -24,17 +25,17 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
-import org.w3c.dom.asList
 
 /**
  * An interface with helper functions to initialise the tests
  */
+
+private const val canvasId: String = "canvasApp"
+
 internal interface OnCanvasTests {
+    fun getCanvas() = document.getElementById(canvasId) as HTMLCanvasElement
 
-    val canvasId: String
-        get() = "canvas1"
-
-    fun createCanvasAndAttach(id: String = canvasId): HTMLCanvasElement {
+    private fun createCanvasAndAttach(): HTMLCanvasElement {
         val canvas = document.createElement("canvas") as HTMLCanvasElement
         canvas.setAttribute("id", canvasId)
         canvas.setAttribute("tabindex", "0")
@@ -43,14 +44,20 @@ internal interface OnCanvasTests {
         return canvas
     }
 
-    fun commonAfterTest() {
+    private fun commonAfterTest() {
         document.getElementById(canvasId)?.remove()
     }
 
-    fun assertApproximatelyEqual(expected: Float, actual: Float, tolerance: Float = 1f) {
-        if (abs(expected - actual) > tolerance) {
-            throw AssertionError("Expected $expected but got $actual. Difference is more than the allowed delta $tolerance")
-        }
+    fun resetCanvas(): HTMLCanvasElement {
+        /** TODO: [kotlin.test.AfterTest] is fixed only in kotlin 2.0
+        see https://youtrack.jetbrains.com/issue/KT-61888
+         */
+        commonAfterTest()
+        return createCanvasAndAttach()
+    }
+
+    fun createComposeWindow(content: @Composable () -> Unit) {
+        CanvasBasedWindow(canvasElementId = canvasId, content = content)
     }
 }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
-import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -49,9 +48,7 @@ class SelectionContainerTests : OnCanvasTests {
 
     @BeforeTest
     fun setup() {
-        // Because AfterTest is fixed only in kotlin 2.0
-        // https://youtrack.jetbrains.com/issue/KT-61888
-        commonAfterTest()
+        resetCanvas()
     }
 
     private fun HTMLCanvasElement.doClick() {
@@ -61,14 +58,13 @@ class SelectionContainerTests : OnCanvasTests {
 
     @Test
     fun canSelectOneWordUsingDoubleClick() = runTest {
-        createCanvasAndAttach()
         val syncChannel = Channel<Selection?>(
             1, onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
 
         var viewConfiguration: ViewConfiguration? = null
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
+        createComposeWindow {
             var selection by remember { mutableStateOf<Selection?>(null) }
 
             androidx.compose.foundation.text.selection.SelectionContainer(
@@ -89,7 +85,7 @@ class SelectionContainerTests : OnCanvasTests {
             )
         }
 
-        val canvas = document.getElementById(canvasId) as HTMLCanvasElement
+        val canvas = getCanvas()
         canvas.dispatchEvent(MouseEvent("mouseenter"))
 
         // single click - no selection expected
@@ -124,15 +120,13 @@ class SelectionContainerTests : OnCanvasTests {
 
     @Test
     fun canSelectOneLineUsingTripleClick() = runTest {
-        createCanvasAndAttach()
-
         val syncChannel = Channel<Selection?>(
             1, onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
 
         var viewConfiguration: ViewConfiguration? = null
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
+        createComposeWindow {
             var selection by remember { mutableStateOf<Selection?>(null) }
 
             androidx.compose.foundation.text.selection.SelectionContainer(
@@ -153,7 +147,7 @@ class SelectionContainerTests : OnCanvasTests {
             )
         }
 
-        val canvas = document.getElementById(canvasId) as HTMLCanvasElement
+        val canvas = getCanvas()
         canvas.dispatchEvent(MouseEvent("mouseenter"))
 
         // triple click
@@ -177,8 +171,6 @@ class SelectionContainerTests : OnCanvasTests {
 
     @Test
     fun twoSingleClicksDoNotTriggerSelection() = runTest {
-        createCanvasAndAttach()
-
         val syncChannel = Channel<Selection?>(
             5, onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
@@ -186,7 +178,7 @@ class SelectionContainerTests : OnCanvasTests {
 
         var viewConfiguration: ViewConfiguration? = null
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
+        createComposeWindow {
             var selection by remember { mutableStateOf<Selection?>(null) }
 
             androidx.compose.foundation.text.selection.SelectionContainer(
@@ -208,7 +200,7 @@ class SelectionContainerTests : OnCanvasTests {
             )
         }
 
-        val canvas = document.getElementById(canvasId) as HTMLCanvasElement
+        val canvas = getCanvas()
         canvas.dispatchEvent(MouseEvent("mouseenter"))
 
         // first single click

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -16,10 +16,8 @@
 
 package androidx.compose.ui.input
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.TextField
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.events.InputEvent
@@ -30,7 +28,6 @@ import androidx.compose.ui.events.keyDownEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.sendFromScope
-import androidx.compose.ui.window.CanvasBasedWindow
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -40,16 +37,12 @@ import kotlinx.browser.document
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
-import org.w3c.dom.HTMLCanvasElement
 
 class TextInputTests : OnCanvasTests  {
 
     @BeforeTest
     fun setup() {
-        // Because AfterTest is fixed only in kotlin 2.0
-        // https://youtrack.jetbrains.com/issue/KT-61888
-        commonAfterTest()
-        createCanvasAndAttach()
+        resetCanvas()
     }
 
     @Test
@@ -59,12 +52,9 @@ class TextInputTests : OnCanvasTests  {
             1, onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
 
-        val canvas = document.getElementById(canvasId) as HTMLCanvasElement
-
         val (firstFocusRequester, secondFocusRequester) = FocusRequester.createRefs()
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
-
+        createComposeWindow {
             TextField(
                 value = "",
                 onValueChange = { value ->
@@ -88,6 +78,8 @@ class TextInputTests : OnCanvasTests  {
         }
 
         assertNull(document.querySelector("textarea"))
+
+        val canvas = getCanvas()
 
         canvas.dispatchEvent(keyDownEvent("s"))
         canvas.dispatchEvent(keyDownEvent("t"))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -16,42 +16,33 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.sendFromScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.browser.document
 import kotlinx.browser.window
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withContext
-import org.w3c.dom.HTMLCanvasElement
 
 
-class ComposeWindowLifecycleTest {
-    private val canvasId = "canvas1"
+class ComposeWindowLifecycleTest : OnCanvasTests {
 
-    @AfterTest
-    fun cleanup() {
-        document.getElementById(canvasId)?.remove()
+    @BeforeTest
+    fun setup() {
+        resetCanvas()
     }
 
     @Test
     @Ignore // ignored while investigating CI issues: this test opens a new browser window which can be the cause
     fun allEvents() = runTest {
-        val canvas = document.createElement("canvas") as HTMLCanvasElement
-        canvas.setAttribute("id", canvasId)
-        canvas.setAttribute("tabindex", "0")
-
-        document.body!!.appendChild(canvas)
+        val canvas = getCanvas()
         canvas.focus()
 
         val lifecycleOwner = ComposeWindow(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -22,38 +22,31 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.onClick
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
-import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.browser.document
 import kotlinx.coroutines.NonCancellable.isActive
 import kotlinx.coroutines.test.runTest
-import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.MouseEventInit
 
-class MouseEventsTest {
+class MouseEventsTest : OnCanvasTests {
 
-    private val canvasId = "canvas1"
-
-    @AfterTest
-    fun cleanup() {
-        document.getElementById(canvasId)?.remove()
+    @BeforeTest
+    fun setup() {
+        resetCanvas()
     }
 
     @Test
     fun testPointerEvents() = runTest {
-        val canvasElement = document.createElement("canvas") as HTMLCanvasElement
-        canvasElement.setAttribute("id", canvasId)
-        document.body!!.appendChild(canvasElement)
-
         val pointerEvents = mutableListOf<PointerEvent>()
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
+        createComposeWindow {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -67,10 +60,11 @@ class MouseEventsTest {
             ) {}
         }
 
+        val canvas = getCanvas()
 
-        canvasElement.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
-        canvasElement.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
-        canvasElement.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
+        canvas.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
+        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
 
         assertEquals(3, pointerEvents.size)
         assertEquals(PointerEventType.Enter, pointerEvents[0].type)
@@ -81,8 +75,8 @@ class MouseEventsTest {
         assertEquals(PointerEventType.Release, pointerEvents[2].type)
         assertEquals(PointerButton.Primary, pointerEvents[2].button)
 
-        canvasElement.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
-        canvasElement.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
+        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
+        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
         assertEquals(5, pointerEvents.size)
 
         // Check for secondary button
@@ -95,14 +89,10 @@ class MouseEventsTest {
     @OptIn(ExperimentalFoundationApi::class)
     @Test
     fun testOnClickWithPointerMatchers() = runTest {
-        val canvasElement = document.createElement("canvas") as HTMLCanvasElement
-        canvasElement.setAttribute("id", canvasId)
-        document.body!!.appendChild(canvasElement)
-
         var primaryClickedCounter = 0
         var secondaryClickedCounter = 0
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
+        createComposeWindow {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -111,15 +101,17 @@ class MouseEventsTest {
             ) {}
         }
 
-        canvasElement.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
-        canvasElement.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
-        canvasElement.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
+        val canvas = getCanvas()
+
+        canvas.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
+        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
 
         assertEquals(1, primaryClickedCounter)
         assertEquals(0, secondaryClickedCounter)
 
-        canvasElement.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
-        canvasElement.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
+        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
+        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
 
         assertEquals(1, primaryClickedCounter)
         assertEquals(1, secondaryClickedCounter)
@@ -127,14 +119,9 @@ class MouseEventsTest {
 
     @Test
     fun testPointerButtonIsNullForNoClickEvents() = runTest {
-        val canvasElement = document.createElement("canvas") as HTMLCanvasElement
-        canvasElement.setAttribute("id", canvasId)
-        document.body!!.appendChild(canvasElement)
-
-
         var event: PointerEvent? = null
 
-        CanvasBasedWindow(canvasElementId = canvasId) {
+        createComposeWindow {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -150,15 +137,17 @@ class MouseEventsTest {
 
         assertEquals(null, event)
 
-        canvasElement.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        val canvas = getCanvas()
+
+        canvas.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
         assertEquals(PointerEventType.Enter, event!!.type)
         assertEquals(null, event!!.button)
 
-        canvasElement.dispatchEvent(MouseEvent("mousemove", MouseEventInit(101, 101, clientX = 101, clientY = 101)))
+        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(101, 101, clientX = 101, clientY = 101)))
         assertEquals(PointerEventType.Move, event!!.type)
         assertEquals(null, event!!.button)
 
-        canvasElement.dispatchEvent(MouseEvent("mouseleave", MouseEventInit(0, 0, clientX = 0, clientY = 0)))
+        canvas.dispatchEvent(MouseEvent("mouseleave", MouseEventInit(0, 0, clientX = 0, clientY = 0)))
         assertEquals(PointerEventType.Exit, event!!.type)
         assertEquals(null, event!!.button)
     }


### PR DESCRIPTION
This fixes very subtle issues with sending test events to the wrong canvas which was actually created by different test suite.

This particular PR, however doesn't solve the issue of running this tests in parallel - changes of this kind are big enough to have them as a separate PR