### PR TITLE
Fix input methods position on the screen

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.android.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TextInputService
 import androidx.emoji2.text.EmojiCompat
 import java.lang.ref.WeakReference
 import kotlin.math.roundToInt
@@ -59,9 +60,14 @@ private const val DEBUG_CLASS = "AndroidLegacyPlatformTextInputServiceAdapter"
 @VisibleForTesting
 internal var inputMethodManagerFactory: (View) -> InputMethodManager = ::InputMethodManagerImpl
 
+@Suppress("DEPRECATION")
 @Composable
-internal actual fun legacyPlatformTextInputServiceAdapter():
-    LegacyPlatformTextInputServiceAdapter = remember { AndroidLegacyPlatformTextInputServiceAdapter() }
+internal actual fun legacyTextInputServiceAdapterAndService():
+    Pair<LegacyPlatformTextInputServiceAdapter, TextInputService> {
+    val adapter = remember { AndroidLegacyPlatformTextInputServiceAdapter() }
+    val service = remember { TextInputService(adapter) }
+    return adapter to service
+}
 
 internal class AndroidLegacyPlatformTextInputServiceAdapter :
     LegacyPlatformTextInputServiceAdapter() {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -28,7 +28,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.text.handwriting.stylusHandwriting
-import androidx.compose.foundation.text.input.internal.legacyPlatformTextInputServiceAdapter
+import androidx.compose.foundation.text.input.internal.legacyTextInputServiceAdapterAndService
 import androidx.compose.foundation.text.input.internal.legacyTextInputAdapter
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.OffsetProvider
@@ -221,10 +221,8 @@ internal fun CoreTextField(
     textScrollerPosition: TextFieldScrollerPosition? = null,
 ) {
     val focusRequester = remember { FocusRequester() }
-    val legacyTextInputServiceAdapter = legacyPlatformTextInputServiceAdapter()
-    val textInputService: TextInputService = remember {
-        TextInputService(legacyTextInputServiceAdapter)
-    }
+    val (legacyTextInputServiceAdapter, textInputService) =
+        legacyTextInputServiceAdapterAndService()
 
     // CompositionLocals
     val density = LocalDensity.current

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.kt
@@ -26,11 +26,12 @@ import androidx.compose.ui.platform.PlatformTextInputSession
 import androidx.compose.ui.platform.SoftwareKeyboardController
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.text.input.PlatformTextInputService
+import androidx.compose.ui.text.input.TextInputService
 import kotlinx.coroutines.Job
 
 @Composable
-internal expect fun legacyPlatformTextInputServiceAdapter():
-    LegacyPlatformTextInputServiceAdapter
+internal expect fun legacyTextInputServiceAdapterAndService():
+    Pair<LegacyPlatformTextInputServiceAdapter, TextInputService>
 
 /**
  * An implementation of the legacy [PlatformTextInputService] interface that delegates to a

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -50,11 +50,11 @@ internal actual fun legacyTextInputServiceAdapterAndService():
                 onEditCommand: (List<EditCommand>) -> Unit,
                 onImeActionPerformed: (ImeAction) -> Unit
             ) {
-                session = service?.startInput(value, imeOptions, onEditCommand, onImeActionPerformed)
+                session = service.startInput(value, imeOptions, onEditCommand, onImeActionPerformed)
             }
 
             override fun stopInput() {
-                service?.stopInput()
+                service.stopInput()
                 session?.dispose()
                 session = null
             }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -28,15 +28,18 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TextInputService
 import androidx.compose.ui.text.input.TextInputSession
 
 // TODO remove after https://youtrack.jetbrains.com/issue/COMPOSE-740/Implement-BasicTextField2
 @Suppress("DEPRECATION")
 @OptIn(InternalTextApi::class)
 @Composable
-internal actual fun legacyPlatformTextInputServiceAdapter(): LegacyPlatformTextInputServiceAdapter {
-    val service = LocalTextInputService.current
-    return remember(service) {
+internal actual fun legacyTextInputServiceAdapterAndService():
+    Pair<LegacyPlatformTextInputServiceAdapter, TextInputService>
+{
+    val service = LocalTextInputService.current!!
+    val adapter = remember(service) {
         object : LegacyPlatformTextInputServiceAdapter() {
             private var session: TextInputSession? = null
             override fun startStylusHandwriting() {}
@@ -79,4 +82,5 @@ internal actual fun legacyPlatformTextInputServiceAdapter(): LegacyPlatformTextI
             }
         }
     }
+    return adapter to service
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -33,6 +33,7 @@ import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
 import java.awt.font.TextHitInfo
+import java.awt.im.InputMethodRequests
 import java.awt.image.BufferedImage
 import java.awt.image.MultiResolutionImage
 import java.text.AttributedString
@@ -85,6 +86,9 @@ fun Window.sendKeyEvent(
     mostRecentFocusOwner!!.dispatchEvent(event)
     return event.isConsumed
 }
+
+fun Window.focusedInputMethodRequests(): InputMethodRequests? =
+    mostRecentFocusOwner!!.inputMethodRequests
 
 fun Window.sendKeyTypedEvent(
     char: Char,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.withTimeout
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
 import androidx.compose.ui.window.launchApplication as realLaunchApplication
+import javax.swing.JFrame
 
 
 internal fun runApplicationTest(
@@ -120,12 +121,23 @@ internal class WindowTestScope(
     var isOpen by mutableStateOf(true)
     private val initialRecomposers = Recomposer.runningRecomposers.value
 
+    lateinit var window: JFrame
+
     fun launchTestApplication(
         content: @Composable ApplicationScope.() -> Unit
     ) = realLaunchApplication {
         if (isOpen) {
             content()
         }
+    }
+
+    fun launchTestWindowApplication(
+        content: @Composable WindowScope.() -> Unit
+    ) = launchTestApplication {
+       Window(onCloseRequest = ::exitApplication) {
+           this@WindowTestScope.window = window
+           content()
+       }
     }
 
     // Overload `launchApplication` to prohibit calling it from tests

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypingLocationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypingLocationTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window.window
+
+import androidx.compose.material.TextField
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focusedInputMethodRequests
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.sendKeyEvent
+import androidx.compose.ui.sendKeyTypedEvent
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.window.WindowTestScope
+import androidx.compose.ui.window.runApplicationTest
+import java.awt.event.KeyEvent.KEY_PRESSED
+import java.awt.event.KeyEvent.KEY_RELEASED
+import org.junit.Test
+
+class WindowTypingLocationTest {
+    @Test
+    fun `input methods text location going right when type`() = runTextFieldTest {
+        val location0 = window.focusedInputMethodRequests()!!.getTextLocation(null)
+
+        window.sendKeyEvent(81, 'a', KEY_PRESSED)
+        window.sendKeyTypedEvent('a')
+        window.sendKeyEvent(81, 'a', KEY_RELEASED)
+
+        awaitIdle()
+        val location1 = window.focusedInputMethodRequests()!!.getTextLocation(null)
+
+        window.sendKeyEvent(81, 'a', KEY_PRESSED)
+        window.sendKeyTypedEvent('a')
+        window.sendKeyEvent(81, 'a', KEY_RELEASED)
+        awaitIdle()
+        val location2 = window.focusedInputMethodRequests()!!.getTextLocation(null)
+
+        assert(location2.x > location1.x && location1.x > location0.x)
+        // don't check location0.y, as it is different for empty text field
+        assert(location2.y == location1.y)
+    }
+
+    @Test
+    fun `input methods text location is inside window`() = runTextFieldTest {
+        val windowLocation = window.contentPane.locationOnScreen
+        val windowSize = window.contentPane.size
+
+        val location0 = window.focusedInputMethodRequests()!!.getTextLocation(null)
+
+        window.sendKeyEvent(81, 'a', KEY_PRESSED)
+        window.sendKeyTypedEvent('a')
+        window.sendKeyEvent(81, 'a', KEY_RELEASED)
+        awaitIdle()
+        val location1 = window.focusedInputMethodRequests()!!.getTextLocation(null)
+
+        window.sendKeyEvent(81, 'a', KEY_PRESSED)
+        window.sendKeyTypedEvent('a')
+        window.sendKeyEvent(81, 'a', KEY_RELEASED)
+        awaitIdle()
+        val location2 = window.focusedInputMethodRequests()!!.getTextLocation(null)
+
+        assert(location0.x in windowLocation.x..windowLocation.x + windowSize.width)
+        assert(location1.x in windowLocation.x..windowLocation.x + windowSize.width)
+        assert(location2.x in windowLocation.x..windowLocation.x + windowSize.width)
+        assert(location0.y in windowLocation.y..windowLocation.y + windowSize.height)
+        assert(location1.y in windowLocation.y..windowLocation.y + windowSize.height)
+        assert(location2.y in windowLocation.y..windowLocation.y + windowSize.height)
+    }
+
+
+    private fun runTextFieldTest(body: suspend WindowTestScope.() -> Unit) = runApplicationTest(
+        hasAnimations = true,
+        animationsDelayMillis = 100
+    ) {
+        launchTestWindowApplication {
+            var text by remember { mutableStateOf(TextFieldValue()) }
+
+            val focusRequester = FocusRequester()
+            TextField(
+                value = text,
+                onValueChange = { text = it },
+                modifier = Modifier.focusRequester(focusRequester)
+            )
+
+            LaunchedEffect(focusRequester) {
+                focusRequester.requestFocus()
+            }
+        }
+        awaitIdle()
+        body()
+    }
+}


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5056/Exception-in-thread-AWT-EventQueue-0-java.lang.NullPointerException-Cannot-read-field-x-because-rc-is-null

In the upstream 1.7, there were significant changes - PlatformTextInputService was deprecated. The adapter for CMP platform was wrongly written (1825ef75). Wrongly, because `notifyFocusedRect` is no longer called. It is used for showing input methods on the screen:
![image](https://github.com/user-attachments/assets/fdfe097c-c236-475c-b2e7-5a6ecb46b0f3)

1.6.11 chain:
```
CoreTextField <- LocalTextInputService
```
1.7.0-alpha01 chain (wrong):
```
val serviceAdapter = LegacyPlatformTextInputServiceAdapter(LocalTextInputService)
CoreTextField <- serviceAdapter
CoreTextField <- TextInputService(serviceAdapter)
```

In this PR:
```
CoreTextField <- LegacyPlatformTextInputServiceAdapter(LocalTextInputService)
CoreTextField <- LocalTextInputService
```

## Testing

1. New test
2. Manual on Windows with Chinese layout

Needed to be tested by QA.

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ Fix input methods position on the screen and `NullPointerException: Cannot read field`