### PR TITLE
Suppress deprecation in ExternalDragTest and change sample to use new drag-and-drop API

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ExternalDragTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ExternalDragTest.kt
@@ -46,6 +46,7 @@ import java.awt.Window
 import org.junit.Test
 
 @OptIn(ExperimentalComposeUiApi::class)
+@Suppress("DEPRECATION_ERROR")
 class ExternalDragTest {
     @Test
     fun `drag inside component that close to top left corner`() = runApplicationTest {


### PR DESCRIPTION
Fix ExternalDragTest and change sample to use new drag-and-drop API
