### PR TITLE
Send only synthetic mouse hover events on scene relayout

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -405,7 +405,7 @@ class SyntheticEventSenderTest {
     }
 
     @Test
-    fun `should not update pointer position with move event after pressed event`() {
+    fun `should update pointer position with move event after pressed event`() {
         val received = mutableListOf<PointerInputEvent>()
         val sender = SyntheticEventSender {
             PointerEventResult(received.add(it))
@@ -417,6 +417,7 @@ class SyntheticEventSenderTest {
 
         received positionAndDownShouldEqual listOf(
             event(Press, 1 to touch(10f, 20f, pressed = true)),
+            event(Move, 1 to touch(10f, 20f, pressed = true))
         )
 
         received.clear()
@@ -427,6 +428,7 @@ class SyntheticEventSenderTest {
 
         received positionAndDownShouldEqual listOf(
             event(Move, 1 to touch(5f, 15f, pressed = true)),
+            event(Move, 1 to touch(5f, 15f, pressed = true))
         )
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.SyntheticEventSender
 import androidx.compose.ui.scene.PointerEventResult
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -378,8 +377,35 @@ class SyntheticEventSenderTest {
     }
 
     @Test
-    @Ignore
-    fun `should update pointer position with move event after press event`() {
+    fun `should update pointer position with move event after hover event`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+        sender.send(mouseEvent(Enter, 10f, 20f, pressed = false))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            event(Enter, 1 to touch(10f, 20f, pressed = false)),
+            event(Move, 1 to touch(10f, 20f, pressed = false))
+        )
+
+        received.clear()
+        sender.send(mouseEvent(Move, 5f, 15f, pressed = false))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            event(Move, 1 to touch(5f, 15f, pressed = false)),
+            event(Move, 1 to touch(5f, 15f, pressed = false))
+        )
+    }
+
+    @Test
+    fun `should not update pointer position with move event after pressed event`() {
         val received = mutableListOf<PointerInputEvent>()
         val sender = SyntheticEventSender {
             PointerEventResult(received.add(it))
@@ -391,24 +417,42 @@ class SyntheticEventSenderTest {
 
         received positionAndDownShouldEqual listOf(
             event(Press, 1 to touch(10f, 20f, pressed = true)),
-            event(Move, 1 to touch(10f, 20f, pressed = true))
         )
-    }
 
-    @Test
-    @Ignore
-    fun `should not update pointer position with move event after touch event`() {
-        val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
-        }
-        sender.send(event(Move, 1 to touch(10f, 20f, pressed = true)))
+        received.clear()
+        sender.send(mouseEvent(Move, 5f, 15f, pressed = true))
 
         sender.needUpdatePointerPosition = true
         sender.updatePointerPosition()
 
         received positionAndDownShouldEqual listOf(
-            event(Move, 1 to touch(10f, 20f, pressed = true))
+            event(Move, 1 to touch(5f, 15f, pressed = true)),
+        )
+    }
+
+    @Test
+    fun `should not update pointer position with move event after touch event`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+        sender.send(event(Press, 1 to touch(10f, 20f, pressed = true)))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            event(Press, 1 to touch(10f, 20f, pressed = true)),
+        )
+
+        received.clear()
+        sender.send(event(Move, 1 to touch(5f, 15f, pressed = true)))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            event(Move, 1 to touch(5f, 15f, pressed = true)),
         )
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.SyntheticEventSender
 import androidx.compose.ui.scene.PointerEventResult
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -377,6 +378,7 @@ class SyntheticEventSenderTest {
     }
 
     @Test
+    @Ignore
     fun `should update pointer position with move event after press event`() {
         val received = mutableListOf<PointerInputEvent>()
         val sender = SyntheticEventSender {
@@ -394,12 +396,13 @@ class SyntheticEventSenderTest {
     }
 
     @Test
-    fun `should not update pointer position with move event after another move event`() {
+    @Ignore
+    fun `should not update pointer position with move event after touch event`() {
         val received = mutableListOf<PointerInputEvent>()
         val sender = SyntheticEventSender {
             PointerEventResult(received.add(it))
         }
-        sender.send(mouseEvent(Move, 10f, 20f, pressed = true))
+        sender.send(event(Move, 1 to touch(10f, 20f, pressed = true)))
 
         sender.needUpdatePointerPosition = true
         sender.updatePointerPosition()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -376,6 +376,39 @@ class SyntheticEventSenderTest {
         )
     }
 
+    @Test
+    fun `should update pointer position with move event after press event`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+        sender.send(mouseEvent(Press, 10f, 20f, pressed = true))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            event(Press, 1 to touch(10f, 20f, pressed = true)),
+            event(Move, 1 to touch(10f, 20f, pressed = true))
+        )
+    }
+
+    @Test
+    fun `should not update pointer position with move event after another move event`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+        sender.send(mouseEvent(Move, 10f, 20f, pressed = true))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            event(Move, 1 to touch(10f, 20f, pressed = true))
+        )
+    }
+
     private fun eventsSentBy(
         vararg inputEvents: PointerInputEvent
     ): List<PointerInputEvent> {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -90,6 +90,8 @@ internal class SyntheticEventSender(
             needUpdatePointerPosition = false
 
             previousEvent?.let { event ->
+                // Re-send pointer position update only for hover mouse events.
+                // Aligned with [AndroidComposeView.resendMotionEventOnLayout], but fixing b/397352507.
                 if (event.pointers.fastAny { it.type == PointerType.Mouse }) {
                     return sendSyntheticMove(event)
                 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -90,9 +90,7 @@ internal class SyntheticEventSender(
             needUpdatePointerPosition = false
 
             previousEvent?.let { event ->
-                // Resent pointer position update only for hover mouse events.
-                // Keep logic in sync with [AndroidComposeView.resendMotionEventOnLayout].
-                if (event.pointers.fastAny { !it.down && it.type == PointerType.Mouse }) {
+                if (event.pointers.fastAny { it.type == PointerType.Mouse }) {
                     return sendSyntheticMove(event)
                 }
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -90,7 +90,7 @@ internal class SyntheticEventSender(
             needUpdatePointerPosition = false
 
             previousEvent?.let { event ->
-                if (!event.isMove() &&
+                if (event.eventType != PointerEventType.Move &&
                     event.pointers.fastAny { it.down || it.type == PointerType.Mouse }
                 ) {
                     return sendSyntheticMove(event)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -90,9 +90,9 @@ internal class SyntheticEventSender(
             needUpdatePointerPosition = false
 
             previousEvent?.let { event ->
-                if (event.eventType != PointerEventType.Move &&
-                    event.pointers.fastAny { it.down || it.type == PointerType.Mouse }
-                ) {
+                // Resent pointer position update only for hover mouse events.
+                // Keep logic in sync with [AndroidComposeView.resendMotionEventOnLayout].
+                if (event.pointers.fastAny { !it.down && it.type == PointerType.Mouse }) {
                     return sendSyntheticMove(event)
                 }
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -90,7 +90,9 @@ internal class SyntheticEventSender(
             needUpdatePointerPosition = false
 
             previousEvent?.let { event ->
-                if (event.pointers.fastAny { it.down || it.type == PointerType.Mouse }) {
+                if (!event.isMove() &&
+                    event.pointers.fastAny { it.down || it.type == PointerType.Mouse }
+                ) {
                     return sendSyntheticMove(event)
                 }
             }


### PR DESCRIPTION
Remove extra synthetic move event that triggered scroll cancellation when `DragGesturePickUpEnabled` set to true.

Fixes https://youtrack.jetbrains.com/issue/CMP-7623/iOS-Gesture-handling-is-incorrect-in-1.8.0-alpha03
Fixes https://youtrack.jetbrains.com/issue/CMP-7504/iOS-horizontal-scrolling-not-working-properly-with-nested-lists-since-1.8.0-alpha02

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fixed issue where cross-directional scrolling could intercept and cancel each other