### PR TITLE
Handling js-related global errors in web tests

### DIFF
--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -30,7 +30,8 @@ config.client.mocha.timeout = 10000;
 // This enables running tests on a custom html page without iframe
 config.client.useIframe = false
 config.client.runInParent = true
-config.customClientContextFile = path.resolve(configPath, "static", "client_with_context.html")
+config.staticFilesDir =  path.resolve(configPath, "static");
+config.customClientContextFile = path.resolve(config.staticFilesDir, "client_with_context.html")
 
 function KarmaWebpackOutputFramework(config) {
     // This controller is instantiated and set during the preprocessor phase by the karma-webpack plugin
@@ -46,11 +47,18 @@ function KarmaWebpackOutputFramework(config) {
     }
 
     config.files.push({
+        pattern: `${config.staticFilesDir}/**/*.js`,
+        included: true,
+        served: true,
+        watched: false
+    });
+
+    config.files.push({
         pattern: `${controller.outputPath}/**/*`,
         included: false,
         served: true,
         watched: false
-    })
+    });
 }
 
 const KarmaWebpackOutputPlugin = {

--- a/mpp/karma.config.d/wasm/static/common-tests.js
+++ b/mpp/karma.config.d/wasm/static/common-tests.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+window.addEventListener("error", (message, source, lineno, colno, error) => {
+    console.log(`[web] error message: ${message} \n`);
+    console.log(`[web] error source: ${source} \n`);
+    console.log(`[web] error lineno: ${lineno} \n`);
+    console.log(`[web] error colno: ${colno} \n`);
+    console.log(`[web] error error: ${error} \n`);
+
+    return true;
+});
+
+
+window.addEventListener("unhandledrejection", (event) => {
+    console.log(`[web] unhandled Promise rejection ${event.reason} \n`);
+});
+
+window.addEventListener("rejectionhandled", (event) => {
+        console.log(`[web] handled Promise rejection; reason: ${event.reason} \n`);
+    }, false
+);


### PR DESCRIPTION
This particular PR introduces to our test workflow small js file that injects (through the karma means) to any test suit running. 
The purpose of this file is to log all js-related errors - and in particular Promise-rejections - that happened during test runs. 

Here's how one can check what's the difference: Just break some js-related code and run the tests, you'll see the error in the logs.

For instance, instead of
```kotlin
private fun DummyTouchEventInit(): TouchEventInit = js("({ changedTouches: [new Touch({identifier: 0, target: document})] })")
```

you can write, for instance, 
```kotlin
private fun DummyTouchEventInit(): TouchEventInit = js("({ changedTouches: [new Douch({identifier: 0, target: document})] })")
```