### PR TITLE
Ignore ios-unrelated test onDensityChange_shouldUpdateFlingBehavior

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/test/IgnoreTargetsActuals.desktop.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/test/IgnoreTargetsActuals.desktop.kt
@@ -16,3 +16,5 @@
 package kotlinx.test
 
 actual typealias IgnoreWasmTarget = DoNothing
+
+actual typealias IgnoreUIKitTarget = DoNothing

--- a/compose/foundation/foundation/src/macosTest/kotlin/test/IgnoreTargetsActuals.macos.kt
+++ b/compose/foundation/foundation/src/macosTest/kotlin/test/IgnoreTargetsActuals.macos.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package kotlinx.test
 
 actual typealias IgnoreWasmTarget = DoNothing
+
+actual typealias IgnoreUIKitTarget = DoNothing

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -58,6 +58,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.test.IgnoreUIKitTarget
 import kotlinx.test.IgnoreWasmTarget
 
 @OptIn(ExperimentalTestApi::class)
@@ -2477,7 +2478,7 @@ class ScrollableTest {
     }
 
     @Test
-    @Ignore // TODO(https://youtrack.jetbrains.com/issue/CMP-7220) Fails on iOS
+    @IgnoreUIKitTarget // Density not taken into account in CupertinoFlingBehaviour
     fun onDensityChange_shouldUpdateFlingBehavior() = runSkikoComposeUiTest {
         var density by mutableStateOf(density)
         var flingDelta = 0f

--- a/compose/foundation/foundation/src/skikoTest/kotlin/test/IgnoreTargets.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/test/IgnoreTargets.kt
@@ -18,3 +18,5 @@ package kotlinx.test
 annotation class DoNothing
 
 expect annotation class IgnoreWasmTarget()
+
+expect annotation class IgnoreUIKitTarget()

--- a/compose/foundation/foundation/src/uikitTest/kotlin/test/IgnoreTargetsActuals.uikit.kt
+++ b/compose/foundation/foundation/src/uikitTest/kotlin/test/IgnoreTargetsActuals.uikit.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package kotlinx.test
 
-actual typealias IgnoreWasmTarget = kotlin.test.Ignore
+actual typealias IgnoreWasmTarget = DoNothing
 
-actual typealias IgnoreUIKitTarget = DoNothing
+actual typealias IgnoreUIKitTarget = kotlin.test.Ignore

--- a/compose/foundation/foundation/src/wasmJsTest/kotlin/test/IgnoreTargetsActuals.wasmJs.kt
+++ b/compose/foundation/foundation/src/wasmJsTest/kotlin/test/IgnoreTargetsActuals.wasmJs.kt
@@ -16,3 +16,5 @@
 package kotlinx.test
 
 actual typealias IgnoreWasmTarget = kotlin.test.Ignore
+
+actual typealias IgnoreUIKitTarget = DoNothing


### PR DESCRIPTION
The test is not relevant for iOS because:
- density not taken into account in CupertinoFlingBehaviour
- on iOS, fling behavior does not change noticeably with changing views scale

Fixes https://youtrack.jetbrains.com/issue/CMP-7220/Fix-onDensityChangeshouldUpdateFlingBehavior-test
