### PR TITLE
Don't access directly event dispatching in OnCanvasTests

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -36,21 +36,17 @@ private const val canvasId: String = "canvasApp"
 internal interface OnCanvasTests {
     fun getCanvas() = document.getElementById(canvasId) as HTMLCanvasElement
 
-    fun createCanvas(): HTMLCanvasElement {
-        val canvas = document.createElement("canvas") as HTMLCanvasElement
-        canvas.setAttribute("id", canvasId)
-        canvas.setAttribute("tabindex", "0")
-
-        return canvas
-    }
-
     private fun resetCanvas() {
         /** TODO: [kotlin.test.AfterTest] is fixed only in kotlin 2.0
         see https://youtrack.jetbrains.com/issue/KT-61888
          */
         document.getElementById(canvasId)?.remove()
 
-        document.body!!.appendChild(createCanvas())
+        val canvas = document.createElement("canvas") as HTMLCanvasElement
+        canvas.setAttribute("id", canvasId)
+        canvas.setAttribute("tabindex", "0")
+
+        document.body!!.appendChild(canvas)
     }
 
     fun createComposeWindow(content: @Composable () -> Unit) {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
+import org.w3c.dom.events.Event
 
 /**
  * An interface with helper functions to initialise the tests
@@ -35,22 +36,33 @@ private const val canvasId: String = "canvasApp"
 internal interface OnCanvasTests {
     fun getCanvas() = document.getElementById(canvasId) as HTMLCanvasElement
 
-    fun resetCanvas(): HTMLCanvasElement {
+    fun createCanvas(): HTMLCanvasElement {
+        val canvas = document.createElement("canvas") as HTMLCanvasElement
+        canvas.setAttribute("id", canvasId)
+        canvas.setAttribute("tabindex", "0")
+
+        return canvas
+    }
+
+    private fun resetCanvas() {
         /** TODO: [kotlin.test.AfterTest] is fixed only in kotlin 2.0
         see https://youtrack.jetbrains.com/issue/KT-61888
          */
         document.getElementById(canvasId)?.remove()
 
-        val canvas = document.createElement("canvas") as HTMLCanvasElement
-        canvas.setAttribute("id", canvasId)
-        canvas.setAttribute("tabindex", "0")
-
-        document.body!!.appendChild(canvas)
-        return canvas
+        document.body!!.appendChild(createCanvas())
     }
 
     fun createComposeWindow(content: @Composable () -> Unit) {
+        resetCanvas()
         CanvasBasedWindow(canvasElementId = canvasId, content = content)
+    }
+
+    fun dispatchEvents(vararg events: Any) {
+        val canvas = getCanvas()
+        for (event in events) {
+            canvas.dispatchEvent(event as Event)
+        }
     }
 }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -28,12 +28,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.browser.document
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -45,11 +43,6 @@ import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.MouseEventInit
 
 class SelectionContainerTests : OnCanvasTests {
-
-    @BeforeTest
-    fun setup() {
-        resetCanvas()
-    }
 
     private fun HTMLCanvasElement.doClick() {
         dispatchEvent(MouseEvent("mousedown", MouseEventInit(5, 5, 5, 5, buttons = 1, button = 1)))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
@@ -23,17 +23,11 @@ import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import kotlin.math.abs
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 
 class TextTests : OnCanvasTests {
-
-    @BeforeTest
-    fun setup() {
-        resetCanvas()
-    }
 
     companion object {
         private fun assertApproximatelyEqual(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.events.keyDownEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.sendFromScope
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -39,11 +38,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
 
 class TextInputTests : OnCanvasTests  {
-
-    @BeforeTest
-    fun setup() {
-        resetCanvas()
-    }
 
     @Test
     fun keyboardEventPassedToTextField() = runTest {
@@ -79,38 +73,43 @@ class TextInputTests : OnCanvasTests  {
 
         assertNull(document.querySelector("textarea"))
 
-        val canvas = getCanvas()
+        dispatchEvents(
+            keyDownEvent("s"),
+            keyDownEvent("t"),
+            keyDownEvent("e"),
+            keyDownEvent("p"),
+            keyDownEvent("1")
+        )
 
-        canvas.dispatchEvent(keyDownEvent("s"))
-        canvas.dispatchEvent(keyDownEvent("t"))
-        canvas.dispatchEvent(keyDownEvent("e"))
-        canvas.dispatchEvent(keyDownEvent("p"))
-        canvas.dispatchEvent(keyDownEvent("1"))
 
         assertEquals("step1", textInputChannel.receive())
         assertNull(document.querySelector("textarea"))
 
         // trigger virtual keyboard
-        canvas.dispatchEvent(createTouchEvent("touchstart"))
+        dispatchEvents(createTouchEvent("touchstart"))
         secondFocusRequester.requestFocus()
 
         assertNotNull(document.querySelector("textarea"))
 
-        canvas.dispatchEvent(keyDownEvent("s"))
-        canvas.dispatchEvent(keyDownEvent("t"))
-        canvas.dispatchEvent(keyDownEvent("e"))
-        canvas.dispatchEvent(keyDownEvent("p"))
-        canvas.dispatchEvent(keyDownEvent("2"))
+        dispatchEvents(
+            keyDownEvent("s"),
+            keyDownEvent("t"),
+            keyDownEvent("e"),
+            keyDownEvent("p"),
+            keyDownEvent("2")
+        )
 
         assertEquals("step2", textInputChannel.receive())
 
         val backingField = document.querySelector("textarea")!!
 
-        backingField.dispatchEvent(keyDownEvent("s"))
-        backingField.dispatchEvent(keyDownEvent("t"))
-        backingField.dispatchEvent(keyDownEvent("e"))
-        backingField.dispatchEvent(keyDownEvent("p"))
-        backingField.dispatchEvent(keyDownEvent("3"))
+        dispatchEvents(
+            keyDownEvent("s"),
+            keyDownEvent("t"),
+            keyDownEvent("e"),
+            keyDownEvent("p"),
+            keyDownEvent("3")
+        )
 
         assertEquals("step2step3", textInputChannel.receive())
 
@@ -123,14 +122,16 @@ class TextInputTests : OnCanvasTests  {
         assertEquals("step2step3step4", textInputChannel.receive())
 
         // trigger hardware keyboard
-        canvas.dispatchEvent(createMouseEvent("mousedown"))
+        dispatchEvents(createMouseEvent("mousedown"))
         firstFocusRequester.requestFocus()
 
-        canvas.dispatchEvent(keyDownEvent("s"))
-        canvas.dispatchEvent(keyDownEvent("t"))
-        canvas.dispatchEvent(keyDownEvent("e"))
-        canvas.dispatchEvent(keyDownEvent("p"))
-        canvas.dispatchEvent(keyDownEvent("5"))
+        dispatchEvents(
+            keyDownEvent("s"),
+            keyDownEvent("t"),
+            keyDownEvent("e"),
+            keyDownEvent("p"),
+            keyDownEvent("5")
+        )
 
         assertEquals("step1step5", textInputChannel.receive())
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.sendFromScope
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -33,12 +32,6 @@ import kotlinx.coroutines.test.runTest
 
 
 class ComposeWindowLifecycleTest : OnCanvasTests {
-
-    @BeforeTest
-    fun setup() {
-        resetCanvas()
-    }
-
     @Test
     @Ignore // ignored while investigating CI issues: this test opens a new browser window which can be the cause
     fun allEvents() = runTest {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.NonCancellable.isActive
@@ -36,11 +35,6 @@ import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.MouseEventInit
 
 class MouseEventsTest : OnCanvasTests {
-
-    @BeforeTest
-    fun setup() {
-        resetCanvas()
-    }
 
     @Test
     fun testPointerEvents() = runTest {
@@ -60,11 +54,11 @@ class MouseEventsTest : OnCanvasTests {
             ) {}
         }
 
-        val canvas = getCanvas()
-
-        canvas.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
-        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
-        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
+        dispatchEvents(
+            MouseEvent("mouseenter", MouseEventInit(100, 100)),
+            MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)),
+            MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0))
+        )
 
         assertEquals(3, pointerEvents.size)
         assertEquals(PointerEventType.Enter, pointerEvents[0].type)
@@ -75,8 +69,11 @@ class MouseEventsTest : OnCanvasTests {
         assertEquals(PointerEventType.Release, pointerEvents[2].type)
         assertEquals(PointerButton.Primary, pointerEvents[2].button)
 
-        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
-        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
+        dispatchEvents(
+            MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)),
+            MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0))
+        )
+
         assertEquals(5, pointerEvents.size)
 
         // Check for secondary button
@@ -101,17 +98,19 @@ class MouseEventsTest : OnCanvasTests {
             ) {}
         }
 
-        val canvas = getCanvas()
-
-        canvas.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
-        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
-        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
+        dispatchEvents(
+            MouseEvent("mouseenter", MouseEventInit(100, 100)),
+            MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)),
+            MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0))
+        )
 
         assertEquals(1, primaryClickedCounter)
         assertEquals(0, secondaryClickedCounter)
 
