### PR TITLE
Fix FPS drops when dragging scrollable content

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -490,42 +490,6 @@ class WindowInputEventTest {
         assertThat(deltas.all { it == Offset(0f, 1f) }).isTrue()
     }
 
-    @Test
-    fun `catch only the first scroll event in one frame`() = runApplicationTest {
-        lateinit var window: ComposeWindow
-
-        val deltas = mutableListOf<Offset>()
-
-        launchTestApplication {
-            Window(
-                onCloseRequest = ::exitApplication,
-                state = rememberWindowState(width = 200.dp, height = 100.dp)
-            ) {
-                window = this.window
-
-                Box(
-                    Modifier
-                        .fillMaxSize()
-                        .onFirstPointerEvent(PointerEventType.Scroll) {
-                            deltas.add(it.changes.first().scrollDelta)
-                        }
-                )
-            }
-        }
-
-        awaitIdle()
-        assertThat(deltas.size).isEqualTo(0)
-
-        val eventCount = 500
-
-        repeat(eventCount) {
-            window.sendMouseWheelEvent(100, 50, WHEEL_UNIT_SCROLL, wheelRotation = 1.0)
-        }
-        awaitIdle()
-        assertThat(deltas.size).isEqualTo(1)
-        assertThat(deltas.first()).isEqualTo(Offset(0f, 1f))
-    }
-
     @Test(timeout = 5000)
     fun `receive buttons and modifiers`() = runApplicationTest {
         lateinit var window: ComposeWindow

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -40,8 +40,8 @@ import androidx.compose.ui.node.SnapshotInvalidationTracker
 import androidx.compose.ui.platform.GlobalSnapshotManager
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.util.trace
-import kotlin.coroutines.CoroutineContext
 import kotlin.concurrent.Volatile
+import kotlin.coroutines.CoroutineContext
 
 /**
  * BaseComposeScene is an internal abstract class that implements the ComposeScene interface.
@@ -79,7 +79,7 @@ internal abstract class BaseComposeScene(
         private set
 
     private var isInvalidationDisabled = false
-    private var hasPendingDisabledInvalidations = false
+    private var hasPostponedInvalidations = false
     private inline fun <T> postponeInvalidation(traceTag: String, crossinline block: () -> T): T = trace(traceTag) {
         check(!isClosed) { "postponeInvalidation called after ComposeScene is closed" }
         isInvalidationDisabled = true
@@ -93,7 +93,7 @@ internal abstract class BaseComposeScene(
             isInvalidationDisabled = false
         }.also {
             updateInvalidations()
-            hasPendingDisabledInvalidations = false
+            hasPostponedInvalidations = false
         }
     }
 
@@ -102,10 +102,10 @@ internal abstract class BaseComposeScene(
     protected fun updateInvalidations() {
         hasPendingDraws = frameClock.hasAwaiters ||
             snapshotInvalidationTracker.hasInvalidations ||
-            hasPendingDisabledInvalidations
+            hasPostponedInvalidations
         if (hasPendingDraws && !isClosed && composition != null) {
             if (isInvalidationDisabled) {
-                hasPendingDisabledInvalidations = true
+                hasPostponedInvalidations = true
             } else {
                 invalidate()
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -79,7 +79,6 @@ internal abstract class BaseComposeScene(
         private set
 
     private var isInvalidationDisabled = false
-    private var hasPostponedInvalidations = false
     private inline fun <T> postponeInvalidation(traceTag: String, crossinline block: () -> T): T = trace(traceTag) {
         check(!isClosed) { "postponeInvalidation called after ComposeScene is closed" }
         isInvalidationDisabled = true
@@ -93,12 +92,12 @@ internal abstract class BaseComposeScene(
             isInvalidationDisabled = false
         }.also {
             updateInvalidations()
-            hasPostponedInvalidations = false
         }
     }
 
     @Volatile
     private var hasPendingDraws = true
+    private var hasPostponedInvalidations = false
     protected fun updateInvalidations() {
         hasPendingDraws = frameClock.hasAwaiters ||
             snapshotInvalidationTracker.hasInvalidations ||
@@ -107,6 +106,7 @@ internal abstract class BaseComposeScene(
             if (isInvalidationDisabled) {
                 hasPostponedInvalidations = true
             } else {
+                hasPostponedInvalidations = false
                 invalidate()
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -218,6 +218,9 @@ internal class MetalRedrawer(
         target = DisplayLinkProxy {
             val targetTimestamp = currentTargetTimestamp ?: return@DisplayLinkProxy
 
+            // Run all scheduled operations in current Run Loop first, then do rendering.
+            NSRunLoop.currentRunLoop().runUntilDate(NSDate())
+
             displayLinkConditions.onDisplayLinkTick {
                 draw(waitUntilCompletion = false, targetTimestamp)
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -218,9 +218,6 @@ internal class MetalRedrawer(
         target = DisplayLinkProxy {
             val targetTimestamp = currentTargetTimestamp ?: return@DisplayLinkProxy
 
-            // Run all scheduled operations in current Run Loop first, then do rendering.
-            NSRunLoop.currentRunLoop().runUntilDate(NSDate())
-
             displayLinkConditions.onDisplayLinkTick {
                 draw(waitUntilCompletion = false, targetTimestamp)
             }


### PR DESCRIPTION
Apply all scheduled effects after each interaction event so that they are applied synchronously.

Fixes: https://youtrack.jetbrains.com/issue/CMP-1644
Fixes: https://youtrack.jetbrains.com/issue/CMP-4438

## Release Notes

### Fixes - iOS
Fix frame drops when dragging scrollable content on iOS