### PR TITLE
Use actual openURL method in demo

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/AnimationFreezeBug.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/AnimationFreezeBug.kt
@@ -25,15 +25,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import platform.Foundation.NSURL.Companion.URLWithString
 import platform.UIKit.UIApplication
-import platform.Foundation.NSURL
 
 val AnimationFreezeBug = Screen.Example("AnimationFreezeBug") {
     Column(modifier = Modifier.fillMaxSize()) {
         var state by remember { mutableStateOf(true) }
         Switch(checked = state, onCheckedChange = {
             state = it
-            UIApplication.sharedApplication.openURL(NSURL.URLWithString("app-settings:")!!)
+            UIApplication.sharedApplication.openURL(
+                url = URLWithString("app-settings:")!!,
+                options = emptyMap<Any?, Any>(),
+                completionHandler = null
+            )
         })
     }
 }


### PR DESCRIPTION
Fixes the following error on iOS 18:
```
The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).
```

Related bug: https://youtrack.jetbrains.com/issue/CMP-6699