### PR TITLE
Pass focusedRectInRoot to the input method via a flow.

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3584,6 +3584,7 @@ public abstract interface class androidx/compose/ui/platform/PlatformTextInputIn
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputMethodRequest {
 	public abstract fun getEditProcessor ()Landroidx/compose/ui/text/input/EditProcessor;
+	public abstract fun getFocusedRectInRoot ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getImeOptions ()Landroidx/compose/ui/text/input/ImeOptions;
 	public abstract fun getOnEditCommand ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getOnImeAction ()Lkotlin/jvm/functions/Function1;
@@ -3600,9 +3601,8 @@ public final class androidx/compose/ui/platform/PlatformTextInputModifierNodeKt 
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSession {
-	public fun notifyFocusedRect (Landroidx/compose/ui/geometry/Rect;)V
 	public abstract fun startInputMethod (Landroidx/compose/ui/platform/PlatformTextInputMethodRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateSelectionState (Landroidx/compose/ui/text/input/TextFieldValue;)V
+	public fun updateTextFieldValue (Landroidx/compose/ui/text/input/TextFieldValue;)V
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSessionScope : androidx/compose/ui/platform/PlatformTextInputSession, kotlinx/coroutines/CoroutineScope {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
@@ -26,16 +27,39 @@ import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.coroutines.flow.Flow
 
 actual interface PlatformTextInputMethodRequest {
+    /** The editor state. */
     @ExperimentalComposeUiApi
     val state: TextFieldValue
+
+    /** Keyboard configuration such as single line, autocorrect etc. */
     @ExperimentalComposeUiApi
     val imeOptions: ImeOptions
+
+    /** Can be called to perform edit commands on the text field state. */
     @ExperimentalComposeUiApi
     val onEditCommand: (List<EditCommand>) -> Unit
+
+    /** The callback called when the editor action arrives. */
     @ExperimentalComposeUiApi
     val onImeAction: ((ImeAction) -> Unit)?
+
+    /** The edit processor. */
     @ExperimentalComposeUiApi
     val editProcessor: EditProcessor?
+
+    /**
+     * A flow with the layout of text in the editor's.
+     *
+     * When the layout changes, new values will be emitted by the flow.
+     */
     @ExperimentalComposeUiApi
     val textLayoutResult: Flow<TextLayoutResult>
+
+    /**
+     * A flow with the rectangle (relative to root) of the area where the actual editing occurs.
+     *
+     * As the area changes, new values will be emitted by the flow.
+     */
+    @ExperimentalComposeUiApi
+    val focusedRectInRoot: Flow<Rect>
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
@@ -17,15 +17,11 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.input.TextFieldValue
 
 actual interface PlatformTextInputSession {
     actual suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing
 
     @ExperimentalComposeUiApi
-    fun updateSelectionState(newState: TextFieldValue) = Unit
-
-    @ExperimentalComposeUiApi
-    fun notifyFocusedRect(rect: Rect) = Unit
+    fun updateTextFieldValue(newValue: TextFieldValue) = Unit
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -91,7 +91,6 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -638,8 +637,8 @@ internal class ComposeSceneMediator(
                 }
             }
 
-        override fun updateSelectionState(newState: TextFieldValue) {
-            textInputService.updateState(oldValue = null, newValue = newState)
+        override fun updateTextFieldValue(newValue: TextFieldValue) {
+            textInputService.updateState(oldValue = null, newValue = newValue)
         }
     }
 }


### PR DESCRIPTION
Instead of calling a function on `PlatformTextInputSession`, pass the focused rect in root as a flow to `SkikoPlatformTextInputMethodRequest`. This way the flow's values are only calculated if they're actually needed by the platform (for example on iOS, they're not needed currently).

It aligns the way we pass data to the session with https://github.com/JetBrains/compose-multiplatform-core/pull/1598

This is a refactoring only, there should be no visible functionality changes.


