### PR TITLE
Remove an obsolete change CL 1841395

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.kt
@@ -755,8 +755,6 @@ internal class SuspendingPointerInputModifierNodeImpl(
                 )
             }
 
-        if (newChanges.isEmpty()) return
-
         val cancelEvent = PointerEvent(newChanges)
 
         currentEvent = cancelEvent


### PR DESCRIPTION
The [check](https://android-review.googlesource.com/c/platform/frameworks/support/+/1841395) is not necessary anymore thanks to https://android-review.googlesource.com/c/platform/frameworks/support/+/1861780, which makes it impossible for `newChanges` list to be empty.

Note: YT issue - https://youtrack.jetbrains.com/issue/CMP-5766/ 