### PR TITLE
Fix `ArrayList` support in `SavedStateHandle`

### DIFF
--- a/lifecycle/lifecycle-viewmodel-savedstate/src/jbMain/kotlin/androidx/lifecycle/SavedStateHandle.jb.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/jbMain/kotlin/androidx/lifecycle/SavedStateHandle.jb.kt
@@ -296,10 +296,29 @@ actual class SavedStateHandle {
 
                 // References
                 is Bundle,
+                is String,
                 is CharSequence -> true
 
                 // Scalar arrays
-                is ByteArray -> true
+                is BooleanArray,
+                is ByteArray,
+                is CharArray,
+                is DoubleArray,
+                is FloatArray,
+                is IntArray,
+                is LongArray,
+                is ShortArray -> true
+
+                // Reference arrays
+                // [bundleOf] might support [List] instead of [ArrayList] in some cases.
+                is List<*> -> {
+                    // Unlike JVM, there is no reflection available to check component type
+                    when (value.firstOrNull()) {
+                        is Int,
+                        is String -> true
+                        else -> value.isEmpty()
+                    }
+                }
 
                 else -> false
             }


### PR DESCRIPTION
Fixes [CMP-5907](https://youtrack.jetbrains.com/issue/CMP-5907)

## Testing
```kt
stackEntry.savedStateHandle["key"] = listOf("1", "2", "3")
```

This should be tested by QA

## Release Notes
### Fixes - Navigation
- _(prerelease fix)_ Fix `IllegalArgumentException` on putting lists into `savedStateHandle`
