### PR TITLE
Make `KeyInputElement` and `KeyInputNode` private, as in AOSP

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/key/KeyInputModifier.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/key/KeyInputModifier.kt
@@ -46,7 +46,7 @@ fun Modifier.onKeyEvent(onKeyEvent: (KeyEvent) -> Boolean): Modifier =
 fun Modifier.onPreviewKeyEvent(onPreviewKeyEvent: (KeyEvent) -> Boolean): Modifier =
     this then KeyInputElement(onKeyEvent = null, onPreKeyEvent = onPreviewKeyEvent)
 
-internal data class KeyInputElement(
+private data class KeyInputElement(
     val onKeyEvent: ((KeyEvent) -> Boolean)?,
     val onPreKeyEvent: ((KeyEvent) -> Boolean)?
 ) : ModifierNodeElement<KeyInputNode>() {
@@ -69,7 +69,7 @@ internal data class KeyInputElement(
     }
 }
 
-internal class KeyInputNode(
+private class KeyInputNode(
     var onEvent: ((KeyEvent) -> Boolean)?,
     var onPreEvent: ((KeyEvent) -> Boolean)?
 ) : KeyInputModifierNode, Modifier.Node() {


### PR DESCRIPTION
`KeyInputElement` and `KeyInputNode` were made `internal` in https://github.com/JetBrains/compose-multiplatform-core/pull/712, but this doesn't appear necessary anymore. So instead of upstreaming the change, I'm making them `private`.

