### PR TITLE
Remove no longer needed check for KeyEvent.type != KeyDown in TextFieldKeyEventHandler

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.kt
@@ -153,10 +153,6 @@ internal abstract class TextFieldKeyEventHandler {
             }
         }
 
-        if (event.type != KeyEventType.KeyDown) {
-            return false
-        }
-
         val command = keyMapping.map(event)
         if (command == null || (command.editsText && !editable)) {
             return false


### PR DESCRIPTION
This check was made unnecessary in changes from upstream.

Fixes https://youtrack.jetbrains.com/issue/CMP-5757