### PR TITLE
Remove MainTestClockImpl.onTimeAdvanced

### DIFF
--- a/compose/ui/ui-test/src/commonMain/kotlin/androidx/compose/ui/test/AbstractMainTestClock.kt
+++ b/compose/ui/ui-test/src/commonMain/kotlin/androidx/compose/ui/test/AbstractMainTestClock.kt
@@ -24,8 +24,7 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 internal abstract class AbstractMainTestClock(
     private val testScheduler: TestCoroutineScheduler,
     private val frameDelayMillis: Long,
-    private val runOnUiThread: (action: () -> Unit) -> Unit,
-    private val onTimeAdvanced: ((currentTime: Long) -> Unit)? = null,
+    private val runOnUiThread: (action: () -> Unit) -> Unit
 ) : MainTestClock {
 
     override val currentTime: Long
@@ -70,8 +69,6 @@ internal abstract class AbstractMainTestClock(
             // `currentTime + delayTimeMillis`. See `advanceTimeBy`.
             // Therefore we also call `runCurrent` as it's done in TestCoroutineDispatcher
             testScheduler.runCurrent()
-
-            onTimeAdvanced?.invoke(currentTime)
         }
     }
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -158,8 +158,7 @@ class SkikoComposeUiTest @InternalTestApi constructor(
     private val testScope = TestScope(coroutineDispatcher)
     override val mainClock: MainTestClock = MainTestClockImpl(
         testScheduler = coroutineDispatcher.scheduler,
-        frameDelayMillis = FRAME_DELAY_MILLIS,
-        onTimeAdvanced = ::render
+        frameDelayMillis = FRAME_DELAY_MILLIS
     )
     private val uncaughtExceptionHandler = UncaughtExceptionHandler()
     private val infiniteAnimationPolicy = object : InfiniteAnimationPolicy {

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/MainTestClockImpl.skikoMain.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/MainTestClockImpl.skikoMain.kt
@@ -16,17 +16,13 @@
 
 package androidx.compose.ui.test
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
 
-@OptIn(ExperimentalCoroutinesApi::class)
 internal class MainTestClockImpl(
     testScheduler: TestCoroutineScheduler,
-    frameDelayMillis: Long,
-    onTimeAdvanced: (Long) -> Unit
+    frameDelayMillis: Long
 ) : AbstractMainTestClock(
     testScheduler = testScheduler,
     frameDelayMillis = frameDelayMillis,
-    runOnUiThread = ::runOnUiThread,
-    onTimeAdvanced = onTimeAdvanced
+    runOnUiThread = ::runOnUiThread
 )

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -231,6 +231,22 @@ class TestBasicsTest {
     }
 
     @Test
+    fun advancingClockByLessThanFrameDoesNotRecompose() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        var value by mutableIntStateOf(1)
+        var compositionValue = 0
+        setContent {
+            compositionValue = value
+        }
+        assertEquals(1, compositionValue)
+        value = 2
+        mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
+        assertEquals(1, compositionValue)
+        mainClock.advanceTimeByFrame()
+        assertEquals(2, compositionValue)
+    }
+
+    @Test
     fun launchedEffectsRunAfterComposition() = runComposeUiTest {
         val actions = mutableListOf<String>()
         setContent {


### PR DESCRIPTION
Now that we have a rendering loop in tests, it's no longer necessary to call `render` every time the test clock is advanced. In fact, it is incorrect to do so. The following test succeeds on Android, but fails on the desktop:

```
    @Test
    fun advancingClockByLessThanFrameDoesNotRecompose() = runComposeUiTest {
        mainClock.autoAdvance = false
        var value by mutableIntStateOf(1)
        var compositionValue = 0
        setContent {
            compositionValue = value
        }
        assertEquals(1, compositionValue)
        value = 2
        mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
        assertEquals(1, compositionValue)
    }
```

Following that, our changes to `AbstractMainTestClock` are no longer needed, and [Upstreaming. commonization. ui-test. AbstractMainTestClock](https://youtrack.jetbrains.com/issue/CMP-5776/Upstreaming.-commonization.-ui-test.-AbstractMainTestClock) is also no longer needed.

<!-- Optional -->
Fixes https://youtrack.jetbrains.com/issue/CMP-5776/Upstreaming.-commonization.-ui-test.-AbstractMainTestClock

## Testing
Added a new unit test.

## Release Notes
### Breaking Changes - Tests
- Advancing `mainClock` such that it doesn't reach the next frame, will no longer cause a recomposition.
