### PR TITLE
Do not revalidate window after resizing.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/util/Windows.desktop.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowPosition
 import androidx.compose.ui.window.density
-import androidx.compose.ui.window.layoutDirection
 import androidx.compose.ui.window.layoutDirectionFor
 import java.awt.Component
 import java.awt.Dialog
@@ -120,7 +119,6 @@ private fun Window.setSizeImpl(size: DpSize) {
         if (isWidthSpecified) width else computedPreferredSize!!.width,
         if (isHeightSpecified) height else computedPreferredSize!!.height,
     )
-    revalidate()  // Calls doLayout on the ComposeLayer, causing it to update its size
 }
 
 internal fun Window.setPositionImpl(


### PR DESCRIPTION
This revalidation was added in https://github.com/JetBrains/compose-multiplatform-core/pull/442, but that problem no longer reproduces.

I'm not really sure why this revalidation causes [Resizing the window using WindowState breaks the UI](https://youtrack.jetbrains.com/issue/CMP-6550/Resizing-the-window-using-WindowState-breaks-the-UI
), but it doesn't appear to be needed.

Fixes https://youtrack.jetbrains.com/issue/CMP-6550/Resizing-the-window-using-WindowState-breaks-the-UI

## Testing
Tested manually with
```
@OptIn(ExperimentalComposeUiApi::class)
fun main() {
    application {
        val state = rememberWindowState()
        var value by remember { mutableStateOf(0) }

        Window(onCloseRequest = ::exitApplication, state = state, undecorated = true) {
            Box(Modifier.fillMaxSize().background(Color.Yellow)) {
                Box(
                    contentAlignment = Alignment.Center,
                    modifier = Modifier.size(200.dp).offset(x = 10.dp, y = 10.dp).background(Color.Red)
                ) {
                    val windowInfo = LocalWindowInfo.current
                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
                        Text("$value")
                        Text("${windowInfo.containerSize}")
                    }
                }
            }

            LaunchedEffect(Unit) {
                while (true) {
                    state.size = DpSize(700.dp, 500.dp)
                    value += 1
                    delay(DELAY)
                    state.size = DpSize(800.dp, 600.dp)
                    value += 1
                    delay(DELAY)
                }
            }
        }
    }
}

const val DELAY = 300L
```

This could be tested by QA

## Release Notes
### Fixes - Desktop
- Fix UI glitch when resizing a Compose window via its `WindowState`.
