### PR TITLE
Fix app freezing when pressing middle mouse button on native macOS

### DIFF
--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -167,10 +167,10 @@ private class ComposeWindow(
             onMouseEvent(event, PointerEventType.Release, PointerButton.Secondary)
         }
         override fun otherMouseDown(event: NSEvent) {
-            onMouseEvent(event, PointerEventType.Release, PointerButton(event.buttonNumber.toInt()))
+            onMouseEvent(event, PointerEventType.Press, PointerButton(event.buttonNumber.toInt()))
         }
         override fun otherMouseUp(event: NSEvent) {
-            onMouseEvent(event, PointerEventType.Press, PointerButton(event.buttonNumber.toInt()))
+            onMouseEvent(event, PointerEventType.Release, PointerButton(event.buttonNumber.toInt()))
         }
         override fun mouseMoved(event: NSEvent) {
             onMouseEvent(event, PointerEventType.Move)


### PR DESCRIPTION
A native macOS app stops responding after pressing middle mouse button once. This PR fixes this by correcting a typo in the event handling of ComposeWindow.macos.kt.

## Testing
Tested using mpp demo sample on macOS arm64
