### PR TITLE
Implementations of SynchronizedObject for different platforms

### DIFF
--- a/compose/runtime/runtime/api/desktop/runtime.api
+++ b/compose/runtime/runtime/api/desktop/runtime.api
@@ -18,6 +18,7 @@ public final class androidx/compose/runtime/ActualDesktop_desktopKt {
 
 public final class androidx/compose/runtime/ActualJvm_jvmKt {
 	public static final fun identityHashCode (Ljava/lang/Object;)I
+	public static final fun synchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public abstract interface class androidx/compose/runtime/Applier {
@@ -729,10 +730,6 @@ public abstract interface class androidx/compose/runtime/State {
 	public abstract fun getValue ()Ljava/lang/Object;
 }
 
-public final class androidx/compose/runtime/SynchronizationKt {
-	public static final fun synchronized (Landroidx/compose/runtime/SynchronizedObject;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
 public final class androidx/compose/runtime/Updater {
 	public static final synthetic fun box-impl (Landroidx/compose/runtime/Composer;)Landroidx/compose/runtime/Updater;
 	public static fun constructor-impl (Landroidx/compose/runtime/Composer;)Landroidx/compose/runtime/Composer;
@@ -1017,7 +1014,7 @@ public final class androidx/compose/runtime/snapshots/SnapshotContextElementKt {
 public final class androidx/compose/runtime/snapshots/SnapshotKt {
 	public static final fun current (Landroidx/compose/runtime/snapshots/StateRecord;)Landroidx/compose/runtime/snapshots/StateRecord;
 	public static final fun current (Landroidx/compose/runtime/snapshots/StateRecord;Landroidx/compose/runtime/snapshots/Snapshot;)Landroidx/compose/runtime/snapshots/StateRecord;
-	public static final fun getLock ()Landroidx/compose/runtime/SynchronizedObject;
+	public static final fun getLock ()Ljava/lang/Object;
 	public static final fun getSnapshotInitializer ()Landroidx/compose/runtime/snapshots/Snapshot;
 	public static final fun notifyWrite (Landroidx/compose/runtime/snapshots/Snapshot;Landroidx/compose/runtime/snapshots/StateObject;)V
 	public static final fun readable (Landroidx/compose/runtime/snapshots/StateRecord;Landroidx/compose/runtime/snapshots/StateObject;)Landroidx/compose/runtime/snapshots/StateRecord;

--- a/compose/runtime/runtime/api/desktop/runtime.api
+++ b/compose/runtime/runtime/api/desktop/runtime.api
@@ -18,7 +18,7 @@ public final class androidx/compose/runtime/ActualDesktop_desktopKt {
 
 public final class androidx/compose/runtime/ActualJvm_jvmKt {
 	public static final fun identityHashCode (Ljava/lang/Object;)I
-	public static final fun synchronized (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static final fun synchronized (Landroidx/compose/runtime/SynchronizedObject;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public abstract interface class androidx/compose/runtime/Applier {
@@ -730,6 +730,10 @@ public abstract interface class androidx/compose/runtime/State {
 	public abstract fun getValue ()Ljava/lang/Object;
 }
 
+public final class androidx/compose/runtime/SynchronizationKt {
+	public static final synthetic fun synchronized (Landroidx/compose/runtime/SynchronizedObject;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
 public final class androidx/compose/runtime/Updater {
 	public static final synthetic fun box-impl (Landroidx/compose/runtime/Composer;)Landroidx/compose/runtime/Updater;
 	public static fun constructor-impl (Landroidx/compose/runtime/Composer;)Landroidx/compose/runtime/Composer;
@@ -1014,7 +1018,7 @@ public final class androidx/compose/runtime/snapshots/SnapshotContextElementKt {
 public final class androidx/compose/runtime/snapshots/SnapshotKt {
 	public static final fun current (Landroidx/compose/runtime/snapshots/StateRecord;)Landroidx/compose/runtime/snapshots/StateRecord;
 	public static final fun current (Landroidx/compose/runtime/snapshots/StateRecord;Landroidx/compose/runtime/snapshots/Snapshot;)Landroidx/compose/runtime/snapshots/StateRecord;
-	public static final fun getLock ()Ljava/lang/Object;
+	public static final fun getLock ()Landroidx/compose/runtime/SynchronizedObject;
 	public static final fun getSnapshotInitializer ()Landroidx/compose/runtime/snapshots/Snapshot;
 	public static final fun notifyWrite (Landroidx/compose/runtime/snapshots/Snapshot;Landroidx/compose/runtime/snapshots/StateObject;)V
 	public static final fun readable (Landroidx/compose/runtime/snapshots/StateRecord;Landroidx/compose/runtime/snapshots/StateObject;)Landroidx/compose/runtime/snapshots/StateRecord;

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -180,6 +180,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 }
             }
 
+            posixMain.dependsOn(nativeMain)
+
             jbMain {
                 dependsOn(commonMain)
                 dependencies {
@@ -189,8 +191,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             desktopMain.dependsOn(jbMain)
             jsNativeMain.dependsOn(jbMain)
 
+            darwinMain {
+                dependsOn(posixMain)
+            }
+
             linuxMain {
-                dependsOn(nativeMain)
+                dependsOn(posixMain)
             }
 
             linuxTest {

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/BroadcastFrameClock.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/BroadcastFrameClock.kt
@@ -43,7 +43,7 @@ class BroadcastFrameClock(
         }
     }
 
-    private val lock = createSynchronizedObject()
+    private val lock = SynchronizedObject()
     private var failureCause: Throwable? = null
     private var awaiters = mutableListOf<FrameAwaiter<*>>()
     private var spareList = mutableListOf<FrameAwaiter<*>>()

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/BroadcastFrameClock.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/BroadcastFrameClock.kt
@@ -43,7 +43,7 @@ class BroadcastFrameClock(
         }
     }
 
-    private val lock = SynchronizedObject()
+    private val lock = createSynchronizedObject()
     private var failureCause: Throwable? = null
     private var awaiters = mutableListOf<FrameAwaiter<*>>()
     private var spareList = mutableListOf<FrameAwaiter<*>>()

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
@@ -460,7 +460,7 @@ internal class CompositionImpl(
     private val pendingModifications = AtomicReference<Any?>(null)
 
     // Held when making changes to self or composer
-    private val lock = createSynchronizedObject()
+    private val lock = SynchronizedObject()
 
     /**
      * A set of remember observers that were potentially abandoned between [composeContent] or

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
@@ -460,7 +460,7 @@ internal class CompositionImpl(
     private val pendingModifications = AtomicReference<Any?>(null)
 
     // Held when making changes to self or composer
-    private val lock = createSynchronizedObject()
+    private val lock = SynchronizedObject()
 
     /**
      * A set of remember observers that were potentially abandoned between [composeContent] or
@@ -691,15 +691,19 @@ internal class CompositionImpl(
             null -> {
                 // Do nothing, just start composing.
             }
+
             PendingApplyNoModifications -> {
                 composeRuntimeError("pending composition has not been applied")
             }
+
             is Set<*> -> {
                 addPendingInvalidationsLocked(toRecord as Set<Any>, forgetConditionalScopes = true)
             }
+
             is Array<*> -> for (changed in toRecord as Array<Set<Any>>) {
                 addPendingInvalidationsLocked(changed, forgetConditionalScopes = true)
             }
+
             else -> composeRuntimeError("corrupt pendingModifications drain: $pendingModifications")
         }
     }
@@ -710,15 +714,19 @@ internal class CompositionImpl(
             PendingApplyNoModifications -> {
                 // No work to do
             }
+
             is Set<*> -> {
                 addPendingInvalidationsLocked(toRecord as Set<Any>, forgetConditionalScopes = false)
             }
+
             is Array<*> -> for (changed in toRecord as Array<Set<Any>>) {
                 addPendingInvalidationsLocked(changed, forgetConditionalScopes = false)
             }
+
             null -> composeRuntimeError(
                 "calling recordModificationsOf and applyChanges concurrently is not supported"
             )
+
             else -> composeRuntimeError(
                 "corrupt pendingModifications drain: $pendingModifications"
             )
@@ -1094,7 +1102,7 @@ internal class CompositionImpl(
             invalidationDelegate = to as CompositionImpl
             invalidationDelegateGroup = groupIndex
             try {
-               block()
+                block()
             } finally {
                 invalidationDelegate = null
                 invalidationDelegateGroup = 0

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Composition.kt
@@ -460,7 +460,7 @@ internal class CompositionImpl(
     private val pendingModifications = AtomicReference<Any?>(null)
 
     // Held when making changes to self or composer
-    private val lock = SynchronizedObject()
+    private val lock = createSynchronizedObject()
 
     /**
      * A set of remember observers that were potentially abandoned between [composeContent] or
@@ -691,19 +691,15 @@ internal class CompositionImpl(
             null -> {
                 // Do nothing, just start composing.
             }
-
             PendingApplyNoModifications -> {
                 composeRuntimeError("pending composition has not been applied")
             }
-
             is Set<*> -> {
                 addPendingInvalidationsLocked(toRecord as Set<Any>, forgetConditionalScopes = true)
             }
-
             is Array<*> -> for (changed in toRecord as Array<Set<Any>>) {
                 addPendingInvalidationsLocked(changed, forgetConditionalScopes = true)
             }
-
             else -> composeRuntimeError("corrupt pendingModifications drain: $pendingModifications")
         }
     }
@@ -714,19 +710,15 @@ internal class CompositionImpl(
             PendingApplyNoModifications -> {
                 // No work to do
             }
-
             is Set<*> -> {
                 addPendingInvalidationsLocked(toRecord as Set<Any>, forgetConditionalScopes = false)
             }
-
             is Array<*> -> for (changed in toRecord as Array<Set<Any>>) {
                 addPendingInvalidationsLocked(changed, forgetConditionalScopes = false)
             }
-
             null -> composeRuntimeError(
                 "calling recordModificationsOf and applyChanges concurrently is not supported"
             )
-
             else -> composeRuntimeError(
                 "corrupt pendingModifications drain: $pendingModifications"
             )
@@ -1102,7 +1094,7 @@ internal class CompositionImpl(
             invalidationDelegate = to as CompositionImpl
             invalidationDelegateGroup = groupIndex
             try {
-                block()
+               block()
             } finally {
                 invalidationDelegate = null
                 invalidationDelegateGroup = 0

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Latch.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Latch.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  */
 internal class Latch {
 
-    private val lock = createSynchronizedObject()
+    private val lock = SynchronizedObject()
     private var awaiters = mutableListOf<Continuation<Unit>>()
     private var spareList = mutableListOf<Continuation<Unit>>()
 

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Latch.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Latch.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
  */
 internal class Latch {
 
-    private val lock = SynchronizedObject()
+    private val lock = createSynchronizedObject()
     private var awaiters = mutableListOf<Continuation<Unit>>()
     private var spareList = mutableListOf<Continuation<Unit>>()
 

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
@@ -201,7 +201,7 @@ class Recomposer(
         PendingWork
     }
 
-    private val stateLock = createSynchronizedObject()
+    private val stateLock = SynchronizedObject()
 
     // Begin properties guarded by stateLock
     private var runnerJob: Job? = null

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
@@ -201,19 +201,20 @@ class Recomposer(
         PendingWork
     }
 
-    private val stateLock = createSynchronizedObject()
+    private val stateLock = SynchronizedObject()
 
     // Begin properties guarded by stateLock
     private var runnerJob: Job? = null
     private var closeCause: Throwable? = null
     private val _knownCompositions = mutableListOf<ControlledComposition>()
     private var _knownCompositionsCache: List<ControlledComposition>? = null
-    private val knownCompositions get() = _knownCompositionsCache ?: run {
-        val compositions = _knownCompositions
-        val newCache = if (compositions.isEmpty()) emptyList() else ArrayList(compositions)
-        _knownCompositionsCache = newCache
-        newCache
-    }
+    private val knownCompositions
+        get() = _knownCompositionsCache ?: run {
+            val compositions = _knownCompositions
+            val newCache = if (compositions.isEmpty()) emptyList() else ArrayList(compositions)
+            _knownCompositionsCache = newCache
+            newCache
+        }
     private var snapshotInvalidations = MutableScatterSet<Any>()
     private val compositionInvalidations = mutableVectorOf<ControlledComposition>()
     private val compositionsAwaitingApply = mutableListOf<ControlledComposition>()
@@ -290,11 +291,14 @@ class Recomposer(
     internal override val recomposeCoroutineContext: CoroutineContext
         get() = EmptyCoroutineContext
 
-    private val hasBroadcastFrameClockAwaitersLocked: Boolean get() =
-        !frameClockPaused && broadcastFrameClock.hasAwaiters
+    private val hasBroadcastFrameClockAwaitersLocked: Boolean
+        get() =
+            !frameClockPaused && broadcastFrameClock.hasAwaiters
 
-    private val hasBroadcastFrameClockAwaiters: Boolean get() =
-        synchronized(stateLock) { hasBroadcastFrameClockAwaitersLocked }
+    private val hasBroadcastFrameClockAwaiters: Boolean
+        get() =
+            synchronized(stateLock) { hasBroadcastFrameClockAwaitersLocked }
+
     /**
      * Determine the new value of [_state]. Call only while locked on [stateLock].
      * If it returns a continuation, that continuation should be resumed after releasing the lock.
@@ -317,18 +321,21 @@ class Recomposer(
             errorState != null -> {
                 State.Inactive
             }
+
             runnerJob == null -> {
                 snapshotInvalidations = MutableScatterSet()
                 compositionInvalidations.clear()
                 if (hasBroadcastFrameClockAwaitersLocked) State.InactivePendingWork
                 else State.Inactive
             }
+
             compositionInvalidations.isNotEmpty() ||
                 snapshotInvalidations.isNotEmpty() ||
                 compositionsAwaitingApply.isNotEmpty() ||
                 compositionValuesAwaitingInsert.isNotEmpty() ||
                 concurrentCompositionsOutstanding > 0 ||
                 hasBroadcastFrameClockAwaitersLocked -> State.PendingWork
+
             else -> State.Idle
         }
 
@@ -382,6 +389,7 @@ class Recomposer(
                 .fastMapNotNull { it as? CompositionImpl }
                 .fastForEach { it.invalidateGroupsWithKey(key) }
         }
+
         fun saveStateAndDisposeForHotReload(): List<HotReloadable> {
             val compositions: List<ControlledComposition> = synchronized(stateLock) {
                 knownCompositions
@@ -1022,7 +1030,7 @@ class Recomposer(
                         changed.fastForEach {
                             if (
                                 it is StateObjectImpl &&
-                                    !it.isReadIn(ReaderKind.Composition)
+                                !it.isReadIn(ReaderKind.Composition)
                             ) {
                                 // continue if we know that state is never read in composition
                                 return@fastForEach
@@ -1184,7 +1192,8 @@ class Recomposer(
     ): ControlledComposition? {
         if (composition.isComposing ||
             composition.isDisposed ||
-            compositionsRemoved?.contains(composition) == true) return null
+            compositionsRemoved?.contains(composition) == true
+        ) return null
 
         return if (
             composing(composition, modifiedValues) {
@@ -1221,7 +1230,9 @@ class Recomposer(
                 // may release content when it is moved as it is recomposed when move.
                 val toInsert = if (
                     pairs.fastAll { it.second == null } || pairs.fastAll { it.second != null }
-                ) { pairs } else {
+                ) {
+                    pairs
+                } else {
                     // Return the content not moving to the awaiting list. These will come back
                     // here in the next iteration of the caller's loop and either have content
                     // to move or by still needing to create the content.

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Synchronization.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Synchronization.kt
@@ -18,5 +18,9 @@ package androidx.compose.runtime
 
 internal expect class SynchronizedObject()
 
+@Suppress("CONFLICTING_OVERLOADS")
+internal fun createSynchronizedObject() = SynchronizedObject()
+
 @PublishedApi
 internal expect inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R
+

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/SynchronizedObject.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/SynchronizedObject.kt
@@ -18,9 +18,5 @@ package androidx.compose.runtime
 
 internal expect class SynchronizedObject()
 
-@Suppress("CONFLICTING_OVERLOADS")
-internal fun createSynchronizedObject() = SynchronizedObject()
-
 @PublishedApi
 internal expect inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R
-

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/Snapshot.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/Snapshot.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.SnapshotThreadLocal
+import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.checkPrecondition
 import androidx.compose.runtime.collection.wrapIntoSet
 import androidx.compose.runtime.currentThreadId
@@ -35,7 +36,6 @@ import androidx.compose.runtime.snapshots.Snapshot.Companion.takeSnapshot
 import androidx.compose.runtime.snapshots.SnapshotApplyResult.Failure
 import androidx.compose.runtime.snapshots.SnapshotApplyResult.Success
 import androidx.compose.runtime.synchronized
-import androidx.compose.runtime.createSynchronizedObject
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -1838,7 +1838,7 @@ private val threadSnapshot = SnapshotThreadLocal<Snapshot>()
  * of the fields below.
  */
 @PublishedApi
-internal val lock = createSynchronizedObject()
+internal val lock = SynchronizedObject()
 
 @PublishedApi
 internal inline fun <T> sync(block: () -> T): T = synchronized(lock, block)

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/Snapshot.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/Snapshot.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.DisallowComposableCalls
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.SnapshotThreadLocal
-import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.checkPrecondition
 import androidx.compose.runtime.collection.wrapIntoSet
 import androidx.compose.runtime.currentThreadId
@@ -36,6 +35,7 @@ import androidx.compose.runtime.snapshots.Snapshot.Companion.takeSnapshot
 import androidx.compose.runtime.snapshots.SnapshotApplyResult.Failure
 import androidx.compose.runtime.snapshots.SnapshotApplyResult.Success
 import androidx.compose.runtime.synchronized
+import androidx.compose.runtime.createSynchronizedObject
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -1838,7 +1838,7 @@ private val threadSnapshot = SnapshotThreadLocal<Snapshot>()
  * of the fields below.
  */
 @PublishedApi
-internal val lock = SynchronizedObject()
+internal val lock = createSynchronizedObject()
 
 @PublishedApi
 internal inline fun <T> sync(block: () -> T): T = synchronized(lock, block)

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateList.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateList.kt
@@ -17,11 +17,11 @@
 package androidx.compose.runtime.snapshots
 
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.external.kotlinx.collections.immutable.PersistentList
 import androidx.compose.runtime.external.kotlinx.collections.immutable.persistentListOf
 import androidx.compose.runtime.requirePrecondition
 import androidx.compose.runtime.synchronized
-import androidx.compose.runtime.createSynchronizedObject
 import kotlin.jvm.JvmName
 
 /**
@@ -258,7 +258,7 @@ class SnapshotStateList<T> : StateObject, MutableList<T>, RandomAccess {
  * In code the requires this lock and calls `writable` (or other operation that acquires the
  * snapshot global lock), this lock *MUST* be acquired first to avoid deadlocks.
  */
-private val sync = createSynchronizedObject()
+private val sync = SynchronizedObject()
 
 private fun modificationError(): Nothing =
     error("Cannot modify a state list through an iterator")

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateList.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateList.kt
@@ -17,11 +17,11 @@
 package androidx.compose.runtime.snapshots
 
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.external.kotlinx.collections.immutable.PersistentList
 import androidx.compose.runtime.external.kotlinx.collections.immutable.persistentListOf
 import androidx.compose.runtime.requirePrecondition
 import androidx.compose.runtime.synchronized
+import androidx.compose.runtime.createSynchronizedObject
 import kotlin.jvm.JvmName
 
 /**
@@ -258,7 +258,7 @@ class SnapshotStateList<T> : StateObject, MutableList<T>, RandomAccess {
  * In code the requires this lock and calls `writable` (or other operation that acquires the
  * snapshot global lock), this lock *MUST* be acquired first to avoid deadlocks.
  */
-private val sync = SynchronizedObject()
+private val sync = createSynchronizedObject()
 
 private fun modificationError(): Nothing =
     error("Cannot modify a state list through an iterator")

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateMap.kt
@@ -17,10 +17,10 @@
 package androidx.compose.runtime.snapshots
 
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.external.kotlinx.collections.immutable.PersistentMap
 import androidx.compose.runtime.external.kotlinx.collections.immutable.persistentHashMapOf
 import androidx.compose.runtime.synchronized
-import androidx.compose.runtime.createSynchronizedObject
 import kotlin.jvm.JvmName
 
 /**
@@ -284,7 +284,7 @@ private class SnapshotMapValueSet<K, V>(
  * In code the requires this lock and calls `writable` (or other operation that acquires the
  * snapshot global lock), this lock *MUST* be acquired first to avoid deadlocks.
  */
-private val sync = createSynchronizedObject()
+private val sync = SynchronizedObject()
 
 private abstract class StateMapMutableIterator<K, V>(
     val map: SnapshotStateMap<K, V>,

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateMap.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateMap.kt
@@ -17,10 +17,10 @@
 package androidx.compose.runtime.snapshots
 
 import androidx.compose.runtime.Stable
-import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.external.kotlinx.collections.immutable.PersistentMap
 import androidx.compose.runtime.external.kotlinx.collections.immutable.persistentHashMapOf
 import androidx.compose.runtime.synchronized
+import androidx.compose.runtime.createSynchronizedObject
 import kotlin.jvm.JvmName
 
 /**
@@ -284,7 +284,7 @@ private class SnapshotMapValueSet<K, V>(
  * In code the requires this lock and calls `writable` (or other operation that acquires the
  * snapshot global lock), this lock *MUST* be acquired first to avoid deadlocks.
  */
-private val sync = SynchronizedObject()
+private val sync = createSynchronizedObject()
 
 private abstract class StateMapMutableIterator<K, V>(
     val map: SnapshotStateMap<K, V>,

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
@@ -22,6 +22,7 @@ import androidx.collection.MutableScatterSet
 import androidx.compose.runtime.AtomicReference
 import androidx.compose.runtime.DerivedState
 import androidx.compose.runtime.DerivedStateObserver
+import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.TestOnly
 import androidx.compose.runtime.collection.ScopeMap
 import androidx.compose.runtime.collection.fastForEach
@@ -33,7 +34,6 @@ import androidx.compose.runtime.observeDerivedStateRecalculations
 import androidx.compose.runtime.requirePrecondition
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.runtime.synchronized
-import androidx.compose.runtime.createSynchronizedObject
 
 /**
  * Helper class to efficiently observe snapshot state reads. See [observeReads] for more details.
@@ -195,7 +195,7 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
         }
     }
 
-    private val observedScopeMapsLock = createSynchronizedObject()
+    private val observedScopeMapsLock = SynchronizedObject()
 
     /**
      * Method to call when unsubscribing from the apply observer.

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
@@ -22,6 +22,7 @@ import androidx.collection.MutableScatterSet
 import androidx.compose.runtime.AtomicReference
 import androidx.compose.runtime.DerivedState
 import androidx.compose.runtime.DerivedStateObserver
+import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.TestOnly
 import androidx.compose.runtime.collection.ScopeMap
 import androidx.compose.runtime.collection.fastForEach
@@ -33,7 +34,6 @@ import androidx.compose.runtime.observeDerivedStateRecalculations
 import androidx.compose.runtime.requirePrecondition
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.runtime.synchronized
-import androidx.compose.runtime.createSynchronizedObject
 
 /**
  * Helper class to efficiently observe snapshot state reads. See [observeReads] for more details.
@@ -142,6 +142,7 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
                     result = old as Set<Any>?
                     new = null
                 }
+
                 is List<*> -> {
                     result = old[0] as Set<Any>?
                     new = when {
@@ -150,6 +151,7 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
                         else -> null
                     }
                 }
+
                 else -> report()
             }
             if (pendingChanges.compareAndSet(old, new)) {
@@ -195,7 +197,7 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
         }
     }
 
-    private val observedScopeMapsLock = createSynchronizedObject()
+    private val observedScopeMapsLock = SynchronizedObject()
 
     /**
      * Method to call when unsubscribing from the apply observer.

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserver.kt
@@ -22,7 +22,6 @@ import androidx.collection.MutableScatterSet
 import androidx.compose.runtime.AtomicReference
 import androidx.compose.runtime.DerivedState
 import androidx.compose.runtime.DerivedStateObserver
-import androidx.compose.runtime.SynchronizedObject
 import androidx.compose.runtime.TestOnly
 import androidx.compose.runtime.collection.ScopeMap
 import androidx.compose.runtime.collection.fastForEach
@@ -34,6 +33,7 @@ import androidx.compose.runtime.observeDerivedStateRecalculations
 import androidx.compose.runtime.requirePrecondition
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.runtime.synchronized
+import androidx.compose.runtime.createSynchronizedObject
 
 /**
  * Helper class to efficiently observe snapshot state reads. See [observeReads] for more details.
@@ -142,7 +142,6 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
                     result = old as Set<Any>?
                     new = null
                 }
-
                 is List<*> -> {
                     result = old[0] as Set<Any>?
                     new = when {
@@ -151,7 +150,6 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
                         else -> null
                     }
                 }
-
                 else -> report()
             }
             if (pendingChanges.compareAndSet(old, new)) {
@@ -197,7 +195,7 @@ class SnapshotStateObserver(private val onChangedExecutor: (callback: () -> Unit
         }
     }
 
-    private val observedScopeMapsLock = SynchronizedObject()
+    private val observedScopeMapsLock = createSynchronizedObject()
 
     /**
      * Method to call when unsubscribing from the apply observer.

--- a/compose/runtime/runtime/src/darwinMain/kotlin/runtime/SynchronizedObject.darwin.kt
+++ b/compose/runtime/runtime/src/darwinMain/kotlin/runtime/SynchronizedObject.darwin.kt
@@ -16,11 +16,4 @@
 
 package androidx.compose.runtime
 
-internal expect class SynchronizedObject()
-
-@Suppress("CONFLICTING_OVERLOADS")
-internal fun createSynchronizedObject() = SynchronizedObject()
-
-@PublishedApi
-internal expect inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R
-
+internal actual val PTHREAD_MUTEX_ERRORCHECK: Int = platform.posix.PTHREAD_MUTEX_ERRORCHECK

--- a/compose/runtime/runtime/src/desktopMain/kotlin/androidx/compose/runtime/Synchronization.kt
+++ b/compose/runtime/runtime/src/desktopMain/kotlin/androidx/compose/runtime/Synchronization.kt
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-@file:JvmName("ActualJvm_jvmKt")
-@file:JvmMultifileClass
-
 package androidx.compose.runtime
 
-internal actual class SynchronizedObject
+import kotlin.DeprecationLevel.*
 
 @PublishedApi
-internal actual inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R =
-    kotlin.synchronized(lock, block)
+@JvmName("synchronized")
+@Deprecated(level = HIDDEN, message = "Use SynchronizedObjectKt.synchronized() instead")
+internal fun <R> oldSynchronized(lock: SynchronizedObject, block: () -> R): R = synchronized(lock, block)

--- a/compose/runtime/runtime/src/jsWasmMain/kotlin/androidx/compose/runtime/SynchronizedObject.jsWasm.kt
+++ b/compose/runtime/runtime/src/jsWasmMain/kotlin/androidx/compose/runtime/SynchronizedObject.jsWasm.kt
@@ -16,11 +16,8 @@
 
 package androidx.compose.runtime
 
-internal expect class SynchronizedObject()
-
-@Suppress("CONFLICTING_OVERLOADS")
-internal fun createSynchronizedObject() = SynchronizedObject()
+@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-37316
+internal actual typealias SynchronizedObject = Any
 
 @PublishedApi
-internal expect inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R
-
+internal actual inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R = block()

--- a/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
+++ b/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/ActualJvm.jvm.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:JvmName("ActualJvm_jvmKt")
+@file:JvmMultifileClass
+
 package androidx.compose.runtime
 
 import androidx.compose.runtime.snapshots.Snapshot

--- a/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/SynchronizedObject.jvm.kt
+++ b/compose/runtime/runtime/src/jvmMain/kotlin/androidx/compose/runtime/SynchronizedObject.jvm.kt
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
+@file:JvmName("ActualJvm_jvmKt")
+@file:JvmMultifileClass
+
 package androidx.compose.runtime
 
-internal expect class SynchronizedObject()
-
-@Suppress("CONFLICTING_OVERLOADS")
-internal fun createSynchronizedObject() = SynchronizedObject()
+@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-37316
+internal actual typealias SynchronizedObject = Any
 
 @PublishedApi
-internal expect inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R
-
+internal actual inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R =
+    kotlin.synchronized(lock, block)

--- a/compose/runtime/runtime/src/linuxMain/kotlin/androidx/compose/runtime/SynchronizedObject.linux.kt
+++ b/compose/runtime/runtime/src/linuxMain/kotlin/androidx/compose/runtime/SynchronizedObject.linux.kt
@@ -16,11 +16,4 @@
 
 package androidx.compose.runtime
 
-internal expect class SynchronizedObject()
-
-@Suppress("CONFLICTING_OVERLOADS")
-internal fun createSynchronizedObject() = SynchronizedObject()
-
-@PublishedApi
-internal expect inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R
-
+internal actual val PTHREAD_MUTEX_ERRORCHECK: Int = platform.posix.PTHREAD_MUTEX_ERRORCHECK.toInt()

--- a/compose/runtime/runtime/src/mingwX64Main/kotlin/androidx/compose/runtime/SynchronizedObject.mingwX64.kt
+++ b/compose/runtime/runtime/src/mingwX64Main/kotlin/androidx/compose/runtime/SynchronizedObject.mingwX64.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package androidx.compose.runtime
+
+import kotlinx.atomicfu.*
+
+@PublishedApi
+@Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")
+internal actual inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R {
+    lock.run {
+        lock()
+        return try {
+            block()
+        } finally {
+            unlock()
+        }
+    }
+}
+
+/**
+ * Re-entrant spin lock implementation.
+ *
+ * `SynchronizedObject` from `kotlinx-atomicfu` library was used before.
+ * However, it is still [experimental](https://github.com/Kotlin/kotlinx-atomicfu?tab=readme-ov-file#locks)
+ * and has [a performance problem](https://github.com/Kotlin/kotlinx-atomicfu/issues/412)
+ * that seriously affects Compose.
+ *
+ * Using a posix mutex is [problematic for mingwX64](https://youtrack.jetbrains.com/issue/KT-70449/Posix-declarations-differ-much-for-mingwX64-and-LinuxDarwin-targets),
+ * so we just use a simple spin lock for mingwX64 (maybe reconsidered in case of problems).
+ */
+internal actual class SynchronizedObject actual constructor() {
+
+    companion object {
+        private const val NO_OWNER = -1L
+    }
+
+    private val owner: AtomicLong = atomic(NO_OWNER)
+    private var reEnterCount: Int = 0
+
+    fun lock() {
+        if (owner.value == currentThreadId()) {
+            reEnterCount += 1
+        } else {
+            // Busy wait
+            while (!owner.compareAndSet(NO_OWNER, currentThreadId())){}
+        }
+    }
+
+    fun unlock() {
+        require (owner.value == currentThreadId())
+        if (reEnterCount > 0) {
+            reEnterCount -= 1
+        } else {
+            owner.value = NO_OWNER
+        }
+    }
+}

--- a/compose/runtime/runtime/src/nativeTest/kotlin/androidx/compose/runtime/SynchronizationTest.kt
+++ b/compose/runtime/runtime/src/nativeTest/kotlin/androidx/compose/runtime/SynchronizationTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import kotlin.concurrent.AtomicInt
+import kotlin.native.concurrent.*
+import kotlin.test.*
+
+private const val iterations = 100
+private const val nWorkers = 4
+private const val increments = 500
+private const val nLocks = 5
+
+private fun nest(lock: SynchronizedObject, nestedLocks: Int, count: AtomicInt) {
+    synchronized(lock) {
+        if (nestedLocks == 1) {
+            val oldValue = count.value
+            count.value = oldValue + 1
+        } else {
+            nest(lock, nestedLocks - 1, count)
+        }
+    }
+}
+
+/**
+ * Test is taken from [kotlinx-atomicfu](https://github.com/Kotlin/kotlinx-atomicfu) with a few modifications.
+*/
+class SynchronizedTest {
+    @Test
+    fun stressCounterTest() {
+        repeat(iterations) {
+            val workers = Array(nWorkers) { Worker.start() }
+            val counter = AtomicInt(0)
+            val so = SynchronizedObject()
+            workers.forEach { worker ->
+                worker.execute(TransferMode.SAFE, {
+                    counter to so
+                }) { (count, lock) ->
+                    repeat(increments) {
+                        val nestedLocks = (1..3).random()
+                        nest(lock, nestedLocks, count)
+                    }
+                }
+            }
+            workers.forEach {
+                it.requestTermination().result
+            }
+            assertEquals(nWorkers * increments, counter.value)
+        }
+    }
+
+    @Test
+    fun manyLocksTest() {
+        repeat(iterations) {
+            val workers = Array(nWorkers) { Worker.start() }
+            val counters = Array(nLocks) { AtomicInt(0) }
+            val locks = Array(nLocks) { SynchronizedObject() }
+            workers.forEach { worker ->
+                worker.execute(TransferMode.SAFE, {
+                    counters to locks
+                }) { (counters, locks) ->
+                    locks.forEachIndexed { i, lock ->
+                        repeat(increments) {
+                            synchronized(lock) {
+                                val oldValue = counters[i].value
+                                counters[i].value = oldValue + 1
+                            }
+                        }
+                    }
+                }
+            }
+            workers.forEach {
+                it.requestTermination().result
+            }
+            assertEquals(nWorkers * nLocks * increments, counters.sumOf { it.value })
+        }
+    }
+}

--- a/compose/runtime/runtime/src/posixMain/kotlin/androidx/compose/runtime/SynchronizedObject.posix.kt
+++ b/compose/runtime/runtime/src/posixMain/kotlin/androidx/compose/runtime/SynchronizedObject.posix.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.runtime
+
+import kotlin.native.ref.createCleaner
+import kotlinx.cinterop.Arena
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.ptr
+import platform.posix.pthread_mutex_destroy
+import platform.posix.pthread_mutex_init
+import platform.posix.pthread_mutex_lock
+import platform.posix.pthread_mutex_t
+import platform.posix.pthread_mutex_unlock
+import platform.posix.pthread_mutexattr_destroy
+import platform.posix.pthread_mutexattr_init
+import platform.posix.pthread_mutexattr_settype
+import platform.posix.pthread_mutexattr_t
+import kotlinx.atomicfu.*
+import kotlinx.atomicfu.AtomicInt
+import platform.posix.pthread_cond_destroy
+import platform.posix.pthread_cond_init
+import platform.posix.pthread_cond_signal
+import platform.posix.pthread_cond_t
+import platform.posix.pthread_cond_wait
+
+/**
+ * Wrapper for `platform.posix.PTHREAD_MUTEX_ERRORCHECK` which is represented as `kotlin.Int` on darwin
+ * platforms and `kotlin.UInt` on linuxX64.
+ *
+ * See: [KT-41509](https://youtrack.jetbrains.com/issue/KT-41509)
+ */
+internal expect val PTHREAD_MUTEX_ERRORCHECK: Int
+
+/**
+ * A synchronized object that provides thread-safe locking and unlocking operations.
+ *
+ * `SynchronizedObject` from `kotlinx-atomicfu` library was used before.
+ * However, it is still [experimental](https://github.com/Kotlin/kotlinx-atomicfu?tab=readme-ov-file#locks)
+ *  and has [a performance problem](https://github.com/Kotlin/kotlinx-atomicfu/issues/412)
+ *  that seriously affects Compose.
+ *
+ *  This implementation is optimized for a non-contention case
+ *  (that is the case for the current state of Compose for iOS), so it does not create a posix mutex
+ *  when there is no contention: using a posix mutex has its own performance overheads.
+ *  On the other hand, it does not just spin lock in case of contention,
+ *  protecting from an occasional battery drain.
+ */
+internal actual class SynchronizedObject actual constructor() {
+
+    companion object {
+        private const val NO_OWNER = -1L
+    }
+
+    private val owner: AtomicLong = atomic(NO_OWNER)
+    private var reEnterCount: Int = 0
+    private val waiters: AtomicInt = atomic(0)
+
+    private val monitorWrapper: MonitorWrapper by lazy { MonitorWrapper() }
+    private val monitor: NativeMonitor get() = monitorWrapper.monitor
+
+    fun lock() {
+        if (owner.value == currentThreadId()) {
+            reEnterCount += 1
+        } else if (waiters.incrementAndGet() > 1) {
+            waitForUnlockAndLock()
+        } else {
+            if (!owner.compareAndSet(NO_OWNER, currentThreadId())) {
+                waitForUnlockAndLock()
+            }
+        }
+    }
+
+    private fun waitForUnlockAndLock() {
+        withMonitor(monitor) {
+            while (!owner.compareAndSet(NO_OWNER, currentThreadId())) {
+                wait()
+            }
+        }
+    }
+
+    fun unlock() {
+        require (owner.value == currentThreadId())
+        if (reEnterCount > 0) {
+            reEnterCount -= 1
+        } else {
+            owner.value = NO_OWNER
+            if (waiters.decrementAndGet() > 0) {
+                withMonitor(monitor) {
+                    notify()
+                }
+            }
+        }
+    }
+
+    private inline fun withMonitor(monitor: NativeMonitor, block: NativeMonitor.() -> Unit) {
+        monitor.run {
+            enter()
+            return try {
+                block()
+            } finally {
+                exit()
+            }
+        }
+    }
+
+    private class MonitorWrapper {
+        val monitor: NativeMonitor = NativeMonitor()
+        val cleaner = createCleaner(monitor, NativeMonitor::dispose)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private class NativeMonitor {
+        private val arena: Arena = Arena()
+        private val cond: pthread_cond_t = arena.alloc()
+        private val mutex: pthread_mutex_t = arena.alloc()
+        private val attr: pthread_mutexattr_t = arena.alloc()
+
+        init {
+            require (pthread_cond_init(cond.ptr, null) == 0)
+            require(pthread_mutexattr_init(attr.ptr) == 0)
+            require (pthread_mutexattr_settype(attr.ptr, PTHREAD_MUTEX_ERRORCHECK) == 0)
+            require(pthread_mutex_init(mutex.ptr, attr.ptr) == 0)
+        }
+
+        fun enter() = require(pthread_mutex_lock(mutex.ptr) == 0)
+
+        fun exit() = require(pthread_mutex_unlock(mutex.ptr) == 0)
+
+        fun wait() = require(pthread_cond_wait(cond.ptr, mutex.ptr) == 0)
+
+        fun notify() = require (pthread_cond_signal(cond.ptr) == 0)
+
+        fun dispose() {
+            pthread_cond_destroy(cond.ptr)
+            pthread_mutex_destroy(mutex.ptr)
+            pthread_mutexattr_destroy(attr.ptr)
+            arena.clear()
+        }
+    }
+}
+
+@PublishedApi
+@Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")
+internal actual inline fun <R> synchronized(lock: SynchronizedObject, block: () -> R): R {
+    lock.run {
+        lock()
+        return try {
+            block()
+        } finally {
+            unlock()
+        }
+    }
+}

--- a/compose/runtime/runtime/src/posixMain/kotlin/androidx/compose/runtime/SynchronizedObject.posix.kt
+++ b/compose/runtime/runtime/src/posixMain/kotlin/androidx/compose/runtime/SynchronizedObject.posix.kt
@@ -51,14 +51,14 @@ internal expect val PTHREAD_MUTEX_ERRORCHECK: Int
  *
  * `SynchronizedObject` from `kotlinx-atomicfu` library was used before.
  * However, it is still [experimental](https://github.com/Kotlin/kotlinx-atomicfu?tab=readme-ov-file#locks)
- *  and has [a performance problem](https://github.com/Kotlin/kotlinx-atomicfu/issues/412)
- *  that seriously affects Compose.
+ * and has [a performance problem](https://github.com/Kotlin/kotlinx-atomicfu/issues/412)
+ * that seriously affects Compose.
  *
- *  This implementation is optimized for a non-contention case
- *  (that is the case for the current state of Compose for iOS), so it does not create a posix mutex
- *  when there is no contention: using a posix mutex has its own performance overheads.
- *  On the other hand, it does not just spin lock in case of contention,
- *  protecting from an occasional battery drain.
+ * This implementation is optimized for a non-contention case
+ * (that is the case for the current state of Compose for iOS), so it does not create a posix mutex
+ * when there is no contention: using a posix mutex has its own performance overheads.
+ * On the other hand, it does not just spin lock in case of contention,
+ * protecting from an occasional battery drain.
  */
 internal actual class SynchronizedObject actual constructor() {
 

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -202,6 +202,7 @@ tasks.register("testUIKit") {
     val uikitTestSubtaskName = "uikit$suffix"
     val instrumentedTestSubtaskName = "uikitInstrumented$suffix"
 
+    dependsOn(":compose:runtime:runtime:$uikitTestSubtaskName")
     dependsOn(":compose:ui:ui-text:$uikitTestSubtaskName")
     dependsOn(":compose:ui:ui:$uikitTestSubtaskName")
     dependsOn(":compose:ui:ui:$instrumentedTestSubtaskName")


### PR DESCRIPTION
## Proposed Changes

Several implementations of SynchronizedObject for different platforms:

1. JVM's "synchronized" is used for JVM platforms
2. no-op is used for Web target
3. Benaphore-like is used on Linux and Darwin with a backup path to pthread_cond
4. Re-entrant spin lock is used on mingwX64

See for details: https://youtrack.jetbrains.com/issue/CMP-1182/Investigate-possible-implementations-of-SynchronizedObject

## Testing

Test: SynchronizationTest.kt is added to Kotlin/Native targets, compose.runtime tests are added to UIKit testing.

## Issues Fixed

Fixes: https://youtrack.jetbrains.com/issue/CMP-1182/Investigate-possible-implementations-of-SynchronizedObject
