### PR TITLE
Refactor interop touches handling

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropExample.kt
@@ -16,19 +16,24 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,27 +46,298 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.findRootCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.uikit.LocalUIViewController
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.viewinterop.UIKitViewController
+import androidx.compose.ui.window.ComposeUIViewController
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.objcPtr
 import kotlinx.cinterop.readValue
-import kotlinx.coroutines.delay
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
+import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSSelectorFromString
 import platform.MapKit.MKMapView
 import platform.UIKit.NSTextAlignmentCenter
+import platform.UIKit.UIAction
+import platform.UIKit.UIButton
+import platform.UIKit.UIButtonTypeSystem
 import platform.UIKit.UIColor
 import platform.UIKit.UIControlEventEditingChanged
+import platform.UIKit.UIControlStateNormal
 import platform.UIKit.UIEvent
 import platform.UIKit.UILabel
+import platform.UIKit.UIMenu
+import platform.UIKit.UINavigationController
+import platform.UIKit.UIScrollView
 import platform.UIKit.UITextField
-import platform.UIKit.UIView
 import platform.UIKit.UIViewController
+import platform.UIKit.addChildViewController
+import platform.UIKit.didMoveToParentViewController
+
+val InteropExample = Screen.Example("Interop") {
+    Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+        UIKitViewInteractionModeSection()
+        UIKitViewControllerSection()
+        TextSection()
+        TextFieldSection()
+        ModalNavigationSection()
+        UIMenuSection()
+        ComposeSwipeBackFullscreenSection()
+        UIScrollViewSection()
+        ComposeInsideScrollViewSection()
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun UIKitViewInteractionModeSection() {
+    Text("UIKitView - interactionMode")
+    UIKitView(
+        factory = { TouchReactingView("Cooperative, Default") },
+        modifier = Modifier.fillMaxWidth().height(40.dp),
+        properties = UIKitInteropProperties(
+            interactionMode = UIKitInteropInteractionMode.Cooperative()
+        )
+    )
+    UIKitView(
+        factory = { TouchReactingView("Cooperative, 1000 ms") },
+        modifier = Modifier.fillMaxWidth().height(40.dp),
+        properties = UIKitInteropProperties(
+            interactionMode = UIKitInteropInteractionMode.Cooperative(delayMillis = 1000)
+        )
+    )
+    UIKitView(
+        factory = { TouchReactingView("Non-cooperative") },
+        modifier = Modifier.fillMaxWidth().height(40.dp),
+        properties = UIKitInteropProperties(
+            interactionMode = UIKitInteropInteractionMode.NonCooperative
+        )
+    )
+    UIKitView(
+        factory = { TouchReactingView("Non-interactive") },
+        modifier = Modifier.fillMaxWidth().height(40.dp),
+        properties = UIKitInteropProperties(
+            interactionMode = null
+        )
+    )
+}
+
+@Composable
+private fun TextFieldSection() {
+    var text by remember { mutableStateOf("Type something") }
+    Text("Material TextField:")
+    TextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth())
+
+    Text("UITextField:")
+    ComposeUITextField(
+        text,
+        onValueChange = { text = it },
+        Modifier.fillMaxWidth().height(40.dp)
+    )
+}
+
+@Composable
+private fun ModalNavigationSection() {
+    Text("Modal navigation:")
+    val controller = LocalUIViewController.current
+    Button({
+        controller.presentModalViewController(
+            ComposeUIViewController { ModalViewContent() },
+            animated = true
+        )
+    }, modifier = Modifier.fillMaxWidth().height(40.dp)) {
+        Text("Show modal view")
+    }
+}
+
+@Composable
+private fun ComposeInsideScrollViewSection() {
+    Text("Compose scene inside scroll view:")
+    val parent = LocalUIViewController.current
+    UIKitView(
+        factory = {
+            val scrollView = UIScrollView()
+            scrollView.setContentSize(CGSizeMake(1000.0, 100.0))
+            scrollView.backgroundColor = UIColor.whiteColor
+
+            val composeViewController = ComposeUIViewController {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.LightGray)
+                ) {
+                    Button(
+                        onClick = { println("Clicked") },
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                    ) {
+                        Column {
+                            Text("Compose Button")
+                            Text("(shouldn't click when swipe over)", fontSize = 10.sp)
+                        }
+                    }
+                }
+            }
+            parent.addChildViewController(composeViewController)
+            scrollView.addSubview(composeViewController.view)
+            composeViewController.view.setFrame(CGRectMake(10.0, 10.0, 300.0, 80.0))
+            composeViewController.didMoveToParentViewController(parent)
+
+            scrollView
+        },
+        modifier = Modifier.fillMaxWidth().height(100.dp),
+    )
+}
+
+@Composable
+private fun ComposeSwipeBackFullscreenSection() {
+    Text("Swipe back on modal navigation:")
+    val controller = LocalUIViewController.current
+    Button({
+        val navigationController = UINavigationController()
+        navigationController.setViewControllers(listOf(
+            ComposeUIViewController { ModalViewContent() }.also { it.title = "Screen 1"},
+            ComposeUIViewController { ModalViewContent() }.also { it.title = "Screen 2"},
+            ComposeUIViewController { ModalViewContent() }.also { it.title = "Screen 3"}
+        ))
+
+        controller.presentModalViewController(navigationController, animated = true)
+    }, modifier = Modifier.fillMaxWidth().height(40.dp)) {
+        Text("Show UINavigationController")
+    }
+}
+
+@Composable
+private fun UIScrollViewSection() {
+    Text("Horizontal interop UIScrollView:")
+    UIKitView(
+        factory = {
+            val scrollView = UIScrollView()
+            scrollView.setContentSize(CGSizeMake(1000.0, 100.0))
+            scrollView.backgroundColor = UIColor.lightGrayColor
+            scrollView
+        },
+        modifier = Modifier.fillMaxWidth().height(100.dp),
+        update = {
+            println("MKMapView updated")
+        }
+    )
+
+    Text("Vertical interop UIScrollView:")
+    var scrollViewSize by mutableStateOf(DpSize.Zero)
+    val density = LocalDensity.current
+    UIKitView(
+        factory = {
+            val scrollView = UIScrollView()
+            scrollView.setContentSize(
+                CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
+            )
+            scrollView.backgroundColor = UIColor.lightGrayColor
+            scrollView
+        },
+        update = { scrollView ->
+            scrollView.setContentSize(
+                CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
+            )
+        },
+        modifier = Modifier.fillMaxWidth().height(400.dp).onSizeChanged {
+            scrollViewSize = with(density) {
+                DpSize(it.width.toDp(), it.height.toDp())
+            }
+        }
+    )
+}
+
+@Composable
+private fun TextSection() {
+    Text("Material and Native text:")
+    Row(modifier = Modifier.fillMaxWidth().height(40.dp)) {
+        Text(
+            text = "material.Text",
+            modifier = Modifier.weight(0.5f).height(40.dp)
+                .wrapContentHeight(Alignment.CenterVertically),
+            letterSpacing = 0.sp,
+            style = MaterialTheme.typography.body1
+        )
+        UIKitView(
+            factory = {
+                val label = UILabel(frame = CGRectZero.readValue())
+                label.text = "UIKit.UILabel"
+                label.textColor = UIColor.blackColor
+                label
+            },
+            modifier = Modifier.weight(0.5f).height(40.dp)
+                .border(1.dp, Color.Blue),
+            onReset = { /* Just to make it reusable */ }
+        )
+    }
+}
+
+@Composable
+@OptIn(ExperimentalComposeUiApi::class)
+private fun UIKitViewControllerSection() {
+    var updatedValue by remember { mutableStateOf(null as Offset?) }
+
+    Text("UIViewController subclass:")
+    UIKitViewController(
+        factory = {
+            BlueViewController()
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(100.dp)
+            .onGloballyPositioned { coordinates ->
+                val rootCoordinates = coordinates.findRootCoordinates()
+                val box =
+                    rootCoordinates.localBoundingBoxOf(coordinates, clipBounds = false)
+                updatedValue = box.topLeft
+            },
+        update = { viewController ->
+            updatedValue?.let {
+                viewController.label.text = "Custom UIViewController:\n${it.x}, ${it.y}"
+            }
+        },
+        properties = UIKitInteropProperties(
+            isNativeAccessibilityEnabled = true
+        )
+    )
+}
+
+@Composable
+fun UIMenuSection() {
+    Text("UIMenu:")
+    UIKitView(
+        factory = {
+            UIButton.buttonWithType(UIButtonTypeSystem).apply {
+                showsMenuAsPrimaryAction = true
+                menu = UIMenu.menuWithChildren(
+                    listOf(
+                        UIAction.actionWithTitle("Menu Item 1", null, null) {
+                            println("Selected 'Menu Item 1'")
+                        },
+                        UIAction.actionWithTitle("Menu Item 2", null, null) {
+                            println("Selected 'Menu Item 2'")
+                        },
+                        UIAction.actionWithTitle("Menu Item 3", null, null) {
+                            println("Selected 'Menu Item 3'")
+                        }
+                    )
+                )
+                setTitle("Open UIMenu", forState = UIControlStateNormal)
+            }
+        },
+        modifier = Modifier.fillMaxWidth().height(40.dp)
+    )
+}
 
 private class BlueViewController : UIViewController(nibName = null, bundle = null) {
     val label = UILabel()
@@ -73,6 +349,7 @@ private class BlueViewController : UIViewController(nibName = null, bundle = nul
     override fun viewDidLoad() {
         super.viewDidLoad()
 
+        label.setNumberOfLines(2)
         label.textAlignment = NSTextAlignmentCenter
         label.textColor = UIColor.whiteColor
         label.backgroundColor = UIColor.blueColor
@@ -103,127 +380,61 @@ private class BlueViewController : UIViewController(nibName = null, bundle = nul
     }
 }
 
-private class TouchReactingView : UIView(frame = CGRectZero.readValue()) {
+private class TouchReactingView(val label: String) : UIButton(frame = CGRectZero.readValue()) {
     init {
-        setUserInteractionEnabled(true)
-
         setDefaultColor()
+        setTitle(label, forState = UIControlStateNormal)
     }
 
     private fun setDefaultColor() {
-        backgroundColor = UIColor.greenColor
+        backgroundColor = UIColor.darkGrayColor
     }
 
     override fun touchesBegan(touches: Set<*>, withEvent: UIEvent?) {
         super.touchesBegan(touches, withEvent)
         backgroundColor = UIColor.redColor
+        println("[${label}]: Touches Began")
     }
 
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent?) {
         super.touchesMoved(touches, withEvent)
+        println("[${label}]: Touches Moved")
     }
 
     override fun touchesEnded(touches: Set<*>, withEvent: UIEvent?) {
         super.touchesEnded(touches, withEvent)
         setDefaultColor()
+        println("[${label}]: Touches Ended")
     }
 
     override fun touchesCancelled(touches: Set<*>, withEvent: UIEvent?) {
         super.touchesCancelled(touches, withEvent)
         setDefaultColor()
+        println("[${label}]: Touches Cancelled")
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
-val InteropExample = Screen.Example("Interop") {
-    var text by remember { mutableStateOf("Type something") }
-    var updatedValue by remember { mutableStateOf(null as Offset?) }
-
-
-    LazyColumn(Modifier.fillMaxSize()) {
-        item {
-            var temp by remember { mutableStateOf(0) }
-
-            LaunchedEffect(Unit) {
-                while (true) {
-                    temp += 1
-                    delay(1000)
-                }
-            }
-
-            UIKitView(
-                factory = {
-                    println("Factory called $temp")
-                    MKMapView()
-                },
-                modifier = Modifier.fillMaxWidth().height(200.dp),
-                update = {
-                    println("MKMapView updated")
-                }
+@Composable
+fun ModalViewContent() {
+    Column {
+        Box(Modifier.fillMaxWidth().weight(1f).background(Color.LightGray)) {
+            Text(
+                text = "Non-scrollable area.\nSwipe down to hide modal view",
+                modifier = Modifier.align(Alignment.Center)
             )
         }
-        item {
-            UIKitViewController(
-                factory = {
-                    BlueViewController()
-                },
+        Column(Modifier.fillMaxWidth().weight(1f).verticalScroll(rememberScrollState())) {
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(100.dp)
-                    .onGloballyPositioned { coordinates ->
-                        val rootCoordinates = coordinates.findRootCoordinates()
-                        val box =
-                            rootCoordinates.localBoundingBoxOf(coordinates, clipBounds = false)
-                        updatedValue = box.topLeft
-                    },
-                update = { viewController ->
-                    updatedValue?.let {
-                        viewController.label.text = "${it.x}, ${it.y}"
-                    }
-                },
-                properties = UIKitInteropProperties(
-                    interactionMode = null,
-                    isNativeAccessibilityEnabled = false
-                )
-            )
-        }
-        items(100) { index ->
-            when (index % 3) {
-                0 -> Row(
-                    modifier = Modifier.fillMaxWidth().height(40.dp),
-                ) {
-                    Text(
-                        text = "material.Text $index",
-                        modifier = Modifier.weight(0.5f).height(40.dp)
-                            .wrapContentHeight(Alignment.CenterVertically),
-                        letterSpacing = 0.sp,
-                        style = MaterialTheme.typography.body1
-                    )
-                    UIKitView(
-                        factory = {
-                            val label = UILabel(frame = CGRectZero.readValue())
-                            label.text = "UIKit.UILabel $index"
-                            label.textColor = UIColor.blackColor
-                            label
-                        },
-                        modifier = Modifier.weight(0.5f).height(40.dp)
-                            .border(1.dp, Color.Blue),
-                        onReset = { /* Just to make it reusable */ },
-                        properties = UIKitInteropProperties(
-                            interactionMode = null
-                        )
-                    )
-                }
-                1 -> UIKitView(
-                    factory = { TouchReactingView() },
-                    modifier = Modifier.fillMaxWidth().height(40.dp),
-                )
-
-                2 -> TextField(text, onValueChange = { text = it }, Modifier.fillMaxWidth())
-                3 -> ComposeUITextField(
-                    text,
-                    onValueChange = { text = it },
-                    Modifier.fillMaxWidth().height(40.dp)
+                    .background(Color.Gray)
+                    .padding(top = 100.dp)
+                    .height(1000.dp)
+            ) {
+                // TODO: https://youtrack.jetbrains.com/issue/CMP-5707
+                Text(
+                    text = "Scrollable area.\nSwipe down to collapse - does not work yet.",
+                    modifier = Modifier.align(Alignment.TopCenter)
                 )
             }
         }
@@ -237,6 +448,7 @@ val InteropExample = Screen.Example("Interop") {
  * updated text comes as a parameter of the callback
  * @param modifier a [Modifier] for this text field. Size should be specified in modifier.
  */
+@OptIn(BetaInteropApi::class)
 @Composable
 private fun ComposeUITextField(value: String, onValueChange: (String) -> Unit, modifier: Modifier) {
     val latestOnValueChanged by rememberUpdatedState(onValueChange)

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -15,38 +15,23 @@
  */
 
 #import <UIKit/UIKit.h>
-#import <UIKit/UIGestureRecognizerSubclass.h>
-#import "CMPMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface CMPGestureRecognizer : UIGestureRecognizer
 
-/// Class that propery exposes the methods of `UIGestureRecognizerDelegate` to Kotlin without signature conflicts.
-/// Default implementations return the same result as if the selector wasn't implemented at all, following the Apple documentation
-/// See https://developer.apple.com/documentation/uikit/uigesturerecognizerdelegate
-@interface CMPGestureRecognizerDelegateProxy : NSObject <UIGestureRecognizerDelegate>
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
-- (BOOL)gestureRecognizerShouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer otherGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer CMP_CAN_OVERRIDE;
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
-- (BOOL)gestureRecognizerShouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer otherGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer CMP_CAN_OVERRIDE;
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
-- (BOOL)gestureRecognizerShouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer otherGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer CMP_CAN_OVERRIDE;
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 
-@end
+- (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer *)preventedGestureRecognizer;
 
-
-@interface CMPGestureRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
-
-- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event CMP_ABSTRACT_FUNCTION;
-
-- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event CMP_ABSTRACT_FUNCTION;
-
-- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event CMP_ABSTRACT_FUNCTION;
-
-- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event CMP_ABSTRACT_FUNCTION;
+- (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer;
 
 @end
-
 
 NS_ASSUME_NONNULL_END
- 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -16,51 +16,30 @@
 
 #import "CMPGestureRecognizer.h"
 
-@implementation CMPGestureRecognizerDelegateProxy
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return [self gestureRecognizerShouldRequireFailureOfGestureRecognizer:gestureRecognizer otherGestureRecognizer:otherGestureRecognizer];
-}
-
-- (BOOL)gestureRecognizerShouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer otherGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return NO;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return [self gestureRecognizerShouldRecognizeSimultaneouslyWithGestureRecognizer:gestureRecognizer otherGestureRecognizer:otherGestureRecognizer];
-}
-
-- (BOOL)gestureRecognizerShouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer otherGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return NO;
-}
-
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return [self gestureRecognizerShouldBeRequiredToFailByGestureRecognizer:gestureRecognizer otherGestureRecognizer:otherGestureRecognizer];
-}
-
-- (BOOL)gestureRecognizerShouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer otherGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return NO;
-}
-
-@end
-
-
 @implementation CMPGestureRecognizer
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    CMP_ABSTRACT_FUNCTION_CALLED
+    [super touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    CMP_ABSTRACT_FUNCTION_CALLED
+    [super touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    CMP_ABSTRACT_FUNCTION_CALLED
+    [super touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    CMP_ABSTRACT_FUNCTION_CALLED
+    [super touchesCancelled:touches withEvent:event];
+}
+
+- (BOOL)canPreventGestureRecognizer:(UIGestureRecognizer *)preventedGestureRecognizer {
+    return [super canPreventGestureRecognizer:preventedGestureRecognizer];
+}
+
+- (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer {
+    return [super canBePreventedByGestureRecognizer:preventingGestureRecognizer];
 }
 
 @end

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/draganddrop/UIKitDragAndDropManager.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/draganddrop/UIKitDragAndDropManager.uikit.kt
@@ -46,23 +46,24 @@ import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIBezierPath
 import platform.UIKit.UIColor
 import platform.UIKit.UIDragInteraction
+import platform.UIKit.UIDragInteractionDelegateProtocol
 import platform.UIKit.UIDragItem
 import platform.UIKit.UIDragSessionProtocol
 import platform.UIKit.UIDropInteraction
-import platform.UIKit.UIDropOperationForbidden
-import platform.UIKit.UIDropProposal
-import platform.UIKit.UIDropSessionProtocol
-import platform.UIKit.addInteraction
-import platform.UIKit.UIDragInteractionDelegateProtocol
 import platform.UIKit.UIDropInteractionDelegateProtocol
 import platform.UIKit.UIDropOperation
 import platform.UIKit.UIDropOperationCopy
+import platform.UIKit.UIDropOperationForbidden
+import platform.UIKit.UIDropProposal
+import platform.UIKit.UIDropSessionProtocol
 import platform.UIKit.UIImageView
+import platform.UIKit.UILongPressGestureRecognizer
 import platform.UIKit.UIPreviewParameters
 import platform.UIKit.UIPreviewTarget
 import platform.UIKit.UITargetedDragPreview
 import platform.UIKit.UIView
 import platform.UIKit.UIViewContentMode
+import platform.UIKit.addInteraction
 
 /**
  * Context of a drag session initiated from Compose.
@@ -320,6 +321,15 @@ internal class UIKitDragAndDropManager(
     init {
         view.addInteraction(UIDragInteraction(delegate = dragInteractionProxy))
         view.addInteraction(UIDropInteraction(delegate = dropInteractionProxy))
+
+        // UIDragInteraction adds its own gesture recogniser that can cancel the gesture that is
+        // responsive to touch handling. Ignore this gesture if the drag session is not started
+        // or empty.
+        view.canIgnoreDragGesture = { gestureRecognizer ->
+            (gestureRecognizer is UILongPressGestureRecognizer &&
+                gestureRecognizer.view == view &&
+                dragSessionContext?.transferData?.items?.isNotEmpty() != true)
+        }
     }
 
     private fun <R> withDragSessionContext(block: DragSessionContext.() -> R): R? =

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -50,7 +50,6 @@ import androidx.compose.ui.viewinterop.UIKitInteropTransaction
 import androidx.compose.ui.window.ComposeView
 import androidx.compose.ui.window.DisplayLinkListener
 import androidx.compose.ui.window.FocusStack
-import androidx.compose.ui.window.GestureEvent
 import androidx.compose.ui.window.MetalView
 import androidx.compose.ui.window.ViewControllerBasedLifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -70,7 +69,6 @@ import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGSize
 import platform.UIKit.UIApplication
-import platform.UIKit.UIEvent
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UITraitCollection
@@ -336,7 +334,6 @@ internal class ComposeHostingViewController(
                     createComposeSceneContext = ::createComposeSceneContext,
                     hostCompositionLocals = { ProvideContainerCompositionLocals(it) },
                     metalView = layers.metalView,
-                    onGestureEvent = layers::onGestureEvent,
                     initDensity = density,
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
@@ -381,7 +378,6 @@ internal class ComposeHostingViewController(
         windowContext = windowContext,
         coroutineContext = coroutineContext,
         redrawer = rootMetalView.redrawer,
-        onGestureEvent = ::onGestureEvent,
         composeSceneFactory = ::createComposeScene,
     ).also { mediator ->
         mediator.updateInteractionRect()
@@ -405,20 +401,6 @@ internal class ComposeHostingViewController(
             }
         }
         mediator?.isAccessibilityEnabled = isAccessibilityEnabled
-    }
-
-    /**
-     * When there is an ongoing gesture, we need notify redrawer about it. It should unconditionally
-     * unpause CADisplayLink which affects frequency of polling UITouch events on high frequency
-     * display and force it to match display refresh rate.
-     *
-     * Otherwise [UIEvent]s will be dispatched with the 60hz frequency.
-     */
-    private fun onGestureEvent(gestureEvent: GestureEvent) {
-        rootMetalView.needsProactiveDisplayLink = when (gestureEvent) {
-            GestureEvent.BEGAN -> true
-            GestureEvent.ENDED -> false
-        }
     }
 
     private fun dispose() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -19,7 +19,6 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.ui.backhandler.LocalBackGestureDispatcher
 import androidx.compose.ui.backhandler.UIKitBackGestureDispatcher
 import androidx.compose.ui.graphics.Canvas
@@ -41,11 +40,9 @@ import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toRect
 import androidx.compose.ui.window.FocusStack
-import androidx.compose.ui.window.GestureEvent
 import androidx.compose.ui.window.MetalView
 import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.CValue
-import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGPoint
 import platform.UIKit.UIWindow
 
@@ -54,7 +51,6 @@ internal class UIKitComposeSceneLayer(
     private val createComposeSceneContext: (PlatformContext) -> ComposeSceneContext,
     private val hostCompositionLocals: @Composable (@Composable () -> Unit) -> Unit,
     private val metalView: MetalView,
-    onGestureEvent: (GestureEvent) -> Unit,
     private val initDensity: Density,
     private val initLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
@@ -85,7 +81,6 @@ internal class UIKitComposeSceneLayer(
         windowContext = windowContext,
         coroutineContext = compositionContext.effectCoroutineContext,
         redrawer = metalView.redrawer,
-        onGestureEvent = onGestureEvent,
         composeSceneFactory = ::createComposeScene
     )
 
@@ -163,7 +158,6 @@ internal class UIKitComposeSceneLayer(
         view.removeFromSuperview()
     }
 
-    @OptIn(ExperimentalComposeApi::class)
     @Composable
     private fun ProvideComposeSceneLayerCompositionLocals(
         content: @Composable () -> Unit

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
@@ -17,10 +17,11 @@
 package androidx.compose.ui.scene
 
 import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.window.centroidLocationInView
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
+import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGPoint
+import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIEvent
 import platform.UIKit.UITouch
@@ -120,4 +121,34 @@ internal class UIKitComposeSceneLayerView(
         super.didMoveToWindow()
         onDidMoveToWindow(window)
     }
+}
+
+/**
+ * Calculate the centroid location of the touches in the given collection.
+ *
+ * @param view The view in which coordinate space calculation is performed.
+ *
+ * @return The centroid location of the touches in [this] collection in the coordinate space
+ * of the given [view]. Or `null` if [this] is empty.
+ */
+private fun Collection<UITouch>.centroidLocationInView(view: UIView): CValue<CGPoint>? {
+    if (isEmpty()) {
+        return null
+    }
+
+    var centroidX = 0.0
+    var centroidY = 0.0
+
+    for (touch in this) {
+        val location = touch.locationInView(view)
+        location.useContents {
+            centroidX += x
+            centroidY += y
+        }
+    }
+
+    return CGPointMake(
+        x = centroidX / size.toDouble(),
+        y = centroidY / size.toDouble()
+    )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/InteropView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/InteropView.uikit.kt
@@ -17,17 +17,18 @@
 package androidx.compose.ui.viewinterop
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import androidx.compose.ui.interop.UIKitViewController
 import androidx.compose.ui.semantics.AccessibilityKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.uikit.utils.CMPInteropWrappingView
-import androidx.compose.ui.interop.UIKitView
-import androidx.compose.ui.interop.UIKitViewController
 import kotlinx.cinterop.readValue
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIResponder
 import platform.UIKit.UIView
 import platform.UIKit.UIViewController
+import platform.UIKit.setIsAccessibilityElement
 
 /**
  * On iOS [InteropView] is a [UIResponder], which is a base class for [UIView] and [UIViewController]
@@ -51,11 +52,18 @@ internal actual typealias InteropViewGroup = UIView
  * @see UIKitInteropInteractionMode
  */
 internal class InteropWrappingView(
-    var interactionMode: UIKitInteropInteractionMode?
+    interactionMode: UIKitInteropInteractionMode?
 ) : CMPInteropWrappingView(frame = CGRectZero.readValue()) {
     var actualAccessibilityContainer: Any? = null
 
+    var interactionMode: UIKitInteropInteractionMode? = interactionMode
+        set(value) {
+            field = value
+            setIsAccessibilityElement(value != null)
+        }
+
     init {
+        setIsAccessibilityElement(interactionMode != null)
         // required to properly clip the content of the wrapping view in case interop unclipped
         // bounds are larger than clipped bounds
         clipsToBounds = true

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
@@ -103,7 +103,7 @@ internal class ComposeView(
         isAnimating = true
         updateLayout()
         metalView.redrawer.isForcedToPresentWithTransactionEveryFrame = true
-        metalView.needsProactiveDisplayLink = true
+        metalView.redrawer.ongoingInteractionEventsCount++
         scope.launch {
             try {
                 animations()
@@ -113,7 +113,7 @@ internal class ComposeView(
                 isAnimating = false
                 updateLayout()
                 metalView.redrawer.isForcedToPresentWithTransactionEveryFrame = true
-                metalView.needsProactiveDisplayLink = true
+                metalView.redrawer.ongoingInteractionEventsCount++
             }
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -166,11 +166,15 @@ internal class MetalRedrawer(
     }
 
     /**
-     * Set to `true` if need always running invalidation-independent displayLink for forcing UITouch
-     * events to come at the fastest possible cadence.
-     * Otherwise, touch events can come at rate lower than actual display refresh rate.
+     * Runs invalidation-independent displayLink for forcing UITouch events to come at the fastest
+     * possible cadence. Otherwise, touch events can come at rate lower than actual display refresh
+     * rate.
      */
-    var needsProactiveDisplayLink by displayLinkConditions::needsToBeProactive
+    var ongoingInteractionEventsCount: Int = 0
+        set(value) {
+            field = value
+            displayLinkConditions.needsToBeProactive = value > 0
+        }
 
     /**
      * True if Metal layer can be opaque. In this case if no interop views are present, Metal

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalView.uikit.kt
@@ -63,11 +63,6 @@ internal class MetalView(
     var canBeOpaque by redrawer::canBeOpaque
 
     /**
-     * @see [MetalRedrawer.needsProactiveDisplayLink]
-     */
-    var needsProactiveDisplayLink by redrawer::needsProactiveDisplayLink
-
-    /**
      * Indicates that the view needs to be drawn synchronously with the next layout pass to avoid
      * flickering.
      */

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -154,7 +154,6 @@ internal class UserInputGestureRecognizer(
 
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent) {
         super.touchesMoved(touches, withEvent)
-        NSRunLoop.mainRunLoop.runUntilDate(NSDate())
 
         val result = onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.MOVED)
         if (result.anyMovementConsumed) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -273,9 +273,6 @@ internal class UserInputGestureRecognizer(
     private fun isScrollViewAtTheEndOfScrollableContent(recognizer: UIGestureRecognizer): Boolean {
         val pan = recognizer as? UIPanGestureRecognizer ?: return false
         val scrollView = recognizer.view as? UIScrollView ?: return false
-        if (scrollView.isDecelerating() || scrollView.isDragging()) {
-            return false
-        }
 
         val (diffX, diffY) = pan.translationInView(scrollView).useContents { x to y }
         val (offsetX, offsetY) = scrollView.contentOffset.useContents { x to y }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -16,14 +16,12 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
+import androidx.compose.ui.scene.PointerEventResult
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
-import androidx.compose.ui.uikit.utils.CMPGestureRecognizerDelegateProxy
+import androidx.compose.ui.unit.toPlatformInsets
 import androidx.compose.ui.viewinterop.InteropView
 import androidx.compose.ui.viewinterop.InteropWrappingView
 import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
@@ -35,20 +33,22 @@ import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRectZero
+import platform.Foundation.NSDate
+import platform.Foundation.NSRunLoop
+import platform.Foundation.runUntilDate
 import platform.UIKit.UIEvent
 import platform.UIKit.UIGestureRecognizer
-import platform.UIKit.UITapGestureRecognizer
-import platform.UIKit.UIScreenEdgePanGestureRecognizer
-import platform.UIKit.UIGestureRecognizerDelegateProtocol
 import platform.UIKit.UIGestureRecognizerState
 import platform.UIKit.UIGestureRecognizerStateBegan
 import platform.UIKit.UIGestureRecognizerStateCancelled
 import platform.UIKit.UIGestureRecognizerStateChanged
 import platform.UIKit.UIGestureRecognizerStateEnded
-import platform.UIKit.UIGestureRecognizerStateFailed
 import platform.UIKit.UIGestureRecognizerStatePossible
+import platform.UIKit.UIPanGestureRecognizer
 import platform.UIKit.UIPress
 import platform.UIKit.UIPressesEvent
+import platform.UIKit.UIScreenEdgePanGestureRecognizer
+import platform.UIKit.UIScrollView
 import platform.UIKit.UITouch
 import platform.UIKit.UIView
 import platform.UIKit.setState
@@ -70,31 +70,6 @@ internal enum class TouchesEventKind {
     /**
      * [UIEvent] when `touchesEnded`
      */
-    ENDED,
-
-    /**
-     * [UIEvent] when `touchesCancelled`
-     */
-    CANCELLED,
-
-    /**
-     * Compose withdraws from processing touches. They are now processed by an interop view.
-     */
-    REDIRECTED
-}
-
-/**
- * An event of gesture lifecycle change.
- */
-internal enum class GestureEvent {
-    /**
-     * First touch in the sequence just happened.
-     */
-    BEGAN,
-
-    /**
-     * No more touches are present.
-     */
     ENDED
 }
 
@@ -106,151 +81,22 @@ private val UIGestureRecognizerState.isOngoing: Boolean
         }
 
 /**
- * Enum class representing the possible hit test result of [UserInputViewHitTestResult].
- * This enum is used solely to determine the strategy of touch event delivery and
- * doesn't require any additional information about the hit-tested view itself.
- */
-private sealed interface UserInputViewHitTestResult {
-    data object Self : UserInputViewHitTestResult
-
-    data object NonCooperativeChildView : UserInputViewHitTestResult
-
-    /**
-     * Hit test result is Cooperative child view, that allows a delay of [delayMillis] milliseconds.
-     */
-    class CooperativeChildView(
-        val delayMillis: Int
-    ) : UserInputViewHitTestResult {
-        val delaySeconds: Double
-            get() = delayMillis.toDouble() / 1000.0
-    }
-}
-
-/**
- * An implementation of [UIGestureRecognizerDelegateProtocol] methods exposed by
- * [CMPGestureRecognizerDelegateProxy].
- */
-private class UserInputGestureRecognizerDelegateProxy : CMPGestureRecognizerDelegateProxy() {
-    override fun gestureRecognizerShouldRecognizeSimultaneouslyWithGestureRecognizer(
-        gestureRecognizer: UIGestureRecognizer,
-        otherGestureRecognizer: UIGestureRecognizer
-    ): Boolean {
-        // We should recognize simultaneously only with the gesture recognizers
-        // belonging to itself or to the views up in the hierarchy.
-        // An exception: UIScreenEdgePanGestureRecognizer, this always has precedence over us and is
-        // not allowed to recognize simultaneously
-
-        // Can't proceed if either view is null
-        val view = gestureRecognizer.view ?: return false
-        val otherView = otherGestureRecognizer.view ?: return false
-
-        val otherIsAscendant = !otherView.isDescendantOfView(view)
-
-        if (otherIsAscendant && otherGestureRecognizer is UIScreenEdgePanGestureRecognizer) {
-            return false
-        }
-
-        // Only allow simultaneous recognition if the other gesture recognizer is attached to the same view
-        // or to a view up in the hierarchy
-        return otherView == view || otherIsAscendant
-    }
-
-    override fun gestureRecognizerShouldRequireFailureOfGestureRecognizer(
-        gestureRecognizer: UIGestureRecognizer,
-        otherGestureRecognizer: UIGestureRecognizer
-    ): Boolean {
-        // Two situations are possible here.
-        // 1. If it's a gesture recognizer of a descendant (interop) view,
-        // we should wait until it fails,
-        // if it's a UITapGestureRecognizer.
-        //
-        // 2. It's a gesture recognizer of the view itself, or it's an ascendant view.
-        // We don't require failure of it, unless it's a `UIScreenEdgePanGestureRecognizer`.
-
-        val view = gestureRecognizer.view ?: return false
-        val otherView = otherGestureRecognizer.view ?: return false
-
-        val otherIsDescendant = otherView.isDescendantOfView(view)
-        val otherIsAscendantOrSameView = !otherIsDescendant
-
-        // (1)
-        if (otherIsDescendant && otherGestureRecognizer is UITapGestureRecognizer) {
-            return true
-        }
-
-        // (2)
-        if (otherIsAscendantOrSameView && otherGestureRecognizer is UIScreenEdgePanGestureRecognizer) {
-            return true
-        }
-
-        return false
-    }
-
-    override fun gestureRecognizerShouldBeRequiredToFailByGestureRecognizer(
-        gestureRecognizer: UIGestureRecognizer,
-        otherGestureRecognizer: UIGestureRecognizer
-    ): Boolean {
-
-        // otherGestureRecognizer is UITapGestureRecognizer,
-        // it must not wait till we fail and has priority
-        if (otherGestureRecognizer is UITapGestureRecognizer) {
-            return false
-        }
-
-        val view = gestureRecognizer.view ?: return false
-        val otherView = otherGestureRecognizer.view ?: return false
-
-        val otherIsDescendant = otherView.isDescendantOfView(view)
-        val otherIsAscendantOrSameView = !otherIsDescendant
-
-        if (otherIsAscendantOrSameView && otherGestureRecognizer is UIScreenEdgePanGestureRecognizer) {
-            return false
-        }
-
-        // Otherwise it is required to fail (aka other kind of gesture recognizer on interop view)
-        return gestureRecognizer.view != otherGestureRecognizer.view
-    }
-}
-
-/**
- * Implementation of [CMPGestureRecognizer] that handles touch events and forwards
+ * Implementation of [UIGestureRecognizer] that handles touch events and forwards
  * them. The main difference from the original [UIView] touches based is that it's built on top of
- * [CMPGestureRecognizer], which play differently with UIKit touches processing and are required
+ * [UIGestureRecognizer], which play differently with UIKit touches processing and are required
  * for the correct handling of the touch events in interop scenarios, because they rely on
  * [UIGestureRecognizer] failure requirements and touches interception, which is an exclusive way
  * to control touches delivery to [UIView]s and their [UIGestureRecognizer]s in a fine-grain manner.
  */
-private class UserInputGestureRecognizer(
-    private var onTouchesEvent: (view: UIView, touches: Set<*>, event: UIEvent?, phase: TouchesEventKind) -> Unit,
-    private var onGestureEvent: (GestureEvent) -> Unit
+internal class UserInputGestureRecognizer(
+    private var onTouchesEvent: (touches: Set<*>, event: UIEvent?, phase: TouchesEventKind) -> PointerEventResult,
+    private var onCancelAllTouches: (touches: Set<*>) -> Unit,
+    private var canIgnoreDragGesture: (UIGestureRecognizer) -> Boolean
 ) : CMPGestureRecognizer(target = null, action = null) {
-    private val delegateProxy = UserInputGestureRecognizerDelegateProxy()
-
-    /**
-     * The actual view that was hit-tested by the first touch in the sequence.
-     * It could be an interop view, for example.
-     * If there are tracked touches, the assignment is ignored.
-     */
-    var hitTestResult: UserInputViewHitTestResult? = null
-        set(value) {
-            /**
-             * Only remember the first hit-tested view in the sequence.
-             */
-            if (initialLocation == null) {
-                field = value
-            }
-        }
-
-    /**
-     * Initial centroid location in the sequence to measure the motion slop and to determine whether the gesture
-     * should be recognized or failed and pass touches to interop views.
-     */
-    private var initialLocation: CValue<CGPoint>? = null
-
     /**
      * Touches that are currently tracked by the gesture recognizer.
      */
-    private val trackedTouches: MutableSet<UITouch> = mutableSetOf()
+    private val trackedTouches: MutableMap<UITouch, UIKitInteropInteractionMode?> = mutableMapOf()
 
     /**
      * Scheduled job for the gesture recognizer failure.
@@ -258,11 +104,6 @@ private class UserInputGestureRecognizer(
     private var failureJob: Job? = null
 
     init {
-        // Assign delegateProxy to be the delegate of this gesture recognizer.
-        // Delegates are weakly referenced in UIKit,
-        // so we need to keep a reference to it as a property.
-        delegate = delegateProxy
-
         // When recognized, immediately cancel all touches in the subviews.
         // This scenario shouldn't happen due to `delaysTouchesBegan`, so it's
         // more of a defensive line.
@@ -273,224 +114,179 @@ private class UserInputGestureRecognizer(
         delaysTouchesBegan = true
     }
 
-    /**
-     * Checks whether the centroid location of [trackedTouches] has exceeded the scrolling slop
-     * relative to [initialLocation]
-     */
-    private val isLocationDeltaAboveSlop: Boolean
-        get() {
-            val initialLocation = initialLocation ?: return false
-            val centroidLocation = trackedTouchesCentroidLocation ?: return false
-
-            val slop = CUPERTINO_TOUCH_SLOP.toDouble()
-
-            val dx = centroidLocation.useContents { x - initialLocation.useContents { x } }
-            val dy = centroidLocation.useContents { y - initialLocation.useContents { y } }
-
-            return dx * dx + dy * dy > slop * slop
-        }
-
-    /**
-     * Calculates the centroid of the tracked touches.
-     */
-    private val trackedTouchesCentroidLocation: CValue<CGPoint>?
-        get() = view?.let {
-            trackedTouches.centroidLocationInView(it)
-        }
-
-    /**
-     * There are following scenarios:
-     *
-     * 1. Those are first touches in the sequence, [UserInputView] is hit-tested.
-     * In this case we should start the gesture recognizer immediately
-     * and start forwarding touches to the Compose runtime.
-     *
-     * 2. Those are first touches in the sequence, an interop view is hit-tested.
-     * In this case we intercept touches from interop views until the gesture recognizer is
-     * explicitly failed.
-     * See [UIGestureRecognizer.delaysTouchesBegan].
-     * In the same time we schedule a failure in
-     * [scheduleFailure], which will pass intercepted touches to the interop views
-     * if the gesture is not recognized within a time frame allowed by hit tested cooperative
-     * child view.
-     * The similar approach is used by [UIScrollView](https://developer.apple.com/documentation/uikit/uiscrollview)
-     *
-     * 3. Those are not the first touches in the sequence.
-     * A gesture is recognized.
-     * We should continue with scenario (1), we don't yet support multitouch sequence in
-     * compose and interop view simultaneously (e.g. scrolling native horizontal
-     * scroll and compose horizontal scroll with different fingers)
-     *
-     * 4. Those are not the first touches in the sequence.
-     * A gesture is not recognized.
-     * See if centroid of the tracked touches has moved enough to recognize the gesture.
-     *
-     * TODO (https://youtrack.jetbrains.com/issue/CMP-5877/iOS-non-eager-touch-interception):
-     *  An improvement to the current implementation would be to remove the delay if hitTest
-     *  on ComposeScene didn't go through a node, that has a PointerFilter attached
-     *  (e.g. a scrollable)
-     */
     override fun touchesBegan(touches: Set<*>, withEvent: UIEvent) {
-        if (hitTestResult == UserInputViewHitTestResult.NonCooperativeChildView) {
-            // If the child view opts out of the delay logic, the gesture should fail immediately.
-            // Consequently, touches will be forwarded straight to the interop child view,
-            // bypassing Compose.
-            // Compose will not receive any touches until all fingers are lifted.
-            setState(UIGestureRecognizerStateFailed)
-            return
+        super.touchesBegan(touches, withEvent)
+
+        val touchesToInteractionMode = touches.map { touch ->
+            touch as UITouch
+            val point = touch.locationInView(view)
+            val hitTestResult = view?.hitTest(point, withEvent)?.takeIf { it != view }
+            touch to hitTestResult?.findAncestorInteropWrappingView()?.interactionMode
+        }.toMap()
+
+        fun startTouchesEvent() {
+            val isInitialTouches = trackedTouches.isEmpty()
+            trackedTouches.putAll(touchesToInteractionMode)
+            onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.BEGAN)
+            if (isInitialTouches) {
+                setState(UIGestureRecognizerStatePossible)
+            } else if (state.isOngoing) {
+                setState(UIGestureRecognizerStateChanged)
+            }
         }
 
-        val areTouchesInitial = startTrackingTouches(touches)
-
-        onTouchesEvent(trackedTouches, withEvent, TouchesEventKind.BEGAN)
-
-        if (state.isOngoing || hitTestResult == UserInputViewHitTestResult.Self) {
-            // Golden path, immediately start/continue the gesture recognizer if possible and pass touches.
-            when (state) {
-                UIGestureRecognizerStatePossible -> {
-                    setState(UIGestureRecognizerStateBegan)
-                }
-
-                UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    setState(UIGestureRecognizerStateChanged)
-                }
+        val interactionMode = touchesToInteractionMode.values.findMostRestrictedInteractionMode()
+        when (interactionMode) {
+            is UIKitInteropInteractionMode.Cooperative -> {
+                startTouchesEvent()
+                scheduleTouchesFailureIfNeeded(interactionMode.delayMillis)
             }
-        } else {
-            if (areTouchesInitial) {
-                // We are in the scenario (2), we should schedule failure and pass touches to the
-                // interop view.
-                when (val cooperativeChildView = hitTestResult) {
-                    is UserInputViewHitTestResult.CooperativeChildView ->
-                        scheduleFailure(cooperativeChildView.delaySeconds)
-                    else -> {}
-                }
-            } else {
-                // We are in the scenario (4), check if the gesture recognizer should be recognized.
-                checkPanIntent()
+
+            UIKitInteropInteractionMode.NonCooperative -> {
+                cancelAllTrackedTouches()
+            }
+
+            null -> {
+                startTouchesEvent()
             }
         }
     }
 
-    /**
-     * There are the following scenarios:
-     *
-     * 1. The [UserInputView] is hit-tested, or a gesture is already recognized.
-     * In this case, we should just forward the touches.
-     *
-     * 2. An interop view is hit-tested. In this case we should check if the pan intent is met.
-     */
     override fun touchesMoved(touches: Set<*>, withEvent: UIEvent) {
-        onTouchesEvent(trackedTouches, withEvent, TouchesEventKind.MOVED)
+        super.touchesMoved(touches, withEvent)
+        NSRunLoop.mainRunLoop.runUntilDate(NSDate())
 
-        if (state.isOngoing || hitTestResult == UserInputViewHitTestResult.Self) {
-            // Golden path, just update the gesture recognizer state and pass touches to
-            // the Compose runtime.
+        val result = onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.MOVED)
+        if (result.anyMovementConsumed) {
+            if (!state.isOngoing) {
+                setState(UIGestureRecognizerStateBegan)
 
-            when (state) {
-                UIGestureRecognizerStateBegan, UIGestureRecognizerStateChanged -> {
-                    setState(UIGestureRecognizerStateChanged)
-                }
+                cancelTouchesFailure()
             }
-        } else {
-            checkPanIntent()
         }
     }
 
-    /**
-     * There are the following scenarios:
-     *
-     * 1. The [UserInputView] is hit-tested, or a gesture is already recognized.
-     * Update the gesture recognizer state and forward touches to the Compose runtime.
-     *
-     * 2. An interop view is hit-tested.
-     * In this case if there are no tracked touches left, we need to allow all the touches to be
-     * passed to the interop view by failing explicitly.
-     */
     override fun touchesEnded(touches: Set<*>, withEvent: UIEvent) {
-        onTouchesEvent(trackedTouches, withEvent, TouchesEventKind.ENDED)
+        super.touchesEnded(touches, withEvent)
 
-        stopTrackingTouches(touches)
+        fun endTouchesEvent() {
+            setState(UIGestureRecognizerStateEnded)
+            onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.ENDED)
+            stopTrackingTouches(touches)
+        }
 
-        if (state.isOngoing || hitTestResult == UserInputViewHitTestResult.Self) {
-            // Golden path, just update the gesture recognizer state and pass touches to
-            // the Compose runtime.
-
-            if (state.isOngoing) {
-
-                setState(
-                    if (trackedTouches.isEmpty()) {
-                        UIGestureRecognizerStateEnded
-                    } else {
-                        UIGestureRecognizerStateChanged
-                    }
-                )
-            }
+        if (state.isOngoing) {
+            endTouchesEvent()
         } else {
-            if (trackedTouches.isEmpty()) {
-                // Explicitly fail the gesture, cancelling a scheduled failure
-                cancelScheduledFailure()
-
-                setState(UIGestureRecognizerStateFailed)
+            val hasHitTestResult = touches.firstNotNullOfOrNull { trackedTouches[it] } != null
+            if (hasHitTestResult) {
+                cancelAllTrackedTouches()
+            } else {
+                endTouchesEvent()
             }
         }
     }
 
-    /**
-     * There are the following scenarios:
-     *
-     * 1. The [UserInputView] is hit-tested, or a gesture is already recognized.
-     * Update the gesture recognizer state and pass touches to the Compose runtime.
-     *
-     * 2. An interop view is hit-tested. In this case if there are no tracked touches left -
-     * we need to allow all the touches to be passed to the interop view by failing explicitly.
-     */
     override fun touchesCancelled(touches: Set<*>, withEvent: UIEvent) {
-        onTouchesEvent(trackedTouches, withEvent, TouchesEventKind.CANCELLED)
+        super.touchesCancelled(touches, withEvent)
 
-        stopTrackingTouches(touches)
+        cancelAllTrackedTouches()
+    }
 
-        if (hitTestResult == UserInputViewHitTestResult.Self) {
-            // Golden path, just update the gesture recognizer state.
+    private fun cancelAllTrackedTouches() {
+        setState(UIGestureRecognizerStateCancelled)
+        onCancelAllTouches(trackedTouches.keys)
+        trackedTouches.clear()
+        cancelTouchesFailure()
+    }
 
-            if (state.isOngoing) {
-                setState(
-                    if (trackedTouches.isEmpty()) {
-                        UIGestureRecognizerStateCancelled
-                    } else {
-                        UIGestureRecognizerStateChanged
-                    }
-                )
+    private fun Collection<UIKitInteropInteractionMode?>.findMostRestrictedInteractionMode() =
+        minBy {
+            when (it) {
+                UIKitInteropInteractionMode.NonCooperative -> 0
+                is UIKitInteropInteractionMode.Cooperative -> it.delayMillis
+                null -> Int.MAX_VALUE
+            }
+        }
+
+    override fun canBePreventedByGestureRecognizer(
+        preventingGestureRecognizer: UIGestureRecognizer
+    ): Boolean {
+        return if (canIgnoreDragGesture(preventingGestureRecognizer)) {
+            false
+        } else if (preventingGestureRecognizer is UserInputGestureRecognizer
+            && preventingGestureRecognizer.state.isOngoing) {
+            cancelAllTrackedTouches()
+            true
+        } else if (isViewInChildHierarchy(preventingGestureRecognizer.view)) {
+            if ((state == UIGestureRecognizerStatePossible || state.isOngoing) &&
+                isScrollViewAtTheEndOfScrollableContent(preventingGestureRecognizer)
+            ) {
+                false
+            } else {
+                cancelAllTrackedTouches()
+                true
             }
         } else {
-            if (trackedTouches.isEmpty()) {
-                // Those were the last touches in the sequence
-                // Explicitly fail the gesture, cancelling a scheduled failure
-                cancelScheduledFailure()
-
-                // If touches were withheld, give it a chance to be passed to the interop view
-                setState(UIGestureRecognizerStateFailed)
+            if (state.isOngoing || !preventingGestureRecognizer.state.isOngoing) {
+                false
+            } else {
+                cancelAllTrackedTouches()
+                true
             }
         }
     }
 
-    /**
-     * Fail the gesture recognizer explicitly.
-     *
-     * It means we need to pass all the tracked touches to the runtime as canceled and set failed
-     * state on the gesture recognizer.
-     *
-     * Intercepted touches will be passed to the interop views by UIKit due to
-     * [UIGestureRecognizer.delaysTouchesBegan]
-     */
-    fun fail() {
-        // Allow withheld touches to be passed to the interop view
-        setState(UIGestureRecognizerStateFailed)
+    override fun canPreventGestureRecognizer(
+        preventedGestureRecognizer: UIGestureRecognizer
+    ): Boolean {
+        return if (isViewInChildHierarchy(preventedGestureRecognizer.view)) {
+            super.canPreventGestureRecognizer(preventedGestureRecognizer)
+        } else if (preventedGestureRecognizer is UIScreenEdgePanGestureRecognizer) {
+            false
+        } else {
+            state == UIGestureRecognizerStatePossible || state.isOngoing
+        }
+    }
 
-        // We won't receive other touches events until all fingers are lifted, so we can't rely
-        // on touchesEnded/touchesCancelled to reset the state.  We need to immediately notify
-        // Compose about the redirected touches and reset the state manually.
-        onTouchesEvent(trackedTouches, null, TouchesEventKind.REDIRECTED)
-        stopTrackingAllTouches()
+    /**
+     * Checks if compose can get priority over interop view with UIScrollView on it.
+     *
+     * @return return true if UIScrollView can no longer scroll content in the direction of the user
+     * gesture that UIScrollView detected.
+     */
+    private fun isScrollViewAtTheEndOfScrollableContent(recognizer: UIGestureRecognizer): Boolean {
+        val pan = recognizer as? UIPanGestureRecognizer ?: return false
+        val scrollView = recognizer.view as? UIScrollView ?: return false
+        if (scrollView.isDecelerating()) return false
+
+        val (diffX, diffY) = pan.translationInView(scrollView).useContents { x to y }
+        val (offsetX, offsetY) = scrollView.contentOffset.useContents { x to y }
+        val (contentWidth, contentHeight) = scrollView.contentSize.useContents { width to height }
+        val (scrollWidth, scrollHeight) = scrollView.bounds.useContents { size.width to size.height }
+        val insets = scrollView.contentInset.toPlatformInsets()
+
+        val endOfHorizontal = (diffX > 0 && offsetX <= insets.left.value) ||
+            (diffX < 0 && offsetX >= contentWidth - scrollWidth + insets.right.value) ||
+            diffX == 0.0
+
+        val endOfVertical = (diffY > 0 && offsetY <= insets.top.value) ||
+            (diffY < 0 && offsetY >= contentHeight - scrollHeight + insets.bottom.value) ||
+            diffY == 0.0
+
+        return endOfHorizontal && endOfVertical
+    }
+
+    private fun isViewInChildHierarchy(child: UIView?): Boolean {
+        val view = view ?: return false
+        var iteratingView = child
+        while (iteratingView != null) {
+            if (view == iteratingView) {
+                return true
+            }
+            iteratingView = iteratingView.superview
+        }
+        return false
     }
 
     /**
@@ -499,15 +295,13 @@ private class UserInputGestureRecognizer(
      * some rare scenarios.
      */
     fun dispose() {
-        cancelScheduledFailure()
-        fail()
-        onTouchesEvent = { _, _, _, _ -> }
-        onGestureEvent = {}
+        cancelTouchesFailure()
+        onTouchesEvent = { _, _, _ -> PointerEventResult(anyMovementConsumed = false) }
         trackedTouches.clear()
     }
 
     /**
-     * Schedule the gesture recognizer failure after [failureDelaySeconds].
+     * Schedule the gesture recognizer failure after [delayMills].
      *
      * We still pass the touches to the interop view
      * until the gesture recognizer is explicitly failed.
@@ -518,62 +312,23 @@ private class UserInputGestureRecognizer(
      *
      * This only happens if the hitTest is not the [UserInputView] itself.
      *
-     * @see [fail]
-     * @see [cancelScheduledFailure]
+     * @see [cancelTouchesFailure]
      */
-    private fun scheduleFailure(failureDelaySeconds: Double) {
+    private fun scheduleTouchesFailureIfNeeded(delayMills: Int) {
         failureJob?.cancel()
 
-        failureJob = CoroutineScope(Dispatchers.Main).launch {
-            delay(failureDelaySeconds.toDuration(DurationUnit.SECONDS))
+        if (delayMills != Int.MAX_VALUE) {
+            failureJob = CoroutineScope(Dispatchers.Main).launch {
+                delay(delayMills.toLong())
 
-            fail()
+                cancelAllTrackedTouches()
+            }
         }
     }
 
-    private fun cancelScheduledFailure() {
+    private fun cancelTouchesFailure() {
         failureJob?.cancel()
         failureJob = null
-    }
-
-    /**
-     * Starts tracking the given touches.
-     * Remembers the [initialLocation] if those are the first touches in the sequence.
-     * @return `true` if the touches are initial, `false` otherwise.
-     */
-    private fun startTrackingTouches(touches: Set<*>): Boolean {
-        val areTouchesInitial = trackedTouches.isEmpty()
-
-        for (touch in touches) {
-            trackedTouches.add(touch as UITouch)
-        }
-
-        if (areTouchesInitial) {
-            onGestureEvent(GestureEvent.BEGAN)
-            initialLocation = trackedTouchesCentroidLocation
-        }
-
-        return areTouchesInitial
-    }
-
-    /**
-     * Check if the centroid of tracked touches has moved past the scroll slop.
-     * If so, cancel the scheduled failure and recognize the gesture.
-     * Touches intercepted from child views will be discarded due to [delaysTouchesBegan].
-     *
-     * Otherwise, do nothing.
-     */
-    private fun checkPanIntent() {
-        if (isLocationDeltaAboveSlop) {
-            cancelScheduledFailure()
-
-            // When the state changes to UIGestureRecognizerStateBegan,
-            // iOS simply discards the touches
-            // intercepted due to [delaysTouchesBegan]
-            // and prevents them from being sent
-            // to the interop view.
-            setState(UIGestureRecognizerStateBegan)
-        }
     }
 
     /**
@@ -584,37 +339,6 @@ private class UserInputGestureRecognizer(
         for (touch in touches) {
             trackedTouches.remove(touch as UITouch)
         }
-
-        if (trackedTouches.isEmpty()) {
-            onGestureEnded()
-        }
-    }
-
-    /**
-     * Stops tracking all [trackedTouches]. End the gesture and reset the internal state.
-     */
-    private fun stopTrackingAllTouches() {
-        trackedTouches.clear()
-
-        onGestureEnded()
-    }
-
-    /**
-     * Process the moment when all tracked touches are lifted (or canceled due to system events).
-     */
-    private fun onGestureEnded() {
-        initialLocation = null
-        onGestureEvent(GestureEvent.ENDED)
-    }
-
-    private fun onTouchesEvent(
-        touches: Set<*>,
-        event: UIEvent?,
-        phase: TouchesEventKind
-    ) {
-        val view = view ?: return
-
-        onTouchesEvent(view, touches, event, phase)
     }
 }
 
@@ -624,7 +348,6 @@ private class UserInputGestureRecognizer(
  *
  * @param hitTestInteropView A callback to find an [InteropView] at the given point.
  * @param onTouchesEvent A callback to notify the Compose runtime about touch events.
- * @param onGestureEvent A callback to notify that touches sequence state has began or ended.
  * @param isPointInsideInteractionBounds A callback to check if the given point is within the interaction
  * bounds as defined by the owning implementation.
  * @param onKeyboardPresses A callback to notify the Compose runtime about keyboard presses.
@@ -632,10 +355,10 @@ private class UserInputGestureRecognizer(
  * lightweight generics.
  */
 internal class UserInputView(
-    private var hitTestInteropView: (point: CValue<CGPoint>, event: UIEvent?) -> UIView?,
-    onTouchesEvent: (view: UIView, touches: Set<*>, event: UIEvent?, phase: TouchesEventKind) -> Unit,
-    onGestureEvent: (GestureEvent) -> Unit,
+    private var hitTestInteropView: (point: CValue<CGPoint>) -> UIView?,
     private var isPointInsideInteractionBounds: (CValue<CGPoint>) -> Boolean,
+    onTouchesEvent: (touches: Set<*>, event: UIEvent?, phase: TouchesEventKind) -> PointerEventResult,
+    onCancelAllTouches: (touches: Set<*>) -> Unit,
     private var onKeyboardPresses: (Set<*>) -> Unit,
 ) : UIView(CGRectZero.readValue()) {
     /**
@@ -647,12 +370,15 @@ internal class UserInputView(
      */
     private val gestureRecognizer = UserInputGestureRecognizer(
         onTouchesEvent = onTouchesEvent,
-        onGestureEvent = onGestureEvent
+        onCancelAllTouches = onCancelAllTouches,
+        canIgnoreDragGesture = { canIgnoreDragGesture(it) }
     )
+
+    // See [UIKitDragAndDropManager] for more context
+    var canIgnoreDragGesture: (UIGestureRecognizer) -> Boolean = { false }
 
     init {
         multipleTouchEnabled = true
-        userInteractionEnabled = true
 
         addGestureRecognizer(gestureRecognizer)
     }
@@ -670,27 +396,15 @@ internal class UserInputView(
     }
 
     override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? =
-        savingHitTestResult {
-            if (!isPointInsideInteractionBounds(point)) {
-                null
-            } else {
-                // Check if a scene contains an [InteropView] in the given point.
-                val interopView = hitTestInteropView(point, withEvent)
-
-                if (interopView == null) {
-                    // Native [hitTest] happens after [pointInside] is checked. If hit testing
-                    // inside ComposeScene didn't yield any interop view, then we should return [this]
-                    this
-                } else {
-                    // Transform the point to the interop view's coordinate system.
-                    // And perform native [hitTest] on the interop view.
-                    // Return this view if the interop view doesn't handle the hit test.
-                    interopView.hitTest(
-                        point = convertPoint(point, toView = interopView),
-                        withEvent = withEvent
-                    ) ?: this
-                }
-            }
+        if (isPointInsideInteractionBounds(point)) {
+            hitTestInteropView(point)?.let { interopView ->
+                interopView.hitTest(
+                    point = convertPoint(point, toView = interopView),
+                    withEvent = withEvent
+                )
+            } ?: this
+        } else {
+            null
         }
 
     /**
@@ -701,47 +415,11 @@ internal class UserInputView(
         removeGestureRecognizer(gestureRecognizer)
         gestureRecognizer.dispose()
 
-        hitTestInteropView = { _, _ -> null }
+        hitTestInteropView = { null }
 
         isPointInsideInteractionBounds = { false }
+        canIgnoreDragGesture = { false }
         onKeyboardPresses = {}
-    }
-
-    /**
-     * Execute the given [hitTestBlock] and save the result to the gesture recognizer handler, so
-     * that it can be used later to determine if the gesture recognizer should be recognized
-     * or failed.
-     */
-    private fun savingHitTestResult(hitTestBlock: () -> UIView?): UIView? {
-        val result = hitTestBlock()
-        gestureRecognizer.hitTestResult = if (result == null) {
-            null
-        } else {
-            if (result == this) {
-                UserInputViewHitTestResult.Self
-            } else {
-                // All views beneath are considered to be interop views.
-                // If the hit-tested view is not a descendant of [InteropWrappingView], then it
-                // should be considered as a view that doesn't want to cooperate with Compose.
-
-                val interactionMode = result.findAncestorInteropWrappingView()?.interactionMode
-
-                when (interactionMode) {
-                    is UIKitInteropInteractionMode.Cooperative -> {
-                        UserInputViewHitTestResult.CooperativeChildView(
-                            delayMillis = interactionMode.delayMillis
-                        )
-                    }
-
-                    is UIKitInteropInteractionMode.NonCooperative -> {
-                        UserInputViewHitTestResult.NonCooperativeChildView
-                    }
-
-                    null -> UserInputViewHitTestResult.Self
-                }
-            }
-        }
-        return result
     }
 }
 


### PR DESCRIPTION
Update the inner logic of the `UserInputGestureRecognizer`, which is responsible for handling and sending touches to Compose:
- Rework the interception of Interop gestures while maintaining the same user experience.
- UIScrollView subclasses get higher priority over Compose scrolling when content can be scrolled.
- Support the ability to abort gestures when overtaken by gesture recognisers or Interop views.
Update `InteropWrappingView' to properly disable interop views for touches when it's needed.
Refactor `MetalRedrawer' to simplify the calculation of the `needsToBeProactive` flag.

Fixes https://youtrack.jetbrains.com/issue/CMP-7296/UIKit-UIMenu-is-not-dismissed-on-click-of-Composable
Fixes https://youtrack.jetbrains.com/issue/CMP-6683/iOS-prohibit-interop-tap-interceptions
Fixes: https://youtrack.jetbrains.com/issue/CMP-7014/iOS-interactive-pop-fails-sometimes-when-integrating-Compose-into-UINavigationController
Fixes: https://youtrack.jetbrains.com/issue/CMP-3806/Nested-scrolling-does-not-interopate-with-Swift-UI-scrolling-on-iOS
Fixes: https://youtrack.jetbrains.com/issue/CMP-1606/iOS-integrate-touches-consumption
Fixes: https://youtrack.jetbrains.com/issue/CMP-5877/iOS-non-eager-touch-interception
Partially fixes: https://youtrack.jetbrains.com/issue/CMP-5707/iOS-compose-inside-modal-pan-interop

## Release Notes
### Fixes - iOS
- Fixed issues where the interactive pop gesture would stop working.
- Fixes an issue where it's not possible to close the `UIMenu` that appears over the Compose content.
### Features - iOS
- Compose works correctly with nested `UIScrollView`s, as well as within `UIScrollView`s.
- Added the ability to close modal Compose view controllers (with non-scrollable content on them) with a swipe gesture.
