### PR TITLE
Make formatWithSkeleton internal

### DIFF
--- a/compose/material3/material3/api/desktop/material3.api
+++ b/compose/material3/material3/api/desktop/material3.api
@@ -2083,10 +2083,6 @@ public final class androidx/compose/material3/carousel/CarouselStateKt {
 	public static final fun rememberCarouselState (ILkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Landroidx/compose/material3/carousel/CarouselState;
 }
 
-public final class androidx/compose/material3/internal/CalendarModel_skikoKt {
-	public static final fun formatWithSkeleton (JLjava/lang/String;Ljava/util/Locale;Ljava/util/Map;)Ljava/lang/String;
-}
-
 public final class androidx/compose/material3/pulltorefresh/PullToRefreshDefaults {
 	public static final field $stable I
 	public static final field INSTANCE Landroidx/compose/material3/pulltorefresh/PullToRefreshDefaults;

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/CalendarModel.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/CalendarModel.skiko.kt
@@ -18,16 +18,14 @@ package androidx.compose.material3.internal
 
 import androidx.compose.material3.CalendarLocale
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.internal.PlatformDateFormat
 
 
 @ExperimentalMaterial3Api
 internal actual fun createCalendarModel(locale: CalendarLocale): CalendarModel =
     KotlinxDatetimeCalendarModel(locale)
 
-
 @ExperimentalMaterial3Api
-actual fun formatWithSkeleton(
+internal actual fun formatWithSkeleton(
     utcTimeMillis: Long,
     skeleton: String,
     locale: CalendarLocale,


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/CMP-6777/Make-formatWithSkeleton-internal

## Release Notes
### Fixes - iOS
- Fixed visibility of `androidx.compose.material3.internal.formatWithSkeleton` that was accidently marked as public