### PR TITLE
Fixed double recomposition on the first screen in iOS

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediatorView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediatorView.uikit.kt
@@ -52,8 +52,8 @@ internal class ComposeSceneMediatorView(
     override fun layoutSubviews() {
         super.layoutSubviews()
 
-        runOnAppearedIfEligible()
         onLayoutSubviews()
+        runOnAppearedIfEligible()
     }
 
     override fun didMoveToWindow() {


### PR DESCRIPTION

Fixes https://youtrack.jetbrains.com/issue/CMP-6829/First-screen-is-recomposed-twice-on-iOS-Compose-1.7.0-rc01

## Testing
This should be tested by QA. 
`println()` inside the first composable function in the application

## Release Notes
### Fixes - iOS
- Fixed double recomposition on the first screen

