### PR TITLE
Deprecate `Modifier.onExternalDrag` and move `DragData` into ui.draganddrop

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -606,8 +606,24 @@ public abstract interface class androidx/compose/ui/draganddrop/DragAndDropTrans
 
 public final class androidx/compose/ui/draganddrop/DragAndDrop_desktopKt {
 	public static final fun DragAndDropTransferable (Ljava/awt/datatransfer/Transferable;)Landroidx/compose/ui/draganddrop/DragAndDropTransferable;
-	public static final fun dragData (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Landroidx/compose/ui/DragData;
+	public static final fun dragData (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Landroidx/compose/ui/draganddrop/DragData;
 	public static final fun getAwtTransferable (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Ljava/awt/datatransfer/Transferable;
+}
+
+public abstract interface class androidx/compose/ui/draganddrop/DragData {
+}
+
+public abstract interface class androidx/compose/ui/draganddrop/DragData$FilesList : androidx/compose/ui/draganddrop/DragData {
+	public abstract fun readFiles ()Ljava/util/List;
+}
+
+public abstract interface class androidx/compose/ui/draganddrop/DragData$Image : androidx/compose/ui/draganddrop/DragData {
+	public abstract fun readImage ()Landroidx/compose/ui/graphics/painter/Painter;
+}
+
+public abstract interface class androidx/compose/ui/draganddrop/DragData$Text : androidx/compose/ui/draganddrop/DragData {
+	public abstract fun getBestMimeType ()Ljava/lang/String;
+	public abstract fun readText ()Ljava/lang/String;
 }
 
 public final class androidx/compose/ui/draw/AlphaKt {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ExternalDrag.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ExternalDrag.desktop.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.AwtWindowDragTargetListener.WindowDragValue
+import androidx.compose.ui.draganddrop.deprecatedDragData
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.painter.Painter
@@ -45,14 +46,23 @@ import java.awt.dnd.DropTargetListener
 /**
  * Represent data that is being dragged (or dropped) to a component from outside an application.
  */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Use the new drag-and-drop API: Modifier.dragAndDropTarget"
+)
+@Suppress("DEPRECATION_ERROR")
 @ExperimentalComposeUiApi
 interface DragData {
     /**
      * Represents list of files drag and dropped to a component.
      */
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Use the new drag-and-drop API: Modifier.dragAndDropTarget"
+    )
     interface FilesList : DragData {
         /**
-         * Returns list of file paths drag and droppped to an application in a URI format.
+         * Returns list of file paths drag and dropped to an application in a URI format.
          */
         fun readFiles(): List<String>
     }
@@ -60,6 +70,10 @@ interface DragData {
     /**
      * Represents an image drag and dropped to a component.
      */
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Use the new drag-and-drop API: Modifier.dragAndDropTarget"
+    )
     interface Image : DragData {
         /**
          * Returns an image drag and dropped to an application as a [Painter] type.
@@ -70,6 +84,10 @@ interface DragData {
     /**
      * Represent text drag and dropped to a component.
      */
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Use the new drag-and-drop API: Modifier.dragAndDropTarget"
+    )
     interface Text : DragData {
         /**
          * Provides the best MIME type that describes text returned in [readText]
@@ -89,6 +107,10 @@ interface DragData {
  *
  * @see onExternalDrag
  */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Use the new drag-and-drop API: Modifier.dragAndDropTarget"
+)
 @ExperimentalComposeUiApi
 @Immutable
 class ExternalDragValue(
@@ -99,6 +121,7 @@ class ExternalDragValue(
     /**
      * Data that it being dragged (or dropped) in a component bounds
      */
+    @Suppress("DEPRECATION_ERROR")
     val dragData: DragData
 )
 
@@ -110,6 +133,11 @@ class ExternalDragValue(
  * @param onDragExit is called if the pointer exited the component bounds.
  * @param onDrop is called when the pointer is released.
  */
+@Deprecated(
+    level = DeprecationLevel.ERROR,
+    message = "Use the new drag-and-drop API: Modifier.dragAndDropTarget"
+)
+@Suppress("DEPRECATION_ERROR")
 @ExperimentalComposeUiApi
 @Composable
 fun Modifier.onExternalDrag(
@@ -176,6 +204,7 @@ fun Modifier.onExternalDrag(
  *
  * [Window] allows having only one [DropTarget], so this is the main [DropTarget] that handles all the drag subscriptions
  */
+@Suppress("DEPRECATION_ERROR")
 @OptIn(ExperimentalComposeUiApi::class)
 internal class AwtWindowDropTarget(
     private val window: Window
@@ -398,6 +427,7 @@ internal class AwtWindowDropTarget(
     }
 }
 
+@Suppress("DEPRECATION_ERROR")
 @OptIn(ExperimentalComposeUiApi::class)
 internal class AwtWindowDragTargetListener(
     private val window: Window,
@@ -412,7 +442,7 @@ internal class AwtWindowDragTargetListener(
         onDragEnterWindow(
             WindowDragValue(
                 dtde.location.windowOffset(),
-                dtde.transferable.dragData()
+                dtde.transferable.deprecatedDragData()
             )
         )
     }
@@ -421,7 +451,7 @@ internal class AwtWindowDragTargetListener(
         onDragInsideWindow(
             WindowDragValue(
                 dtde.location.windowOffset(),
-                dtde.transferable.dragData()
+                dtde.transferable.deprecatedDragData()
             )
         )
     }
@@ -447,7 +477,7 @@ internal class AwtWindowDragTargetListener(
 
         val transferable = dtde.transferable
         try {
-            onDrop(WindowDragValue(dtde.location.windowOffset(), transferable.dragData()))
+            onDrop(WindowDragValue(dtde.location.windowOffset(), transferable.deprecatedDragData()))
             dtde.dropComplete(true)
         } catch (e: Exception) {
             onDragExit()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/AwtDragData.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/AwtDragData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package androidx.compose.ui
+package androidx.compose.ui.draganddrop
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.toPainter
 import java.awt.Image
@@ -44,20 +45,22 @@ internal fun Transferable.dragData(): DragData {
 @OptIn(ExperimentalComposeUiApi::class)
 private object UnknownDragData : DragData
 
+@Suppress("DEPRECATION_ERROR")
 @OptIn(ExperimentalComposeUiApi::class)
 private class DragDataFilesListImpl(
     private val transferable: Transferable
-) : DragData.FilesList {
+) : DragData.FilesList, androidx.compose.ui.DragData.FilesList {
     override fun readFiles(): List<String> {
         val files = transferable.getTransferData(DataFlavor.javaFileListFlavor) as List<*>
         return files.filterIsInstance<File>().map { it.toURI().toString() }
     }
 }
 
+@Suppress("DEPRECATION_ERROR")
 @OptIn(ExperimentalComposeUiApi::class)
 private class DragDataImageImpl(
     private val transferable: Transferable
-) : DragData.Image {
+) : DragData.Image, androidx.compose.ui.DragData.Image {
     override fun readImage(): Painter {
         return (transferable.getTransferData(DataFlavor.imageFlavor) as Image).painter()
     }
@@ -80,11 +83,12 @@ private class DragDataImageImpl(
     }
 }
 
+@Suppress("DEPRECATION_ERROR")
 @OptIn(ExperimentalComposeUiApi::class)
 private class DragDataTextImpl(
     private val bestTextFlavor: DataFlavor,
     private val transferable: Transferable
-) : DragData.Text {
+) : DragData.Text, androidx.compose.ui.DragData.Text {
     override val bestMimeType: String = bestTextFlavor.mimeType
 
     override fun readText(): String {
@@ -92,3 +96,10 @@ private class DragDataTextImpl(
         return reader.readText()
     }
 }
+
+/**
+ * Returns the same value as [Transferable.dragData] but as an instance of the deprecated
+ * `androidx.compose.ui.DragData`. Remove this, along with the rest of the deprecated DnD API in 1.8
+ */
+@Suppress("DEPRECATION_ERROR")
+internal fun Transferable.deprecatedDragData() = dragData() as androidx.compose.ui.DragData

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -16,10 +16,9 @@
 
 package androidx.compose.ui.draganddrop
 
-import androidx.compose.ui.DragData
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.dragData
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.painter.Painter
 import java.awt.datatransfer.Transferable
 import java.awt.dnd.DropTargetDragEvent
 import java.awt.dnd.DropTargetDropEvent
@@ -138,6 +137,47 @@ val DragAndDropEvent.awtTransferable: Transferable
  */
 @ExperimentalComposeUiApi
 fun DragAndDropEvent.dragData(): DragData = awtTransferable.dragData()
+
+/**
+ * Represent data that is being dragged (or dropped) to a component from outside an application.
+ */
+@ExperimentalComposeUiApi
+interface DragData {
+    /**
+     * Represents list of files drag and dropped to a component.
+     */
+    interface FilesList : DragData {
+        /**
+         * Returns list of file paths drag and droppped to an application in a URI format.
+         */
+        fun readFiles(): List<String>
+    }
+
+    /**
+     * Represents an image drag and dropped to a component.
+     */
+    interface Image : DragData {
+        /**
+         * Returns an image drag and dropped to an application as a [Painter] type.
+         */
+        fun readImage(): Painter
+    }
+
+    /**
+     * Represent text drag and dropped to a component.
+     */
+    interface Text : DragData {
+        /**
+         * Provides the best MIME type that describes text returned in [readText]
+         */
+        val bestMimeType: String
+
+        /**
+         * Returns a text dropped to an application.
+         */
+        fun readText(): String
+    }
+}
 
 internal actual val DragAndDropEvent.positionInRoot: Offset
     get() = positionInRootImpl


### PR DESCRIPTION
`Modifier.onExternalDrag` and all related APIs are now deprecated.

The only surviving API, `DragData` has been moved into the `ui.draganddrop` package. Note that this is an API change.

Fixes https://youtrack.jetbrains.com/issue/CMP-5977

## Testing
No testing necessary

## Release Notes
### Breaking changes - Desktop
`Modifier.onExternalDrag` has been deprecated in favor of the new `Modifier.dragAndDropTarget`.