### PR TITLE
Fix storing of Array in SavedStateHandle/Bundle

### DIFF
--- a/lifecycle/lifecycle-viewmodel-savedstate/src/jbMain/kotlin/androidx/lifecycle/SavedStateHandle.jb.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/jbMain/kotlin/androidx/lifecycle/SavedStateHandle.jb.kt
@@ -310,6 +310,16 @@ actual class SavedStateHandle {
                 is ShortArray -> true
 
                 // Reference arrays
+                is Array<*> -> {
+                    // Unlike JVM, there is no reflection available to check component type
+                    when (value.firstOrNull()) {
+                        is String,
+                        is CharSequence -> true
+                        // Narrowed alternative of Android's [putParcelableArray]
+                        is Bundle -> true
+                        else -> value.isEmpty()
+                    }
+                }
                 // [bundleOf] might support [List] instead of [ArrayList] in some cases.
                 is List<*> -> {
                     // Unlike JVM, there is no reflection available to check component type


### PR DESCRIPTION
Fixes [CMP-5907 IllegalArgumentException: Can't put value with type class java.util.ArrayList (Kotlin reflection is not available) into saved state](https://youtrack.jetbrains.com/issue/CMP-5907)

## Testing
```
previousEntry.savedStateHandle[key] = arrayOf("1", "2", "3")
```