### PR TITLE
Fix interop initial z-order placement on Windows

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropContainer.desktop.kt
@@ -131,25 +131,6 @@ internal class SwingInteropContainer(
 
     private val scheduledUpdatesSwapchain = ScheduledUpdatesSwapchain(requestRedraw)
 
-    /**
-     * Index of last interop component in [root].
-     *
-     * [ComposeSceneMediator] might keep extra components in the same container.
-     * So based on [placeInteropAbove] they should go below or under all interop views.
-     *
-     * @see ComposeSceneMediator.contentComponent
-     * @see ComposeSceneMediator.invisibleComponent
-     */
-    private val lastInteropIndex: Int
-        get() {
-            var lastInteropIndex = interopComponents.size - 1
-            if (!placeInteropAbove) {
-                val nonInteropComponents = root.componentCount - interopComponents.size
-                lastInteropIndex += nonInteropComponents
-            }
-            return lastInteropIndex
-        }
-
     override fun contains(holder: InteropViewHolder): Boolean =
         interopComponents.contains(holder.group)
 
@@ -168,6 +149,10 @@ internal class SwingInteropContainer(
             snapshotObserver.start()
         }
 
+        // [ComposeSceneMediator] might keep extra components in the same container.
+        // Reed it before modifying both [interopComponents] and [root] to get consistent result
+        val nonInteropComponents = root.componentCount - interopComponents.size
+
         // Add this component to [interopComponents] to track count and clip rects
         val alreadyAdded = group in interopComponents
         if (!alreadyAdded) {
@@ -176,6 +161,13 @@ internal class SwingInteropContainer(
 
         // Iterate through a Compose layout tree in draw order and count interop view below this one
         val countBelow = countInteropComponentsBelow(holder)
+
+        // Index of last interop component in [root]
+        var lastInteropIndex = interopComponents.size - 1
+        // Based on [placeInteropAbove] interop views should go below or under all interop views
+        if (!placeInteropAbove) {
+            lastInteropIndex += nonInteropComponents
+        }
 
         // AWT/Swing uses the **REVERSE ORDER** for drawing and events
         val awtIndex = lastInteropIndex - countBelow


### PR DESCRIPTION
Fix counting of non-interop components for initial interop placement on Windows. It was a regression after #1340: it subtracts `root.componentCount` before change and `interopComponents.size` after a change that results in an incorrect value during initial placement. Any further invalidations like window resizing corrected the problem.

Fixes https://youtrack.jetbrains.com/issue/CMP-7375

## Testing
Manually - screenshot testing in this case requires DX rendering, so our CI won't handle that.

## Release Notes
### Fixes - Desktop
- Fix interop initial z-order placement on Windows with `compose.interop.blending` flag (1.7.0 regression)
