### PR TITLE
New layers. Fix 7% FPS regression

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
@@ -325,7 +325,7 @@ actual class GraphicsLayer internal constructor(
                 drawShadow(canvas)
             }
 
-            if (clip || shadowElevation > 0f) {
+            if (clip) {
                 canvas.save()
                 restoreCount++
 

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.toSize
 import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.jetbrains.skia.IRect
 import org.jetbrains.skia.Surface
@@ -520,7 +521,48 @@ class SkiaGraphicsLayerTest {
                     return shadowCount > 0
                 }
                 with(pixmap) {
+                    // Verify that pixels above top edge have some shadow
                     assertTrue(
+                        hasShadowPixels(
+                            targetColor,
+                            left,
+                            top - 4,
+                            right,
+                            top
+                        )
+                    )
+                    // Verify that pixels to the left of the left edge have some shadow
+                    assertTrue(
+                        hasShadowPixels(
+                            targetColor,
+                            left - 4,
+                            top,
+                            left,
+                            bottom
+                        )
+                    )
+                    // Verify that pixels to the right of the right edge have some shadow
+                    assertTrue(
+                        hasShadowPixels(
+                            targetColor,
+                            right,
+                            top,
+                            right + 4,
+                            bottom
+                        )
+                    )
+                    // Verify that pixels to the below the bottom edge have some shadow
+                    assertTrue(
+                        hasShadowPixels(
+                            targetColor,
+                            left,
+                            bottom,
+                            right,
+                            bottom + 4
+                        )
+                    )
+                    // Verify that interior top left region does not have shadow pixels
+                    assertFalse(
                         hasShadowPixels(
                             targetColor,
                             left,
@@ -529,7 +571,8 @@ class SkiaGraphicsLayerTest {
                             top + radius.toInt()
                         )
                     )
-                    assertTrue(
+                    // Verify that interior top right region does not have shadow pixels
+                    assertFalse(
                         hasShadowPixels(
                             targetColor,
                             right - radius.toInt(),
@@ -538,7 +581,8 @@ class SkiaGraphicsLayerTest {
                             top + radius.toInt()
                         )
                     )
-                    assertTrue(
+                    // Verify that interior bottom left region does not have shadow pixels
+                    assertFalse(
                         hasShadowPixels(
                             targetColor,
                             left,
@@ -547,7 +591,8 @@ class SkiaGraphicsLayerTest {
                             bottom
                         )
                     )
-                    assertTrue(
+                    // Verify that interior bottom right region does not have shadow pixels
+                    assertFalse(
                         hasShadowPixels(
                             targetColor,
                             right - radius.toInt(),
@@ -557,7 +602,7 @@ class SkiaGraphicsLayerTest {
                         )
                     )
                 }
-            }
+            },
         )
     }
 
@@ -911,9 +956,9 @@ class SkiaGraphicsLayerTest {
                 val fullSize = size
                 val layerSize =
                     Size(
-                            fullSize.width.roundToInt() - inset * 2,
-                            fullSize.height.roundToInt() - inset * 2
-                        )
+                        fullSize.width.roundToInt() - inset * 2,
+                        fullSize.height.roundToInt() - inset * 2
+                    )
                         .toIntSize()
 
                 val layer =


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7359/10-FPS-regression-after-changing-layer-implementation
Fixes https://youtrack.jetbrains.com/issue/CMP-6619

Also removes clipping where it shouldn't clip. Example:
```
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.runtime.Composable
import androidx.compose.ui.Modifier
import androidx.compose.ui.draw.drawWithCache
import androidx.compose.ui.geometry.Offset
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.graphics.drawscope.translate
import androidx.compose.ui.graphics.layer.drawLayer
import androidx.compose.ui.unit.IntSize
import androidx.compose.ui.unit.toSize

var left = 0
var top = 0
var right = 0
var bottom = 0
val targetColor = Color.White
val radius = 50f

@Composable
fun MainView() {
    Box(Modifier.fillMaxSize().drawWithCache {
        val halfSize =
            IntSize((this.size.width / 2f).toInt(), (this.size.height / 2f).toInt())

        left = (this.size.width / 4f).toInt()
        top = (this.size.width / 4f).toInt()
        right = left + halfSize.width
        bottom = top + halfSize.height

        val layer =
            obtainGraphicsLayer().apply {
                record(size = halfSize) { drawRect(targetColor) }
                setRoundRectOutline(Offset.Zero, halfSize.toSize(), radius)
                shadowElevation = 20f
            }

        onDrawWithContent {
            drawRect(targetColor)
            translate(left.toFloat(), top.toFloat()) { drawLayer(layer) }
        }
    })
}
```
Looks the same on Android now:
<img src="https://github.com/user-attachments/assets/099da4fe-793b-46a8-bd3b-40c1113f4f74" width="200"><img src="https://github.com/user-attachments/assets/5eeaaab2-2f7f-449f-a10d-60896844a8c5" width="200">

Previous behaviour:
<img src="https://github.com/user-attachments/assets/a2c6a267-bd34-439c-b249-6b258ffafc3e" width="200">


## Testing
1. Performance see https://youtrack.jetbrains.com/issue/CMP-7359/10-FPS-regression-after-changing-layer-implementation#focus=Comments-27-11366632.0-0

2. The changed test `SkiaGraphicsLayerTest.testElevationRoundRect` tests the same behavior as `AndroidGraphicsLayerTest.testElevationRoundRect` (the test was copied from there)