### PR TITLE
`copyAnnotation.sh`. `to-integration` branch is created from a wrong commit

### DIFF
--- a/scripts/copy/impl/copyToJbMain.sh
+++ b/scripts/copy/impl/copyToJbMain.sh
@@ -29,9 +29,8 @@ git checkout --quiet $(git merge-base $CURRENT_COMMIT $JB_MAIN_BRANCH) -B $TO_JB
 )
 echo "Created $TO_JB_MAIN_BRANCH"
 
-INTEGRATION_BRANCH=$(git config branch.integration.remote)/integration
 TO_INTEGRATION_BRANCH=integration-copy/$FIRST_FOLDER/$CURRENT_COMMIT/to-integration
-git checkout --quiet $(git merge-base $CURRENT_COMMIT $INTEGRATION_BRANCH) -B $TO_INTEGRATION_BRANCH
+git checkout --quiet $CURRENT_COMMIT -B $TO_INTEGRATION_BRANCH
 $DIR/mergeEmpty.sh $TO_JB_MAIN_BRANCH
 echo "Created $TO_INTEGRATION_BRANCH"
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7226/copyAnnotation.sh.-to-integration-branch-is-created-from-a-wrong-commit

We took the base commit between the current and `origin/integration`. But it can be old. Instead, we should take just the current commit, because we copied it, not the base one.

## Testing
Rerun `copyAnnotation.sh` from eecb9af750be5ffb945e9c92d0fab8918b1bfdc7 (The green commit in the issue)
