### PR TITLE
Fix keyboard closing while scrolling content with Text Fields

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -54,7 +54,6 @@ internal actual fun legacyTextInputServiceAdapterAndService():
             }
 
             override fun stopInput() {
-                service.stopInput()
                 session?.dispose()
                 session = null
             }


### PR DESCRIPTION
Do not call text input service directly to stop input from the `LegacyPlatformTextInputServiceAdapter`

Fixes https://youtrack.jetbrains.com/issue/CMP-6643/iOS-The-keyboard-closes-while-scrolling-textfield-content-which-is-being-partially-overlapped-by-textfield

## Release Notes
### Fixes - iOS
- Fix keyboard closing while scrolling content with Text Fields