### PR TITLE
Fix selection handlers height for BasicTextField

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
@@ -45,6 +45,7 @@ import androidx.compose.foundation.text.input.internal.TextFieldDecoratorModifie
 import androidx.compose.foundation.text.input.internal.TextFieldTextLayoutModifier
 import androidx.compose.foundation.text.input.internal.TextLayoutState
 import androidx.compose.foundation.text.input.internal.TransformedTextFieldState
+import androidx.compose.foundation.text.input.internal.selection.TextFieldHandleState
 import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState
 import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState.InputType
 import androidx.compose.foundation.text.selection.SelectionHandle
@@ -458,6 +459,7 @@ internal fun TextFieldSelectionHandles(
             modifier = Modifier.pointerInput(selectionState) {
                 with(selectionState) { selectionHandleGestures(true) }
             },
+            lineHeight = startHandleState.lineHeight,
             minTouchTargetSize = MinTouchTargetSizeForHandles,
         )
     }
@@ -481,6 +483,7 @@ internal fun TextFieldSelectionHandles(
             modifier = Modifier.pointerInput(selectionState) {
                 with(selectionState) { selectionHandleGestures(false) }
             },
+            lineHeight = endHandleState.lineHeight,
             minTouchTargetSize = MinTouchTargetSizeForHandles,
         )
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldHandleState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldHandleState.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.ResolvedTextDirection
 internal data class TextFieldHandleState(
     val visible: Boolean,
     val position: Offset,
+    val lineHeight: Float,
     val direction: ResolvedTextDirection,
     val handlesCrossed: Boolean
 ) {
@@ -32,6 +33,7 @@ internal data class TextFieldHandleState(
         val Hidden = TextFieldHandleState(
             visible = false,
             position = Offset.Unspecified,
+            lineHeight = 0f,
             direction = ResolvedTextDirection.Ltr,
             handlesCrossed = false
         )

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -1216,14 +1216,16 @@ internal class TextFieldSelectionState(
         } else {
             selection.end
         }
-        return layoutResult.multiParagraph.getLineHeight(offset)
+        val line = layoutResult.getLineForOffset(offset)
+        return layoutResult.multiParagraph.getLineHeight(line)
     }
 
     private fun getCursorLineHeight(): Float {
         val layoutResult = textLayoutState.layoutResult ?: return 0f
         val selection = textFieldState.visualText.selection
         if (!selection.collapsed) return 0f
-        return layoutResult.multiParagraph.getLineHeight(selection.start)
+        val line = layoutResult.getLineForOffset(selection.start)
+        return layoutResult.multiParagraph.getLineHeight(line)
     }
 
     private fun getHandlePosition(isStartHandle: Boolean): Offset {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -280,6 +280,7 @@ internal class TextFieldSelectionState(
         return TextFieldHandleState(
             visible = true,
             position = if (includePosition) getCursorRect().bottomCenter else Offset.Unspecified,
+            lineHeight = getCursorLineHeight(),
             direction = ResolvedTextDirection.Ltr,
             handlesCrossed = false
         )
@@ -1201,9 +1202,28 @@ internal class TextFieldSelectionState(
         return TextFieldHandleState(
             visible = true,
             position = coercedPosition,
+            lineHeight = getHandleLineHeight(isStartHandle),
             direction = direction,
             handlesCrossed = handlesCrossed
         )
+    }
+
+    private fun getHandleLineHeight(isStartHandle: Boolean): Float {
+        val layoutResult = textLayoutState.layoutResult ?: return 0f
+        val selection = textFieldState.visualText.selection
+        val offset = if (isStartHandle) {
+            selection.start
+        } else {
+            selection.end
+        }
+        return layoutResult.multiParagraph.getLineHeight(offset)
+    }
+
+    private fun getCursorLineHeight(): Float {
+        val layoutResult = textLayoutState.layoutResult ?: return 0f
+        val selection = textFieldState.visualText.selection
+        if (!selection.collapsed) return 0f
+        return layoutResult.multiParagraph.getLineHeight(selection.start)
     }
 
     private fun getHandlePosition(isStartHandle: Boolean): Offset {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.kt
@@ -84,21 +84,6 @@ internal expect fun SelectionHandle(
     modifier: Modifier,
 )
 
-@Composable
-internal fun SelectionHandle(
-    offsetProvider: OffsetProvider,
-    isStartHandle: Boolean,
-    direction: ResolvedTextDirection,
-    handlesCrossed: Boolean,
-    minTouchTargetSize: DpSize,
-    modifier: Modifier,
-) {
-    SelectionHandle(
-        offsetProvider, isStartHandle, direction,
-        handlesCrossed, minTouchTargetSize, 0f, modifier,
-    )
-}
-
 /**
  * Avoids boxing of [Offset] which is an inline value class.
  */

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.skiko.kt
@@ -86,7 +86,8 @@ internal actual fun SelectionHandle(
                 return offset
             }
         },
-        handleReferencePoint = handleReferencePoint) {
+        handleReferencePoint = handleReferencePoint
+    ) {
         SelectionHandleIcon(
             modifier = modifier.semantics {
                 val position = offsetProvider.provide()
@@ -105,7 +106,6 @@ internal actual fun SelectionHandle(
 }
 
 @Composable
-/*@VisibleForTesting*/
 internal fun SelectionHandleIcon(
     modifier: Modifier,
     iconVisible: () -> Boolean,


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

Fixes https://youtrack.jetbrains.com/issue/CMP-6634/iOS.-BTF2.-Selection-handlers-looks-wrong

## Testing
This should be tested by QA

## Release Notes

### Fixes - iOS
- _(prerelease fix)_ Fix selection handlers height for `BasicTextField` on iOS