### PR TITLE
Launch Chrome with `--no-sandbox` key in karma

### DIFF
--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -72,7 +72,7 @@ config.frameworks.push("webpack-output");
 config.customLaunchers = {
     ChromeForComposeTests: {
         base: "Chrome",
-        flags: ["--disable-search-engine-choice-screen"]
+        flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
     }
 }
 

--- a/mpp/karma.config.d/wasm/static/common-tests.js
+++ b/mpp/karma.config.d/wasm/static/common-tests.js
@@ -26,10 +26,18 @@ window.addEventListener("error", (message, source, lineno, colno, error) => {
 
 
 window.addEventListener("unhandledrejection", (event) => {
-    console.log(`[web] unhandled Promise rejection ${event.reason} \n`);
+    try {
+        console.log(`[web] unhandled Promise rejection ${event.reason} \n`);
+    } catch (e) {
+        console.log(e);
+    }
 });
 
 window.addEventListener("rejectionhandled", (event) => {
-        console.log(`[web] handled Promise rejection; reason: ${event.reason} \n`);
+        try {
+            console.log(`[web] handled Promise rejection ${event.reason} \n`);
+        } catch (e) {
+            console.log(e);
+        }
     }, false
 );


### PR DESCRIPTION
This doubles `sh/js-errors-safe-report` but launches browser with `--no-sandbox` key