### PR TITLE
CfW: Fix Clipboard events handling for BasicTextField2

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
@@ -347,6 +347,7 @@ internal fun BasicTextField(
             }
         }
 
+    // TODO: upstreaming https://youtrack.jetbrains.com/issue/CMP-7517/Upstream-rememberClipboardEventsHandler
     rememberClipboardEventsHandler(
         isEnabled = isFocused,
         onPaste = { textFieldSelectionState.pasteAsPlainText(it) },

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/BasicTextField.kt
@@ -347,6 +347,13 @@ internal fun BasicTextField(
             }
         }
 
+    rememberClipboardEventsHandler(
+        isEnabled = isFocused,
+        onPaste = { textFieldSelectionState.pasteAsPlainText(it) },
+        onCopy = { textFieldSelectionState.copyWithResult() },
+        onCut = { textFieldSelectionState.cutWithResult() }
+    )
+
     SideEffect {
         // These properties are not backed by snapshot state, so they can't be updated directly in
         // composition.

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.kt
@@ -18,6 +18,7 @@ package androidx.compose.foundation.text
 
 import androidx.compose.runtime.Composable
 
+// TODO: upstreaming https://youtrack.jetbrains.com/issue/CMP-7517/Upstream-rememberClipboardEventsHandler
 @Composable
 internal expect inline fun rememberClipboardEventsHandler(
     crossinline onPaste: (String) -> Unit = {},

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -298,6 +298,7 @@ internal fun CoreTextField(
     manager.editable = !readOnly
     manager.enabled = enabled
 
+    // TODO: upstreaming https://youtrack.jetbrains.com/issue/CMP-7517/Upstream-rememberClipboardEventsHandler
     rememberClipboardEventsHandler(
         isEnabled = state.hasFocus,
         onCopy = { manager.onCopyWithResult() },

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -1282,6 +1282,13 @@ internal class TextFieldSelectionState(
         textFieldState.deleteSelectedText()
     }
 
+    fun cutWithResult(): String? {
+        val text = textFieldState.visualText
+        if (text.selection.collapsed) return null
+        textFieldState.deleteSelectedText()
+        return text.getSelectedText().toString()
+    }
+
     /**
      * Whether a copy operation can execute now and modify the clipboard. The copy operation
      * requires the selection to not be collapsed, and the text field to NOT be a password.
@@ -1306,6 +1313,14 @@ internal class TextFieldSelectionState(
         if (!cancelSelection) return
 
         textFieldState.collapseSelectionToMax()
+    }
+
+    fun copyWithResult(cancelSelection: Boolean = true): String? {
+        val text = textFieldState.visualText
+        if (text.selection.collapsed) return null
+
+        if (cancelSelection) textFieldState.collapseSelectionToMax()
+        return text.getSelectedText().toString()
     }
 
     /**
@@ -1359,6 +1374,13 @@ internal class TextFieldSelectionState(
 
         textFieldState.replaceSelectedText(
             clipboardText,
+            undoBehavior = TextFieldEditUndoBehavior.NeverMerge
+        )
+    }
+
+    fun pasteAsPlainText(text: String) {
+        textFieldState.replaceSelectedText(
+            text,
             undoBehavior = TextFieldEditUndoBehavior.NeverMerge
         )
     }

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
@@ -109,6 +109,7 @@ internal fun SelectionContainer(
     manager.onSelectionChange = onSelectionChange
     manager.selection = selection
 
+    // TODO: upstreaming https://youtrack.jetbrains.com/issue/CMP-7517/Upstream-rememberClipboardEventsHandler
     rememberClipboardEventsHandler(
         onCopy = { manager.getSelectedText()?.text },
         isEnabled = manager.isNonEmptySelection()


### PR DESCRIPTION
Fixes [CMP-7435](https://youtrack.jetbrains.com/issue/CMP-7435/Web-BasicTextField2.-Characters-cant-be-pasted)


## Release Notes

### Fixes - Web
- The `BasicTextField` handles browser copy/cut/paste events correctly now. Previously, they were ignored.  


