### PR TITLE
Update iOS Demo App launcher

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -1,53 +1,75 @@
-// Use `xcodegen` first, then `open ./SkikoSample.xcodeproj` and then Run button in XCode.
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package androidx.compose.mpp.demo
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ExperimentalComposeApi
-import androidx.compose.runtime.remember
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.main.defaultUIKitMain
-import androidx.compose.ui.platform.AccessibilityDebugLogger
-import androidx.compose.ui.platform.AccessibilitySyncOptions
-import androidx.compose.ui.window.ComposeUIViewController
 import androidx.compose.mpp.demo.bugs.IosBugs
 import androidx.compose.mpp.demo.bugs.StartRecompositionCheck
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.uikit.ComposeUIViewControllerDelegate
+import androidx.compose.ui.window.ComposeUIViewController
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.autoreleasepool
+import kotlinx.cinterop.cstr
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.toCValues
+import platform.Foundation.NSStringFromClass
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationDelegateProtocol
+import platform.UIKit.UIApplicationDelegateProtocolMeta
+import platform.UIKit.UIApplicationMain
+import platform.UIKit.UIResponder
+import platform.UIKit.UIResponderMeta
+import platform.UIKit.UIScreen
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
 
-@OptIn(ExperimentalComposeApi::class, ExperimentalComposeUiApi::class)
+/**
+ * To run the demo project:
+ * - install the latest version of the XCode
+ * - in terminal, navigate to the directory "compose/mpp/demo"
+ * - run the `./regenerate_xcode_project.sh` command
+ * - XCode will open this project automatically
+ * - press the Run (Cmd+R) button in the XCode
+ */
+@OptIn(ExperimentalComposeUiApi::class)
 fun main(vararg args: String) {
     androidx.compose.ui.util.enableTraceOSLog()
 
     val arg = args.firstOrNull() ?: ""
-    defaultUIKitMain("ComposeDemo", ComposeUIViewController(configure = {
-        accessibilitySyncOptions = AccessibilitySyncOptions.WhenRequiredByAccessibilityServices(object: AccessibilityDebugLogger {
-            override fun log(message: Any?) {
-                if (message == null) {
-                    println()
-                } else {
-                    println("[a11y]: $message")
-                }
+    UIKitMain {
+        ComposeUIViewController(configure = {
+            delegate = object : ComposeUIViewControllerDelegate {
+                override val preferredStatusBarStyle: UIStatusBarStyle?
+                    get() = preferredStatusBarStyleValue
+
+                override val prefersStatusBarHidden: Boolean?
+                    get() = prefersStatusBarHiddenValue
+
+                override val preferredStatysBarAnimation: UIStatusBarAnimation?
+                    get() = preferredStatysBarAnimationValue
             }
-        })
-
-        delegate = object : ComposeUIViewControllerDelegate {
-            override val preferredStatusBarStyle: UIStatusBarStyle?
-                get() = preferredStatusBarStyleValue
-
-            override val prefersStatusBarHidden: Boolean?
-                get() = prefersStatusBarHiddenValue
-
-            override val preferredStatysBarAnimation: UIStatusBarAnimation?
-                get() = preferredStatysBarAnimationValue
+        }) {
+            IosDemo(arg)
         }
-    }) {
-        IosDemo(arg)
-    })
+    }
 }
 
 @Composable
@@ -66,8 +88,47 @@ fun IosDemo(arg: String, makeHostingController: ((Int) -> UIViewController)? = n
     }
     when (arg) {
         "demo=StartRecompositionCheck" ->
-            // The issue tested by this demo can be properly reproduced/tested only right after app start
+            // The issue tested by this demo can be properly reproduced/tested only right after app
+            // start
             StartRecompositionCheck.content()
         else -> app.Content()
+    }
+}
+
+private lateinit var MakeRootViewController: () -> UIViewController
+@OptIn(BetaInteropApi::class)
+private fun UIKitMain(makeRootViewController: () -> UIViewController) {
+    MakeRootViewController = makeRootViewController
+    memScoped {
+        val argc = 1
+        val argv = arrayOf("ComposeDemo").map { it.cstr.ptr }.toCValues()
+        autoreleasepool {
+            UIApplicationMain(argc, argv, null, NSStringFromClass(IOSAppDelegate))
+        }
+    }
+}
+
+@Suppress("PARAMETER_NAME_CHANGED_ON_OVERRIDE")
+@OptIn(BetaInteropApi::class)
+private class IOSAppDelegate : UIResponder, UIApplicationDelegateProtocol {
+    companion object Companion : UIResponderMeta(), UIApplicationDelegateProtocolMeta
+
+    @OverrideInit
+    constructor() : super()
+
+    private var _window: UIWindow? = null
+    override fun window() = _window
+    override fun setWindow(window: UIWindow?) {
+        _window = window
+    }
+
+    override fun application(
+        application: UIApplication,
+        didFinishLaunchingWithOptions: Map<Any?, *>?
+    ): Boolean {
+        window = UIWindow(frame = UIScreen.mainScreen.bounds)
+        window!!.rootViewController = MakeRootViewController()
+        window!!.makeKeyAndVisible()
+        return true
     }
 }


### PR DESCRIPTION
- Add copyright
- Update build and run instructions
- Remove deprecated method usage
- Fix potential crashes in the app, like crash on swipe back

Fixes https://youtrack.jetbrains.com/issue/CMP-6727/Swipe-back-crashes-when-app-started-from-defaultUIKitMai