### PR TITLE
Report ComposeAccessibleComponents as invisible if their semantics config has SemanticsProperties.HideFromAccessibility

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform.a11y
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.node.Nodes
@@ -359,10 +358,11 @@ internal class ComposeAccessible(
             return semanticsNode.size.toAwtDimension()
         }
 
-        @OptIn(ExperimentalComposeUiApi::class)
+        @Suppress("DEPRECATION")
         override fun isVisible(): Boolean =
-            !semanticsConfig.contains(SemanticsProperties.InvisibleToUser) &&
-            !semanticsNode.outerSemanticsNode.requireCoordinator(Nodes.Semantics).isTransparent()
+            !semanticsNode.outerSemanticsNode.requireCoordinator(Nodes.Semantics).isTransparent() &&
+                !semanticsConfig.contains(SemanticsProperties.InvisibleToUser) &&
+                !semanticsConfig.contains(SemanticsProperties.HideFromAccessibility)
 
         override fun isEnabled(): Boolean =
             semanticsConfig.getOrNull(SemanticsProperties.Disabled) == null

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.isContainer
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.role
@@ -55,6 +56,7 @@ import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
 import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleText
+import kotlin.test.assertFalse
 import kotlin.test.fail
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertEquals
@@ -171,6 +173,23 @@ class AccessibilityTest {
         }
 
         test.onNodeWithTag("box").assertHasAccessibleRole(AccessibleRole.GROUP_BOX)
+    }
+
+    @Test
+    fun hideFromA11yMakesComponentInvisible() = runDesktopA11yTest {
+        test.setContent {
+            Text(
+                text = "Hello",
+                modifier = Modifier.testTag("text")
+                    .semantics {
+                        hideFromAccessibility()
+                    }
+            )
+        }
+
+        assertFalse("Component should be invisible to accessibility, but isn't") {
+            test.onNodeWithTag("text").fetchAccessibleComponent().isVisible
+        }
     }
 
     @Test


### PR DESCRIPTION
`InvisibleToUser` is now deprecated in favor of `HideFromAccessibility`, which we need to support.

## Testing
- Added a unit test

## Release Notes
### Fixes - Desktop
- Elements marked with `Modifier.semantics { hideFromAccessibility() }` should now be correctly hidden from a11y.
