### PR TITLE
Fix accessibility for dialogs

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -19,13 +19,10 @@ package androidx.compose.ui.window
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -35,10 +32,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.layout.EmptyLayout
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
@@ -199,11 +193,6 @@ private fun DialogLayout(
 ) {
     val currentContent by rememberUpdatedState(content)
 
-    // HACK: The solution is taken from the popup implementation.
-    // Make the dialogue content reload a second time so that it can be indexed properly for accessibility.
-    var layoutParentBoundsInWindow: Rect? by remember { mutableStateOf(null) }
-    EmptyLayout(Modifier.onGloballyPositioned { layoutParentBoundsInWindow = it.boundsInWindow() })
-
     val layer = rememberComposeSceneLayer(
         focusable = true
     )
@@ -212,14 +201,12 @@ private fun DialogLayout(
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     layer.Content {
         val platformInsets = properties.platformInsets
-        val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@Content
         val containerSize = LocalWindowInfo.current.containerSize
         val measurePolicy = rememberDialogMeasurePolicy(
             layer = layer,
             properties = properties,
             containerSize = containerSize,
-            platformInsets = platformInsets,
-            parentBoundsInWindow = parentBoundsInWindow
+            platformInsets = platformInsets
         )
         PlatformInsetsConfig.excludeInsets(
             safeInsets = properties.usePlatformInsets,
@@ -254,9 +241,8 @@ private fun rememberDialogMeasurePolicy(
     layer: ComposeSceneLayer,
     properties: DialogProperties,
     containerSize: IntSize,
-    platformInsets: PlatformInsets,
-    parentBoundsInWindow: Rect
-) = remember(layer, properties, containerSize, platformInsets, parentBoundsInWindow) {
+    platformInsets: PlatformInsets
+) = remember(layer, properties, containerSize, platformInsets) {
     RootMeasurePolicy(
         platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -195,7 +195,6 @@ private fun DialogLayout(
     content: @Composable () -> Unit
 ) {
     val currentContent by rememberUpdatedState(content)
-    val platformInsets = properties.platformInsets
 
     // HACK: The solution is taken from the popup implementation.
     // Make the dialogue content reload a second time so that it can be indexed properly for accessibility.
@@ -209,6 +208,7 @@ private fun DialogLayout(
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     layer.Content {
+        val platformInsets = properties.platformInsets
         val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@Content
         val containerSize = LocalWindowInfo.current.containerSize
         val measurePolicy = rememberDialogMeasurePolicy(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
@@ -36,6 +37,8 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.EmptyLayout
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformInsetsConfig
@@ -198,8 +201,8 @@ private fun DialogLayout(
 
     // HACK: The solution is taken from the popup implementation.
     // Make the dialogue content reload a second time so that it can be indexed properly for accessibility.
-    var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
-    EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
+    var layoutParentBoundsInWindow: Rect? by remember { mutableStateOf(null) }
+    EmptyLayout(Modifier.onGloballyPositioned { layoutParentBoundsInWindow = it.boundsInWindow() })
 
     val layer = rememberComposeSceneLayer(
         focusable = true
@@ -252,7 +255,7 @@ private fun rememberDialogMeasurePolicy(
     properties: DialogProperties,
     containerSize: IntSize,
     platformInsets: PlatformInsets,
-    parentBoundsInWindow: IntRect
+    parentBoundsInWindow: Rect
 ) = remember(layer, properties, containerSize, platformInsets, parentBoundsInWindow) {
     RootMeasurePolicy(
         platformInsets = platformInsets,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1091,7 +1091,8 @@ internal class AccessibilityMediator(
             while (true) {
                 invalidationChannel.receive()
 
-                // Await all changes in accessibility tree and consume all invalidations
+                // Wait until all changes in the accessibility tree have been completed
+                // and consume all invalidations
                 delay(1)
                 while (invalidationChannel.tryReceive().isSuccess) {
                     // Workaround for the channel buffering two invalidations despite the capacity of 1

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1091,8 +1091,9 @@ internal class AccessibilityMediator(
             while (true) {
                 invalidationChannel.receive()
 
+                // Await and consume all invalidations
+                delay(timeMillis = 1)
                 while (invalidationChannel.tryReceive().isSuccess) {
-                    // Do nothing, just consume the channel
                     // Workaround for the channel buffering two invalidations despite the capacity of 1
                 }
 
@@ -1176,8 +1177,10 @@ internal class AccessibilityMediator(
     fun onLayoutChange(nodeId: Int) {
         debugLogger?.log("onLayoutChange (nodeId=$nodeId)")
 
-        // TODO: Sync invalidated nodes subtree
+        // TODO: Properly implement layout invalidation, taking into account that semantics
+        //  can also change after the `onLayoutChange` event.
         if (accessibilityElementsMap[nodeId] == null) {
+            // Forcing tree recalculation when a node with unknown nodeId occurred.
             invalidationKind = SemanticsTreeInvalidationKind.COMPLETE
         } else {
             invalidatedBoundsNodeIds.add(nodeId)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1093,7 +1093,7 @@ internal class AccessibilityMediator(
 
                 // Wait until all changes in the accessibility tree have been completed
                 // and consume all invalidations
-                delay(1)
+                delay(timeMillis = 1)
                 while (invalidationChannel.tryReceive().isSuccess) {
                     // Workaround for the channel buffering two invalidations despite the capacity of 1
                 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1091,7 +1091,7 @@ internal class AccessibilityMediator(
             while (true) {
                 invalidationChannel.receive()
 
-                // Await and consume all invalidations
+                // Await all changes in accessibility tree and consume all invalidations
                 delay(1)
                 while (invalidationChannel.tryReceive().isSuccess) {
                     // Workaround for the channel buffering two invalidations despite the capacity of 1

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1091,8 +1091,9 @@ internal class AccessibilityMediator(
             while (true) {
                 invalidationChannel.receive()
 
+                // Await and consume all invalidations
+                delay(1)
                 while (invalidationChannel.tryReceive().isSuccess) {
-                    // Do nothing, just consume the channel
                     // Workaround for the channel buffering two invalidations despite the capacity of 1
                 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1091,9 +1091,8 @@ internal class AccessibilityMediator(
             while (true) {
                 invalidationChannel.receive()
 
-                // Await and consume all invalidations
-                delay(timeMillis = 1)
                 while (invalidationChannel.tryReceive().isSuccess) {
+                    // Do nothing, just consume the channel
                     // Workaround for the channel buffering two invalidations despite the capacity of 1
                 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1091,10 +1091,8 @@ internal class AccessibilityMediator(
             while (true) {
                 invalidationChannel.receive()
 
-                // Wait until all changes in the accessibility tree have been completed
-                // and consume all invalidations
-                delay(timeMillis = 1)
                 while (invalidationChannel.tryReceive().isSuccess) {
+                    // Do nothing, just consume the channel
                     // Workaround for the channel buffering two invalidations despite the capacity of 1
                 }
 
@@ -1178,9 +1176,13 @@ internal class AccessibilityMediator(
     fun onLayoutChange(nodeId: Int) {
         debugLogger?.log("onLayoutChange (nodeId=$nodeId)")
 
-        invalidatedBoundsNodeIds.add(nodeId)
+        // TODO: Sync invalidated nodes subtree
+        if (accessibilityElementsMap[nodeId] == null) {
+            invalidationKind = SemanticsTreeInvalidationKind.COMPLETE
+        } else {
+            invalidatedBoundsNodeIds.add(nodeId)
+        }
 
-        // unprocessedInvalidationKind will be set to BOUNDS in sync(), it's a strict subset of COMPLETE
         invalidationChannel.trySend(Unit)
     }
 


### PR DESCRIPTION
Add delay to wait until all elements in semantic tree are finalised

Fixes https://youtrack.jetbrains.com/issue/CMP-6938/Accessibility-does-not-work-for-dialogs-with-platformLayers-enabled

## Release Notes
### Fixes - iOS
- Fix Accessibility Items availability inside dialogs