### PR TITLE
Revert creating the ScrollableState for `textFieldScrollable` in an external function

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
@@ -18,7 +18,6 @@ package androidx.compose.foundation.text
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
-import androidx.compose.foundation.clipScrollableContainer
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.rememberScrollableState
@@ -94,9 +93,15 @@ internal fun Modifier.textFieldScrollable(
     //  setting these
     val wrappedScrollableState =
         remember(scrollableState, scrollerPosition) {
-            createScrollableState(scrollableState, scrollerPosition)
+            object : ScrollableState by scrollableState {
+                override val canScrollForward by derivedStateOf {
+                    scrollerPosition.offset < scrollerPosition.maximum
+                }
+                override val canScrollBackward by derivedStateOf {
+                    scrollerPosition.offset > 0f
+                }
+            }
         }
-
     val scroll = Modifier.scrollable(
         orientation = scrollerPosition.orientation,
         reverseDirection = reverseDirection,
@@ -105,22 +110,7 @@ internal fun Modifier.textFieldScrollable(
         interactionSource = interactionSource,
         enabled = enabled && scrollerPosition.maximum != 0f
     )
-
     scroll
-
-}
-
-// Workaround for K/JS
-private inline fun createScrollableState(
-    scrollableState: ScrollableState,
-    scrollerPosition: TextFieldScrollerPosition
-): ScrollableState {
-    return object : ScrollableState by scrollableState {
-        override val canScrollForward by derivedStateOf {
-            scrollerPosition.offset < scrollerPosition.maximum
-        }
-        override val canScrollBackward by derivedStateOf { scrollerPosition.offset > 0f }
-    }
 }
 
 // Layout


### PR DESCRIPTION
Revert [creating the ScrollableState in an external function](https://github.com/JetBrains/compose-multiplatform-core/commit/156260c741c8e767f0b4e1ffbc9f2ad2423e32db#diff-109e8bcef65965d4803010fc4541542a620aed8e7fe596bd013ce4935c7cd058R112). This was needed to work around a K/JS bug that no longer appears to exist.

Fixes https://youtrack.jetbrains.com/issue/CMP-5747/Upstreaming.-feature.-foundation-text.-TextFieldScrollerPosition

## Testing
Ran the JS demo; textfield seems to work.
