### PR TITLE
Fix kotlin.IndexOutOfBoundsException.

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainer.uikit.kt
@@ -384,7 +384,7 @@ internal class ComposeContainer(
         lifecycleOwner.dispose()
         mediator?.dispose()
         mediator = null
-        layers.fastForEach {
+        layers.fastForEachReversed {
             it.close()
         }
     }


### PR DESCRIPTION
Close a ComposeSceneLayer will also remove it from the container, thus making the layers modified while being iterated. Iterating the layers reversely may be the simplest fix since the removal always happens to the last element.

