### PR TITLE
Add initial dnd action

### DIFF
--- a/compose/mpp/demo/src/desktopMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.desktop.kt
+++ b/compose/mpp/demo/src/desktopMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.desktop.kt
@@ -17,12 +17,10 @@
 package androidx.compose.mpp.demo.components
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.draganddrop.dragAndDropSource
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -56,7 +54,7 @@ import java.awt.datatransfer.StringSelection
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 actual fun DragAndDropExample() {
     val exportedText = "Hello, DnD!"
@@ -100,6 +98,7 @@ actual fun DragAndDropExample() {
                         DragAndDropTransferAction.Move,
                         DragAndDropTransferAction.Link,
                     ),
+                    initialAction = DragAndDropTransferAction.Copy,
                     dragDecorationOffset = offset,
                     onTransferCompleted = { action ->
                         println("Action at source: $action")

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -563,9 +563,10 @@ public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction$Com
 
 public final class androidx/compose/ui/draganddrop/DragAndDropTransferData {
 	public static final field $stable I
-	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDragDecorationOffset-F1C5BW0 ()J
+	public final fun getInitialAction ()Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;
 	public final fun getOnTransferCompleted ()Lkotlin/jvm/functions/Function1;
 	public final fun getSupportedActions ()Ljava/lang/Iterable;
 	public final fun getTransferable ()Landroidx/compose/ui/draganddrop/DragAndDropTransferable;

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -41,6 +41,13 @@ actual class DragAndDropTransferData(
     val supportedActions: Iterable<DragAndDropTransferAction>,
 
     /**
+     * The initial transfer action when the drag starts; must be one of the values in
+     * [supportedActions].
+     */
+    @property:ExperimentalComposeUiApi
+    val initialAction: DragAndDropTransferAction,
+
+    /**
      * The offset of the pointer relative to the drag decoration.
      */
     @property:ExperimentalComposeUiApi

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -299,8 +299,7 @@ internal class ComposeTransferHandler(private val rootContainer: JComponent) : T
                 0,
                 false
             ),
-            // This seems to be ignored, and the initial action is MOVE regardless
-            MOVE
+            transferData.initialAction.awtAction
         )
     }
 


### PR DESCRIPTION
We currently have the initial transfer action hardcoded to `Move`, but this doesn't work if `Move` is not one of the supported actions. As AWT allows specifying the initial action, we should support it too.

This PR adds an `initialAction` parameter to `DragAndDropTransferData`, which allows the developer to specify it.

Fixes https://youtrack.jetbrains.com/issue/CMP-6881

## Testing
Tested manually.

## Release Notes
### Features - Desktop
- Allow specifying the initial transfer action when a drag-and-drop session starts on `dragAndDropSource`.
