### PR TITLE
Pass `externalAccessibleFactory` to SkiaSwingLayer.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.scene.ComposeSceneMediator
 import java.awt.Dimension
 import java.awt.Graphics
 import javax.accessibility.Accessible
-import javax.accessibility.AccessibleContext
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.jetbrains.skiko.SkikoRenderDelegate
@@ -46,7 +45,12 @@ internal class SwingSkiaLayerComponent(
     override val contentComponent: SkiaSwingLayer =
         object : SkiaSwingLayer(
             renderDelegate = renderDelegate,
-            analytics = skiaLayerAnalytics
+            analytics = skiaLayerAnalytics,
+            externalAccessibleFactory = {
+                // It depends on initialization order, so explicitly
+                // apply `checkNotNull` for "non-null" field.
+                checkNotNull(mediator.accessible)
+            }
         ) {
             override fun paint(g: Graphics) {
                 mediator.onChangeDensity()
@@ -64,10 +68,6 @@ internal class SwingSkiaLayerComponent(
                 super.getPreferredSize()
             } else {
                 mediator.preferredSize
-            }
-
-            override fun getAccessibleContext(): AccessibleContext? {
-                return mediator.accessible.accessibleContext
             }
         }
 


### PR DESCRIPTION
Pass `ComposeSceneAccessible` correctly to `SkiaSwingLayer` (like we do to `SkiaLayer`) so that `NativeAccessibleFocusHelper` can do its trick.

Fixes https://youtrack.jetbrains.com/issue/CMP-7059/Accessible-focus-traversal-doesnt-work-with-compose.swing.render.on.graphicstrue

## Testing
Tested manually on 
```
import androidx.compose.material.*
import androidx.compose.ui.awt.ComposePanel
import java.awt.GridLayout
import javax.swing.JButton
import javax.swing.JFrame
import javax.swing.JPanel
import javax.swing.SwingUtilities

fun main() {
    System.setProperty("compose.swing.render.on.graphics", "true")

    SwingUtilities.invokeLater {
        val frame = JFrame()
        frame.setSize(800, 200)
        frame.defaultCloseOperation = JFrame.EXIT_ON_CLOSE

        val panel = JPanel(GridLayout(1, 4))
        panel.add(JButton("Swing Button"))
        panel.add(ComposePanel().apply {
            setContent {
                Button(onClick = {}) { Text("Compose Button")}
            }
        })
        panel.add(JButton("Swing Button"))
        panel.add(ComposePanel().apply {
            setContent {
                Button(onClick = {}) { Text("Compose Button")}
            }
        })

        frame.contentPane.add(panel)

        frame.isVisible = true
    }
}
```

## Release Notes
### Fixes - Desktop
- Fix accessibility focus when using `compose.swing.render.on.graphics=true`