### PR TITLE
[web] Send DOM events directly to the ComposeWindow in all OnCanvasTests-derived tests

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -256,7 +256,7 @@ internal class ComposeWindow(
         canvasEvents.addDisposableEvent(type) { event -> handler(event as T) }
     }
 
-    private fun processKeyboardEvent(keyboardEvent: KeyboardEvent) {
+    internal fun processKeyboardEvent(keyboardEvent: KeyboardEvent) {
         val processed = scene.sendKeyEvent(keyboardEvent.toComposeEvent())
         if (processed) keyboardEvent.preventDefault()
     }
@@ -399,7 +399,7 @@ internal class ComposeWindow(
         isDisposed = true
     }
 
-    private fun onTouchEvent(
+    internal fun onTouchEvent(
         event: TouchEvent,
         offset: Offset,
     ) {
@@ -443,7 +443,7 @@ internal class ComposeWindow(
 
     }
 
-    private fun onMouseEvent(
+    internal fun onMouseEvent(
         event: MouseEvent,
     ) {
         keyboardModeState = KeyboardModeState.Hardware

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -70,23 +70,16 @@ internal interface OnCanvasTests {
         document.body!!.appendChild(canvas)
     }
 
-    fun composableContent(content: @Composable () -> Unit) {
+    fun composableContent(content: @Composable () -> Unit): ComposeWindow {
         // We should use this method whenever we are relying on the fact that document coordinates start exactly at (0, 0)
         // TODO: strictly speaking, this way one test suit affects the other in that sense that styles can be injected by different tests suite
         injectDefaultStyles()
         resetCanvas()
-        createComposeViewport(content)
+        return createComposeViewport(content)
     }
 
-    fun createComposeViewport(content: @Composable () -> Unit) {
-        ComposeWindow(canvas = getCanvas(), content = content, state = DefaultWindowState(document.documentElement!!))
-    }
-
-    fun dispatchEvents(vararg events: Any) {
-        val canvas = getCanvas()
-        for (event in events) {
-            canvas.dispatchEvent(event as Event)
-        }
+    fun createComposeViewport(content: @Composable () -> Unit): ComposeWindow {
+        return ComposeWindow(canvas = getCanvas(), content = content, state = DefaultWindowState(document.documentElement!!))
     }
 }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.events.createTouchEvent
 import androidx.compose.ui.events.keyDownEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.sendFromScope
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -36,6 +37,7 @@ import kotlinx.browser.document
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
+import org.w3c.dom.TouchEvent
 
 class TextInputTests : OnCanvasTests  {
 
@@ -48,7 +50,7 @@ class TextInputTests : OnCanvasTests  {
 
         val (firstFocusRequester, secondFocusRequester) = FocusRequester.createRefs()
 
-        composableContent {
+        val composeWindow = composableContent {
             TextField(
                 value = "",
                 onValueChange = { value ->
@@ -73,43 +75,37 @@ class TextInputTests : OnCanvasTests  {
 
         assertNull(document.querySelector("textarea"))
 
-        dispatchEvents(
-            keyDownEvent("s"),
-            keyDownEvent("t"),
-            keyDownEvent("e"),
-            keyDownEvent("p"),
-            keyDownEvent("1")
-        )
+        composeWindow.processKeyboardEvent(keyDownEvent("s"))
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("e"))
+        composeWindow.processKeyboardEvent(keyDownEvent("p"))
+        composeWindow.processKeyboardEvent(keyDownEvent("1"))
 
 
         assertEquals("step1", textInputChannel.receive())
         assertNull(document.querySelector("textarea"))
 
         // trigger virtual keyboard
-        dispatchEvents(createTouchEvent("touchstart"))
+        composeWindow.onTouchEvent(createTouchEvent("touchstart") as TouchEvent, Offset.Zero)
         secondFocusRequester.requestFocus()
 
         assertNotNull(document.querySelector("textarea"))
 
-        dispatchEvents(
-            keyDownEvent("s"),
-            keyDownEvent("t"),
-            keyDownEvent("e"),
-            keyDownEvent("p"),
-            keyDownEvent("2")
-        )
+        composeWindow.processKeyboardEvent(keyDownEvent("s"))
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("e"))
+        composeWindow.processKeyboardEvent(keyDownEvent("p"))
+        composeWindow.processKeyboardEvent(keyDownEvent("2"))
 
         assertEquals("step2", textInputChannel.receive())
 
         val backingField = document.querySelector("textarea")!!
 
-        dispatchEvents(
-            keyDownEvent("s"),
-            keyDownEvent("t"),
-            keyDownEvent("e"),
-            keyDownEvent("p"),
-            keyDownEvent("3")
-        )
+        composeWindow.processKeyboardEvent(keyDownEvent("s"))
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("e"))
+        composeWindow.processKeyboardEvent(keyDownEvent("p"))
+        composeWindow.processKeyboardEvent(keyDownEvent("3"))
 
         assertEquals("step2step3", textInputChannel.receive())
 
@@ -122,16 +118,14 @@ class TextInputTests : OnCanvasTests  {
         assertEquals("step2step3step4", textInputChannel.receive())
 
         // trigger hardware keyboard
-        dispatchEvents(createMouseEvent("mousedown"))
+        composeWindow.onMouseEvent(createMouseEvent("mousedown"))
         firstFocusRequester.requestFocus()
 
-        dispatchEvents(
-            keyDownEvent("s"),
-            keyDownEvent("t"),
-            keyDownEvent("e"),
-            keyDownEvent("p"),
-            keyDownEvent("5")
-        )
+        composeWindow.processKeyboardEvent(keyDownEvent("s"))
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("e"))
+        composeWindow.processKeyboardEvent(keyDownEvent("p"))
+        composeWindow.processKeyboardEvent(keyDownEvent("5"))
 
         assertEquals("step1step5", textInputChannel.receive())
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.sendFromScope
 import androidx.lifecycle.Lifecycle
@@ -26,7 +25,6 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
@@ -34,16 +32,10 @@ import kotlinx.coroutines.test.runTest
 
 class ComposeWindowLifecycleTest : OnCanvasTests {
 
-    private lateinit var lifecycleOwner: LifecycleOwner
-
-    override fun createComposeViewport(content: @Composable () -> Unit) {
-        lifecycleOwner = ComposeWindow(canvas = getCanvas(), content = content, state = DefaultWindowState(document.documentElement!!))
-    }
-
     @Test
     @Ignore // ignored while investigating CI issues: this test opens a new browser window which can be the cause
     fun allEvents() = runTest {
-        composableContent {  }
+        val lifecycleOwner = composableContent {  }
 
         getCanvas().focus()
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/KeyEventTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/KeyEventTests.kt
@@ -47,7 +47,8 @@ class KeyEventTests : OnCanvasTests {
         val fr = FocusRequester()
         var mapping = ""
         var k: Key? = null
-        composableContent {
+
+        val composeWindow = composableContent {
             Box(
                 Modifier.size(1000.dp).background(Color.Red).focusRequester(fr).focusTarget()
                     .onKeyEvent {
@@ -71,7 +72,7 @@ class KeyEventTests : OnCanvasTests {
 
 
         ('a'..'z').forEachIndexed { index, c ->
-            dispatchEvents(keyDownEvent(c.toString()))
+            composeWindow.processKeyboardEvent(keyDownEvent(c.toString()))
             assertEquals(listOfKeys[index], k)
         }
 
@@ -82,7 +83,7 @@ class KeyEventTests : OnCanvasTests {
 
         ('0'..'9').forEachIndexed { index, c ->
             val id = c.toString()
-            dispatchEvents(keyDownEvent(id, code = "Digit${id}"))
+            composeWindow.processKeyboardEvent(keyDownEvent(id, code = "Digit${id}"))
             assertEquals(listOfNumbers[index], k)
         }
     }
@@ -96,7 +97,7 @@ class KeyEventTests : OnCanvasTests {
         var lastKeyEvent: KeyEvent? = null
         var stopPropagation = true
 
-        composableContent {
+        val composeWindow = composableContent {
             TextField(
                 value = textValue.value,
                 onValueChange = { textValue.value = it },
@@ -110,18 +111,18 @@ class KeyEventTests : OnCanvasTests {
             }
         }
 
-        dispatchEvents(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
         assertEquals(Key.T, lastKeyEvent!!.key)
         assertEquals("", textValue.value)
 
         stopPropagation = false
-        dispatchEvents(
-            keyDownEvent("t"),
-            keyDownEvent("e"),
-            keyDownEvent("s"),
-            keyDownEvent("t"),
-            keyDownEvent("x")
-        )
+
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("e"))
+        composeWindow.processKeyboardEvent(keyDownEvent("s"))
+        composeWindow.processKeyboardEvent(keyDownEvent("t"))
+        composeWindow.processKeyboardEvent(keyDownEvent("x"))
+
         assertEquals(Key.X, lastKeyEvent!!.key)
         assertEquals("testx", textValue.value)
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.NonCancellable.isActive
@@ -41,7 +40,7 @@ class MouseEventsTest : OnCanvasTests {
     fun testPointerEvents() = runTest {
         val pointerEvents = mutableListOf<PointerEvent>()
 
-        composableContent {
+        val composeWindow = composableContent {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -55,11 +54,9 @@ class MouseEventsTest : OnCanvasTests {
             ) {}
         }
 
-        dispatchEvents(
-            MouseEvent("mouseenter", MouseEventInit(100, 100)),
-            MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)),
-            MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0))
-        )
+        composeWindow.onMouseEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        composeWindow.onMouseEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
+        composeWindow.onMouseEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
 
         assertEquals(3, pointerEvents.size)
         assertEquals(PointerEventType.Enter, pointerEvents[0].type)
@@ -70,10 +67,8 @@ class MouseEventsTest : OnCanvasTests {
         assertEquals(PointerEventType.Release, pointerEvents[2].type)
         assertEquals(PointerButton.Primary, pointerEvents[2].button)
 
-        dispatchEvents(
-            MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)),
-            MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0))
-        )
+        composeWindow.onMouseEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
+        composeWindow.onMouseEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
 
         assertEquals(5, pointerEvents.size)
 
@@ -90,7 +85,7 @@ class MouseEventsTest : OnCanvasTests {
         var primaryClickedCounter = 0
         var secondaryClickedCounter = 0
 
-        composableContent {
+        val composeWindow = composableContent {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -99,19 +94,16 @@ class MouseEventsTest : OnCanvasTests {
             ) {}
         }
 
-        dispatchEvents(
-            MouseEvent("mouseenter", MouseEventInit(100, 100)),
-            MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)),
-            MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0))
-        )
+
+        composeWindow.onMouseEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        composeWindow.onMouseEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 0, buttons = 1)))
+        composeWindow.onMouseEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 0, buttons = 0)))
 
         assertEquals(1, primaryClickedCounter)
         assertEquals(0, secondaryClickedCounter)
 
-        dispatchEvents(
-            MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)),
-            MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0))
-        )
+        composeWindow.onMouseEvent(MouseEvent("mousedown", MouseEventInit(100, 100, button = 2, buttons = 2)))
+        composeWindow.onMouseEvent(MouseEvent("mouseup", MouseEventInit(100, 100, button = 2, buttons = 0)))
 
         assertEquals(1, primaryClickedCounter)
         assertEquals(1, secondaryClickedCounter)
@@ -121,7 +113,7 @@ class MouseEventsTest : OnCanvasTests {
     fun testPointerButtonIsNullForNoClickEvents() = runTest {
         var event: PointerEvent? = null
 
-        composableContent {
+        val composeWindow = composableContent {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -137,15 +129,15 @@ class MouseEventsTest : OnCanvasTests {
 
         assertEquals(null, event)
 
-        dispatchEvents(MouseEvent("mouseenter", MouseEventInit(100, 100)))
+        composeWindow.onMouseEvent(MouseEvent("mouseenter", MouseEventInit(100, 100)))
         assertEquals(PointerEventType.Enter, event!!.type)
         assertEquals(null, event!!.button)
 
-        dispatchEvents(MouseEvent("mousemove", MouseEventInit(101, 101, clientX = 101, clientY = 101)))
+        composeWindow.onMouseEvent(MouseEvent("mousemove", MouseEventInit(101, 101, clientX = 101, clientY = 101)))
         assertEquals(PointerEventType.Move, event!!.type)
         assertEquals(null, event!!.button)
 
-        dispatchEvents(MouseEvent("mouseleave", MouseEventInit(0, 0, clientX = 0, clientY = 0)))
+        composeWindow.onMouseEvent(MouseEvent("mouseleave", MouseEventInit(0, 0, clientX = 0, clientY = 0)))
         assertEquals(PointerEventType.Exit, event!!.type)
         assertEquals(null, event!!.button)
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
@@ -36,6 +36,7 @@ class PreventDefaultTest : OnCanvasTests {
     fun testPreventDefault() {
         val fr = FocusRequester()
         var changedValue = ""
+
         composableContent {
             TextField(
                 value = "",
@@ -47,25 +48,27 @@ class PreventDefaultTest : OnCanvasTests {
             }
         }
 
-        var stack = mutableListOf<Boolean>()
+        val stack = mutableListOf<Boolean>()
+
+        val canvas = getCanvas()
 
         getCanvas().addEventListener("keydown", { event ->
             stack.add(event.defaultPrevented)
         })
 
         // dispatchEvent synchronously invokes all the listeners
-        dispatchEvents(keyDownEvent("c"))
+        canvas.dispatchEvent(keyDownEvent("c"))
         assertEquals(1, stack.size)
         assertTrue(stack.last())
 
-        dispatchEvents(keyDownEventUnprevented())
+        canvas.dispatchEvent(keyDownEventUnprevented())
         assertEquals(2, stack.size)
         assertFalse(stack.last())
 
         assertEquals(changedValue, "c")
 
-        // copy shortcut should not be prevented (we let browser create a corresponding event)
-        dispatchEvents(keyDownEvent("c", metaKey = true, ctrlKey = true))
+        // copy shortcut should not be prevented (we let the browser create a corresponding event)
+        canvas.dispatchEvent(keyDownEvent("c", metaKey = true, ctrlKey = true))
         assertEquals(3, stack.size)
         assertFalse(stack.last())
 


### PR DESCRIPTION
Under particular circumstances browser dispatchEvent can contribute to flakiness of our tests This is especially true when it will come to the wheel events

The PreventDefaultTest preserves tests with dispatch due to the nature of this particular test suit
