### PR TITLE
Don't delete previous symbol if last key pressed was the DeadKey

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/KeyboardActionsExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/textfield/KeyboardActionsExample.kt
@@ -109,7 +109,7 @@ private fun TextBlock(
         OutlinedTextField(
             value = textState.value,
             onValueChange = { textState.value = it },
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp).onKeyEvent { println("KEY EVENT $this"); false },
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
             textStyle = TextStyle(fontSize = 12.sp, fontWeight = FontWeight.Normal),
             keyboardOptions = KeyboardOptions(imeAction = imeActionName),
             keyboardActions = keyboardActions

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingTextArea.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingTextArea.kt
@@ -47,6 +47,7 @@ internal class BackingTextArea(
     private val textArea: HTMLTextAreaElement = createHtmlInput()
 
     private fun processEvent(evt: KeyboardEvent): Boolean {
+        // source element is currently in composition session (after "compositionstart" but before "compositionend")
         if (evt.isComposing) return false
         // Unidentified keys is what we get when we press key on a virtual keyboard
         // TODO: In theory nothing stops us from passing Unidentified keys but this yet to be investigated:
@@ -58,11 +59,12 @@ internal class BackingTextArea(
     }
 
     private fun initEvents(htmlInput: EventTarget) {
-        var keyEventPrecedesUpdate = false
+        var removeSymbolOnCompositionStart = false
 
         DomInputService(htmlInput, object : DomInputListener {
             override fun onKeyDown(evt: KeyboardEvent) {
-                keyEventPrecedesUpdate = processEvent(evt)
+                // Dead keys occur whenever we are in pre-composition mode, initialized by typing OS-specific special keyboard shortcut
+                removeSymbolOnCompositionStart = processEvent(evt) && evt.key != "Dead"
             }
 
             override fun onKeyUp(evt: KeyboardEvent) {
@@ -72,9 +74,9 @@ internal class BackingTextArea(
             override fun onCompositionStart(evt: CompositionEvent) {
                 // whenever very first time compose happens, corresponding keydown event happens earlier
                 // so we have to manually delete last key entered
-                if (keyEventPrecedesUpdate) {
+                if (removeSymbolOnCompositionStart) {
                     onEditCommand(listOf(DeleteSurroundingTextInCodePointsCommand(1, 0)))
-                    keyEventPrecedesUpdate = false
+                    removeSymbolOnCompositionStart = false
                 }
             }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/BackingTextAreaTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/BackingTextAreaTests.kt
@@ -118,7 +118,16 @@ class BackingTextAreaTests {
         assertEquals(
             listOf(),
             lastEditCommand,
-            "when compositionstart is triggered, last keyboard event should be ignored only if meaningful keyboard event happened"
+            "when compositionstart is triggered, last keyboard event should be ignored  if Unidentified key is pressed and not released"
+        )
+
+        textArea.dispatchEvent(keyEvent("Dead"))
+        textArea.dispatchEvent(CompositionEvent("compositionstart"))
+
+        assertEquals(
+            listOf(),
+            lastEditCommand,
+            "when compositionstart is triggered, last keyboard event should be ignored if DeadKey is pressed and not released"
         )
 
 


### PR DESCRIPTION
This is a small fix for https://youtrack.jetbrains.com/issue/CMP-7264/Web-TextFields.-Previous-character-is-deleted-when-using-option-e-i...-combination
