### PR TITLE
Fix "Context menu on desktop shows incorrect items after the second showing"

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -55,6 +55,7 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
 import java.awt.Component
 import java.awt.MouseInfo
@@ -107,7 +108,7 @@ class DefaultContextMenuRepresentation(
             var inputModeManager: InputModeManager? by mutableStateOf(null)
 
             Popup(
-                focusable = true,
+                properties = PopupProperties(focusable = true),
                 onDismissRequest = { state.status = ContextMenuState.Status.Closed },
                 popupPositionProvider = rememberPopupPositionProviderAtPosition(
                     positionPx = status.rect.center

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -224,12 +224,13 @@ class ContextMenuData(
     val next: ContextMenuData?
 ) {
 
-    internal val allItems: List<ContextMenuItem> get() = allItemsSeq.toList()
-
-    private val allItemsSeq: Sequence<ContextMenuItem>
-        get() = sequence {
-            yieldAll(items())
-            next?.let { yieldAll(it.allItemsSeq) }
+    internal val allItems: List<ContextMenuItem>
+        get() = buildList {
+            var current: ContextMenuData? = this@ContextMenuData
+            while (current != null) {
+                addAll(current.items())
+                current = current.next
+            }
         }
 
     override fun equals(other: Any?): Boolean {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/ContextMenuProvider.desktop.kt
@@ -224,11 +224,9 @@ class ContextMenuData(
     val next: ContextMenuData?
 ) {
 
-    internal val allItems: List<ContextMenuItem> by lazy {
-        allItemsSeq.toList()
-    }
+    internal val allItems: List<ContextMenuItem> get() = allItemsSeq.toList()
 
-    internal val allItemsSeq: Sequence<ContextMenuItem>
+    private val allItemsSeq: Sequence<ContextMenuItem>
         get() = sequence {
             yieldAll(items())
             next?.let { yieldAll(it.allItemsSeq) }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/DesktopPlatform.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/DesktopPlatform.desktop.kt
@@ -42,11 +42,14 @@ internal enum class DesktopPlatform {
          */
         val Current get() = overriddenCurrent ?: _current
 
+        /**
+         * Override [DesktopPlatform.Current] during [body] execution
+         */
         @VisibleForTesting
-        fun withOverriddenCurrent(newCurrent: DesktopPlatform, body: () -> Unit) {
+        inline fun <T> withOverriddenCurrent(newCurrent: DesktopPlatform, body: () -> T): T {
             try {
                 overriddenCurrent = newCurrent
-                body()
+                return body()
             } finally {
                 overriddenCurrent = null
             }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/DesktopPlatform.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/DesktopPlatform.desktop.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.foundation
 
+import org.jetbrains.annotations.VisibleForTesting
+
 internal enum class DesktopPlatform {
     Linux,
     Windows,
@@ -23,16 +25,30 @@ internal enum class DesktopPlatform {
     Unknown;
 
     companion object {
-        /**
-         * Identify OS on which the application is currently running.
-         */
-        val Current: DesktopPlatform by lazy {
+        private var overriddenCurrent: DesktopPlatform? = null
+
+        private val _current: DesktopPlatform by lazy {
             val name = System.getProperty("os.name")
             when {
                 name?.startsWith("Linux") == true -> Linux
                 name?.startsWith("Win") == true -> Windows
                 name == "Mac OS X" -> MacOS
                 else -> Unknown
+            }
+        }
+
+        /**
+         * Identify OS on which the application is currently running.
+         */
+        val Current get() = overriddenCurrent ?: _current
+
+        @VisibleForTesting
+        fun withOverriddenCurrent(newCurrent: DesktopPlatform, body: () -> Unit) {
+            try {
+                overriddenCurrent = newCurrent
+                body()
+            } finally {
+                overriddenCurrent = null
             }
         }
     }

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -40,7 +40,7 @@ import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.TextRange
-import kotlin.coroutines.CoroutineContext
+import kotlin.test.assertEquals
 import org.junit.Test
 
 
@@ -83,6 +83,8 @@ class ContextMenuTest {
                 }
             )
         }
+
+        assertEquals(1, childrenCount)
     }
 
     // https://youtrack.jetbrains.com/issue/CMP-7083/Context-menu-on-desktop-shows-incorrect-items-after-the-second-showing
@@ -129,13 +131,6 @@ class ContextMenuTest {
         onNodeWithText(localization.cut).assertIsNotPlaced()
         onNodeWithText(localization.paste).assertIsNotPlaced()
         onNodeWithText(localization.selectAll).assertIsNotPlaced()
-
-        onNodeWithTag("textfield").performTextInputSelection(TextRange(0, "Tex".length))
-        onNodeWithTag("textfield").performMouseInput { rightClick() }
-        onNodeWithText(localization.copy).isDisplayed()
-        onNodeWithText(localization.cut).isDisplayed()
-        onNodeWithText(localization.paste).isDisplayed()
-        onNodeWithText(localization.selectAll).isDisplayed()
     }
 
     private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -16,27 +16,43 @@
 
 package androidx.compose.foundation
 
+import androidx.compose.foundation.copyPasteAndroidTests.lazy.list.assertIsNotPlaced
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.test.junit4.createComposeRule
-import kotlin.test.assertEquals
-import org.junit.Rule
+import androidx.compose.ui.platform.LocalLocalization
+import androidx.compose.ui.platform.PlatformLocalization
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performTextInputSelection
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.rightClick
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.TextRange
+import kotlin.coroutines.CoroutineContext
 import org.junit.Test
 
 
+@OptIn(ExperimentalTestApi::class)
 class ContextMenuTest {
-
-    @get:Rule
-    val rule = createComposeRule()
 
     // https://github.com/JetBrains/compose-multiplatform/issues/2729
     @Test
-    fun `contextMenuArea emits one child when open`() {
+    fun `contextMenuArea emits one child when open`() = runContextMenuTest {
         var childrenCount = 0
 
-        rule.setContent {
+        setContent {
             // We can't just look up the number of children via the semantic node tree because
             // the layout added for the context menu (the empty one in PopupLayout) is not a
             // semantic node
@@ -57,18 +73,74 @@ class ContextMenuTest {
                             )
                         },
                         state = state
-                    ){
+                    ) {
                         Box(content = {})
                     }
                 },
                 measurePolicy = { measurables, _ ->
                     childrenCount = measurables.size
-                    layout(0, 0){}
+                    layout(0, 0) {}
                 }
             )
         }
-
-        assertEquals(1, childrenCount)
     }
 
+    // https://youtrack.jetbrains.com/issue/CMP-7083/Context-menu-on-desktop-shows-incorrect-items-after-the-second-showing
+    @Test
+    fun `different items for different selections in textfield`() = runContextMenuTest {
+        val localization = object : PlatformLocalization {
+            override val copy = "copy"
+            override val cut = "cut"
+            override val paste = "paste"
+            override val selectAll = "selectAll"
+        }
+        setContent {
+            CompositionLocalProvider(LocalLocalization provides localization) {
+                BasicTextField("Text", {}, Modifier.testTag("textfield"))
+            }
+        }
+
+        onNodeWithText(localization.copy).assertIsNotPlaced()
+        onNodeWithText(localization.cut).assertIsNotPlaced()
+        onNodeWithText(localization.paste).assertIsNotPlaced()
+        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+
+        onNodeWithTag("textfield").performMouseInput { rightClick() }
+        onNodeWithText(localization.copy).assertIsNotPlaced()
+        onNodeWithText(localization.cut).assertIsNotPlaced()
+        onNodeWithText(localization.paste).isDisplayed()
+        onNodeWithText(localization.selectAll).isDisplayed()
+
+        onNodeWithTag("textfield").performKeyInput { pressKey(Key.Escape) }
+        onNodeWithText(localization.copy).assertIsNotPlaced()
+        onNodeWithText(localization.cut).assertIsNotPlaced()
+        onNodeWithText(localization.paste).assertIsNotPlaced()
+        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+
+        onNodeWithTag("textfield").performTextInputSelection(TextRange(0, "Text".length))
+        onNodeWithTag("textfield").performMouseInput { rightClick() }
+        onNodeWithText(localization.copy).isDisplayed()
+        onNodeWithText(localization.cut).isDisplayed()
+        onNodeWithText(localization.paste).isDisplayed()
+        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+
+        onNodeWithTag("textfield").performKeyInput { pressKey(Key.Escape) }
+        onNodeWithText(localization.copy).assertIsNotPlaced()
+        onNodeWithText(localization.cut).assertIsNotPlaced()
+        onNodeWithText(localization.paste).assertIsNotPlaced()
+        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+
+        onNodeWithTag("textfield").performTextInputSelection(TextRange(0, "Tex".length))
+        onNodeWithTag("textfield").performMouseInput { rightClick() }
+        onNodeWithText(localization.copy).isDisplayed()
+        onNodeWithText(localization.cut).isDisplayed()
+        onNodeWithText(localization.paste).isDisplayed()
+        onNodeWithText(localization.selectAll).isDisplayed()
+    }
+
+    private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
+        DesktopPlatform.withOverriddenCurrent(DesktopPlatform.Unknown) {
+            block()
+        }
+    }
 }

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.platform.ClipboardManager
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalLocalization
 import androidx.compose.ui.platform.PlatformLocalization
 import androidx.compose.ui.platform.testTag
@@ -39,6 +41,7 @@ import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import kotlin.test.assertEquals
 import org.junit.Test
@@ -96,8 +99,15 @@ class ContextMenuTest {
             override val paste = "paste"
             override val selectAll = "selectAll"
         }
+        val clipboardManager = object : ClipboardManager {
+            override fun setText(annotatedString: AnnotatedString) = Unit
+            override fun getText() = AnnotatedString("text")
+        }
         setContent {
-            CompositionLocalProvider(LocalLocalization provides localization) {
+            CompositionLocalProvider(
+                LocalLocalization provides localization,
+                LocalClipboardManager provides clipboardManager,
+            ) {
                 BasicTextField("Text", {}, Modifier.testTag("textfield"))
             }
         }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7083/Context-menu-on-desktop-shows-incorrect-items-after-second-showing

The issue was that after the first click we remembered context items, but they are constructed dynamically depending on the selected text.

## Testing
- the snippet from the issue
- a new unit test

## Release Notes
### Fixes - Desktop
- Fix "Context menu on desktop shows incorrect items after the second showing"