### PR TITLE
Deprecate CupertinoScrollDecayAnimationSpec and CupertinoOverscrollEffect

### DIFF
--- a/compose/animation/animation-core/src/uikitMain/kotlin/androidx/compose/animation/core/cupertino/CupertinoScrollDecayAnimationSpec.kt
+++ b/compose/animation/animation-core/src/uikitMain/kotlin/androidx/compose/animation/core/cupertino/CupertinoScrollDecayAnimationSpec.kt
@@ -30,6 +30,7 @@ import platform.UIKit.UIScrollViewDecelerationRateNormal
  * @property decelerationRate The rate at which the velocity decelerates over time.
  * Default value is equal to one used by default UIScrollView behavior.
  */
+@Deprecated("Will be moved to separate library in the future")
 class CupertinoScrollDecayAnimationSpec(
     private val decelerationRate: Float = UIScrollViewDecelerationRateNormal.toFloat()
 ) : FloatDecayAnimationSpec {

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Overscroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Overscroll.uikit.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")
+
 package androidx.compose.foundation
 
 import androidx.compose.foundation.cupertino.CupertinoOverscrollEffect
@@ -29,7 +31,6 @@ import androidx.compose.ui.unit.LayoutDirection
 internal actual fun rememberPlatformOverscrollEffect(): OverscrollEffect? =
     rememberOverscrollEffect(applyClip = false)
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun rememberOverscrollEffect(applyClip: Boolean): OverscrollEffect {
     val density = LocalDensity.current.density

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Overscroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Overscroll.uikit.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION")
-
 package androidx.compose.foundation
 
 import androidx.compose.foundation.cupertino.CupertinoOverscrollEffect

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -20,7 +20,6 @@ import androidx.compose.animation.core.AnimationState
 import androidx.compose.animation.core.VectorConverter
 import androidx.compose.animation.core.animateTo
 import androidx.compose.animation.core.spring
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -86,7 +85,7 @@ private data class CupertinoOverscrollAvailableDelta(
  * @param applyClip Some consumers of overscroll effect apply clip by themselves and some don't,
  * thus this flag is needed to update our modifier chain and make the clipping correct in every case while avoiding redundancy
  */
-@ExperimentalFoundationApi
+@Deprecated("Will be moved to separate library in the future")
 class CupertinoOverscrollEffect(
     private val density: Float,
     layoutDirection: LayoutDirection,

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -85,8 +85,7 @@ private data class CupertinoOverscrollAvailableDelta(
  * @param applyClip Some consumers of overscroll effect apply clip by themselves and some don't,
  * thus this flag is needed to update our modifier chain and make the clipping correct in every case while avoiding redundancy
  */
-@Deprecated("Will be moved to separate library in the future")
-class CupertinoOverscrollEffect(
+internal class CupertinoOverscrollEffect(
     private val density: Float,
     layoutDirection: LayoutDirection,
     val applyClip: Boolean

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoScrollDecayAnimationSpec.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoScrollDecayAnimationSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package androidx.compose.animation.core.cupertino
+package androidx.compose.foundation.cupertino
 
 import androidx.compose.animation.core.FloatDecayAnimationSpec
 import kotlin.math.abs
@@ -30,8 +30,7 @@ import platform.UIKit.UIScrollViewDecelerationRateNormal
  * @property decelerationRate The rate at which the velocity decelerates over time.
  * Default value is equal to one used by default UIScrollView behavior.
  */
-@Deprecated("Will be moved to separate library in the future")
-class CupertinoScrollDecayAnimationSpec(
+internal class CupertinoScrollDecayAnimationSpec(
     private val decelerationRate: Float = UIScrollViewDecelerationRateNormal.toFloat()
 ) : FloatDecayAnimationSpec {
 

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/Scrollable.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/Scrollable.uikit.kt
@@ -17,16 +17,13 @@
 package androidx.compose.foundation.gestures
 
 import androidx.compose.animation.core.generateDecayAnimationSpec
+import androidx.compose.foundation.cupertino.CupertinoScrollDecayAnimationSpec
 import androidx.compose.foundation.gestures.cupertino.CupertinoFlingBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 
-@Suppress("DEPRECATION")
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    CupertinoFlingBehavior(
-        androidx.compose.animation.core.cupertino.CupertinoScrollDecayAnimationSpec()
-            .generateDecayAnimationSpec()
-    )
+    CupertinoFlingBehavior(CupertinoScrollDecayAnimationSpec().generateDecayAnimationSpec())
 
 @Composable
 internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/Scrollable.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/gestures/Scrollable.uikit.kt
@@ -16,14 +16,17 @@
 
 package androidx.compose.foundation.gestures
 
-import androidx.compose.animation.core.cupertino.CupertinoScrollDecayAnimationSpec
 import androidx.compose.animation.core.generateDecayAnimationSpec
 import androidx.compose.foundation.gestures.cupertino.CupertinoFlingBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 
+@Suppress("DEPRECATION")
 internal actual fun platformDefaultFlingBehavior(): ScrollableDefaultFlingBehavior =
-    CupertinoFlingBehavior(CupertinoScrollDecayAnimationSpec().generateDecayAnimationSpec())
+    CupertinoFlingBehavior(
+        androidx.compose.animation.core.cupertino.CupertinoScrollDecayAnimationSpec()
+            .generateDecayAnimationSpec()
+    )
 
 @Composable
 internal actual fun rememberPlatformDefaultFlingBehavior(): FlingBehavior =


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/CMP-6775/Update-Cupertino-Overscroll-and-Fling-API

## Release Notes
### Migration Notes - iOS
- Experimental classes `CupertinoScrollDecayAnimationSpec` and `CupertinoOverscrollEffect` are removed from public API