### PR TITLE
Restore commonMain to AOSP state (remove getter compilation fix)

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimeFormat.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimeFormat.kt
@@ -19,11 +19,5 @@ package androidx.compose.material3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 
-// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) revert to expect get()
-internal val is24HourFormat: Boolean
-  @Composable
-  @ReadOnlyComposable get() = is24HourFormat()
-
-@Composable
-@ReadOnlyComposable
-internal expect fun is24HourFormat(): Boolean
+internal expect val is24HourFormat: Boolean
+    @Composable @ReadOnlyComposable get

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TimePicker.kt
@@ -1984,16 +1984,8 @@ private enum class LayoutId {
     InnerCircle,
 }
 
-// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) fix expect composable getter
-@OptIn(ExperimentalMaterial3Api::class)
-internal val defaultTimePickerLayoutType: TimePickerLayoutType
-    @Composable
-    @ReadOnlyComposable get() = defaultTimePickerLayoutType()
-
-@Composable
-@ReadOnlyComposable
-@OptIn(ExperimentalMaterial3Api::class)
-internal expect fun defaultTimePickerLayoutType() : TimePickerLayoutType
+internal expect val defaultTimePickerLayoutType: TimePickerLayoutType
+    @Composable @ReadOnlyComposable get
 
 private const val FullCircle: Float = (PI * 2).toFloat()
 private const val HalfCircle: Float = FullCircle / 2f

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/internal/SystemBarsDefaultInsets.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/internal/SystemBarsDefaultInsets.kt
@@ -19,9 +19,5 @@ package androidx.compose.material3.internal
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.runtime.Composable
 
-// TODO(https://github.com/JetBrains/compose-multiplatform/issues/3373) revert to expect get()
-internal val WindowInsets.Companion.systemBarsForVisualComponents: WindowInsets
-    @Composable get() = systemBarsForVisualComponents()
-
-@Composable
-internal expect fun WindowInsets.Companion.systemBarsForVisualComponents(): WindowInsets
+internal expect val WindowInsets.Companion.systemBarsForVisualComponents: WindowInsets
+    @Composable get

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimeFormat.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimeFormat.skiko.kt
@@ -20,7 +20,7 @@ import androidx.compose.material3.internal.PlatformDateFormat
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 
-@Composable
-@ReadOnlyComposable
-internal actual fun is24HourFormat(): Boolean =
-    PlatformDateFormat(defaultLocale()).is24HourFormat()
+internal actual val is24HourFormat
+    @Composable
+    @ReadOnlyComposable
+    get(): Boolean = PlatformDateFormat(defaultLocale()).is24HourFormat()

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimePicker.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/TimePicker.skiko.kt
@@ -21,16 +21,17 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalWindowInfo
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
-@Composable
-@ReadOnlyComposable
-internal actual fun defaultTimePickerLayoutType(): TimePickerLayoutType {
-    return with(LocalWindowInfo.current) {
-        if (containerSize.height < containerSize.width) {
-            TimePickerLayoutType.Horizontal
-        } else {
-            TimePickerLayoutType.Vertical
+internal actual val defaultTimePickerLayoutType
+    @OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+    @Composable
+    @ReadOnlyComposable
+    get(): TimePickerLayoutType {
+        return with(LocalWindowInfo.current) {
+            if (containerSize.height < containerSize.width) {
+                TimePickerLayoutType.Horizontal
+            } else {
+                TimePickerLayoutType.Vertical
+            }
         }
     }
-}
 

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/SystemBarsDefaultInsets.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/SystemBarsDefaultInsets.skiko.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 
-// TODO upstream to commonMain
-@Composable
-internal actual fun WindowInsets.Companion.systemBarsForVisualComponents(): WindowInsets =
-    WindowInsets.systemBars
+internal actual val WindowInsets.Companion.systemBarsForVisualComponents
+    @Composable
+    get(): WindowInsets = WindowInsets.systemBars


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/CMP-3373 is no longer reproducible (code compiles)

Restore to the last merged Material3 (1.4.0-alpha04) for code changed in https://youtrack.jetbrains.com/issue/CMP-3373

## Testing
- CI passes

## Release Notes
N/A