### PR TITLE
Fix failing desktop tests

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -24,7 +24,7 @@ import org.junit.Test
 @OptIn(ExperimentalComposeUiApi::class)
 class ComposeSceneInputTest {
     @Test
-    fun move() = ImageComposeScene(100, 100).use { scene ->
+    fun move() = ImageComposeScene(100, 100).useInUiThread { scene ->
         val background = FillBox()
 
         scene.setContent {
@@ -54,7 +54,7 @@ class ComposeSceneInputTest {
     }
 
     @Test
-    fun `move to popup`() = ImageComposeScene(100, 100).use { scene ->
+    fun `move to popup`() = ImageComposeScene(100, 100).useInUiThread { scene ->
         val background = FillBox()
         val cutPopup = PopupState(IntRect(-20, -20, 40, 40))
         val overlappedPopup = PopupState(IntRect(20, 20, 60, 60))
@@ -118,7 +118,7 @@ class ComposeSceneInputTest {
     }
 
     @Test
-    fun click() = ImageComposeScene(100, 100).use { scene ->
+    fun click() = ImageComposeScene(100, 100).useInUiThread { scene ->
         val background = FillBox()
 
         scene.setContent {
@@ -149,7 +149,7 @@ class ComposeSceneInputTest {
     fun `pressed popup should own received moves outside popup`() = ImageComposeScene(
         100,
         100
-    ).use { scene ->
+    ).useInUiThread { scene ->
         val background = FillBox()
         val cutPopup = PopupState(IntRect(-20, -20, 40, 40))
         val overlappedPopup = PopupState(IntRect(20, 20, 60, 60))
@@ -269,7 +269,7 @@ class ComposeSceneInputTest {
     }
 
     @Test
-    fun scroll() = ImageComposeScene(100, 100).use { scene ->
+    fun scroll() = ImageComposeScene(100, 100).useInUiThread { scene ->
         val background = FillBox()
 
         scene.setContent {
@@ -295,7 +295,7 @@ class ComposeSceneInputTest {
     }
 
     @Test
-    fun touch() = ImageComposeScene(100, 100).use { scene ->
+    fun touch() = ImageComposeScene(100, 100).useInUiThread { scene ->
         val background = FillBox()
 
         scene.setContent {
@@ -333,7 +333,7 @@ class ComposeSceneInputTest {
     @Test
     fun `multitouch, send multiple touch changes as multiple events`() = ImageComposeScene(
         100, 100
-    ).use { scene ->
+    ).useInUiThread { scene ->
         val background = FillBox()
 
         scene.setContent {
@@ -405,7 +405,7 @@ class ComposeSceneInputTest {
     @Test
     fun `multitouch, send multiple touch changes in a single event`() = ImageComposeScene(
         100, 100
-    ).use { scene ->
+    ).useInUiThread { scene ->
         val background = FillBox()
 
         scene.setContent {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeWindowTest.kt
@@ -43,6 +43,7 @@ import java.awt.event.MouseEvent.BUTTON1
 import java.awt.event.MouseEvent.MOUSE_ENTERED
 import java.awt.event.MouseEvent.MOUSE_MOVED
 import java.awt.event.WindowEvent
+import kotlin.math.roundToInt
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.GraphicsApi
@@ -155,8 +156,8 @@ class ComposeWindowTest {
 
                 assertThat(window.windowContext.windowInfo.containerSize)
                     .isEqualTo(IntSize(
-                        width = (234 * window.density.density).toInt(),
-                        height = (345 * window.density.density).toInt(),
+                        width = (234 * window.density.density).roundToInt(),
+                        height = (345 * window.density.density).roundToInt(),
                     ))
             } finally {
                 window.dispose()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.window.window.toSize
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
@@ -556,7 +557,7 @@ class DialogWindowTest {
                         // toInt() because this is how ComposeWindow rounds decimal sizes
                         // (see ComposeBridge.updateSceneSize)
                         actualCanvasSize = size.toInt()
-                        expectedCanvasSizePx = expectedCanvasSize().toSize().toInt()
+                        expectedCanvasSizePx = expectedCanvasSize().toSize().roundToIntSize()
                     }
                 }
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -47,10 +47,10 @@ import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
-import java.awt.SystemColor.window
 import java.awt.Toolkit
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import kotlin.math.roundToInt
 import kotlin.test.assertEquals
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -636,8 +636,8 @@ class WindowTest {
             assertEquals(1, constraintsList.size)
             assertEquals(
                 Constraints(
-                    maxWidth = expectedSize.width.toInt(),
-                    maxHeight = expectedSize.height.toInt()
+                    maxWidth = expectedSize.width.roundToInt(),
+                    maxHeight = expectedSize.height.roundToInt()
                 ),
                 constraintsList.first()
             )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -468,7 +468,7 @@ class WindowTest {
                         // toInt() because this is how the ComposeWindow rounds decimal sizes
                         // (see ComposeBridge.updateSceneSize)
                         actualCanvasSize = size.toInt()
-                        expectedCanvasSizePx = expectedCanvasSize().toSize().toInt()
+                        expectedCanvasSizePx = expectedCanvasSize().toSize().roundToIntSize()
                     }
                 }
             }


### PR DESCRIPTION
1. Fix flaky tests because of [GlobalSnapshotManager](https://youtrack.jetbrains.com/issue/CMP-7374/Execution-of-ComposeScenes-in-other-threads-is-affected-by-GlobalSnapshotManager-in-main-thread):
```
Expected :Exit
Actual   :Move
<Click to see difference>

java.lang.AssertionError: expected:<Exit> but was:<Move>
	at androidx.compose.ui.AssertKt.isEqualTo(Assert.kt:26)
	at androidx.compose.ui.EventTestUtilsKt.assertHas-PfEQiPw(EventTestUtils.kt:65)
	at androidx.compose.ui.EventTestUtilsKt.assertReceivedLast-PfEQiPw(EventTestUtils.kt:58)
	at androidx.compose.ui.ComposeSceneInputTest.move to popup(ComposeSceneInputTest.kt:92)
```

2. Fix failing window desktop tests if density = 1.5:
```
expected: 351 x 517
but was : 351 x 518
Expected :351 x 517
Actual   :351 x 518
<Click to see difference>

expected: 351 x 517
but was : 351 x 518
	at androidx.compose.ui.awt.ComposeWindowTest$don't override user preferred size$1.invokeSuspend(ComposeWindowTest.kt:158)
```