### PR TITLE
Align Compose components semantics with UIKit views accessibility

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -41,11 +41,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *__nullable)accessibilityValue CMP_ABSTRACT_FUNCTION;
 
+- (__nullable id<UITextInput>)accessibilityTextInputResponder CMP_ABSTRACT_FUNCTION;
+
 - (CGRect)accessibilityFrame CMP_ABSTRACT_FUNCTION;
 
 - (BOOL)isAccessibilityElement CMP_ABSTRACT_FUNCTION;
 
 - (BOOL)accessibilityActivate CMP_ABSTRACT_FUNCTION;
+
+- (void)accessibilityIncrement CMP_ABSTRACT_FUNCTION;
+
+- (void)accessibilityDecrement CMP_ABSTRACT_FUNCTION;
 
 // Private SDK method. Calls when the item is swipe-to-focused in VoiceOver.
 - (BOOL)accessibilityScrollToVisible;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -80,6 +80,10 @@ NS_ASSUME_NONNULL_BEGIN
     CMP_ABSTRACT_FUNCTION_CALLED
 }
 
+- (__nullable id<UITextInput>)accessibilityTextInputResponder {
+    CMP_ABSTRACT_FUNCTION_CALLED
+}
+
 - (NSString *__nullable)accessibilityValue {
     CMP_ABSTRACT_FUNCTION_CALLED
 }
