### PR TITLE
Enable some previously ignored (@IgnoreJsTarget) tests in compose-runtime for web targets

### DIFF
--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/CompositionTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/CompositionTests.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.test.IgnoreJsTarget
 import kotlinx.coroutines.withContext
-import kotlinx.test.IgnoreJsAndNative
 
 @Composable fun Container(content: @Composable () -> Unit) = content()
 
@@ -3718,8 +3717,6 @@ class CompositionTests {
     }
 
     @Test // Regression test for b/249050560
-    @IgnoreJsTarget
-    // TODO(o.k.): fails due to old js-only change in ComposerLambdaMemoization.rememberExpression
     fun testFunctionInstances() = compositionTest {
         var state by mutableStateOf(0)
         functionInstance = { -1 }

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/CompoundHashKeyTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/CompoundHashKeyTests.kt
@@ -25,14 +25,12 @@ import androidx.compose.runtime.mock.CompositionTestScope
 import androidx.compose.runtime.mock.NonReusableText
 import androidx.compose.runtime.mock.compositionTest
 import androidx.compose.runtime.mock.expectNoChanges
-import kotlinx.test.IgnoreJsTarget
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class CompoundHashKeyTests {
     @Test // b/157905524
-    //@IgnoreJsTarget
     fun testWithSubCompose() = compositionTest {
         val outerKeys = mutableListOf<Int>()
         val innerKeys = mutableListOf<Int>()

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/RecomposerTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/RecomposerTests.kt
@@ -109,7 +109,6 @@ class RecomposerTests {
     }
 
     @Test
-    //@IgnoreJsTarget
     fun testRecomposition() = compositionTest {
         val counter = Counter()
         val triggers =

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateListTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateListTests.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import androidx.compose.runtime.runTest
-import kotlinx.test.IgnoreJsTarget
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SnapshotStateListTests {
@@ -550,7 +549,6 @@ class SnapshotStateListTests {
     }
 
     @Test
-    @IgnoreJsTarget // TODO(karpovich): Fix? timeout on node.js
     fun concurrentGlobalModification_add() = runTest(UnconfinedTestDispatcher()) {
         repeat(100) {
             val list = mutableStateListOf<Int>()
@@ -564,7 +562,6 @@ class SnapshotStateListTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
     fun concurrentGlobalModifications_addAll() = runTest(
         UnconfinedTestDispatcher(), timeoutMs = 10_000
     ) {
@@ -588,7 +585,6 @@ class SnapshotStateListTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
     fun concurrentMixingWriteApply_add() = runTest(timeoutMs = 30_000) {
         repeat(10) {
             val lists = Array(100) { mutableStateListOf<Int>() }.toList()
@@ -616,7 +612,6 @@ class SnapshotStateListTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
     fun concurrentMixingWriteApply_addAll_clear() = runTest(
         UnconfinedTestDispatcher(), timeoutMs = 30_000
     ) {
@@ -649,7 +644,6 @@ class SnapshotStateListTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
     fun concurrentMixingWriteApply_addAll_removeRange() = runTest(
         UnconfinedTestDispatcher(), timeoutMs = 30_000
     ) {

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateMapTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateMapTests.kt
@@ -33,8 +33,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import androidx.compose.runtime.runTest
 import kotlinx.test.IgnoreJsAndNative
-import kotlinx.test.IgnoreJsTarget
-import kotlinx.test.IgnoreNativeTarget
 
 class SnapshotStateMapTests {
     @Test
@@ -481,7 +479,6 @@ class SnapshotStateMapTests {
     }
 
     @Test
-    @IgnoreJsTarget
     @OptIn(ExperimentalCoroutinesApi::class)
     fun concurrentModificationInGlobal_put_new() = runTest(UnconfinedTestDispatcher()) {
         repeat(100) {
@@ -495,7 +492,6 @@ class SnapshotStateMapTests {
     }
 
     @Test
-    @IgnoreJsTarget
     @OptIn(ExperimentalCoroutinesApi::class)
     fun concurrentModificationInGlobal_put_replace() = runTest(UnconfinedTestDispatcher()) {
         repeat(100) {
@@ -517,7 +513,6 @@ class SnapshotStateMapTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
     fun concurrentMixingWriteApply_set() = runTest(timeoutMs = 30_000) {
         repeat(10) {
             val maps = Array(100) { mutableStateMapOf<Int, Int>() }.toList()
@@ -545,7 +540,6 @@ class SnapshotStateMapTests {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    @IgnoreJsTarget // Not relevant in a single threaded environment
     fun concurrentMixingWriteApply_clear() = runTest(timeoutMs = 30_000) {
         repeat(10) {
             val maps = Array(100) { mutableStateMapOf<Int, Int>() }.toList()

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserverTestsCommon.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotStateObserverTestsCommon.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.structuralEqualityPolicy
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.test.IgnoreJsTarget
 
 class SnapshotStateObserverTestsCommon {
 
@@ -691,7 +690,6 @@ class SnapshotStateObserverTestsCommon {
     }
 
     @Test
-    @IgnoreJsTarget
     fun readingDerivedState_invalidatesWhenValueNotChanged() {
         var changes = 0
         val changeBlock: (Any) -> Unit = { changes++ }
@@ -716,7 +714,6 @@ class SnapshotStateObserverTestsCommon {
     }
 
     @Test
-    @IgnoreJsTarget
     fun readingDerivedState_invalidatesIfReadBeforeSnapshotAdvance() {
         var changes = 0
         val changeBlock: (Any) -> Unit = {

--- a/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotTests.kt
+++ b/compose/runtime/runtime/src/nonEmulatorCommonTest/kotlin/androidx/compose/runtime/snapshots/SnapshotTests.kt
@@ -47,7 +47,6 @@ import kotlin.test.assertNotSame
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
-import kotlinx.test.IgnoreJsTarget
 
 class SnapshotTests {
     @Test
@@ -648,9 +647,6 @@ class SnapshotTests {
     }
 
     @Test
-    @IgnoreJsTarget
-    // Ignored for web, until we merge this change from the upstream:
-    // https://android-review.googlesource.com/c/platform/frameworks/support/+/2940347
     fun changingAnEqualityPolicyStateToItsCurrentValueIsNotConsideredAChange() {
         val value = boxInt(0)
         val state = mutableStateOf(value, referentialEqualityPolicy())

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -21,4 +21,17 @@ config.customLaunchers = {
     }
 }
 
-config.browsers = ["ChromeForComposeTests"]
+config.browsers = ["ChromeForComposeTests"];
+
+// A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
+(function() {
+    const originalExit = process.exit;
+    process.exit = function(code) {
+        console.log('Delaying exit for logs...');
+        // This extra time allows any pending I/O operations (such as printing logs) to complete,
+        // preventing flakiness when Kotlin marks a test as complete.
+        setTimeout(() => {
+            originalExit(code);
+        }, 5000);
+    };
+})();

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -74,4 +74,17 @@ config.customLaunchers = {
     }
 }
 
-config.browsers = ["ChromeForComposeTests"]
+config.browsers = ["ChromeForComposeTests"];
+
+// A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
+(function() {
+    const originalExit = process.exit;
+    process.exit = function(code) {
+        console.log('Delaying exit for logs...');
+        // This extra time allows any pending I/O operations (such as printing logs) to complete,
+        // preventing flakiness when Kotlin marks a test as complete.
+        setTimeout(() => {
+            originalExit(code);
+        }, 5000);
+    };
+})();


### PR DESCRIPTION
These tests pass now. 