### PR TITLE
Fix a memory leak

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -382,6 +382,7 @@ internal class ComposeHostingViewController(
     }
 
     private fun dispose() {
+        metalView.dispose()
         lifecycleOwner.dispose()
         mediator?.dispose()
         rootView.dispose()


### PR DESCRIPTION
Add missing `dispose` call.

Fixes https://youtrack.jetbrains.com/issue/CMP-6933/There-seems-to-be-a-memory-leak-in-the-iOS-system

## Testing
https://youtrack.jetbrains.com/issue/CMP-6933/There-seems-to-be-a-memory-leak-in-the-iOS-system no longer leaks

## Release Notes
### Fixes - iOS 
- Memory leak due to Compose view controller never GCed.
