### PR TITLE
Temporary revert global shadow positioning

### DIFF
--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayerTest.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.toIntSize
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toSize
 import kotlin.math.roundToInt
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -377,6 +378,7 @@ class SkiaGraphicsLayerTest {
         )
     }
 
+    @Ignore // Enable after switching to dynamic shadows
     @Test
     fun testElevation() {
         var layer: GraphicsLayer?
@@ -419,6 +421,7 @@ class SkiaGraphicsLayerTest {
         )
     }
 
+    @Ignore // Enable after switching to dynamic shadows
     @Test
     fun testElevationPath() {
         var layer: GraphicsLayer?
@@ -473,6 +476,7 @@ class SkiaGraphicsLayerTest {
         )
     }
 
+    @Ignore // Enable after switching to dynamic shadows
     @Test
     fun testElevationRoundRect() {
         var layer: GraphicsLayer?


### PR DESCRIPTION
Reverts shadow behavior changes from #1754 until #1766

In the current intermediate state it has the next problems:
- Missing shadows updates inside inner layers (might be fixed by introducing more states https://github.com/JetBrains/compose-multiplatform-core/commit/d3b624cb18527e4faf4fd973b29e7461c4919a35)
- Incorrect positioning of shadows in a scrollable list: position inside scroll inside position on screen (no easy fix, only #1766 or revert)