### PR TITLE
Fix "Android target depends on prerelease versions"

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
@@ -133,11 +133,21 @@ internal class CustomRootComponent(
     fun addUsageFromConfiguration(configuration: Configuration, defaultUsage: KotlinUsageContext) {
         val newDependency = customizeDependencyPerConfiguration(configuration)
 
+        // Dependencies from metadataApiElements, metadataSourcesElements.
+        // Includes not only commonMain, but also other non-target sourceSets (skikoMain, webMain)
+        val metadataDependencies = rootComponent.usages.flatMap { it.dependencies }
+
+        // Dependencies from debugApiElements and other Android configurations
+        val androidDependencies = defaultUsage.dependencies.toSet()
+
+        // Intersection of metadataDependencies and androidDependencies gives us commonMain deps
+        val commonMainDependencies = metadataDependencies.filter { it in androidDependencies }
+
         extraUsages.add(
             CustomUsage(
                 name = configuration.name,
                 attributes = configuration.attributes,
-                dependencies = setOf(newDependency) + defaultUsage.dependencies
+                dependencies = setOf(newDependency) + commonMainDependencies
             )
         )
     }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5864/Compose-UI-test-error-on-android-No-static-method-forceEnableAppTracing

Regression after https://github.com/JetBrains/compose-multiplatform-core/pull/1367

During redirection we added dependencies from `androidMain.dependencies` to the Android target, which contains a lot of prerelease versions. Also, we usually don't update `androidMain` during merges.

Instead of `androidMain` we should use `commonMain`. Pure `androidMain` dependencies are added transitively from `androidx` redirection.

## Testing

1.
```
./gradlew :mpp:publishComposeJbToMavenLocal
```
`~/.m2/repository/org/jetbrains/compose/ui/ui-test/0.0.0-SNAPSHOT/ui-test-0.0.0-SNAPSHOT.module`, search `monitor`. It doesn't exist anymore

2. Retest https://github.com/JetBrains/compose-multiplatform-core/pull/1328

This should be tested by QA.

## Release Notes
### Fixes - Android
- _(prerelease fix)_ Fix "Compose UI test error on android: No static method forceEnableAppTracing"
- _(prerelease fix)_ Fix "Android target depends on prerelease versions"