### PR TITLE
Fix Navigation 2.8.0-rc01 bad merge

### DIFF
--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDestination.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDestination.jb.kt
@@ -139,7 +139,7 @@ public actual open class NavDestination actual constructor(
         return matchingDeepLink
     }
 
-    private fun matchDeepLinkRequest(route: String): DeepLinkMatch? {
+    protected fun matchDeepLinkRequest(route: String): DeepLinkMatch? {
         if (deepLinks.isEmpty()) {
             return null
         }

--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavGraph.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavGraph.jb.kt
@@ -47,7 +47,7 @@ public actual open class NavGraph actual constructor(navGraphNavigator: Navigato
         lastVisited: NavDestination
     ): DeepLinkMatch? {
         // First search through any deep links directly added to this NavGraph
-        val bestMatch = super.matchDeepLink(route)
+        val bestMatch = matchDeepLinkRequest(route)
 
         // If searchChildren is true, search through all child destinations for a matching deeplink
         val bestChildMatch =


### PR DESCRIPTION
Fix `StackOverflowError` after #1517
```
Exception in thread "AWT-EventQueue-0" java.lang.StackOverflowError
	at androidx.navigation.NavGraph.matchDeepLinkComprehensive(NavGraph.jb.kt)
	at androidx.navigation.NavDestination.matchDeepLink(NavDestination.jb.kt:130)
	at androidx.navigation.NavGraph.matchDeepLinkComprehensive(NavGraph.jb.kt:50)
	at androidx.navigation.NavDestination.matchDeepLink(NavDestination.jb.kt:130)
	at androidx.navigation.NavGraph.matchDeepLinkComprehensive(NavGraph.jb.kt:50)
	at androidx.navigation.NavDestination.matchDeepLink(NavDestination.jb.kt:130)
	at androidx.navigation.NavGraph.matchDeepLinkComprehensive(NavGraph.jb.kt:50)
	at androidx.navigation.NavDestination.matchDeepLink(NavDestination.jb.kt:130)
	at androidx.navigation.NavGraph.matchDeepLinkComprehensive(NavGraph.jb.kt:50)
```
