### PR TITLE
Support semantics traversal and sort

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIAccessibilityTraits)accessibilityTraits;
 
+- (UIAccessibilityContainerType)accessibilityContainerType;
+
 - (NSString *__nullable)accessibilityIdentifier;
 
 - (NSString *__nullable)accessibilityHint;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -41,6 +41,10 @@ NS_ASSUME_NONNULL_BEGIN
     return [super accessibilityTraits];
 }
 
+- (UIAccessibilityContainerType)accessibilityContainerType {
+    return [super accessibilityContainerType];
+}
+
 - (NSString *__nullable)accessibilityIdentifier {
     return [super accessibilityIdentifier];
 }


### PR DESCRIPTION
Apply semantics sort and semantics traversal to calculate accessibility elements location and order.

Fixes https://youtrack.jetbrains.com/issue/CMP-7300/iOS-Accessibility-Modal-navigation-drawer-content-does-not-seem-to-be-recognised
Fixes https://youtrack.jetbrains.com/issue/CMP-6762/Add-accessibility-API-from-platform-specifig-logic
Fixes https://youtrack.jetbrains.com/issue/CMP-7260/Support-UIAccessibilityContainerType
Fixes https://youtrack.jetbrains.com/issue/CMP-7562/Calculate-the-order-and-location-of-semantic-elements-in-the-same-way-as-its-done-on-Android

## Release Notes
### Features - iOS
- Calculate the order and location of semantic elements in the same way as it's done on Android.
- Support `UIAccessibilityContainerTypeSemanticGroup` for traversal groups