### PR TITLE
Clear the surface before each frame in SkikoComposeUiTest.render

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -60,6 +60,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
+import org.jetbrains.skia.Color
 import org.jetbrains.skia.IRect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.currentNanoTime
@@ -237,6 +238,7 @@ class SkikoComposeUiTest @InternalTestApi constructor(
      * Render the scene at the given time.
      */
     private fun render(timeMillis: Long) {
+        surface.canvas.clear(Color.TRANSPARENT)
         scene.render(
             surface.canvas.asComposeCanvas(),
             timeMillis * NanoSecondsPerMilliSecond


### PR DESCRIPTION
We weren't clearing the surface/canvas onto which the UI was being rendered in tests. This resulted in `captureToImage` returning wrong images for UI that did not completely fill the canvas.
This PR clears the surface before each frame in `SkikoComposeUiTest.render()`.

## Testing
Before the fix, the test below produced images where the indicator gradually filled up to a circle and never became smaller.
```
    @OptIn(ExperimentalTestApi::class)
    @Test
    fun progressScreenshotTest() = runComposeUiTest {
        mainClock.autoAdvance = false

        setContent {
            CircularProgressIndicator(
                Modifier.size(50.dp)
            )
        }

        val dir = File("screenshots").also { it.mkdirs() }
        repeat(60) {
            ImageIO.write(onRoot().captureToImage().toAwtImage(), "png", File(dir, "circular-progress-$it.png"))
            mainClock.advanceTimeByFrame()
        }
    }
```

## Release Notes
### Fixes - Tests
- Clear the canvas before rendering each frame in tests, to avoid drawing different frames on top of each other, resulting in incorrect images being returned by `captureToImage`.