### PR TITLE
Restore matrix precision after performance optimizations

### DIFF
--- a/compose/ui/ui-graphics/src/androidInstrumentedTest/kotlin/androidx/compose/ui/graphics/AndroidMatrixTest.kt
+++ b/compose/ui/ui-graphics/src/androidInstrumentedTest/kotlin/androidx/compose/ui/graphics/AndroidMatrixTest.kt
@@ -60,7 +60,7 @@ class AndroidMatrixTest {
         assertThat(point[0]).isWithin(delta).of(0f)
         assertThat(point[1]).isWithin(delta).of(0f)
         p.mapPoints(point, floatArrayOf(100f, 0f))
-        assertThat(point[0]).isWithin(delta).of(86.48648f)
+        assertThat(point[0]).isWithin(delta).of(86.60254f)
         assertThat(point[1]).isWithin(delta).of(50f)
 
         val composeMatrix = Matrix().apply { setFrom(p) }

--- a/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/Matrix.kt
+++ b/compose/ui/ui-graphics/src/commonMain/kotlin/androidx/compose/ui/graphics/Matrix.kt
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:Suppress("NOTHING_TO_INLINE")
+
+@file:Suppress("NOTHING_TO_INLINE", "KotlinRedundantDiagnosticSuppress")
 
 package androidx.compose.ui.graphics
 
@@ -23,8 +24,9 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.util.fastIsFinite
 import androidx.compose.ui.util.fastMaxOf
 import androidx.compose.ui.util.fastMinOf
-import androidx.compose.ui.util.normalizedAngleCos
-import androidx.compose.ui.util.normalizedAngleSin
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
 
 // NOTE: This class contains a number of tests like this:
 //
@@ -350,9 +352,9 @@ value class Matrix(
         // See top-level comment
         if (values.size < 16) return
 
-        val d = degrees * (1.0f / 360.0f)
-        val s = normalizedAngleSin(d)
-        val c = normalizedAngleCos(d)
+        val r = degrees * (PI / 180.0)
+        val s = sin(r).toFloat()
+        val c = cos(r).toFloat()
 
         val a01 = this[0, 1]
         val a02 = this[0, 2]
@@ -389,9 +391,9 @@ value class Matrix(
         // See top-level comment
         if (values.size < 16) return
 
-        val d = degrees * (1.0f / 360.0f)
-        val s = normalizedAngleSin(d)
-        val c = normalizedAngleCos(d)
+        val r = degrees * (PI / 180.0)
+        val s = sin(r).toFloat()
+        val c = cos(r).toFloat()
 
         val a00 = this[0, 0]
         val a02 = this[0, 2]
@@ -428,9 +430,9 @@ value class Matrix(
         // See top-level comment
         if (values.size < 16) return
 
-        val d = degrees * (1.0f / 360.0f)
-        val s = normalizedAngleSin(d)
-        val c = normalizedAngleCos(d)
+        val r = degrees * (PI / 180.0)
+        val s = sin(r).toFloat()
+        val c = cos(r).toFloat()
 
         val a00 = this[0, 0]
         val a10 = this[1, 0]
@@ -534,9 +536,9 @@ value class Matrix(
         scaleZ: Float = 1f
     ) {
         // X
-        val rx = rotationX * (1.0f / 360.0f)
-        val rsx = normalizedAngleSin(rx)
-        val rcx = normalizedAngleCos(rx)
+        val rx = rotationX * (PI / 180.0)
+        val rsx = sin(rx).toFloat()
+        val rcx = cos(rx).toFloat()
 
         var v11 = rcx
         var v12 = rsx
@@ -548,9 +550,9 @@ value class Matrix(
         var v32 = translationY * rsx + translationZ * rcx
 
         // Y
-        val ry = rotationY * (1.0f / 360.0f)
-        val rsy = normalizedAngleSin(ry)
-        val rcy = normalizedAngleCos(ry)
+        val ry = rotationY * (PI / 180.0)
+        val rsy = sin(ry).toFloat()
+        val rcy = cos(ry).toFloat()
 
         var v00 = rcy
         var v02 = -rsy
@@ -565,9 +567,9 @@ value class Matrix(
         v32 = -translationX * rsy + v32 * rcy
 
         // Z
-        val rz = rotationZ * (1.0f / 360.0f)
-        val rsz = normalizedAngleSin(rz)
-        val rcz = normalizedAngleCos(rz)
+        val rz = rotationZ * (PI / 180.0)
+        val rsz = sin(rz).toFloat()
+        val rcz = cos(rz).toFloat()
 
         val a10 = v10
         v10 = -rsz * v00 + rcz * v10

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicsLayerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicsLayerTest.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.test.junit4.DesktopScreenshotTestRule
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import kotlin.test.Ignore
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
@@ -150,8 +149,6 @@ class GraphicsLayerTest {
 
     }
 
-    // FIXME: It's a regression after performance optimizations from https://r.android.com/3127234
-    @Ignore("https://youtrack.jetbrains.com/issue/CMP-6764")
     @Test
     fun rotationX() {
 
@@ -167,8 +164,6 @@ class GraphicsLayerTest {
         screenshotRule.write(snapshot)
     }
 
-    // FIXME: It's a regression after performance optimizations from https://r.android.com/3127234
-    @Ignore("https://youtrack.jetbrains.com/issue/CMP-6764")
     @Test
     fun rotationY() {
 
@@ -183,9 +178,6 @@ class GraphicsLayerTest {
         }
         screenshotRule.write(snapshot)
     }
-
-    // FIXME: It's a regression after performance optimizations from https://r.android.com/3127234
-    @Ignore("https://youtrack.jetbrains.com/issue/CMP-6764")
     @Test
     fun rotationZ() {
 
@@ -201,8 +193,6 @@ class GraphicsLayerTest {
         screenshotRule.write(snapshot)
     }
 
-    // FIXME: It's a regression after performance optimizations from https://r.android.com/3127234
-    @Ignore("https://youtrack.jetbrains.com/issue/CMP-6764")
     @Test
     fun rotationXYZ() {
 
@@ -220,8 +210,6 @@ class GraphicsLayerTest {
         screenshotRule.write(snapshot)
     }
 
-    // FIXME: It's a regression after performance optimizations from https://r.android.com/3127234
-    @Ignore("https://youtrack.jetbrains.com/issue/CMP-6764")
     @Test
     fun `nested layer transformations`() {
         val snapshot = renderComposeScene(width = 40, height = 40) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderNodeLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderNodeLayerTest.kt
@@ -601,12 +601,8 @@ class RenderNodeLayerTest {
     )
 
     private fun assertMapping(from: Offset, to: Offset) {
-        // TODO: Fix precision and lower tolerance back.
-        //  It's a regression after performance optimizations from https://r.android.com/3127234
-        //  Now the error is up to 0.17346 in a few tests
-        //  https://youtrack.jetbrains.com/issue/CMP-6764
-        assertEquals(from, matrix.map(to), 0.2f)
-        assertEquals(to, inverseMatrix.map(from), 0.2f)
+        assertEquals(from, matrix.map(to), 0.001f)
+        assertEquals(to, inverseMatrix.map(from), 0.001f)
     }
 
     private fun assertEquals(expected: Offset, actual: Offset, absoluteTolerance: Float) {


### PR DESCRIPTION
It was a regression after performance optimizations from https://r.android.com/3127234
Google issue: https://issuetracker.google.com/issues/371920679
Fixes https://youtrack.jetbrains.com/issue/CMP-6764