### PR TITLE
Fixes for Xcode 16

### DIFF
--- a/compose/ui/ui-uikit/build.gradle
+++ b/compose/ui/ui-uikit/build.gradle
@@ -146,9 +146,10 @@ private def configure(target, isDevice, architecture, testTarget) {
             utils {
                 headersPath.eachFileRecurse {
                     if (it.name.endsWith('.h')) {
-                        headers(it)
+                        extraOpts("-header", it.name)
                     }
                 }
+                compilerOpts("-I${headersPath}")
             }
         }
     }

--- a/compose/ui/ui-uikit/src/nativeInterop/cinterop/utils.def
+++ b/compose/ui/ui-uikit/src/nativeInterop/cinterop/utils.def
@@ -1,3 +1,5 @@
 linkerOpts = -framework UIKit
 package = androidx.compose.ui.uikit.utils
 language = Objective-C
+compilerOpts = -D_Float16=short
+headerFilter = CMP*


### PR DESCRIPTION
The changes were prepared by Timofey to fix Cinterop issues with Xcode 16.

Fixes locally:

```
Exception in thread "main" java.lang.Error: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.0.sdk/usr/include/math.h:614:27: error: _Float16 is not supported on this target
```

Knowing issue with Xcode 16:
https://youtrack.jetbrains.com/issue/KT-71747

Until it is fixed, Xcode 15 is used on CI