### PR TITLE
Revert a WA - Fix ArrayIndexOutOfBoundsException on iOS and Wasm

### DIFF
--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/AnimationSpec.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/AnimationSpec.kt
@@ -658,9 +658,7 @@ public class KeyframesSpec<T>(public val config: KeyframesSpecConfig<T>) :
             timestamps.add(config.durationMillis)
         }
 
-        //the reason is https://youtrack.jetbrains.com/issue/KT-70005
-        //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
-        if (timestamps.isNotEmpty()) timestamps.sort()
+        timestamps.sort()
 
         return VectorizedKeyframesSpec(
             timestamps = timestamps,
@@ -775,9 +773,7 @@ public class KeyframesWithSplineSpec<T>(
             timestamps.add(config.durationMillis)
         }
 
-        //the reason is https://youtrack.jetbrains.com/issue/KT-70005
-        //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
-        if (timestamps.isNotEmpty()) timestamps.sort()
+        timestamps.sort()
         return VectorizedMonoSplineKeyframesSpec(
             timestamps = timestamps,
             keyframes = timeToVectorMap,

--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/VectorizedAnimationSpec.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/VectorizedAnimationSpec.kt
@@ -251,9 +251,7 @@ internal constructor(
                     times.add(durationMillis)
                 }
 
-                //the reason is https://youtrack.jetbrains.com/issue/KT-70005
-                //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
-                if (times.isNotEmpty()) times.sort()
+                times.sort()
                 return@run times
             },
         keyframes =

--- a/compose/material3/adaptive/adaptive-layout/src/commonMain/kotlin/androidx/compose/material3/adaptive/layout/PaneExpansionState.kt
+++ b/compose/material3/adaptive/adaptive-layout/src/commonMain/kotlin/androidx/compose/material3/adaptive/layout/PaneExpansionState.kt
@@ -588,9 +588,7 @@ private fun List<PaneExpansionAnchor>.toPositions(
     forEachIndexed { index, anchor ->
         anchors.add(IndexedAnchorPosition(anchor.positionIn(maxExpansionWidth, density), index))
     }
-    //the reason is https://youtrack.jetbrains.com/issue/KT-70005
-    //it was fixed in androidx.collection:collection:1.5.0-alpha01, but we redirect on 1.4.0 yet
-    if (!anchors.isEmpty()) anchors.sort()
+    anchors.sort()
     return anchors
 }
 


### PR DESCRIPTION
The WA was introduced in https://github.com/JetBrains/compose-multiplatform-core/pull/1548

Since we redirect to collections of 1.5.0-alpha version, we don't need the workaround anymore
