### PR TITLE
Fix missed implementation for `DrawerPredictiveBackHandler`

### DIFF
--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/NavigationDrawer.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/NavigationDrawer.skiko.kt
@@ -16,13 +16,81 @@
 
 package androidx.compose.material3
 
+import androidx.compose.animation.core.animate
+import androidx.compose.material3.internal.BackEventCompat
+import androidx.compose.material3.internal.PredictiveBack
+import androidx.compose.material3.internal.PredictiveBackHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.launch
 
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-1301/Implement-DrawerPredictiveBackHandler
-
+// This is a copy-paste from NavigationDrawer.android.kt
+//  TODO: Remove expect/actual and move this code to common
 @Composable
 internal actual fun DrawerPredictiveBackHandler(
     drawerState: DrawerState,
     content: @Composable (DrawerPredictiveBackState) -> Unit
 ) {
+    val drawerPredictiveBackState = remember { DrawerPredictiveBackState() }
+    val scope = rememberCoroutineScope()
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+    val maxScaleXDistanceGrow: Float
+    val maxScaleXDistanceShrink: Float
+    val maxScaleYDistance: Float
+    with(LocalDensity.current) {
+        maxScaleXDistanceGrow = PredictiveBackDrawerMaxScaleXDistanceGrow.toPx()
+        maxScaleXDistanceShrink = PredictiveBackDrawerMaxScaleXDistanceShrink.toPx()
+        maxScaleYDistance = PredictiveBackDrawerMaxScaleYDistance.toPx()
+    }
+
+    PredictiveBackHandler(enabled = drawerState.isOpen) { progress ->
+        try {
+            progress.collect { backEvent ->
+                drawerPredictiveBackState.update(
+                    PredictiveBack.transform(backEvent.progress),
+                    backEvent.swipeEdge == BackEventCompat.EDGE_LEFT,
+                    isRtl,
+                    maxScaleXDistanceGrow,
+                    maxScaleXDistanceShrink,
+                    maxScaleYDistance
+                )
+            }
+        } catch (e: CancellationException) {
+            drawerPredictiveBackState.clear()
+        } finally {
+            if (drawerPredictiveBackState.swipeEdgeMatchesDrawer) {
+                // If swipe edge matches drawer gravity and we've stretched the drawer horizontally,
+                // un-stretch it smoothly so that it hides completely during the drawer close.
+                scope.launch {
+                    animate(
+                        initialValue = drawerPredictiveBackState.scaleXDistance,
+                        targetValue = 0f
+                    ) { value, _ ->
+                        drawerPredictiveBackState.scaleXDistance = value
+                    }
+                    drawerPredictiveBackState.clear()
+                }
+            }
+            drawerState.close()
+        }
+    }
+
+    LaunchedEffect(drawerState.isClosed) {
+        if (drawerState.isClosed) {
+            drawerPredictiveBackState.clear()
+        }
+    }
+
+    content(drawerPredictiveBackState)
 }
+
+internal val PredictiveBackDrawerMaxScaleXDistanceGrow = 12.dp
+internal val PredictiveBackDrawerMaxScaleXDistanceShrink = 24.dp
+internal val PredictiveBackDrawerMaxScaleYDistance = 48.dp


### PR DESCRIPTION
Since `PredictiveBackHandler` were previously commonized (without actual implementation yet), it's no longer necessary to wrap usages of it into expect/actual. It fixes missing implementation of `DrawerPredictiveBackHandler` on non-Android platforms.

Fixes https://youtrack.jetbrains.com/issue/CMP-1301 and https://youtrack.jetbrains.com/issue/CMP-7309

## Release Notes
### Fixes - Multiple Platforms
- Fix missing implementation on non-Android platforms for `ModalDrawerSheet` overload with `DrawerState` argument