### PR TITLE
Pass first `supportedAction` as the action to exportAsDrag 

### DIFF
--- a/compose/mpp/demo/src/desktopMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.desktop.kt
+++ b/compose/mpp/demo/src/desktopMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.desktop.kt
@@ -17,12 +17,10 @@
 package androidx.compose.mpp.demo.components
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.draganddrop.dragAndDropSource
 import androidx.compose.foundation.draganddrop.dragAndDropTarget
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -56,7 +54,7 @@ import java.awt.datatransfer.StringSelection
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 actual fun DragAndDropExample() {
     val exportedText = "Hello, DnD!"

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -54,7 +54,13 @@ actual class DragAndDropTransferData(
      */
     @property:ExperimentalComposeUiApi
     val onTransferCompleted: ((userAction: DragAndDropTransferAction?) -> Unit)? = null,
-)
+) {
+
+    init {
+        require(supportedActions.firstOrNull() != null) { "supportedActions may not be empty" }
+    }
+
+}
 
 /**
  * Represents the actual object transferred during a drag-and-drop.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -299,8 +299,9 @@ internal class ComposeTransferHandler(private val rootContainer: JComponent) : T
                 0,
                 false
             ),
-            // This seems to be ignored, and the initial action is MOVE regardless
-            MOVE
+            // This seems to be ignored, other than verifying that it's one of the flags returned in
+            // `getSourceActions`
+            transferData.supportedActions.first().awtAction
         )
     }
 


### PR DESCRIPTION
We currently have the initial transfer action hardcoded to `Move`, but this doesn't work if `Move` is not one of the supported actions. This PR passes the first supported action instead.

Fixes https://youtrack.jetbrains.com/issue/CMP-6881

## Testing
Tested manually.

## Release Notes
### Fixes - Desktop
- Fix drag-and-drop when the list of supported actions doesn't include `Move`.