### PR TITLE
Copy getAllUncoveredSemanticsNodesToIntObjectMap to skikoMain

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/semantics/SemanticsOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/semantics/SemanticsOwner.skiko.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.semantics
+
+import androidx.collection.IntObjectMap
+import androidx.collection.MutableIntObjectMap
+import androidx.collection.emptyIntObjectMap
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.semantics.SemanticsProperties.HideFromAccessibility
+import androidx.compose.ui.semantics.SemanticsProperties.InvisibleToUser
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.roundToIntRect
+
+internal fun SemanticsNode.isImportantForAccessibility() =
+    !isHidden &&
+        (unmergedConfig.isMergingSemanticsOfDescendants ||
+            unmergedConfig.containsImportantForAccessibility())
+
+@Suppress("DEPRECATION")
+internal val SemanticsNode.isHidden: Boolean
+    // A node is considered hidden if it is transparent, or explicitly is hidden from accessibility.
+    // This also checks if the node has been marked as `invisibleToUser`, which is what the
+    // `hiddenFromAccessibility` API used to  be named.
+    get() =
+        isTransparent ||
+            (unmergedConfig.contains(HideFromAccessibility) ||
+                unmergedConfig.contains(InvisibleToUser))
+
+private val DefaultFakeNodeBounds = Rect(0f, 0f, 10f, 10f)
+
+/** Semantics node with adjusted bounds for the uncovered(by siblings) part. */
+internal class SemanticsNodeWithAdjustedBounds(
+    val semanticsNode: SemanticsNode,
+    val adjustedBounds: IntRect
+)
+
+/**
+ * Finds pruned [SemanticsNode]s in the tree owned by this [SemanticsOwner]. A semantics node
+ * completely covered by siblings drawn on top of it will be pruned. Return the results in a map.
+ */
+internal fun SemanticsOwner.getAllUncoveredSemanticsNodesToIntObjectMap(
+    customRootNodeId: Int
+): IntObjectMap<SemanticsNodeWithAdjustedBounds> {
+    val root = unmergedRootSemanticsNode
+    if (!root.layoutNode.isPlaced || !root.layoutNode.isAttached) {
+        return emptyIntObjectMap()
+    }
+
+    // Default capacity chosen to accommodate common scenarios
+    val nodes = MutableIntObjectMap<SemanticsNodeWithAdjustedBounds>(48)
+
+    val unaccountedSpace = SemanticsRegion()
+    unaccountedSpace.set(root.boundsInRoot.roundToIntRect())
+
+    fun findAllSemanticNodesRecursive(currentNode: SemanticsNode, region: SemanticsRegion) {
+        val notAttachedOrPlaced =
+            !currentNode.layoutNode.isPlaced || !currentNode.layoutNode.isAttached
+        if (
+            (unaccountedSpace.isEmpty && currentNode.id != root.id) ||
+                (notAttachedOrPlaced && !currentNode.isFake)
+        ) {
+            return
+        }
+        val touchBoundsInRoot = currentNode.touchBoundsInRoot.roundToIntRect()
+
+        region.set(touchBoundsInRoot)
+
+        val virtualViewId =
+            if (currentNode.id == root.id) {
+                customRootNodeId
+            } else {
+                currentNode.id
+            }
+        if (region.intersect(unaccountedSpace)) {
+            nodes[virtualViewId] = SemanticsNodeWithAdjustedBounds(currentNode, region.bounds)
+            // Children could be drawn outside of parent, but we are using clipped bounds for
+            // accessibility now, so let's put the children recursion inside of this if. If later
+            // we decide to support children drawn outside of parent, we can move it out of the
+            // if block.
+            val children = currentNode.replacedChildren
+            for (i in children.size - 1 downTo 0) {
+                // Links in text nodes are semantics children. But for Android accessibility support
+                // we don't publish them to the accessibility services because they are exposed
+                // as UrlSpan/ClickableSpan spans instead
+                if (children[i].config.contains(SemanticsProperties.LinkTestMarker)) {
+                    continue
+                }
+                findAllSemanticNodesRecursive(children[i], region)
+            }
+            if (currentNode.isImportantForAccessibility()) {
+                unaccountedSpace.difference(touchBoundsInRoot)
+            }
+        } else {
+            if (currentNode.isFake) {
+                val parentNode = currentNode.parent
+                // use parent bounds for fake node
+                val boundsForFakeNode =
+                    if (parentNode?.layoutInfo?.isPlaced == true) {
+                        parentNode.boundsInRoot
+                    } else {
+                        DefaultFakeNodeBounds
+                    }
+                nodes[virtualViewId] =
+                    SemanticsNodeWithAdjustedBounds(currentNode, boundsForFakeNode.roundToIntRect())
+            } else if (virtualViewId == customRootNodeId) {
+                // Root view might have WRAP_CONTENT layout params in which case it will have zero
+                // bounds if there is no other content with semantics. But we need to always send
+                // the
+                // root view info as there are some other apps (e.g. Google Assistant) that depend
+                // on accessibility info
+                nodes[virtualViewId] = SemanticsNodeWithAdjustedBounds(currentNode, region.bounds)
+            }
+        }
+    }
+
+    findAllSemanticNodesRecursive(root, SemanticsRegion())
+    return nodes
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/semantics/SemanticsRegion.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/semantics/SemanticsRegion.skiko.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.semantics
+
+import androidx.compose.ui.unit.IntRect
+import org.jetbrains.skia.IRect
+import org.jetbrains.skia.Region
+
+/** Wrapper around platform-specific Region class */
+internal interface SemanticsRegion {
+    fun set(rect: IntRect)
+
+    fun intersect(region: SemanticsRegion): Boolean
+
+    fun difference(rect: IntRect): Boolean
+
+    val bounds: IntRect
+    val isEmpty: Boolean
+}
+
+private class SemanticRegionImpl : SemanticsRegion {
+    val region = Region()
+
+    override fun set(rect: IntRect) {
+        region.setRect(IRect.makeLTRB(rect.left, rect.top, rect.right, rect.bottom))
+    }
+
+    override val bounds: IntRect
+        get() = region.bounds.let {
+            IntRect(it.left, it.top, it.right, it.bottom)
+        }
+
+    override val isEmpty: Boolean
+        get() = region.isEmpty
+
+    override fun intersect(region: SemanticsRegion): Boolean {
+        return this.region.op((region as SemanticRegionImpl).region, Region.Op.INTERSECT)
+    }
+
+    override fun difference(rect: IntRect): Boolean {
+        return region.op(IRect.makeLTRB(rect.left, rect.top, rect.right, rect.bottom), Region.Op.DIFFERENCE)
+    }
+}
+
+/** Builder that creates wrapper around platform-specific Region class */
+internal fun SemanticsRegion(): SemanticsRegion = SemanticRegionImpl()


### PR DESCRIPTION
Move the semantic tree traversal function, including helper utils, to common code. Introduce SemanticRegion as a wrapper around the platform's Region class.

Test: AndroidComposeViewAccessibilityDelegateCompatTest, ScrollCaptureTest
Change-Id: Ibb25e7eac48ed0b61a9318b004669f0d7d0c8b97

