### PR TITLE
Fix window redirecting

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -118,7 +118,7 @@ artifactRedirecting.androidx.annotation.version=1.8.0
 artifactRedirecting.androidx.lifecycle.version=2.8.4
 artifactRedirecting.androidx.navigation.version=2.8.0-rc01
 artifactRedirecting.androidx.savedstate.version=1.2.1
-artifactRedirecting.androidx.window.core.version=1.3.0
+artifactRedirecting.androidx.window.version=1.3.0
 
 # For the purpose of substituteForRedirectedPublishedDependencies (look for it in the code)
 artifactRedirecting.modules-for-knative-manifest=\


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6599/artifactRedirecting.androidx.window.core.version1.3.0-isnt-correct

## Testing
1. ./gradlew :mpp:publishComposeJbToMavenLocal
2. See in ~./.m2/repository/org/jetbrains/androidx/window/window-core/0.0.0-SNAPSHOT/window-core-0.0.0-SNAPSHOT.module:
```
      "name": "debugRuntimeElements-published",
      "attributes": {
        "com.android.build.api.attributes.BuildTypeAttr": "debug",
        "org.gradle.category": "library",
        "org.gradle.usage": "java-runtime",
        "org.jetbrains.kotlin.platform.type": "androidJvm"
      },
      "dependencies": [
        {
          "group": "androidx.window",
          "module": "window-core",
          "version": {
            "requires": "1.3.0"
          }
        },
```
