### PR TITLE
Configure beyondBoundsItemCount default value for LazyList

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/lazy/LazyList.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/lazy/LazyList.android.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.lazy
+
+import androidx.compose.runtime.Composable
+
+@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 0

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyList.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyList.kt
@@ -71,7 +71,7 @@ internal fun LazyList(
     /** The overscroll effect to render and dispatch events to */
     overscrollEffect: OverscrollEffect?,
     /** Number of items to layout before and after the visible items */
-    beyondBoundsItemCount: Int = 0,
+    beyondBoundsItemCount: Int = defaultLazyListBeyondBoundsItemCount(),
     /** The alignment to align items horizontally. Required when isVertical is true */
     horizontalAlignment: Alignment.Horizontal? = null,
     /** The vertical arrangement for items. Required when isVertical is true */
@@ -388,3 +388,5 @@ private fun rememberLazyListMeasurePolicy(
             measureResult
         }
     }
+
+@Composable internal expect fun defaultLazyListBeyondBoundsItemCount(): Int

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/lazy/LazyList.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/lazy/LazyList.jsWasm.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.lazy
+
+import androidx.compose.runtime.Composable
+
+@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 0

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/lazy/LazyList.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/lazy/LazyList.jvm.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.lazy
+
+import androidx.compose.runtime.Composable
+
+@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 0

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/lazy/LazyList.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/lazy/LazyList.macos.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.lazy
+
+import androidx.compose.runtime.Composable
+
+@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 0

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/lazy/LazyList.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/lazy/LazyList.uikit.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.lazy
+
+import androidx.compose.runtime.Composable
+
+@Composable internal actual fun defaultLazyListBeyondBoundsItemCount(): Int = 0


### PR DESCRIPTION
Add internal API to configure beyondBoundsItemCount default value for LazyList.
Test: BaseLazyListTestWithOrientation

Change-Id: Ifb524510f62ea196b6e01b02a7b139b04d6d1250