### PR TITLE
Deprecate defaultUIKitMain() in order to remove it

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -21,34 +21,30 @@ fun main(vararg args: String) {
     androidx.compose.ui.util.enableTraceOSLog()
 
     val arg = args.firstOrNull() ?: ""
-    defaultUIKitMain("ComposeDemo") {
-        ComposeUIViewController(configure = {
-            accessibilitySyncOptions =
-                AccessibilitySyncOptions.WhenRequiredByAccessibilityServices(object :
-                    AccessibilityDebugLogger {
-                    override fun log(message: Any?) {
-                        if (message == null) {
-                            println()
-                        } else {
-                            println("[a11y]: $message")
-                        }
-                    }
-                })
-
-            delegate = object : ComposeUIViewControllerDelegate {
-                override val preferredStatusBarStyle: UIStatusBarStyle?
-                    get() = preferredStatusBarStyleValue
-
-                override val prefersStatusBarHidden: Boolean?
-                    get() = prefersStatusBarHiddenValue
-
-                override val preferredStatysBarAnimation: UIStatusBarAnimation?
-                    get() = preferredStatysBarAnimationValue
+    defaultUIKitMain("ComposeDemo", ComposeUIViewController(configure = {
+        accessibilitySyncOptions = AccessibilitySyncOptions.WhenRequiredByAccessibilityServices(object: AccessibilityDebugLogger {
+            override fun log(message: Any?) {
+                if (message == null) {
+                    println()
+                } else {
+                    println("[a11y]: $message")
+                }
             }
-        }) {
-            IosDemo(arg)
+        })
+
+        delegate = object : ComposeUIViewControllerDelegate {
+            override val preferredStatusBarStyle: UIStatusBarStyle?
+                get() = preferredStatusBarStyleValue
+
+            override val prefersStatusBarHidden: Boolean?
+                get() = prefersStatusBarHiddenValue
+
+            override val preferredStatysBarAnimation: UIStatusBarAnimation?
+                get() = preferredStatysBarAnimationValue
         }
-    }
+    }) {
+        IosDemo(arg)
+    })
 }
 
 @Composable

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -1,8 +1,6 @@
 // Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Run button in XCode.
 package androidx.compose.mpp.demo
 
-import androidx.compose.mpp.demo.bugs.IosBugs
-import androidx.compose.mpp.demo.bugs.StartRecompositionCheck
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.remember
@@ -10,8 +8,13 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.main.defaultUIKitMain
 import androidx.compose.ui.platform.AccessibilityDebugLogger
 import androidx.compose.ui.platform.AccessibilitySyncOptions
-import androidx.compose.ui.uikit.ComposeUIViewControllerDelegate
 import androidx.compose.ui.window.ComposeUIViewController
+import androidx.compose.mpp.demo.bugs.IosBugs
+import androidx.compose.mpp.demo.bugs.StartRecompositionCheck
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.uikit.ComposeUIViewControllerDelegate
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UIViewController

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -1,6 +1,8 @@
 // Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Run button in XCode.
 package androidx.compose.mpp.demo
 
+import androidx.compose.mpp.demo.bugs.IosBugs
+import androidx.compose.mpp.demo.bugs.StartRecompositionCheck
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.remember
@@ -8,13 +10,8 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.main.defaultUIKitMain
 import androidx.compose.ui.platform.AccessibilityDebugLogger
 import androidx.compose.ui.platform.AccessibilitySyncOptions
-import androidx.compose.ui.window.ComposeUIViewController
-import androidx.compose.mpp.demo.bugs.IosBugs
-import androidx.compose.mpp.demo.bugs.StartRecompositionCheck
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.uikit.ComposeUIViewControllerDelegate
+import androidx.compose.ui.window.ComposeUIViewController
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UIViewController
@@ -24,30 +21,34 @@ fun main(vararg args: String) {
     androidx.compose.ui.util.enableTraceOSLog()
 
     val arg = args.firstOrNull() ?: ""
-    defaultUIKitMain("ComposeDemo", ComposeUIViewController(configure = {
-        accessibilitySyncOptions = AccessibilitySyncOptions.WhenRequiredByAccessibilityServices(object: AccessibilityDebugLogger {
-            override fun log(message: Any?) {
-                if (message == null) {
-                    println()
-                } else {
-                    println("[a11y]: $message")
-                }
+    defaultUIKitMain("ComposeDemo") {
+        ComposeUIViewController(configure = {
+            accessibilitySyncOptions =
+                AccessibilitySyncOptions.WhenRequiredByAccessibilityServices(object :
+                    AccessibilityDebugLogger {
+                    override fun log(message: Any?) {
+                        if (message == null) {
+                            println()
+                        } else {
+                            println("[a11y]: $message")
+                        }
+                    }
+                })
+
+            delegate = object : ComposeUIViewControllerDelegate {
+                override val preferredStatusBarStyle: UIStatusBarStyle?
+                    get() = preferredStatusBarStyleValue
+
+                override val prefersStatusBarHidden: Boolean?
+                    get() = prefersStatusBarHiddenValue
+
+                override val preferredStatysBarAnimation: UIStatusBarAnimation?
+                    get() = preferredStatysBarAnimationValue
             }
-        })
-
-        delegate = object : ComposeUIViewControllerDelegate {
-            override val preferredStatusBarStyle: UIStatusBarStyle?
-                get() = preferredStatusBarStyleValue
-
-            override val prefersStatusBarHidden: Boolean?
-                get() = prefersStatusBarHiddenValue
-
-            override val preferredStatysBarAnimation: UIStatusBarAnimation?
-                get() = preferredStatysBarAnimationValue
+        }) {
+            IosDemo(arg)
         }
-    }) {
-        IosDemo(arg)
-    })
+    }
 }
 
 @Composable

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/main/DefaultIOSMain.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/main/DefaultIOSMain.uikit.kt
@@ -35,8 +35,9 @@ import platform.UIKit.UIWindow
 private var _rootViewController: UIViewController? = null
 
 @Deprecated(
-    "Crashes app under some circumstances. Will be removed in the upcoming release.",
-    ReplaceWith("Create UIApplication on your own if needed.")
+    "Not supposed to be a public API. Will be removed in the upcoming release.",
+    ReplaceWith("Follow the guidelines to create an iOS application:" +
+        "https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-create-first-app.html")
 )
 fun defaultUIKitMain(executableName: String, rootViewController: UIViewController) {
     _rootViewController = rootViewController
@@ -51,8 +52,9 @@ fun defaultUIKitMain(executableName: String, rootViewController: UIViewControlle
 }
 
 @Deprecated(
-    "Will be removed in the upcoming release.",
-    ReplaceWith("Implement UIApplicationDelegate on your own if needed.")
+    "Not supposed to be a public API. Will be removed in the upcoming release.",
+    ReplaceWith("Follow the guidelines to create an iOS application:" +
+        "https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-multiplatform-create-first-app.html")
 )
 class DefaultIOSAppDelegate : UIResponder, UIApplicationDelegateProtocol {
     companion object Companion : UIResponderMeta(), UIApplicationDelegateProtocolMeta

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/main/DefaultIOSMain.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/main/DefaultIOSMain.uikit.kt
@@ -16,14 +16,36 @@
 
 package androidx.compose.ui.main
 
-import kotlinx.cinterop.*
-import platform.UIKit.*
-import platform.Foundation.*
+import kotlinx.cinterop.ObjCObjectBase
+import kotlinx.cinterop.autoreleasepool
+import kotlinx.cinterop.cstr
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toCValues
+import platform.Foundation.NSStringFromClass
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDelegateProtocol
+import platform.UIKit.UIApplicationDelegateProtocolMeta
+import platform.UIKit.UIApplicationMain
+import platform.UIKit.UIResponder
+import platform.UIKit.UIResponderMeta
+import platform.UIKit.UIScreen
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
 
-private var _rootViewController: UIViewController? = null
+private var _makeRootViewController: (() -> UIViewController)? = null
 
-fun defaultUIKitMain(executableName: String, rootViewController: UIViewController) {
-    _rootViewController = rootViewController
+@Deprecated(
+    message = "Replaced by function with postpone controller load",
+    replaceWith = ReplaceWith(
+        expression = "defaultUIKitMain(executableName, makeRootViewController)",
+        imports = arrayOf("androidx.compose.ui.main")
+    )
+)
+fun defaultUIKitMain(executableName: String, rootViewController: UIViewController)
+    = defaultUIKitMain(executableName) { rootViewController }
+
+fun defaultUIKitMain(executableName: String, makeRootViewController: () -> UIViewController) {
+    _makeRootViewController = makeRootViewController
     val args = emptyArray<String>()
     memScoped {
         val argc = args.size + 1
@@ -48,7 +70,7 @@ class DefaultIOSAppDelegate : UIResponder, UIApplicationDelegateProtocol {
 
     override fun application(application: UIApplication, didFinishLaunchingWithOptions: Map<Any?, *>?): Boolean {
         window = UIWindow(frame = UIScreen.mainScreen.bounds)
-        window!!.rootViewController = _rootViewController
+        window!!.rootViewController = _makeRootViewController?.invoke()
         window!!.makeKeyAndVisible()
         return true
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/main/DefaultIOSMain.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/main/DefaultIOSMain.uikit.kt
@@ -32,20 +32,14 @@ import platform.UIKit.UIScreen
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
 
-private var _makeRootViewController: (() -> UIViewController)? = null
+private var _rootViewController: UIViewController? = null
 
 @Deprecated(
-    message = "Replaced by function with postpone controller load",
-    replaceWith = ReplaceWith(
-        expression = "defaultUIKitMain(executableName, makeRootViewController)",
-        imports = arrayOf("androidx.compose.ui.main")
-    )
+    "Crashes app under some circumstances. Will be removed in the upcoming release.",
+    ReplaceWith("Create UIApplication on your own if needed.")
 )
-fun defaultUIKitMain(executableName: String, rootViewController: UIViewController)
-    = defaultUIKitMain(executableName) { rootViewController }
-
-fun defaultUIKitMain(executableName: String, makeRootViewController: () -> UIViewController) {
-    _makeRootViewController = makeRootViewController
+fun defaultUIKitMain(executableName: String, rootViewController: UIViewController) {
+    _rootViewController = rootViewController
     val args = emptyArray<String>()
     memScoped {
         val argc = args.size + 1
@@ -56,6 +50,10 @@ fun defaultUIKitMain(executableName: String, makeRootViewController: () -> UIVie
     }
 }
 
+@Deprecated(
+    "Will be removed in the upcoming release.",
+    ReplaceWith("Implement UIApplicationDelegate on your own if needed.")
+)
 class DefaultIOSAppDelegate : UIResponder, UIApplicationDelegateProtocol {
     companion object Companion : UIResponderMeta(), UIApplicationDelegateProtocolMeta
 
@@ -70,7 +68,7 @@ class DefaultIOSAppDelegate : UIResponder, UIApplicationDelegateProtocol {
 
     override fun application(application: UIApplication, didFinishLaunchingWithOptions: Map<Any?, *>?): Boolean {
         window = UIWindow(frame = UIScreen.mainScreen.bounds)
-        window!!.rootViewController = _makeRootViewController?.invoke()
+        window!!.rootViewController = _rootViewController
         window!!.makeKeyAndVisible()
         return true
     }


### PR DESCRIPTION
Currently the app crashes on a swipe back gesture, if the root controller is a `UINavigationController`.
The UIApplication should be initialized before the view controller is being created.
`defaultUIKitMain` should be moved to the demo app and should not be part of the public API.

## Release Notes

### Fixes - iOS
- Deprecate `defaultUIKitMain()`