### PR TITLE
Create PlatformTextInputService2 and transition desktop to it

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -19,8 +19,11 @@ package androidx.compose.foundation.text.input.internal
 import androidx.compose.foundation.content.internal.ReceiveContentConfiguration
 import androidx.compose.foundation.text.computeSizeForDefaultText
 import androidx.compose.foundation.text.focusedRectInRoot
+import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.TextFieldCharSequence
+import androidx.compose.foundation.text.input.delete
 import androidx.compose.foundation.text.input.setSelectionCoerced
+import androidx.compose.foundation.text.offsetByCodePoints
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Rect
@@ -29,16 +32,19 @@ import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSession
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.TextEditingScope
+import androidx.compose.ui.text.input.TextEditorState
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSession(
@@ -73,10 +79,18 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         }
     }
 
+    fun editText(block: TextEditingScope.() -> Unit) {
+        state.editUntransformedTextAsUser {
+            with(TextEditingScope(this)) {
+                block()
+            }
+        }
+    }
+
     coroutineScope {
-        launch {
+        val outputValueFlow = callbackFlow {
             state.collectImeNotifications { _, newValue, _ ->
-                updateTextFieldValue(newValue.toTextFieldValue())
+                trySend(newValue.toTextFieldValue())
             }
         }
 
@@ -105,15 +119,18 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
 
         startInputMethod(
             SkikoPlatformTextInputMethodRequest(
-                state = state.untransformedText.toTextFieldValue(),
+                value = { state.untransformedText.toTextFieldValue() },
+                state = state.untransformedText.asTextEditorState(),
                 imeOptions = imeOptions,
                 onEditCommand = ::onEditCommand,
                 onImeAction = onImeAction,
                 editProcessor = editProcessor,
+                outputValue = outputValueFlow,
                 textLayoutResult = snapshotFlow(layoutState::layoutResult).filterNotNull(),
                 focusedRectInRoot = focusedRectInRootFlow,
                 textFieldRectInRoot = textFieldRectInRoot,
-                textClippingRectInRoot = textClippingRectInRoot
+                textClippingRectInRoot = textClippingRectInRoot,
+                editText = ::editText
             )
         )
     }
@@ -123,14 +140,115 @@ private fun TextFieldCharSequence.toTextFieldValue() =
     TextFieldValue(toString(), selection, composition)
 
 @OptIn(ExperimentalComposeUiApi::class)
+private fun TextFieldCharSequence.asTextEditorState() = object : TextEditorState {
+
+    override val length: Int
+        get() = this@asTextEditorState.length
+
+    override fun get(index: Int): Char = this@asTextEditorState[index]
+
+    override fun subSequence(startIndex: Int, endIndex: Int): CharSequence {
+        return this@asTextEditorState.subSequence(startIndex, endIndex)
+    }
+
+    override val selection: TextRange
+        get() = this@asTextEditorState.selection
+
+    override val composition: TextRange?
+        get() = this@asTextEditorState.composition
+
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScope {
+
+    private var TextFieldBuffer.cursor: Int
+        get() = if (selection.collapsed) selection.end else -1
+        set(value) {
+            setSelectionCoerced(value, value)
+        }
+
+    override fun deleteSurroundingTextInCodePoints(
+        lengthBeforeCursor: Int,
+        lengthAfterCursor: Int
+    ) {
+        val charSequence = buffer.asCharSequence()
+        val selection = buffer.selection
+        buffer.delete(
+            start = selection.end,
+            end = charSequence.offsetByCodePoints(
+                index = selection.end,
+                offset = lengthAfterCursor
+            )
+        )
+        buffer.delete(
+            start = charSequence.offsetByCodePoints(
+                index = selection.start,
+                offset = -lengthBeforeCursor
+            ),
+            end = selection.start
+        )
+    }
+
+    override fun commitText(text: CharSequence, newCursorPosition: Int) {
+        // API description says replace ongoing composition text if there. Then, if there is no
+        // composition text, insert text into cursor position or replace selection.
+        val replacementRange = buffer.composition ?: buffer.selection
+        buffer.replace(replacementRange.start, replacementRange.end, text)
+
+        // After replace function is called, the editing buffer places the cursor at the end of the
+        // modified range.
+        val newCursor = buffer.cursor
+
+        // See API description for the meaning of newCursorPosition.
+        val newCursorInBuffer =
+            if (newCursorPosition > 0) {
+                newCursor + newCursorPosition - 1
+            } else {
+                newCursor + newCursorPosition - text.length
+            }
+        buffer.setSelectionCoerced(newCursorInBuffer, newCursorInBuffer)
+    }
+
+    override fun setComposingText(text: CharSequence, newCursorPosition: Int) {
+        val replacementRange = buffer.composition ?: buffer.selection
+        // API doc says, if there is ongoing composing text, replace it with new text.
+        // If there is no composing text, insert composing text into cursor position with
+        // removing selected text if any.
+        buffer.replace(replacementRange.start, replacementRange.end, text)
+        if (text.isNotEmpty()) {
+            buffer.setComposition(replacementRange.start, replacementRange.start + text.length)
+        }
+
+        // After replace function is called, the editing buffer places the cursor at the end of the
+        // modified range.
+        val newCursor = buffer.cursor
+
+        // See API description for the meaning of newCursorPosition.
+        val newCursorInBuffer =
+            if (newCursorPosition > 0) {
+                newCursor + newCursorPosition - 1
+            } else {
+                newCursor + newCursorPosition - text.length
+            }
+
+        buffer.cursor = newCursorInBuffer
+    }
+}
+
+
+@OptIn(ExperimentalComposeUiApi::class)
 private data class SkikoPlatformTextInputMethodRequest(
-    override val state: TextFieldValue,
+    override val value: () -> TextFieldValue,
+    override val state: TextEditorState,
     override val imeOptions: ImeOptions,
     override val onEditCommand: (List<EditCommand>) -> Unit,
     override val onImeAction: ((ImeAction) -> Unit)?,
     override val editProcessor: EditProcessor?,
+    override val outputValue: Flow<TextFieldValue>,
     override val textLayoutResult: Flow<TextLayoutResult>,
     override val focusedRectInRoot: Flow<Rect>,
     override val textFieldRectInRoot: Flow<Rect>,
-    override val textClippingRectInRoot: Flow<Rect>
+    override val textClippingRectInRoot: Flow<Rect>,
+    override val editText: (block: TextEditingScope.() -> Unit) -> Unit
 ): PlatformTextInputMethodRequest

--- a/compose/ui/ui-text/api/desktop/ui-text.api
+++ b/compose/ui/ui-text/api/desktop/ui-text.api
@@ -1359,6 +1359,12 @@ public abstract interface class androidx/compose/ui/text/input/PlatformTextInput
 	public fun updateTextLayoutResult (Landroidx/compose/ui/text/input/TextFieldValue;Landroidx/compose/ui/text/input/OffsetMapping;Landroidx/compose/ui/text/TextLayoutResult;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/geometry/Rect;Landroidx/compose/ui/geometry/Rect;)V
 }
 
+public abstract interface class androidx/compose/ui/text/input/PlatformTextInputService2 {
+	public abstract fun focusedRectChanged (Landroidx/compose/ui/geometry/Rect;)V
+	public abstract fun startInput (Landroidx/compose/ui/text/input/TextEditorState;Landroidx/compose/ui/text/input/ImeOptions;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun stopInput ()V
+}
+
 public final class androidx/compose/ui/text/input/SetComposingRegionCommand : androidx/compose/ui/text/input/EditCommand {
 	public static final field $stable I
 	public fun <init> (II)V
@@ -1392,6 +1398,17 @@ public final class androidx/compose/ui/text/input/SetSelectionCommand : androidx
 	public final fun getStart ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class androidx/compose/ui/text/input/TextEditingScope {
+	public abstract fun commitText (Ljava/lang/CharSequence;I)V
+	public abstract fun deleteSurroundingTextInCodePoints (II)V
+	public abstract fun setComposingText (Ljava/lang/CharSequence;I)V
+}
+
+public abstract interface class androidx/compose/ui/text/input/TextEditorState : java/lang/CharSequence {
+	public abstract fun getComposition-MzsxiRA ()Landroidx/compose/ui/text/TextRange;
+	public abstract fun getSelection-d9O1mEE ()J
 }
 
 public final class androidx/compose/ui/text/input/TextFieldValue {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/input/PlatformTextInputService2.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/input/PlatformTextInputService2.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.input
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.text.TextRange
+
+/**
+ * An adapter for `foundation.TextFieldState`, which is not accessible in the `ui` module.
+ *
+ * The text itself is provided by the [CharSequence] supertype.
+ * The selection is provided by [selection].
+ * The composition is provided by [composition].
+ */
+@ExperimentalComposeUiApi
+interface TextEditorState : CharSequence {
+    /**
+     * The selection in the text field.
+     */
+    val selection: TextRange
+
+    /**
+     * The composition in the text field.
+     */
+    val composition: TextRange?
+}
+
+/**
+ * The scope in which the [PlatformTextInputService2] implementation can make changes to the
+ * [TextEditorState].
+ */
+@ExperimentalComposeUiApi
+interface TextEditingScope {
+    /**
+     * Deletes text around the cursor.
+     *
+     * This intends to replicate [DeleteSurroundingTextInCodePointsCommand] for
+     * [PlatformTextInputService2].
+     */
+    fun deleteSurroundingTextInCodePoints(lengthBeforeCursor: Int, lengthAfterCursor: Int)
+
+    /**
+     * Commits text and repositions the cursor.
+     *
+     * This intends to replicate [CommitTextCommand] for [PlatformTextInputService2].
+     */
+    fun commitText(text: CharSequence, newCursorPosition: Int)
+
+    /**
+     * Sets the composing text and repositions the cursor.
+     *
+     * This intends to replicate [SetComposingTextCommand] for [PlatformTextInputService2].
+     */
+    fun setComposingText(text: CharSequence, newCursorPosition: Int)
+}
+
+/**
+ * The interface for classes responsible for platform-specific behaviors of text fields.
+ */
+@ExperimentalComposeUiApi
+interface PlatformTextInputService2 {
+    /**
+     * Starts the text input session for given text field.
+     */
+    fun startInput(
+        state: TextEditorState,
+        imeOptions: ImeOptions,
+        editText: (block: TextEditingScope.() -> Unit) -> Unit,
+    )
+
+    /**
+     * Ends the current text input session.
+     */
+    fun stopInput()
+
+    /**
+     * Notifies the implementation of the rectangle where the actual text editing happens (at the
+     * caret).
+     *
+     * @param rect The rectangle, relative to root.
+     */
+    fun focusedRectChanged(rect: Rect)
+}

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3590,14 +3590,17 @@ public abstract interface class androidx/compose/ui/platform/PlatformTextInputIn
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputMethodRequest {
 	public abstract fun getEditProcessor ()Landroidx/compose/ui/text/input/EditProcessor;
+	public abstract fun getEditText ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getFocusedRectInRoot ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getImeOptions ()Landroidx/compose/ui/text/input/ImeOptions;
 	public abstract fun getOnEditCommand ()Lkotlin/jvm/functions/Function1;
 	public abstract fun getOnImeAction ()Lkotlin/jvm/functions/Function1;
-	public abstract fun getState ()Landroidx/compose/ui/text/input/TextFieldValue;
+	public abstract fun getOutputValue ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getState ()Landroidx/compose/ui/text/input/TextEditorState;
 	public abstract fun getTextClippingRectInRoot ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getTextFieldRectInRoot ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getTextLayoutResult ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getValue ()Lkotlin/jvm/functions/Function0;
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputModifierNode : androidx/compose/ui/node/DelegatableNode {
@@ -3610,7 +3613,6 @@ public final class androidx/compose/ui/platform/PlatformTextInputModifierNodeKt 
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSession {
 	public abstract fun startInputMethod (Landroidx/compose/ui/platform/PlatformTextInputMethodRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateTextFieldValue (Landroidx/compose/ui/text/input/TextFieldValue;)V
 }
 
 public abstract interface class androidx/compose/ui/platform/PlatformTextInputSessionScope : androidx/compose/ui/platform/PlatformTextInputSession, kotlinx/coroutines/CoroutineScope {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -104,7 +104,7 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     }
 
     fun inputMethodTextChanged(event: InputMethodEvent) {
-        if (!event.isConsumed) {
+        if ((currentInput != null) && !event.isConsumed) {
             replaceInputMethodText(event)
             event.consume()
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.PlatformTextInputService2
+import androidx.compose.ui.text.input.TextEditingScope
+import androidx.compose.ui.text.input.TextEditorState
+import androidx.compose.ui.text.substring
+import java.awt.Rectangle
+import java.awt.event.InputMethodEvent
+import java.awt.event.KeyEvent
+import java.awt.font.TextHitInfo
+import java.awt.im.InputMethodRequests
+import java.text.AttributedCharacterIterator
+import java.text.AttributedString
+import java.text.CharacterIterator
+import kotlin.math.max
+import kotlin.math.min
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
+
+internal class DesktopTextInputService2(
+    private val component: PlatformComponent
+) : PlatformTextInputService2 {
+
+    private var currentInputMethodRequests: InputMethodRequestsImpl? = null
+
+    override fun startInput(
+        state: TextEditorState,
+        imeOptions: ImeOptions,
+        editText: (block: TextEditingScope.() -> Unit) -> Unit
+    ) {
+        component.enableInput(
+            InputMethodRequestsImpl(component, state, editText).also {
+                currentInputMethodRequests = it
+            }
+        )
+    }
+
+    override fun stopInput() {
+        component.disableInput()
+
+        this.currentInputMethodRequests = null
+    }
+
+    override fun focusedRectChanged(rect: Rect) {
+        currentInputMethodRequests?.focusedRect = rect
+    }
+
+    fun onKeyEvent(keyEvent: KeyEvent) {
+        when (keyEvent.id) {
+            KeyEvent.KEY_TYPED ->
+                currentInputMethodRequests?.charKeyPressed = true
+            KeyEvent.KEY_RELEASED ->
+                currentInputMethodRequests?.charKeyPressed = false
+        }
+    }
+
+    fun inputMethodTextChanged(event: InputMethodEvent) {
+        val inputMethodRequests = currentInputMethodRequests ?: return
+        if (!event.isConsumed) {
+            inputMethodRequests.replaceInputMethodText(event)
+            event.consume()
+        }
+    }
+
+}
+
+private class InputMethodRequestsImpl(
+    private val component: PlatformComponent,
+    private val state: TextEditorState,
+    private val editText: (block: TextEditingScope.() -> Unit) -> Unit
+) : InputMethodRequests {
+
+    private val selection: TextRange
+        get() = state.selection
+
+    private val composition: TextRange?
+        get() = state.composition
+
+    var focusedRect: Rect? = null
+
+    // This is required to support input of accented characters using press-and-hold method (http://support.apple.com/kb/PH11264).
+    // JDK currently properly supports this functionality only for TextComponent/JTextComponent descendants.
+    // For our editor component we need this workaround.
+    // After https://bugs.openjdk.java.net/browse/JDK-8074882 is fixed, this workaround should be replaced with a proper solution.
+    var charKeyPressed: Boolean = false
+    var needToDeletePreviousChar: Boolean = false
+
+    override fun getLocationOffset(x: Int, y: Int): TextHitInfo? {
+        if (composition != null) {
+            // TODO: to properly implement this method we need to somehow have access to
+            //  Paragraph at this point
+            return TextHitInfo.leading(0)
+        }
+        return null
+    }
+
+    override fun cancelLatestCommittedText(
+        attributes: Array<AttributedCharacterIterator.Attribute>?
+    ): AttributedCharacterIterator? {
+        return null
+    }
+
+    override fun getInsertPositionOffset(): Int {
+        val composedStartIndex = composition?.start ?: 0
+        val composedEndIndex = composition?.end ?: 0
+
+        val caretIndex = selection.start
+        if (caretIndex < composedStartIndex) {
+            return caretIndex
+        }
+        if (caretIndex < composedEndIndex) {
+            return composedStartIndex
+        }
+        return caretIndex - (composedEndIndex - composedStartIndex)
+    }
+
+    override fun getCommittedTextLength() =
+        state.length - (composition?.length ?: 0)
+
+    override fun getSelectedText(
+        attributes: Array<AttributedCharacterIterator.Attribute>?
+    ): AttributedCharacterIterator {
+        if (charKeyPressed && (hostOs == OS.MacOS)) {
+            needToDeletePreviousChar = true
+        }
+        val str = state.substring(selection)
+        return AttributedString(str).iterator
+    }
+
+    override fun getTextLocation(offset: TextHitInfo?): Rectangle? {
+        return focusedRect?.let {
+            val x = (it.right / component.density.density).toInt() +
+                component.locationOnScreen.x
+            val y = (it.top / component.density.density).toInt() +
+                component.locationOnScreen.y
+            Rectangle(x, y, it.width.toInt(), it.height.toInt())
+        }
+    }
+
+    override fun getCommittedText(
+        beginIndex: Int,
+        endIndex: Int,
+        attributes: Array<AttributedCharacterIterator.Attribute>?
+    ): AttributedCharacterIterator {
+        val comp = composition
+        // When input is performed with Pinyin and backspace pressed,
+        // comp is null and beginIndex > endIndex.
+        // TODO Check is this an expected behavior?
+        val range = TextRange(
+            start = beginIndex.coerceAtMost(state.length),
+            end = endIndex.coerceAtMost(state.length)
+        )
+        if (comp == null) {
+            val res = state.substring(range)
+            return AttributedString(res).iterator
+        }
+        val committed = state.substring(
+            TextRange(
+                min(range.min, comp.min).coerceAtMost(state.length),
+                max(range.max, comp.max).coerceAtMost(state.length)
+            )
+        )
+        return AttributedString(committed).iterator
+    }
+
+    fun replaceInputMethodText(event: InputMethodEvent) {
+        val committed = event.text?.toStringUntil(event.committedCharacterCount) ?: ""
+        val composing = event.text?.toStringFrom(event.committedCharacterCount) ?: ""
+
+        editText {
+            if (needToDeletePreviousChar && selection.min > 0 && composing.isEmpty()) {
+                needToDeletePreviousChar = false
+                deleteSurroundingTextInCodePoints(1, 0)
+            }
+            commitText(committed, 1)
+            if (composing.isNotEmpty()) {
+                setComposingText(composing, 1)
+            }
+        }
+    }
+
+}
+
+private fun AttributedCharacterIterator.toStringUntil(index: Int) = StringBuilder().apply {
+    var i = index
+    if (i > 0) {
+        var c: Char = setIndex(0)
+        while (i > 0) {
+            append(c)
+            c = next()
+            i--
+        }
+    }
+}
+
+private fun AttributedCharacterIterator.toStringFrom(index: Int) = StringBuilder().apply {
+    var c: Char = setIndex(index)
+    while (c != CharacterIterator.DONE) {
+        append(c)
+        c = next()
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeFeatureFlags
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.SessionMutex
 import androidx.compose.ui.awt.AwtEventListener
@@ -46,6 +45,7 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.platform.AwtDragAndDropManager
 import androidx.compose.ui.platform.DelegateRootForTestListener
 import androidx.compose.ui.platform.DesktopTextInputService
+import androidx.compose.ui.platform.DesktopTextInputService2
 import androidx.compose.ui.platform.EmptyViewConfiguration
 import androidx.compose.ui.platform.PlatformComponent
 import androidx.compose.ui.platform.PlatformContext
@@ -59,7 +59,6 @@ import androidx.compose.ui.platform.a11y.AccessibilityController
 import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.semantics.SemanticsOwner
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
@@ -142,6 +141,7 @@ internal class ComposeSceneMediator(
 
     private val platformComponent = DesktopPlatformComponent()
     private val textInputService = DesktopTextInputService(platformComponent)
+    private val textInputService2 = DesktopTextInputService2(platformComponent)
     private val _platformContext = DesktopPlatformContext()
     val platformContext: PlatformContext get() = _platformContext
 
@@ -234,6 +234,9 @@ internal class ComposeSceneMediator(
             if (isDisposed) return
             catchExceptions {
                 textInputService.inputMethodTextChanged(event)
+            }
+            catchExceptions {
+                textInputService2.inputMethodTextChanged(event)
             }
         }
     }
@@ -478,6 +481,7 @@ internal class ComposeSceneMediator(
         }
         val composeEvent = event.toComposeEvent()
         textInputService.onKeyEvent(event)
+        textInputService2.onKeyEvent(event)
         windowContext.setKeyboardModifiers(composeEvent.internal.modifiers)
         if (onPreviewKeyEvent(composeEvent) ||
             scene.sendKeyEvent(composeEvent) ||
@@ -786,31 +790,24 @@ internal class ComposeSceneMediator(
             coroutineScope {
                 launch {
                     request.focusedRectInRoot.collect {
-                        textInputService.notifyFocusedRect(it)
+                        textInputService2.focusedRectChanged(it)
                     }
                 }
 
                 suspendCancellableCoroutine<Nothing> { continuation ->
-                    textInputService.startInput(
-                        value = request.state,
+                    textInputService2.startInput(
+                        state = request.state,
                         imeOptions = request.imeOptions,
-                        onEditCommand = request.onEditCommand,
-                        onImeActionPerformed = request.onImeAction ?: {}
+                        editText = request.editText,
                     )
 
                     continuation.invokeOnCancellation {
-                        textInputService.stopInput()
+                        textInputService2.stopInput()
                     }
                 }
             }
         }
-
-        @ExperimentalComposeUiApi
-        override fun updateTextFieldValue(newValue: TextFieldValue) {
-            textInputService.updateState(oldValue = null, newValue = newValue)
-        }
     }
-
 
     private class InvisibleComponent : Component() {
         fun requestFocusTemporary(): Boolean {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
@@ -23,13 +23,19 @@ import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.TextEditingScope
+import androidx.compose.ui.text.input.TextEditorState
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.coroutines.flow.Flow
 
 actual interface PlatformTextInputMethodRequest {
     /** The editor state. */
     @ExperimentalComposeUiApi
-    val state: TextFieldValue
+    val value: () -> TextFieldValue
+
+    /** The editor state. */
+    @ExperimentalComposeUiApi
+    val state: TextEditorState
 
     /** Keyboard configuration such as single line, autocorrect etc. */
     @ExperimentalComposeUiApi
@@ -46,6 +52,9 @@ actual interface PlatformTextInputMethodRequest {
     /** The edit processor. */
     @ExperimentalComposeUiApi
     val editProcessor: EditProcessor?
+
+    @ExperimentalComposeUiApi
+    val outputValue: Flow<TextFieldValue>
 
     /**
      * A flow with the layout of text in the editor's.
@@ -80,4 +89,10 @@ actual interface PlatformTextInputMethodRequest {
      */
     @ExperimentalComposeUiApi
     val textClippingRectInRoot: Flow<Rect>
+
+    /**
+     * Allows the text input service to edit the text.
+     */
+    @ExperimentalComposeUiApi
+    val editText: (block: TextEditingScope.() -> Unit) -> Unit
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputSession.skiko.kt
@@ -16,12 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.text.input.TextFieldValue
-
 actual interface PlatformTextInputSession {
     actual suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing
-
-    @ExperimentalComposeUiApi
-    fun updateTextFieldValue(newValue: TextFieldValue) = Unit
 }


### PR DESCRIPTION
Transition the implementation of the platform text input service for BTF2 away from using `PlatformTextInputService` and `TextFieldValue`.

This PR adds a `PlatformTextInputService2` which communicates with `PlatformTextInputSession.platformSpecificTextInputSession` via `TextFieldState` rather than `TextFieldValue`.

To edit the text, `PlatformTextInputService2` is given a `TextEditingScope` in which it can call functions that perform the transformations needed by the platform input method implementation. These functions roughly correspond to the `EditCommand` implementations for the old `PlatformTextInputService`. There are currently only the functions needed by the desktop implementation of `PlatformTextInputService2`, but the intention is to add the functions needed by web and iOS as they transition to `PlatformTextInputService2` too.

Fixes https://youtrack.jetbrains.com/issue/CMP-7600/Only-the-first-character-is-made-temporarily-visible-in-SecureTextField-with-TextObfuscationMode.RevealLastTyped-and-composite

## Release Notes
### Fixes - Desktop
- Fixed only the first character being temporarily shown in a `SecureTextField`.
- Changes in `TextFieldState` are now correctly reported to the transformations when inputting composite characters (e.g. ㅀ), instead of the whole text being replaced on each new character.