### PR TITLE
Simplify intermediate source set configuration in compose/ui/ui

### DIFF
--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -226,8 +226,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsWasmMain.dependsOn(notMobileMain)
             macosMain.dependsOn(notMobileMain)
 
+            webCommonW3C {}
+
             jsMain {
-                kotlin.srcDir("src/webCommonW3C/kotlin")
+                dependsOn(webCommonW3C)
                 dependsOn(jsWasmMain)
                 dependencies {
                     api(libs.skikoCommon)
@@ -235,7 +237,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             }
 
             wasmJsMain {
-                kotlin.srcDir("src/webCommonW3C/kotlin")
+                dependsOn(webCommonW3C)
                 dependsOn(jsWasmMain)
                 dependencies {
                     implementation(libs.kotlinStdlib)

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -226,10 +226,8 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jsWasmMain.dependsOn(notMobileMain)
             macosMain.dependsOn(notMobileMain)
 
-            webCommonW3C {}
-
             jsMain {
-                dependsOn(webCommonW3C)
+                kotlin.srcDir("src/webCommonW3C/kotlin")
                 dependsOn(jsWasmMain)
                 dependencies {
                     api(libs.skikoCommon)
@@ -237,7 +235,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             }
 
             wasmJsMain {
-                dependsOn(webCommonW3C)
+                kotlin.srcDir("src/webCommonW3C/kotlin")
                 dependsOn(jsWasmMain)
                 dependencies {
                     implementation(libs.kotlinStdlib)

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/Actuals.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/Actuals.js.kt
@@ -21,5 +21,3 @@ internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
         "Object.getPrototypeOf(a).constructor == Object.getPrototypeOf(b).constructor"
     )) as Boolean
 }
-
-internal actual fun getCurrentThreadId(): Long = 0

--- a/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/platform/Actuals.jsNative.kt
+++ b/compose/ui/ui/src/jsNativeMain/kotlin/androidx/compose/ui/platform/Actuals.jsNative.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,4 @@
 
 package androidx.compose.ui.platform
 
-internal actual fun simpleIdentityToString(obj: Any, name: String?): String {
-    val className = name ?: obj::class.qualifiedName ?: "<object>"
-    return "$className@${obj.hashCode()}"
-}
+internal actual fun Any.nativeClass(): Any = this::class

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/Actuals.jsWasm.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/Actuals.jsWasm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-package androidx.compose.ui.platform
+package androidx.compose.ui
 
-internal actual fun Any.nativeClass(): Any = this::class
-
-internal actual fun simpleIdentityToString(obj: Any, name: String?): String {
-    val className = name ?: "<object>"
-    return "$className@${obj.hashCode()}"
-}
+internal actual fun getCurrentThreadId(): Long = 0

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/platform/Actuals.jsWasm.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/platform/Actuals.jsWasm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2023 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,6 @@
 package androidx.compose.ui.platform
 
 internal actual fun simpleIdentityToString(obj: Any, name: String?): String {
-    val className = name ?: obj::class.qualifiedName ?: "<object>"
+    val className = name ?: "<object>"
     return "$className@${obj.hashCode()}"
 }

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/Actuals.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/Actuals.wasm.kt
@@ -16,15 +16,6 @@
 
 package androidx.compose.ui
 
-@JsFun("x => { try { Object.getPrototypeOf(x) } catch(e) { return true; }; return false; }")
-private external fun isNotJs(x: JsAny): Boolean
-
-@JsFun("(a, b) => Object.getPrototypeOf(a).constructor == Object.getPrototypeOf(b).constructor")
-private external fun areObjectsOfSameTypeJsImpl(a: JsAny, b: JsAny): Boolean
-
-
 internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a === b || a::class == b::class
 }
-
-internal actual fun getCurrentThreadId(): Long = 0


### PR DESCRIPTION
In particular, following entities are actualized earlier (thus, avoiding code reduplication):

    *  nativeClass actualization belongs to the jsNativeMain shared intermediate sourceSet
    *  getCurrentThreadId actualization nelongs to the jsWasmMain shared intermediate sourceSet

The reasoning behind this changes (which make self per se) is to simplify build in order to find what causes troubles with js tests
