### PR TITLE
Fix diacritics input in BTF2 on macOS via long-press

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -34,9 +34,10 @@ import java.awt.im.InputMethodRequests
 import java.text.AttributedCharacterIterator
 import java.text.AttributedString
 import java.text.CharacterIterator
-import java.util.Locale
 import kotlin.math.max
 import kotlin.math.min
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
 
 internal class DesktopTextInputService(private val component: PlatformComponent) :
     PlatformTextInputService {
@@ -116,7 +117,7 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
         val composing = event.text?.toStringFrom(event.committedCharacterCount).orEmpty()
         val ops = mutableListOf<EditCommand>()
 
-        if (needToDeletePreviousChar && isMac && input.value.selection.min > 0 && composing.isEmpty()) {
+        if (needToDeletePreviousChar && input.value.selection.min > 0 && composing.isEmpty()) {
             needToDeletePreviousChar = false
             ops.add(DeleteSurroundingTextInCodePointsCommand(1, 0))
         }
@@ -166,7 +167,7 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
             override fun getSelectedText(
                 attributes: Array<AttributedCharacterIterator.Attribute>?
             ): AttributedCharacterIterator {
-                if (charKeyPressed) {
+                if (charKeyPressed && (hostOs == OS.MacOS)) {
                     needToDeletePreviousChar = true
                 }
                 val str = input.value.text.substring(input.value.selection)
@@ -235,6 +236,3 @@ private fun AttributedCharacterIterator.toStringFrom(index: Int): String {
     }
     return String(strBuf)
 }
-
-private val isMac =
-    System.getProperty("os.name").lowercase(Locale.ENGLISH).startsWith("mac")

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.platform.a11y.AccessibilityController
 import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -783,6 +784,11 @@ internal class ComposeSceneMediator(
                     textInputService.stopInput()
                 }
             })
+        }
+
+        @ExperimentalComposeUiApi
+        override fun updateSelectionState(newState: TextFieldValue) {
+            textInputService.updateState(oldValue = null, newValue = newState)
         }
 
         @ExperimentalComposeUiApi


### PR DESCRIPTION
Fix diacritics input in BTF2 on macOS via long-press.

Note that the fix itself is to call `textInputService.updateState` whenever the text changes. The changes in `DesktopPlatformInput.desktop.kt` are just a minor refactoring.

## Testing
Tested manually by long-pressing 'c' on:
```
val state = rememberTextFieldState()
TextField(state, modifier = Modifier.width(200.dp))
```
Unfortunately the implementation is not robust enough to be tested automatically. It depends on a call to `InputMethodRequests.getSelectedText` to activate the behavior, which is not possible to do in a test. We may want to improve this implementation in the future, by imitating what Swing does in `JTextComponent.replaceInputMethodText`.

This should be tested by QA

## Release Notes
### Fixes - Desktop
Fixed input of diacritics via long-press on macOS in `TextField(TextFieldState)` (aka `BasicTextField2`).
