### PR TITLE
CMP-7240: Update non-android navigateUp to handle single-entry back stack correctly

### DIFF
--- a/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavController.jb.kt
+++ b/navigation/navigation-runtime/src/jbMain/kotlin/androidx/navigation/NavController.jb.kt
@@ -672,8 +672,13 @@ public actual open class NavController {
 
     @MainThread
     public actual open fun navigateUp(): Boolean {
-        // TODO If there's only one entry, then we may have deep linked into a specific destination
-        return popBackStack()
+        if (destinationCountOnBackStack == 1) {
+            // opposite to the android implementation, we don't start a new window for deep links,
+            // so we mustn't reopen an initial screen here
+            return false
+        } else {
+            return popBackStack()
+        }
     }
 
     /** Gets the number of non-NavGraph destinations on the back stack */


### PR DESCRIPTION
Previously, we cleared the backstack completely on navigation up on a root screen.

Describe proposed changes and the issue being fixed

Fixes https://youtrack.jetbrains.com/issue/CMP-7240

## Release Notes
### Fixes - Navigation
- Fix incorrect navigation up on the root screen for non-android targets