### PR TITLE
Add header file to cinterop inputs

### DIFF
--- a/compose/ui/ui-uikit/build.gradle
+++ b/compose/ui/ui-uikit/build.gradle
@@ -115,8 +115,8 @@ private def configure(target, isDevice, architecture, testTarget) {
     }
 
     target.compilations.main {
-        def taskName = "${compileTaskProvider.name}ObjCLib"
-        project.tasks.register(taskName, Exec) {
+        def libTaskName = "${compileTaskProvider.name}ObjCLib"
+        project.tasks.register(libTaskName, Exec) {
             inputs.dir(frameworkSourcesDir)
                     .withPropertyName("${frameworkName}-${sdkName}")
                     .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -140,13 +140,16 @@ private def configure(target, isDevice, architecture, testTarget) {
             )
         }
 
-        tasks[compileTaskProvider.name].dependsOn(taskName)
+        tasks[compileTaskProvider.name].dependsOn(libTaskName)
 
         cinterops {
             utils {
+                def cinteropTask = tasks[interopProcessingTaskName]
+
                 headersPath.eachFileRecurse {
                     if (it.name.endsWith('.h')) {
                         extraOpts("-header", it.name)
+                        cinteropTask.inputs.file(it)
                     }
                 }
                 compilerOpts("-I${headersPath}")


### PR DESCRIPTION
Fixes issue where cinterop task does not update headers when Obj-C lib files are changed