### PR TITLE
Throw a more descriptive error on adding nodes directly inside `application`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -269,12 +269,26 @@ private object YieldFrameClock : MonotonicFrameClock {
     }
 }
 
-private class ApplicationApplier : Applier<Unit> {
-    override val current: Unit = Unit
-    override fun down(node: Unit) = Unit
+private class ApplicationApplier : Applier<Any> {
+    override val current: Any = Unit
+    override fun down(node: Any) = Unit
     override fun up() = Unit
-    override fun insertTopDown(index: Int, instance: Unit) = Unit
-    override fun insertBottomUp(index: Int, instance: Unit) = Unit
+    override fun insertTopDown(index: Int, instance: Any) {
+        if (instance !is Unit) {
+            throw IllegalStateException(
+                "Composable content may not be added directly into " +
+                    ApplicationScope::class.simpleName
+            )
+        }
+    }
+    override fun insertBottomUp(index: Int, instance: Any) {
+        if (instance !is Unit) {
+            throw IllegalStateException(
+                "Composable content may not be added directly into " +
+                    ApplicationScope::class.simpleName
+            )
+        }
+    }
     override fun remove(index: Int, count: Int) = Unit
     override fun move(from: Int, to: Int, count: Int) = Unit
     override fun clear() = Unit


### PR DESCRIPTION
Currently, we fail with an enigmatic
```
ClassCastException: class androidx.compose.ui.node.LayoutNode cannot be cast to class kotlin.Unit
```

It will now fail with
```
IllegalStateException: Composable content may not be added directly into ApplicationScope
```

Fixes https://youtrack.jetbrains.com/issue/CMP-6604
