### PR TITLE
Revert Hoverable to AOSP state

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Hoverable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Hoverable.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.unit.IntSize
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
 /**
@@ -87,10 +86,8 @@ private class HoverableNode(private var interactionSource: MutableInteractionSou
     ) {
         if (pass == PointerEventPass.Main) {
             when (pointerEvent.type) {
-                PointerEventType.Enter -> coroutineScope
-                    .launch(start = CoroutineStart.UNDISPATCHED) { emitEnter() }
-                PointerEventType.Exit -> coroutineScope
-                    .launch(start = CoroutineStart.UNDISPATCHED) { emitExit() }
+                PointerEventType.Enter -> coroutineScope.launch { emitEnter() }
+                PointerEventType.Exit -> coroutineScope.launch { emitExit() }
             }
         }
     }


### PR DESCRIPTION
Reverted to https://github.com/androidx/androidx/blob/6c04a79c5c3a5fdb6d5221eb344fe1ed98227957/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/Hoverable.kt#L89

The changes were added to avoid input lag during scrolling on hoverable items: https://github.com/JetBrains/compose-multiplatform-core/pull/188

But after that we introduced another change - flush all effects before each frame (https://github.com/JetBrains/compose-multiplatform-core/pull/1260):
```
BaseComposeScene {
  override fun render(canvas: Canvas, nanoTime: Long) {
    recomposer.performScheduledEffects()
    ...
  }
}
```
This makes the first fix not needed.

## Testing
```
import androidx.compose.foundation.background
import androidx.compose.foundation.hoverable
import androidx.compose.foundation.interaction.HoverInteraction
import androidx.compose.foundation.interaction.MutableInteractionSource
import androidx.compose.foundation.layout.fillMaxWidth
import androidx.compose.foundation.layout.height
import androidx.compose.foundation.lazy.LazyColumn
import androidx.compose.foundation.lazy.items
import androidx.compose.material.Text
import androidx.compose.runtime.Composable
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.runtime.getValue
import androidx.compose.runtime.mutableStateOf
import androidx.compose.runtime.remember
import androidx.compose.runtime.setValue
import androidx.compose.ui.Modifier
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication

fun main() {
    singleWindowApplication {
        Test()
    }
}

@Composable
private fun Test() {
    LazyColumn {
        items((0..200).toList()) {
            val interactionSource = remember { MutableInteractionSource() }
            var hovered by remember { mutableStateOf(false) }
            LaunchedEffect(interactionSource) {
                interactionSource.interactions.collect { interaction ->
                    when (interaction) {
                        is HoverInteraction.Enter -> hovered = true
                        is HoverInteraction.Exit -> hovered = false
                    }
                }
            }

            Text(
                it.toString(),
                Modifier
                    .background(if (hovered) Color.Blue else Color.White)
                    .hoverable(interactionSource)
                    .height(20.dp)
                    .fillMaxWidth()
            )
        }
    }
}
```

Scroll without moving - see that latency of hovers didn't change compared to the jb-main state

## Release Notes
N/A