### PR TITLE
Fix interop views location when overscroll applied

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -141,7 +141,7 @@ class CupertinoOverscrollEffect(
 
     override val node: DelegatableNode = CupertinoOverscrollNode(
         offset = { visibleOverscrollOffset },
-        updateCoordinates = { scrollSize = it.size.toSize() },
+        onCoordinatesUpdate = { scrollSize = it.size.toSize() },
         applyClip = applyClip
     )
 
@@ -441,11 +441,11 @@ class CupertinoOverscrollEffect(
 
 private class CupertinoOverscrollNode(
     val offset: Density.() -> IntOffset,
-    val updateCoordinates: (LayoutCoordinates) -> Unit,
+    val onCoordinatesUpdate: (LayoutCoordinates) -> Unit,
     val applyClip: Boolean
 ): LayoutModifierNode, LayoutAwareModifierNode, DrawModifierNode, Modifier.Node() {
     override fun onPlaced(coordinates: LayoutCoordinates) {
-        updateCoordinates(coordinates)
+        onCoordinatesUpdate(coordinates)
     }
 
     override fun ContentDrawScope.draw() {

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -458,12 +458,6 @@ private class CupertinoOverscrollNode(
                 right = rect.right,
                 bottom = rect.bottom,
             ) { this@draw.drawContent() }
-//            clipRect(
-//                top = maxOf(0f, -offset.y.toFloat()),
-//                bottom = size.height - maxOf(0, offset.y),
-//                left = maxOf(0f, -offset.x.toFloat()),
-//                right = size.width - maxOf(0, offset.x)
-//            ) { this@draw.drawContent() }
         } else {
             this@draw.drawContent()
         }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
@@ -43,6 +42,7 @@ import androidx.compose.ui.node.LayoutModifierNode
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.round
@@ -141,7 +141,7 @@ class CupertinoOverscrollEffect(
 
     override val node: DelegatableNode = CupertinoOverscrollNode(
         offset = { visibleOverscrollOffset },
-        onRemeasured = { scrollSize = it.size.toSize() },
+        onNodeRemeasured = { scrollSize = it.toSize() },
         applyClip = applyClip
     )
 
@@ -441,12 +441,10 @@ class CupertinoOverscrollEffect(
 
 private class CupertinoOverscrollNode(
     val offset: Density.() -> IntOffset,
-    val onRemeasured: (LayoutCoordinates) -> Unit,
+    val onNodeRemeasured: (IntSize) -> Unit,
     val applyClip: Boolean
 ): LayoutModifierNode, LayoutAwareModifierNode, DrawModifierNode, Modifier.Node() {
-    override fun onPlaced(coordinates: LayoutCoordinates) {
-        onRemeasured(coordinates)
-    }
+    override fun onRemeasured(size: IntSize) = onNodeRemeasured(size)
 
     override fun ContentDrawScope.draw() {
         if (applyClip) {

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -141,7 +141,7 @@ class CupertinoOverscrollEffect(
 
     override val node: DelegatableNode = CupertinoOverscrollNode(
         offset = { visibleOverscrollOffset },
-        onCoordinatesUpdate = { scrollSize = it.size.toSize() },
+        onRemeasured = { scrollSize = it.size.toSize() },
         applyClip = applyClip
     )
 
@@ -441,11 +441,11 @@ class CupertinoOverscrollEffect(
 
 private class CupertinoOverscrollNode(
     val offset: Density.() -> IntOffset,
-    val onCoordinatesUpdate: (LayoutCoordinates) -> Unit,
+    val onRemeasured: (LayoutCoordinates) -> Unit,
     val applyClip: Boolean
 ): LayoutModifierNode, LayoutAwareModifierNode, DrawModifierNode, Modifier.Node() {
     override fun onPlaced(coordinates: LayoutCoordinates) {
-        onCoordinatesUpdate(coordinates)
+        onRemeasured(coordinates)
     }
 
     override fun ContentDrawScope.draw() {

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -28,7 +28,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
@@ -448,17 +450,25 @@ private class CupertinoOverscrollNode(
 
     override fun ContentDrawScope.draw() {
         if (applyClip) {
-            val offset = offset()
+            val bounds = Rect(-offset().toOffset(), size)
+            val rect = size.toRect().intersect(bounds)
             clipRect(
-                top = maxOf(0f, -offset.y.toFloat()),
-                bottom = size.height - maxOf(0, offset.y),
-                left = maxOf(0f, -offset.x.toFloat()),
-                right = size.width - maxOf(0, offset.x)
+                left = rect.left,
+                top = rect.top,
+                right = rect.right,
+                bottom = rect.bottom,
             ) { this@draw.drawContent() }
+//            clipRect(
+//                top = maxOf(0f, -offset.y.toFloat()),
+//                bottom = size.height - maxOf(0, offset.y),
+//                left = maxOf(0f, -offset.x.toFloat()),
+//                right = size.width - maxOf(0, offset.x)
+//            ) { this@draw.drawContent() }
         } else {
             this@draw.drawContent()
         }
     }
+
 
     override fun MeasureScope.measure(
         measurable: Measurable,

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -468,8 +468,7 @@ private class CupertinoOverscrollNode(
     ): MeasureResult {
         val placeable = measurable.measure(constraints)
         return layout(placeable.width, placeable.height) {
-            val (x, y) = offset()
-            placeable.placeWithLayer(x, y)
+            placeable.placeWithLayer(offset())
         }
     }
 }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -27,17 +27,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
-import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
+import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -138,16 +141,9 @@ class CupertinoOverscrollEffect(
 
     override val node: DelegatableNode = CupertinoOverscrollNode(
         offset = { visibleOverscrollOffset },
-        coordinates = { scrollSize = it.size.toSize() },
+        updateCoordinates = { scrollSize = it.size.toSize() },
         applyClip = applyClip
     )
-
-    private fun Modifier.clipIfNeeded(): Modifier =
-        if (applyClip) {
-            clipToBounds() then this
-        } else {
-            this
-        }
 
     private fun NestedScrollSource.toCupertinoScrollSource(): CupertinoScrollSource? =
         when (this) {
@@ -445,29 +441,36 @@ class CupertinoOverscrollEffect(
 
 private class CupertinoOverscrollNode(
     val offset: Density.() -> IntOffset,
-    val coordinates: (LayoutCoordinates) -> Unit,
+    val updateCoordinates: (LayoutCoordinates) -> Unit,
     val applyClip: Boolean
-): LayoutAwareModifierNode, DrawModifierNode, Modifier.Node() {
-
-    override val shouldAutoInvalidate: Boolean = true
+): LayoutModifierNode, LayoutAwareModifierNode, DrawModifierNode, Modifier.Node() {
+    override fun onPlaced(coordinates: LayoutCoordinates) {
+        updateCoordinates(coordinates)
+    }
 
     override fun ContentDrawScope.draw() {
         if (applyClip) {
-            clipRect { this@draw.drawContentWithOffset() }
+            val offset = offset()
+            clipRect(
+                top = maxOf(0f, -offset.y.toFloat()),
+                bottom = size.height - maxOf(0, offset.y),
+                left = maxOf(0f, -offset.x.toFloat()),
+                right = size.width - maxOf(0, offset.x)
+            ) { this@draw.drawContent() }
         } else {
-            this@draw.drawContentWithOffset()
+            this@draw.drawContent()
         }
     }
 
-    private fun ContentDrawScope.drawContentWithOffset() {
-        val offset = offset()
-        translate(left = offset.x.toFloat(), top = offset.y.toFloat()) {
-            this@drawContentWithOffset.drawContent()
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints
+    ): MeasureResult {
+        val placeable = measurable.measure(constraints)
+        return layout(placeable.width, placeable.height) {
+            val (x, y) = offset()
+            placeable.placeWithLayer(x, y)
         }
-    }
-
-    override fun onPlaced(coordinates: LayoutCoordinates) {
-        coordinates(coordinates)
     }
 }
 


### PR DESCRIPTION
Apply a geometry transformation to the Overscroll effect node.
Modify the clip effect to cut content outside its node's initial geometry.

Fixes: https://youtrack.jetbrains.com/issue/CMP-7370/iOS-Overscroll-doesnt-move-iterop-views