### PR TITLE
Use separate `SnapshotStateObserver` in `SkiaGraphicsContext`

### DIFF
--- a/compose/ui/ui-graphics/api/desktop/ui-graphics.api
+++ b/compose/ui/ui-graphics/api/desktop/ui-graphics.api
@@ -992,8 +992,11 @@ public final class androidx/compose/ui/graphics/SkiaColorFilter_skikoKt {
 	public static final fun asSkiaColorFilter (Landroidx/compose/ui/graphics/ColorFilter;)Lorg/jetbrains/skia/ColorFilter;
 }
 
-public final class androidx/compose/ui/graphics/SkiaGraphicsContext_skikoKt {
-	public static final fun GraphicsContext (Landroidx/compose/runtime/snapshots/SnapshotStateObserver;)Landroidx/compose/ui/graphics/GraphicsContext;
+public final class androidx/compose/ui/graphics/SkiaGraphicsContext : androidx/compose/ui/graphics/GraphicsContext {
+	public fun <init> ()V
+	public fun createGraphicsLayer ()Landroidx/compose/ui/graphics/layer/GraphicsLayer;
+	public final fun dispose ()V
+	public fun releaseGraphicsLayer (Landroidx/compose/ui/graphics/layer/GraphicsLayer;)V
 }
 
 public final class androidx/compose/ui/graphics/SkiaImageAsset_skikoKt {

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
@@ -19,19 +19,22 @@ package androidx.compose.ui.graphics
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.layer.GraphicsLayer
-import kotlin.js.JsName
 
-/**
- * Create a new [GraphicsContext].
- */
 @InternalComposeUiApi
-@JsName("createGraphicsContext")
-fun GraphicsContext(snapshotObserver: SnapshotStateObserver): GraphicsContext =
-    SkiaGraphicsContext(snapshotObserver)
+class SkiaGraphicsContext() : GraphicsContext {
+    private val snapshotObserver = SnapshotStateObserver { command ->
+        command()
+    }
 
-private class SkiaGraphicsContext(
-    private val snapshotObserver: SnapshotStateObserver
-) : GraphicsContext {
+    init {
+        snapshotObserver.start()
+    }
+
+    fun dispose() {
+        snapshotObserver.stop()
+        snapshotObserver.clear()
+    }
+
     override fun createGraphicsLayer(): GraphicsLayer {
         return GraphicsLayer(snapshotObserver)
     }

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
@@ -217,7 +217,10 @@ actual class GraphicsLayer internal constructor(
         ) {
             snapshotObserver.observeReads(
                 scope = this,
-                onValueChangedForScope = { it.requestDraw() },
+                onValueChangedForScope = {
+                    // Can be called from another thread
+                    it.requestDraw()
+                },
                 block = block
             )
         }
@@ -464,6 +467,8 @@ actual class GraphicsLayer internal constructor(
             childDependenciesTracker.removeDependencies {
                 it.onRemovedFromParentLayer()
             }
+
+            snapshotObserver.clear(this)
         }
     }
 

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.graphics.layer
 
-import androidx.compose.runtime.snapshots.SnapshotStateObserver
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
@@ -27,6 +26,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.SkiaGraphicsContext
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
@@ -968,11 +968,7 @@ class SkiaGraphicsLayerTest {
         verify: ((PixelMap) -> Unit)? = null,
         entireScene: Boolean = false
     ) {
-        val observer = SnapshotStateObserver { command ->
-            command()
-        }
-        observer.start()
-        val graphicsContext = GraphicsContext(observer)
+        val graphicsContext = SkiaGraphicsContext()
         val surfaceWidth = TEST_WIDTH * 2
         val surfaceHeight = TEST_HEIGHT * 2
         val surface = Surface.makeRasterN32Premul(surfaceWidth, surfaceHeight)
@@ -1001,8 +997,7 @@ class SkiaGraphicsLayerTest {
             verify?.invoke(imageBitmap.toPixelMap())
         } finally {
             surface.close()
-            observer.stop()
-            observer.clear()
+            graphicsContext.dispose()
         }
     }
 

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/OwnerSnapshotObserver.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/node/OwnerSnapshotObserver.kt
@@ -25,7 +25,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateObserver
 @Suppress("CallbackName") // TODO rename this and SnapshotStateObserver. b/173401548
 internal class OwnerSnapshotObserver(onChangedExecutor: (callback: () -> Unit) -> Unit) {
 
-    internal val observer = SnapshotStateObserver(onChangedExecutor)
+    private val observer = SnapshotStateObserver(onChangedExecutor)
 
     private val onCommitAffectingLookaheadMeasure: (LayoutNode) -> Unit = { layoutNode ->
         if (layoutNode.isValidOwnerScope) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.GraphicsContext
 import androidx.compose.ui.graphics.Matrix
+import androidx.compose.ui.graphics.SkiaGraphicsContext
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.key.Key
@@ -125,6 +126,7 @@ internal class RootNodeOwner(
 
     private val rootSemanticsNode = EmptySemanticsModifier()
     private val snapshotObserver = snapshotInvalidationTracker.snapshotObserver()
+    private val graphicsContext = SkiaGraphicsContext()
 
     private val rootModifier = EmptySemanticsElement(rootSemanticsNode)
         .focusProperties {
@@ -178,6 +180,7 @@ internal class RootNodeOwner(
         check(!isDisposed) { "RootNodeOwner is already disposed" }
         platformContext.rootForTestListener?.onRootForTestDisposed(rootForTest)
         snapshotObserver.stopObserving()
+        graphicsContext.dispose()
         // we don't need to call root.detach() because root will be garbage collected
         isDisposed = true
     }
@@ -316,7 +319,7 @@ internal class RootNodeOwner(
         override val inputModeManager get() = platformContext.inputModeManager
         override val clipboardManager = PlatformClipboardManager()
         override val accessibilityManager = DefaultAccessibilityManager()
-        override val graphicsContext = GraphicsContext(this@RootNodeOwner.snapshotObserver.observer)
+        override val graphicsContext get() = this@RootNodeOwner.graphicsContext
         override val textToolbar get() = platformContext.textToolbar
         override val autofillTree = AutofillTree()
         override val autofill: Autofill?  get() = null


### PR DESCRIPTION
As @igordmn [noticed](https://github.com/JetBrains/compose-multiplatform-core/pull/1574#discussion_r1765408228) it's better to use separate observer.

Current solution might cause
```
Exception in thread "AWT-EventQueue-0" java.lang.ClassCastException: class androidx.compose.ui.graphics.layer.GraphicsLayer cannot be cast to class androidx.compose.ui.node.OwnerScope (androidx.compose.ui.graphics.layer.GraphicsLayer and androidx.compose.ui.node.OwnerScope are in unnamed module of loader 'app')
	at androidx.compose.ui.node.OwnerSnapshotObserver$clearInvalidObservations$1.invoke(OwnerSnapshotObserver.kt:137)
	at androidx.compose.ui.node.OwnerSnapshotObserver$clearInvalidObservations$1.invoke(OwnerSnapshotObserver.kt:137)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver$ObservedScopeMap.removeScopeIf(SnapshotStateObserver.kt:541)
	at androidx.compose.runtime.snapshots.SnapshotStateObserver.clearIf(SnapshotStateObserver.kt:307)
	at androidx.compose.ui.node.OwnerSnapshotObserver.clearInvalidObservations$ui(OwnerSnapshotObserver.kt:137)
	at androidx.compose.ui.node.RootNodeOwner.clearInvalidObservations(RootNodeOwner.skiko.kt:188)
	at androidx.compose.ui.node.RootNodeOwner.draw(RootNodeOwner.skiko.kt:228)
	at androidx.compose.ui.scene.CanvasLayersComposeSceneImpl.draw(CanvasLayersComposeScene.skiko.kt:250)
	at androidx.compose.ui.scene.BaseComposeScene.render(BaseComposeScene.skiko.kt:190)
	at androidx.compose.ui.scene.ComposeSceneMediator$onRender$1$1.invoke(ComposeSceneMediator.desktop.kt:574)
	at androidx.compose.ui.scene.ComposeSceneMediator$onRender$1$1.invoke(ComposeSceneMediator.desktop.kt:572)
	at androidx.compose.ui.viewinterop.SwingInteropContainer.postponingExecutingScheduledUpdates(SwingInteropContainer.desktop.kt:229)
	at androidx.compose.ui.scene.ComposeSceneMediator.onRender(ComposeSceneMediator.desktop.kt:572)
	at org.jetbrains.skiko.SkiaLayer.update$skiko(SkiaLayer.awt.kt:533)
	at org.jetbrains.skiko.redrawer.AWTRedrawer.update(AWTRedrawer.kt:54)
	at org.jetbrains.skiko.redrawer.MetalRedrawer$frameDispatcher$1.invokeSuspend(MetalRedrawer.kt:83)
	at org.jetbrains.skiko.redrawer.MetalRedrawer$frameDispatcher$1.invoke(MetalRedrawer.kt)
	at org.jetbrains.skiko.redrawer.MetalRedrawer$frameDispatcher$1.invoke(MetalRedrawer.kt)
	at org.jetbrains.skiko.FrameDispatcher$job$1.invokeSuspend(FrameDispatcher.kt:33)
```

Fixes https://youtrack.jetbrains.com/issue/CMP-6705

## Testing
No local reproduction 😢 , just report from @chrisbanes 
This should be tested by QA