@@ -93,6 +97,14 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)accessibilityActivate {
+    CMP_ABSTRACT_FUNCTION_CALLED
+}
+
+- (void)accessibilityIncrement {
+    CMP_ABSTRACT_FUNCTION_CALLED
+}
+
+- (void)accessibilityDecrement {
     CMP_ABSTRACT_FUNCTION_CALLED
 }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -1,0 +1,468 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.accessibility
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Button
+import androidx.compose.material.Checkbox
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.LinearProgressIndicator
+import androidx.compose.material.RadioButton
+import androidx.compose.material.RangeSlider
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Slider
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.TriStateCheckbox
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.test.assertAccessibilityTree
+import androidx.compose.ui.test.findNode
+import androidx.compose.ui.test.firstAccessibleNode
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
+import platform.UIKit.UIAccessibilityTraitAdjustable
+import platform.UIKit.UIAccessibilityTraitButton
+import platform.UIKit.UIAccessibilityTraitHeader
+import platform.UIKit.UIAccessibilityTraitImage
+import platform.UIKit.UIAccessibilityTraitNotEnabled
+import platform.UIKit.UIAccessibilityTraitSelected
+import platform.UIKit.UIAccessibilityTraitStaticText
+import platform.UIKit.UIAccessibilityTraitToggleButton
+import platform.UIKit.accessibilityActivate
+import platform.UIKit.accessibilityDecrement
+import platform.UIKit.accessibilityIncrement
+
+class ComponentsAccessibilitySemanticTest {
+
+    @Test
+    fun testButtonNodeActionAndSemantic() = runUIKitInstrumentedTest {
+        var tapped = false
+        setContentWithAccessibilityEnabled {
+            Button({ tapped = true }) {
+                Text("Content")
+            }
+        }
+
+        assertAccessibilityTree {
+            isAccessibilityElement = true
+            traits(UIAccessibilityTraitButton)
+        }
+
+        val node = firstAccessibleNode()
+        node.element?.accessibilityActivate()
+        assertTrue(tapped)
+    }
+
+    @OptIn(ExperimentalMaterialApi::class)
+    @Test
+    fun testProgressNodesSemantic() = runUIKitInstrumentedTest {
+        var sliderValue = 0.4f
+        setContentWithAccessibilityEnabled {
+            Column {
+                Slider(
+                    value = sliderValue,
+                    onValueChange = { sliderValue = it }
+                )
+                LinearProgressIndicator(progress = 0.7f)
+                RangeSlider(
+                    value = 30f..70f,
+                    onValueChange = {},
+                    valueRange = 0f..100f
+                )
+            }
+        }
+
+        assertAccessibilityTree {
+            // Slider
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitAdjustable)
+                value = "40%"
+            }
+
+            // LinearProgressIndicator
+            node {
+                isAccessibilityElement = true
+                value = "70%"
+                traits()
+            }
+
+            // Range Slider
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitAdjustable)
+                value = "43%"
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitAdjustable)
+                value = "57%"
+            }
+        }
+    }
+
+    @Test
+    fun testSliderAction() = runUIKitInstrumentedTest {
+        var sliderValue = 0.4f
+        setContentWithAccessibilityEnabled {
+            Slider(
+                value = sliderValue,
+                onValueChange = { sliderValue = it },
+                modifier = Modifier.testTag("Slider")
+            )
+        }
+
+        var oldValue = sliderValue
+        val sliderNode = findNode("Slider")
+        sliderNode.element?.accessibilityIncrement()
+        assertTrue(oldValue < sliderValue)
+
+        oldValue = sliderValue
+        sliderNode.element?.accessibilityDecrement()
+        assertTrue(oldValue > sliderValue)
+    }
+
+    @Test
+    fun testToggleAndCheckboxSemantic() = runUIKitInstrumentedTest {
+        setContentWithAccessibilityEnabled {
+            Column {
+                Switch(false, {})
+                Checkbox(false, {})
+                TriStateCheckbox(ToggleableState.On, {})
+                TriStateCheckbox(ToggleableState.Off, {})
+                TriStateCheckbox(ToggleableState.Indeterminate, {})
+            }
+        }
+
+        assertAccessibilityTree {
+            // Switch
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+                if (available(OS.Ios to OSVersion(major = 17))) {
+                    traits(UIAccessibilityTraitToggleButton)
+                }
+            }
+            // Checkbox
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+            // ToggleableState
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitSelected
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+        }
+    }
+
+    @Test
+    fun testToggleAndCheckboxAction() = runUIKitInstrumentedTest {
+        var switch by mutableStateOf(false)
+        var checkbox by mutableStateOf(false)
+        var triStateCheckbox by mutableStateOf(ToggleableState.Off)
+
+        setContentWithAccessibilityEnabled {
+            Column {
+                Switch(
+                    checked = switch,
+                    onCheckedChange = { switch = it },
+                    modifier = Modifier.testTag("Switch")
+                )
+                Checkbox(
+                    checked = checkbox,
+                    onCheckedChange = { checkbox = it },
+                    modifier = Modifier.testTag("Checkbox")
+                )
+                TriStateCheckbox(
+                    state = triStateCheckbox,
+                    onClick = { triStateCheckbox = ToggleableState.On },
+                    modifier = Modifier.testTag("TriStateCheckbox")
+                )
+            }
+        }
+
+        findNode("Switch").element?.accessibilityActivate()
+        assertTrue(switch)
+        waitForIdle()
+        findNode("Switch").element?.accessibilityActivate()
+        assertFalse(switch)
+
+        findNode("Checkbox").element?.accessibilityActivate()
+        assertTrue(checkbox)
+        waitForIdle()
+        findNode("Checkbox").element?.accessibilityActivate()
+        assertFalse(checkbox)
+
+        findNode("TriStateCheckbox").element?.accessibilityActivate()
+        assertEquals(ToggleableState.On, triStateCheckbox)
+    }
+
+    @Test
+    fun testRadioButtonSelection() = runUIKitInstrumentedTest {
+        var selectedIndex by mutableStateOf(0)
+
+        setContentWithAccessibilityEnabled {
+            Column {
+                RadioButton(selected = selectedIndex == 0, onClick = { selectedIndex = 0 })
+                RadioButton(selected = selectedIndex == 1, onClick = { selectedIndex = 1 })
+                RadioButton(
+                    selected = selectedIndex == 2,
+                    onClick = { selectedIndex = 2 },
+                    Modifier.testTag("RadioButton")
+                )
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitSelected
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+        }
+
+        findNode("RadioButton").element?.accessibilityActivate()
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitSelected
+                )
+            }
+        }
+
+        selectedIndex = 0
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitSelected
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
+        }
+    }
+
+    @Test
+    fun testImageSemantics() = runUIKitInstrumentedTest {
+        setContentWithAccessibilityEnabled {
+            Column {
+                Image(
+                    ImageBitmap(10, 10),
+                    contentDescription = null,
+                    modifier = Modifier.testTag("Image 1")
+                )
+                Image(
+                    ImageBitmap(10, 10),
+                    contentDescription = null,
+                    modifier = Modifier.testTag("Image 2").semantics { role = Role.Image }
+                )
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = false
+                identifier = "Image 1"
+            }
+            node {
+                isAccessibilityElement = true
+                identifier = "Image 2"
+                traits(UIAccessibilityTraitImage)
+            }
+        }
+    }
+
+    @Test
+    fun testTextSemantics() = runUIKitInstrumentedTest {
+        setContentWithAccessibilityEnabled {
+            Column {
+                Text("Static Text", modifier = Modifier.testTag("Text 1"))
+                Text("Custom Button", modifier = Modifier.testTag("Text 2").clickable {  })
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                identifier = "Text 1"
+                label = "Static Text"
+                traits(UIAccessibilityTraitStaticText)
+            }
+            node {
+                isAccessibilityElement = true
+                identifier = "Text 2"
+                label = "Custom Button"
+                traits(UIAccessibilityTraitButton)
+            }
+        }
+    }
+
+    @Test
+    fun testDisabledSemantics() = runUIKitInstrumentedTest {
+        setContentWithAccessibilityEnabled {
+            Column {
+                Button({}, enabled = false) {}
+                TextField("", {}, enabled = false)
+                Slider(value = 0f, onValueChange = {}, enabled = false)
+                Switch(checked = false, onCheckedChange = {}, enabled = false)
+                Checkbox(checked = false, onCheckedChange = {}, enabled = false)
+                TriStateCheckbox(state = ToggleableState.Off, onClick = {}, enabled = false)
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitNotEnabled
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitNotEnabled
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitAdjustable,
+                    UIAccessibilityTraitNotEnabled
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                if (available(OS.Ios to OSVersion(major = 17))) {
+                    traits(
+                        UIAccessibilityTraitButton,
+                        UIAccessibilityTraitToggleButton,
+                        UIAccessibilityTraitNotEnabled
+                    )
+                } else {
+                    traits(
+                        UIAccessibilityTraitButton,
+                        UIAccessibilityTraitNotEnabled
+                    )
+                }
+            }
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitNotEnabled
+                )
+            }
+            node {
+                isAccessibilityElement = true
+                traits(
+                    UIAccessibilityTraitButton,
+                    UIAccessibilityTraitNotEnabled
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testHeadingSemantics() = runUIKitInstrumentedTest {
+        setContentWithAccessibilityEnabled {
+            Scaffold(topBar = {
+                TopAppBar {
+                    Text("Header", modifier = Modifier.semantics { heading() })
+                }
+            }) {
+                Column {
+                    Text("Content")
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                label = "Header"
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitHeader)
+            }
+            node {
+                label = "Content"
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitStaticText)
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.accessibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
 import androidx.compose.material.ExperimentalMaterialApi
@@ -32,6 +33,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.TriStateCheckbox
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -47,6 +49,7 @@ import androidx.compose.ui.test.assertAccessibilityTree
 import androidx.compose.ui.test.findNode
 import androidx.compose.ui.test.firstAccessibleNode
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.text.buildAnnotatedString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -75,11 +78,19 @@ class ComponentsAccessibilitySemanticTest {
             Button({ tapped = true }) {
                 Text("Content")
             }
+            Button({ }) {}
         }
 
         assertAccessibilityTree {
-            isAccessibilityElement = true
-            traits(UIAccessibilityTraitButton)
+            node {
+                isAccessibilityElement = true
+                label = "Content"
+                traits(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+            }
         }
 
         val node = firstAccessibleNode()
@@ -330,6 +341,11 @@ class ComponentsAccessibilitySemanticTest {
                     contentDescription = null,
                     modifier = Modifier.testTag("Image 2").semantics { role = Role.Image }
                 )
+                Image(
+                    ImageBitmap(10, 10),
+                    contentDescription = "Abstract Picture",
+                    modifier = Modifier.testTag("Image 3")
+                )
             }
         }
 
@@ -337,10 +353,17 @@ class ComponentsAccessibilitySemanticTest {
             node {
                 isAccessibilityElement = false
                 identifier = "Image 1"
+                traits()
+            }
+            node {
+                isAccessibilityElement = false
+                identifier = "Image 2"
+                traits(UIAccessibilityTraitImage)
             }
             node {
                 isAccessibilityElement = true
-                identifier = "Image 2"
+                identifier = "Image 3"
+                label = "Abstract Picture"
                 traits(UIAccessibilityTraitImage)
             }
         }
@@ -351,7 +374,7 @@ class ComponentsAccessibilitySemanticTest {
         setContentWithAccessibilityEnabled {
             Column {
                 Text("Static Text", modifier = Modifier.testTag("Text 1"))
-                Text("Custom Button", modifier = Modifier.testTag("Text 2").clickable {  })
+                Text("Custom Button", modifier = Modifier.testTag("Text 2").clickable { })
             }
         }
 
@@ -460,6 +483,47 @@ class ComponentsAccessibilitySemanticTest {
             }
             node {
                 label = "Content"
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitStaticText)
+            }
+        }
+    }
+
+    @Test
+    fun testSelectionContainer() = runUIKitInstrumentedTest {
+        @Composable
+        fun LabeledInfo(label: String, data: String) {
+            Text(
+                buildAnnotatedString {
+                    append("$label: ")
+                    append(data)
+                }
+            )
+        }
+
+        setContentWithAccessibilityEnabled {
+            SelectionContainer {
+                Column {
+                    Text("Title")
+                    LabeledInfo("Subtitle", "subtitle")
+                    LabeledInfo("Details", "details")
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                label = "Title"
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitStaticText)
+            }
+            node {
+                label = "Subtitle: subtitle"
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitStaticText)
+            }
+            node {
+                label = "Details: details"
                 isAccessibilityElement = true
                 traits(UIAccessibilityTraitStaticText)
             }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.accessibility
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
@@ -39,6 +40,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.heading
@@ -526,6 +528,76 @@ class ComponentsAccessibilitySemanticTest {
                 label = "Details: details"
                 isAccessibilityElement = true
                 traits(UIAccessibilityTraitStaticText)
+            }
+        }
+    }
+
+    @Test
+    fun testVisibleNodes() = runUIKitInstrumentedTest {
+        var alpha by mutableStateOf(0f)
+
+        setContentWithAccessibilityEnabled {
+            Text("Hidden", modifier = Modifier.graphicsLayer {
+                this.alpha = alpha
+            })
+        }
+
+        assertAccessibilityTree {
+            label = "Hidden"
+            isAccessibilityElement = false
+        }
+
+        alpha = 1f
+        assertAccessibilityTree {
+            label = "Hidden"
+            isAccessibilityElement = true
+        }
+    }
+
+    @Test
+    fun testVisibleNodeContainers() = runUIKitInstrumentedTest {
+        var alpha by mutableStateOf(0f)
+
+        setContentWithAccessibilityEnabled {
+            Column {
+                Text("Text 1")
+                Row(modifier = Modifier.graphicsLayer {
+                    this.alpha = alpha
+                }) {
+                    Text("Text 2")
+                    Text("Text 3")
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                label = "Text 1"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 2"
+                isAccessibilityElement = false
+            }
+            node {
+                label = "Text 3"
+                isAccessibilityElement = false
+            }
+        }
+
+        alpha = 1f
+        assertAccessibilityTree {
+            node {
+                label = "Text 1"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 2"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 3"
+                isAccessibilityElement = true
             }
         }
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -193,10 +193,7 @@ internal class UIKitInstrumentedTest {
 
     fun waitForIdle(timeoutMillis: Long = 5_000) {
         waitUntil(
-            conditionDescription = "waitForIdle: timeout ${timeoutMillis}ms reached.\n" +
-                "hasPendingChanges = ${Snapshot.current.hasPendingChanges()}\n" +
-                "isApplyObserverNotificationPending = ${Snapshot.isApplyObserverNotificationPending}\n" +
-                "hasInvalidations = ${hostingViewController.hasInvalidations()}",
+            conditionDescription = "waitForIdle: timeout ${timeoutMillis}ms reached.",
             timeoutMillis = timeoutMillis
         ) { isIdle }
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -193,7 +193,10 @@ internal class UIKitInstrumentedTest {
 
     fun waitForIdle(timeoutMillis: Long = 5_000) {
         waitUntil(
-            conditionDescription = "waitForIdle: timeout ${timeoutMillis}ms reached.",
+            conditionDescription = "waitForIdle: timeout ${timeoutMillis}ms reached.\n" +
+                "hasPendingChanges = ${Snapshot.current.hasPendingChanges()}\n" +
+                "isApplyObserverNotificationPending = ${Snapshot.isApplyObserverNotificationPending}\n" +
+                "hasInvalidations = ${hostingViewController.hasInvalidations()}",
             timeoutMillis = timeoutMillis
         ) { isIdle }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -125,8 +125,8 @@ private object CachedAccessibilityPropertyKeys {
 }
 
 // Private accessibility trait for text fields
-internal var CMPAccessibilityTraitTextField: UIAccessibilityTraits = 1UL shl 18
-internal var CMPAccessibilityTraitIsEditing: UIAccessibilityTraits = 1UL shl 21
+internal val CMPAccessibilityTraitTextField: UIAccessibilityTraits = 1UL shl 18
+internal val CMPAccessibilityTraitIsEditing: UIAccessibilityTraits = 1UL shl 21
 
 /**
  * Represents a projection of the Compose semantics node to the iOS world.


### PR DESCRIPTION
Update UIAccessibility properties calculation to align Compose component semantics with the expected UIKit component behaviour.

Fixes: https://youtrack.jetbrains.com/issue/CMP-7223/Support-accessibility-semantics-for-various-components
Also fixes:
https://youtrack.jetbrains.com/issue/CMP-4586/first-element-in-dropdown-does-not-have-a-hitbox-in-iOS-accessibility
https://youtrack.jetbrains.com/issue/CMP-4795/Order-of-accessibility-nodes-is-wrong
https://youtrack.jetbrains.com/issue/CMP-7209/iOS-Accessibility-doesnt-always-return-isChecked-value-from-radioButton-as-False

## Testing
See [CMP-7223](https://youtrack.jetbrains.com/issue/CMP-7223/Support-accessibility-semantics-for-various-components)

## Release Notes
### Features - iOS
- Align Compose components semantics with UIKit views accessibility