### PR TITLE
emptyTestPerformance, increase waiting time

### DIFF
--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -308,7 +308,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun emptyTestPerformance() = runTest(timeout = 3.seconds) {
+    fun emptyTestPerformance() = runTest(timeout = 6.seconds) {
         repeat(100) {
             runComposeUiTest {
                 setContent { }


### PR DESCRIPTION
It fails after the new Skia:

```
kotlinx.coroutines.test.UncompletedCoroutinesError: kotlinx.coroutines.test.UncompletedCoroutinesError: After waiting for 3s, the test coroutine is not completing
kotlinx.coroutines.test.UncompletedCoroutinesError: After waiting for 3s, the test coroutine is not completing
  at app//kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$2$1.invoke(TestBuilders.kt:351)
  at app//kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$2$1.invoke(TestBuilders.kt:335)
  at app//kotlinx.coroutines.InvokeOnCancelling.invoke(JobSupport.kt:1428)
  at app//kotlinx.coroutines.JobSupport.notifyCancelling(JobSupport.kt:1473)
  at app//kotlinx.coroutines.JobSupport.tryMakeCancelling(JobSupport.kt:796)
  at app//kotlinx.coroutines.JobSupport.makeCancelling(JobSupport.kt:756)
  at app//kotlinx.coroutines.JobSupport.cancelImpl$kotlinx_coroutines_core(JobSupport.kt:672)
  at app//kotlinx.coroutines.JobSupport.cancelCoroutine(JobSupport.kt:659)
  at app//kotlinx.coroutines.TimeoutCoroutine.run(Timeout.kt:156)
  at app//kotlinx.coroutines.EventLoopImplBase$DelayedRunnableTask.run(EventLoop.common.kt:498)
  at app//kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:277)
  at app//kotlinx.coroutines.DefaultExecutor.run(DefaultExecutor.kt:105)
  at java.base@17.0.6/java.lang.Thread.run(Thread.java:833)
```

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/d294cc79-baf6-4046-9852-55c1b7a4e09d" />

https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_AllPersonalBuild/4972661

I checked on my machine - didn't get increase in time, so it looks like it is just on CI it is near the limit.

I will run [benchmarks](https://youtrack.jetbrains.com/issue/CMP-7559/Compare-benchmarks-for-new-Skia) to be sure.

## Release Notes
N/A