### PR TITLE
COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE - use COMPOSE version

### DIFF
--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -206,7 +206,7 @@ COMPOSE_FOUNDATION = { group = "org.jetbrains.compose.foundation", atomicGroupVe
 COMPOSE_MATERIAL = { group = "org.jetbrains.compose.material", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_MATERIAL3_ADAPTIVE = { group = "org.jetbrains.compose.material3.adaptive", atomicGroupVersion = "versions.COMPOSE_MATERIAL3_ADAPTIVE" }
-COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3", overrideInclude = [ ":compose:material3:material3-adaptive-navigation-suite" ] }
+COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE", overrideInclude = [ ":compose:material3:material3-adaptive-navigation-suite" ] }
 COMPOSE_RUNTIME = { group = "org.jetbrains.compose.runtime", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_RUNTIME_TRACING = { group = "androidx.compose.runtime", atomicGroupVersion = "versions.COMPOSE_RUNTIME_TRACING", overrideInclude = [ ":compose:runtime:runtime-tracing" ] }
 COMPOSE_UI = { group = "org.jetbrains.compose.ui", atomicGroupVersion = "versions.COMPOSE" }


### PR DESCRIPTION
Because we don't use/override material3 version, we align it with COMPOSE.

The last dev was built with 9999.0.0:

![image](https://github.com/user-attachments/assets/07966757-d011-4a1f-b571-b12a1536965f)
