### PR TITLE
Fix ArrayIndexOutOfBoundsException on iOS and Wasm

### DIFF
--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/AnimationSpec.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/AnimationSpec.kt
@@ -680,7 +680,10 @@ class KeyframesSpec<T>(val config: KeyframesSpecConfig<T>) : DurationBasedAnimat
         if (!config.keyframes.contains(config.durationMillis)) {
             timestamps.add(config.durationMillis)
         }
-        timestamps.sort()
+
+        //the reason is https://youtrack.jetbrains.com/issue/KT-70005
+        //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
+        if (timestamps.isNotEmpty()) timestamps.sort()
 
         return VectorizedKeyframesSpec(
             timestamps = timestamps,
@@ -788,7 +791,10 @@ class KeyframesWithSplineSpec<T>(
         if (!config.keyframes.contains(config.durationMillis)) {
             timestamps.add(config.durationMillis)
         }
-        timestamps.sort()
+
+        //the reason is https://youtrack.jetbrains.com/issue/KT-70005
+        //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
+        if (timestamps.isNotEmpty()) timestamps.sort()
         return VectorizedMonoSplineKeyframesSpec(
             timestamps = timestamps,
             keyframes = timeToVectorMap,

--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/VectorizedAnimationSpec.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/VectorizedAnimationSpec.kt
@@ -262,7 +262,10 @@ class VectorizedKeyframesSpec<V : AnimationVector> internal constructor(
             if (!keyframes.containsKey(durationMillis)) {
                 times.add(durationMillis)
             }
-            times.sort()
+
+            //the reason is https://youtrack.jetbrains.com/issue/KT-70005
+            //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
+            if (times.isNotEmpty()) times.sort()
             return@run times
         },
         keyframes = kotlin.run {

--- a/compose/material3/adaptive/adaptive-layout/src/commonMain/kotlin/androidx/compose/material3/adaptive/layout/PaneExpansionState.kt
+++ b/compose/material3/adaptive/adaptive-layout/src/commonMain/kotlin/androidx/compose/material3/adaptive/layout/PaneExpansionState.kt
@@ -218,7 +218,8 @@ private fun List<PaneExpansionAnchor>.toPositions(
             anchors.add(maxExpansionWidth * anchor.percentage / 100)
         }
     }
-    //https://youtrack.jetbrains.com/issue/KT-70005
+    //the reason is https://youtrack.jetbrains.com/issue/KT-70005
+    //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
     if (anchors.isNotEmpty()) anchors.sort()
     return anchors
 }


### PR DESCRIPTION
PR adds workaround for [KT-70005](https://youtrack.jetbrains.com/issue/KT-70005) which was fixed in **androidx.collection** `1.5.0-alpha01` but the project depends on `1.4.0`

Fixes: [CMP-6576](https://youtrack.jetbrains.com/issue/CMP-6576) ListDetailPaneScaffold from material3-adaptive throws ArrayIndexOutOfBoundsException on iOS

## Release notes
### Fixes - iOS
- _(prerelease fix)_ Fix "`ListDetailPaneScaffold` from material3-adaptive throws ArrayIndexOutOfBoundsException"