### PR TITLE
Fix the transparency hack on Windows

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -32,7 +32,6 @@ import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelListener
-import javax.swing.JLayeredPane
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
 /**
@@ -42,7 +41,7 @@ internal class ComposeWindowPanel(
     private val window: Window,
     private val isUndecorated: () -> Boolean,
     skiaLayerAnalytics: SkiaLayerAnalytics,
-) : JLayeredPane() {
+) : JLayeredPaneWithTransparencyHack() {
     private var isDisposed = false
 
     // AWT can leak JFrame in some cases
@@ -87,7 +86,7 @@ internal class ComposeWindowPanel(
                 }
                 field = value
                 composeContainer.onWindowTransparencyChanged(value)
-                setTransparent(value)
+                isOpaque = !value
                 window.background = getTransparentWindowBackground(value, renderApi)
             }
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -18,9 +18,9 @@ package androidx.compose.ui.scene
 
 import org.jetbrains.skia.Rect as SkRect
 import androidx.compose.runtime.CompositionContext
+import androidx.compose.ui.awt.JLayeredPaneWithTransparencyHack
 import androidx.compose.ui.awt.RenderSettings
 import androidx.compose.ui.awt.getTransparentWindowBackground
-import androidx.compose.ui.awt.setTransparent
 import androidx.compose.ui.awt.toAwtRectangle
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
@@ -42,7 +42,6 @@ import java.awt.Point
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import javax.swing.JDialog
-import javax.swing.JLayeredPane
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
@@ -73,14 +72,14 @@ internal class WindowComposeSceneLayer(
             renderApi = composeContainer.renderApi
         )
     }
-    private val container = object : JLayeredPane() {
+    private val container = object : JLayeredPaneWithTransparencyHack() {
         override fun addNotify() {
             super.addNotify()
             mediator?.onComponentAttached()
         }
     }.also {
         it.layout = null
-        it.setTransparent(transparent)
+        it.isOpaque = !transparent
 
         dialog.contentPane = it
     }


### PR DESCRIPTION
by drawing the background manually, without setting `isOpaque==true`.

Fixes https://youtrack.jetbrains.com/issue/CMP-7354

## Testing
Tested manually on Windows with
```
@OptIn(ExperimentalFoundationApi::class)
fun main() = application {
    val windowState = rememberWindowState()
    Window(
        state = windowState,
        onCloseRequest = ::exitApplication,
        transparent = true,
        undecorated = true
    ) {
        Box(
            modifier = Modifier
                .size(100.dp)
                .background(Color.Cyan)
                .onClick {
                    windowState.position =
                        WindowPosition.Absolute(
                            x = windowState.position.x + 4.dp,
                            y = windowState.position.y + 4.dp
                        )
                }
        )
    }
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed the background of transparent windows/dialogs on Windows becoming opaque as the window is moved.