### PR TITLE
Fix IME candidate popup position for BasicTextField2

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -17,16 +17,24 @@
 package androidx.compose.foundation.text.input.internal
 
 import androidx.compose.foundation.content.internal.ReceiveContentConfiguration
+import androidx.compose.foundation.text.computeSizeForDefaultText
 import androidx.compose.foundation.text.input.setSelectionCoerced
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSession
 import androidx.compose.ui.platform.ViewConfiguration
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -75,9 +83,31 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
 
     coroutineScope {
         launch {
-            state.collectImeNotifications{ _, newValue, _ ->
+            state.collectImeNotifications { _, newValue, _ ->
                 val newTextFieldValue = TextFieldValue(newValue.text.toString(), newValue.selection, newValue.composition)
                 updateSelectionState(newTextFieldValue)
+            }
+        }
+
+        launch {
+            snapshotFlow {
+                val layoutResult = layoutState.layoutResult ?: return@snapshotFlow null
+                val layoutCoords = layoutState.textLayoutNodeCoordinates ?: return@snapshotFlow null
+                focusedRectInRoot(
+                    layoutResult = layoutResult,
+                    layoutCoordinates = layoutCoords,
+                    focusOffset = state.visualText.selection.max,
+                    sizeForDefaultText = {
+                        layoutResult.layoutInput.let {
+                            computeSizeForDefaultText(it.style, it.density, it.fontFamilyResolver)
+                        }
+                    }
+
+                )
+            }.collect { rect ->
+                if (rect != null) {
+                    notifyFocusedRect(rect)
+                }
             }
         }
 
@@ -105,3 +135,30 @@ private data class SkikoPlatformTextInputMethodRequest(
     override val onImeAction: ((ImeAction) -> Unit)?,
     override val editProcessor: EditProcessor?
 ): PlatformTextInputMethodRequest
+
+/**
+ * Computes the bounds of the area where text editing is in progress, relative to the root.
+ */
+// Adapted from TextFieldDelegate.notifyFocusedRect
+// TODO: Move this function into TextFieldDelegate.kt, and call it from both places.
+private fun focusedRectInRoot(
+    layoutResult: TextLayoutResult,
+    layoutCoordinates: LayoutCoordinates,
+    focusOffset: Int,
+    sizeForDefaultText: () -> IntSize
+): Rect {
+    val bbox = when {
+        focusOffset < layoutResult.layoutInput.text.length -> {
+            layoutResult.getBoundingBox(focusOffset)
+        }
+        focusOffset != 0 -> {
+            layoutResult.getBoundingBox(focusOffset - 1)
+        }
+        else -> { // empty text.
+            val size = sizeForDefaultText()
+            Rect(0f, 0f, 1.0f, size.height.toFloat())
+        }
+    }
+    val globalLT = layoutCoordinates.localToRoot(Offset(bbox.left, bbox.top))
+    return Rect(Offset(globalLT.x, globalLT.y), Size(bbox.width, bbox.height))
+}

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3592,6 +3592,7 @@ public final class androidx/compose/ui/platform/PlatformTextInputModifierNodeKt 
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSession {
+	public fun notifyFocusedRect (Landroidx/compose/ui/geometry/Rect;)V
 	public abstract fun startInputMethod (Landroidx/compose/ui/platform/PlatformTextInputMethodRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun updateSelectionState (Landroidx/compose/ui/text/input/TextFieldValue;)V
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -89,13 +89,8 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
         currentInput?.value = newValue
     }
 
-    // TODO(https://github.com/JetBrains/compose-jb/issues/2040): probably the position of input method
-    //  popup isn't correct now
-    @Deprecated("This method should not be called, use BringIntoViewRequester instead.")
     override fun notifyFocusedRect(rect: Rect) {
-        currentInput?.let { input ->
-            input.focusedRect = rect
-        }
+        currentInput?.focusedRect = rect
     }
 
     fun onKeyEvent(keyEvent: KeyEvent) {
@@ -115,23 +110,23 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     }
 
     private fun replaceInputMethodText(event: InputMethodEvent) {
-        currentInput?.let { input ->
-            val committed = event.text?.toStringUntil(event.committedCharacterCount).orEmpty()
-            val composing = event.text?.toStringFrom(event.committedCharacterCount).orEmpty()
-            val ops = mutableListOf<EditCommand>()
+        val input = currentInput ?: return
 
-            if (needToDeletePreviousChar && isMac && input.value.selection.min > 0 && composing.isEmpty()) {
-                needToDeletePreviousChar = false
-                ops.add(DeleteSurroundingTextInCodePointsCommand(1, 0))
-            }
+        val committed = event.text?.toStringUntil(event.committedCharacterCount).orEmpty()
+        val composing = event.text?.toStringFrom(event.committedCharacterCount).orEmpty()
+        val ops = mutableListOf<EditCommand>()
 
-            ops.add(CommitTextCommand(committed, 1))
-            if (composing.isNotEmpty()) {
-                ops.add(SetComposingTextCommand(composing, 1))
-            }
-
-            input.onEditCommand.invoke(ops)
+        if (needToDeletePreviousChar && isMac && input.value.selection.min > 0 && composing.isEmpty()) {
+            needToDeletePreviousChar = false
+            ops.add(DeleteSurroundingTextInCodePointsCommand(1, 0))
         }
+
+        ops.add(CommitTextCommand(committed, 1))
+        if (composing.isNotEmpty()) {
+            ops.add(SetComposingTextCommand(composing, 1))
+        }
+
+        input.onEditCommand.invoke(ops)
     }
 
     private fun methodRequestsForInput(input: CurrentInput) =

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.SessionMutex
 import androidx.compose.ui.awt.AwtEventListener
@@ -782,6 +783,11 @@ internal class ComposeSceneMediator(
                     textInputService.stopInput()
                 }
             })
+        }
+
+        @ExperimentalComposeUiApi
+        override fun notifyFocusedRect(rect: Rect) {
+            textInputService.notifyFocusedRect(rect)
         }
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window.window
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowTestScope
+import androidx.compose.ui.window.runApplicationTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.experimental.theories.DataPoint
+
+open class BaseWindowTextFieldTest {
+    internal interface TextFieldTestScope {
+        val window: ComposeWindow
+        val text: String
+
+        @Composable
+        fun TextField()
+
+        suspend fun awaitIdle()
+
+        suspend fun assertStateEquals(actual: String, selection: TextRange, composition: TextRange?)
+    }
+
+    internal fun runTextFieldTest(
+        textFieldKind: TextFieldKind,
+        name: String,
+        body: suspend TextFieldTestScope.() -> Unit
+    ) = runApplicationTest(
+        hasAnimations = true,
+        animationsDelayMillis = 100
+    ) {
+        var scope: TextFieldTestScope? = null
+        launchTestApplication {
+            Window(onCloseRequest = ::exitApplication) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    if (scope == null) {
+                        scope = textFieldKind.createScope(this@runApplicationTest, window)
+                    }
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("$name ($scope)")
+                        Box(Modifier.border(1.dp, Color.Black).padding(8.dp)) {
+                            scope!!.TextField()
+                        }
+                    }
+                }
+            }
+        }
+
+        awaitIdle()
+        scope!!.body()
+    }
+
+    internal fun interface TextFieldKind {
+        fun createScope(windowTestScope: WindowTestScope, window: ComposeWindow): TextFieldTestScope
+    }
+
+    companion object {
+        @JvmField
+        @DataPoint
+        internal val TextField1: TextFieldKind = TextFieldKind { windowTestScope, window ->
+            object : TextFieldTestScope {
+                override val window: ComposeWindow
+                    get() = window
+
+                private var textFieldValue by mutableStateOf(TextFieldValue())
+
+                override val text: String
+                    get() = textFieldValue.text
+
+                override suspend fun awaitIdle() {
+                    windowTestScope.awaitIdle()
+                }
+
+                @Composable
+                override fun TextField() {
+                    val focusRequester = FocusRequester()
+                    BasicTextField(
+                        value = textFieldValue,
+                        onValueChange = { textFieldValue = it },
+                        modifier = Modifier.focusRequester(focusRequester)
+                    )
+
+                    LaunchedEffect(focusRequester) {
+                        focusRequester.requestFocus()
+                    }
+                }
+
+                override suspend fun assertStateEquals(
+                    actual: String,
+                    selection: TextRange,
+                    composition: TextRange?
+                ) {
+                    windowTestScope.awaitIdle()
+                    assertThat(textFieldValue.text).isEqualTo(actual)
+                    assertThat(textFieldValue.selection).isEqualTo(selection)
+                    assertThat(textFieldValue.composition).isEqualTo(composition)
+                }
+
+                override fun toString() = "TextField1"
+            }
+        }
+
+        @JvmField
+        @DataPoint
+        internal val TextField2: TextFieldKind = TextFieldKind { windowTestScope, window ->
+            object : TextFieldTestScope {
+                override val window: ComposeWindow
+                    get() = window
+
+                private val textFieldState = TextFieldState()
+
+                override val text: String
+                    get() = textFieldState.text.toString()
+
+                override suspend fun awaitIdle() {
+                    windowTestScope.awaitIdle()
+                }
+
+                @Composable
+                override fun TextField() {
+                    val focusRequester = FocusRequester()
+                    BasicTextField(
+                        state = textFieldState,
+                        modifier = Modifier.focusRequester(focusRequester)
+                    )
+
+                    LaunchedEffect(focusRequester) {
+                        focusRequester.requestFocus()
+                    }
+                }
+
+                override suspend fun assertStateEquals(
+                    actual: String,
+                    selection: TextRange,
+                    composition: TextRange?
+                ) {
+                    windowTestScope.awaitIdle()
+                    assertThat(textFieldState.text.toString()).isEqualTo(actual)
+                    assertThat(textFieldState.selection).isEqualTo(selection)
+                    assertThat(textFieldState.composition).isEqualTo(composition)
+
+                }
+
+                override fun toString() = "TextField2"
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -16,38 +16,12 @@
 
 package androidx.compose.ui.window.window
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.awt.ComposeWindow
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.sendInputEvent
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendKeyTypedEvent
 import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowTestScope
-import androidx.compose.ui.window.runApplicationTest
-import com.google.common.truth.Truth.assertThat
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
-import org.junit.experimental.theories.DataPoint
 import org.junit.experimental.theories.Theories
 import org.junit.experimental.theories.Theory
 import org.junit.runner.RunWith
@@ -60,11 +34,11 @@ import org.junit.runner.RunWith
  * The OS names in test names just represent a unique order of input events on these OSes.
  */
 @RunWith(Theories::class)
-class WindowTypeTest {
+class WindowTypeTest : BaseWindowTextFieldTest() {
     @Theory
     internal fun `q, w, space, backspace 4x (English)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "English") {
+    ) = runTextFieldTest(textFieldKind, "English") {
         // q
         window.sendKeyEvent(81, 'q', KEY_PRESSED)
         window.sendKeyTypedEvent('q')
@@ -111,7 +85,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, space, backspace 4x (Russian)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Russian") {
+    ) = runTextFieldTest(textFieldKind, "Russian") {
         // q
         window.sendKeyEvent(81, 'й', KEY_PRESSED)
         window.sendKeyTypedEvent('й')
@@ -158,7 +132,7 @@ class WindowTypeTest {
     @Theory
     internal fun `f, g, space, backspace 4x (Arabic)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Arabic") {
+    ) = runTextFieldTest(textFieldKind, "Arabic") {
         // q
         window.sendKeyEvent(70, 'ب', KEY_PRESSED)
         window.sendKeyTypedEvent('ب')
@@ -205,7 +179,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, space, backspace 4x (Korean, Windows)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, Windows") {
+    ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // q
         window.sendInputEvent("ㅂ", 0)
         window.sendKeyEvent(81, 'q', KEY_RELEASED)
@@ -253,7 +227,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, backspace 3x (Korean, Windows)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, Windows") {
+    ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // q
         window.sendInputEvent("ㅂ", 0)
         window.sendKeyEvent(81, 'q', KEY_RELEASED)
@@ -287,7 +261,7 @@ class WindowTypeTest {
     @Theory
     internal fun `f, g, space, backspace 3x (Korean, Windows)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, Windows") {
+    ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // f
         window.sendInputEvent("ㄹ", 0)
         window.sendKeyEvent(81, 'f', KEY_RELEASED)
@@ -328,7 +302,7 @@ class WindowTypeTest {
     @Theory
     internal fun `f, g, backspace 2x (Korean, Windows)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, Windows") {
+    ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // f
         window.sendInputEvent("ㄹ", 0)
         window.sendKeyEvent(81, 'f', KEY_RELEASED)
@@ -360,7 +334,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, space, backspace 4x (Korean, macOS)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, macOS") {
+    ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // q
         window.sendInputEvent("ㅂ", 0)
         window.sendKeyEvent(81, 'ㅂ', KEY_RELEASED)
@@ -407,7 +381,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, backspace 3x (Korean, macOS)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, macOS") {
+    ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // q
         window.sendInputEvent("ㅂ", 0)
         window.sendKeyEvent(81, 'ㅂ', KEY_RELEASED)
@@ -445,7 +419,7 @@ class WindowTypeTest {
     @Theory
     internal fun `t, y, space, backspace 3x (Korean, macOS)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, macOS") {
+    ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // t
         window.sendInputEvent("ㅅ", 0)
         window.sendKeyEvent(84, 'ㅅ', KEY_RELEASED)
@@ -484,7 +458,7 @@ class WindowTypeTest {
     @Theory
     internal fun `t, y, backspace 2x (Korean, macOS)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, macOS") {
+    ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // t
         window.sendInputEvent("ㅅ", 0)
         window.sendKeyEvent(84, 'ㅅ', KEY_RELEASED)
@@ -518,7 +492,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, space, backspace 4x (Korean, Linux)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Korean, Linux") {
+    ) = runTextFieldTest(textFieldKind, "Korean, Linux") {
         // q
         window.sendInputEvent("ㅂ", 0)
         window.sendKeyEvent(0, 'ㅂ', KEY_RELEASED)
@@ -567,7 +541,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, space, backspace 3x (Chinese, Windows)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Chinese, Windows") {
+    ) = runTextFieldTest(textFieldKind, "Chinese, Windows") {
         // q
         window.sendInputEvent("q", 0)
         window.sendKeyEvent(81, 'q', KEY_RELEASED)
@@ -606,7 +580,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, backspace 3x (Chinese, Windows)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Chinese, Windows") {
+    ) = runTextFieldTest(textFieldKind, "Chinese, Windows") {
         // q
         window.sendInputEvent("q", 0)
         window.sendKeyEvent(81, 'q', KEY_RELEASED)
@@ -638,7 +612,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, space, backspace 3x (Chinese, macOS)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Chinese, macOS") {
+    ) = runTextFieldTest(textFieldKind, "Chinese, macOS") {
         // q
         window.sendInputEvent("q", 0)
         window.sendKeyEvent(81, 'q', KEY_RELEASED)
@@ -676,7 +650,7 @@ class WindowTypeTest {
     @Theory
     internal fun `q, w, backspace 3x (Chinese, macOS)`(
         textFieldKind: TextFieldKind
-    ) = runTypeTest(textFieldKind, "Chinese, macOS") {
+    ) = runTextFieldTest(textFieldKind, "Chinese, macOS") {
         // q
         window.sendInputEvent("q", 0)
         window.sendKeyEvent(81, 'q', KEY_RELEASED)
@@ -702,143 +676,5 @@ class WindowTypeTest {
         window.sendKeyTypedEvent(Char(8))
         window.sendKeyEvent(8, Char(8), KEY_RELEASED)
         assertStateEquals("", selection = TextRange(0), composition = null)
-    }
-
-    internal interface TypeTestScope {
-        val windowTestScope: WindowTestScope
-        val window: ComposeWindow
-        val text: String
-
-        @Composable
-        fun TextField()
-
-        suspend fun assertStateEquals(actual: String, selection: TextRange, composition: TextRange?)
-
-    }
-
-    private fun runTypeTest(
-        textFieldKind: TextFieldKind = TextField1,
-        name: String,
-        body: suspend TypeTestScope.() -> Unit
-    ) = runApplicationTest(
-        hasAnimations = true,
-        animationsDelayMillis = 100
-    ) {
-        var scope: TypeTestScope? = null
-        launchTestApplication {
-            Window(onCloseRequest = ::exitApplication) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    if (scope == null) {
-                        scope = textFieldKind.createScope(this@runApplicationTest, window)
-                    }
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("$name ($scope)")
-                        Box(Modifier.border(1.dp, Color.Black).padding(8.dp)) {
-                            scope!!.TextField()
-                        }
-                    }
-                }
-            }
-        }
-
-        awaitIdle()
-        scope!!.body()
-    }
-
-    internal fun interface TextFieldKind {
-        fun createScope(windowTestScope: WindowTestScope, window: ComposeWindow): TypeTestScope
-    }
-
-    companion object {
-        @JvmField
-        @DataPoint
-        internal val TextField1: TextFieldKind = TextFieldKind { windowTestScope, window ->
-            object : TypeTestScope {
-                override val windowTestScope: WindowTestScope
-                    get() = windowTestScope
-
-                override val window: ComposeWindow
-                    get() = window
-
-                private var textFieldValue by mutableStateOf(TextFieldValue())
-
-                override val text: String
-                    get() = textFieldValue.text
-
-                @Composable
-                override fun TextField() {
-                    val focusRequester = FocusRequester()
-                    BasicTextField(
-                        value = textFieldValue,
-                        onValueChange = { textFieldValue = it },
-                        modifier = Modifier.focusRequester(focusRequester)
-                    )
-
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
-                    }
-                }
-
-                override suspend fun assertStateEquals(
-                    actual: String,
-                    selection: TextRange,
-                    composition: TextRange?
-                ) {
-                    windowTestScope.awaitIdle()
-                    assertThat(textFieldValue.text).isEqualTo(actual)
-                    assertThat(textFieldValue.selection).isEqualTo(selection)
-                    assertThat(textFieldValue.composition).isEqualTo(composition)
-                }
-
-                override fun toString() = "TextField1"
-            }
-        }
-
-        @JvmField
-        @DataPoint
-        internal val TextField2: TextFieldKind = TextFieldKind { windowTestScope, window ->
-            object : TypeTestScope {
-                override val windowTestScope: WindowTestScope
-                    get() = windowTestScope
-
-                override val window: ComposeWindow
-                    get() = window
-
-                private val textFieldState = TextFieldState()
-
-                override val text: String
-                    get() = textFieldState.text.toString()
-
-                @Composable
-                override fun TextField() {
-                    val focusRequester = FocusRequester()
-                    BasicTextField(
-                        state = textFieldState,
-                        modifier = Modifier.focusRequester(focusRequester)
-                    )
-
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
-                    }
-                }
-
-                override suspend fun assertStateEquals(
-                    actual: String,
-                    selection: TextRange,
-                    composition: TextRange?
-                ) {
-                    windowTestScope.awaitIdle()
-                    assertThat(textFieldState.text.toString()).isEqualTo(actual)
-                    assertThat(textFieldState.selection).isEqualTo(selection)
-                    assertThat(textFieldState.composition).isEqualTo(composition)
-
-                }
-
-                override fun toString() = "TextField2"
-            }
-        }
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypingLocationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypingLocationTest.kt
@@ -16,28 +16,24 @@
 
 package androidx.compose.ui.window.window
 
-import androidx.compose.material.TextField
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.focusedInputMethodRequests
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendKeyTypedEvent
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.window.WindowTestScope
-import androidx.compose.ui.window.runApplicationTest
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
-import org.junit.Test
+import org.junit.experimental.theories.Theories
+import org.junit.experimental.theories.Theory
+import org.junit.runner.RunWith
 
-class WindowTypingLocationTest {
-    @Test
-    fun `input methods text location going right when type`() = runTextFieldTest {
+@RunWith(Theories::class)
+class WindowTypingLocationTest: BaseWindowTextFieldTest() {
+    @Theory
+    internal fun `input methods text location going right when type`(
+        textFieldKind: TextFieldKind,
+    ) = runTextFieldTest(
+        textFieldKind = textFieldKind,
+        name = "input methods text location going right when type"
+    ) {
         val location0 = window.focusedInputMethodRequests()!!.getTextLocation(null)
 
         window.sendKeyEvent(81, 'a', KEY_PRESSED)
@@ -58,8 +54,13 @@ class WindowTypingLocationTest {
         assert(location2.y == location1.y)
     }
 
-    @Test
-    fun `input methods text location is inside window`() = runTextFieldTest {
+    @Theory
+    internal fun `input methods text location is inside window`(
+        textFieldKind: TextFieldKind,
+    ) = runTextFieldTest(
+        textFieldKind = textFieldKind,
+        name = "input methods text location inside window",
+    ) {
         val windowLocation = window.contentPane.locationOnScreen
         val windowSize = window.contentPane.size
 
@@ -83,28 +84,5 @@ class WindowTypingLocationTest {
         assert(location0.y in windowLocation.y..windowLocation.y + windowSize.height)
         assert(location1.y in windowLocation.y..windowLocation.y + windowSize.height)
         assert(location2.y in windowLocation.y..windowLocation.y + windowSize.height)
-    }
-
-
-    private fun runTextFieldTest(body: suspend WindowTestScope.() -> Unit) = runApplicationTest(
-        hasAnimations = true,
-        animationsDelayMillis = 100
-    ) {
-        launchTestWindowApplication {
-            var text by remember { mutableStateOf(TextFieldValue()) }
-
-            val focusRequester = FocusRequester()
-            TextField(
-                value = text,
-                onValueChange = { text = it },
-                modifier = Modifier.focusRequester(focusRequester)
-            )
-
-            LaunchedEffect(focusRequester) {
-                focusRequester.requestFocus()
-            }
-        }
-        awaitIdle()
-        body()
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
@@ -17,10 +17,15 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.input.TextFieldValue
 
 actual interface PlatformTextInputSession {
     actual suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing
+
     @ExperimentalComposeUiApi
     fun updateSelectionState(newState: TextFieldValue) = Unit
+
+    @ExperimentalComposeUiApi
+    fun notifyFocusedRect(rect: Rect) = Unit
 }


### PR DESCRIPTION
PlatformTextInputSession.platformSpecificTextInputSession now calls `DesktopTextInputService.notifyFocusedRect` to tell the system where to place the IME candidate window for languages such as Chinese.

Fixes https://youtrack.jetbrains.com/issue/CMP-7467

<img width="801" alt="image" src="https://github.com/user-attachments/assets/2261273b-0371-4b07-b4f0-a6e6befbdf6f" />

## Testing
- Added testing with BasicTextField2 to `WindowTypingLocationTest`.
- Tested manually with:
```
import androidx.compose.foundation.layout.*
import androidx.compose.foundation.text.input.rememberTextFieldState
import androidx.compose.material.*
import androidx.compose.runtime.*
import androidx.compose.ui.*
import androidx.compose.ui.unit.*
import androidx.compose.ui.window.*

fun main() = singleWindowApplication {
    Column(
        Modifier.fillMaxSize().padding(16.dp),
    ) {
        Text("TextField")
        var value by remember { mutableStateOf("") }
        TextField(value = value, onValueChange = { value = it }, modifier = Modifier.width(200.dp))

        Spacer(Modifier.height(64.dp))
        Text("TextField2")
        val state = rememberTextFieldState()
        TextField(state, modifier = Modifier.width(200.dp))
    }
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed the positioning of the IME candidate popup for `TextField(TextFieldState)` (aka `BasicTextField2`).