### PR TITLE
Fixed textfield gestures on iOS in btf1

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -373,35 +373,9 @@ internal fun CoreTextField(
         }
     }
 
-    val pointerModifier =
-        Modifier.updateSelectionTouchMode { state.isInTouchMode = it }
-            .tapPressTextFieldModifier(interactionSource, enabled) { offset ->
-                requestFocusAndShowKeyboardIfNeeded(state, focusRequester, !readOnly)
-                if (state.hasFocus && enabled) {
-                    if (state.handleState != HandleState.Selection) {
-                        state.layoutResult?.let { layoutResult ->
-                            TextFieldDelegate.setCursorOffset(
-                                offset,
-                                layoutResult,
-                                state.processor,
-                                offsetMapping,
-                                state.onValueChange
-                            )
-                            // Won't enter cursor state when text is empty.
-                            if (state.textDelegate.text.isNotEmpty()) {
-                                state.handleState = HandleState.Cursor
-                            }
-                        }
-                    } else {
-                        manager.deselect(offset)
-                    }
-                }
-            }
-            .selectionGestureInput(
-                mouseSelectionObserver = manager.mouseSelectionObserver,
-                textDragObserver = manager.touchSelectionObserver,
-            )
-            .pointerHoverIcon(textPointerIcon)
+    val pointerModifier = Modifier.textFieldPointer(
+        manager, enabled, interactionSource, state, focusRequester, readOnly, offsetMapping
+    )
 
     val drawModifier =
         Modifier.drawBehind {


### PR DESCRIPTION
Fixed change omitted during merge in common code

<!-- Optional -->
Fixes https://youtrack.jetbrains.com/issue/CMP-7583

## Testing
Open Test App, go Components -> TextFields -> Any textfield screen (AlmostFullScreen for example)
Should be tested manually by QA

## Release Notes
N/A