### PR TITLE
Fix ComposeUIViewController transparent background

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -362,7 +362,9 @@ internal class ComposeHostingViewController(
             render = { canvas, nanoTime ->
                 mediator?.render(canvas.asComposeCanvas(), nanoTime)
             }
-        )
+        ).apply {
+            canBeOpaque = configuration.opaque
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6801

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix transparent background of `ComposeUIViewController`