### PR TITLE
Make `FontCache` creation lazy in `FontLoader` and `SkiaFontLoader`.

### DIFF
--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -37,6 +37,7 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -288,5 +289,15 @@ class TestBasicsTest {
             sourceValue = 1
         }
         assertEquals(targetValue, 0)
+    }
+
+    @Test
+    fun emptyTestPerformance() {
+        repeat(1000) {
+            runComposeUiTest {
+                setContent {
+                }
+            }
+        }
     }
 }

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -292,11 +292,10 @@ class TestBasicsTest {
     }
 
     @Test
-    fun emptyTestPerformance() {
-        repeat(1000) {
+    fun emptyTestPerformance() = runTest(timeout = 3.seconds) {
+        repeat(100) {
             runComposeUiTest {
-                setContent {
-                }
+                setContent { }
             }
         }
     }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/font/SkiaFontLoader.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/font/SkiaFontLoader.skiko.kt
@@ -25,8 +25,12 @@ import androidx.compose.ui.text.platform.PlatformFont
 import org.jetbrains.skia.paragraph.FontCollection
 
 internal class SkiaFontLoader(
-    private val fontCache: FontCache = FontCache()
+    fontCacheProvider: () -> FontCache
 ) : PlatformFontLoader {
+
+    constructor(fontCache: FontCache = FontCache()) : this (fontCacheProvider = { fontCache })
+
+    private val fontCache: FontCache by lazy(fontCacheProvider)
 
     val fontCollection: FontCollection
         get() = fontCache.fonts
@@ -63,5 +67,6 @@ internal class SkiaFontLoader(
         return loadBlocking(font)
     }
 
-    override val cacheKey: Any = fontCache // results are valid for all shared caches
+    override val cacheKey: Any
+        get() = fontCache // results are valid for all shared caches
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -30,10 +30,8 @@ import androidx.compose.ui.text.font.GenericFontFamily
 import androidx.compose.ui.text.font.LoadedFontFamily
 import androidx.compose.ui.text.font.Typeface
 import androidx.compose.ui.text.font.createFontFamilyResolver
-import org.jetbrains.skia.FontMgr
 import org.jetbrains.skia.FontMgrWithFallback
 import org.jetbrains.skia.paragraph.FontCollection
-import org.jetbrains.skia.paragraph.TypefaceFontProvider
 import org.jetbrains.skia.paragraph.TypefaceFontProviderWithFallback
 
 expect sealed class PlatformFont() : Font {
@@ -174,8 +172,10 @@ fun Typeface(typeface: SkTypeface, alias: String? = null): Typeface {
 )
 class FontLoader : Font.ResourceLoader {
 
-    internal val fontCache: FontCache = FontCache()
-    internal val fontFamilyResolver: FontFamily.Resolver = createFontFamilyResolver(fontCache)
+    private val fontCache: FontCache by lazy { FontCache() }
+    internal val fontFamilyResolver: FontFamily.Resolver by lazy {
+        createFontFamilyResolver(fontCache)
+    }
 
     // TODO: we need to support:
     //  1. font collection (.ttc). Looks like skia currently doesn't have


### PR DESCRIPTION
We are currently creating `FontMgrWithFallback` (via `FontCache`) twice for each `OwnerImpl`.
This takes a long time and is unnecessary if the app doesn't render text (and unnecessary to do twice even if it does). It is especially pronounced in tests, where in tests like
```
    @Test
    fun emptyTestPerformance() = repeat(1000) {
        runComposeUiTest {
            setContent { }
        }
    }
```
almost all the time is spent on creating these objects.

This PR makes creating `FontCache` lazy in `FontLoader` and `SkiaFontLoader`. With this, the above test goes from ~30 seconds to ~1.5 seconds on my computer. It also speeds up the creation of
1. Top level windows/scenes that don't render text.
2. Sub-windows/scenes, whether or not they render text.

## Testing
Added a new unit test.

## Release Notes
### Fixes - Multiple Platforms 
- The overhead for running an empty test has been significantly reduced.