### PR TITLE
Revert RootMeasurePolicy change #265 and align RootMeasurePolicy with Jetpack Compose

### DIFF
--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -81,7 +81,7 @@ class TestBasicsTest {
     @Test
     fun inputEventAdvancesClock() = runComposeUiTest {
         setContent {
-            Box(Modifier.testTag("box"))
+            Box(Modifier.testTag("box").size(100.dp))
         }
 
         val clockBefore = mainClock.currentTime

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/RootMeasurePolicy.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/RootMeasurePolicy.kt
@@ -18,6 +18,8 @@ package androidx.compose.ui.layout
 
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastMap
 
@@ -33,18 +35,28 @@ internal object RootMeasurePolicy :
             }
             1 -> {
                 val placeable = measurables[0].measure(constraints)
-                layout(constraints.maxWidth, constraints.maxHeight) {
+                layout(
+                    constraints.constrainWidth(placeable.width),
+                    constraints.constrainHeight(placeable.height)
+                ) {
                     placeable.placeRelativeWithLayer(0, 0)
                 }
             }
             else -> {
-                val placeables = measurables.fastMap {
-                    it.measure(constraints)
-                }
-                layout(constraints.maxWidth, constraints.maxHeight) {
-                    placeables.fastForEach { placeable ->
-                        placeable.placeRelativeWithLayer(0, 0)
+                var maxWidth = 0
+                var maxHeight = 0
+                val placeables =
+                    measurables.fastMap {
+                        it.measure(constraints).apply {
+                            maxWidth = maxOf(width, maxWidth)
+                            maxHeight = maxOf(height, maxHeight)
+                        }
                     }
+                layout(
+                    constraints.constrainWidth(maxWidth),
+                    constraints.constrainHeight(maxHeight)
+                ) {
+                    placeables.fastForEach { placeable -> placeable.placeRelativeWithLayer(0, 0) }
                 }
             }
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
@@ -55,8 +55,13 @@ internal fun WindowContentLayout(
 
             val contentPlaceables = buildList(measurables.size) {
                 measurables.fastForEach {
-                    if (it != resizerMeasurable)
-                        add(it.measure(constraints))
+                    if (it != resizerMeasurable) {
+                        val newConstraints = constraints.copy(
+                            minWidth = constraints.maxWidth,
+                            minHeight = constraints.maxHeight
+                        )
+                        add(it.measure(newConstraints))
+                    }
                 }
             }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
@@ -55,13 +55,8 @@ internal fun WindowContentLayout(
 
             val contentPlaceables = buildList(measurables.size) {
                 measurables.fastForEach {
-                    if (it != resizerMeasurable) {
-                        val newConstraints = constraints.copy(
-                            minWidth = constraints.maxWidth,
-                            minHeight = constraints.maxHeight
-                        )
-                        add(it.measure(newConstraints))
-                    }
+                    if (it != resizerMeasurable)
+                        add(it.measure(constraints))
                 }
             }
 


### PR DESCRIPTION
This PR is about upstreaming (reverting the change we thought that need to be upstreamed).

**TL;DR;**
- Revert old [change in RootMeasurePolicy](https://github.com/JetBrains/compose-multiplatform-core/pull/265). Take the RootMeasurePolicy as it is in Jetpack Compose androidx-main
- To be discussed: Make the first (root) node take the entire window size (I did that to fix the behaviour to make it like it was in #265, but I believe we don't need to do that. More about it below).  **UPD**:  _the change caused some tests failures. I reverted it. But the discussion can continue. I left some comments below_

**Description:**
2 years ago we [changed](https://github.com/JetBrains/compose-multiplatform-core/pull/265) the RootMeasurePolicy to make the first node take the entire window size (to match Android behaviour).

Since then, our source code evolved and that change stopped behaving as it was intended to (noticed during upstreaming preparation).  But it's okay, IMO. 

Now, I believe we don't need the first (root) node to take the entire window size. Why:
- It makes it ignore the sizes set by a developer using `.size(width, height)` modifier
- If there is more than 1 node, each of them would be maxWidth, maxHeight. 

_Note_: the above 2 points are true on Android. But I don't understand [why](https://kotlinlang.slack.com/archives/G010KHY484C/p1730374648186239?thread_ts=1729697565.345709&cid=G010KHY484C)

I see only 1 reason to have the first (root) node to take the entire window size:
- As shown in https://github.com/JetBrains/compose-multiplatform-core/pull/265, it looks like the node doesn't follow LayoutDirection (RTL, LTR). 

But it was my mistake back then (not correct assumption about LocalLayoutDirection composition local). The node is layed out according its parent LayoutDirection. If we add `CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl)`, all the node's children would still be layed out in Ltr. But the 2nd-level children would be layed out according to their parent LayoutDirection (Rtl).

 