### PR TITLE
Make k/wasm variants of compose-ui and compose-foundation depend on a new library with w3c kotlin API

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -219,6 +219,13 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                     implementation(libs.mockitoKotlin)
                 }
             }
+
+            wasmJsMain {
+                dependencies {
+                    implementation(libs.kotlinX.w3c)
+                }
+            }
+
             desktopTest.kotlin.srcDirs("src/desktopTest/kotlin")
 
             nativeTest.dependsOn(jsNativeTest)

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -222,7 +222,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             wasmJsMain {
                 dependencies {
-                    implementation(libs.kotlinX.w3c)
+                    implementation(libs.kotlinXw3c)
                 }
             }
 

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -165,7 +165,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsTest.dependsOn(jbTest)
             nativeTest.dependsOn(jbTest)
 
-            wasmJsMain.dependsOn(jsWasmMain)
+            wasmJsMain {
+                dependsOn(jsWasmMain)
+                dependencies {
+                    implementation(libs.kotlinXw3c)
+                }
+            }
             wasmJsTest.dependsOn(jbTest)
 
             nativeMain {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -241,7 +241,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                     implementation(libs.kotlinStdlib)
                     implementation(libs.create("skikoWasm"))
                     implementation(libs.create("skikoWasmWasm"))
-                    api(libs.kotlinX.w3c)
+                    api(libs.kotlinXw3c)
                 }
             }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -241,6 +241,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                     implementation(libs.kotlinStdlib)
                     implementation(libs.create("skikoWasm"))
                     implementation(libs.create("skikoWasmWasm"))
+                    api(libs.kotlinX.w3c)
                 }
             }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -197,7 +197,7 @@ kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = 
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.12.0" }
 kotlinPoetJavaPoet = { module = "com.squareup:kotlinpoet-javapoet", version = "1.12.0" }
 kotlinXHtml = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.7.3" }
-kotlinX-w3c = { module = "org.jetbrains.kotlinx:kotlinx-browser", version = "0.1" }
+kotlinXw3c = { module = "org.jetbrains.kotlinx:kotlinx-browser", version = "0.1" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 kspApi = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 kspGradlePluginz = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -197,6 +197,7 @@ kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = 
 kotlinPoet = { module = "com.squareup:kotlinpoet", version = "1.12.0" }
 kotlinPoetJavaPoet = { module = "com.squareup:kotlinpoet-javapoet", version = "1.12.0" }
 kotlinXHtml = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.7.3" }
+kotlinX-w3c = { module = "org.jetbrains.kotlinx:kotlinx-browser", version = "0.1" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 kspApi = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 kspGradlePluginz = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }


### PR DESCRIPTION
The new library: org.jetbrains.kotlinx:kotlinx-browser

This is a preparation for the future, when w3c API won't be a part of kotlin-wasm stdlib anymore. 
By doing it now we make sure that the developers won't have to add the dependency themselves after they update to kotlin 2.1.x

Closes: https://youtrack.jetbrains.com/issue/CMP-5910/CfW-k-wasm-use-new-library-for-w3c
