### PR TITLE
Set the default version to 9999.0.0-SNAPSHOT, pin all dependencies

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/LibraryVersionsService.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/LibraryVersionsService.kt
@@ -74,7 +74,13 @@ abstract class LibraryVersionsService : BuildService<LibraryVersionsService.Para
                     versionForTag
                 } else {
                     // Do not use version from toml to about accidentally publish "stable" version
-                    "0.0.0-SNAPSHOT"
+                    //
+                    // We use a big version, so it will win in case of version conflict during
+                    // local runs:
+                    // project("compose:ui") -> lifecycle-runtime-compose:2.8.4 -> compose.runtime:runtime:1.6.11
+                    // project("compose:ui") -> project("compose:runtime")
+                    // project("compose:runtime") should override compose.runtime:runtime:1.6.11 by default
+                    "9999.0.0-SNAPSHOT"
                 }
             Version.parseOrNull(versionValue)
                 ?: throw GradleException(

--- a/collection/collection/build.gradle
+++ b/collection/collection/build.gradle
@@ -64,7 +64,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 implementation(libs.atomicFu)
             }
         }

--- a/compose/animation/animation-core/build.gradle
+++ b/compose/animation/animation-core/build.gradle
@@ -98,7 +98,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:ui:ui-util"))
                 implementation(libs.kotlinStdlibCommon)
                 api(libs.kotlinCoroutinesCore)
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             commonTest {

--- a/compose/foundation/foundation-layout/build.gradle
+++ b/compose/foundation/foundation-layout/build.gradle
@@ -93,7 +93,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(project(":compose:ui:ui"))
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             androidMain.dependencies {

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -113,7 +113,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:ui:ui-text"))
                 implementation(project(":compose:ui:ui-util"))
                 implementation(project(':compose:foundation:foundation-layout'))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
             androidMain.dependencies {
                 api("androidx.annotation:annotation:1.1.0")

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -111,7 +111,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:animation:animation"))
                 implementation(project(":compose:foundation:foundation-layout"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(project(":annotation:annotation"))
+                implementation(("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
             }
 
             androidMain.dependencies {

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -111,7 +111,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:animation:animation"))
                 implementation(project(":compose:foundation:foundation-layout"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             androidMain.dependencies {

--- a/compose/material3/adaptive/adaptive-layout/build.gradle
+++ b/compose/material3/adaptive/adaptive-layout/build.gradle
@@ -58,7 +58,7 @@ kotlin {
                 implementation(project(":compose:foundation:foundation-layout"))
                 implementation(project(":compose:ui:ui-geometry"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(project(":window:window-core"))
+                implementation("org.jetbrains.androidx.window:window-core:1.3.1")
                 implementation(project(":collection:collection"))
             }
         }
@@ -66,7 +66,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.kotlinTest)
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 implementation(project(":kruth:kruth"))
             }
         }

--- a/compose/material3/adaptive/adaptive/build.gradle
+++ b/compose/material3/adaptive/adaptive/build.gradle
@@ -52,7 +52,7 @@ kotlin {
                 implementation(libs.kotlinStdlibCommon)
                 api(project(":compose:foundation:foundation"))
                 api(project(":compose:ui:ui-geometry"))
-                api(project(":window:window-core"))
+                api("org.jetbrains.androidx.window:window-core:1.3.1")
             }
         }
 

--- a/compose/material3/material3-adaptive-navigation-suite/build.gradle
+++ b/compose/material3/material3-adaptive-navigation-suite/build.gradle
@@ -52,8 +52,8 @@ kotlin {
                 implementation(project(":compose:material3:material3"))
                 implementation(project(":compose:material3:adaptive:adaptive"))
                 implementation(project(":compose:ui:ui"))
-                implementation(project(":window:window-core"))
-                api(project(":annotation:annotation"))
+                implementation("org.jetbrains.androidx.window:window-core:1.3.1")
+                api(project("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
             }
         }
 

--- a/compose/material3/material3-adaptive-navigation-suite/build.gradle
+++ b/compose/material3/material3-adaptive-navigation-suite/build.gradle
@@ -53,7 +53,7 @@ kotlin {
                 implementation(project(":compose:material3:adaptive:adaptive"))
                 implementation(project(":compose:ui:ui"))
                 implementation("org.jetbrains.androidx.window:window-core:1.3.1")
-                api(project("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
         }
 

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -114,7 +114,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
                 implementation(project(":compose:ui:ui-util"))
                 implementation(project(":compose:foundation:foundation-layout"))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 implementation(project(":collection:collection"))
             }
 

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -117,7 +117,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.kotlinStdlibCommon)
                 implementation(libs.kotlinCoroutinesCore)
                 implementation(libs.atomicFu)
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 implementation(project(":collection:collection"))
             }
             jvmMain.dependencies {

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -90,7 +90,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:ui:ui-util"))
                 implementation(project(":compose:ui:ui-geometry"))
                 implementation(project(":collection:collection"))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -103,7 +103,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(libs.kotlinStdlib)
                 api(libs.kotlinStdlibCommon)
 
-                implementation(project(":annotation:annotation"))
+                implementation(project("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -103,7 +103,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(libs.kotlinStdlib)
                 api(libs.kotlinStdlibCommon)
 
-                implementation(project("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -112,7 +112,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(libs.kotlinCoroutinesTest)
                 api(libs.kotlinStdlibCommon)
 
-                implementation(project(":annotation:annotation"))
+                implementation(project("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -112,7 +112,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(libs.kotlinCoroutinesTest)
                 api(libs.kotlinStdlibCommon)
 
-                implementation(project("org.jetbrains.compose.annotation-internal:annotation:1.7.1"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -118,7 +118,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:ui:ui-geometry"))
 
                 implementation(project(":collection:collection"))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
 
             jvmMain.dependencies {

--- a/compose/ui/ui-unit/build.gradle
+++ b/compose/ui/ui-unit/build.gradle
@@ -79,7 +79,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
             jvmMain.dependencies {
                 implementation(libs.kotlinStdlib)

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -170,7 +170,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-text")
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 implementation("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
                 implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4")
                 implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -171,10 +171,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
                 implementation(project(":annotation:annotation"))
-                implementation(project(":lifecycle:lifecycle-common"))
-                implementation(project(":lifecycle:lifecycle-runtime"))
-                implementation(project(":lifecycle:lifecycle-runtime-compose"))
-                implementation(project(":lifecycle:lifecycle-viewmodel"))
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4")
             }
 
             androidMain.dependencies {

--- a/graphics/graphics-shapes/build.gradle
+++ b/graphics/graphics-shapes/build.gradle
@@ -70,8 +70,8 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinStdlibCommon)
-                implementation(project(":collection:collection"))
-                implementation(project(":annotation:annotation"))
+                implementation("org.jetbrains.compose.collection-internal:collection:1.7.1")
+                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
         }
 

--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -71,7 +71,7 @@ kotlin {
             dependencies {
                 api(libs.kotlinStdlib)
                 api(libs.kotlinCoroutinesCore)
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
         }
 

--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -61,10 +61,10 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 implementation(project(":lifecycle:lifecycle-common"))
                 api project(":lifecycle:lifecycle-runtime")
-                api(project(":compose:runtime:runtime"))
+                api("org.jetbrains.compose.runtime:runtime:1.7.1")
 
                 implementation(libs.kotlinStdlib)
             }

--- a/lifecycle/lifecycle-runtime/build.gradle
+++ b/lifecycle/lifecycle-runtime/build.gradle
@@ -58,7 +58,7 @@ kotlin {
             dependencies {
                 api(libs.kotlinStdlib)
                 api(project(":lifecycle:lifecycle-common"))
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
         }
 

--- a/lifecycle/lifecycle-viewmodel-compose/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-compose/build.gradle
@@ -52,10 +52,10 @@ kotlin {
                 api project(":lifecycle:lifecycle-common")
                 api project(":lifecycle:lifecycle-viewmodel")
                 api project(":lifecycle:lifecycle-viewmodel-savedstate")
-                api project(":savedstate:savedstate")
-                api project(":compose:runtime:runtime")
-                api project(":compose:runtime:runtime-saveable")
-                api project(":compose:ui:ui")
+                api "org.jetbrains.androidx.savedstate:savedstate:1.2.2"
+                api "org.jetbrains.compose.runtime:runtime:1.7.1"
+                api "org.jetbrains.compose.runtime:runtime-saveable:1.7.1"
+                api "org.jetbrains.compose.ui:ui:1.7.1"
 
                 implementation(libs.kotlinStdlib)
                 implementation project(":core:core-bundle")

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -64,11 +64,11 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 api(project(":core:core-bundle"))
                 api(project(":lifecycle:lifecycle-common"))
                 api(project(":lifecycle:lifecycle-viewmodel"))
-                api(project(":savedstate:savedstate"))
+                api("org.jetbrains.androidx.savedstate:savedstate:1.2.2")
                 api(libs.kotlinStdlib)
             }
         }

--- a/lifecycle/lifecycle-viewmodel/build.gradle
+++ b/lifecycle/lifecycle-viewmodel/build.gradle
@@ -78,7 +78,7 @@ kotlin {
 
         commonMain {
             dependencies {
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 api(libs.kotlinStdlib)
                 api(libs.kotlinCoroutinesCore)
             }

--- a/navigation/navigation-common/build.gradle
+++ b/navigation/navigation-common/build.gradle
@@ -53,15 +53,15 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                api project(":annotation:annotation")
-                api project(":collection:collection")
+                api "org.jetbrains.compose.annotation-internal:annotation:1.7.1"
+                api "org.jetbrains.compose.collection-internal:collection:1.7.1"
                 api project(":core:core-bundle")
                 api project(":core:core-uri")
                 api project(":lifecycle:lifecycle-common")
                 api project(":lifecycle:lifecycle-runtime")
                 api project(":lifecycle:lifecycle-viewmodel")
                 api project(":lifecycle:lifecycle-viewmodel-savedstate")
-                api project(":savedstate:savedstate")
+                api "org.jetbrains.androidx.savedstate:savedstate:1.2.2"
 
                 api(libs.kotlinStdlib)
                 implementation(libs.kotlinSerializationCore)

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -46,21 +46,21 @@ kotlin {
         commonMain {
             dependencies {
                 api project(":core:core-bundle")
-                implementation project(":compose:foundation:foundation-layout")
-                implementation project(":compose:animation:animation-core")
-                api project(":compose:animation:animation")
-                api project(":compose:runtime:runtime")
-                api project(":compose:runtime:runtime-saveable")
-                api project(":compose:ui:ui")
-                api project(":lifecycle:lifecycle-common")
-                api project(":lifecycle:lifecycle-runtime")
-                api project(":lifecycle:lifecycle-runtime-compose")
-                api project(":lifecycle:lifecycle-viewmodel")
-                api project(":lifecycle:lifecycle-viewmodel-compose")
-                api project(":lifecycle:lifecycle-viewmodel-savedstate")
+                implementation "org.jetbrains.compose.foundation:foundation-layout:1.7.1"
+                implementation "org.jetbrains.compose.animation:animation-core:1.7.1"
+                api "org.jetbrains.compose.animation:animation:1.7.1"
+                api "org.jetbrains.compose.runtime:runtime:1.7.1"
+                api "org.jetbrains.compose.runtime:runtime-saveable:1.7.1"
+                api "org.jetbrains.compose.ui:ui:1.7.1"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.8.4"
                 api project(":navigation:navigation-common")
                 api project(":navigation:navigation-runtime")
-                api project(":savedstate:savedstate")
+                api "org.jetbrains.androidx.savedstate:savedstate:1.2.2"
 
                 implementation(libs.kotlinStdlibCommon)
                 implementation(libs.kotlinSerializationCore)

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -50,16 +50,16 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                api project(":annotation:annotation")
-                implementation project(":collection:collection")
+                api "org.jetbrains.compose.annotation-internal:annotation:1.7.1"
+                implementation "org.jetbrains.compose.collection-internal:collection:1.7.1"
                 api project(":core:core-bundle")
                 api project(":core:core-uri")
-                api project(":lifecycle:lifecycle-common")
-                api project(":lifecycle:lifecycle-runtime")
-                api project(":lifecycle:lifecycle-viewmodel")
-                api project(":lifecycle:lifecycle-viewmodel-savedstate")
+                api "org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4"
+                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.8.4"
                 api project(":navigation:navigation-common")
-                api project(":savedstate:savedstate")
+                api "org.jetbrains.androidx.savedstate:savedstate:1.2.2"
 
                 api(libs.kotlinStdlib)
                 implementation(libs.kotlinSerializationCore)

--- a/savedstate/savedstate/build.gradle
+++ b/savedstate/savedstate/build.gradle
@@ -49,9 +49,9 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 api(project(":core:core-bundle"))
-                api(project(":lifecycle:lifecycle-common"))
+                api("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
             }
         }
         jvmMain {

--- a/window/window-core/build.gradle
+++ b/window/window-core/build.gradle
@@ -66,7 +66,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                api(project(":annotation:annotation"))
+                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }
         }
 


### PR DESCRIPTION
These are preparation to build Compose 1.8.0-alpha01 from `jb-main` branch.

1. Set the default version to 9999.0.0-SNAPSHOT. It is needed for pinning, more in the code comment.

**Alternative**
Move versioning from CI to `libraryversions.toml`. It will contain all next versions we need to publish, and they are always greater than the pinned versions. This requires some work and I didn't plan it in the short term.

**Disadvantage**
We can accidentally publish it to the dev repo. But users won't see it in the suggestions because it is `-SNAPSHOT`.

This is also true for the alternative, so we have this disadvantage anyway.

2. Pin all dependencies to be able to not release them.

Not pinned dependencies:
- collection (new API needed)
- core (new lib core-uri)
- shapes (no stable version)

## Testing
1. Build
```
./gradlew publishComposeJbToMavenLocal
```
2. Check module files
3. Sync and run the version on the desktop template
4. run1, runDemo