### PR TITLE
Remove deprecated core-bundle APIs in lifecycle modules

### DIFF
--- a/lifecycle/lifecycle-viewmodel-compose/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-compose/build.gradle
@@ -52,13 +52,12 @@ kotlin {
                 api project(":lifecycle:lifecycle-common")
                 api project(":lifecycle:lifecycle-viewmodel")
                 api project(":lifecycle:lifecycle-viewmodel-savedstate")
-                api "org.jetbrains.androidx.savedstate:savedstate:1.2.2"
-                api "org.jetbrains.compose.runtime:runtime:1.7.1"
-                api "org.jetbrains.compose.runtime:runtime-saveable:1.7.1"
-                api "org.jetbrains.compose.ui:ui:1.7.1"
+                api project(":savedstate:savedstate")
+                api project(":compose:runtime:runtime")
+                api project(":compose:runtime:runtime-saveable")
+                api project(":compose:ui:ui")
 
                 implementation(libs.kotlinStdlib)
-                implementation project(":core:core-bundle")
             }
         }
 

--- a/lifecycle/lifecycle-viewmodel-compose/src/commonMain/kotlin/androidx/lifecycle/viewmodel/compose/SavedStateHandleSaver.kt
+++ b/lifecycle/lifecycle-viewmodel-compose/src/commonMain/kotlin/androidx/lifecycle/viewmodel/compose/SavedStateHandleSaver.kt
@@ -26,10 +26,10 @@ import androidx.compose.runtime.saveable.autoSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotMutableState
-import androidx.core.bundle.Bundle
-import androidx.core.bundle.bundleOf
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.SavedStateHandle.Companion.validateValue
+import androidx.savedstate.SavedState
+import androidx.savedstate.read
 import androidx.savedstate.savedState
 import kotlin.jvm.JvmName
 import kotlin.properties.PropertyDelegateProvider
