### PR TITLE
Align ComposableLambda k/wasm implementation with k/jvm and k/native

### DIFF
--- a/compose/runtime/runtime/src/wasmJsMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.wasm.kt
+++ b/compose/runtime/runtime/src/wasmJsMain/kotlin/androidx/compose/runtime/internal/ComposableLambda.wasm.kt
@@ -33,261 +33,33 @@ import androidx.compose.runtime.Stable
 
 @ComposeCompilerApi
 @Stable
-actual interface ComposableLambda {
-    actual operator fun invoke(c: Composer, changed: Int): Any?
-
-    actual operator fun invoke(p1: Any?, c: Composer, changed: Int): Any?
-
-    actual operator fun invoke(p1: Any?, p2: Any?, c: Composer, changed: Int): Any?
-
-    actual operator fun invoke(p1: Any?, p2: Any?, p3: Any?, c: Composer, changed: Int): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        c: Composer,
-        changed: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        c: Composer,
-        changed: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        c: Composer,
-        changed: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        c: Composer,
-        changed: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        c: Composer,
-        changed: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        c: Composer,
-        changed: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        p13: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        p13: Any?,
-        p14: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        p13: Any?,
-        p14: Any?,
-        p15: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        p13: Any?,
-        p14: Any?,
-        p15: Any?,
-        p16: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        p13: Any?,
-        p14: Any?,
-        p15: Any?,
-        p16: Any?,
-        p17: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-
-    actual operator fun invoke(
-        p1: Any?,
-        p2: Any?,
-        p3: Any?,
-        p4: Any?,
-        p5: Any?,
-        p6: Any?,
-        p7: Any?,
-        p8: Any?,
-        p9: Any?,
-        p10: Any?,
-        p11: Any?,
-        p12: Any?,
-        p13: Any?,
-        p14: Any?,
-        p15: Any?,
-        p16: Any?,
-        p17: Any?,
-        p18: Any?,
-        c: Composer,
-        changed: Int,
-        changed1: Int
-    ): Any?
-}
+actual interface ComposableLambda :
+    Function2<Composer, Int, Any?>,
+    Function3<Any?, Composer, Int, Any?>,
+    Function4<Any?, Any?, Composer, Int, Any?>,
+    Function5<Any?, Any?, Any?, Composer, Int, Any?>,
+    Function6<Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+    Function7<Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+    Function8<Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+    Function9<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+    Function10<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+    Function11<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Any?>,
+    Function13<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Int,
+        Any?>,
+    Function14<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer, Int, Int,
+        Any?>,
+    Function15<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Composer,
+        Int, Int, Any?>,
+    Function16<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+        Composer, Int, Int, Any?>,
+    Function17<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+        Composer, Int,
+        Int, Any?>,
+    Function18<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+        Any?, Composer, Int, Int, Any?>,
+    Function19<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+        Any?, Any?, Composer, Int, Int, Any?>,
+    Function20<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+        Any?, Any?, Any?, Composer, Int, Int, Any?>,
+    Function21<Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?, Any?,
+        Any?, Any?, Any?, Any?, Composer, Int, Int, Any?>

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+config.client.mocha = config.client.mocha || {};
+config.client.mocha.timeout = 10000;
+
 config.customLaunchers = {
     ChromeForComposeTests: {
         base: "Chrome",


### PR DESCRIPTION
Due to some similarities between k/js and k/wasm targets, the previous implementation was taken from k/js where it's not possible to inherit from kotlin.Function types. But it's not the case in k/wasm.