### PR TITLE
Empty page  each test run

### DIFF
--- a/mpp/karma.config.d/wasm/static/common-tests.js
+++ b/mpp/karma.config.d/wasm/static/common-tests.js
@@ -42,7 +42,7 @@ window.addEventListener("rejectionhandled", (event) => {
     }, false
 );
 
-beforeEach(function() {
+afterEach(function() {
     // This is the part of mocha configuration which guarantees that DOM elements are recreated for each test
     let canvasAppContainer = document.createElement("div");
     canvasAppContainer.setAttribute("id", "canvasApp");

--- a/mpp/karma.config.d/wasm/static/common-tests.js
+++ b/mpp/karma.config.d/wasm/static/common-tests.js
@@ -42,9 +42,9 @@ window.addEventListener("rejectionhandled", (event) => {
     }, false
 );
 
-afterEach(function() {
+beforeEach(function() {
     // This is the part of mocha configuration which guarantees that DOM elements are recreated for each test
-    let canvasAppContainer = document.createElement("div");
+    const canvasAppContainer = document.createElement("div");
     canvasAppContainer.setAttribute("id", "canvasApp");
     document.body.replaceChildren(canvasAppContainer);
 });

--- a/mpp/karma.config.d/wasm/static/common-tests.js
+++ b/mpp/karma.config.d/wasm/static/common-tests.js
@@ -41,3 +41,10 @@ window.addEventListener("rejectionhandled", (event) => {
         }
     }, false
 );
+
+beforeEach(function() {
+    // This is the part of mocha configuration which guarantees that DOM elements are recreated for each test
+    let canvasAppContainer = document.createElement("div");
+    canvasAppContainer.setAttribute("id", "canvasApp");
+    document.body.replaceChildren(canvasAppContainer);
+});

--- a/mpp/karma.config.d/wasm/static/compose_context.html
+++ b/mpp/karma.config.d/wasm/static/compose_context.html
@@ -9,35 +9,41 @@ Reloaded before every execution run.
   <title></title>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
-</head>
-<body>
+
   <style>
+    html {
+      height: 100%;
+      width: 100%;
+    }
     body { margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%; }
 
     canvas {
       outline: 0
     }
 
+    /*
+    element with this id is created for each test run byt the mocha runner
+    see common-tests.js
+    */
     #canvasApp {
       width: 100%;
       height: 100%;
     }
   </style>
-  <div id="canvasApp" />
-  <!-- The scripts need to be in the body DOM element, as some test running frameworks need the body
-       to have already been created so they can insert their magic into it. For example, if loaded
-       before body, Angular Scenario test framework fails to find the body and crashes and burns in
-       an epic manner. -->
-  <script src="context.js"></script>
-  <script type="text/javascript">
-    // Configure our Karma and set up bindings
-    %CLIENT_CONFIG%
-    window.__karma__.setupContext(window);
-
-    // All served files with the latest timestamps
-    %MAPPINGS%
-  </script>
-  <!-- Dynamically replaced with <script> tags -->
-  %SCRIPTS%
+</head>
+<body>
 </body>
+
+<script src="context.js"></script>
+<script type="text/javascript">
+  // Configure our Karma and set up bindings
+  %CLIENT_CONFIG%
+  window.__karma__.setupContext(window);
+
+  // All served files with the latest timestamps
+  %MAPPINGS%
+</script>
+<!-- Dynamically replaced with <script> tags -->
+%SCRIPTS%
+
 </html>

--- a/mpp/karma.config.d/wasm/static/compose_context.html
+++ b/mpp/karma.config.d/wasm/static/compose_context.html
@@ -11,10 +11,6 @@ Reloaded before every execution run.
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 
   <style>
-    html {
-      height: 100%;
-      width: 100%;
-    }
     body { margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%; }
 
     canvas {
@@ -32,7 +28,6 @@ Reloaded before every execution run.
   </style>
 </head>
 <body>
-  <div id="canvasApp" />
 </body>
 
 <script src="context.js"></script>

--- a/mpp/karma.config.d/wasm/static/compose_context.html
+++ b/mpp/karma.config.d/wasm/static/compose_context.html
@@ -15,6 +15,7 @@ Reloaded before every execution run.
       height: 100%;
       width: 100%;
     }
+    body { margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%; }
 
     canvas {
       outline: 0
@@ -30,7 +31,7 @@ Reloaded before every execution run.
     }
   </style>
 </head>
-<body style="margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%;">
+<body>
 </body>
 
 <script src="context.js"></script>

--- a/mpp/karma.config.d/wasm/static/compose_context.html
+++ b/mpp/karma.config.d/wasm/static/compose_context.html
@@ -15,7 +15,6 @@ Reloaded before every execution run.
       height: 100%;
       width: 100%;
     }
-    body { margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%; }
 
     canvas {
       outline: 0
@@ -31,7 +30,7 @@ Reloaded before every execution run.
     }
   </style>
 </head>
-<body>
+<body style="margin: 0; padding: 0; overflow: hidden; width: 100%; height: 100%;">
 </body>
 
 <script src="context.js"></script>

--- a/mpp/karma.config.d/wasm/static/compose_context.html
+++ b/mpp/karma.config.d/wasm/static/compose_context.html
@@ -32,6 +32,7 @@ Reloaded before every execution run.
   </style>
 </head>
 <body>
+  <div id="canvasApp" />
 </body>
 
 <script src="context.js"></script>


### PR DESCRIPTION
Karma behaved unpredictably on cleaning the page so I've decided to enforce this via mocha configuration.
Hopefully, this is the las time when we bother about such issues. 

js target is not covered but I suggest to introduce it when we'll fix js tests 

May be later or we should take care of events as well, but as of know this is overkill. To make sure that there's nothing on page apart of container we need is all we would we'll need for a long time (if not for forever). 