### PR TITLE
Report radio button (Role.RadioButton) state through AccessibleValue and in getAccessibleStateSet.

### DIFF
--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -343,6 +343,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(libs.kotlinCoroutinesSwing)
                 implementation(libs.kotlinCoroutinesTest)
                 implementation(project(":compose:material:material"))
+                implementation(project(":compose:material3:material3"))
                 implementation(project(":compose:ui:ui-test-junit4"))
             }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -314,8 +314,12 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleValue(): AccessibleValue? {
+            val role = semanticsConfig.getOrNull(SemanticsProperties.Role)
+            // On macOS/VoiceOver, the a11y system appears to inspect the value we return here for
+            // checkboxes and radio buttons. On Windows, it looks at getAccessibleStateSet instead.
             return when {
                 toggleableState != null -> ToggleableAccessibleValue(this)
+                role == Role.RadioButton -> RadioButtonAccessibleValue(this)
                 progressBarRangeInfo != null -> ProgressBarAccessibleValue(this)
                 else -> null
             }
@@ -455,15 +459,6 @@ internal class ComposeAccessible(
                 if (focused == true)
                     add(AccessibleState.FOCUSED)
 
-                when (toggleableState) {
-                    ToggleableState.On ->
-                        add(AccessibleState.CHECKED)
-                    ToggleableState.Indeterminate ->
-                        add(AccessibleState.INDETERMINATE)
-                    ToggleableState.Off, null -> {
-                    }
-                }
-
                 val canExpand = semanticsConfig.getOrNull(SemanticsActions.Expand) != null
                 val canCollapse = semanticsConfig.getOrNull(SemanticsActions.Collapse) != null
 
@@ -476,15 +471,50 @@ internal class ComposeAccessible(
                 if (canCollapse)
                     add(AccessibleState.EXPANDED)
 
-                if (canCollapse)
-                    add(AccessibleState.EXPANDED)
+                when (semanticsConfig.getOrNull(SemanticsProperties.Role)) {
+                    // Note that this is not executed on macOS (for checkboxes or radio buttons),
+                    // where the system inspects the value returned by getAccessibleValue instead.
+                    Role.Checkbox -> addCheckedStateForCheckbox()
+                    Role.RadioButton -> addCheckedStateForRadioButton()
+                    else -> {  // Default case, for other (possibly null) roles
+                        addDefaultStateForToggleableState()
 
-                if (selected != null)
-                    add(AccessibleState.SELECTABLE)
+                        if (selected != null)
+                            add(AccessibleState.SELECTABLE)
 
-                if (selected == true)
-                    add(AccessibleState.SELECTED)
+                        if (selected == true)
+                            add(AccessibleState.SELECTED)
+                    }
+                }
             }
+        }
+
+        private fun AccessibleStateSet.addCheckedStateForCheckbox() {
+            // Checkbox uses Modifier.triStateToggleable, which sets
+            // SemanticsPropertyReceiver.toggleableState
+            addDefaultStateForToggleableState()
+        }
+
+        private fun AccessibleStateSet.addCheckedStateForRadioButton() {
+            // RadioButton uses Modifier.selectable, which sets
+            // SemanticsPropertyReceiver.selected
+            if (selected == true) {
+                add(AccessibleState.CHECKED)
+            }
+        }
+
+        private fun AccessibleStateSet.addDefaultStateForToggleableState() {
+            val state = when (toggleableState) {
+                ToggleableState.On -> AccessibleState.CHECKED
+                // AccessibleState.INDETERMINATE doesn't appear to affect NVDA, and it's not clear
+                // whether it's even suitable to this case, but we return it anyway because there
+                // don't appear to be any adverse effects, and perhaps some other screen reader,
+                // or a testing framework will find it useful.
+                ToggleableState.Indeterminate -> AccessibleState.INDETERMINATE
+                ToggleableState.Off, null -> null
+            }
+            if (state != null)
+                add(state)
         }
 
         open inner class ComposeAccessibleText : AccessibleText,
@@ -842,6 +872,27 @@ private class ToggleableAccessibleValue(
             ToggleableState.On -> 1
             else -> 0
         }
+    }
+
+    override fun setCurrentAccessibleValue(n: Number?): Boolean {
+        // TODO: Implement this
+        return false
+    }
+
+    override fun getMinimumAccessibleValue(): Number {
+        return 0
+    }
+
+    override fun getMaximumAccessibleValue(): Number {
+        return 1
+    }
+}
+
+private class RadioButtonAccessibleValue(
+    val component: ComposeAccessible.ComposeAccessibleComponent
+): AccessibleValue {
+    override fun getCurrentAccessibleValue(): Number {
+        return if (component.selected == true) 1 else 0
     }
 
     override fun setCurrentAccessibleValue(n: Number?): Boolean {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
@@ -55,12 +56,17 @@ import java.awt.Point
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
 import javax.accessibility.AccessibleRole
+import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleText
+import javax.accessibility.AccessibleValue
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Test
+
 
 @OptIn(ExperimentalTestApi::class)
 class AccessibilityTest {
@@ -189,6 +195,84 @@ class AccessibilityTest {
 
         assertFalse("Component should be invisible to accessibility, but isn't") {
             test.onNodeWithTag("text").fetchAccessibleComponent().isVisible
+        }
+    }
+
+    @Test
+    fun materialRadioButtonHasCorrectCheckedStates() = runDesktopA11yTest {
+        var selected by mutableStateOf(true)
+        test.setContent {
+            Column {
+                androidx.compose.material.RadioButton(
+                    selected = selected,
+                    onClick = { },
+                    modifier = Modifier
+                        .testTag("radioButton")
+                )
+                androidx.compose.material3.RadioButton(
+                    selected = selected,
+                    onClick = { },
+                    modifier = Modifier
+                        .testTag("radioButton3")
+                )
+            }
+        }
+
+        with(test.onNodeWithTag("radioButton")) {
+            assertCurrentAccessibleValueEquals(1)
+            assertHasAccessibleState(AccessibleState.CHECKED)
+        }
+        with(test.onNodeWithTag("radioButton3")) {
+            assertCurrentAccessibleValueEquals(1)
+            assertHasAccessibleState(AccessibleState.CHECKED)
+        }
+        selected = false
+        with(test.onNodeWithTag("radioButton")) {
+            assertCurrentAccessibleValueEquals(0)
+            assertDoesNotHaveAccessibleState(AccessibleState.CHECKED)
+        }
+        with(test.onNodeWithTag("radioButton3")) {
+            assertCurrentAccessibleValueEquals(0)
+            assertDoesNotHaveAccessibleState(AccessibleState.CHECKED)
+        }
+    }
+
+    @Test
+    fun materialCheckboxHasCorrectCheckedStates() = runDesktopA11yTest {
+        var checked by mutableStateOf(true)
+        test.setContent {
+            Column {
+                androidx.compose.material.Checkbox(
+                    checked = checked,
+                    onCheckedChange = { },
+                    modifier = Modifier
+                        .testTag("checkBox")
+                )
+                androidx.compose.material3.Checkbox(
+                    checked = checked,
+                    onCheckedChange = { },
+                    modifier = Modifier
+                        .testTag("checkBox3")
+                )
+            }
+        }
+
+        with(test.onNodeWithTag("checkBox")) {
+            assertCurrentAccessibleValueEquals(1)
+            assertHasAccessibleState(AccessibleState.CHECKED)
+        }
+        with(test.onNodeWithTag("checkBox3")) {
+            assertCurrentAccessibleValueEquals(1)
+            assertHasAccessibleState(AccessibleState.CHECKED)
+        }
+        checked = false
+        with(test.onNodeWithTag("checkBox")) {
+            assertCurrentAccessibleValueEquals(0)
+            assertDoesNotHaveAccessibleState(AccessibleState.CHECKED)
+        }
+        with(test.onNodeWithTag("checkBox3")) {
+            assertCurrentAccessibleValueEquals(0)
+            assertDoesNotHaveAccessibleState(AccessibleState.CHECKED)
         }
     }
 
@@ -328,4 +412,35 @@ internal class ComposeA11yTestScope(
         assertThat(fetchAccessible().accessibleContext!!.accessibleRole).isEqualTo(role)
     }
 
+    /**
+     * Asserts that the [AccessibleContext] corresponding to the given semantics node has the given
+     * state.
+     */
+    fun SemanticsNodeInteraction.assertHasAccessibleState(state: AccessibleState) {
+        assertTrue("Accessible context expected to, but does not have state: $state") {
+            fetchAccessible().accessibleContext!!.accessibleStateSet.contains(state)
+        }
+    }
+
+    /**
+     * Asserts that the [AccessibleContext] corresponding to the given semantics node does not have
+     * the given state.
+     */
+    fun SemanticsNodeInteraction.assertDoesNotHaveAccessibleState(state: AccessibleState) {
+        assertFalse("Accessible context expected to not contain, but does have state: $state") {
+            fetchAccessible().accessibleContext!!.accessibleStateSet.contains(state)
+        }
+    }
+
+    /**
+     * Asserts that the [AccessibleContext] corresponding to the given semantics node has the given
+     * current accessible numeric value ([AccessibleValue.getCurrentAccessibleValue]).
+     */
+    fun SemanticsNodeInteraction.assertCurrentAccessibleValueEquals(number: Number) {
+        assertEquals(
+            expected = number,
+            actual = fetchAccessible().accessibleContext!!.accessibleValue.currentAccessibleValue,
+            message = "Current accessible value expected to, but does not equal: $number",
+        )
+    }
 }


### PR DESCRIPTION
Material radio buttons use `Modifier.selectable`, which in turn sets `SemanticsProperties.Selected`. We should therefore add `AccessibleState.CHECKED` to the `AccessibleStateSet` (for Windows) and report their state using an `AccessibleValue` (for macOS), like we do for checkboxes.

See discussion in https://jetbrains.slack.com/archives/C076VK0LGH1/p1737645905185459 for more details.

Fixes https://youtrack.jetbrains.com/issue/CMP-7469

## Testing
- Added unit tests

## Release Notes
### Fixes - Desktop
- Radio buttons and any other elements using `Modifier.selectable` with `Role.RadioButton` will have their state reported to accessibility via `AccessibleValue.getCurrentAccessibleValue()` and as `AccessibleState.CHECKED` in `getAccessibleStateSet()`.
