### PR TITLE
Move material3-common to COMPOSE_MATERIAL3_COMMON group

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -57,7 +57,6 @@ val libraryToComponents = mapOf(
         ComposeComponent(":compose:foundation:foundation-layout"),
         ComposeComponent(":compose:material:material"),
         ComposeComponent(":compose:material3:material3"),
-        ComposeComponent(":compose:material3:material3-common"),
         //ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
         ComposeComponent(":compose:material:material-navigation"),
@@ -89,6 +88,9 @@ val libraryToComponents = mapOf(
         ),
         ComposeComponent(":compose:ui:ui-unit"),
         ComposeComponent(":compose:ui:ui-util"),
+    ),
+    "COMPOSE_MATERIAL3_COMMON" to listOf(
+        ComposeComponent(":compose:material3:material3-common"),
     ),
     "COMPOSE_MATERIAL3_ADAPTIVE" to listOf(
         ComposeComponent(":compose:material3:adaptive:adaptive"),


### PR DESCRIPTION
- It has its own versioning
- we don't pass its version from CI (we should add it in `Library.kt`)
- because of this 9999.0.0-SNAPSHOT is published:
![image](https://github.com/user-attachments/assets/95392d97-65f3-4744-a16b-06e613c7aa10)
(already removed from `dev` manually)