### PR TITLE
Pointer icons for native macOS

### DIFF
--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.macos.kt
@@ -16,12 +16,11 @@
 
 package androidx.compose.ui.input.pointer
 
-// uikit doesn't seem to have NSCursor.
-// TODO: consider having it for macos though.
-object DummyPointerIcon : PointerIcon
-private data class DarwinCursor(val id: String): PointerIcon
+import platform.AppKit.NSCursor
 
-internal actual val pointerIconDefault: PointerIcon = DarwinCursor("default")
-internal actual val pointerIconCrosshair: PointerIcon = DarwinCursor("crosshair")
-internal actual val pointerIconText: PointerIcon = DarwinCursor("text")
-internal actual val pointerIconHand: PointerIcon = DarwinCursor("hand")
+internal data class MacosCursor(val cursor: NSCursor): PointerIcon
+
+internal actual val pointerIconDefault: PointerIcon = MacosCursor(NSCursor.arrowCursor)
+internal actual val pointerIconCrosshair: PointerIcon = MacosCursor(NSCursor.crosshairCursor)
+internal actual val pointerIconText: PointerIcon = MacosCursor(NSCursor.IBeamCursor)
+internal actual val pointerIconHand: PointerIcon = MacosCursor(NSCursor.pointingHandCursor)

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.toComposeEvent
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.platform.MacosTextInputService
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.WindowInfoImpl
@@ -44,6 +45,7 @@ import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SkiaLayer
 import org.jetbrains.skiko.SkikoRenderDelegate
 import platform.AppKit.NSBackingStoreBuffered
+import platform.AppKit.NSCursor
 import platform.AppKit.NSEvent
 import platform.AppKit.NSTrackingActiveAlways
 import platform.AppKit.NSTrackingActiveInKeyWindow
@@ -93,6 +95,14 @@ private class ComposeWindow(
         object : PlatformContext by PlatformContext.Empty {
             override val windowInfo get() = _windowInfo
             override val textInputService get() = macosTextInputService
+            override fun setPointerIcon(pointerIcon: PointerIcon) {
+                when (pointerIcon) {
+                    PointerIcon.Default -> NSCursor.arrowCursor.set()
+                    PointerIcon.Crosshair -> NSCursor.crosshairCursor.set()
+                    PointerIcon.Text -> NSCursor.IBeamCursor.set()
+                    PointerIcon.Hand -> NSCursor.pointingHandCursor.set()
+                }
+            }
         }
     private val skiaLayer = SkiaLayer()
     private val scene = CanvasLayersComposeScene(

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.toComposeEvent
+import androidx.compose.ui.input.pointer.MacosCursor
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -96,12 +97,8 @@ private class ComposeWindow(
             override val windowInfo get() = _windowInfo
             override val textInputService get() = macosTextInputService
             override fun setPointerIcon(pointerIcon: PointerIcon) {
-                when (pointerIcon) {
-                    PointerIcon.Default -> NSCursor.arrowCursor.set()
-                    PointerIcon.Crosshair -> NSCursor.crosshairCursor.set()
-                    PointerIcon.Text -> NSCursor.IBeamCursor.set()
-                    PointerIcon.Hand -> NSCursor.pointingHandCursor.set()
-                }
+                val cursor = (pointerIcon as? MacosCursor)?.cursor ?: NSCursor.arrowCursor
+                cursor.set()
             }
         }
     private val skiaLayer = SkiaLayer()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.uikit.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.input.pointer
 
 // uikit doesn't seem to have NSCursor.
-object DummyPointerIcon : PointerIcon
 private data class UIKitCursor(val id: String): PointerIcon
 
 internal actual val pointerIconDefault: PointerIcon = UIKitCursor("default")

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.uikit.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.pointer
+
+// uikit doesn't seem to have NSCursor.
+object DummyPointerIcon : PointerIcon
+private data class UIKitCursor(val id: String): PointerIcon
+
+internal actual val pointerIconDefault: PointerIcon = UIKitCursor("default")
+internal actual val pointerIconCrosshair: PointerIcon = UIKitCursor("crosshair")
+internal actual val pointerIconText: PointerIcon = UIKitCursor("text")
+internal actual val pointerIconHand: PointerIcon = UIKitCursor("hand")


### PR DESCRIPTION
Set the correct NSCursor depending on the pointer icon provided by compose.

## Testing

Tested using mpp demo sample on macOS arm64. Open a screen with a text field and the cursor changes.