### PR TITLE
Set a separate versioning for COMPOSE_MATERIAL3_ADAPTIVE

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -64,14 +64,16 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 
 `-Pjetbrains.publication.version.CORE_BUNDLE`,
 `-Pjetbrains.publication.version.COMPOSE`,
+`-Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE`,
 `-Pjetbrains.publication.version.LIFECYCLE`,
 `-Pjetbrains.publication.version.NAVIGATION`,
-`-Pjetbrains.publication.version.SAVEDSTATE`
+`-Pjetbrains.publication.version.SAVEDSTATE`,
+`-Pjetbrains.publication.version.WINDOW`,
 
 The default value for the version is `0.0.0-SNAPSHOT`
 
 And library groups:
-`-Pjetbrains.publication.libraries=CORE_BUNDLE,COMPOSE,LIFECYCLE,NAVIGATION,SAVEDSTATE,WINDOW`
+`-Pjetbrains.publication.libraries=CORE_BUNDLE,COMPOSE,COMPOSE_MATERIAL3_ADAPTIVE,LIFECYCLE,NAVIGATION,SAVEDSTATE,WINDOW`
 
 The default value includes all libraries.
 

--- a/buildSrc/private/src/main/kotlin/androidx/build/LibraryVersionsService.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/LibraryVersionsService.kt
@@ -63,7 +63,7 @@ abstract class LibraryVersionsService : BuildService<LibraryVersionsService.Para
         val versions = getTable("versions")
         val libsGroupsAndVersions = parameters.libsOverrideVersions.get()
         versions.keySet().associateWith { versionName ->
-            val tagName = libsGroupsAndVersions.keys.firstOrNull { versionName.startsWith(it) }
+            val tagName = libsGroupsAndVersions.keys.firstOrNull { versionName == it }
             val versionForTag = libsGroupsAndVersions[tagName]
             val versionValue =
                 if (versionName.startsWith("COMPOSE") &&

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -191,11 +191,11 @@ CARDVIEW = { group = "androidx.cardview", atomicGroupVersion = "versions.CARDVIE
 CAR_APP = { group = "androidx.car.app", atomicGroupVersion = "versions.CAR_APP" }
 COLLECTION = { group = "androidx.collection", atomicGroupVersion = "versions.COLLECTION" }
 COMPOSE_ANIMATION = { group = "org.jetbrains.compose.animation", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_COMPILER = { group = "org.jetbrains.compose.compiler", atomicGroupVersion = "versions.COMPOSE_COMPILER" }
+COMPOSE_COMPILER = { group = "org.jetbrains.compose.compiler", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_DESKTOP = { group = "org.jetbrains.compose.desktop", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_FOUNDATION = { group = "org.jetbrains.compose.foundation", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_MATERIAL = { group = "org.jetbrains.compose.material", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3" }
+COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_MATERIAL3_COMMON = { group = "org.jetbrains.compose.material3.common", atomicGroupVersion = "versions.COMPOSE_MATERIAL3_COMMON", overrideInclude = [ ":compose:material3:material3-common" ] }
 COMPOSE_MATERIAL3_ADAPTIVE = { group = "org.jetbrains.compose.material3.adaptive", atomicGroupVersion = "versions.COMPOSE_MATERIAL3_ADAPTIVE" }
 COMPOSE_RUNTIME = { group = "org.jetbrains.compose.runtime", atomicGroupVersion = "versions.COMPOSE" }

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -54,9 +54,6 @@ val libraryToComponents = mapOf(
         ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
         ComposeComponent(":compose:material3:material3-window-size-class"),
-        ComposeComponent(":compose:material3:adaptive:adaptive"),
-        ComposeComponent(":compose:material3:adaptive:adaptive-layout"),
-        ComposeComponent(":compose:material3:adaptive:adaptive-navigation"),
         ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":compose:runtime:runtime-saveable", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":compose:ui:ui"),
@@ -83,6 +80,11 @@ val libraryToComponents = mapOf(
         ),
         ComposeComponent(":compose:ui:ui-unit"),
         ComposeComponent(":compose:ui:ui-util"),
+    ),
+    "COMPOSE_MATERIAL3_ADAPTIVE" to listOf(
+        ComposeComponent(":compose:material3:adaptive:adaptive"),
+        ComposeComponent(":compose:material3:adaptive:adaptive-layout"),
+        ComposeComponent(":compose:material3:adaptive:adaptive-navigation"),
     ),
     "LIFECYCLE" to listOf(
         ComposeComponent(


### PR DESCRIPTION
Also, change the overriding mechanism, now strict name is required

## Testing
```
gradlew :mpp:publishComposeJbToMavenLocal -Pjetbrains.publication.version.COMPOSE=0.1.0 -Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE=0.2.0 -Pjetbrains.publication.libraries=COMPOSE_MATERIAL3_ADAPTIVE
```
creates `.m2\repository\org\jetbrains\compose\material3\adaptive\adaptive\0.2.0` that depends on Compose 0.1.0