### PR TITLE
Fix SearchBar PredictiveBack's animation when a back action was canceled.

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SearchBar.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SearchBar.kt
@@ -83,6 +83,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.structuralEqualityPolicy
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -125,6 +126,7 @@ import kotlin.math.min
 import kotlin.math.roundToInt
 import kotlin.math.sign
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * <a href="https://m3.material.io/components/search/overview" class="external"
@@ -183,6 +185,7 @@ fun SearchBar(
     windowInsets: WindowInsets = SearchBarDefaults.windowInsets,
     content: @Composable ColumnScope.() -> Unit,
 ) {
+    val coroutineScope = rememberCoroutineScope()
     val animationProgress = remember { Animatable(initialValue = if (expanded) 1f else 0f) }
     val finalBackProgress = remember { mutableFloatStateOf(Float.NaN) }
     val firstBackEvent = remember { mutableStateOf<BackEventCompat?>(null) }
@@ -220,13 +223,15 @@ fun SearchBar(
                 finalBackProgress.floatValue = animationProgress.value
                 onExpandedChange(false)
             } catch (e: CancellationException) {
-                animationProgress.animateTo(
-                    targetValue = 1f,
-                    animationSpec = AnimationPredictiveBackExitFloatSpec
-                )
-                finalBackProgress.floatValue = Float.NaN
-                firstBackEvent.value = null
-                currentBackEvent.value = null
+                coroutineScope.launch {
+                    animationProgress.animateTo(
+                        targetValue = 1f,
+                        animationSpec = AnimationPredictiveBackExitFloatSpec
+                    )
+                    finalBackProgress.floatValue = Float.NaN
+                    firstBackEvent.value = null
+                    currentBackEvent.value = null
+                }
             }
         }
     }


### PR DESCRIPTION
It is not possible to run a suspend function when the progress flow is canceled because the onBack suspend lambda is canceled as well.

https://android-review.googlesource.com/c/platform/frameworks/support/+/3454206

## Release Notes
### Fixes - Multiple Platforms
- Fix SearchBar PredictiveBack's animation when a back action was canceled.
