### PR TITLE
AOSP commonization: removing seemingly redundant drag cancellation for iOS magnifier

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/LongPressTextDragObserver.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/LongPressTextDragObserver.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.util.fastAny
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/LongPressTextDragObserver.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/LongPressTextDragObserver.kt
@@ -77,13 +77,6 @@ internal suspend fun PointerInputScope.detectDownAndDragGesturesWithObserver(
     coroutineScope {
         launch(start = CoroutineStart.UNDISPATCHED) { detectPreDragGesturesWithObserver(observer) }
         launch(start = CoroutineStart.UNDISPATCHED) { detectDragGesturesWithObserver(observer) }
-            .invokeOnCompletion {
-                // Otherwise observer won't be notified if
-                // composable was disposed before the drag cancellation
-                if (it is CancellationException){
-                    observer.onCancel()
-                }
-            }
     }
 }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
@@ -461,10 +461,7 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
                 updateFloatingToolbar(show = true)
             }
 
-            override fun onCancel() {
-                draggingHandle = null
-                currentDragPosition = null
-            }
+            override fun onCancel() {}
         }
 
     /** [TextDragObserver] for dragging the cursor to change the selection in TextField. */


### PR DESCRIPTION
Potentially fixes [CMP-5763](https://youtrack.jetbrains.com/issue/CMP-5763/Upstreaming.-bug.-foundation.-iOS-magnifier.-fix-text-selection) and [CMP-5764](https://youtrack.jetbrains.com/issue/CMP-5764/Upstreaming.-bug.-foundation.-iOS-magnifier.-fix-drag-cancellation)

I wasn't able to reproduce the bug, which should be fixed by these lines ([it was introduced here](https://github.com/JetBrains/compose-multiplatform-core/pull/1000#issuecomment-2004723614)), so I suggest retesting magnifier behavior without these lines and removing them afterwards if my suspicion is correct.