### PR TITLE
Remove AccessibilitySyncOptions. Make the accessibility tree load lazily.

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/NativePopupWithComposePopupExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/NativePopupWithComposePopupExample.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.AccessibilitySyncOptions
 import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ComposeUIViewController
@@ -55,18 +54,12 @@ import platform.UIKit.sheetPresentationController
 val NativePopupWithComposePopupExample = Screen.Example("Native popup with Compose popup") {
     val viewController = LocalUIViewController.current
 
-    val syncOptions = AccessibilitySyncOptions.WhenRequiredByAccessibilityServices
-
     Column {
         Button(onClick = {
             val presentedViewController = UIViewController(nibName = null, bundle = null)
             presentedViewController.view.backgroundColor = UIColor.yellowColor
 
-            val composeViewController = ComposeUIViewController(
-                configure = {
-                    accessibilitySyncOptions = syncOptions
-                }
-            ) {
+            val composeViewController = ComposeUIViewController {
                 var showComposePopup by remember { mutableStateOf(false) }
                 var showComposeDialog by remember { mutableStateOf(false) }
 
@@ -166,9 +159,7 @@ val NativePopupWithComposePopupExample = Screen.Example("Native popup with Compo
 
         Button(
             onClick = {
-                val composeViewController = ComposeUIViewController(configure = {
-                    accessibilitySyncOptions = syncOptions
-                }) {
+                val composeViewController = ComposeUIViewController {
                     IosDemo("", null)
                 }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -81,7 +81,7 @@ class ComponentsAccessibilitySemanticTest {
     @Test
     fun testButtonNodeActionAndSemantic() = runUIKitInstrumentedTest {
         var tapped = false
-        setContentWithAccessibilityEnabled {
+        setContent {
             Button({ tapped = true }) {
                 Text("Content")
             }
@@ -115,7 +115,7 @@ class ComponentsAccessibilitySemanticTest {
     @Test
     fun testProgressNodesSemantic() = runUIKitInstrumentedTest {
         var sliderValue = 0.4f
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Slider(
                     value = sliderValue,
@@ -162,7 +162,7 @@ class ComponentsAccessibilitySemanticTest {
     @Test
     fun testSliderAction() = runUIKitInstrumentedTest {
         var sliderValue = 0.4f
-        setContentWithAccessibilityEnabled {
+        setContent {
             Slider(
                 value = sliderValue,
                 onValueChange = { sliderValue = it },
@@ -182,7 +182,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testToggleAndCheckboxSemantic() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Switch(false, {})
                 Checkbox(false, {})
@@ -231,7 +231,7 @@ class ComponentsAccessibilitySemanticTest {
         var checkbox by mutableStateOf(false)
         var triStateCheckbox by mutableStateOf(ToggleableState.Off)
 
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Switch(
                     checked = switch,
@@ -271,7 +271,7 @@ class ComponentsAccessibilitySemanticTest {
     fun testRadioButtonSelection() = runUIKitInstrumentedTest {
         var selectedIndex by mutableStateOf(0)
 
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 RadioButton(selected = selectedIndex == 0, onClick = { selectedIndex = 0 })
                 RadioButton(selected = selectedIndex == 1, onClick = { selectedIndex = 1 })
@@ -342,7 +342,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testImageSemantics() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Image(
                     ImageBitmap(10, 10),
@@ -384,7 +384,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testTextSemantics() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Text("Static Text", modifier = Modifier.testTag("Text 1"))
                 Text("Custom Button", modifier = Modifier.testTag("Text 2").clickable { })
@@ -409,7 +409,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testDisabledSemantics() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Button({}, enabled = false) {}
                 TextField("", {}, enabled = false)
@@ -476,7 +476,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testHeadingSemantics() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Scaffold(topBar = {
                 TopAppBar {
                     Text("Header", modifier = Modifier.semantics { heading() })
@@ -514,7 +514,7 @@ class ComponentsAccessibilitySemanticTest {
             )
         }
 
-        setContentWithAccessibilityEnabled {
+        setContent {
             SelectionContainer {
                 Column {
                     Text("Title")
@@ -547,7 +547,7 @@ class ComponentsAccessibilitySemanticTest {
     fun testVisibleNodes() = runUIKitInstrumentedTest {
         var alpha by mutableStateOf(0f)
 
-        setContentWithAccessibilityEnabled {
+        setContent {
             Text("Hidden", modifier = Modifier.graphicsLayer {
                 this.alpha = alpha
             })
@@ -569,7 +569,7 @@ class ComponentsAccessibilitySemanticTest {
     fun testVisibleNodeContainers() = runUIKitInstrumentedTest {
         var alpha by mutableStateOf(0f)
 
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Text("Text 1")
                 Row(modifier = Modifier.graphicsLayer {
@@ -615,7 +615,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testAccessibilityContainer() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column(modifier = Modifier.testTag("Container")) {
                 Text("Text 1")
                 Text("Text 2")
@@ -638,7 +638,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testAccessibilityInterop() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column(modifier = Modifier.testTag("Container")) {
                 UIKitView(
                     factory = {
@@ -691,7 +691,7 @@ class ComponentsAccessibilitySemanticTest {
 
     @Test
     fun testChildrenOfCollapsedNode() = runUIKitInstrumentedTest {
-        setContentWithAccessibilityEnabled {
+        setContent {
             Column {
                 Row(modifier = Modifier.testTag("row").clickable {}) {
                     Text("Foo", modifier = Modifier.testTag("row_title"))

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/LayersAccessibilityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/LayersAccessibilityTest.kt
@@ -32,7 +32,7 @@ class LayersAccessibilityTest {
         val topPopup = mutableStateOf(false)
         val bottomPopup = mutableStateOf(false)
         val topPopupFocusable = mutableStateOf(false)
-        setContentWithAccessibilityEnabled {
+        setContent {
             Text("Root")
             if (bottomPopup.value) {
                 Popup {
@@ -93,7 +93,7 @@ class LayersAccessibilityTest {
     @Test
     fun testNodesCoveredByDialog() = runUIKitInstrumentedTest {
         val showDialog = mutableStateOf(false)
-        setContentWithAccessibilityEnabled {
+        setContent {
             Text("Root")
             Popup {
                 Text("Popup")
@@ -136,7 +136,7 @@ class LayersAccessibilityTest {
     fun testLayersAppearanceOrder() = runUIKitInstrumentedTest {
         val bottomLayer = mutableStateOf(false)
         val middleLayers = mutableStateOf(false)
-        setContentWithAccessibilityEnabled {
+        setContent {
             Text("Root")
             if (bottomLayer.value) {
                 Popup(properties = PopupProperties(focusable = true)) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -17,9 +17,7 @@
 package androidx.compose.ui.test
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.snapshots.Snapshot
-import androidx.compose.ui.platform.AccessibilitySyncOptions
 import androidx.compose.ui.platform.InfiniteAnimationPolicy
 import androidx.compose.ui.scene.ComposeHostingViewController
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
@@ -95,11 +93,6 @@ internal class UIKitInstrumentedTest {
     }
 
     private val coroutineContext = Dispatchers.Main + infiniteAnimationPolicy
-
-    @OptIn(ExperimentalComposeApi::class)
-    fun setContentWithAccessibilityEnabled(content: @Composable () -> Unit) {
-        setContent({ accessibilitySyncOptions = AccessibilitySyncOptions.Always }, content)
-    }
 
     fun setContent(
         configure: ComposeUIViewControllerConfiguration.() -> Unit = {},

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -617,7 +617,7 @@ internal class AccessibilityMediator(
     coroutineContext: CoroutineContext,
     val performEscape: () -> Boolean
 ) {
-    private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
+    private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.Initial
         set(value) {
             field = value
             debugLogger?.log("Focus mode: $focusMode")

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.accessibility.AccessibilityScrollEventResult
@@ -30,6 +29,7 @@ import androidx.compose.ui.platform.accessibility.isScreenReaderFocusable
 import androidx.compose.ui.platform.accessibility.scrollIfPossible
 import androidx.compose.ui.platform.accessibility.scrollToCenterRectIfNeeded
 import androidx.compose.ui.platform.accessibility.unclippedBoundsInWindow
+import androidx.compose.ui.scene.ComposeSceneMediatorView
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -38,8 +38,8 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.uikit.utils.CMPAccessibilityElement
 import androidx.compose.ui.unit.asCGRect
-import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.asDpRect
+import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toRect
 import androidx.compose.ui.viewinterop.InteropWrappingView
 import androidx.compose.ui.viewinterop.NativeAccessibilityViewSemanticsKey
@@ -302,6 +302,35 @@ private object CachedAccessibilityPropertyKeys {
 
 @OptIn(BetaInteropApi::class)
 @ExportObjCClass
+private class AccessibilityRoot(
+    val mediator: AccessibilityMediator
+) : CMPAccessibilityElement(DUMMY_UI_ACCESSIBILITY_CONTAINER) {
+    var element: AccessibilityElement? = null
+        set(value) {
+            field = value
+            field?.parent = this
+        }
+
+    override fun isAccessibilityElement(): Boolean = false
+
+    override fun accessibilityElementCount(): NSInteger = if (mediator.isEnabled) 1 else 0
+
+    override fun accessibilityElementAtIndex(index: NSInteger): Any? =
+        if (mediator.isEnabled) {
+            mediator.activateAccessibilityIfNeeded()
+            element
+        } else {
+            null
+        }
+
+    override fun accessibilityContainer() = mediator.view
+
+    override fun accessibilityFrame(): CValue<CGRect> =
+        mediator.view.convertRect(mediator.view.bounds, toView = null)
+}
+
+@OptIn(BetaInteropApi::class)
+@ExportObjCClass
 private class AccessibilityElement(
     private var node: AccessibilityNode,
     children: List<AccessibilityElement>
@@ -532,29 +561,6 @@ private class NodesSyncResult(
 )
 
 /**
- * A sealed class that represents the options for syncing the Compose SemanticsNode tree with the iOS UIAccessibility tree.
- */
-@ExperimentalComposeApi
-enum class AccessibilitySyncOptions {
-    /**
-     * Never sync the tree.
-     */
-    Never,
-
-    /**
-     * Sync the tree only when the accessibility services are running.
-     */
-    WhenRequiredByAccessibilityServices,
-
-    /**
-     * Always sync the tree, can be quite handy for debugging and testing.
-     * Be aware that there is a significant overhead associated with doing it that can degrade
-     * the visual performance of the app.
-     */
-    Always
-}
-
-/**
  * An interface for logging accessibility debug messages.
  */
 internal interface AccessibilityDebugLogger {
@@ -606,13 +612,12 @@ private sealed interface AccessibilityElementFocusMode {
  * A class responsible for mediating between the tree of specific SemanticsOwner and the iOS accessibility tree.
  */
 internal class AccessibilityMediator(
-    val view: UIView,
+    val view: ComposeSceneMediatorView,
     val owner: SemanticsOwner,
     coroutineContext: CoroutineContext,
     val performEscape: () -> Boolean
-): NSObject() {
-
-    private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.Initial
+) {
+    private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
         set(value) {
             field = value
             debugLogger?.log("Focus mode: $focusMode")
@@ -633,10 +638,6 @@ internal class AccessibilityMediator(
      */
     private val invalidationChannel = Channel<Unit>(1, onBufferOverflow = BufferOverflow.DROP_LATEST)
 
-    /**
-     * Remembered [AccessibilityDebugLogger] after last sync, if logging is enabled according to
-     * [AccessibilitySyncOptions].
-     */
     var debugLogger: AccessibilityDebugLogger? = null
         private set
 
@@ -650,7 +651,7 @@ internal class AccessibilityMediator(
      */
     private val coroutineScope = CoroutineScope(coroutineContext + job)
 
-    private var rootElement: AccessibilityElement? = null
+    private val root = AccessibilityRoot(mediator = this)
 
     /**
      * A map of all [AccessibilityElementKey] currently present in the tree to corresponding
@@ -678,13 +679,18 @@ internal class AccessibilityMediator(
     init {
         accessibilityDebugLogger?.log("AccessibilityMediator for $view created")
 
-        view.accessibilityElements = listOf<NSObject>()
+        view.accessibilityElements = listOf(root)
         coroutineScope.launch {
             // The main loop that listens for invalidations and performs the tree syncing
             // Will exit on CancellationException from within await on `invalidationChannel.receive()`
             // when [job] is cancelled
             while (true) {
                 invalidationChannel.receive()
+
+                // Estimated delay between the iOS Accessibility Engine sync intervals.
+                // There is no reason to post change notifications more frequently because the iOS
+                // Accessibility Engine will ignore them.
+                delay(100)
 
                 while (invalidationChannel.tryReceive().isSuccess) {
                     // Do nothing, just consume the channel
@@ -694,31 +700,56 @@ internal class AccessibilityMediator(
                 debugLogger = accessibilityDebugLogger.takeIf { isEnabled }
 
                 if (isEnabled) {
-                    val result: NodesSyncResult
-
-                    val time = measureTime {
-                        result = sync(invalidationKind)
+                    if (isAccessibilityActive) {
+                        scheduleAccessibilityDisablingAndCleanup()
+                        val time = measureTime {
+                            sync(invalidationKind)
+                        }
+                        debugLogger?.log("AccessibilityMediator.sync took $time")
                     }
-
-                    debugLogger?.log("AccessibilityMediator.sync took $time")
-                    debugLogger?.log("LayoutChanged, newElementToFocus: ${result.newElementToFocus}")
-
-                    val notificationName = if (result.isScreenChange) {
-                        UIAccessibilityScreenChangedNotification
-                    } else {
-                        UIAccessibilityLayoutChangedNotification
-                    }
-                    UIAccessibilityPostNotification(notificationName, result.newElementToFocus)
-                } else {
-                    if (view.accessibilityElements?.isEmpty() != true) {
-                        view.accessibilityElements = listOf<NSObject>()
-                        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, null)
-                    }
+                } else if (root.element != null) {
+                    root.element = null
+                    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, null)
                 }
 
                 invalidationKind = SemanticsTreeInvalidationKind.BOUNDS
             }
         }
+    }
+
+    /**
+     * Indicates that accessibility has recently been requested and can be considered active.
+     * The flag is set to false if no accessibility tree reads occur for some time.
+     */
+    private var isAccessibilityActive: Boolean = false
+
+    private var disableAccessibilityJob: Job? = null
+
+    private fun scheduleAccessibilityDisablingAndCleanup() {
+        if (disableAccessibilityJob != null) {
+            return
+        }
+        disableAccessibilityJob = coroutineScope.launch {
+            // Allow some time for the iOS Accessibility Engine to read the updated accessibility
+            // elements tree. If no new reads occur during this time, it is assumed that iOS
+            // Accessibility has been disabled and resources can be cleaned up.
+            delay(2000)
+
+            cleanUp()
+        }
+    }
+
+    private fun cancelAccessibilityDisabling() {
+        disableAccessibilityJob?.cancel()
+        disableAccessibilityJob = null
+    }
+
+    fun activateAccessibilityIfNeeded() {
+        isAccessibilityActive = true
+        if (root.element == null) {
+            completeSync().postNotification()
+        }
+        cancelAccessibilityDisabling()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -779,12 +810,21 @@ internal class AccessibilityMediator(
 
     fun dispose() {
         job.cancel()
+        disableAccessibilityJob?.cancel()
         view.accessibilityElements = listOf<NSObject>()
 
         for (element in accessibilityElementsMap.values) {
             element.dispose()
         }
-        rootElement = null
+
+        cleanUp()
+    }
+
+    private fun cleanUp() {
+        disableAccessibilityJob = null
+        isAccessibilityActive = false
+
+        root.element = null
         accessibilityElementsMap.clear()
     }
 
@@ -885,8 +925,7 @@ internal class AccessibilityMediator(
             "Root view must not be an accessibility element"
         }
 
-        rootElement = traverseSemanticsTree(rootSemanticsNode)
-        view.accessibilityElements = listOfNotNull(rootElement)
+        root.element = traverseSemanticsTree(rootSemanticsNode)
 
         debugLogger?.let {
             debugTraverse(it, view)
@@ -912,7 +951,7 @@ internal class AccessibilityMediator(
                 if (element != null && !CGRectIsEmpty(element.accessibilityFrame())) {
                     NodesSyncResult(element.takeIf { it !== focusedElement }, isScreenChange = false)
                 } else if (focusedElement is AccessibilityElement) {
-                    val newFocusedElement = rootElement?.let { findFocusableElement(it) }
+                    val newFocusedElement = root.element?.let { findFocusableElement(it) }
 
                     focusMode = if (newFocusedElement is AccessibilityElement) {
                         AccessibilityElementFocusMode.KeepFocus(newFocusedElement.key)
@@ -958,10 +997,7 @@ internal class AccessibilityMediator(
             return null
         }
 
-        rootElement?.let {
-            @Suppress("CAST_NEVER_SUCCEEDS")
-            findElement(it as NSObject, centerPoint)
-        }
+        findElement(root as NSObject, centerPoint)
 
         return closestElement?.second
     }
@@ -1003,6 +1039,15 @@ internal class AccessibilityMediator(
         }
         return null
     }
+
+    private fun NodesSyncResult.postNotification() {
+        val notificationName = if (isScreenChange) {
+            UIAccessibilityScreenChangedNotification
+        } else {
+            UIAccessibilityLayoutChangedNotification
+        }
+        UIAccessibilityPostNotification(notificationName, newElementToFocus)
+    }
 }
 
 /**
@@ -1037,6 +1082,13 @@ private fun debugTraverse(debugLogger: AccessibilityDebugLogger, accessibilityOb
             }
         }
 
+        is AccessibilityRoot -> {
+            debugLogger.log("${indent}Root")
+            accessibilityObject.element?.let {
+                debugTraverse(debugLogger, it, depth + 1)
+            }
+        }
+
         else -> {
             throw IllegalStateException("Unexpected accessibility object type: ${accessibilityObject::class}")
         }
@@ -1052,6 +1104,11 @@ private fun debugContainmentChain(accessibilityObject: Any): String {
         when (val constCurrentObject = currentObject) {
             is AccessibilityElement -> {
                 currentObject = constCurrentObject.parent
+            }
+
+            is AccessibilityRoot -> {
+                strings.add("Root")
+                currentObject = constCurrentObject.accessibilityContainer()
             }
 
             is UIView -> {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.SystemTheme
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.hapticfeedback.CupertinoHapticFeedback
-import androidx.compose.ui.platform.AccessibilitySyncOptions
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
@@ -60,8 +59,6 @@ import kotlin.time.toDuration
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
-import kotlinx.cinterop.ObjCAction
-import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -69,11 +66,6 @@ import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGSize
-import platform.Foundation.NSNotificationCenter
-import platform.Foundation.NSSelectorFromString
-import platform.UIKit.UIAccessibilityIsVoiceOverRunning
-import platform.UIKit.UIAccessibilityVoiceOverStatusChanged
-import platform.UIKit.UIAccessibilityVoiceOverStatusDidChangeNotification
 import platform.UIKit.UIApplication
 import platform.UIKit.UIEvent
 import platform.UIKit.UIStatusBarAnimation
@@ -187,13 +179,6 @@ internal class ComposeHostingViewController(
 
         configuration.delegate.viewDidLoad()
         systemThemeState.value = traitCollection.userInterfaceStyle.asComposeSystemTheme()
-
-        NSNotificationCenter.defaultCenter.addObserver(
-            observer = this,
-            selector = NSSelectorFromString(::onAccessibilityChanged.name),
-            name = UIAccessibilityVoiceOverStatusDidChangeNotification,
-            `object` = null
-        )
     }
 
     override fun viewDidLayoutSubviews() {
@@ -402,10 +387,8 @@ internal class ComposeHostingViewController(
      * Enables or disables accessibility for each layer, as well as the root mediator, taking into
      * account layer order and ability to overlay underlying content.
      */
-    @ObjCAction
     private fun onAccessibilityChanged() {
-        var isAccessibilityEnabled =
-            configuration.accessibilitySyncOptions.isGlobalAccessibilityEnabled
+        var isAccessibilityEnabled = true
         layers.withLayers {
             it.fastForEachReversed { layer ->
                 layer.isAccessibilityEnabled = isAccessibilityEnabled
@@ -437,12 +420,6 @@ internal class ComposeHostingViewController(
         mediator = null
 
         layers.dispose(hasViewAppeared)
-
-        NSNotificationCenter.defaultCenter.removeObserver(
-            observer = this,
-            name = UIAccessibilityVoiceOverStatusChanged,
-            `object` = null
-        )
     }
 
     private fun attachLayer(layer: UIKitComposeSceneLayer) {
@@ -491,12 +468,3 @@ private fun getLayoutDirection() =
         UIUserInterfaceLayoutDirection.UIUserInterfaceLayoutDirectionRightToLeft -> LayoutDirection.Rtl
         else -> LayoutDirection.Ltr
     }
-
-@OptIn(ExperimentalComposeApi::class)
-private val AccessibilitySyncOptions.isGlobalAccessibilityEnabled
-    get() =
-        when (this) {
-            AccessibilitySyncOptions.Never -> false
-            AccessibilitySyncOptions.WhenRequiredByAccessibilityServices -> UIAccessibilityIsVoiceOverRunning()
-            AccessibilitySyncOptions.Always -> true
-        }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -108,7 +108,7 @@ import platform.UIKit.UIView
  * @property performEscape A lambda to delegate accessibility escape operation. Returns true if the escape was handled, false otherwise.
  */
 private class SemanticsOwnerListenerImpl(
-    private val rootView: UIView,
+    private val rootView: ComposeSceneMediatorView,
     private val coroutineContext: CoroutineContext,
     private val performEscape: () -> Boolean
 ) : PlatformContext.SemanticsOwnerListener {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.uikit
 
 import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.platform.AccessibilitySyncOptions
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UIViewController
@@ -43,16 +42,6 @@ class ComposeUIViewControllerConfiguration {
     )
     @Suppress("DEPRECATION")
     var delegate: ComposeUIViewControllerDelegate = object : ComposeUIViewControllerDelegate {}
-
-    /**
-     * @see [AccessibilitySyncOptions]
-     *
-     * By default, accessibility sync is enabled when required by accessibility services and debug
-     * logging is disabled.
-     */
-    @ExperimentalComposeApi
-    var accessibilitySyncOptions: AccessibilitySyncOptions =
-        AccessibilitySyncOptions.WhenRequiredByAccessibilityServices
 
     /**
      * Determines whether the Compose view should have an opaque background.
@@ -125,6 +114,7 @@ sealed interface OnFocusBehavior {
     /**
      * The Compose view will stay on the current position.
      */
+    @Suppress("unused")
     data object DoNothing : OnFocusBehavior
 
     /**


### PR DESCRIPTION
Make the accessibility tree load lazily. The tree will load completely after the first request from the iOS accessibility engine, and dispose when the screen reader no longer interacts with it.
Remove AccessibilitySyncOptions because it is no loner needed.
Lazy load allows to add support of VoiceControl as well as other screen-reader based features.

Fixes (partially) https://youtrack.jetbrains.com/issue/CMP-7268/High-CPU-consumption-when-using-accessibility
Fixes https://youtrack.jetbrains.com/issue/CMP-6770/Remove-AccessibilitySyncOptions

## Release Notes
### Features - iOS
- Support VoiceControl on iOS.
- `AccessibilitySyncOptions` removed. The accessibility tree is built on demand.
### Fixes - iOS
- Performance issues when iOS screen reader is active fixed.
