### PR TITLE
Fixed `Modifier.clickable` binary compatibility with 1.6 on iOS and Web

### DIFF
--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/Clickable.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/Clickable.jsNative.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+
+@Deprecated("Maintained for binary compatibility", level = DeprecationLevel.HIDDEN)
+fun Modifier.clickable(
+    interactionSource: MutableInteractionSource,
+    indication: Indication?,
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    onClick: () -> Unit
+): Modifier = clickable(
+    interactionSource = interactionSource as MutableInteractionSource?,
+    indication = indication,
+    enabled = enabled,
+    onClickLabel = onClickLabel,
+    role = role,
+    onClick = onClick
+)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6668

## Testing
material 1.6.x + foundation 1.7

## Release Notes
### Fixes - Multiple Platforms
- Fixed `Modifier.clickable` binary compatibility with 1.6 on non-JVM targets
