### PR TITLE
Fix a desktop backhandler behavior

### DIFF
--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcher.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcher.jb.kt
@@ -79,11 +79,10 @@ open class BackGestureDispatcher {
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal class BackGestureListenerImpl(
-    scope: CoroutineScope,
+    private val scope: CoroutineScope,
     onBack: suspend (progress: Flow<BackEventCompat>) -> Unit,
     private val onReadyStateChanged: (isReady: Boolean) -> Unit
 ) : BackGestureListener {
-    var onBackScope: CoroutineScope = scope
     var currentOnBack: suspend (progress: Flow<BackEventCompat>) -> Unit = onBack
     private var channel: Channel<BackEventCompat>? = null
     private var progressJob: Job? = null
@@ -132,7 +131,7 @@ internal class BackGestureListenerImpl(
         progressJob = null
     }
 
-    private fun provideProgress(flow: Flow<BackEventCompat>): Job = onBackScope.launch {
+    private fun provideProgress(flow: Flow<BackEventCompat>): Job = scope.launch {
         var completed = false
         currentOnBack(flow.onCompletion { completed = true })
         check(completed) { "You must collect the progress flow" }

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcher.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcher.jb.kt
@@ -80,10 +80,9 @@ open class BackGestureDispatcher {
 @OptIn(ExperimentalComposeUiApi::class)
 internal class BackGestureListenerImpl(
     private val scope: CoroutineScope,
-    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit,
+    private val onBack: suspend (progress: Flow<BackEventCompat>) -> Unit,
     private val onReadyStateChanged: (isReady: Boolean) -> Unit
 ) : BackGestureListener {
-    var currentOnBack: suspend (progress: Flow<BackEventCompat>) -> Unit = onBack
     private var channel: Channel<BackEventCompat>? = null
     private var progressJob: Job? = null
 
@@ -133,7 +132,7 @@ internal class BackGestureListenerImpl(
 
     private fun provideProgress(flow: Flow<BackEventCompat>): Job = scope.launch {
         var completed = false
-        currentOnBack(flow.onCompletion { completed = true })
+        onBack(flow.onCompletion { completed = true })
         check(completed) { "You must collect the progress flow" }
     }
 }

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
@@ -43,19 +43,18 @@ actual fun PredictiveBackHandler(
     onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
 )  {
     val backGestureDispatcher = LocalBackGestureDispatcher.current ?: return
+    val onBackScope = rememberCoroutineScope()
 
     // ensure we don't re-register callbacks when onBack changes
     val currentOnBack by rememberUpdatedState(onBack)
-    val onBackScope = rememberCoroutineScope()
 
     val listener = remember {
         BackGestureListenerImpl(onBackScope, currentOnBack) { backGestureDispatcher.activeListenerChanged() }
     }
 
     // we want to use the same callback, but ensure we adjust the variable on recomposition
-    remember(currentOnBack, onBackScope) {
+    remember(currentOnBack) {
         listener.currentOnBack = currentOnBack
-        listener.onBackScope = onBackScope
     }
 
     LaunchedEffect(enabled) { listener.enabled = enabled }

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
@@ -19,8 +19,10 @@ package androidx.compose.ui.backhandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.lifecycle.Lifecycle
@@ -41,15 +43,24 @@ actual fun PredictiveBackHandler(
     onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
 )  {
     val backGestureDispatcher = LocalBackGestureDispatcher.current ?: return
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val scope = rememberCoroutineScope()
+
+    // ensure we don't re-register callbacks when onBack changes
+    val currentOnBack by rememberUpdatedState(onBack)
+    val onBackScope = rememberCoroutineScope()
 
     val listener = remember {
-        BackGestureListenerImpl(scope, onBack) { backGestureDispatcher.activeListenerChanged() }
+        BackGestureListenerImpl(onBackScope, currentOnBack) { backGestureDispatcher.activeListenerChanged() }
+    }
+
+    // we want to use the same callback, but ensure we adjust the variable on recomposition
+    remember(currentOnBack, onBackScope) {
+        listener.currentOnBack = currentOnBack
+        listener.onBackScope = onBackScope
     }
 
     LaunchedEffect(enabled) { listener.enabled = enabled }
 
+    val lifecycleOwner = LocalLifecycleOwner.current
     LaunchedEffect(lifecycleOwner) {
         lifecycleOwner.lifecycle.currentStateFlow.collect { state ->
             listener.active = (state == Lifecycle.State.STARTED || state == Lifecycle.State.RESUMED)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/backhandler/DesktopBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/backhandler/DesktopBackGestureDispatcher.kt
@@ -26,18 +26,18 @@ import androidx.compose.ui.input.key.type
 @OptIn(ExperimentalComposeUiApi::class)
 internal class DesktopBackGestureDispatcher: BackGestureDispatcher() {
     fun onKeyEvent(event: KeyEvent): Boolean {
-        if (event.type == KeyEventType.KeyUp && event.key == Key.Escape) {
-            onBack()
-            return true
+        if (event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+            return onBack()
         } else {
             return false
         }
     }
 
-    private fun onBack() {
+    private fun onBack(): Boolean {
         activeListener?.let {
             it.onStarted()
             it.onCompleted()
-        }
+            return true
+        } ?: return false
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -329,7 +329,7 @@ internal class ComposeContainer(
         mediator.setKeyEventListeners(
             onPreviewKeyEvent = onPreviewKeyEvent,
             onKeyEvent = {
-                backGestureDispatcher.onKeyEvent(it) || onKeyEvent(it)
+                onKeyEvent(it) || backGestureDispatcher.onKeyEvent(it)
             }
         )
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -327,10 +327,10 @@ internal class ComposeContainer(
         onKeyEvent: (KeyEvent) -> Boolean = { false },
     ) {
         mediator.setKeyEventListeners(
-            onPreviewKeyEvent = {
-                onPreviewKeyEvent(it) || backGestureDispatcher.onKeyEvent(it)
-            },
-            onKeyEvent = onKeyEvent
+            onPreviewKeyEvent = onPreviewKeyEvent,
+            onKeyEvent = {
+                backGestureDispatcher.onKeyEvent(it) || onKeyEvent(it)
+            }
         )
     }
 


### PR DESCRIPTION
Change an `Esc` button interception from `onPreviewKeyEvent` to `onKeyEvent` in the desktop BackGestureDispatcher implementation. It fixes problems when user's code handles the Esc-button.
Fix a problem when an onBack callback is updated but listener is not.

Fixes: https://youtrack.jetbrains.com/issue/CMP-7569

## Release Notes
### Fixes - Multiple Platforms
- _(prerelease fix)_ Change an `Esc` button interception from `onPreviewKeyEvent` to `onKeyEvent` in the desktop `BackGestureDispatcher` implementation. It fixes problems when user's code handles the `Esc`-button.
- _(prerelease fix)_ Fix a problem when an `onBack` callback is updated but listener is not.
