### PR TITLE
[web] Fix EventTargetListener::dispose with AbortController invocation

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/EventTargetListenerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/EventTargetListenerTests.kt
@@ -56,8 +56,6 @@ class EventTargetListenerTests {
         el.dispatchEvent(MouseEvent("mousedown"))
         assertEquals(listOf(1, 1, 1), log, "removing from document should not affect log")
 
-//TODO: this won't work as supposed because lambda passed on the javascript side won't be disposed
-
         listener.dispose()
 
         el.dispatchEvent(MouseEvent("mousedown"))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/EventTargetListenerTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/events/EventTargetListenerTests.kt
@@ -58,9 +58,9 @@ class EventTargetListenerTests {
 
 //TODO: this won't work as supposed because lambda passed on the javascript side won't be disposed
 
-//        listener.dispose()
-//
-//        el.dispatchEvent(MouseEvent("mousedown"))
-//        assertEquals(listOf(1, 1, 1), log, "after dispose log should not be updated")
+        listener.dispose()
+
+        el.dispatchEvent(MouseEvent("mousedown"))
+        assertEquals(listOf(1, 1, 1), log, "after dispose log should not be updated")
     }
 }


### PR DESCRIPTION
In theory we can be back to removeEventListener approach when lambdas will behave correctly in the wasm target but if  AbortController approach works I don't see any reason why we should be back to this approach