### PR TITLE
Add API to cancel pointer input in ComposeScene

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3737,6 +3737,7 @@ public final class androidx/compose/ui/scene/CanvasLayersComposeScene_skikoKt {
 
 public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public abstract fun calculateContentSize-YbymL2g ()J
+	public abstract fun cancelAllPointers ()V
 	public abstract fun close ()V
 	public abstract fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3737,7 +3737,7 @@ public final class androidx/compose/ui/scene/CanvasLayersComposeScene_skikoKt {
 
 public abstract interface class androidx/compose/ui/scene/ComposeScene {
 	public abstract fun calculateContentSize-YbymL2g ()J
-	public abstract fun cancelAllPointers ()V
+	public abstract fun cancelPointerInput ()V
 	public abstract fun close ()V
 	public abstract fun getCompositionLocalContext ()Landroidx/compose/runtime/CompositionLocalContext;
 	public abstract fun getDensity ()Landroidx/compose/ui/unit/Density;

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.PositionCalculator
 import androidx.compose.ui.layout.RootMeasurePolicy
 import androidx.compose.ui.modifier.ModifierLocalManager
-import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.DefaultAccessibilityManager
 import androidx.compose.ui.platform.DefaultHapticFeedback
 import androidx.compose.ui.platform.DelegatingSoftwareKeyboardController
@@ -266,6 +265,10 @@ internal class RootNodeOwner(
             density = density,
             containerSize = platformContext.windowInfo.containerSize
         )
+    }
+
+    fun onCancelPointerInput() {
+        pointerInputEventProcessor.processCancel()
     }
 
     @OptIn(InternalCoreApi::class)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -59,6 +59,7 @@ internal abstract class BaseComposeScene(
         ComposeSceneInputHandler(
             prepareForPointerInputEvent = ::doMeasureAndLayout,
             processPointerInputEvent = ::processPointerInputEvent,
+            cancelPointerInput = ::cancelPointerInput,
             processKeyEvent = ::processKeyEvent
         )
 
@@ -250,6 +251,10 @@ internal abstract class BaseComposeScene(
         }
     }
 
+    override fun cancelAllPointers() {
+        inputHandler.cancelAllPointers()
+    }
+
     override fun sendKeyEvent(keyEvent: KeyEvent): Boolean = postponeInvalidation("BaseComposeScene:sendKeyEvent") {
         inputHandler.onKeyEvent(keyEvent).also {
             recomposer.performScheduledEffects()
@@ -263,9 +268,9 @@ internal abstract class BaseComposeScene(
 
     protected abstract fun createComposition(content: @Composable () -> Unit): Composition
 
-    protected abstract fun processPointerInputEvent(
-        event: PointerInputEvent
-    ): PointerEventResult
+    protected abstract fun processPointerInputEvent(event: PointerInputEvent): PointerEventResult
+
+    protected abstract fun cancelPointerInput()
 
     protected abstract fun processKeyEvent(keyEvent: KeyEvent): Boolean
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -59,7 +59,7 @@ internal abstract class BaseComposeScene(
         ComposeSceneInputHandler(
             prepareForPointerInputEvent = ::doMeasureAndLayout,
             processPointerInputEvent = ::processPointerInputEvent,
-            cancelPointerInput = ::cancelPointerInput,
+            cancelPointerInput = ::processCancelPointerInput,
             processKeyEvent = ::processKeyEvent
         )
 
@@ -251,8 +251,8 @@ internal abstract class BaseComposeScene(
         }
     }
 
-    override fun cancelAllPointers() {
-        inputHandler.cancelAllPointers()
+    override fun cancelPointerInput() {
+        inputHandler.cancelPointerInput()
     }
 
     override fun sendKeyEvent(keyEvent: KeyEvent): Boolean = postponeInvalidation("BaseComposeScene:sendKeyEvent") {
@@ -270,7 +270,7 @@ internal abstract class BaseComposeScene(
 
     protected abstract fun processPointerInputEvent(event: PointerInputEvent): PointerEventResult
 
-    protected abstract fun cancelPointerInput()
+    protected abstract fun processCancelPointerInput()
 
     protected abstract fun processKeyEvent(keyEvent: KeyEvent): Boolean
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -241,7 +241,7 @@ private class CanvasLayersComposeSceneImpl(
         return result
     }
 
-    override fun cancelPointerInput() {
+    override fun processCancelPointerInput() {
         forEachOwner {
             it.onCancelPointerInput()
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -242,10 +242,8 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     override fun cancelPointerInput() {
-        _ownersCopyCache.withCopy {
-            it.fastForEach {
-                it.onCancelPointerInput()
-            }
+        forEachOwner {
+            it.onCancelPointerInput()
         }
 
         // Reset gesture owner because all ongoing gestures are cancelled

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -241,6 +241,13 @@ private class CanvasLayersComposeSceneImpl(
         return result
     }
 
+    override fun cancelPointerInput() {
+        mainOwner.onCancelPointerInput()
+
+        // Reset gesture owner because all ongoing gestures are cancelled
+        gestureOwner = null
+    }
+
     override fun processKeyEvent(keyEvent: KeyEvent): Boolean =
         focusedLayer?.onKeyEvent(keyEvent) ?: mainOwner.onKeyEvent(keyEvent)
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -242,7 +242,11 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     override fun cancelPointerInput() {
-        mainOwner.onCancelPointerInput()
+        _ownersCopyCache.withCopy {
+            it.fastForEach {
+                it.onCancelPointerInput()
+            }
+        }
 
         // Reset gesture owner because all ongoing gestures are cancelled
         gestureOwner = null

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -230,10 +230,10 @@ interface ComposeScene {
     ): PointerEventResult
 
     /**
-     * Cancel all ongoing pointers in the content. It's expected that upcoming pointer events will
+     * Cancel ongoing pointer input in the content. It's expected that upcoming pointer events will
      * only represent new pointers.
      */
-    fun cancelAllPointers()
+    fun cancelPointerInput()
 
     /**
      * Send [KeyEvent] to the content.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -230,6 +230,12 @@ interface ComposeScene {
     ): PointerEventResult
 
     /**
+     * Cancel all ongoing pointers in the content. It's expected that upcoming pointer events will
+     * only represent new pointers.
+     */
+    fun cancelAllPointers()
+
+    /**
      * Send [KeyEvent] to the content.
      * @return true if the event was consumed by the content
      */

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -50,6 +50,7 @@ import org.jetbrains.skiko.currentNanoTime
 internal class ComposeSceneInputHandler(
     private val prepareForPointerInputEvent: () -> Unit,
     processPointerInputEvent: (PointerInputEvent) -> PointerEventResult,
+    private val cancelPointerInput: () -> Unit,
     private val processKeyEvent: (KeyEvent) -> Boolean,
 ) {
     private val defaultPointerStateTracker = DefaultPointerStateTracker()
@@ -96,6 +97,11 @@ internal class ComposeSceneInputHandler(
             nativeEvent,
             button
         )
+    }
+
+    fun cancelAllPointers() {
+        syntheticEventSender.reset()
+        cancelPointerInput()
     }
 
     fun onPointerEvent(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -99,9 +99,9 @@ internal class ComposeSceneInputHandler(
         )
     }
 
-    fun cancelAllPointers() {
+    fun cancelPointerInput() {
         syntheticEventSender.reset()
-        cancelPointerInput()
+        this.cancelPointerInput.invoke()
     }
 
     fun onPointerEvent(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -165,6 +165,10 @@ private class PlatformLayersComposeSceneImpl(
     override fun processPointerInputEvent(event: PointerInputEvent) =
         mainOwner.onPointerInput(event)
 
+    override fun cancelPointerInput() {
+        mainOwner.onCancelPointerInput()
+    }
+
     override fun processKeyEvent(keyEvent: KeyEvent): Boolean =
         mainOwner.onKeyEvent(keyEvent)
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -165,7 +165,7 @@ private class PlatformLayersComposeSceneImpl(
     override fun processPointerInputEvent(event: PointerInputEvent) =
         mainOwner.onPointerInput(event)
 
-    override fun cancelPointerInput() {
+    override fun processCancelPointerInput() {
         mainOwner.onCancelPointerInput()
     }
 

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/BaseComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/BaseComposeSceneTest.kt
@@ -101,7 +101,7 @@ class BaseComposeSceneTest {
             }
 
             scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
-            scene.cancelAllPointers()
+            scene.cancelPointerInput()
 
             assertEquals(1, cancellationsCount)
         }
@@ -128,7 +128,7 @@ class BaseComposeSceneTest {
 
             // Start and cancel click
             scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
-            scene.cancelAllPointers()
+            scene.cancelPointerInput()
             scene.sendPointerEvent(PointerEventType.Release, Offset(40f, 40f))
 
             // Perform second click

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/BaseComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/BaseComposeSceneTest.kt
@@ -21,15 +21,18 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.unit.IntSize
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 
@@ -92,15 +95,12 @@ class BaseComposeSceneTest {
         scenes.forEach { scene ->
             var cancellationsCount = 0
             scene.setContent {
-                Box(modifier = Modifier.fillMaxSize().pointerInput(PointerEventPass.Initial) {
-                    suspendCancellableCoroutine {
-                        cancellationsCount++
-                    }
+                Box(modifier = Modifier.fillMaxSize().onCancel {
+                    cancellationsCount++
                 })
             }
 
             scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
-            scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
             scene.cancelAllPointers()
 
             assertEquals(1, cancellationsCount)
@@ -122,15 +122,46 @@ class BaseComposeSceneTest {
                 })
             }
 
+            // Perform first click
             scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
-            scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 20f))
+            scene.sendPointerEvent(PointerEventType.Release, Offset(40f, 40f))
+
+            // Start and cancel click
+            scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
             scene.cancelAllPointers()
+            scene.sendPointerEvent(PointerEventType.Release, Offset(40f, 40f))
 
+            // Perform second click
             scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
-            scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 20f))
+            scene.sendPointerEvent(PointerEventType.Release, Offset(40f, 40f))
 
-            // Getting one click instead of two
-            assertEquals(1, clicksCount)
+            // Should be only two clicks
+            assertEquals(2, clicksCount)
         }
+    }
+}
+
+internal fun Modifier.onCancel(onCancel: () -> Unit) = this then TestCancellable(onCancel)
+
+private class TestCancellable(
+    private val onCancel: () -> Unit
+) : ModifierNodeElement<CancellableNode>() {
+    override fun create() = CancellableNode(onCancel)
+    override fun hashCode(): Int = 0
+    override fun equals(other: Any?): Boolean = false
+    override fun update(node: CancellableNode) { node.onCancel = onCancel }
+}
+
+private class CancellableNode(
+    var onCancel: () -> Unit
+): DelegatingNode(), PointerInputModifierNode {
+    override fun onPointerEvent(
+        pointerEvent: PointerEvent,
+        pass: PointerEventPass,
+        bounds: IntSize
+    ) {}
+
+    override fun onCancelPointerInput() {
+        onCancel()
     }
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
@@ -70,7 +70,7 @@ class CanvasLayersComposeSceneTest {
             }
 
             scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
-            scene.cancelAllPointers()
+            scene.cancelPointerInput()
 
             assertFalse(rootCancelled)
             assertTrue(popupCancelled)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
@@ -19,9 +19,15 @@ package androidx.compose.ui.scene
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 
@@ -41,6 +47,33 @@ class CanvasLayersComposeSceneTest {
             assertEquals(1, invalidationCount)
             scene.size = IntSize(120, 120)
             assertEquals(2, invalidationCount)
+        } finally {
+            scene.close()
+        }
+    }
+
+    @Test
+    fun cancelClickForGestureOwner() = runTest(StandardTestDispatcher()) {
+        var rootCancelled = false
+        var popupCancelled = false
+        val scene = CanvasLayersComposeScene(
+            size = IntSize(100, 100),
+            coroutineContext = coroutineContext,
+        )
+        try {
+            scene.setContent {
+                Box(modifier = Modifier.fillMaxSize().onCancel { rootCancelled = true })
+
+                Dialog(onDismissRequest = {}, properties = DialogProperties()) {
+                    Box(modifier = Modifier.fillMaxSize().onCancel { popupCancelled = true })
+                }
+            }
+
+            scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
+            scene.cancelAllPointers()
+
+            assertFalse(rootCancelled)
+            assertTrue(popupCancelled)
         } finally {
             scene.close()
         }


### PR DESCRIPTION
Required to properly implement interop touches and predictive back-handling.
Add `cancelAllPointers()` method to `ComposeScene`.
Cancel ongoing session in `SyntheticEventSender`.
Pass event to the root node owner.