### PR TITLE
Draw the cursor of the new TextField without blurring.

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -80,8 +80,10 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import kotlin.math.floor
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.math.round
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -299,7 +301,7 @@ internal class TextFieldSelectionState(
         if (!value.selection.collapsed) return Rect.Zero
         val cursorRect = layoutResult.getCursorRect(value.selection.start)
 
-        val cursorWidth = with(density) { DefaultCursorThickness.toPx() }
+        val cursorWidth = with(density) { floor(DefaultCursorThickness.toPx()).coerceAtLeast(1f) }
         // left and right values in cursorRect should be the same but in any case use the
         // logically correct anchor.
         val cursorCenterX =
@@ -317,6 +319,13 @@ internal class TextFieldSelectionState(
                 // than the maximum value.
                 .coerceAtMost(layoutResult.size.width - cursorWidth / 2)
                 .coerceAtLeast(cursorWidth / 2)
+                .let {
+                    // When cursor width is odd, draw it in the middle of a pixel,
+                    // to avoid blurring due to antialiasing.
+                    if (cursorWidth.toInt() % 2 == 1) {
+                        floor(it) + 0.5f  // round to nearest n+0.5
+                    } else round(it)
+                }
 
         return Rect(
             left = coercedCursorCenterX - cursorWidth / 2,


### PR DESCRIPTION
Similarly to https://github.com/JetBrains/compose-multiplatform-core/pull/1664 draw the cursor for the new `TextField` without blurring too.

## Testing
Tested manually with
```
fun main() = singleWindowApplication {
    val defaultDensity = LocalDensity.current.density
    var density by remember { mutableStateOf(defaultDensity) }
    CompositionLocalProvider(LocalDensity provides Density(density)) {
        Column {
            val textState = rememberTextFieldState("")
            TextField(
                state = textState,
            )

            Spacer(Modifier.height(32.dp))

            Text("Density")
            Row {
                var densityText by remember { mutableStateOf(density.toString()) }
                TextField(
                    value = densityText,
                    onValueChange = { densityText = it },
                )
                Button(onClick = {
                    density = densityText.toFloatOrNull() ?: density
                }) {
                    Text("Set density")
                }
            }
        }
    }
}
```