@@ -59,7 +59,9 @@ fun <T : Any> SavedStateHandle.saveable(
     saver as Saver<T, Any>
     // value is restored using the SavedStateHandle or created via [init] lambda
     @Suppress("DEPRECATION") // Bundle.get has been deprecated in API 31
-    val value = get<Bundle?>(key)?.get("value")?.let(saver::restore) ?: init()
+    val value = get<SavedState?>(key)?.read {
+        if (contains("value")) getSavedState("value") else null
+    }?.let(saver::restore) ?: init()
 
     // Hook up saving the state to the SavedStateHandle
     setSavedStateProvider(key) {

--- a/lifecycle/lifecycle-viewmodel-savedstate/api/desktop/lifecycle-viewmodel-savedstate.api
+++ b/lifecycle/lifecycle-viewmodel-savedstate/api/desktop/lifecycle-viewmodel-savedstate.api
@@ -1,6 +1,5 @@
 public abstract class androidx/lifecycle/AbstractSavedStateViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public fun <init> ()V
-	public synthetic fun <init> (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/core/bundle/Bundle;)V
 	public fun <init> (Landroidx/savedstate/SavedStateRegistryOwner;Landroidx/savedstate/SavedState;)V
 	protected fun create (Ljava/lang/String;Lkotlin/reflect/KClass;Landroidx/lifecycle/SavedStateHandle;)Landroidx/lifecycle/ViewModel;
 	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
@@ -12,7 +11,6 @@ public final class androidx/lifecycle/SavedStateHandle {
 	public fun <init> (Ljava/util/Map;)V
 	public final fun clearSavedStateProvider (Ljava/lang/String;)V
 	public final fun contains (Ljava/lang/String;)Z
-	public static final synthetic fun createHandle (Landroidx/core/bundle/Bundle;Landroidx/core/bundle/Bundle;)Landroidx/lifecycle/SavedStateHandle;
 	public static final fun createHandle (Landroidx/savedstate/SavedState;Landroidx/savedstate/SavedState;)Landroidx/lifecycle/SavedStateHandle;
 	public final fun get (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun getMutableStateFlow (Ljava/lang/String;Ljava/lang/Object;)Lkotlinx/coroutines/flow/MutableStateFlow;
@@ -25,7 +23,6 @@ public final class androidx/lifecycle/SavedStateHandle {
 }
 
 public final class androidx/lifecycle/SavedStateHandle$Companion {
-	public final synthetic fun createHandle (Landroidx/core/bundle/Bundle;Landroidx/core/bundle/Bundle;)Landroidx/lifecycle/SavedStateHandle;
 	public final fun createHandle (Landroidx/savedstate/SavedState;Landroidx/savedstate/SavedState;)Landroidx/lifecycle/SavedStateHandle;
 	public final fun validateValue (Ljava/lang/Object;)Z
 }

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -49,7 +49,6 @@ androidXMultiplatform {
                 api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
                 api(project(":savedstate:savedstate"))
                 api(project(":lifecycle:lifecycle-viewmodel"))
-                implementation("org.jetbrains.androidx.core:core-bundle:1.1.0-alpha01")
                 api(libs.kotlinStdlib)
                 api(libs.kotlinCoroutinesCore)
                 api(libs.kotlinSerializationCore)

--- a/lifecycle/lifecycle-viewmodel-savedstate/src/commonMain/kotlin/androidx/lifecycle/AbstractSavedStateViewModelFactory.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/commonMain/kotlin/androidx/lifecycle/AbstractSavedStateViewModelFactory.kt
@@ -15,7 +15,6 @@
  */
 package androidx.lifecycle
 
-import androidx.core.bundle.Bundle
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.savedstate.SavedState
 import androidx.savedstate.SavedStateRegistryOwner
@@ -51,12 +50,6 @@ public expect abstract class AbstractSavedStateViewModelFactory :
     constructor(
         owner: SavedStateRegistryOwner,
         defaultArgs: SavedState?
-    )
-
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Use constructor with SavedState")
-    constructor(
-        owner: SavedStateRegistryOwner,
-        defaultArgs: Bundle?
     )
 
     /**

--- a/lifecycle/lifecycle-viewmodel-savedstate/src/commonMain/kotlin/androidx/lifecycle/SavedStateHandle.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/commonMain/kotlin/androidx/lifecycle/SavedStateHandle.kt
@@ -17,7 +17,6 @@ package androidx.lifecycle
 
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
-import androidx.core.bundle.Bundle
 import androidx.savedstate.SavedState
 import androidx.savedstate.SavedStateRegistry.SavedStateProvider
 import kotlin.jvm.JvmStatic
@@ -225,16 +224,6 @@ expect class SavedStateHandle {
     @MainThread fun clearSavedStateProvider(key: String)
 
     companion object {
-
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        @JvmStatic
-        @Suppress("DEPRECATION")
-        @Deprecated(
-            level = DeprecationLevel.HIDDEN,
-            message = "Use createHandle with SavedState instead"
-        )
-        fun createHandle(restoredState: Bundle?, defaultState: Bundle?): SavedStateHandle
-
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @JvmStatic
         @Suppress("DEPRECATION")

--- a/lifecycle/lifecycle-viewmodel-savedstate/src/nonAndroidMain/kotlin/androidx/lifecycle/AbstractSavedStateViewModelFactory.nonAndroid.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/nonAndroidMain/kotlin/androidx/lifecycle/AbstractSavedStateViewModelFactory.nonAndroid.kt
@@ -15,7 +15,6 @@
  */
 package androidx.lifecycle
 
-import androidx.core.bundle.Bundle
 import androidx.lifecycle.ViewModelProvider.Companion.VIEW_MODEL_KEY
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.savedstate.SavedState
@@ -31,12 +30,6 @@ public actual abstract class AbstractSavedStateViewModelFactory :
     actual constructor(
         owner: SavedStateRegistryOwner,
         defaultArgs: SavedState?
-    )
-
-    @Deprecated(level = DeprecationLevel.HIDDEN, message = "Use constructor with SavedState")
-    actual constructor(
-        owner: SavedStateRegistryOwner,
-        defaultArgs: Bundle?
     )
 
     /**

--- a/lifecycle/lifecycle-viewmodel-savedstate/src/nonAndroidMain/kotlin/androidx/lifecycle/SavedStateHandle.nonAndroid.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/nonAndroidMain/kotlin/androidx/lifecycle/SavedStateHandle.nonAndroid.kt
@@ -18,7 +18,6 @@ package androidx.lifecycle
 
 import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
-import androidx.core.bundle.Bundle
 import androidx.lifecycle.internal.SavedStateHandleImpl
 import androidx.lifecycle.internal.isAcceptableType
 import androidx.savedstate.SavedState
@@ -78,30 +77,6 @@ actual class SavedStateHandle {
     }
 
     actual companion object {
-
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        @JvmStatic
-        @Suppress("DEPRECATION")
-        @Deprecated(
-            level = DeprecationLevel.HIDDEN,
-            message = "Use createHandle with SavedState instead"
-        )
-        actual fun createHandle(
-            restoredState: Bundle?,
-            defaultState: Bundle?,
-        ): SavedStateHandle {
-            val initialState = restoredState ?: defaultState
-
-            // If there is no restored state or default state, an empty SavedStateHandle is created.
-            if (initialState == null) return SavedStateHandle()
-
-            val state = mutableMapOf<String, Any?>()
-            for (key in initialState.keySet()) {
-                state[key as String] = initialState[key]
-            }
-
-            return SavedStateHandle(initialState = state)
-        }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @JvmStatic


### PR DESCRIPTION
Remove deprecated core-bundle APIs in lifecycle modules

## Release Notes
### Breaking Changes - Multiple Platforms
- Multiplatform lifecycle was migrated from a internal `core-bundle` module to the androidx SavedState. Libraries that use `org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate`  or `org.jetbrains.androidx.savedstate:savedstate` should migrate to the latest version
