### PR TITLE
Adds experimental PointerIcon.fromKeyword function to change the browser cursor in Web source set

### DIFF
--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.js.kt
@@ -16,44 +16,23 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+
 object DummyPointerIcon : PointerIcon
 
 internal data class BrowserCursor(val id: String): PointerIcon
 
-// Extracted from: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
-// Note: cursor existence may vary in different browsers and OS's
+/**
+ * Creates [PointerIcon] from provided cursor keyword.
+ * @param keyword one of the values representing the cursor appearance in a browser.
+ * @see <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/cursor">https://developer.mozilla.org/en-US/docs/Web/CSS/cursor</a>
+ */
+@ExperimentalComposeUiApi
+fun PointerIcon.Companion.fromKeyword(keyword: String): PointerIcon {
+    return BrowserCursor(keyword)
+}
 
 internal actual val pointerIconDefault: PointerIcon = BrowserCursor("default")
 internal actual val pointerIconCrosshair: PointerIcon = BrowserCursor("crosshair")
 internal actual val pointerIconText: PointerIcon = BrowserCursor("text")
 internal actual val pointerIconHand: PointerIcon = BrowserCursor("pointer")
-
-val ContextMenu: PointerIcon = BrowserCursor("context-menu")
-val Help: PointerIcon = BrowserCursor("help")
-val Wait: PointerIcon = BrowserCursor("wait")
-val Cell: PointerIcon = BrowserCursor("cell")
-val VerticalText: PointerIcon = BrowserCursor("vertical-text")
-val Alias: PointerIcon = BrowserCursor("alias")
-val Copy: PointerIcon = BrowserCursor("copy")
-val Move: PointerIcon = BrowserCursor("move")
-val NoDrop: PointerIcon = BrowserCursor("no-drop")
-val NotAllowed: PointerIcon = BrowserCursor("not-allowed")
-val Grab: PointerIcon = BrowserCursor("grab")
-val Grabbing: PointerIcon = BrowserCursor("grabbing")
-val AllScroll: PointerIcon = BrowserCursor("all-scroll")
-val ColumnResize: PointerIcon = BrowserCursor("col-resize")
-val RowResize: PointerIcon = BrowserCursor("row-resize")
-val NResize: PointerIcon = BrowserCursor("n-resize")
-val EResize: PointerIcon = BrowserCursor("e-resize")
-val SResize: PointerIcon = BrowserCursor("s-resize")
-val WResize: PointerIcon = BrowserCursor("w-resize")
-val NEResize: PointerIcon = BrowserCursor("ne-resize")
-val NWResize: PointerIcon = BrowserCursor("nw-resize")
-val SEResize: PointerIcon = BrowserCursor("se-resize")
-val SwResize: PointerIcon = BrowserCursor("sw-resize")
-val EWresize: PointerIcon = BrowserCursor("ew-resize")
-val NSResize: PointerIcon = BrowserCursor("ns-resize")
-val NESWResize: PointerIcon = BrowserCursor("nesw-resize")
-val NWSEResize: PointerIcon = BrowserCursor("nwse-resize")
-val ZoomIn: PointerIcon = BrowserCursor("zoom-in")
-val ZoomOut: PointerIcon = BrowserCursor("zoom-out")

--- a/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.js.kt
+++ b/compose/ui/ui/src/jsWasmMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.js.kt
@@ -20,7 +20,40 @@ object DummyPointerIcon : PointerIcon
 
 internal data class BrowserCursor(val id: String): PointerIcon
 
+// Extracted from: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
+// Note: cursor existence may vary in different browsers and OS's
+
 internal actual val pointerIconDefault: PointerIcon = BrowserCursor("default")
 internal actual val pointerIconCrosshair: PointerIcon = BrowserCursor("crosshair")
 internal actual val pointerIconText: PointerIcon = BrowserCursor("text")
 internal actual val pointerIconHand: PointerIcon = BrowserCursor("pointer")
+
+val ContextMenu: PointerIcon = BrowserCursor("context-menu")
+val Help: PointerIcon = BrowserCursor("help")
+val Wait: PointerIcon = BrowserCursor("wait")
+val Cell: PointerIcon = BrowserCursor("cell")
+val VerticalText: PointerIcon = BrowserCursor("vertical-text")
+val Alias: PointerIcon = BrowserCursor("alias")
+val Copy: PointerIcon = BrowserCursor("copy")
+val Move: PointerIcon = BrowserCursor("move")
+val NoDrop: PointerIcon = BrowserCursor("no-drop")
+val NotAllowed: PointerIcon = BrowserCursor("not-allowed")
+val Grab: PointerIcon = BrowserCursor("grab")
+val Grabbing: PointerIcon = BrowserCursor("grabbing")
+val AllScroll: PointerIcon = BrowserCursor("all-scroll")
+val ColumnResize: PointerIcon = BrowserCursor("col-resize")
+val RowResize: PointerIcon = BrowserCursor("row-resize")
+val NResize: PointerIcon = BrowserCursor("n-resize")
+val EResize: PointerIcon = BrowserCursor("e-resize")
+val SResize: PointerIcon = BrowserCursor("s-resize")
+val WResize: PointerIcon = BrowserCursor("w-resize")
+val NEResize: PointerIcon = BrowserCursor("ne-resize")
+val NWResize: PointerIcon = BrowserCursor("nw-resize")
+val SEResize: PointerIcon = BrowserCursor("se-resize")
+val SwResize: PointerIcon = BrowserCursor("sw-resize")
+val EWresize: PointerIcon = BrowserCursor("ew-resize")
+val NSResize: PointerIcon = BrowserCursor("ns-resize")
+val NESWResize: PointerIcon = BrowserCursor("nesw-resize")
+val NWSEResize: PointerIcon = BrowserCursor("nwse-resize")
+val ZoomIn: PointerIcon = BrowserCursor("zoom-in")
+val ZoomOut: PointerIcon = BrowserCursor("zoom-out")


### PR DESCRIPTION
Adds remaining cursors pointer icons in Web source set which are available in https://developer.mozilla.org/en-US/docs/Web/CSS/cursor
Note that not all of the cursors are available in all browsers and OS's but they default to default one if not available
If you were planning a different approach, i'm open to feedback

Fixes [https://youtrack.jetbrains.com/issue/CMP-6951/Consider-making-BrowserCursor-dataclass-public-or-add-more-PointerIcons-to-WasmJs-target](https://youtrack.jetbrains.com/issue/CMP-6951/Consider-making-BrowserCursor-dataclass-public-or-add-more-PointerIcons-to-WasmJs-target)

## Release Notes
### Features - Web
- Adds experimental `PointerIcon.fromKeyword` function to change the browser cursor
