### PR TITLE
Do not use states for layer invalidation without new layers

### DIFF
--- a/compose/ui/ui-graphics/api/desktop/ui-graphics.api
+++ b/compose/ui/ui-graphics/api/desktop/ui-graphics.api
@@ -1003,6 +1003,7 @@ public final class androidx/compose/ui/graphics/SkiaGraphicsContext : androidx/c
 	public fun <init> ()V
 	public fun createGraphicsLayer ()Landroidx/compose/ui/graphics/layer/GraphicsLayer;
 	public final fun dispose ()V
+	public final fun getActiveGraphicsLayersCount ()I
 	public fun releaseGraphicsLayer (Landroidx/compose/ui/graphics/layer/GraphicsLayer;)V
 }
 

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaGraphicsContext.skiko.kt
@@ -26,6 +26,10 @@ class SkiaGraphicsContext() : GraphicsContext {
         command()
     }
 
+    // Temporary workaround to disable state tracking workaround inside old internal layers
+    var activeGraphicsLayersCount = 0
+        private set
+
     init {
         snapshotObserver.start()
     }
@@ -36,10 +40,14 @@ class SkiaGraphicsContext() : GraphicsContext {
     }
 
     override fun createGraphicsLayer(): GraphicsLayer {
+        activeGraphicsLayersCount++
         return GraphicsLayer(snapshotObserver)
     }
 
     override fun releaseGraphicsLayer(layer: GraphicsLayer) {
-        layer.release()
+        if (!layer.isReleased) {
+            activeGraphicsLayersCount--
+            layer.release()
+        }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -475,6 +475,7 @@ internal class RootNodeOwner(
                         density
                     },
                     measureDrawBounds = platformContext.measureDrawLayerBounds,
+                    requiresStateWorkaround = { graphicsContext.activeGraphicsLayersCount > 0 },
                     invalidateParentLayer = {
                         invalidateParentLayer()
                         snapshotInvalidationTracker.requestDraw()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/RenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/RenderNodeLayer.skiko.kt
@@ -66,6 +66,7 @@ import org.jetbrains.skia.ShadowUtils
 internal class RenderNodeLayer(
     private var density: Density,
     measureDrawBounds: Boolean,
+    private val requiresStateWorkaround: () -> Boolean,
     private val invalidateParentLayer: () -> Unit,
     private val drawBlock: (canvas: Canvas, parentLayer: GraphicsLayer?) -> Unit,
     private val onDestroy: () -> Unit = {}
@@ -218,12 +219,14 @@ internal class RenderNodeLayer(
             picture?.close()
             picture = null
         }
-        drawState.value = Unit
+        if (requiresStateWorkaround()) {
+            drawState.value = Unit
+        }
         invalidateParentLayer()
     }
 
     override fun drawLayer(canvas: Canvas, parentLayer: GraphicsLayer?) {
-        if (parentLayer != null) {
+        if (requiresStateWorkaround() && parentLayer != null) {
             // Read the state because any changes to the state should trigger re-drawing of [GraphicsLayer].
             drawState.value
         }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderNodeLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderNodeLayerTest.kt
@@ -596,6 +596,7 @@ class RenderNodeLayerTest {
     ) = RenderNodeLayer(
         Density(1f, 1f),
         measureDrawBounds = false,
+        requiresStateWorkaround = { false },
         invalidateParentLayer = invalidateParentLayer,
         drawBlock = drawBlock,
     )


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6877/Do-not-use-states-for-layer-invalidation-without-new-layers

Disable state tracking for old internal layers if there is no need to do so (no active new layers).
It's considered as a temporary solution for 1.7.x

It's probably better to wait @igordmn before merging

## Testing
Run [LazyGrid benchmark](https://github.com/JetBrains/compose-multiplatform/blob/master/benchmarks/ios/jvm-vs-kotlin-native/src/commonMain/kotlin/benchmarks/lazygrid/LazyGrid.kt) 