-        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
-        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
+        dispatchEvents(
+            MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)),
+            MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0))
+        )
 
         assertEquals(1, primaryClickedCounter)
         assertEquals(1, secondaryClickedCounter)
@@ -137,17 +136,15 @@ class MouseEventsTest : OnCanvasTests {
 
         assertEquals(null, event)
 
-        val canvas = getCanvas()
-
-        canvas.dispatchEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        dispatchEvents(MouseEvent("mouseenter", MouseEventInit(100, 100)))
         assertEquals(PointerEventType.Enter, event!!.type)
         assertEquals(null, event!!.button)
 
-        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(101, 101, clientX = 101, clientY = 101)))
+        dispatchEvents(MouseEvent("mousemove", MouseEventInit(101, 101, clientX = 101, clientY = 101)))
         assertEquals(PointerEventType.Move, event!!.type)
         assertEquals(null, event!!.button)
 
-        canvas.dispatchEvent(MouseEvent("mouseleave", MouseEventInit(0, 0, clientX = 0, clientY = 0)))
+        dispatchEvents(MouseEvent("mouseleave", MouseEventInit(0, 0, clientX = 0, clientY = 0)))
         assertEquals(PointerEventType.Exit, event!!.type)
         assertEquals(null, event!!.button)
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.TextField
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.events.keyDownEvent
+import androidx.compose.ui.events.keyDownEventUnprevented
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PreventDefaultTest : OnCanvasTests {
+
+    @Test
+    fun testPreventDefault() {
+        val fr = FocusRequester()
+        var changedValue = ""
+        createComposeWindow {
+            TextField(
+                value = "",
+                onValueChange = { changedValue = it },
+                modifier = Modifier.fillMaxSize().focusRequester(fr)
+            )
+            SideEffect {
+                fr.requestFocus()
+            }
+        }
+
+        var stack = mutableListOf<Boolean>()
+
+        getCanvas().addEventListener("keydown", { event ->
+            stack.add(event.defaultPrevented)
+        })
+
+        // dispatchEvent synchronously invokes all the listeners
+        dispatchEvents(keyDownEvent("c"))
+        assertEquals(1, stack.size)
+        assertTrue(stack.last())
+
+        dispatchEvents(keyDownEventUnprevented())
+        assertEquals(2, stack.size)
+        assertFalse(stack.last())
+
+        assertEquals(changedValue, "c")
+
+        // copy shortcut should not be prevented (we let browser create a corresponding event)
+        dispatchEvents(keyDownEvent("c", metaKey = true, ctrlKey = true))
+        assertEquals(3, stack.size)
+        assertFalse(stack.last())
+
+        assertEquals(changedValue, "c")
+
+    }
+}


### PR DESCRIPTION
The main idea behind this PR is to make OnCanvasTests (almost) HTMLCanvasElement-agnostic, in particular when it comes to dispatching events to the application