### PR TITLE
Reimplement textfield cursor drawing to be sharp without using `isAntiAlias=false`

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldCursor.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldCursor.kt
@@ -25,9 +25,7 @@ import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.platform.LocalCursorBlinkEnabled
 import androidx.compose.ui.platform.LocalWindowInfo
@@ -35,6 +33,7 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Dp
 import kotlin.math.floor
+import kotlin.math.round
 
 internal fun Modifier.cursor(
     state: LegacyTextFieldState,
@@ -77,19 +76,21 @@ internal fun Modifier.cursor(
                                 // smaller than the maximum value.
                                 .coerceAtMost(size.width - cursorWidth / 2)
                                 .coerceAtLeast(cursorWidth / 2)
-
-                        // TODO(demin): check how it looks on android before upstream
-                        drawIntoCanvas {
-                            it.drawLine(
-                                Offset(cursorX, cursorRect.top),
-                                Offset(cursorX, cursorRect.bottom),
-                                Paint().apply {
-                                    cursorBrush.applyTo(size, this, cursorAlphaValue)
-                                    strokeWidth = cursorWidth
-                                    isAntiAlias = false
+                                .let {
+                                    // When cursor width is odd, draw it in the middle of a pixel,
+                                    // to avoid blurring due to antialiasing.
+                                    if (cursorWidth.toInt() % 2 == 1) {
+                                        floor(it) + 0.5f  // round to nearest n+0.5
+                                    } else round(it)
                                 }
-                            )
-                        }
+
+                        drawLine(
+                            brush = cursorBrush,
+                            start = Offset(cursorX, cursorRect.top),
+                            end = Offset(cursorX, cursorRect.bottom),
+                            alpha = cursorAlphaValue,
+                            strokeWidth = cursorWidth
+                        )
                     }
                 }
             } else {


### PR DESCRIPTION
Following feedback from Google, we're reimplementing it without allocating a `Paint` (which is needed to use `isAntialias=false`).

Draw the cursor sharp by drawing it at the correct pixel coordinates.