### PR TITLE
Remove workaround to prevent textfield cursor tests from hanging

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/CursorAnimationState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/CursorAnimationState.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.AtomicReference
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.platform.InfiniteAnimationPolicy
-import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
@@ -54,7 +52,7 @@ internal class CursorAnimationState {
      * Won't return until the animation cancelled via [cancelAndHide] or this coroutine's [Job] is
      * cancelled. In both cases, the cursor will always end up hidden.
      */
-    suspend fun snapToVisibleAndAnimate() = runCursorAnimation {
+    suspend fun snapToVisibleAndAnimate() {
         coroutineScope {
             // Can't do a single atomic update because we need to get the old value before launching
             // the new coroutine. So we set to null first, and then launch only if still null (i.e.
@@ -96,19 +94,3 @@ internal class CursorAnimationState {
         job?.cancel()
     }
 }
-
-/**
- * Runs the infinite animation in [block], taking into account the current
- * [InfiniteAnimationPolicy].
- *
- * This is needed to allow the text field cursor blinking to be cancelled by
- * [InfiniteAnimationPolicy] as if it was an animation. Otherwise `waitForIdle` in tests with a
- * focused text field will never return. Note that on Android this isn't needed because there
- * `waitForIdle` appears to completely ignore delayed tasks (see
- * https://issuetracker.google.com/issues/324768454 for details).
- */
-private suspend fun runCursorAnimation(block: suspend () -> Unit) =
-    when (val policy = coroutineContext[InfiniteAnimationPolicy]) {
-        null -> block()
-        else -> policy.onInfiniteOperation { block() }
-    }


### PR DESCRIPTION
Following https://github.com/JetBrains/compose-multiplatform-core/pull/1550, the workaround for textfield cursor tests introduced in ddb98eb4060f5dd23c18d4ce20effb9e2cded99d is no longer needed.

There is also no longer a need to [upstream it](https://github.com/JetBrains/compose-multiplatform-core/commit/7955583edcc8c7fd30602f4f03e9d7f84351f4af#diff-3c4127a6390adc892d265f3a683949a984bab372917aa4d21ff7338b185b6f93R112).

Fixes https://youtrack.jetbrains.com/issue/CMP-5765/Upstreaming.-bug.-ui-test.-dont-hang-on-cursor-animation

## Testing
Ran `TextFieldCursorTest`.
