### PR TITLE
OnCanvasTests creates ComposeWindow and injects "reset CSS" styles every time we are actually creating canvas

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.window.CanvasBasedWindow
 import androidx.compose.ui.window.ComposeWindow
 import androidx.compose.ui.window.DefaultWindowState
 import kotlinx.browser.document
@@ -40,7 +39,7 @@ internal interface OnCanvasTests {
 
     companion object {
         private var injected: Boolean = false
-        fun injectDefaultStyles() {
+        private fun injectDefaultStyles() {
             if (injected) return
             injected = true
             document.head!!.appendChild(
@@ -72,8 +71,10 @@ internal interface OnCanvasTests {
     }
 
     fun composableContent(content: @Composable () -> Unit) {
+        // We should use this method whenever we are relying on the fact that document coordinates start exactly at (0, 0)
+        // TODO: strictly speaking, this way one test suit affects the other in that sense that styles can be injected by different tests suite
+        injectDefaultStyles()
         resetCanvas()
-
         createComposeViewport(content)
     }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -18,6 +18,8 @@ package androidx.compose.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.CanvasBasedWindow
+import androidx.compose.ui.window.ComposeWindow
+import androidx.compose.ui.window.DefaultWindowState
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +27,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import org.w3c.dom.HTMLCanvasElement
+import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.events.Event
 
 /**
@@ -34,6 +37,25 @@ import org.w3c.dom.events.Event
 private const val canvasId: String = "canvasApp"
 
 internal interface OnCanvasTests {
+
+    companion object {
+        private var injected: Boolean = false
+        fun injectDefaultStyles() {
+            if (injected) return
+            injected = true
+            document.head!!.appendChild(
+                (document.createElement("style") as HTMLStyleElement).apply {
+                    type = "text/css"
+                    appendChild(
+                        document.createTextNode(
+                            "body { margin: 0;}}"
+                        )
+                    )
+                }
+            )
+        }
+    }
+
     fun getCanvas() = document.getElementById(canvasId) as HTMLCanvasElement
 
     private fun resetCanvas() {
@@ -49,9 +71,14 @@ internal interface OnCanvasTests {
         document.body!!.appendChild(canvas)
     }
 
-    fun createComposeWindow(content: @Composable () -> Unit) {
+    fun composableContent(content: @Composable () -> Unit) {
         resetCanvas()
-        CanvasBasedWindow(canvasElementId = canvasId, content = content)
+
+        createComposeViewport(content)
+    }
+
+    fun createComposeViewport(content: @Composable () -> Unit) {
+        ComposeWindow(canvas = getCanvas(), content = content, state = DefaultWindowState(document.documentElement!!))
     }
 
     fun dispatchEvents(vararg events: Any) {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -45,13 +45,6 @@ import org.w3c.dom.events.MouseEventInit
 
 class SelectionContainerTests : OnCanvasTests {
 
-    @BeforeTest
-    fun setup() {
-        // We should use this method whenever we are relying on the fact that document coordinates start exactly at (0, 0)
-        // TODO: strictly speaking, this way one test suit affects the other in that sense that styles can be injected by different tests suite
-        OnCanvasTests.injectDefaultStyles()
-    }
-
     private fun HTMLCanvasElement.doClick() {
         dispatchEvent(MouseEvent("mousedown", MouseEventInit(5, 5, 5, 5, buttons = 1, button = 1)))
         dispatchEvent(MouseEvent("mouseup", MouseEventInit(5, 5, 5, 5, buttons = 0, button = 1)))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/SelectionContainerTests.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.ViewConfiguration
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -44,6 +45,13 @@ import org.w3c.dom.events.MouseEventInit
 
 class SelectionContainerTests : OnCanvasTests {
 
+    @BeforeTest
+    fun setup() {
+        // We should use this method whenever we are relying on the fact that document coordinates start exactly at (0, 0)
+        // TODO: strictly speaking, this way one test suit affects the other in that sense that styles can be injected by different tests suite
+        OnCanvasTests.injectDefaultStyles()
+    }
+
     private fun HTMLCanvasElement.doClick() {
         dispatchEvent(MouseEvent("mousedown", MouseEventInit(5, 5, 5, 5, buttons = 1, button = 1)))
         dispatchEvent(MouseEvent("mouseup", MouseEventInit(5, 5, 5, 5, buttons = 0, button = 1)))
@@ -57,7 +65,7 @@ class SelectionContainerTests : OnCanvasTests {
 
         var viewConfiguration: ViewConfiguration? = null
 
-        createComposeWindow {
+        composableContent {
             var selection by remember { mutableStateOf<Selection?>(null) }
 
             androidx.compose.foundation.text.selection.SelectionContainer(
@@ -119,7 +127,7 @@ class SelectionContainerTests : OnCanvasTests {
 
         var viewConfiguration: ViewConfiguration? = null
 
-        createComposeWindow {
+        composableContent {
             var selection by remember { mutableStateOf<Selection?>(null) }
 
             androidx.compose.foundation.text.selection.SelectionContainer(
@@ -171,7 +179,7 @@ class SelectionContainerTests : OnCanvasTests {
 
         var viewConfiguration: ViewConfiguration? = null
 
-        createComposeWindow {
+        composableContent {
             var selection by remember { mutableStateOf<Selection?>(null) }
 
             androidx.compose.foundation.text.selection.SelectionContainer(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
@@ -47,7 +47,7 @@ class TextTests : OnCanvasTests {
         val headingOnPositioned = Channel<Float>(10)
         val subtitleOnPositioned = Channel<Float>(10)
 
-        createComposeWindow {
+        composableContent {
             val density = LocalDensity.current.density
             Row {
                 Text(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -48,7 +48,7 @@ class TextInputTests : OnCanvasTests  {
 
         val (firstFocusRequester, secondFocusRequester) = FocusRequester.createRefs()
 
-        createComposeWindow {
+        composableContent {
             TextField(
                 value = "",
                 onValueChange = { value ->

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.sendFromScope
 import androidx.lifecycle.Lifecycle
@@ -32,17 +33,19 @@ import kotlinx.coroutines.test.runTest
 
 
 class ComposeWindowLifecycleTest : OnCanvasTests {
+
+    private lateinit var lifecycleOwner: LifecycleOwner
+
+    override fun createComposeViewport(content: @Composable () -> Unit) {
+        lifecycleOwner = ComposeWindow(canvas = getCanvas(), content = content, state = DefaultWindowState(document.documentElement!!))
+    }
+
     @Test
     @Ignore // ignored while investigating CI issues: this test opens a new browser window which can be the cause
     fun allEvents() = runTest {
-        val canvas = getCanvas()
-        canvas.focus()
+        composableContent {  }
 
-        val lifecycleOwner = ComposeWindow(
-            canvas = canvas,
-            content = {},
-            state = DefaultWindowState(document.documentElement!!)
-        )
+        getCanvas().focus()
 
         val eventsChannel = Channel<Lifecycle.Event>(10)
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/KeyEventTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/KeyEventTests.kt
@@ -47,7 +47,7 @@ class KeyEventTests : OnCanvasTests {
         val fr = FocusRequester()
         var mapping = ""
         var k: Key? = null
-        createComposeWindow {
+        composableContent {
             Box(
                 Modifier.size(1000.dp).background(Color.Red).focusRequester(fr).focusTarget()
                     .onKeyEvent {
@@ -96,7 +96,7 @@ class KeyEventTests : OnCanvasTests {
         var lastKeyEvent: KeyEvent? = null
         var stopPropagation = true
 
-        createComposeWindow {
+        composableContent {
             TextField(
                 value = textValue.value,
                 onValueChange = { textValue.value = it },

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -37,13 +37,6 @@ import org.w3c.dom.events.MouseEventInit
 
 class MouseEventsTest : OnCanvasTests {
 
-    @BeforeTest
-    fun setup() {
-        // We should use this method whenever we are relying on the fact that document coordinates start exactly at (0, 0)
-        // TODO: strictly speaking, this way one test suit affects the other in that sense that styles can be injected by different tests suite
-        OnCanvasTests.injectDefaultStyles()
-    }
-
     @Test
     fun testPointerEvents() = runTest {
         val pointerEvents = mutableListOf<PointerEvent>()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.NonCancellable.isActive
@@ -36,11 +37,18 @@ import org.w3c.dom.events.MouseEventInit
 
 class MouseEventsTest : OnCanvasTests {
 
+    @BeforeTest
+    fun setup() {
+        // We should use this method whenever we are relying on the fact that document coordinates start exactly at (0, 0)
+        // TODO: strictly speaking, this way one test suit affects the other in that sense that styles can be injected by different tests suite
+        OnCanvasTests.injectDefaultStyles()
+    }
+
     @Test
     fun testPointerEvents() = runTest {
         val pointerEvents = mutableListOf<PointerEvent>()
 
-        createComposeWindow {
+        composableContent {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -89,7 +97,7 @@ class MouseEventsTest : OnCanvasTests {
         var primaryClickedCounter = 0
         var secondaryClickedCounter = 0
 
-        createComposeWindow {
+        composableContent {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -120,7 +128,7 @@ class MouseEventsTest : OnCanvasTests {
     fun testPointerButtonIsNullForNoClickEvents() = runTest {
         var event: PointerEvent? = null
 
-        createComposeWindow {
+        composableContent {
             Box(
                 modifier = Modifier
                     .fillMaxSize()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.events.keyDownEvent
 import androidx.compose.ui.events.keyDownEventUnprevented
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,7 +36,7 @@ class PreventDefaultTest : OnCanvasTests {
     fun testPreventDefault() {
         val fr = FocusRequester()
         var changedValue = ""
-        createComposeWindow {
+        composableContent {
             TextField(
                 value = "",
                 onValueChange = { changedValue = it },


### PR DESCRIPTION
Additionally, this actually fixes ComposeWindowLifecycleTest (which is, unfortunately till has to be ignored because of the chanel inconsistency issue)