### PR TITLE
Batch frequent Marked Text edit commands

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/IOSSkikoInput.uikit.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.DpOffset
 
 internal interface IOSSkikoInput {
@@ -26,6 +25,16 @@ internal interface IOSSkikoInput {
     fun updateFloatingCursor(offset: DpOffset)
 
     fun endFloatingCursor()
+
+    /**
+     * Delays all edit commands until [endEditBatch] is being called.
+     */
+    fun beginEditBatch()
+
+    /**
+     * Performs all editing commands, starting from the [beginEditBatch] call.
+     */
+    fun endEditBatch()
 
     /**
      * A Boolean value that indicates whether the text-entry object has any text.
@@ -116,23 +125,4 @@ internal interface IOSSkikoInput {
      * Returned value must be in range between 0 and length of text (inclusive).
      */
     fun positionFromPosition(position: Long, offset: Long): Long
-
-    object Empty : IOSSkikoInput {
-        override fun beginFloatingCursor(offset: DpOffset) = Unit
-        override fun updateFloatingCursor(offset: DpOffset)  = Unit
-        override fun endFloatingCursor()  = Unit
-        override fun hasText(): Boolean = false
-        override fun insertText(text: String) = Unit
-        override fun deleteBackward() = Unit
-        override fun endOfDocument(): Long = 0L
-        override fun getSelectedTextRange(): IntRange? = null
-        override fun setSelectedTextRange(range: IntRange?) = Unit
-        override fun selectAll() = Unit
-        override fun textInRange(range: IntRange): String = ""
-        override fun replaceRange(range: IntRange, text: String) = Unit
-        override fun setMarkedText(markedText: String?, selectedRange: IntRange) = Unit
-        override fun markedTextRange(): IntRange? = null
-        override fun unmarkText() = Unit
-        override fun positionFromPosition(position: Long, offset: Long): Long = 0
-    }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -162,6 +162,7 @@ internal class UIKitTextInputService(
     }
 
     override fun stopInput() {
+        flushEditCommandsIfNeeded()
         currentInput = null
         _tempCurrentInputSession = null
         currentImeOptions = null
@@ -277,8 +278,8 @@ internal class UIKitTextInputService(
         flushEditCommandsIfNeeded()
     }
 
-    private fun flushEditCommandsIfNeeded() {
-        if (editBatchDepth == 0 && editCommandsBatch.isNotEmpty()) {
+    fun flushEditCommandsIfNeeded(force: Boolean = false) {
+        if ((force || editBatchDepth == 0) && editCommandsBatch.isNotEmpty()) {
             val commandList = editCommandsBatch.toList()
             editCommandsBatch.clear()
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -162,7 +162,7 @@ internal class UIKitTextInputService(
     }
 
     override fun stopInput() {
-        flushEditCommandsIfNeeded()
+        flushEditCommandsIfNeeded(force = true)
         currentInput = null
         _tempCurrentInputSession = null
         currentImeOptions = null

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -466,6 +466,7 @@ internal class ComposeSceneMediator(
     }
 
     fun render(canvas: Canvas, nanoTime: Long) {
+        textInputService.flushEditCommandsIfNeeded(force = true)
         scene.render(canvas, nanoTime)
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -240,7 +240,12 @@ internal class IntermediateTextInputUIView(
 
         // Due to iOS specifics, [setMarkedText] can be called several times in a row. Batching
         // helps to avoid text input problems, when Composables use parameters set during
-        // recomposition instead of the current ones.
+        // recomposition instead of the current ones. Example:
+        // 1. State "1" -> TextField(text = "1")
+        // 2. setMarkedText "12" -> Not equal to TextField(text = "1") -> State "12"
+        // 3. setMarkedText "1" -> Equal to TextField(text = "1") -> State remains "12"
+        // scene.render() - Recomposes TextField
+        // 4. State "12" -> TextField(text = "12") - Invalid state. Should be TextField(text = "1")
         input?.withBatch {
             input?.setMarkedText(markedText, relativeTextRange)
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -239,7 +239,8 @@ internal class IntermediateTextInputUIView(
         val relativeTextRange = locationRelative until locationRelative + lengthRelative
 
         // Due to iOS specifics, [setMarkedText] can be called several times in a row. Batching
-        // helps to avoid text input problems caused by too frequent dispaltching of input commands.
+        // helps to avoid text input problems, when Composables use parameters set during
+        // recomposition instead of the current ones.
         input?.withBatch {
             input?.setMarkedText(markedText, relativeTextRange)
         }


### PR DESCRIPTION
Add code that joins several frequent text edit commands into a single commands batch.

Fixes https://youtrack.jetbrains.com/issue/CMP-6786/when-use-Chinese-keyboard-inputs-get-interrupted.

## Release Notes
### Fixes - iOS
- Fixes an interruption while typing characters on a Chinese keyboard