### PR TITLE
Delete a fix For Ctrl+Backspace in an empty TextField as it's obsolete

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextPreparedSelection.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextPreparedSelection.kt
@@ -325,7 +325,6 @@ internal abstract class BaseTextPreparedSelection<T : BaseTextPreparedSelection<
     }
 
     private fun charOffset(offset: Int) = offset.coerceAtMost(text.length - 1)
-            .coerceAtLeast(0)
 
     companion object {
         /**


### PR DESCRIPTION
The fix https://github.com/JetBrains/compose-multiplatform-core/pull/329 is obsolete. It's implemented in the upstream repository: https://android-review.googlesource.com/c/platform/frameworks/support/+/2425401

We delete this fix made in our fork to reduce the diff between our repositories.

___

The previously added tests for the fixed bug still pass: https://github.com/JetBrains/compose-multiplatform-core/blob/1ec1b58c0662d4874b7294f13a79a2e34105d047/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt#L256

