### PR TITLE
Set `browser` as a default for JS and Wasm targets config

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXMultiplatformExtension.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXMultiplatformExtension.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithHostTests
+import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsBrowserDsl
 import org.jetbrains.kotlin.gradle.targets.js.dsl.KotlinJsTargetDsl
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
@@ -292,12 +293,14 @@ open class AndroidXMultiplatformExtension(val project: Project) {
 
     @JvmOverloads
     fun js(
-        block: Action<KotlinJsTargetDsl>? = null
+        block: Action<KotlinJsBrowserDsl>? = null
     ): KotlinJsTargetDsl? {
         requestedPlatforms.add(PlatformIdentifier.JS)
         return if (project.enableJs()) {
             kotlinExtension.js().also {
-                block?.execute(it)
+                it.browser {
+                    block?.execute(this)
+                }
             }
         } else {
             null
@@ -307,12 +310,14 @@ open class AndroidXMultiplatformExtension(val project: Project) {
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
     @JvmOverloads
     fun wasm(
-        block: Action<KotlinJsTargetDsl>? = null
+        block: Action<KotlinJsBrowserDsl>? = null
     ): KotlinJsTargetDsl? {
         requestedPlatforms.add(PlatformIdentifier.WASM)
         return if (project.enableWasm()) {
             kotlinExtension.wasmJs().also {
-                block?.execute(it)
+                it.browser {
+                    block?.execute(this)
+                }
             }
         } else {
             null

--- a/core/core-uri/build.gradle
+++ b/core/core-uri/build.gradle
@@ -29,8 +29,8 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
-    js { browser() }
-    wasm { browser() }
+    js()
+    wasm()
 
     defaultPlatform(PlatformIdentifier.ANDROID)
 

--- a/lifecycle/lifecycle-runtime-testing/build.gradle
+++ b/lifecycle/lifecycle-runtime-testing/build.gradle
@@ -42,7 +42,7 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
-    js { browser() }
+    js()
     wasm()
 
     defaultPlatform(PlatformIdentifier.ANDROID)

--- a/navigation/navigation-common/build.gradle
+++ b/navigation/navigation-common/build.gradle
@@ -45,8 +45,8 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
-    js { browser() }
-    wasm { browser() }
+    js()
+    wasm()
 
     defaultPlatform(PlatformIdentifier.ANDROID)
 

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -40,8 +40,6 @@ androidXComposeMultiplatform {
 }
 
 kotlin {
-    wasmJs { browser() }
-
     sourceSets {
         commonMain {
             dependencies {

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -42,8 +42,8 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
-    js { browser() }
-    wasm { browser() }
+    js()
+    wasm()
 
     defaultPlatform(PlatformIdentifier.ANDROID)
 

--- a/navigation/navigation-testing/build.gradle
+++ b/navigation/navigation-testing/build.gradle
@@ -43,7 +43,7 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
-    js { browser() }
+    js()
     wasm()
 
     defaultPlatform(PlatformIdentifier.ANDROID)

--- a/testutils/testutils-navigation/build.gradle
+++ b/testutils/testutils-navigation/build.gradle
@@ -41,7 +41,7 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
-    js { browser() }
+    js()
     wasm()
 
     defaultPlatform(PlatformIdentifier.ANDROID)


### PR DESCRIPTION
Replaces direct `browser()` usage for JS and WASM targets with a centralized browser configuration in the `AndroidXMultiplatformExtension`.

## Release Notes
N/A
