### PR TITLE
Expose missing `startDragAndDropTransfer` method for iOS Drag&Drop

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3354,11 +3354,6 @@ public abstract interface class androidx/compose/ui/platform/PlatformDragAndDrop
 	public abstract fun startDragAndDropTransfer-12SF9DM (Landroidx/compose/ui/draganddrop/DragAndDropTransferData;JLkotlin/jvm/functions/Function1;)Z
 }
 
-public abstract interface class androidx/compose/ui/platform/PlatformDragAndDropTarget : androidx/compose/ui/draganddrop/DragAndDropTarget {
-	public abstract fun acceptDragAndDropTransfer (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Z
-	public abstract fun getHasEligibleDropTarget ()Z
-}
-
 public final class androidx/compose/ui/platform/PlatformInsets {
 	public static final field $stable I
 	public static final field Companion Landroidx/compose/ui/platform/PlatformInsets$Companion;
@@ -3538,7 +3533,7 @@ public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public abstract fun close ()V
 	public abstract fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
-	public abstract fun getDragAndDropTarget ()Landroidx/compose/ui/scene/ComposeSceneDragAndDropTarget;
+	public abstract fun getDragAndDrop ()Landroidx/compose/ui/scene/ComposeSceneDragAndDrop;
 	public abstract fun getFocusManager ()Landroidx/compose/ui/scene/ComposeSceneFocusManager;
 	public abstract fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
 	public abstract fun getSize-bOM6tXw ()Landroidx/compose/ui/unit/IntSize;
@@ -3568,7 +3563,7 @@ public final class androidx/compose/ui/scene/ComposeSceneContext$Companion {
 	public final fun getEmpty ()Landroidx/compose/ui/scene/ComposeSceneContext;
 }
 
-public final class androidx/compose/ui/scene/ComposeSceneDragAndDropTarget : androidx/compose/ui/draganddrop/DragAndDropTarget {
+public final class androidx/compose/ui/scene/ComposeSceneDragAndDrop : androidx/compose/ui/draganddrop/DragAndDropTarget {
 	public static final field $stable I
 	public final fun acceptDragAndDropTransfer (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Z
 	public final fun getHasEligibleDropTarget ()Z
@@ -3579,6 +3574,7 @@ public final class androidx/compose/ui/scene/ComposeSceneDragAndDropTarget : and
 	public fun onExited (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)V
 	public fun onMoved (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)V
 	public fun onStarted (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)V
+	public final fun startDragAndDropTransfer-d-4ec7I (Landroidx/compose/ui/platform/PlatformDragAndDropSource$StartTransferScope;JLkotlin/jvm/functions/Function0;)V
 }
 
 public final class androidx/compose/ui/scene/ComposeSceneFocusManager {

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3533,9 +3533,9 @@ public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public abstract fun close ()V
 	public abstract fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;
-	public abstract fun getDragAndDrop ()Landroidx/compose/ui/scene/ComposeSceneDragAndDrop;
 	public abstract fun getFocusManager ()Landroidx/compose/ui/scene/ComposeSceneFocusManager;
 	public abstract fun getLayoutDirection ()Landroidx/compose/ui/unit/LayoutDirection;
+	public abstract fun getRootDragAndDropNode ()Landroidx/compose/ui/scene/ComposeSceneDragAndDropNode;
 	public abstract fun getSize-bOM6tXw ()Landroidx/compose/ui/unit/IntSize;
 	public abstract fun hasInvalidations ()Z
 	public abstract fun hitTestInteropView-k-4lQ0M (J)Ljava/lang/Object;
@@ -3563,7 +3563,7 @@ public final class androidx/compose/ui/scene/ComposeSceneContext$Companion {
 	public final fun getEmpty ()Landroidx/compose/ui/scene/ComposeSceneContext;
 }
 
-public final class androidx/compose/ui/scene/ComposeSceneDragAndDrop : androidx/compose/ui/draganddrop/DragAndDropTarget {
+public final class androidx/compose/ui/scene/ComposeSceneDragAndDropNode : androidx/compose/ui/draganddrop/DragAndDropTarget {
 	public static final field $stable I
 	public final fun acceptDragAndDropTransfer (Landroidx/compose/ui/draganddrop/DragAndDropEvent;)Z
 	public final fun getHasEligibleDropTarget ()Z

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -175,7 +175,7 @@ internal class AwtDragAndDropManager(
      * Receives and processes events from the [DropTarget] installed in the root component.
      */
     private val dropTargetListener = object : DropTargetListener {
-        override fun dragEnter(dtde: DropTargetDragEvent) = with(dtde) {
+        override fun dragEnter(dtde: DropTargetDragEvent) {
             val event = DragAndDropEvent(dtde)
             val rootNode = getComposeRootDragAndDropNode()
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.toAwtImage
-import androidx.compose.ui.scene.ComposeSceneDragAndDrop
+import androidx.compose.ui.scene.ComposeSceneDragAndDropNode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -81,7 +81,7 @@ internal fun DragAndDropTransferAction.Companion.fromAwtAction(
  */
 internal class AwtDragAndDropManager(
     private val rootContainer: JComponent,
-    private val getComposeDragAndDrop: () -> ComposeSceneDragAndDrop
+    private val getComposeRootDragAndDropNode: () -> ComposeSceneDragAndDropNode
 ) : PlatformDragAndDropManager {
     private val density: Density
         get() = rootContainer.density
@@ -177,13 +177,13 @@ internal class AwtDragAndDropManager(
     private val dropTargetListener = object : DropTargetListener {
         override fun dragEnter(dtde: DropTargetDragEvent) = with(dtde) {
             val event = DragAndDropEvent(dtde)
-            val composeDragAndDrop = getComposeDragAndDrop()
+            val rootNode = getComposeRootDragAndDropNode()
 
             // There's no drag-start event in AWT, so start in dragEnter, and stop in dragExit
-            val acceptedTransfer = composeDragAndDrop.acceptDragAndDropTransfer(event)
+            val acceptedTransfer = rootNode.acceptDragAndDropTransfer(event)
             if (acceptedTransfer) {
-                composeDragAndDrop.onStarted(event)
-                composeDragAndDrop.onEntered(event)
+                rootNode.onStarted(event)
+                rootNode.onEntered(event)
             } else {
                 dtde.rejectDrag()
             }
@@ -191,16 +191,16 @@ internal class AwtDragAndDropManager(
 
         override fun dragExit(dte: DropTargetEvent) {
             val event = DragAndDropEvent(dte)
-            val composeDragAndDrop = getComposeDragAndDrop()
-            composeDragAndDrop.onExited(event)
-            composeDragAndDrop.onEnded(event)
+            val rootNode = getComposeRootDragAndDropNode()
+            rootNode.onExited(event)
+            rootNode.onEnded(event)
         }
 
         override fun dragOver(dtde: DropTargetDragEvent) {
             val event = DragAndDropEvent(dtde)
-            val composeDragAndDrop = getComposeDragAndDrop()
-            composeDragAndDrop.onMoved(event)
-            if (composeDragAndDrop.hasEligibleDropTarget) {
+            val rootNode = getComposeRootDragAndDropNode()
+            rootNode.onMoved(event)
+            if (rootNode.hasEligibleDropTarget) {
                 dtde.acceptDrag(dtde.dropAction)
             } else {
                 dtde.rejectDrag()
@@ -209,16 +209,16 @@ internal class AwtDragAndDropManager(
 
         override fun dropActionChanged(dtde: DropTargetDragEvent) {
             val event = DragAndDropEvent(dtde)
-            val composeDragAndDrop = getComposeDragAndDrop()
-            composeDragAndDrop.onChanged(event)
+            val rootNode = getComposeRootDragAndDropNode()
+            rootNode.onChanged(event)
         }
 
         override fun drop(dtde: DropTargetDropEvent) {
             val event = DragAndDropEvent(dtde)
             dtde.acceptDrop(dtde.dropAction)
-            val composeDragAndDrop = getComposeDragAndDrop()
-            dtde.dropComplete(composeDragAndDrop.onDrop(event))
-            composeDragAndDrop.onEnded(event)
+            val rootNode = getComposeRootDragAndDropNode()
+            dtde.dropComplete(rootNode.onDrop(event))
+            rootNode.onEnded(event)
         }
 
         private fun DragAndDropEvent(dragEvent: DropTargetDragEvent) = DragAndDropEvent(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.toAwtImage
-import androidx.compose.ui.scene.ComposeSceneDragAndDropTarget
+import androidx.compose.ui.scene.ComposeSceneDragAndDrop
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -81,7 +81,7 @@ internal fun DragAndDropTransferAction.Companion.fromAwtAction(
  */
 internal class AwtDragAndDropManager(
     private val rootContainer: JComponent,
-    private val dragAndDropTarget: () -> ComposeSceneDragAndDropTarget
+    private val getComposeDragAndDrop: () -> ComposeSceneDragAndDrop
 ) : PlatformDragAndDropManager {
     private val density: Density
         get() = rootContainer.density
@@ -175,15 +175,15 @@ internal class AwtDragAndDropManager(
      * Receives and processes events from the [DropTarget] installed in the root component.
      */
     private val dropTargetListener = object : DropTargetListener {
-        override fun dragEnter(dtde: DropTargetDragEvent) {
+        override fun dragEnter(dtde: DropTargetDragEvent) = with(dtde) {
             val event = DragAndDropEvent(dtde)
-            val dragAndDropTarget = dragAndDropTarget()
+            val composeDragAndDrop = getComposeDragAndDrop()
 
             // There's no drag-start event in AWT, so start in dragEnter, and stop in dragExit
-            val acceptedTransfer = dragAndDropTarget.acceptDragAndDropTransfer(event)
+            val acceptedTransfer = composeDragAndDrop.acceptDragAndDropTransfer(event)
             if (acceptedTransfer) {
-                dragAndDropTarget.onStarted(event)
-                dragAndDropTarget.onEntered(event)
+                composeDragAndDrop.onStarted(event)
+                composeDragAndDrop.onEntered(event)
             } else {
                 dtde.rejectDrag()
             }
@@ -191,16 +191,16 @@ internal class AwtDragAndDropManager(
 
         override fun dragExit(dte: DropTargetEvent) {
             val event = DragAndDropEvent(dte)
-            val dragAndDropTarget = dragAndDropTarget()
-            dragAndDropTarget.onExited(event)
-            dragAndDropTarget.onEnded(event)
+            val composeDragAndDrop = getComposeDragAndDrop()
+            composeDragAndDrop.onExited(event)
+            composeDragAndDrop.onEnded(event)
         }
 
         override fun dragOver(dtde: DropTargetDragEvent) {
             val event = DragAndDropEvent(dtde)
-            val dragAndDropTarget = dragAndDropTarget()
-            dragAndDropTarget.onMoved(event)
-            if (dragAndDropTarget.hasEligibleDropTarget) {
+            val composeDragAndDrop = getComposeDragAndDrop()
+            composeDragAndDrop.onMoved(event)
+            if (composeDragAndDrop.hasEligibleDropTarget) {
                 dtde.acceptDrag(dtde.dropAction)
             } else {
                 dtde.rejectDrag()
@@ -209,16 +209,16 @@ internal class AwtDragAndDropManager(
 
         override fun dropActionChanged(dtde: DropTargetDragEvent) {
             val event = DragAndDropEvent(dtde)
-            val dragAndDropTarget = dragAndDropTarget()
-            dragAndDropTarget.onChanged(event)
+            val composeDragAndDrop = getComposeDragAndDrop()
+            composeDragAndDrop.onChanged(event)
         }
 
         override fun drop(dtde: DropTargetDropEvent) {
             val event = DragAndDropEvent(dtde)
             dtde.acceptDrop(dtde.dropAction)
-            val dragAndDropTarget = dragAndDropTarget()
-            dtde.dropComplete(dragAndDropTarget.onDrop(event))
-            dragAndDropTarget.onEnded(event)
+            val composeDragAndDrop = getComposeDragAndDrop()
+            dtde.dropComplete(composeDragAndDrop.onDrop(event))
+            composeDragAndDrop.onEnded(event)
         }
 
         private fun DragAndDropEvent(dragEvent: DropTargetDragEvent) = DragAndDropEvent(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -336,9 +336,10 @@ internal class ComposeSceneMediator(
      */
     private var keyboardModifiersRequireUpdate = false
 
-    private val dragAndDropManager = AwtDragAndDropManager(container) {
-        scene.dragAndDrop
-    }
+    private val dragAndDropManager = AwtDragAndDropManager(
+        rootContainer = container,
+        getComposeRootDragAndDropNode = { scene.rootDragAndDropNode },
+    )
 
     init {
         // Transparency is used during redrawer creation that triggered by [addNotify], so

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -337,7 +337,7 @@ internal class ComposeSceneMediator(
     private var keyboardModifiersRequireUpdate = false
 
     private val dragAndDropManager = AwtDragAndDropManager(container) {
-        scene.dragAndDropTarget
+        scene.dragAndDrop
     }
 
     init {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformDragAndDropManager.skiko.kt
@@ -88,26 +88,3 @@ interface PlatformDragAndDropSource {
         ): Boolean
     }
 }
-
-@InternalComposeUiApi
-interface PlatformDragAndDropTarget : DragAndDropTarget {
-    /**
-     * Indicates whether there is a child that is eligible to receive a drop gesture immediately.
-     * This is true if the last move happened over a child that is interested in receiving a drop.
-     */
-    val hasEligibleDropTarget: Boolean
-
-    /**
-     * The entry point to register interest in a drag and drop session for receiving data.
-     *
-     * @return true to indicate interest in the contents of a drag and drop session, false
-     * indicates no interest. If false is returned, this [Modifier] will not receive any
-     * [DragAndDropTarget] events.
-     *
-     * All [DragAndDropModifierNode] instances in the hierarchy will be given an opportunity
-     * to participate in a drag and drop session via this method.
-     */
-    fun acceptDragAndDropTransfer(
-        startEvent: DragAndDropEvent
-    ): Boolean
-}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -149,7 +149,7 @@ private class CanvasLayersComposeSceneImpl(
 
     override val focusManager = ComposeSceneFocusManager { focusedOwner.focusOwner }
 
-    override val dragAndDropTarget = ComposeSceneDragAndDropTarget { focusedOwner.dragAndDropOwner }
+    override val dragAndDrop = ComposeSceneDragAndDrop { focusedOwner.dragAndDropOwner }
 
     private val layers = mutableListOf<AttachedComposeSceneLayer>()
     private val _layersCopyCache = CopiedList {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerType
-import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.setContent
@@ -149,7 +148,7 @@ private class CanvasLayersComposeSceneImpl(
 
     override val focusManager = ComposeSceneFocusManager { focusedOwner.focusOwner }
 
-    override val dragAndDrop = ComposeSceneDragAndDrop { focusedOwner.dragAndDropOwner }
+    override val rootDragAndDropNode = ComposeSceneDragAndDropNode { focusedOwner.dragAndDropOwner }
 
     private val layers = mutableListOf<AttachedComposeSceneLayer>()
     private val _layersCopyCache = CopiedList {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocal
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.LaunchedEffect
@@ -39,15 +38,12 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformContext
-import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.viewinterop.InteropView
 import androidx.compose.ui.viewinterop.pointerInteropFilter
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.Popup
 import org.jetbrains.skiko.currentNanoTime
 
 /**
@@ -114,7 +110,7 @@ interface ComposeScene {
      * The object through which drag-and-drop implementations report drop-target events to the
      * scene.
      */
-    val dragAndDrop: ComposeSceneDragAndDrop
+    val rootDragAndDropNode: ComposeSceneDragAndDropNode
 
     /**
      * Close all resources and subscriptions. Not calling this method when [ComposeScene] is no

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draganddrop.DragAndDropNode
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
@@ -38,6 +39,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
@@ -107,8 +109,10 @@ interface ComposeScene {
     val focusManager: ComposeSceneFocusManager
 
     /**
-     * The object through which drag-and-drop implementations report drop-target events to the
-     * scene.
+     * The root drag&drop node that provides APIs for [PlatformDragAndDropManager] to integrate
+     * [ComposeScene] with the platform.
+     *
+     * @see DragAndDropNode
      */
     val rootDragAndDropNode: ComposeSceneDragAndDropNode
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -114,7 +114,7 @@ interface ComposeScene {
      * The object through which drag-and-drop implementations report drop-target events to the
      * scene.
      */
-    val dragAndDropTarget: ComposeSceneDragAndDropTarget
+    val dragAndDrop: ComposeSceneDragAndDrop
 
     /**
      * Close all resources and subscriptions. Not calling this method when [ComposeScene] is no

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneDragAndDrop.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneDragAndDrop.skiko.kt
@@ -17,28 +17,60 @@
 package androidx.compose.ui.scene
 
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.draganddrop.DragAndDropEvent
 import androidx.compose.ui.draganddrop.DragAndDropNode
+import androidx.compose.ui.draganddrop.DragAndDropStartTransferScope
 import androidx.compose.ui.draganddrop.DragAndDropTarget
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.node.DragAndDropOwner
+import androidx.compose.ui.platform.PlatformDragAndDropManager
+import androidx.compose.ui.platform.PlatformDragAndDropSource
 
-/**
- * The object provided by [ComposeScene] to allow reporting drop-target events to it.
- */
+/** Provides API for [PlatformDragAndDropManager] to integrate [ComposeScene] with the platform. */
+// TODO: Extract to interface and implement it in [DragAndDropNode]
 @InternalComposeUiApi
-class ComposeSceneDragAndDropTarget internal constructor(
+class ComposeSceneDragAndDrop internal constructor(
     private val dragAndDropOwner: () -> DragAndDropOwner,
 ) : DragAndDropTarget {
     private var startedNode: DragAndDropNode? = null
     private val currentNode: DragAndDropNode
         get() = dragAndDropOwner().rootDragAndDropNode
 
+    /**
+     * Indicates whether there is a child that is eligible to receive a drop gesture immediately.
+     * This is true if the last move happened over a child that is interested in receiving a drop.
+     */
     val hasEligibleDropTarget: Boolean
         get() = currentNode.hasEligibleDropTarget
 
+    /**
+     * The entry point to register interest in a drag and drop session for receiving data.
+     *
+     * @return true to indicate interest in the contents of a drag and drop session, false indicates
+     *   no interest. If false is returned, this [Modifier] will not receive any [DragAndDropTarget]
+     *   events.
+     */
     fun acceptDragAndDropTransfer(startEvent: DragAndDropEvent): Boolean {
         ensureStarted(null, startEvent)
         return currentNode.acceptDragAndDropTransfer(startEvent)
+    }
+
+    /**
+     * Initiates a drag-and-drop operation for transferring data.
+     *
+     * @param offset the offset value representing position of the input pointer.
+     * @param isTransferStarted a lambda function that returns true if the drag-and-drop transfer
+     *   has started, or false otherwise.
+     */
+    fun PlatformDragAndDropSource.StartTransferScope.startDragAndDropTransfer(
+        offset: Offset,
+        isTransferStarted: () -> Boolean
+    ): Unit = with(currentNode) {
+        asDragAndDropStartTransferScope().startDragAndDropTransfer(offset, isTransferStarted)
     }
 
     override fun onDrop(event: DragAndDropEvent): Boolean {
@@ -87,3 +119,18 @@ class ComposeSceneDragAndDropTarget internal constructor(
         }
     }
 }
+
+// TODO: Remove after combine [DragAndDropStartTransferScope] and [PlatformDragAndDropSource]
+private fun PlatformDragAndDropSource.StartTransferScope.asDragAndDropStartTransferScope(): DragAndDropStartTransferScope =
+    object : DragAndDropStartTransferScope {
+        override fun startDragAndDropTransfer(
+            transferData: DragAndDropTransferData,
+            decorationSize: Size,
+            drawDragDecoration: DrawScope.() -> Unit
+        ): Boolean =
+            this@asDragAndDropStartTransferScope.startDragAndDropTransfer(
+                transferData = transferData,
+                decorationSize = decorationSize,
+                drawDragDecoration = drawDragDecoration
+            )
+    }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneDragAndDropNode.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneDragAndDropNode.skiko.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.platform.PlatformDragAndDropSource
 /** Provides API for [PlatformDragAndDropManager] to integrate [ComposeScene] with the platform. */
 // TODO: Extract to interface and implement it in [DragAndDropNode]
 @InternalComposeUiApi
-class ComposeSceneDragAndDrop internal constructor(
+class ComposeSceneDragAndDropNode internal constructor(
     private val dragAndDropOwner: () -> DragAndDropOwner,
 ) : DragAndDropTarget {
     private var startedNode: DragAndDropNode? = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -126,7 +126,7 @@ private class PlatformLayersComposeSceneImpl(
 
     override val focusManager = ComposeSceneFocusManager { mainOwner.focusOwner }
 
-    override val dragAndDropTarget = ComposeSceneDragAndDropTarget { mainOwner.dragAndDropOwner }
+    override val dragAndDrop = ComposeSceneDragAndDrop { mainOwner.dragAndDropOwner }
 
     init {
         onOwnerAppended(mainOwner)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -126,7 +126,8 @@ private class PlatformLayersComposeSceneImpl(
 
     override val focusManager = ComposeSceneFocusManager { mainOwner.focusOwner }
 
-    override val dragAndDrop = ComposeSceneDragAndDrop { mainOwner.dragAndDropOwner }
+    // TODO: Extract to interface and return `mainOwner.dragAndDropOwner.rootDragAndDropNode`
+    override val rootDragAndDropNode = ComposeSceneDragAndDropNode { mainOwner.dragAndDropOwner }
 
     init {
         onOwnerAppended(mainOwner)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/draganddrop/UIKitDragAndDropManager.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/draganddrop/UIKitDragAndDropManager.uikit.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformDragAndDropSource
 import androidx.compose.ui.platform.toUIImage
-import androidx.compose.ui.scene.ComposeSceneDragAndDrop
+import androidx.compose.ui.scene.ComposeSceneDragAndDropNode
 import androidx.compose.ui.uikit.utils.CMPDragInteractionProxy
 import androidx.compose.ui.uikit.utils.CMPDropInteractionProxy
 import androidx.compose.ui.unit.Density
@@ -167,10 +167,10 @@ internal class DropSessionContext(
  */
 internal class UIKitDragAndDropManager(
     private val view: UserInputView,
-    private val getComposeDragAndDrop: () -> ComposeSceneDragAndDrop
+    private val getComposeRootDragAndDropNode: () -> ComposeSceneDragAndDropNode
 ) : PlatformDragAndDropManager {
-    private val composeDragAndDrop: ComposeSceneDragAndDrop
-        get() = getComposeDragAndDrop()
+    private val rootNode: ComposeSceneDragAndDropNode
+        get() = getComposeRootDragAndDropNode()
 
     /**
      * Context for an ongoing drag session initiated from Compose.
@@ -217,7 +217,7 @@ internal class UIKitDragAndDropManager(
                 .useContents { asDpOffset() }
                 .toOffset(density)
 
-            with(composeDragAndDrop) {
+            with(rootNode) {
                 startTransferScope.startDragAndDropTransfer(
                     offset = offset,
                     isTransferStarted = { dragSessionContext != null }
@@ -262,7 +262,7 @@ internal class UIKitDragAndDropManager(
             if (dropSessionContext != null) return false
 
             val context = DropSessionContext(view, session)
-            val accepts = composeDragAndDrop.acceptDragAndDropTransfer(context.event)
+            val accepts = rootNode.acceptDragAndDropTransfer(context.event)
             if (accepts) {
                 dropSessionContext = context
             }
@@ -275,15 +275,15 @@ internal class UIKitDragAndDropManager(
             session: UIDropSessionProtocol, interaction: UIDropInteraction
         ) {
             withDropSessionContext {
-                composeDragAndDrop.onDrop(event)
+                rootNode.onDrop(event)
             }
         }
 
         override fun proposalForSessionUpdate(
             session: UIDropSessionProtocol, interaction: UIDropInteraction
         ): UIDropProposal = withDropSessionContext {
-            composeDragAndDrop.onMoved(event)
-            if (composeDragAndDrop.hasEligibleDropTarget) {
+            rootNode.onMoved(event)
+            if (rootNode.hasEligibleDropTarget) {
                 UIDropProposal(UIDropOperationCopy)
             } else {
                 UIDropProposal(UIDropOperationForbidden)
@@ -295,7 +295,7 @@ internal class UIKitDragAndDropManager(
             interaction: UIDropInteraction
         ) {
             withDropSessionContext {
-                composeDragAndDrop.onEntered(event)
+                rootNode.onEntered(event)
             }
         }
 
@@ -304,13 +304,13 @@ internal class UIKitDragAndDropManager(
             interaction: UIDropInteraction
         ) {
             withDropSessionContext {
-                composeDragAndDrop.onExited(event)
+                rootNode.onExited(event)
             }
         }
 
         override fun sessionDidEnd(session: UIDropSessionProtocol, interaction: UIDropInteraction) {
             withDropSessionContext {
-                composeDragAndDrop.onEnded(event)
+                rootNode.onEnded(event)
             }
 
             dropSessionContext = null

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/draganddrop/UIKitDragAndDropManager.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/draganddrop/UIKitDragAndDropManager.uikit.kt
@@ -26,14 +26,17 @@ import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.platform.PlatformDragAndDropManager
+import androidx.compose.ui.platform.PlatformDragAndDropSource
 import androidx.compose.ui.platform.toUIImage
-import androidx.compose.ui.scene.ComposeSceneDragAndDropTarget
+import androidx.compose.ui.scene.ComposeSceneDragAndDrop
 import androidx.compose.ui.uikit.utils.CMPDragInteractionProxy
 import androidx.compose.ui.uikit.utils.CMPDropInteractionProxy
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.asCGRect
+import androidx.compose.ui.unit.asDpOffset
 import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.UserInputView
 import kotlin.math.roundToInt
 import kotlinx.cinterop.readValue
@@ -163,9 +166,12 @@ internal class DropSessionContext(
  * context between iOS and Compose.
  */
 internal class UIKitDragAndDropManager(
-    val view: UserInputView,
-    val getDragAndDropTarget: () -> ComposeSceneDragAndDropTarget
+    private val view: UserInputView,
+    private val getComposeDragAndDrop: () -> ComposeSceneDragAndDrop
 ) : PlatformDragAndDropManager {
+    private val composeDragAndDrop: ComposeSceneDragAndDrop
+        get() = getComposeDragAndDrop()
+
     /**
      * Context for an ongoing drag session initiated from Compose.
      */
@@ -190,41 +196,35 @@ internal class UIKitDragAndDropManager(
         override fun itemsForBeginningSession(
             session: UIDragSessionProtocol, interaction: UIDragInteraction
         ): List<*> {
-            // TODO: temporary stubs
-            return emptyList<UIDragItem>()
-//            val scope = object : DragAndDropSourceScope {
-//                override fun startDragAndDropTransfer(
-//                    transferData: DragAndDropTransferData,
-//                    decorationSize: Size,
-//                    drawDragDecoration: DrawScope.() -> Unit
-//                ): Boolean {
-//                    dragSessionContext = DragSessionContext(
-//                        transferData = transferData,
-//                        decorationSize = decorationSize,
-//                        drawDragDecoration = drawDragDecoration
-//                    )
-//                    return true
-//                }
-//            }
-//
-//            val density = Density(density = view.window?.screen?.scale?.toFloat() ?: 1f)
-//            val offset = session
-//                .locationInView(view)
-//                .useContents {
-//                    asDpOffset()
-//                }
-//                .toOffset(density)
-//
-//            with(rootDragAndDropNode) {
-//                scope.startDragAndDropTransfer(
-//                    offset = offset,
-//                    isTransferStarted = {
-//                        dragSessionContext != null
-//                    }
-//                )
-//            }
-//
-//            return dragSessionContext?.transferData?.items ?: emptyList<UIDragItem>()
+            val startTransferScope = object : PlatformDragAndDropSource.StartTransferScope {
+                override fun startDragAndDropTransfer(
+                    transferData: DragAndDropTransferData,
+                    decorationSize: Size,
+                    drawDragDecoration: DrawScope.() -> Unit
+                ): Boolean {
+                    dragSessionContext = DragSessionContext(
+                        transferData = transferData,
+                        decorationSize = decorationSize,
+                        drawDragDecoration = drawDragDecoration
+                    )
+                    return true
+                }
+            }
+
+            val density = Density(density = view.window?.screen?.scale?.toFloat() ?: 1f)
+            val offset = session
+                .locationInView(view)
+                .useContents { asDpOffset() }
+                .toOffset(density)
+
+            with(composeDragAndDrop) {
+                startTransferScope.startDragAndDropTransfer(
+                    offset = offset,
+                    isTransferStarted = { dragSessionContext != null }
+                )
+            }
+
+            return dragSessionContext?.transferData?.items ?: emptyList<UIDragItem>()
         }
 
         override fun previewForLiftingItemInSession(
@@ -262,9 +262,7 @@ internal class UIKitDragAndDropManager(
             if (dropSessionContext != null) return false
 
             val context = DropSessionContext(view, session)
-
-            val accepts = dragAndDropTarget.acceptDragAndDropTransfer(context.event)
-
+            val accepts = composeDragAndDrop.acceptDragAndDropTransfer(context.event)
             if (accepts) {
                 dropSessionContext = context
             }
@@ -277,15 +275,15 @@ internal class UIKitDragAndDropManager(
             session: UIDropSessionProtocol, interaction: UIDropInteraction
         ) {
             withDropSessionContext {
-                dragAndDropTarget.onDrop(event)
+                composeDragAndDrop.onDrop(event)
             }
         }
 
         override fun proposalForSessionUpdate(
             session: UIDropSessionProtocol, interaction: UIDropInteraction
         ): UIDropProposal = withDropSessionContext {
-            dragAndDropTarget.onMoved(event)
-            if (dragAndDropTarget.hasEligibleDropTarget) {
+            composeDragAndDrop.onMoved(event)
+            if (composeDragAndDrop.hasEligibleDropTarget) {
                 UIDropProposal(UIDropOperationCopy)
             } else {
                 UIDropProposal(UIDropOperationForbidden)
@@ -297,7 +295,7 @@ internal class UIKitDragAndDropManager(
             interaction: UIDropInteraction
         ) {
             withDropSessionContext {
-                dragAndDropTarget.onEntered(event)
+                composeDragAndDrop.onEntered(event)
             }
         }
 
@@ -306,26 +304,18 @@ internal class UIKitDragAndDropManager(
             interaction: UIDropInteraction
         ) {
             withDropSessionContext {
-                dragAndDropTarget.onExited(event)
+                composeDragAndDrop.onExited(event)
             }
         }
 
         override fun sessionDidEnd(session: UIDropSessionProtocol, interaction: UIDropInteraction) {
             withDropSessionContext {
-                dragAndDropTarget.onEnded(event)
+                composeDragAndDrop.onEnded(event)
             }
 
             dropSessionContext = null
         }
     }
-
-    /**
-     * The root [DragAndDropNode] that is used to perform traversal of the drag and drop aware
-     * nodes in the hierarchy. `null` returned implies that the root node is not an actual
-     * [DragAndDropTarget].
-     */
-    private val dragAndDropTarget: ComposeSceneDragAndDropTarget
-        get() = getDragAndDropTarget()
 
     init {
         view.addInteraction(UIDragInteraction(delegate = dragInteractionProxy))

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -279,9 +279,7 @@ internal class ComposeSceneMediator(
 
     private val dragAndDropManager = UIKitDragAndDropManager(
         view = userInputView,
-        getDragAndDropTarget = {
-            scene.dragAndDropTarget
-        }
+        getComposeDragAndDrop = { scene.dragAndDrop },
     )
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.platform.EmptyViewConfiguration
 import androidx.compose.ui.platform.LocalLayoutMargins
 import androidx.compose.ui.platform.LocalSafeArea
 import androidx.compose.ui.platform.PlatformContext
-import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
@@ -279,7 +278,7 @@ internal class ComposeSceneMediator(
 
     private val dragAndDropManager = UIKitDragAndDropManager(
         view = userInputView,
-        getComposeDragAndDrop = { scene.dragAndDrop },
+        getComposeRootDragAndDropNode = { scene.rootDragAndDropNode },
     )
 
     /**


### PR DESCRIPTION
Another intermediate state to get closer with merged into AOSP changes.

The main change is uncommenting `itemsForBeginningSession`, other things are expected to be future adjusted