### PR TITLE
Experimental opt-in flag for concurrent rendering commands encoding

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -32,7 +32,7 @@ import platform.UIKit.UIWindow
  * - XCode will open this project automatically
  * - press the Run (Cmd+R) button in the XCode
  */
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalComposeApi::class)
+@OptIn(ExperimentalComposeUiApi::class)
 fun main(vararg args: String) {
     androidx.compose.ui.util.enableTraceOSLog()
 
@@ -40,7 +40,7 @@ fun main(vararg args: String) {
     UIKitMain {
         ComposeUIViewController(
             configure = {
-                useSeparateRenderThreadWhenPossible = true
+                parallelRendering = true
             }
         ) {
             IosDemo(arg)

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/main.uikit.kt
@@ -4,6 +4,7 @@ package androidx.compose.mpp.demo
 import androidx.compose.mpp.demo.bugs.IosBugs
 import androidx.compose.mpp.demo.bugs.StartRecompositionCheck
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeUIViewController
@@ -31,13 +32,17 @@ import platform.UIKit.UIWindow
  * - XCode will open this project automatically
  * - press the Run (Cmd+R) button in the XCode
  */
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalComposeApi::class)
 fun main(vararg args: String) {
     androidx.compose.ui.util.enableTraceOSLog()
 
     val arg = args.firstOrNull() ?: ""
     UIKitMain {
-        ComposeUIViewController {
+        ComposeUIViewController(
+            configure = {
+                useSeparateRenderThreadWhenPossible = true
+            }
+        ) {
             IosDemo(arg)
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -95,7 +95,7 @@ internal class ComposeHostingViewController(
     )
     private var isInsideSwiftUI = false
     private var mediator: ComposeSceneMediator? = null
-    private val layers = UIKitComposeSceneLayersHolder()
+    private val layers = UIKitComposeSceneLayersHolder(configuration.useSeparateRenderThreadWhenPossible)
     private val layoutDirection get() = getLayoutDirection()
     private var hasViewAppeared: Boolean = false
 
@@ -359,6 +359,7 @@ internal class ComposeHostingViewController(
                     override val isInteropActive = false
                 }
             },
+            useSeparateRenderThreadWhenPossible = configuration.useSeparateRenderThreadWhenPossible,
             render = { canvas, nanoTime ->
                 mediator?.render(canvas.asComposeCanvas(), nanoTime)
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -95,7 +95,7 @@ internal class ComposeHostingViewController(
     )
     private var isInsideSwiftUI = false
     private var mediator: ComposeSceneMediator? = null
-    private val layers = UIKitComposeSceneLayersHolder(configuration.useSeparateRenderThreadWhenPossible)
+    private val layers = UIKitComposeSceneLayersHolder(configuration.parallelRendering)
     private val layoutDirection get() = getLayoutDirection()
     private var hasViewAppeared: Boolean = false
 
@@ -359,7 +359,7 @@ internal class ComposeHostingViewController(
                     override val isInteropActive = false
                 }
             },
-            useSeparateRenderThreadWhenPossible = configuration.useSeparateRenderThreadWhenPossible,
+            useSeparateRenderThreadWhenPossible = configuration.parallelRendering,
             render = { canvas, nanoTime ->
                 mediator?.render(canvas.asComposeCanvas(), nanoTime)
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -30,7 +30,9 @@ import platform.UIKit.UIWindow
 /**
  * A class responsible for managing and rendering [UIKitComposeSceneLayer]s.
  */
-internal class UIKitComposeSceneLayersHolder {
+internal class UIKitComposeSceneLayersHolder(
+    useSeparateRenderThreadWhenPossible: Boolean
+) {
     val hasInvalidations: Boolean
         get() = layers.any { it.hasInvalidations }
 
@@ -49,6 +51,7 @@ internal class UIKitComposeSceneLayersHolder {
 
     val metalView: MetalView = MetalView(
         ::retrieveAndMergeInteropTransactions,
+        useSeparateRenderThreadWhenPossible,
         ::render
     ).apply {
         canBeOpaque = false

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -68,8 +68,11 @@ class ComposeUIViewControllerConfiguration {
     var enforceStrictPlistSanityCheck: Boolean = true
 
     /**
-     * If set to true, the Compose will encoder the rendering commands on a dedicated render thread.
+     * If set to true, the Compose will encode the rendering commands on a dedicated render thread,
+     * when possible.
      * This can improve the performance when no interop UIKit is used.
+     *
+     * It's an experimental API, and the effects of enabling it are not considered stable.
      *
      * Changing this setting outside of `ComposeUIViewController` `configure` argument scope has no effect.
      */

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.uikit
 
 import androidx.compose.runtime.ExperimentalComposeApi
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.AccessibilitySyncOptions
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
@@ -76,8 +77,8 @@ class ComposeUIViewControllerConfiguration {
      *
      * Changing this setting outside of `ComposeUIViewController` `configure` argument scope has no effect.
      */
-    @ExperimentalComposeApi
-    var useSeparateRenderThreadWhenPossible: Boolean = false
+    @ExperimentalComposeUiApi
+    var parallelRendering: Boolean = false
 }
 
 /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -66,6 +66,15 @@ class ComposeUIViewControllerConfiguration {
      * explanation on how to fix the issue.
      */
     var enforceStrictPlistSanityCheck: Boolean = true
+
+    /**
+     * If set to true, the Compose will encoder the rendering commands on a dedicated render thread.
+     * This can improve the performance when no interop UIKit is used.
+     *
+     * Changing this setting outside of `ComposeUIViewController` `configure` argument scope has no effect.
+     */
+    @ExperimentalComposeApi
+    var useSeparateRenderThreadWhenPossible: Boolean = false
 }
 
 /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -127,7 +127,8 @@ internal class InflightCommandBuffers(
 internal class MetalRedrawer(
     private val metalLayer: CAMetalLayer,
     private var retrieveInteropTransaction: () -> UIKitInteropTransaction,
-    private var render: (Canvas, targetTimestamp: NSTimeInterval) -> Unit
+    private val useSeparateRenderThreadWhenPossible: Boolean,
+    private var render: (Canvas, targetTimestamp: NSTimeInterval) -> Unit,
 ) {
     /**
      * A wrapper around CAMetalLayer that allows to perform operations on its drawables without
@@ -383,8 +384,7 @@ internal class MetalRedrawer(
             // TODO: encoding on separate thread requires investigation for reported crashes
             //  https://github.com/JetBrains/compose-multiplatform/issues/3862
             //  https://youtrack.jetbrains.com/issue/COMPOSE-608/iOS-reproduce-and-investigate-parallel-rendering-encoding-crash
-            // val mustEncodeAndPresentOnMainThread = presentsWithTransaction || waitUntilCompletion
-            val mustEncodeAndPresentOnMainThread = true
+            val mustEncodeAndPresentOnMainThread = presentsWithTransaction || waitUntilCompletion || !useSeparateRenderThreadWhenPossible
 
             val encodeAndPresentBlock = {
                 trace("MetalRedrawer:draw:encodeAndPresent") {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalView.uikit.kt
@@ -37,6 +37,7 @@ import platform.UIKit.UIViewMeta
 
 internal class MetalView(
     retrieveInteropTransaction: () -> UIKitInteropTransaction,
+    useSeparateRenderThreadWhenPossible: Boolean,
     render: (Canvas, nanoTime: Long) -> Unit,
 ) : UIView(frame = CGRectZero.readValue()) {
     companion object : UIViewMeta() {
@@ -53,6 +54,7 @@ internal class MetalView(
     val redrawer = MetalRedrawer(
         metalLayer,
         retrieveInteropTransaction,
+        useSeparateRenderThreadWhenPossible
     ) { canvas, targetTimestamp ->
         render(canvas, targetTimestamp.toNanoSeconds())
     }


### PR DESCRIPTION
This PR brings the rendering strategy rolled back in https://github.com/JetBrains/compose-multiplatform-core/pull/907 as an experimental opt-in flag.

Speculative fixes were not successful, and it was removed indefinitely back then.
Now we have updated Skia version and can check if it could be related to some undiscovered and fixed Skia data-race.
The API used for this logic is assumed to be thread-safe.
This is a prerequisite for future monkey-testing that will be enabled by iOS testing infra brought by @ASalavei.

If the following issue is still relevant after Skia update, it will allows us to actually test it and collect the data from the users who enable this flag.
https://youtrack.jetbrains.com/issue/COMPOSE-608/iOS-reproduce-and-investigate-parallel-rendering-encoding-crash

The optimisation saved 30% of time on main thread, which is the main bottleneck in Compose performance on iOS, by offloading GPU commands encoding to the separate thread, so it's still worth looking into.

## Release Notes

### Features - iOS
- (Experimental) `ComposeUIViewControllerConfiguration.useSeparateRenderThreadWhenPossible` flag that allows offloading GPU commands encoding to the separate thread and improving performance.