### PR TITLE
Fix scene scale

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Extensions.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/Extensions.uikit.kt
@@ -50,7 +50,7 @@ internal val UIView.density: Density
         val contentSizeCategory = traitCollection.preferredContentSizeCategory ?: UIContentSizeCategoryUnspecified
 
         return Density(
-            density = screen.nativeScale.toFloat(),
+            density = screen.scale.toFloat(),
             fontScale = uiContentSizeCategoryToFontScaleMap[contentSizeCategory] ?: 1.0f
         )
     }


### PR DESCRIPTION
On some devices, iOS uses a canvas larger than the physical screen resolution of the device to perform rendering operations. The scale factor between points and canvas pixels is represented by `UIScreen.scale`.
`UIScreen.nativeScale` is used to represent the scale factor between points and physical screen pixels. The `nativeScale` also represents how iOS compresses the canvas image to fit the real device screen.
Considering these factors, the DP should represent canvas pixels (not physical device pixels) to match the native iOS canvas density.

### Fixes - Scene scale
Fixes: https://youtrack.jetbrains.com/issue/CMP-6690

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix "White bars on sides on some devices"
