### PR TITLE
Support init route and direct navigation in a browser

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -205,6 +205,7 @@ val testWebJs = tasks.register("testWebJs") {
     dependsOn(":compose:runtime:runtime:jsTest")
     dependsOn(":compose:ui:ui-text:compileTestKotlinJs")
     dependsOn(":compose:ui:ui:compileTestKotlinJs")
+    dependsOn(":navigation:navigation-runtime:jsTest")
 }
 
 val testWebWasm = tasks.register("testWebWasm") {
@@ -215,6 +216,7 @@ val testWebWasm = tasks.register("testWebWasm") {
     dependsOn(":compose:runtime:runtime:wasmJsTest")
     dependsOn(":compose:ui:ui-text:wasmJsTest")
     dependsOn(":compose:ui:ui:wasmJsTest")
+    dependsOn(":navigation:navigation-runtime:wasmJsTest")
 }
 
 tasks.register("testUIKit") {

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -31,6 +31,7 @@ import org.w3c.dom.Window
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
+@ExperimentalBrowserHistoryApi
 suspend fun Window.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -26,7 +26,17 @@ import org.w3c.dom.Window
  *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
  *
  * If there is a custom `getBackStackEntryRoute` implementation,
- * then we don't have a knowledge how to parse urls to support direct navigation via browser address input
+ * then we don't have a knowledge how to parse urls to support direct navigation via browser address input.
+ * In that case, it should be done on the app's side:
+ * ```
+ * window.addEventListener("popstate") { event ->
+ *     event as PopStateEvent
+ *     if (event.state == null) { // empty state means manually entered address
+ *         val url = window.location.toString()
+ *         navController.navigate(...)
+ *     }
+ * }
+ * ```
  *
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -21,14 +21,19 @@ import org.w3c.dom.Window
 /**
  * Binds the browser window state to the given navigation controller.
  *
+ * If `getBackStackEntryRoute` is null, then:
+ *  1) if a browser url contains a destination route on a start then navigates to destination
+ *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
+ *
+ * If there is a custom `getBackStackEntryRoute` implementation,
+ * then we don't have a knowledge how to parse urls to support direct navigation via browser address input
+ *
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
 suspend fun Window.bindToNavigation(
     navController: NavController,
-    getBackStackEntryRoute: (entry: NavBackStackEntry) -> String = {
-        it.getRouteWithArgs()?.let { r -> "#$r" }.orEmpty()
-    }
+    getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {
     @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
     (this as BrowserWindow).bindToNavigation(navController, getBackStackEntryRoute)

--- a/navigation/navigation-runtime/src/jsTest/kotlin/androidx/navigation/BrowserHistoryTest.kt
+++ b/navigation/navigation-runtime/src/jsTest/kotlin/androidx/navigation/BrowserHistoryTest.kt
@@ -50,7 +50,7 @@ class BrowserHistoryTest {
 
     @Test
     fun checkBrowserHistoryStateSynchronizedWithNavigation() = runTest {
-        cleanWindowHistory()
+        val initHistoryLength = goToBrowserRoot()
         val navController = NavHostController().apply {
             navigatorProvider.addNavigator(TestNavigator())
         }
@@ -60,7 +60,7 @@ class BrowserHistoryTest {
         navController.setGraph(navController.createGraph(), null)
         advanceUntilIdle()
 
-        assertThat(window.history.length).isEqualTo(1)
+        assertThat(window.history.length).isEqualTo(initHistoryLength)
         assertThat(window.history.state.toString()).isEqualTo("screen_1")
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_1")
 
@@ -100,15 +100,19 @@ class BrowserHistoryTest {
 
     @Test
     fun checkNavigationSynchronizedWithBrowserHistoryState() = runTest {
-        cleanWindowHistory()
+        val initHistoryLength = goToBrowserRoot()
         val navController = NavHostController().apply {
             navigatorProvider.addNavigator(TestNavigator())
         }
-        val appAddress = with(window.location) { origin + pathname }
-
-        val bind = launch { window.bindToNavigation(navController) }
         navController.setGraph(navController.createGraph(), null)
+
+        val appAddress = with(window.location) { origin + pathname }
+        val bind = launch { window.bindToNavigation(navController) }
         advanceUntilIdle()
+
+        assertThat(window.history.length).isEqualTo(initHistoryLength)
+        assertThat(window.history.state.toString()).isEqualTo("screen_1")
+        assertThat(window.location.toString()).isEqualTo("$appAddress#screen_1")
 
         navController.navigate("screen_2")
         advanceUntilIdle()
@@ -133,8 +137,7 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_6/123?q=")
 
-        window.history.back()
-        waitHistoryStateUpdate()
+        browserBack()
 
         assertThat(window.history.length).isEqualTo(6)
         assertThat(window.history.state.toString().lines())
@@ -142,8 +145,7 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_2")
 
-        window.history.back()
-        waitHistoryStateUpdate()
+        browserBack()
 
         assertThat(window.history.length).isEqualTo(6)
         assertThat(window.history.state.toString().lines())
@@ -151,8 +153,7 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_5")
 
-        window.history.back()
-        waitHistoryStateUpdate()
+        browserBack()
 
         assertThat(window.history.length).isEqualTo(6)
         assertThat(window.history.state.toString().lines())
@@ -160,8 +161,7 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_4")
 
-        window.history.back()
-        waitHistoryStateUpdate()
+        browserBack()
 
         assertThat(window.history.length).isEqualTo(6)
         assertThat(window.history.state.toString().lines())
@@ -178,8 +178,7 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_2")
 
-        window.history.back()
-        waitHistoryStateUpdate()
+        browserBack()
 
         assertThat(window.history.length).isEqualTo(3)
         assertThat(window.history.state.toString().lines())
@@ -187,8 +186,7 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo("$appAddress#screen_2")
 
-        window.history.forward()
-        waitHistoryStateUpdate()
+        browserForward()
 
         assertThat(window.history.length).isEqualTo(3)
         assertThat(window.history.state.toString().lines())
@@ -201,15 +199,19 @@ class BrowserHistoryTest {
 
     @Test
     fun checkBrowserUrlCustomization() = runTest {
-        cleanWindowHistory()
+        val initHistoryLength = goToBrowserRoot()
         val navController = NavHostController().apply {
             navigatorProvider.addNavigator(TestNavigator())
         }
-        val appAddress = with(window.location) { origin + pathname }
-
-        val bind = launch { window.bindToNavigation(navController) { "" } }
         navController.setGraph(navController.createGraph(), null)
+
+        val appAddress = with(window.location) { origin + pathname }
+        val bind = launch { window.bindToNavigation(navController) { "" } }
         advanceUntilIdle()
+
+        assertThat(window.history.length).isEqualTo(initHistoryLength)
+        assertThat(window.history.state.toString()).isEqualTo("screen_1")
+        assertThat(window.location.toString()).isEqualTo(appAddress)
 
         navController.navigate("screen_2")
         advanceUntilIdle()
@@ -220,28 +222,113 @@ class BrowserHistoryTest {
             .inOrder()
         assertThat(window.location.toString()).isEqualTo(appAddress)
 
-        window.history.back()
-        waitHistoryStateUpdate()
+        browserBack()
 
         assertThat(window.history.length).isEqualTo(2)
         assertThat(window.history.state.toString().lines())
             .containsExactly("screen_1")
             .inOrder()
         assertThat(window.location.toString()).isEqualTo(appAddress)
+
+        val nextAddress = "screen_6/123?q=456"
+        window.open("$appAddress#$nextAddress", "_self")!! //like a manual new url loading
+        advanceUntilIdle()
+
+        //compose navigation didn't happen
+        assertThat(window.history.length).isEqualTo(2)
+        assertThat(window.history.state).isNull()
+        assertThat(window.location.toString()).isEqualTo("$appAddress#$nextAddress")
+        assertThat(navController.currentDestination?.route.orEmpty()).isEqualTo("screen_1")
+
+        navController.navigate("screen_3")
+        advanceUntilIdle()
+
+        //and the state was rewritten by the next navigation
+        assertThat(window.history.length).isEqualTo(2)
+        assertThat(window.history.state.toString().lines())
+            .containsExactly("screen_1", "screen_3")
+            .inOrder()
+        assertThat(window.location.toString()).isEqualTo(appAddress)
+
+        browserBack()
+
+        assertThat(window.history.length).isEqualTo(2)
+        assertThat(window.history.state.toString().lines())
+            .containsExactly("screen_1")
+            .inOrder()
+        assertThat(window.location.toString()).isEqualTo(appAddress)
+
+        browserForward()
+
+        assertThat(window.history.length).isEqualTo(2)
+        assertThat(window.history.state.toString().lines())
+            .containsExactly("screen_1", "screen_3")
+            .inOrder()
+        assertThat(window.location.toString()).isEqualTo(appAddress)
+
         bind.cancel()
     }
 
-    private suspend fun cleanWindowHistory() {
+    @Test
+    fun checkInitScreenAndDirectNavigation() = runTest {
+        val initHistoryLength = goToBrowserRoot()
+        val navController = NavHostController().apply {
+            navigatorProvider.addNavigator(TestNavigator())
+        }
+        navController.setGraph(navController.createGraph(), null)
+
+        val appAddress = with(window.location) { origin + pathname }
+        val initAddress = "$appAddress#screen_4"
+        window.history.replaceState(null, "", initAddress)
+
+        val bind = launch { window.bindToNavigation(navController) }
+        advanceUntilIdle()
+
+        assertThat(window.history.length).isEqualTo(initHistoryLength)
+        assertThat(window.history.state.toString().lines())
+            .containsExactly("screen_1", "screen_4")
+            .inOrder()
+        assertThat(window.location.toString()).isEqualTo(initAddress)
+        assertThat(navController.currentDestination?.route.orEmpty()).isEqualTo("screen_4")
+
+        val nextAddress = "screen_6/123?q=456"
+        window.open("$appAddress#$nextAddress", "_self") //like a manual new url loading
+        advanceUntilIdle()
+
+        assertThat(window.history.length).isEqualTo(2)
+        assertThat(window.history.state.toString().lines())
+            .containsExactly("screen_1", "screen_4", nextAddress)
+            .inOrder()
+        assertThat(window.location.toString()).isEqualTo("$appAddress#$nextAddress")
+        assertThat(navController.currentDestination?.route.orEmpty()).isEqualTo("screen_6/{pathId}?q={queryId}")
+
+        bind.cancel()
+    }
+
+    private suspend fun goToBrowserRoot(): Int {
         with(window.history) {
             if (length > 1) {
                 val size = length - 1
                 go(-size)
-                waitHistoryStateUpdate()
+                waitHistoryPopState()
             }
         }
+        val appAddress = with(window.location) { origin + pathname }
+        window.history.replaceState(null, "", appAddress)
+        return window.history.length
     }
 
-    private suspend fun waitHistoryStateUpdate() = suspendCoroutine { cont ->
+    private suspend fun browserBack() {
+        window.history.back()
+        waitHistoryPopState()
+    }
+
+    private suspend fun browserForward() {
+        window.history.forward()
+        waitHistoryPopState()
+    }
+
+    private suspend fun waitHistoryPopState() = suspendCoroutine { cont ->
         window.addEventListener(
             type = "popstate",
             callback = { cont.resume(Unit) },

--- a/navigation/navigation-runtime/src/jsTest/kotlin/androidx/navigation/BrowserHistoryTest.kt
+++ b/navigation/navigation-runtime/src/jsTest/kotlin/androidx/navigation/BrowserHistoryTest.kt
@@ -23,11 +23,13 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import kotlin.test.Test
 import kotlinx.browser.window
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.w3c.dom.AddEventListenerOptions
 
+@OptIn(ExperimentalBrowserHistoryApi::class, ExperimentalCoroutinesApi::class)
 class BrowserHistoryTest {
 
     private fun NavController.createGraph() =

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -31,6 +31,7 @@ import org.w3c.dom.Window
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
+@ExperimentalBrowserHistoryApi
 suspend fun Window.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -26,7 +26,17 @@ import org.w3c.dom.Window
  *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
  *
  * If there is a custom `getBackStackEntryRoute` implementation,
- * then we don't have a knowledge how to parse urls to support direct navigation via browser address input
+ * then we don't have a knowledge how to parse urls to support direct navigation via browser address input.
+ * In that case, it should be done on the app's side:
+ * ```
+ * window.addEventListener("popstate") { event ->
+ *     event as PopStateEvent
+ *     if (event.state == null) { // empty state means manually entered address
+ *         val url = window.location.toString()
+ *         navController.navigate(...)
+ *     }
+ * }
+ * ```
  *
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -21,14 +21,19 @@ import org.w3c.dom.Window
 /**
  * Binds the browser window state to the given navigation controller.
  *
+ * If `getBackStackEntryRoute` is null, then:
+ *  1) if a browser url contains a destination route on a start then navigates to destination
+ *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
+ *
+ * If there is a custom `getBackStackEntryRoute` implementation,
+ * then we don't have a knowledge how to parse urls to support direct navigation via browser address input
+ *
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
 suspend fun Window.bindToNavigation(
     navController: NavController,
-    getBackStackEntryRoute: (entry: NavBackStackEntry) -> String = {
-        it.getRouteWithArgs()?.let { r -> "#$r" }.orEmpty()
-    }
+    getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {
     @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
     (this as BrowserWindow).bindToNavigation(navController, getBackStackEntryRoute)

--- a/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
+++ b/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
@@ -32,11 +32,16 @@ import kotlinx.coroutines.launch
  */
 internal suspend fun BrowserWindow.bindToNavigation(
     navController: NavController,
-    getBackStackEntryRoute: (entry: NavBackStackEntry) -> String
+    getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)?
 ) {
     coroutineScope {
         val localWindow = this@bindToNavigation
         val appAddress = with(localWindow.location) { origin + pathname }
+
+        //initial route
+        if (getBackStackEntryRoute == null) {
+            navController.tryToNavigateToUrlFragment(localWindow)
+        }
 
         launch {
             localWindow.popStateEvents().collect { event ->
@@ -44,6 +49,10 @@ internal suspend fun BrowserWindow.bindToNavigation(
 
                 if (state == null) {
                     //if user manually put a new address or open a new page, then there is no state
+                    //if there is no route customization we can try to find the route
+                    if (getBackStackEntryRoute == null) {
+                        navController.tryToNavigateToUrlFragment(localWindow)
+                    }
                     return@collect
                 }
 
@@ -89,7 +98,13 @@ internal suspend fun BrowserWindow.bindToNavigation(
                 if (entries.isEmpty()) return@collect
                 val routes = entries.map { it.getRouteWithArgs() ?: return@collect }
 
-                val newUri = appAddress + getBackStackEntryRoute(entries.last())
+                val currentDestination = entries.last()
+                val currentRoute = if (getBackStackEntryRoute != null) {
+                    getBackStackEntryRoute(currentDestination)
+                } else {
+                    currentDestination.getRouteAsUrlFragment()
+                }
+                val newUri = appAddress + currentRoute
                 val state = routes.joinToString("\n")
 
                 val currentState = localWindow.history.state
@@ -135,7 +150,7 @@ private fun BrowserWindow.popStateEvents(): Flow<BrowserPopStateEvent> = callbac
 }
 
 private val argPlaceholder = Regex("""\{.*?\}""")
-internal fun NavBackStackEntry.getRouteWithArgs(): String? {
+private fun NavBackStackEntry.getRouteWithArgs(): String? {
     val entry = this
     val route = entry.destination.route ?: return null
     if (!route.contains(argPlaceholder)) return route
@@ -156,9 +171,24 @@ internal fun NavBackStackEntry.getRouteWithArgs(): String? {
     return routeWithFilledArgs
 }
 
+private fun NavBackStackEntry.getRouteAsUrlFragment() =
+    getRouteWithArgs()?.let { r -> "#$r" }.orEmpty()
+
+private fun NavController.tryToNavigateToUrlFragment(localWindow: BrowserWindow) {
+    val route = localWindow.location.hash.substringAfter('#', "")
+    if (route.isNotEmpty()) {
+        try {
+            navigate(route)
+        } catch (e: IllegalArgumentException) {
+            localWindow.console.warn("Can't navigate to '$route'")
+        }
+    }
+}
+
 internal external interface BrowserLocation {
     val origin: String
     val pathname: String
+    val hash: String
 }
 
 internal external interface BrowserHistory {
@@ -180,4 +210,9 @@ internal external interface BrowserEventTarget {
 internal external interface BrowserWindow : BrowserEventTarget {
     val location: BrowserLocation
     val history: BrowserHistory
+    val console: BrowserConsole
+}
+
+internal external interface BrowserConsole {
+    fun warn(msg: String)
 }

--- a/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
+++ b/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
@@ -24,12 +24,18 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 
+@RequiresOptIn(message = "This is an experimental browser API.")
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+annotation class ExperimentalBrowserHistoryApi
+
 /**
  * Binds the browser window state to the given navigation controller.
  *
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute A function that returns the route to show for a given [NavBackStackEntry].
  */
+@ExperimentalBrowserHistoryApi
 internal suspend fun BrowserWindow.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)?


### PR DESCRIPTION
The PR adds a default behavior (if browser route customization was not set):
 - **if** the init url contains a fragment with valid route
 - **if** user enters an url fragment with valid route


**then** navigate to the route

https://github.com/user-attachments/assets/c2675371-968e-4577-b32d-60dbd64494b4

## Testing
 - Test it on a sample project
 - Write unit tests

## Release Notes
### Features - Navigation
- Navigation via a browser address field