### PR TITLE
Enable "androidx.compose.material.material-navigation" publication.

### DIFF
--- a/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/BottomSheetNavigatorDestinationBuilder.kt
+++ b/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/BottomSheetNavigatorDestinationBuilder.kt
@@ -22,6 +22,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDestinationBuilder
 import androidx.navigation.NavDestinationDsl
 import androidx.navigation.NavType
+import kotlin.jvm.JvmSuppressWildcards
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 

--- a/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/NavGraphBuilder.kt
+++ b/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/NavGraphBuilder.kt
@@ -25,6 +25,7 @@ import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavType
 import androidx.navigation.get
+import kotlin.jvm.JvmSuppressWildcards
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -106,8 +106,6 @@ artifactRedirecting.androidx.compose.version=1.8.0-alpha03
 artifactRedirecting.androidx.compose.material3.version=1.4.0-alpha01
 artifactRedirecting.androidx.compose.foundation.version=1.8.0-alpha03
 artifactRedirecting.androidx.compose.material.version=1.8.0-alpha03
-# The latest version is not published yet: https://mvnrepository.com/artifact/androidx.compose.material/material-navigation
-artifactRedirecting.androidx.compose.material.material-navigation.version=1.7.0-beta01
 # Look for `COMPOSE_MATERIAL3_COMMON` in libraryversions.toml
 artifactRedirecting.androidx.compose.material3.common.version=1.0.0-alpha01
 # Look for `COMPOSE_MATERIAL3_ADAPTIVE` in libraryversions.toml

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -60,8 +60,7 @@ val libraryToComponents = mapOf(
         ComposeComponent(":compose:material3:material3-common"),
         //ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
-        //disable 'material-navigation' publication until Google releases its version
-        //ComposeComponent(":compose:material:material-navigation"),
+        ComposeComponent(":compose:material:material-navigation"),
         ComposeComponent(":compose:material3:material3-window-size-class"),
         ComposeComponent(":compose:material3:material3-adaptive-navigation-suite"),
         ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),


### PR DESCRIPTION
It redirects an android artifact to "material.version=1.8.0-alpha03" version