### PR TITLE
Change `runOnIdle` to execute on the UI thread, and to not `waitForIdle` afterward

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ToggleableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ToggleableTest.kt
@@ -52,9 +52,7 @@ class ToggleableTest {
             ).testTag("toggle"))
         }
 
-        runOnIdle {
-            assertEquals(false, state)
-        }
+        assertEquals(false, state)
 
         onRoot().apply {
             performKeyPress(KeyEvent(Key.Tab, KeyEventType.KeyDown))
@@ -66,17 +64,13 @@ class ToggleableTest {
             performKeyPress(KeyEvent(Key.Spacebar, KeyEventType.KeyUp))
         }
 
-        runOnIdle {
-            assertEquals(true, state)
-        }
+        assertEquals(true, state)
 
         onNodeWithTag("toggle").apply {
             performKeyPress(KeyEvent(Key.Spacebar, KeyEventType.KeyDown))
             performKeyPress(KeyEvent(Key.Spacebar, KeyEventType.KeyUp))
         }
 
-        runOnIdle {
-            assertEquals(false, state)
-        }
+        assertEquals(false, state)
     }
 }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -1701,10 +1701,8 @@ class ScrollableTest {
             }
         }
 
-        runOnIdle {
-            assertThat(isOuterInScrollableContainer).isFalse()
-            assertThat(isInnerInScrollableContainer).isTrue()
-        }
+        assertThat(isOuterInScrollableContainer).isFalse()
+        assertThat(isInnerInScrollableContainer).isTrue()
     }
 
     @Test
