### PR TITLE
Enable keyboard focus

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -21,12 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CMPAccessibilityElement : UIAccessibilityElement
 
-// MARK: Unexported methods redeclaration block
-// Redeclared to make it visible to Kotlin for override purposes, workaround for the following issue:
-// https://youtrack.jetbrains.com/issue/KT-56001/Kotlin-Native-import-Objective-C-category-members-as-class-members-if-the-category-is-located-in-the-same-file
-
-- (__nullable id)accessibilityContainer;
-
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions;
 
 - (UIAccessibilityTraits)accessibilityTraits;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -20,14 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation CMPAccessibilityElement
 
-- (void)setAccessibilityContainer:(__nullable id)accessibilityContainer {
-    // NoOp
-}
-
-- (__nullable id)accessibilityContainer {
-    return [self accessibilityContainer];
-}
-
 + (__nullable id)accessibilityContainerOfObject:(id)object {
     // Duck-typing selector dispatch
     return [object accessibilityContainer];

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -17,12 +17,16 @@
 package androidx.compose.ui.backhandler
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toOffset
-import androidx.compose.ui.window.ComposeView
 import kotlin.math.abs
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ObjCAction
@@ -96,6 +100,19 @@ internal class UIKitBackGestureDispatcher(
     private fun removeGestureListeners() {
         leftEdgePanGestureRecognizer.view?.removeGestureRecognizer(leftEdgePanGestureRecognizer)
         rightEdgePanGestureRecognizer.view?.removeGestureRecognizer(rightEdgePanGestureRecognizer)
+    }
+
+    fun onKeyEvent(event: KeyEvent): Boolean {
+        if (event.type == KeyEventType.KeyUp && event.key == Key.Escape) {
+            activeListener?.let {
+                it.onStarted()
+                it.onCompleted()
+            }
+
+            return true
+        } else {
+            return false
+        }
     }
 }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.scene.ComposeSceneFocusManager
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.EditCommand
@@ -65,6 +66,7 @@ internal class UIKitTextInputService(
      * Erasure happens due to K/N not supporting Obj-C lightweight generics.
      */
     private val onKeyboardPresses: (Set<*>) -> Unit,
+    private val focusManager: () -> ComposeSceneFocusManager
 ) : PlatformTextInputService, TextToolbar {
 
     private var currentInput: CurrentInput? = null
@@ -218,6 +220,7 @@ internal class UIKitTextInputService(
         return when (event.key) {
             Key.Enter -> handleEnterKey(event)
             Key.Backspace -> handleBackspace(event)
+            Key.Escape -> handleEscape(event)
             else -> false
         }
     }
@@ -262,6 +265,15 @@ internal class UIKitTextInputService(
     private fun handleBackspace(event: KeyEvent): Boolean {
         // This prevents two characters from being removed for one hardware backspace key press.
         return event.type == KeyEventType.KeyDown
+    }
+
+    private fun handleEscape(event: KeyEvent): Boolean {
+        return if (currentInput != null && event.type == KeyEventType.KeyUp) {
+            focusManager().releaseFocus()
+            true
+        } else {
+            false
+        }
     }
 
     private val editCommandsBatch = mutableListOf<EditCommand>()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -379,6 +379,7 @@ internal class ComposeHostingViewController(
         coroutineContext = coroutineContext,
         redrawer = rootMetalView.redrawer,
         composeSceneFactory = ::createComposeScene,
+        backGestureDispatcher = backGestureDispatcher
     ).also { mediator ->
         mediator.updateInteractionRect()
         mediator.setContent {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.asDpOffset
 import androidx.compose.ui.unit.asDpRect
@@ -74,6 +75,11 @@ internal class UIKitComposeSceneLayer(
         isInterceptingOutsideEvents = { focusable }
     )
 
+    private val backGestureDispatcher = UIKitBackGestureDispatcher(
+        density = view.density,
+        getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
+    )
+
     private val mediator = ComposeSceneMediator(
         parentView = view,
         onFocusBehavior = onFocusBehavior,
@@ -81,7 +87,8 @@ internal class UIKitComposeSceneLayer(
         windowContext = windowContext,
         coroutineContext = compositionContext.effectCoroutineContext,
         redrawer = metalView.redrawer,
-        composeSceneFactory = ::createComposeScene
+        composeSceneFactory = ::createComposeScene,
+        backGestureDispatcher = backGestureDispatcher
     )
 
     private fun isInsideInteractionBounds(point: CValue<CGPoint>): Boolean =
@@ -108,7 +115,7 @@ internal class UIKitComposeSceneLayer(
 
     override var layoutDirection by mediator::layoutDirection
 
-    override var boundsInWindow by mediator::interactionBounds
+    override var boundsInWindow: IntRect by mediator::interactionBounds
 
     override var compositionLocalContext by mediator::compositionLocalContext
 
@@ -123,11 +130,6 @@ internal class UIKitComposeSceneLayer(
         }
 
     private val scrimPaint = Paint()
-
-    private val backGestureDispatcher = UIKitBackGestureDispatcher(
-        density = density,
-        getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
-    )
 
     private fun onDidMoveToWindow(window: UIWindow?) {
         backGestureDispatcher.onDidMoveToWindow(window, view)


### PR DESCRIPTION
Support basic functionality of UIFocusItem and UIFocusItemContainer for AccessibilityElement.
Pass key press to back handler and handle Escape key.
Use Escape key to stop text input.

Fixes https://youtrack.jetbrains.com/issue/CMP-7197/Support-Keyboard-Focus-on-iOS

## Release Notes
### Features - iOS
- Support for focusable nodes when Full Keyboard Access is enabled on iOS