### PR TITLE
Correctly save/restore of `NavController`

### DIFF
--- a/core/core-bundle/src/commonMain/kotlin/androidx/core/bundle/Bundle.kt
+++ b/core/core-bundle/src/commonMain/kotlin/androidx/core/bundle/Bundle.kt
@@ -42,8 +42,8 @@ expect class Bundle() {
     fun putString(key: String?, value: String?)
     fun putCharSequence(key: String?, value: CharSequence?)
     fun putBundle(key: String?, value: Bundle?)
-    fun putIntegerArrayList(key: String?, value: ArrayList<Int>?)
-    fun putStringArrayList(key: String?, value: ArrayList<String>?)
+    fun putIntegerArrayList(key: String?, value: ArrayList<Int?>?)
+    fun putStringArrayList(key: String?, value: ArrayList<String?>?)
     fun putBooleanArray(key: String?, value: BooleanArray?)
     fun putByteArray(key: String?, value: ByteArray?)
     fun putShortArray(key: String?, value: ShortArray?)
@@ -52,8 +52,8 @@ expect class Bundle() {
     fun putLongArray(key: String?, value: LongArray?)
     fun putFloatArray(key: String?, value: FloatArray?)
     fun putDoubleArray(key: String?, value: DoubleArray?)
-    fun putStringArray(key: String?, value: Array<String>?)
-    fun putCharSequenceArray(key: String?, value: Array<CharSequence>?)
+    fun putStringArray(key: String?, value: Array<String?>?)
+    fun putCharSequenceArray(key: String?, value: Array<CharSequence?>?)
 
     fun getBoolean(key: String?): Boolean
     fun getBoolean(key: String?, defaultValue: Boolean): Boolean
@@ -76,8 +76,8 @@ expect class Bundle() {
     fun getCharSequence(key: String?): CharSequence?
     fun getCharSequence(key: String?, defaultValue: CharSequence): CharSequence
     fun getBundle(key: String?): Bundle?
-    fun getIntegerArrayList(key: String?): ArrayList<Int>?
-    fun getStringArrayList(key: String?): ArrayList<String>?
+    fun getIntegerArrayList(key: String?): ArrayList<Int?>?
+    fun getStringArrayList(key: String?): ArrayList<String?>?
     fun getBooleanArray(key: String?): BooleanArray?
     fun getByteArray(key: String?): ByteArray?
     fun getShortArray(key: String?): ShortArray?
@@ -86,8 +86,8 @@ expect class Bundle() {
     fun getLongArray(key: String?): LongArray?
     fun getFloatArray(key: String?): FloatArray?
     fun getDoubleArray(key: String?): DoubleArray?
-    fun getStringArray(key: String?): Array<String>?
-    fun getCharSequenceArray(key: String?): Array<CharSequence>?
+    fun getStringArray(key: String?): Array<String?>?
+    fun getCharSequenceArray(key: String?): Array<CharSequence?>?
 
     @Deprecated("Use the type-safe specific APIs depending on the type of the item to be retrieved")
     operator fun get(key: String?): Any?

--- a/core/core-bundle/src/commonMain/kotlin/androidx/core/bundle/Bundle.kt
+++ b/core/core-bundle/src/commonMain/kotlin/androidx/core/bundle/Bundle.kt
@@ -41,6 +41,7 @@ expect class Bundle() {
     fun putDouble(key: String?, value: Double)
     fun putString(key: String?, value: String?)
     fun putCharSequence(key: String?, value: CharSequence?)
+    fun putBundle(key: String?, value: Bundle?)
     fun putIntegerArrayList(key: String?, value: ArrayList<Int>?)
     fun putStringArrayList(key: String?, value: ArrayList<String>?)
     fun putBooleanArray(key: String?, value: BooleanArray?)
@@ -53,7 +54,6 @@ expect class Bundle() {
     fun putDoubleArray(key: String?, value: DoubleArray?)
     fun putStringArray(key: String?, value: Array<String>?)
     fun putCharSequenceArray(key: String?, value: Array<CharSequence>?)
-    fun putBundle(key: String?, value: Bundle?)
 
     fun getBoolean(key: String?): Boolean
     fun getBoolean(key: String?, defaultValue: Boolean): Boolean
@@ -75,6 +75,7 @@ expect class Bundle() {
     fun getString(key: String?, defaultValue: String): String
     fun getCharSequence(key: String?): CharSequence?
     fun getCharSequence(key: String?, defaultValue: CharSequence): CharSequence
+    fun getBundle(key: String?): Bundle?
     fun getIntegerArrayList(key: String?): ArrayList<Int>?
     fun getStringArrayList(key: String?): ArrayList<String>?
     fun getBooleanArray(key: String?): BooleanArray?
@@ -87,7 +88,6 @@ expect class Bundle() {
     fun getDoubleArray(key: String?): DoubleArray?
     fun getStringArray(key: String?): Array<String>?
     fun getCharSequenceArray(key: String?): Array<CharSequence>?
-    fun getBundle(key: String?): Bundle?
 
     @Deprecated("Use the type-safe specific APIs depending on the type of the item to be retrieved")
     operator fun get(key: String?): Any?
@@ -95,5 +95,7 @@ expect class Bundle() {
 
 /**
  * Returns a new [Bundle] with the given key/value pairs as elements.
+ *
+ * @throws IllegalArgumentException When a value is not a supported type of [Bundle].
  */
 expect fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle

--- a/core/core-bundle/src/jbMain/kotlin/androidx/core/bundle/Bundle.jb.kt
+++ b/core/core-bundle/src/jbMain/kotlin/androidx/core/bundle/Bundle.jb.kt
@@ -45,8 +45,8 @@ actual class Bundle internal constructor(
     actual fun putString(key: String?, value: String?) { setObject(key, value) }
     actual fun putCharSequence(key: String?, value: CharSequence?) { setObject(key, value) }
     actual fun putBundle(key: String?, value: Bundle?) { setObject(key, value) }
-    actual fun putIntegerArrayList(key: String?, value: ArrayList<Int>?) { setObject(key, value) }
-    actual fun putStringArrayList(key: String?, value: ArrayList<String>?) { setObject(key, value) }
+    actual fun putIntegerArrayList(key: String?, value: ArrayList<Int?>?) { setObject(key, value) }
+    actual fun putStringArrayList(key: String?, value: ArrayList<String?>?) { setObject(key, value) }
     actual fun putBooleanArray(key: String?, value: BooleanArray?) { setObject(key, value) }
     actual fun putByteArray(key: String?, value: ByteArray?) { setObject(key, value) }
     actual fun putShortArray(key: String?, value: ShortArray?) { setObject(key, value) }
@@ -55,9 +55,13 @@ actual class Bundle internal constructor(
     actual fun putLongArray(key: String?, value: LongArray?) { setObject(key, value) }
     actual fun putFloatArray(key: String?, value: FloatArray?) { setObject(key, value) }
     actual fun putDoubleArray(key: String?, value: DoubleArray?) { setObject(key, value) }
-    actual fun putStringArray(key: String?, value: Array<String>?) { setObject(key, value) }
-    actual fun putCharSequenceArray(key: String?, value: Array<CharSequence>?) { setObject(key, value) }
+    actual fun putStringArray(key: String?, value: Array<String?>?) { setObject(key, value) }
+    actual fun putCharSequenceArray(key: String?, value: Array<CharSequence?>?) { setObject(key, value) }
 
+    // Narrowed alternative of Android's [putParcelableArray]
+    fun putBundleArray(key: String?, value: Array<Bundle?>?) { setObject(key, value) }
+
+    @Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
     private inline fun <T> setObject(key: String?, value: T) {
         bundleData[key] = value
     }
@@ -86,8 +90,8 @@ actual class Bundle internal constructor(
     actual fun getCharSequence(key: String?, defaultValue: CharSequence): CharSequence =
         getCharSequence(key) ?: defaultValue
     actual fun getBundle(key: String?): Bundle? = getObject(key)
-    actual fun getIntegerArrayList(key: String?): ArrayList<Int>? = getArrayList(key)
-    actual fun getStringArrayList(key: String?): ArrayList<String>? = getArrayList(key)
+    actual fun getIntegerArrayList(key: String?): ArrayList<Int?>? = getArrayList(key)
+    actual fun getStringArrayList(key: String?): ArrayList<String?>? = getArrayList(key)
     actual fun getBooleanArray(key: String?): BooleanArray? = getObject(key)
     actual fun getByteArray(key: String?): ByteArray? = getObject(key)
     actual fun getShortArray(key: String?): ShortArray? = getObject(key)
@@ -96,8 +100,11 @@ actual class Bundle internal constructor(
     actual fun getLongArray(key: String?): LongArray? = getObject(key)
     actual fun getFloatArray(key: String?): FloatArray? = getObject(key)
     actual fun getDoubleArray(key: String?): DoubleArray? = getObject(key)
-    actual fun getStringArray(key: String?): Array<String>? = getArray(key)
-    actual fun getCharSequenceArray(key: String?): Array<CharSequence>? = getArray(key)
+    actual fun getStringArray(key: String?): Array<String?>? = getArray(key)
+    actual fun getCharSequenceArray(key: String?): Array<CharSequence?>? = getArray(key)
+
+    // Narrowed alternative of Android's [getParcelableArray]
+    fun getBundleArray(key: String?): Array<Bundle?>? = getArray(key)
 
     @Deprecated("Use the type-safe specific APIs depending on the type of the item to be retrieved")
     actual operator fun get(key: String?): Any? = bundleData.get(key)
@@ -123,10 +130,10 @@ actual class Bundle internal constructor(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T : Any> getArrayList(key: String?): ArrayList<T>? {
+    private inline fun <reified T : Any> getArrayList(key: String?): ArrayList<T?>? {
         val value = bundleData.get(key) ?: return null
         return try {
-            value as ArrayList<T>?
+            value as ArrayList<T?>?
         } catch (e: ClassCastException) {
             typeWarning(key, value, "ArrayList<" + T::class.canonicalName!! + ">", e)
             null
@@ -134,10 +141,10 @@ actual class Bundle internal constructor(
     }
 
     @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T : Any> getArray(key: String?): Array<T>? {
+    private inline fun <reified T : Any> getArray(key: String?): Array<T?>? {
         val value = bundleData.get(key) ?: return null
         return try {
-            value as Array<T>?
+            value as Array<T?>?
         } catch (e: ClassCastException) {
             typeWarning(key, value, "Array<" + T::class.canonicalName!! + ">", e)
             null

--- a/core/core-bundle/src/jbMain/kotlin/androidx/core/bundle/Bundle.jb.kt
+++ b/core/core-bundle/src/jbMain/kotlin/androidx/core/bundle/Bundle.jb.kt
@@ -19,19 +19,20 @@ package androidx.core.bundle
 import kotlin.reflect.KClass
 
 @Suppress("ReplaceGetOrSet")
-actual class Bundle {
-    private val mMap: MutableMap<String?, Any?>
-    actual constructor() { mMap = LinkedHashMap() }
-    actual constructor(initialCapacity: Int) { mMap = LinkedHashMap(initialCapacity) }
-    actual constructor(bundle: Bundle) { mMap = LinkedHashMap(bundle.mMap) }
+actual class Bundle internal constructor(
+    private val bundleData: MutableMap<String?, Any?>
+) {
+    actual constructor() : this(bundleData = LinkedHashMap())
+    actual constructor(initialCapacity: Int) : this(bundleData = LinkedHashMap(initialCapacity))
+    actual constructor(bundle: Bundle) : this(bundleData = LinkedHashMap(bundle.bundleData))
 
-    actual fun size() = mMap.size
-    actual fun isEmpty() = mMap.isEmpty()
-    actual fun clear() = mMap.clear()
-    actual fun containsKey(key: String?) = mMap.containsKey(key)
-    actual fun remove(key: String?) { mMap.remove(key) }
-    actual fun keySet(): Set<String?> = mMap.keys
-    actual fun putAll(bundle: Bundle) { mMap.putAll(bundle.mMap) }
+    actual fun size(): Int = bundleData.size
+    actual fun isEmpty(): Boolean = bundleData.isEmpty()
+    actual fun clear() { bundleData.clear() }
+    actual fun containsKey(key: String?): Boolean = bundleData.containsKey(key)
+    actual fun remove(key: String?) { bundleData.remove(key) }
+    actual fun keySet(): Set<String?> = bundleData.keys
+    actual fun putAll(bundle: Bundle) { bundleData.putAll(bundle.bundleData) }
 
     actual fun putBoolean(key: String?, value: Boolean) { setObject(key, value) }
     actual fun putByte(key: String?, value: Byte) { setObject(key, value) }
@@ -43,6 +44,7 @@ actual class Bundle {
     actual fun putDouble(key: String?, value: Double) { setObject(key, value) }
     actual fun putString(key: String?, value: String?) { setObject(key, value) }
     actual fun putCharSequence(key: String?, value: CharSequence?) { setObject(key, value) }
+    actual fun putBundle(key: String?, value: Bundle?) { setObject(key, value) }
     actual fun putIntegerArrayList(key: String?, value: ArrayList<Int>?) { setObject(key, value) }
     actual fun putStringArrayList(key: String?, value: ArrayList<String>?) { setObject(key, value) }
     actual fun putBooleanArray(key: String?, value: BooleanArray?) { setObject(key, value) }
@@ -55,10 +57,9 @@ actual class Bundle {
     actual fun putDoubleArray(key: String?, value: DoubleArray?) { setObject(key, value) }
     actual fun putStringArray(key: String?, value: Array<String>?) { setObject(key, value) }
     actual fun putCharSequenceArray(key: String?, value: Array<CharSequence>?) { setObject(key, value) }
-    actual fun putBundle(key: String?, value: Bundle?) { setObject(key, value) }
 
-    private inline fun setObject(key: String?, value: Any?) {
-        mMap[key] = value
+    private inline fun <T> setObject(key: String?, value: T) {
+        bundleData[key] = value
     }
 
     actual fun getBoolean(key: String?): Boolean = getBoolean(key, defaultValue = false)
@@ -84,6 +85,7 @@ actual class Bundle {
     actual fun getCharSequence(key: String?): CharSequence? = getObject(key)
     actual fun getCharSequence(key: String?, defaultValue: CharSequence): CharSequence =
         getCharSequence(key) ?: defaultValue
+    actual fun getBundle(key: String?): Bundle? = getObject(key)
     actual fun getIntegerArrayList(key: String?): ArrayList<Int>? = getArrayList(key)
     actual fun getStringArrayList(key: String?): ArrayList<String>? = getArrayList(key)
     actual fun getBooleanArray(key: String?): BooleanArray? = getObject(key)
@@ -96,49 +98,48 @@ actual class Bundle {
     actual fun getDoubleArray(key: String?): DoubleArray? = getObject(key)
     actual fun getStringArray(key: String?): Array<String>? = getArray(key)
     actual fun getCharSequenceArray(key: String?): Array<CharSequence>? = getArray(key)
-    actual fun getBundle(key: String?): Bundle? = getObject(key)
 
     @Deprecated("Use the type-safe specific APIs depending on the type of the item to be retrieved")
-    actual operator fun get(key: String?): Any? = mMap.get(key)
+    actual operator fun get(key: String?): Any? = bundleData.get(key)
 
-    private inline fun <reified T: Any> getObject(key: String?): T? {
-        val o = mMap.get(key) ?: return null
+    private inline fun <reified T : Any> getObject(key: String?): T? {
+        val value = bundleData.get(key) ?: return null
         return try {
-            o as T?
+            value as T?
         } catch (e: ClassCastException) {
-            typeWarning(key, o, T::class.canonicalName!!, e)
+            typeWarning(key, value, T::class.canonicalName!!, e)
             null
         }
     }
 
-    private inline fun <reified T: Any> getObject(key: String?, defaultValue: T): T {
-        val o = mMap.get(key) ?: return defaultValue
+    private inline fun <reified T : Any> getObject(key: String?, defaultValue: T): T {
+        val value = bundleData.get(key) ?: return defaultValue
         return try {
-            o as T
+            value as T
         } catch (e: ClassCastException) {
-            typeWarning(key, o, T::class.canonicalName!!, defaultValue, e)
+            typeWarning(key, value, T::class.canonicalName!!, defaultValue, e)
             defaultValue
         }
     }
 
     @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T: Any> getArrayList(key: String?): ArrayList<T>? {
-        val o = mMap.get(key) ?: return null
+    private inline fun <reified T : Any> getArrayList(key: String?): ArrayList<T>? {
+        val value = bundleData.get(key) ?: return null
         return try {
-            o as ArrayList<T>?
+            value as ArrayList<T>?
         } catch (e: ClassCastException) {
-            typeWarning(key, o, "ArrayList<" + T::class.canonicalName!! + ">", e)
+            typeWarning(key, value, "ArrayList<" + T::class.canonicalName!! + ">", e)
             null
         }
     }
 
     @Suppress("UNCHECKED_CAST")
-    private inline fun <reified T: Any> getArray(key: String?): Array<T>? {
-        val o = mMap.get(key) ?: return null
+    private inline fun <reified T : Any> getArray(key: String?): Array<T>? {
+        val value = bundleData.get(key) ?: return null
         return try {
-            o as Array<T>?
+            value as Array<T>?
         } catch (e: ClassCastException) {
-            typeWarning(key, o, "Array<" + T::class.canonicalName!! + ">", e)
+            typeWarning(key, value, "Array<" + T::class.canonicalName!! + ">", e)
             null
         }
     }
@@ -172,6 +173,8 @@ actual class Bundle {
     private fun typeWarning(key: String?, value: Any?, className: String, e: RuntimeException) {
         typeWarning(key, value, className, "<null>", e)
     }
+
+    override fun toString(): String = "$bundleData"
 }
 
 actual fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle = Bundle(pairs.size).apply {
@@ -191,10 +194,23 @@ actual fun bundleOf(vararg pairs: Pair<String, Any?>): Bundle = Bundle(pairs.siz
 
             // References
             is Bundle -> putBundle(key, value)
+            is String -> putString(key, value)
             is CharSequence -> putCharSequence(key, value)
 
             // Scalar arrays
+            is BooleanArray -> putBooleanArray(key, value)
             is ByteArray -> putByteArray(key, value)
+            is CharArray -> putCharArray(key, value)
+            is DoubleArray -> putDoubleArray(key, value)
+            is FloatArray -> putFloatArray(key, value)
+            is IntArray -> putIntArray(key, value)
+            is LongArray -> putLongArray(key, value)
+            is ShortArray -> putShortArray(key, value)
+
+            else -> {
+                val valueType = value::class.canonicalName
+                throw IllegalArgumentException("Illegal value type $valueType for key \"$key\"")
+            }
         }
     }
 }

--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavType.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavType.jb.kt
@@ -581,7 +581,8 @@ public actual abstract class NavType<T> actual constructor(
                     get() = "string[]"
 
                 override fun put(bundle: Bundle, key: String, value: Array<String>?) {
-                    bundle.putStringArray(key, value)
+                    @Suppress("UNCHECKED_CAST")
+                    bundle.putStringArray(key, value as Array<String?>?)
                 }
 
                 @Suppress("UNCHECKED_CAST", "DEPRECATION")

--- a/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavBackStackEntryState.jb.kt
+++ b/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavBackStackEntryState.jb.kt
@@ -19,7 +19,6 @@ package androidx.navigation
 import androidx.core.bundle.Bundle
 import androidx.lifecycle.Lifecycle
 
-// TODO: Make @Serializable
 internal data class NavBackStackEntryState(
     val id: String,
     val destinationId: Int,
@@ -48,5 +47,33 @@ internal data class NavBackStackEntryState(
             id,
             savedState
         )
+    }
+
+    fun toBundle(): Bundle = Bundle().apply {
+        putString(KEY_ID, id)
+        putInt(KEY_DESTINATION_ID, destinationId)
+        putBundle(KEY_ARGS, args)
+        putBundle(KEY_SAVED_STATE, savedState)
+    }
+
+    companion object {
+        private const val KEY_ID = "NavBackStackEntryState.id"
+        private const val KEY_DESTINATION_ID = "NavBackStackEntryState.destinationId"
+        private const val KEY_ARGS = "NavBackStackEntryState.args"
+        private const val KEY_SAVED_STATE = "NavBackStackEntryState.savedState"
+
+        fun fromBundle(bundle: Bundle?): NavBackStackEntryState? {
+            if (bundle == null) return null
+            val id = bundle.getString(KEY_ID) ?: return null
+            val destinationId = bundle.getInt(KEY_DESTINATION_ID)
+            val args = bundle.getBundle(KEY_ARGS) ?: return null
+            val savedState = bundle.getBundle(KEY_SAVED_STATE) ?: return null
+            return NavBackStackEntryState(
+                id = id,
+                destinationId = destinationId,
+                args = args,
+                savedState = savedState
+            )
+        }
     }
 }

--- a/savedstate/savedstate/src/jvmMain/kotlin/androidx/savedstate/Recreator.jvm.kt
+++ b/savedstate/savedstate/src/jvmMain/kotlin/androidx/savedstate/Recreator.jvm.kt
@@ -32,13 +32,13 @@ internal class Recreator(
         source.lifecycle.removeObserver(this)
         val bundle: Bundle = owner.savedStateRegistry
             .consumeRestoredStateForKey(COMPONENT_KEY) ?: return
-        val classes: MutableList<String> = bundle.getStringArrayList(CLASSES_KEY)
+        val classes = bundle.getStringArrayList(CLASSES_KEY)
             ?: throw IllegalStateException(
                 "Bundle with restored state for the component " +
                     "\"$COMPONENT_KEY\" must contain list of strings by the key " +
                     "\"$CLASSES_KEY\""
             )
-        for (className: String in classes) {
+        for (className in classes.filterNotNull()) {
             reflectiveNew(className)
         }
     }


### PR DESCRIPTION
Adding a way to put an array of bundles into another bundle and implement saving/restoring `NavBackStackEntryState`/`NavController`

Fixes https://github.com/JetBrains/compose-multiplatform/issues/4735
Fixes [CMP-1403](https://youtrack.jetbrains.com/issue/CMP-1403), [CMP-4735](https://youtrack.jetbrains.com/issue/CMP-4735)

## Testing
Test cases are in attached issues.
This should be tested by QA

## Release Notes

### Fixes - Navigation
- _(prerelease fix)_ Fix saving state for nested `NavHostController`