@@ -1712,12 +1710,10 @@ class ScrollableTest {
         mainClock.autoAdvance = false
 
         var total = 0f
-        val controller = ScrollableState(
-            consumeScrollDelta = {
-                total += it
-                it
-            }
-        )
+        val controller = ScrollableState {
+            total += it
+            it
+        }
         setContentAndGetScope {
             Box(
                 modifier = Modifier
@@ -1729,62 +1725,48 @@ class ScrollableTest {
             )
         }
 
-        runOnIdle {
-            scope.launch {
-                controller.animateScrollBy(
-                    100f,
-                    keyframes {
-                        durationMillis = 2500
-                        // emulate a repeatable animation:
-                        0f at 0
-                        100f at 500
-                        100f at 1000
-                        0f at 1500
-                        0f at 2000
-                        100f at 2500
-                    }
-                )
-            }
+        scope.launch {
+            controller.animateScrollBy(
+                value = 100f,
+                animationSpec = keyframes {
+                    durationMillis = 2500
+                    // emulate a repeatable animation:
+                    0f at 0
+                    100f at 500
+                    100f at 1000
+                    0f at 1500
+                    0f at 2000
+                    100f at 2500
+                }
+            )
         }
 
         mainClock.advanceTimeBy(250)
-        runOnIdle {
-            // in the middle of the first animation
-            assertThat(total).isGreaterThan(0f)
-            assertThat(total).isLessThan(100f)
-        }
+        // in the middle of the first animation
+        assertThat(total).isGreaterThan(0f)
+        assertThat(total).isLessThan(100f)
 
         mainClock.advanceTimeBy(500) // 750 ms
-        runOnIdle {
-            // first animation finished
-            assertThat(total).isEqualTo(100f)
-        }
+        // first animation finished
+        assertThat(total).isEqualTo(100f)
 
         mainClock.advanceTimeBy(250) // 1250 ms
-        runOnIdle {
-            // in the middle of the second animation
-            assertThat(total).isGreaterThan(0f)
-            assertThat(total).isLessThan(100f)
-        }
+        // in the middle of the second animation
+        assertThat(total).isGreaterThan(0f)
+        assertThat(total).isLessThan(100f)
 
         mainClock.advanceTimeBy(500) // 1750 ms
-        runOnIdle {
-            // second animation finished
-            assertThat(total).isEqualTo(0f)
-        }
+        // second animation finished
+        assertThat(total).isEqualTo(0f)
 
         mainClock.advanceTimeBy(500) // 2250 ms
-        runOnIdle {
-            // in the middle of the third animation
-            assertThat(total).isGreaterThan(0f)
-            assertThat(total).isLessThan(100f)
-        }
+        // in the middle of the third animation
+        assertThat(total).isGreaterThan(0f)
+        assertThat(total).isLessThan(100f)
 
         mainClock.advanceTimeBy(500) // 2750 ms
-        runOnIdle {
-            // third animation finished
-            assertThat(total).isEqualTo(100f)
-        }
+        // third animation finished
+        assertThat(total).isEqualTo(100f)
     }
 
     @Test

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/DesktopMenuTest.kt
@@ -223,19 +223,15 @@ class DesktopMenuTest {
             }
         }
 
-        fun performKeyDownAndUp(key: Key) {
-            onNodeWithTag("dropDownMenu").apply {
-                performKeyPress(KeyEvent(key, KeyEventType.KeyDown))
-                performKeyPress(KeyEvent(key, KeyEventType.KeyUp))
-            }
+        fun performKeyDownAndUp(key: Key) = onNodeWithTag("dropDownMenu").apply {
+            performKeyPress(KeyEvent(key, KeyEventType.KeyDown))
+            performKeyPress(KeyEvent(key, KeyEventType.KeyUp))
         }
 
         fun assertClicksCount(i1: Int, i2: Int, i3: Int) {
-            runOnIdle {
-                assertThat(item1Clicked).isEqualTo(i1)
-                assertThat(item2Clicked).isEqualTo(i2)
-                assertThat(item3Clicked).isEqualTo(i3)
-            }
+            assertThat(item1Clicked).isEqualTo(i1)
+            assertThat(item2Clicked).isEqualTo(i2)
+            assertThat(item3Clicked).isEqualTo(i3)
         }
 
         performKeyDownAndUp(Key.DirectionDown)

--- a/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/ExposedDropdownMenuTest.kt
+++ b/compose/material3/material3/src/skikoTest/kotlin/androidx/compose/material3/ExposedDropdownMenuTest.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,6 +64,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -210,7 +210,7 @@ class ExposedDropdownMenuTest {
                     ) {
                         TextField(
                             modifier = Modifier
-                                .menuAnchor()
+                                .menuAnchor(MenuAnchorType.PrimaryEditable)
                                 .then(
                                     if (index == testIndex) Modifier
                                         .testTag(TFTag)
@@ -282,7 +282,11 @@ class ExposedDropdownMenuTest {
         setContent {
             scrollState = rememberScrollState()
             scope = rememberCoroutineScope()
-            Column(Modifier.verticalScroll(scrollState)) {
+            Column(
+                modifier = Modifier
+                    .height(500.dp)
+                    .verticalScroll(scrollState)
+            ) {
                 Spacer(Modifier.height(300.dp))
 
                 val expanded = false
@@ -291,7 +295,7 @@ class ExposedDropdownMenuTest {
                     onExpandedChange = {},
                 ) {
                     TextField(
-                        modifier = Modifier.menuAnchor(),
+                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable),
                         readOnly = true,
                         value = "",
                         onValueChange = {},
@@ -302,9 +306,7 @@ class ExposedDropdownMenuTest {
                         onDismissRequest = {},
                         content = {},
                     )
-                    SideEffect {
-                        compositionCount++
-                    }
+                    compositionCount++
                 }
 
                 Spacer(Modifier.height(300.dp))
@@ -313,13 +315,13 @@ class ExposedDropdownMenuTest {
 
         assertThat(compositionCount).isEqualTo(1)
 
-        runOnIdle {
-            scope.launch {
-                scrollState.animateScrollBy(500f)
-            }
+        scope.launch {
+            scrollState.animateScrollBy(500f)
         }
+        mainClock.advanceTimeBy(10_000)
         waitForIdle()
 
+        assertTrue(scrollState.value > 0)  // Make sure we did scroll
         assertThat(compositionCount).isEqualTo(1)
     }
 
@@ -344,9 +346,7 @@ class ExposedDropdownMenuTest {
         onNodeWithTag(TFTag).assertIsDisplayed()
         onNodeWithTag(MenuItemTag).assertIsDisplayed()
 
-        runOnIdle {
-            assertThat(menuBounds.width).isEqualTo(textFieldBounds.width)
-        }
+        assertThat(menuBounds.width).isEqualTo(textFieldBounds.width)
     }
 
     @Test
@@ -382,7 +382,7 @@ class ExposedDropdownMenuTest {
                 ) {
                     scrollState = rememberScrollState()
                     TextField(
-                        modifier = Modifier.menuAnchor(),
+                        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable),
                         value = "",
                         onValueChange = { },
                         label = { Text("Label") },
@@ -403,13 +403,9 @@ class ExposedDropdownMenuTest {
             }
         }
 
-        runOnIdle {
-            CoroutineScope(Dispatchers.Unconfined).launch {
-                scrollState.scrollTo(scrollState.maxValue)
-            }
+        CoroutineScope(Dispatchers.Unconfined).launch {
+            scrollState.scrollTo(scrollState.maxValue)
         }
-
-        waitForIdle()
 
         onNodeWithTag("MenuContent 1").assertIsNotDisplayed()
         onNodeWithTag("MenuContent 100").assertIsDisplayed()
@@ -423,7 +419,7 @@ class ExposedDropdownMenuTest {
                 onExpandedChange = { },
             ) {
                 TextField(
-                    modifier = Modifier.menuAnchor(),
+                    modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable),
                     value = "",
                     onValueChange = { },
                     label = { Text("Label") },
@@ -458,7 +454,7 @@ class ExposedDropdownMenuTest {
             ) {
                 TextField(
                     modifier = Modifier
-                        .menuAnchor()
+                        .menuAnchor(MenuAnchorType.PrimaryEditable)
                         .testTag(TFTag)
                         .onGloballyPositioned {
                             onTextFieldBoundsChanged?.invoke(it.boundsInRoot())

--- a/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test-junit4/src/desktopTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.Text
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -238,5 +239,46 @@ class TestBasicsTest {
         val initialTime = mainClock.currentTime
         waitForIdle()
         assertEquals(initialTime, mainClock.currentTime)
+    }
+
+    @Test
+    fun runOnIdleExecutesOnUiThread() = runComposeUiTest {
+        lateinit var mainThread: Thread
+        setContent {
+            mainThread = Thread.currentThread()
+        }
+        runOnIdle {
+            assertEquals(Thread.currentThread(), mainThread)
+        }
+    }
+
+    @Test
+    fun runOnIdleExecutesWhenIdle() = runComposeUiTest {
+        var sourceValue by mutableIntStateOf(0)
+        var targetValue = 0
+        setContent {
+            LaunchedEffect(sourceValue) {
+                targetValue = sourceValue
+            }
+        }
+        sourceValue = 1
+        runOnIdle {
+            assertEquals(targetValue, 1)
+        }
+    }
+
+    @Test
+    fun runOnIdleDoesNotWaitForIdleAfterward() = runComposeUiTest {
+        var sourceValue by mutableIntStateOf(0)
+        var targetValue = 0
+        setContent {
+            LaunchedEffect(sourceValue) {
+                targetValue = sourceValue
+            }
+        }
+        runOnIdle {
+            sourceValue = 1
+        }
+        assertEquals(targetValue, 0)
     }
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skikoMain.kt
@@ -302,11 +302,8 @@ class SkikoComposeUiTest @InternalTestApi constructor(
     }
 
     override fun <T> runOnIdle(action: () -> T): T {
-        // We are waiting for idle before and AFTER `action` to guarantee that changes introduced
-        // in `action` are propagated to components. In Android's version, it's executed in the
-        // Main thread which has similar effects.
         waitForIdle()
-        return action().also { waitForIdle() }
+        return runOnUiThread(action)
     }
 
     override fun waitUntil(

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavHostTest.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavHostTest.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
@@ -62,7 +61,6 @@ import androidx.navigation.createGraph
 import androidx.navigation.navigation
 import androidx.navigation.plusAssign
 import androidx.navigation.testing.TestNavHostController
-import androidx.savedstate.SavedStateRegistry
 import androidx.testutils.TestNavigator
 import androidx.testutils.test
 import kotlin.reflect.KClass
@@ -1088,9 +1086,9 @@ class NavHostTest {
 
         runOnIdle { navController.navigate(second) }
 
-        assertThat(model.wasCleared).isFalse()
-
         runOnIdle { navController.popBackStack() }
+
+        assertThat(model.wasCleared).isFalse()
 
         waitForIdle()
 


### PR DESCRIPTION
Our current implementation of `runOnIdle` does two things differently from Android:
1. It does not execute on the UI thread.
2. It includes an additional `waitForIdle` call after `action` has returned.

This PR changes that. aligning the behavior with Android.

## Testing
Describe how you tested your changes. If possible and needed:
- Added new unit tests

## Release Notes
### Breaking Changes - Tests
- `runOnIdle` will now execute `action` on the UI thread aligning the behavior with Android.
- `runOnIdle` will no longer call `waitForIdle` after executing the action aligning the behavior with Android.
