### PR TITLE
Prevent CfW-mobile crash when selecting some text in SelectionContainer

### DIFF
--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.web.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.web.kt
@@ -40,7 +40,7 @@ internal actual fun isCopyKeyEvent(keyEvent: KeyEvent): Boolean {
  * Magnification is not supported on desktop.
  */
 internal actual fun Modifier.selectionMagnifier(manager: SelectionManager): Modifier =
-    TODO("implement js selectionMagnifier")
+    this // TODO for mobile web: https://youtrack.jetbrains.com/issue/CMP-6645
 
 internal actual val SelectionManager.skipCopyKeyEvent: Boolean
     get() = true

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
@@ -144,6 +144,12 @@ class SelectionContainerTest {
         }
         assertTrue(selection.exists())
     }
+
+    @Test
+    fun selectionMagnifierShouldNotCrash() {
+        val sm = SelectionManager(SelectionRegistrarImpl())
+        Modifier.selectionMagnifier(sm)
+    }
 }
 
 private fun Selection?.exists() = (this != null) && !this.toTextRange().collapsed


### PR DESCRIPTION
Currently, the web app would crash in mobile browsers after selecting some text in SelectionContainer.
This is rather a workaround: we simply do nothing. But it's an acceptable one, since not all android and ios versions support selectionMagnifier anyway.
TODO: properly implement Modifier.selectionMagnifier https://youtrack.jetbrains.com/issue/CMP-6645


## Testing
- Added a simple unit test
- tested in Google Chrome on my android device

## Release Notes
### Fixes - Web
- Prevent a crash on mobile web when selecting some text in `SelectionContainer`