### PR TITLE
Pass untransformed text, not visual text, to the input method.

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.foundation.text.input.internal
 
 import androidx.compose.foundation.content.internal.ReceiveContentConfiguration
 import androidx.compose.foundation.text.computeSizeForDefaultText
+import androidx.compose.foundation.text.input.TextFieldCharSequence
 import androidx.compose.foundation.text.input.setSelectionCoerced
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -53,13 +54,7 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
     val editProcessor = EditProcessor()
     fun onEditCommand(commands: List<EditCommand>) {
         editProcessor.reset(
-            value = with(state.visualText) {
-                TextFieldValue(
-                    text = toString(),
-                    selection = selection,
-                    composition = composition
-                )
-            },
+            value = state.untransformedText.toTextFieldValue(),
             textInputSession = null
         )
 
@@ -79,7 +74,6 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
             }
         }
     }
-
 
     coroutineScope {
         launch {
@@ -113,11 +107,7 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
 
         startInputMethod(
             SkikoPlatformTextInputMethodRequest(
-                state = TextFieldValue(
-                    state.visualText.toString(),
-                    state.visualText.selection,
-                    state.visualText.composition,
-                ),
+                state = state.untransformedText.toTextFieldValue(),
                 imeOptions = imeOptions,
                 onEditCommand = ::onEditCommand,
                 onImeAction = onImeAction,
@@ -126,6 +116,9 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         )
     }
 }
+
+private fun TextFieldCharSequence.toTextFieldValue() =
+    TextFieldValue(toString(), selection, composition)
 
 @OptIn(ExperimentalComposeUiApi::class)
 private data class SkikoPlatformTextInputMethodRequest(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -109,7 +109,7 @@ fun Window.sendInputEvent(
         mostRecentFocusOwner,
         InputMethodEvent.INPUT_METHOD_TEXT_CHANGED,
         0,
-        text?.let(::AttributedString)?.iterator,
+        if (text == null) null else AttributedString(text).iterator,
         committedCharacterCount,
         TextHitInfo.leading(0),
         TextHitInfo.leading(0)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith
 class WindowTypeTest : BaseWindowTextFieldTest() {
     @Theory
     internal fun `q, w, space, backspace 4x (English)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "English") {
         // q
         window.sendKeyEvent(81, 'q', KEY_PRESSED)
@@ -84,7 +84,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, space, backspace 4x (Russian)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Russian") {
         // q
         window.sendKeyEvent(81, 'й', KEY_PRESSED)
@@ -131,7 +131,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `f, g, space, backspace 4x (Arabic)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Arabic") {
         // q
         window.sendKeyEvent(70, 'ب', KEY_PRESSED)
@@ -178,7 +178,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, space, backspace 4x (Korean, Windows)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // q
         window.sendInputEvent("ㅂ", 0)
@@ -226,7 +226,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, backspace 3x (Korean, Windows)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // q
         window.sendInputEvent("ㅂ", 0)
@@ -260,7 +260,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `f, g, space, backspace 3x (Korean, Windows)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // f
         window.sendInputEvent("ㄹ", 0)
@@ -301,7 +301,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `f, g, backspace 2x (Korean, Windows)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, Windows") {
         // f
         window.sendInputEvent("ㄹ", 0)
@@ -333,7 +333,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, space, backspace 4x (Korean, macOS)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // q
         window.sendInputEvent("ㅂ", 0)
@@ -380,7 +380,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, backspace 3x (Korean, macOS)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // q
         window.sendInputEvent("ㅂ", 0)
@@ -418,7 +418,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
     // f, g on macOS prints 2 separate symbols (comparing to Windows), so we test t + y
     @Theory
     internal fun `t, y, space, backspace 3x (Korean, macOS)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // t
         window.sendInputEvent("ㅅ", 0)
@@ -457,7 +457,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `t, y, backspace 2x (Korean, macOS)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, macOS") {
         // t
         window.sendInputEvent("ㅅ", 0)
@@ -491,7 +491,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, space, backspace 4x (Korean, Linux)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Korean, Linux") {
         // q
         window.sendInputEvent("ㅂ", 0)
@@ -540,7 +540,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, space, backspace 3x (Chinese, Windows)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Chinese, Windows") {
         // q
         window.sendInputEvent("q", 0)
@@ -579,7 +579,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, backspace 3x (Chinese, Windows)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Chinese, Windows") {
         // q
         window.sendInputEvent("q", 0)
@@ -611,7 +611,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, space, backspace 3x (Chinese, macOS)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Chinese, macOS") {
         // q
         window.sendInputEvent("q", 0)
@@ -649,7 +649,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `q, w, backspace 3x (Chinese, macOS)`(
-        textFieldKind: TextFieldKind
+        textFieldKind: TextFieldKind<*>
     ) = runTextFieldTest(textFieldKind, "Chinese, macOS") {
         // q
         window.sendInputEvent("q", 0)
@@ -677,4 +677,30 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         window.sendKeyEvent(8, Char(8), KEY_RELEASED)
         assertStateEquals("", selection = TextRange(0), composition = null)
     }
+
+//    @Test
+//    fun secureTextFieldWorksWithInputMethods() = runTextFieldTest(
+//        textFieldKind = SecureTextField,
+//        name = "OutputTransform, Chinese, macOS"
+//    ) {
+//        // c
+//        window.sendInputEvent("c", 0)
+//        window.sendKeyEvent(67, 'c', KEY_RELEASED)
+//        assertStateEquals("c", selection = TextRange(1), composition = TextRange(0, 1))
+//
+//        // space
+//        window.sendInputEvent("才", 1)
+//        window.sendKeyEvent(32, ' ', KEY_RELEASED)
+//        assertStateEquals("才", selection = TextRange(1), composition = null)
+//
+//        // c
+//        window.sendInputEvent("c", 0)
+//        window.sendKeyEvent(67, 'c', KEY_RELEASED)
+//        assertStateEquals("才c", selection = TextRange(2), composition = TextRange(1, 2))
+//
+//        // space
+//        window.sendInputEvent("才", 1)
+//        window.sendKeyEvent(32, ' ', KEY_RELEASED)
+//        assertStateEquals("才才", selection = TextRange(2), composition = null)
+//    }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypingLocationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypingLocationTest.kt
@@ -29,7 +29,7 @@ import org.junit.runner.RunWith
 class WindowTypingLocationTest: BaseWindowTextFieldTest() {
     @Theory
     internal fun `input methods text location going right when type`(
-        textFieldKind: TextFieldKind,
+        textFieldKind: TextFieldKind<*>,
     ) = runTextFieldTest(
         textFieldKind = textFieldKind,
         name = "input methods text location going right when type"
@@ -56,7 +56,7 @@ class WindowTypingLocationTest: BaseWindowTextFieldTest() {
 
     @Theory
     internal fun `input methods text location is inside window`(
-        textFieldKind: TextFieldKind,
+        textFieldKind: TextFieldKind<*>,
     ) = runTextFieldTest(
         textFieldKind = textFieldKind,
         name = "input methods text location inside window",


### PR DESCRIPTION
`platformSpecificTextInputSession` incorrectly passes `visualText` to the input method.
This PR changes to passing the untransformed text instead.

Fixes https://youtrack.jetbrains.com/issue/CMP-7574
Fixes https://youtrack.jetbrains.com/issue/CMP-7473
Fixes https://youtrack.jetbrains.com/issue/CMP-7501

## Testing
Tested manually, and also added `SecureTextField` as a textfield kind to run all textfield tests on.

This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Fixed the output of `TextField(TextFieldState)` (aka `BasicTextField2`) transformations incorrectly leeching into the untransformed text itself, when input method is used (Chinese and other languages with multi-keystroke character input).
