### PR TITLE
Fix SwingPanel focus interop

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/FocusSwitcher.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/FocusSwitcher.desktop.kt
@@ -26,10 +26,17 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.viewinterop.InteropViewGroup
-import java.awt.event.FocusEvent
 import java.awt.event.FocusEvent.Cause.TRAVERSAL_BACKWARD
 import java.awt.event.FocusEvent.Cause.TRAVERSAL_FORWARD
 
+/**
+ * This class is for supporting seamless focus switching between Compose and SwingPanel components:
+ * - adds a special [modifier] that redirects focus from Compose to the SwingPanel components
+ * - adds [moveBeforeInteropView], [moveAfterInteropView] that
+ *   redirect focus from SwingPanel to Compose
+ *
+ * See ComposeFocusTest for all edge cases.
+ */
 internal class InteropFocusSwitcher(
     private val group: InteropViewGroup,
     private val focusManager: FocusManager,
@@ -48,7 +55,6 @@ internal class InteropFocusSwitcher(
                 FocusDirection.Previous -> {
                     focusPolicy.getLastComponent(group)?.requestFocus(TRAVERSAL_BACKWARD)
                 }
-                else -> null
             }
         }
     )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/FocusSwitcher.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/FocusSwitcher.desktop.kt
@@ -19,86 +19,110 @@ package androidx.compose.ui.awt
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.FocusProperties
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.viewinterop.InteropViewGroup
 import java.awt.event.FocusEvent
