### PR TITLE
Change `isIdle` in tests to return `true` when there exist delayed tasks

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -48,7 +48,7 @@ internal class TooltipAreaTest {
         onNodeWithTag("elementWithTooltip").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
-
+        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
         onNodeWithTag("tooltip").assertExists()
     }
 
@@ -64,6 +64,7 @@ internal class TooltipAreaTest {
         onNodeWithTag("elementWithTooltip").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
+        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
         onNodeWithTag("tooltip").assertExists()
 
         onNodeWithTag("elementWithTooltip").performMouseInput {
@@ -84,6 +85,7 @@ internal class TooltipAreaTest {
         onNodeWithTag("elementWithTooltip").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
+        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
         onNodeWithTag("tooltip").assertExists()
 
         onNodeWithTag("elementWithTooltip").performMouseInput {
@@ -122,6 +124,7 @@ internal class TooltipAreaTest {
         onNodeWithTag("elementWithTooltip").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
+        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
 
         // Move into the tooltip, but still inside the area
         onNodeWithTag("tooltip").let {
@@ -178,6 +181,7 @@ internal class TooltipAreaTest {
         onNodeWithTag("elementWithTooltip").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
+        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
         onNodeWithTag("tooltip").assertExists()
 
         onNodeWithTag("elementWithTooltip").performMouseInput {
@@ -189,6 +193,7 @@ internal class TooltipAreaTest {
             release()
             moveBy(Offset(10f, 10f))
         }
+        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
         onNodeWithTag("tooltip").assertExists()
     }
 
@@ -196,7 +201,7 @@ internal class TooltipAreaTest {
     private fun SimpleTooltipArea(
         areaSize: Dp = 100.dp,
         tooltipSize: Dp = 20.dp,
-        delayMillis: Int = 500
+        delayMillis: Int = TooltipDelayMillis
     ) {
         TooltipArea(
             tooltip = {
@@ -208,3 +213,5 @@ internal class TooltipAreaTest {
         }
     }
 }
+
+private const val TooltipDelayMillis = 500

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyColumnTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyColumnTest.kt
@@ -69,6 +69,7 @@ import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -359,8 +360,12 @@ class LazyColumnTest {
         val itemIndexWhenInterrupting = state.firstVisibleItemIndex
         val itemOffsetWhenInterrupting = state.firstVisibleItemScrollOffset
 
-        assertThat(itemIndexWhenInterrupting).isNotEqualTo(0)
-        assertThat(itemOffsetWhenInterrupting).isNotEqualTo(0)
+        // It's wrong to assert that both firstVisibleItemIndex and firstVisibleItemScrollOffset are
+        // not 0 because either one could just happen to be 0, even though the list was scrolled
+        // correctly.
+//        assertThat(itemIndexWhenInterrupting).isNotEqualTo(0)
+//        assertThat(itemOffsetWhenInterrupting).isNotEqualTo(0)
+        assertTrue((itemIndexWhenInterrupting > 0) || (itemOffsetWhenInterrupting > 0))
 
         onNodeWithTag(LazyListTag)
             .performTouchInput { down(center) }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -56,7 +56,7 @@ class TestBasicsTest {
 
     // See https://github.com/JetBrains/compose-multiplatform/issues/3117
     @Test
-    fun recompositionCompletesBeforeSetContentReturns() = repeat(1000) {
+    fun recompositionCompletesBeforeSetContentReturns() = repeat(100) {
         runSkikoComposeUiTest {
             var globalValue by atomic(0)
             setContent {
@@ -90,27 +90,6 @@ class TestBasicsTest {
         rule.onNodeWithTag("box").performClick()
         val clockAfter = rule.mainClock.currentTime
         assertTrue(clockAfter > clockBefore, "performClick did not advance the test clock")
-    }
-
-    @Test
-    fun advancingClockRunsRecomposition() {
-        rule.mainClock.autoAdvance = false
-
-        rule.setContent {
-            var text by remember { mutableStateOf("1") }
-            Text(text, modifier = Modifier.testTag("text"))
-
-            LaunchedEffect(Unit) {
-                delay(1_000)
-                text = "2"
-            }
-        }
-
-        rule.onNodeWithTag("text").assertTextEquals("1")
-        rule.mainClock.advanceTimeBy(999, ignoreFrameDuration = true)
-        rule.onNodeWithTag("text").assertTextEquals("1")
-        rule.mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
-        rule.onNodeWithTag("text").assertTextEquals("2")
     }
 
     @Test
@@ -250,5 +229,14 @@ class TestBasicsTest {
         }
 
         assertContentEquals(listOf("Composition", "LaunchedEffect"), actions)
+    }
+
+    @Test
+    fun waitForIdleDoesNotAdvanceClockIfAlreadyIdle() = runComposeUiTest {
+        setContent { }
+
+        val initialTime = mainClock.currentTime
+        waitForIdle()
+        assertEquals(initialTime, mainClock.currentTime)
     }
 }

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -181,4 +181,37 @@ class TestBasicsTest {
         rule.unregisterIdlingResource(idlingResource)
         test(expectedValue = "first")
     }
+
+    @Test(timeout = 500)
+    fun infiniteLoopInLaunchedEffectDoesNotHang() = runComposeUiTest {
+        setContent {
+            LaunchedEffect(Unit) {
+                while (true) {
+                    delay(1000)
+                }
+            }
+        }
+    }
+
+    @Test(timeout = 500)
+    fun delayInLaunchedEffectIsExecutedAfterAdvancingClock() = runComposeUiTest {
+        var value = 0
+        mainClock.autoAdvance = false
+        setContent {
+            LaunchedEffect(Unit) {
+                repeat(5) {
+                    delay(1000)
+                    value = it+1
+                }
+            }
+        }
+
+        assertEquals(0, value)
+        mainClock.advanceTimeBy(999, ignoreFrameDuration = true)
+        assertEquals(0, value)
+        mainClock.advanceTimeBy(2, ignoreFrameDuration = true)
+        assertEquals(1, value)
+        mainClock.advanceTimeBy(2000, ignoreFrameDuration = true)
+        assertEquals(3, value)
+    }
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -291,7 +291,7 @@ class SkikoComposeUiTest @InternalTestApi constructor(
             advanceIfNeededAndRenderNextFrame()
             uncaughtExceptionHandler.throwUncaught()
             if (!areAllResourcesIdle()) {
-                sleep(IDLING_RESOURCES_CHECK_INTERVAL_MS)
+                delay(IDLING_RESOURCES_CHECK_INTERVAL_MS)
             }
             yield()
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/FlushCoroutineDispatcherTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/platform/FlushCoroutineDispatcherTest.kt
@@ -62,7 +62,7 @@ class FlushCoroutineDispatcherTest {
         }
 
         assertEquals((0 until 10000).toList(), actualNumbers)
-        assertFalse(dispatcher.hasTasks())
+        assertFalse(dispatcher.hasImmediateTasks())
     }
 
     // Needs JVM APIs to test (and can't test in a single-threaded (JS) environment anyway)
@@ -79,7 +79,7 @@ class FlushCoroutineDispatcherTest {
 
         try {
             jobExchanger.exchange(Unit)  // Wait for the task to run
-            assertTrue(dispatcher.hasTasks(), "hasTasks == false while executing tasks")
+            assertTrue(dispatcher.hasImmediateTasks(), "hasTasks == false while executing tasks")
         } finally {
             // Allow the task to complete, even if `assertTrue` threw an exception
             jobExchanger.exchange(Unit)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -37,12 +37,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import com.google.common.truth.Truth.assertThat
 import java.awt.BorderLayout
-import java.awt.Component
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.KeyboardFocusManager
 import java.awt.Window
-import java.awt.event.FocusEvent
 import java.awt.event.FocusEvent.Cause
 import java.awt.event.KeyEvent
 import javax.swing.JButton
@@ -51,8 +49,6 @@ import javax.swing.JPanel
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import kotlin.test.assertFalse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.MainUIDispatcher
@@ -954,15 +950,25 @@ class FocusTestScope {
         windows.clear()
     }
 
+    private fun focusOwner() = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner.also {
+        if (it == null) {
+            throw AssertionError(
+                "The focus owner is `null`; " +
+                "This can happen due to interference from the user or the window manager. " +
+                "Try running the test without interacting with any windows."
+            )
+        }
+    }
+
     suspend fun pressNextFocusKey() {
-        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+        val focusOwner = focusOwner()
         focusOwner.dispatchEvent(KeyEvent(focusOwner, KeyEvent.KEY_PRESSED, 0, 0, KeyEvent.VK_TAB, '\t'))
         focusOwner.dispatchEvent(KeyEvent(focusOwner, KeyEvent.KEY_RELEASED, 0, 0, KeyEvent.VK_TAB, '\t'))
         awaitEdtAfterDelay()
     }
 
     suspend fun pressPreviousFocusKey() {
-        val focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+        val focusOwner = focusOwner()
         focusOwner.dispatchEvent(KeyEvent(focusOwner, KeyEvent.KEY_PRESSED, 0, KeyEvent.SHIFT_DOWN_MASK, KeyEvent.VK_TAB, '\t'))
         focusOwner.dispatchEvent(KeyEvent(focusOwner, KeyEvent.KEY_RELEASED, 0, KeyEvent.SHIFT_DOWN_MASK, KeyEvent.VK_TAB, '\t'))
         awaitEdtAfterDelay()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -67,11 +67,15 @@ internal class FlushCoroutineDispatcher(
     }
 
     /**
-     * Whether the dispatcher has any tasks scheduled or currently running.
+     * Whether the dispatcher has immediate tasks pending.
      */
-    fun hasTasks() = synchronized(tasksLock) {
-        immediateTasks.isNotEmpty() || delayedTasks.isNotEmpty()
-    } || isPerformingRun
+    fun hasImmediateTasks() = isPerformingRun ||
+        synchronized(tasksLock) { immediateTasks.isNotEmpty() }
+
+    /**
+     * Whether the dispatcher has delayed tasks pending.
+     */
+    fun hasDelayedTasks() = synchronized(tasksLock) { delayedTasks.isNotEmpty() }
 
     /**
      * Perform all scheduled tasks and wait for the tasks which are already

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/FlushCoroutineDispatcher.skiko.kt
@@ -79,7 +79,7 @@ internal class FlushCoroutineDispatcher(
 
     /**
      * Perform all scheduled tasks and wait for the tasks which are already
-     * performing in the [scope]
+     * performing in the [scope].
      */
     fun flush() = performRun {
         // Run tasks until they're empty in order to executed even ones that are added by the tasks

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneRecomposer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneRecomposer.skiko.kt
@@ -57,8 +57,8 @@ internal class ComposeSceneRecomposer(
      */
     val hasPendingWork: Boolean
         get() = recomposer.hasPendingWork ||
-        effectDispatcher.hasTasks() ||
-        recomposeDispatcher.hasTasks()
+        effectDispatcher.hasImmediateTasks() ||
+        recomposeDispatcher.hasImmediateTasks()
 
     val compositionContext: CompositionContext
         get() = recomposer

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -232,7 +232,7 @@ class RenderPhasesTest {
         waitForIdle()  // Make the effects run
         assertContentEquals(
             expected = listOf("draw", "launchedWithFrame", "launchedFromComposition", "launchedFromEffect"),
-            actual = phases
+            actual = phases.subList(0, 4),
         )
     }
 

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -229,10 +229,9 @@ class RenderPhasesTest {
         assertContentEquals(emptyList(), phases)
         startTest = true
         mainClock.advanceTimeByFrame()
-        waitForIdle()  // Make the effects run
         assertContentEquals(
             expected = listOf("draw", "launchedWithFrame", "launchedFromComposition", "launchedFromEffect"),
-            actual = phases.subList(0, 4),
+            actual = phases
         )
     }
 

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -256,8 +256,8 @@ class DialogTest {
 
         assertEquals(null, lastValueInComposition)
         showDialog = true
-        mainClock.advanceTimeBy(1000)
         waitForIdle()
+        mainClock.advanceTimeBy(1000)
         assertEquals(2, lastValueInComposition)
     }
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -256,6 +256,7 @@ class DialogTest {
 
         assertEquals(null, lastValueInComposition)
         showDialog = true
+        mainClock.advanceTimeBy(1000)
         waitForIdle()
         assertEquals(2, lastValueInComposition)
     }


### PR DESCRIPTION
We currently hang in tests if there's an infinite loop with `delay` in a `LaunchedEffect`:
```
    @Test
    fun loopInLaunchedEffectTest() = runSkikoComposeUiTest {
        setContent {
            LaunchedEffect(Unit) {
                while (true) {
                    delay(1000)
                    println("Tick")
                }
            }
        }
    }
```
This happens because we consider the scene to not be "idle" when there are delayed tasks. Android does not.

Fixes https://youtrack.jetbrains.com/issue/CMP-965/Tests-hang-if-theres-an-infinite-loop-in-LaunchedEffect

Additionally, this PR also runs `render` correctly (recomposition, layout, drawing and effects) each (virtual) frame when the clock is advanced manually by a large value:
```
@Test
fun advancingClockCausesRecompositions() = runComposeUiTest {
    mainClock.autoAdvance = false
    var value by mutableStateOf(0)
    val compositionValues = mutableListOf<Int>()
    setContent {
        compositionValues.add(value)
        val capturedValue = value
        LaunchedEffect(capturedValue) {
            delay(1000)
            value = capturedValue + 1
        }
    }

    assertEquals(0, value)
    mainClock.advanceTimeBy(10000)
    assertContentEquals(0..9, compositionValues)
}
```
Previously, only 0 and 1 would be seen by the composition.

## Testing
- Added unit tests.


## Release Notes
### Fixes - Multiple Platforms
- `waitForIdle`, `awaitIdle` and `runOnIdle` no longer consider Compose to be non-idle when coroutines launched in a composition scope call `delay`. This prevents tests with an infinite loop with `delay` in a `LaunchedEffect` from hanging.
- Tests that advance the test clock (via `mainClock.advanceTimeBy`) will now correctly (re)compose/layout/draw/effects each virtual frame as needed.

### Breaking Changes - Multiple Platforms
- Tests that relied on `waitForIdle`, `awaitIdle` or `runOnIdle` (whether explicit or implicit) executing `delay`-ed coroutines will no longer work correctly. To fix this advance the test time via `mainClock` manually, as needed.
    For example, tests that previously did something like:
    ```
    var updateText by mutableStateOf(false)
    var text by mutableStateOf("0")
    setContent {
        LaunchedEffect(updateText) {
            if (updateText) {
                delay(1000)
                text = "1"
            }
        }
    }
    updateText = true
    waitForIdle()
    assertEquals("1", text)
    ```
    will need to add `mainClock.advanceTimeBy(1000)` after `waitForIdle()`, because `waitForIdle` no longer waits for the `delay`-ed coroutine to complete.
- Tests that advance the test clock (via `mainClock.advanceTimeBy`) may see different behavior with regards to the amount and timing of recomposition, layout, drawing and effects.