### PR TITLE
Fix tracking for multitouch gestures

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -183,6 +183,98 @@ class SyntheticEventSenderTest {
     }
 
     @Test
+    fun `touch, should generate one press at a time on simultaneous touches press`() {
+        eventsSentBy(
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true)
+            ),
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = true)
+            ),
+        ) positionAndDownShouldEqual listOf(
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true)
+            ),
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = false),
+            ),
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = true)
+            )
+        )
+    }
+
+    @Test
+    fun `touch, should generate one release at a time on simultaneous touches release`() {
+        eventsSentBy(
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = true),
+            ),
+            event(
+                Release,
+                1 to touch(1f, 3f, pressed = false),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = true),
+            ),
+            event(
+                Release,
+                2 to touch(10f, 20f, pressed = false),
+                3 to touch(100f, 200f, pressed = false),
+            ),
+        ) positionAndDownShouldEqual listOf(
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = false),
+                3 to touch(100f, 200f, pressed = false),
+            ),
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = false),
+            ),
+            event(
+                Press,
+                1 to touch(1f, 3f, pressed = true),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = true),
+            ),
+            event(
+                Release,
+                1 to touch(1f, 3f, pressed = false),
+                2 to touch(10f, 20f, pressed = true),
+                3 to touch(100f, 200f, pressed = true),
+            ),
+            event(
+                Release,
+                1 to touch(1f, 3f, pressed = false),
+                2 to touch(10f, 20f, pressed = false),
+                3 to touch(100f, 200f, pressed = true),
+            ),
+            event(
+                Release,
+                2 to touch(10f, 20f, pressed = false),
+                3 to touch(100f, 200f, pressed = false),
+            )
+        )
+    }
+
+    @Test
     fun `should consume move event when synthetic events added`() {
         val sender = SyntheticEventSender { event ->
             // Consume only synthetic move event

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -149,7 +149,7 @@ internal class SyntheticEventSender(
                             // TODO is this a typo and it should be `it.id in newReleased`, as in sendMissingPresses?
                             //  or maybe we can even write `down = !sendingAsUp.contains(it.id)` and `down = sendingAsDown.contains(it.id)`
                             //  The test pass in both cases
-                            down = !sendingAsUp.contains(it.id)
+                            down = it.down && !sendingAsUp.contains(it.id)
                         )
                     }
                 )
@@ -161,9 +161,9 @@ internal class SyntheticEventSender(
     }
 
     private fun sendMissingPresses(currentEvent: PointerInputEvent): PointerEventResult {
-        val previousPressed = previousEvent?.pressedIds().orEmpty()
+        val previousPressed = previousEvent?.pressedIds().orEmpty().toSet()
         val currentPressed = currentEvent.pressedIds()
-        val newPressed = (currentPressed - previousPressed.toSet()).toList()
+        val newPressed = (currentPressed - previousPressed).toList()
         val sendingAsDown = HashSet<PointerId>(newPressed.size)
 
         var result = PointerEventResult(anyMovementConsumed = false)
@@ -178,7 +178,7 @@ internal class SyntheticEventSender(
                     type = PointerEventType.Press,
                     copyPointer = {
                         it.copySynthetic(
-                            down = sendingAsDown.contains(it.id)
+                            down = previousPressed.contains(it.id) || sendingAsDown.contains(it.id)
                         )
                     }
                 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -146,9 +146,6 @@ internal class SyntheticEventSender(
                     type = PointerEventType.Release,
                     copyPointer = {
                         it.copySynthetic(
-                            // TODO is this a typo and it should be `it.id in newReleased`, as in sendMissingPresses?
-                            //  or maybe we can even write `down = !sendingAsUp.contains(it.id)` and `down = sendingAsDown.contains(it.id)`
-                            //  The test pass in both cases
                             down = it.down && !sendingAsUp.contains(it.id)
                         )
                     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -185,9 +185,11 @@ internal class UserInputGestureRecognizer(
         super.touchesEnded(touches, withEvent)
 
         fun endTouchesEvent() {
-            setState(UIGestureRecognizerStateEnded)
             onTouchesEvent(trackedTouches.keys, withEvent, TouchesEventKind.ENDED)
             stopTrackingTouches(touches)
+            if (trackedTouches.isEmpty()) {
+                setState(UIGestureRecognizerStateEnded)
+            }
         }
 
         if (state.isOngoing) {


### PR DESCRIPTION
- Fix bug in `SyntheticEventSenderTest` that could send wrong `down` state for pressed and released events when multitouch gesture occurs.
- Fix bug in `UserInputGestureRecognizer` when ending multitouch gestures earlier than necessary.

Fixes https://youtrack.jetbrains.com/issue/CMP-6920/IOS-simultaneous-touch-events-with-3-or-more-fingers-are-not-recieved

## Release Notes
### Fixes - iOS
- Fix touches tracking for multitouch gestures
