### PR TITLE
Fix keyboard shortcuts not working on native macOS

### DIFF
--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.macos.kt
@@ -18,13 +18,17 @@ package androidx.compose.foundation.text
 
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
 
 actual val KeyEvent.isTypedEvent: Boolean
     get() = type == KeyEventType.KeyDown &&
         !isISOControl(utf16CodePoint) &&
-        !isAppKitReserved(utf16CodePoint)
+        !isAppKitReserved(utf16CodePoint) &&
+        !isMetaPressed &&
+        !isCtrlPressed
 
 private fun isISOControl(codePoint: Int): Boolean =
     codePoint in 0x00..0x1F ||


### PR DESCRIPTION
Keyboard shortcuts like copy/paste (COMMAND + C) are not working on native macOS. This PR fixes the issue.

## Testing

Tested using mpp demo sample on macOS arm64
