### PR TITLE
Basic support for BTF2 on iOS

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -26,7 +26,9 @@ import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
 
 internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSession(
     state: TransformedTextFieldState,
@@ -67,18 +69,29 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         }
     }
 
-    startInputMethod(
-        SkikoPlatformTextInputMethodRequest(
-            state = TextFieldValue(
-                state.visualText.toString(),
-                state.visualText.selection,
-                state.visualText.composition,
-            ),
-            imeOptions = imeOptions,
-            onEditCommand = ::onEditCommand,
-            onImeAction = onImeAction
+
+    coroutineScope {
+        launch {
+            state.collectImeNotifications{ _, newValue, _ ->
+                val newTextFieldValue = TextFieldValue(newValue.text.toString(), newValue.selection, newValue.composition)
+                updateSelectionState(newTextFieldValue)
+            }
+        }
+
+        startInputMethod(
+            SkikoPlatformTextInputMethodRequest(
+                state = TextFieldValue(
+                    state.visualText.toString(),
+                    state.visualText.selection,
+                    state.visualText.composition,
+                ),
+                imeOptions = imeOptions,
+                onEditCommand = ::onEditCommand,
+                onImeAction = onImeAction,
+                editProcessor = editProcessor,
+            )
         )
-    )
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -86,5 +99,6 @@ private data class SkikoPlatformTextInputMethodRequest(
     override val state: TextFieldValue,
     override val imeOptions: ImeOptions,
     override val onEditCommand: (List<EditCommand>) -> Unit,
-    override val onImeAction: ((ImeAction) -> Unit)?
+    override val onImeAction: ((ImeAction) -> Unit)?,
+    override val editProcessor: EditProcessor?
 ): PlatformTextInputMethodRequest

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalComposeUiApi::class)
 internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSession(
     state: TransformedTextFieldState,
     layoutState: TextLayoutState,

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -16,9 +16,14 @@
 
 package androidx.compose.mpp.demo.textfield
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -72,6 +77,20 @@ val TextFields = Screen.Selection(
     Screen.Example("BasicTextField") {
         var text by remember { mutableStateOf("usage of BasicTextField") }
         BasicTextField(text, { text = it })
+    },
+
+    Screen.Example("BasicTextField2") {
+        var textFieldState by remember { mutableStateOf("I am TextField") }
+        val textFieldState2 = remember { TextFieldState("I am TextField 2") }
+        Column {
+            BasicTextField(
+                textFieldState,
+                onValueChange = { textFieldState = it },
+                Modifier.padding(16.dp)
+            )
+            Box(Modifier.height(16.dp).fillMaxWidth())
+            BasicTextField(textFieldState2, Modifier.padding(16.dp))
+        }
     },
 
     Screen.Example("RTL and BiDi") {

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/TextFields.kt
@@ -82,14 +82,14 @@ val TextFields = Screen.Selection(
     Screen.Example("BasicTextField2") {
         var textFieldState by remember { mutableStateOf("I am TextField") }
         val textFieldState2 = remember { TextFieldState("I am TextField 2") }
-        Column {
+        Column(Modifier.fillMaxWidth()) {
             BasicTextField(
                 textFieldState,
                 onValueChange = { textFieldState = it },
-                Modifier.padding(16.dp)
+                Modifier.padding(16.dp).fillMaxWidth()
             )
-            Box(Modifier.height(16.dp).fillMaxWidth())
-            BasicTextField(textFieldState2, Modifier.padding(16.dp))
+            Box(Modifier.height(16.dp))
+            BasicTextField(textFieldState2, Modifier.padding(16.dp).fillMaxWidth())
         }
     },
 

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3402,6 +3402,7 @@ public abstract interface class androidx/compose/ui/platform/PlatformTextInputIn
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputMethodRequest {
+	public abstract fun getEditProcessor ()Landroidx/compose/ui/text/input/EditProcessor;
 	public abstract fun getImeOptions ()Landroidx/compose/ui/text/input/ImeOptions;
 	public abstract fun getOnEditCommand ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getOnImeAction ()Lkotlin/jvm/functions/Function1;
@@ -3418,6 +3419,7 @@ public final class androidx/compose/ui/platform/PlatformTextInputModifierNodeKt 
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSession {
 	public abstract fun startInputMethod (Landroidx/compose/ui/platform/PlatformTextInputMethodRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateSelectionState (Landroidx/compose/ui/text/input/TextFieldValue;)V
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSessionScope : androidx/compose/ui/platform/PlatformTextInputSession, kotlinx/coroutines/CoroutineScope {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.platform.a11y.AccessibilityController
 import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.semantics.SemanticsOwner
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -777,8 +776,6 @@ internal class ComposeSceneMediator(
                 }
             })
         }
-
-        override fun updateSelectionState(newState: TextFieldValue) {}
     }
 
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.platform.a11y.AccessibilityController
 import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -776,6 +777,8 @@ internal class ComposeSceneMediator(
                 }
             })
         }
+
+        override fun updateSelectionState(newState: TextFieldValue) {}
     }
 
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
@@ -31,4 +32,6 @@ actual interface PlatformTextInputMethodRequest {
     val onEditCommand: (List<EditCommand>) -> Unit
     @ExperimentalComposeUiApi
     val onImeAction: ((ImeAction) -> Unit)?
+    @ExperimentalComposeUiApi
+    val editProcessor: EditProcessor?
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
@@ -16,6 +16,9 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.ui.text.input.TextFieldValue
+
 actual interface PlatformTextInputSession {
     actual suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing
+    fun updateSelectionState(newState: TextFieldValue)
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
@@ -16,9 +16,11 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.text.input.TextFieldValue
 
 actual interface PlatformTextInputSession {
     actual suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing
-    fun updateSelectionState(newState: TextFieldValue)
+    @ExperimentalComposeUiApi
+    fun updateSelectionState(newState: TextFieldValue) = Unit
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -140,6 +140,25 @@ internal class UIKitTextInputService(
         showSoftwareKeyboard()
     }
 
+    fun startInput(
+        value: TextFieldValue,
+        imeOptions: ImeOptions,
+        editProcessor: EditProcessor?,
+        onEditCommand: (List<EditCommand>) -> Unit,
+        onImeActionPerformed: (ImeAction) -> Unit
+    ) {
+        currentInput = CurrentInput(value, onEditCommand)
+        _tempCurrentInputSession = editProcessor
+        currentImeOptions = imeOptions
+        currentImeActionHandler = onImeActionPerformed
+
+        attachIntermediateTextInputView()
+        textUIView?.input = createSkikoInput()
+        textUIView?.inputTraits = getUITextInputTraits(imeOptions)
+
+        showSoftwareKeyboard()
+    }
+
     override fun stopInput() {
         currentInput = null
         _tempCurrentInputSession = null


### PR DESCRIPTION
- Added basic support for BTF2 for the iOS target
- Added possibility to track the upcoming state in TextInputSession (required for iOS)

<!-- Optional -->
Fixes https://youtrack.jetbrains.com/issue/CMP-5656/Support-TextField2-on-iOS

## Testing
<!-- Optional -->


<!-- Optional -->
This should be tested by QA.

Open test app, go Components -> Textfields -> BasicTextField2, tap on textfield with text I am BasicTextField2 and try to type something

## Release Notes
<!--
Optional, if omitted - won't be included in the changelog

Sections:
- Highlights
- Known issues
- Breaking changes
- Features
- Fixes

Subsections:
- Multiple Platforms
- iOS
- Desktop
- Web
- Resources
- Gradle Plugin
-->
### Features - iOS
- Basic support for `BasicTextField(TextFieldState, ...)` on iOS

