### PR TITLE
Add compose win-arm64 publication in build.gradle.kts

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -135,7 +135,8 @@ val libraryToTasks = mapOf(
             "Jvmlinux-arm64",
             "Jvmmacos-x64",
             "Jvmmacos-arm64",
-            "Jvmwindows-x64"
+            "Jvmwindows-x64",
+            "Jvmwindows-arm64"
         )
     )
 )


### PR DESCRIPTION
IDEs, JBRs, Skiko are already being built for win-arm64. I want to develop JetBrains Toolbox on a Windows Arm laptop and currently there is no published compose desktop for winarm
https://mvnrepository.com/search?q=org.jetbrains.compose.desktop

## Release Notes
- Support Windows ARM