+import java.awt.event.FocusEvent.Cause.TRAVERSAL_BACKWARD
+import java.awt.event.FocusEvent.Cause.TRAVERSAL_FORWARD
 
 internal class InteropFocusSwitcher(
     private val group: InteropViewGroup,
     private val focusManager: FocusManager,
 ) {
-    private val backwardTracker = Tracker {
-        val component = group.focusTraversalPolicy.getFirstComponent(group)
-        if (component != null) {
-            component.requestFocus(FocusEvent.Cause.TRAVERSAL_FORWARD)
-        } else {
-            moveForward()
+    private val focusPolicy get() = group.focusTraversalPolicy
+
+    private var tracker = FocusTracker(
+        properties = {
+            canFocus = focusPolicy.getDefaultComponent(group) != null
+        },
+        onFocus = {
+            when (it) {
+                FocusDirection.Next, FocusDirection.Enter -> {
+                    focusPolicy.getFirstComponent(group)?.requestFocus(TRAVERSAL_FORWARD)
+                }
+                FocusDirection.Previous -> {
+                    focusPolicy.getLastComponent(group)?.requestFocus(TRAVERSAL_BACKWARD)
+                }
+                else -> null
+            }
         }
-    }
+    )
 
-    private val forwardTracker = Tracker {
-        val component = group.focusTraversalPolicy.getLastComponent(group)
-        if (component != null) {
-            component.requestFocus(FocusEvent.Cause.TRAVERSAL_BACKWARD)
-        } else {
-            moveBackward()
-        }
-    }
+    val modifier get() = tracker.modifier
 
-    val backwardTrackerModifier: Modifier
-        get() = backwardTracker.modifier
-
-    val forwardTrackerModifier: Modifier
-        get() = forwardTracker.modifier
-
-    fun moveBackward() {
-        backwardTracker.requestFocusWithoutEvent()
+    fun moveBeforeInteropView() {
+        tracker.requestFocusWithoutEvent()
         focusManager.moveFocus(FocusDirection.Previous)
     }
 
-    fun moveForward() {
-        forwardTracker.requestFocusWithoutEvent()
+    fun moveAfterInteropView() {
+        tracker.requestFocusWithoutEvent()
         focusManager.moveFocus(FocusDirection.Next)
     }
+}
 
-    /**
-     * A helper class that can help:
-     * - to prevent recursive focus events
-     *   (a case when we focus the same element inside `onFocusEvent`)
-     * - to prevent triggering `onFocusEvent` while requesting focus somewhere else
-     */
-    private class Tracker(
-        private val onNonRecursiveFocused: () -> Unit
-    ) {
-        private val requester = FocusRequester()
+private class FocusTracker(
+    properties: FocusProperties.() -> Unit,
+    private val onFocus: (FocusDirection) -> Unit,
+) {
+    private val requester = FocusRequester()
+    private var isRequestingFocus = false
+    private var lastEnteredDirection = FocusDirection.Enter
 
-        private var isRequestingFocus = false
-        private var isHandlingFocus = false
+    fun requestFocusWithoutEvent() {
+        try {
+            isRequestingFocus = true
+            requester.requestFocus()
+        } finally {
+            isRequestingFocus = false
+        }
+    }
 
-        fun requestFocusWithoutEvent() {
-            try {
-                isRequestingFocus = true
-                requester.requestFocus()
-            } finally {
-                isRequestingFocus = false
+    private val childModifier = Modifier
+        .focusProperties(properties)
+        .focusRequester(requester)
+        .onFocusEvent {
+            if (!isRequestingFocus && it.isFocused) {
+                // `parentModifier.onEnter` is always called before `childModifier.onFocusEvent`,
+                // so we always have the actual value
+                onFocus(lastEnteredDirection)
             }
         }
+        .focusTarget()
 
-        val modifier = Modifier
-            .focusRequester(requester)
-            .onFocusEvent {
-                if (!isRequestingFocus && !isHandlingFocus && it.isFocused) {
-                    try {
-                        isHandlingFocus = true
-                        onNonRecursiveFocused()
-                    } finally {
-                        isHandlingFocus = false
-                    }
-                }
+    private val parentModifier = Modifier
+        .focusProperties {
+            canFocus = false
+            onEnter = {
+                lastEnteredDirection = requestedFocusDirection
             }
-            .focusTarget()
-    }
+        }
+        .focusTarget()
+
+    // 2 modifiers:
+    // - parent to intercept onEnter, but without focusing on it
+    // - child to handle the focus
+    //
+    // The logic parent/child is got from [Modifier.focusInteropModifier].
+    //
+    // The difference with Android is that the [childModifier] is requesting the SwingPanel focus,
+    // not the [parentModifier].
+    //
+    // The reason for that is the case when SwingPanel is at the beginning of the window.
+    // In this case we call `onRequestFocusForOwner` when we focus on the first node:
+    //
+    //     parentModifier.onEnter -> onRequestFocusForOwner -> childModifier.onFocusEvent
+    //
+    // If we would also place focusing on a SwingPanel component between
+    // onEnter an onRequestFocusForOwner, onRequestFocusForOwner will override the focus.
+    //
+    // The issue may exist on Android too.
+    val modifier = Modifier
+        .then(parentModifier)
+        .then(childModifier)
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -71,6 +71,8 @@ public fun <T : Component> SwingPanel(
         )
     }
 
+    // TODO(https://youtrack.jetbrains.com/issue/CMP-7557/SwingInteropViewHolder.-Commonization-of-focus-logic-with-different-targets)
+    //  we probably can commonize this logic across different targets (including Android)
     val focusSwitcher = remember { InteropFocusSwitcher(group, focusManager) }
 
     val interopViewHolder = remember {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.EmptyLayout
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.viewinterop.InteropView
 import androidx.compose.ui.viewinterop.LocalInteropContainer
@@ -84,20 +83,16 @@ public fun <T : Component> SwingPanel(
         )
     }
 
-    EmptyLayout(focusSwitcher.backwardTrackerModifier)
-
     InteropView(
         factory = {
             interopViewHolder
         },
-        modifier,
+        modifier.then(focusSwitcher.modifier),
         update = {
             it.background = background.toAwtColor()
             update(it)
         }
     )
-
-    EmptyLayout(focusSwitcher.forwardTrackerModifier)
 }
 
 /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
@@ -61,8 +61,8 @@ internal class SwingInteropViewHolder<T : Component>(
         override fun focusGained(e: FocusEvent) {
             if (e.isFocusGainedHandledBySwingPanel(group)) {
                 when (e.cause) {
-                    FocusEvent.Cause.TRAVERSAL_FORWARD -> focusSwitcher.moveForward()
-                    FocusEvent.Cause.TRAVERSAL_BACKWARD -> focusSwitcher.moveBackward()
+                    FocusEvent.Cause.TRAVERSAL_FORWARD -> focusSwitcher.moveAfterInteropView()
+                    FocusEvent.Cause.TRAVERSAL_BACKWARD -> focusSwitcher.moveBeforeInteropView()
                     else -> Unit
                 }
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -47,7 +47,6 @@ import javax.swing.JButton
 import javax.swing.JFrame
 import javax.swing.JPanel
 import kotlin.random.Random
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
@@ -166,7 +165,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7472
     @Test
     fun `swing panel in the middle of compose panel`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -200,7 +198,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7472
     @Test
     fun `swing panel in the middle of compose window`() = runFocusTest {
         val window = ComposeWindow().disposeOnEnd()
@@ -230,7 +227,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7472
     @Test
     fun `swing panel in the end of compose panel`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -270,7 +266,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7472
     @Test
     fun `swing panel in the beginning of compose panel`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -309,7 +304,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7472
     @Test
     fun `swing panel without compose and outer buttons`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -493,7 +487,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7472
     @Test
     fun `popup with swingPanel`() = runFocusTest {
         val window = ComposeWindow().disposeOnEnd()


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7472/Fix-Swing-interop-focus-after-1.8.0-alpha08-merge

The failing tests were a regression after https://android-review.googlesource.com/c/platform/frameworks/support/+/3417182 that added requesting focus on the owner at the end of a focus transaction:
```
    if (ComposeUiFlags.isViewFocusFixEnabled && requireLayoutNode().getInteropView() == null) {
        // This isn't an AndroidView, so we should be focused on this ComposeView
        requireOwner().focusOwner.requestFocusForOwner(FocusDirection.Next, null)
    }
```

As we can see here, there is an exception case if the node has `SwingPanel` (interop view), because when we focus on this node, it will redirect the focus to the panel itself.

But this exception case didn't work on desktop because we had 2 invisible nodes around `SwingPanel`:
```
backwardTrackerModifier // redirects focus to the component, but then it will be overridden by `requestFocusForOwner`
interopViewModifier
  Swing component
forwardTrackerModifier
```
Now the logic is rewritten similar to Android inside [Modifier.focusInteropModifier](https://github.com/androidx/androidx/blob/7911fcf9e920aeaa476aaa79d322e04c849e0876/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/viewinterop/FocusGroupNode.android.kt#L50):
```
parentModifier // fake node to intercept `onEnter` to know the focus direction
  childModifier  // redirects focus to the component, skip `requestFocusForOwner` because getInteropView() != null
     interopViewModifier
       Swing component
```

Also, the recursive focus check inside `Tracker` is removed, because it is not possible to have recursive calls if we don't request focus inside `onFocusEvent`

# Testing
`ComposeFocusTest` passes, it covers all possible edge cases of focus interop

# Release Notes
N/A