### PR TITLE
Move `SavedStateHandle.toRoute` to common

### DIFF
--- a/navigation/navigation-common/api/desktop/navigation-common.api
+++ b/navigation/navigation-common/api/desktop/navigation-common.api
@@ -433,6 +433,10 @@ public final class androidx/navigation/PopUpToBuilder {
 	public final fun setSaveState (Z)V
 }
 
+public final class androidx/navigation/SavedStateHandleKt {
+	public static final fun internalToRoute (Landroidx/lifecycle/SavedStateHandle;Lkotlin/reflect/KClass;Ljava/util/Map;)Ljava/lang/Object;
+}
+
 public final class androidx/navigation/serialization/RouteDeserializerKt {
 	public static final fun decodeArguments (Lkotlinx/serialization/KSerializer;Landroidx/core/bundle/Bundle;Ljava/util/Map;)Ljava/lang/Object;
 	public static final fun decodeArguments (Lkotlinx/serialization/KSerializer;Landroidx/lifecycle/SavedStateHandle;Ljava/util/Map;)Ljava/lang/Object;

--- a/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/SavedStateHandle.kt
+++ b/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/SavedStateHandle.kt
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-@file:JvmName("SavedStateHandleKt")
-
 package androidx.navigation
 
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.serialization.decodeArguments
 import androidx.navigation.serialization.generateNavArguments
+import kotlin.jvm.JvmSuppressWildcards
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlinx.serialization.InternalSerializationApi


### PR DESCRIPTION
Missed this API from `beta01` 

Fixes https://kotlinlang.slack.com/archives/C3PQML5NU/p1725013925742959

## Testing
This should be tested by QA

## Release Notes
### Fixes - Navigation
- _(prerelease fix)_ Fixed missing commonization for type-safe version of `SavedStateHandle.toRoute`
