### PR TITLE
Revert `matchDeepLinkRequest` from public API

### DIFF
--- a/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDestination.jb.kt
+++ b/navigation/navigation-common/src/jbMain/kotlin/androidx/navigation/NavDestination.jb.kt
@@ -139,7 +139,7 @@ public actual open class NavDestination actual constructor(
         return matchingDeepLink
     }
 
-    protected fun matchDeepLinkRequest(route: String): DeepLinkMatch? {
+    internal fun matchDeepLinkRequest(route: String): DeepLinkMatch? {
         if (deepLinks.isEmpty()) {
             return null
         }


### PR DESCRIPTION
Due to problems with CI reporting, it was missed that after #1525 `protected` is considered as part of public API