### PR TITLE
Scrollable. Fix merge conflict in onPointerEvent

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/Scrollable.kt
@@ -544,7 +544,9 @@ private class ScrollableNode(
         pass: PointerEventPass,
         bounds: IntSize
     ) {
-        super.onPointerEvent(pointerEvent, pass, bounds)
+        if (pointerEvent.changes.fastAny { canDrag.invoke(it) }) {
+            super.onPointerEvent(pointerEvent, pass, bounds)
+        }
         mouseWheelScrollNode.pointerInputNode.onPointerEvent(pointerEvent, pass, bounds)
     }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5069/1.7.0-alpha01-Moving-after-initiating-a-click-cancels-it

Merge was in 51f7f682beaab975073e0f6c72bad8116a1512f7

The fix was in https://android.googlesource.com/platform/frameworks/support/+/9c8b95eb677bed9667bd8df5e4950ab1cd0a5752

## Testing

Manual on the snippet from the issue

## Release notes
### Fixes - Desktop
- _(prerelease fix)_ Fix "Moving after initiating a click cancels it"