### PR TITLE
Fix Pager snapping on iOS

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/snapping/PagerSnapLayoutInfoProvider.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/snapping/PagerSnapLayoutInfoProvider.kt
@@ -205,7 +205,7 @@ private fun PagerState.isLtrDragging() = dragGestureDelta() > 0
 private fun PagerState.isScrollingForward(velocity: Float): Boolean {
     val reverseScrollDirection = layoutInfo.reverseLayout
     val isForward = if (isNotGestureAction()) {
-        velocity > 0
+        velocity < 0
     } else {
         isLtrDragging()
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/snapping/PagerSnapLayoutInfoProvider.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/snapping/PagerSnapLayoutInfoProvider.kt
@@ -205,10 +205,10 @@ private fun PagerState.isLtrDragging() = dragGestureDelta() > 0
 private fun PagerState.isScrollingForward(velocity: Float): Boolean {
     val reverseScrollDirection = layoutInfo.reverseLayout
     val isForward = if (isNotGestureAction()) {
-        velocity
+        velocity > 0
     } else {
-        dragGestureDelta()
-    } < 0
+        isLtrDragging()
+    }
     return (isForward && reverseScrollDirection ||
         !isForward && !reverseScrollDirection)
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6929/HorizontalPager-not-working-properly-on-ios.-Only-CMP-1.7.0

## Release Notes
### Fixes - iOS
- Fix HorizontalPager snapping on iOS