### PR TITLE
Add initial support for testing drag-and-drop in skiko

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -20,13 +20,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.draganddrop.DragAndDropTransferData
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.node.RootForTest
 import androidx.compose.ui.platform.InfiniteAnimationPolicy
 import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformDragAndDropManager
+import androidx.compose.ui.platform.PlatformDragAndDropSource
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.CanvasLayersComposeScene
@@ -446,6 +451,33 @@ class SkikoComposeUiTest @InternalTestApi constructor(
         override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) = Unit
     }
 
+    private inner class TestDragAndDropManager : PlatformDragAndDropManager {
+        override val isRequestDragAndDropTransferRequired: Boolean
+            get() = true
+
+        override fun requestDragAndDropTransfer(
+            source: PlatformDragAndDropSource,
+            offset: Offset
+        ) {
+            var isTransferStarted = false
+            val startTransferScope = object : PlatformDragAndDropSource.StartTransferScope {
+                override fun startDragAndDropTransfer(
+                    transferData: DragAndDropTransferData,
+                    decorationSize: Size,
+                    drawDragDecoration: DrawScope.() -> Unit
+                ): Boolean {
+                    isTransferStarted = true
+                    return true
+                }
+            }
+            with(source) {
+                startTransferScope.startDragAndDropTransfer(offset) {
+                    isTransferStarted
+                }
+            }
+        }
+    }
+
     private inner class TestContext : PlatformContext by PlatformContext.Empty {
         override val windowInfo: WindowInfo = TestWindowInfo()
 
@@ -456,6 +488,8 @@ class SkikoComposeUiTest @InternalTestApi constructor(
 
         override val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener?
             get() = this@SkikoComposeUiTest.semanticsOwnerListener
+
+        override val dragAndDropManager: PlatformDragAndDropManager = TestDragAndDropManager()
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/draganddrop/DesktopDragAndDropTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/draganddrop/DesktopDragAndDropTest.kt
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package androidx.compose.ui
+package androidx.compose.ui.draganddrop
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -24,9 +23,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
-import androidx.compose.ui.draganddrop.DragAndDropEvent
-import androidx.compose.ui.draganddrop.DragAndDropTarget
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.Window
@@ -43,9 +42,8 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import org.junit.Test
 
-class DragAndDropTest {
+class DesktopDragAndDropTest {
 
-    @OptIn(ExperimentalFoundationApi::class)
     @Test
     fun testDragAndDropTarget() = runApplicationTest {
         lateinit var window: ComposeWindow
@@ -114,7 +112,6 @@ class DragAndDropTest {
      * Tests that drag-target works in the presence of multiple compositions (ComposeScenes)
      * attached to the same root component.
      */
-    @OptIn(ExperimentalFoundationApi::class)
     @Test
     fun dragAndDropTargetWorksAfterShowingPopup() = runApplicationTest {
         lateinit var window: ComposeWindow

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/draganddrop/DragAndDropTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/draganddrop/DragAndDropTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.draganddrop
+
+import androidx.compose.foundation.draganddrop.dragAndDropSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.dragAndDrop
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalTestApi::class)
+class DragAndDropTest {
+    @Test
+    fun mouseDragTriggersDragStart() = runComposeUiTest {
+        var transferDataCreated = false
+        setContent {
+            Box(
+                Modifier
+                    .testTag("dragSource")
+                    .size(100.dp)
+                    .dragAndDropSource(
+                        transferData = {
+                            transferDataCreated = true
+                            null
+                        }
+                    )
+            )
+        }
+
+        assertFalse(transferDataCreated)
+
+        onNodeWithTag("dragSource").performMouseInput {
+            dragAndDrop(
+                start = Offset(1f, 1f),
+                end = Offset(99f, 99f),
+            )
+        }
+        assertTrue(transferDataCreated)
+    }
+
+    @Test
+    fun mouseLongPressDoesNotTriggerDragStart() = runComposeUiTest {
+        var transferDataCreated = false
+        setContent {
+            Box(
+                Modifier
+                    .testTag("dragSource")
+                    .size(100.dp)
+                    .dragAndDropSource(
+                        drawDragDecoration = {},
+                        transferData = {
+                            println("Triggered")
+                            transferDataCreated = true
+                            null
+                        }
+                    )
+            )
+        }
+
+        assertFalse(transferDataCreated)
+
+        onNodeWithTag("dragSource").performMouseInput {
+            longClick()
+        }
+        assertFalse(transferDataCreated)
+    }
+
+    @Test
+    fun touchLongPressTriggersDragStart() = runComposeUiTest {
+        var transferDataCreated = false
+        setContent {
+            Box(
+                Modifier
+                    .testTag("dragSource")
+                    .size(100.dp)
+                    .dragAndDropSource(
+                        transferData = {
+                            transferDataCreated = true
+                            null
+                        }
+                    )
+            )
+        }
+
+        assertFalse(transferDataCreated)
+
+        onNodeWithTag("dragSource").performTouchInput {
+            longClick()
+        }
+        assertTrue(transferDataCreated)
+    }
+
+    @Test
+    fun touchDragDoesNotTriggerDragStart() = runComposeUiTest {
+        var transferDataCreated = false
+        setContent {
+            Box(
+                Modifier
+                    .testTag("dragSource")
+                    .size(100.dp)
+                    .dragAndDropSource(
+                        drawDragDecoration = {},
+                        transferData = {
+                            println("Triggered")
+                            transferDataCreated = true
+                            null
+                        }
+                    )
+            )
+        }
+
+        assertFalse(transferDataCreated)
+
+        onNodeWithTag("dragSource").performTouchInput {
+            down(Offset(1f, 1f))
+            moveTo(Offset(99f, 99f))
+            up()
+        }
+        assertFalse(transferDataCreated)
+    }
+}


### PR DESCRIPTION
Add initial support for testing drag-and-drop in skiko and a few actual unit tests.
