### PR TITLE
Implement iOS default NavHost transition animation close to native.

### DIFF
--- a/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
+++ b/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+
+@Composable
+actual fun NavHost(
+    navController: NavHostController,
+    graph: NavGraph,
+    modifier: Modifier,
+    contentAlignment: Alignment,
+    enterTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    exitTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    popEnterTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    popExitTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    sizeTransform: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
+) {
+    NavHost(
+        navController,
+        graph,
+        modifier,
+        contentAlignment,
+        enterTransition,
+        exitTransition,
+        popEnterTransition,
+        popExitTransition,
+        sizeTransform,
+        null
+    )
+}

--- a/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
+++ b/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:JvmName("NavHostKt")
+@file:JvmMultifileClass
+
 package androidx.navigation.compose
 
 import androidx.compose.animation.AnimatedContentTransitionScope

--- a/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
+++ b/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
@@ -49,6 +49,7 @@ actual fun NavHost(
         popEnterTransition,
         popExitTransition,
         sizeTransform,
+        null,
         null
     )
 }

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -490,7 +490,8 @@ internal fun NavHost(
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?,
     drawOnBottomEntryDuringAnimation:
-    (@Composable (isBackAnimation: Boolean, progress: Float) -> Unit)?
+    (@Composable (isBackAnimation: Boolean, progress: Float) -> Unit)?,
+    limitBackGestureSwipeEdge: Int?
 ) {
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -525,17 +526,20 @@ internal fun NavHost(
         }
         try {
             backEvent.collect {
-                if (currentBackStack.size > 1) {
+                val goodEdge =
+                    limitBackGestureSwipeEdge == null || it.swipeEdge == limitBackGestureSwipeEdge
+
+                if (currentBackStack.size > 1 && goodEdge) {
                     inPredictiveBack = true
                     progress = it.progress
                 }
             }
-            if (currentBackStack.size > 1) {
+            if (currentBackStack.size > 1 && inPredictiveBack) {
                 inPredictiveBack = false
                 composeNavigator.popBackStack(currentBackStackEntry!!, false)
             }
         } catch (e: CancellationException) {
-            if (currentBackStack.size > 1) {
+            if (currentBackStack.size > 1 && inPredictiveBack) {
                 inPredictiveBack = false
             }
         }

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:JvmName("NavHostKt")
+@file:JvmMultifileClass
+
 package androidx.navigation.compose
 
 import androidx.collection.mutableObjectFloatMapOf
@@ -56,6 +59,8 @@ import androidx.navigation.compose.internal.PredictiveBackHandler
 import androidx.navigation.createGraph
 import androidx.navigation.get
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
 import kotlin.jvm.JvmSuppressWildcards
 import kotlin.reflect.KClass
 import kotlin.reflect.KType

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -52,6 +52,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.Navigator
+import androidx.navigation.compose.internal.DefaultNavTransitions
 import androidx.navigation.compose.internal.LocalViewModelStoreOwner
 import androidx.navigation.compose.internal.PredictiveBackHandler
 import androidx.navigation.createGraph
@@ -130,16 +131,14 @@ public fun NavHost(
     modifier: Modifier = Modifier,
     contentAlignment: Alignment = Alignment.TopStart,
     route: String? = null,
-    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) = {
-        fadeIn(animationSpec = tween(700))
-    },
-    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) = {
-        fadeOut(animationSpec = tween(700))
-    },
+    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+        DefaultNavTransitions.enterTransition,
+    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+        DefaultNavTransitions.exitTransition,
     popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        enterTransition,
+        DefaultNavTransitions.popEnterTransition,
     popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        exitTransition,
+        DefaultNavTransitions.popExitTransition,
     builder: NavGraphBuilder.() -> Unit
 ) {
     NavHost(
@@ -187,27 +186,23 @@ public fun NavHost(
     enterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        {
-            fadeIn(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.enterTransition,
     exitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        {
-            fadeOut(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.exitTransition,
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        enterTransition,
+        DefaultNavTransitions.popEnterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        exitTransition,
+        DefaultNavTransitions.popExitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
-        null,
+        DefaultNavTransitions.sizeTransform,
     builder: NavGraphBuilder.() -> Unit
 ) {
     NavHost(
@@ -259,27 +254,23 @@ public fun NavHost(
     enterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        {
-            fadeIn(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.enterTransition,
     exitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        {
-            fadeOut(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.exitTransition,
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        enterTransition,
+        DefaultNavTransitions.popEnterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        exitTransition,
+        DefaultNavTransitions.popExitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
-        null,
+        DefaultNavTransitions.sizeTransform,
     builder: NavGraphBuilder.() -> Unit
 ) {
     NavHost(
@@ -331,27 +322,23 @@ public fun NavHost(
     enterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        {
-            fadeIn(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.enterTransition,
     exitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        {
-            fadeOut(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.exitTransition,
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        enterTransition,
+        DefaultNavTransitions.popEnterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        exitTransition,
+        DefaultNavTransitions.popExitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
-        null,
+        DefaultNavTransitions.sizeTransform,
     builder: NavGraphBuilder.() -> Unit
 ) {
     NavHost(
@@ -418,16 +405,14 @@ public fun NavHost(
     graph: NavGraph,
     modifier: Modifier = Modifier,
     contentAlignment: Alignment = Alignment.TopStart,
-    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) = {
-        fadeIn(animationSpec = tween(700))
-    },
-    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) = {
-        fadeOut(animationSpec = tween(700))
-    },
+    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
+        DefaultNavTransitions.enterTransition,
+    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
+        DefaultNavTransitions.exitTransition,
     popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        enterTransition,
+        DefaultNavTransitions.popEnterTransition,
     popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        exitTransition,
+        DefaultNavTransitions.popExitTransition,
 ) {
     NavHost(
         navController,
@@ -466,27 +451,23 @@ public fun NavHost(
     enterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        {
-            fadeIn(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.enterTransition,
     exitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        {
-            fadeOut(animationSpec = tween(700))
-        },
+        DefaultNavTransitions.exitTransition,
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        enterTransition,
+        DefaultNavTransitions.popEnterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        exitTransition,
+        DefaultNavTransitions.popExitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
-        null
+        DefaultNavTransitions.sizeTransform
 ) {
 
     val lifecycleOwner = LocalLifecycleOwner.current

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.kt
@@ -16,8 +16,16 @@
 
 package androidx.navigation.compose.internal
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.navigation.NavBackStackEntry
 import kotlinx.coroutines.flow.Flow
 
 internal expect object LocalViewModelStoreOwner {
@@ -37,3 +45,28 @@ internal expect fun PredictiveBackHandler(
     enabled: Boolean = true,
     onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
 )
+
+internal expect object DefaultNavTransitions {
+    val enterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
+    val exitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
+    val popEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
+    val popExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
+    val sizeTransform: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
+}
+
+internal object StandardDefaultNavTransitions {
+    val enterTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
+        fadeIn(animationSpec = tween(700))
+    }
+    val exitTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
+        fadeOut(animationSpec = tween(700))
+    }
+    val popEnterTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = enterTransition
+    val popExitTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = exitTransition
+    val sizeTransform:
+        (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? = null
+}

--- a/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
+++ b/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+
+@Composable
+actual fun NavHost(
+    navController: NavHostController,
+    graph: NavGraph,
+    modifier: Modifier,
+    contentAlignment: Alignment,
+    enterTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    exitTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    popEnterTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    popExitTransition: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    sizeTransform: @JvmSuppressWildcards (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
+) {
+    NavHost(
+        navController,
+        graph,
+        modifier,
+        contentAlignment,
+        enterTransition,
+        exitTransition,
+        popEnterTransition,
+        popExitTransition,
+        sizeTransform,
+        null
+    )
+}

--- a/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
+++ b/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:JvmName("NavHostKt")
+@file:JvmMultifileClass
+
 package androidx.navigation.compose
 
 import androidx.compose.animation.AnimatedContentTransitionScope

--- a/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
+++ b/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
@@ -49,6 +49,7 @@ actual fun NavHost(
         popEnterTransition,
         popExitTransition,
         sizeTransform,
+        null,
         null
     )
 }

--- a/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.desktop.kt
+++ b/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.desktop.kt
@@ -16,20 +16,4 @@
 
 package androidx.navigation.compose.internal
 
-import androidx.activity.compose.PredictiveBackHandler
-import androidx.compose.runtime.Composable
-import kotlinx.coroutines.flow.Flow
-
-@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-59355
-internal actual typealias LocalViewModelStoreOwner = androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-
-@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-59355
-internal actual typealias BackEventCompat = androidx.activity.BackEventCompat
-
-@Composable
-internal actual fun PredictiveBackHandler(
-    enabled: Boolean,
-    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
-) = PredictiveBackHandler(enabled, onBack)
-
 internal actual typealias DefaultNavTransitions = StandardDefaultNavTransitions

--- a/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/NavHost.macos.kt
+++ b/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/NavHost.macos.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+
+@Composable
+actual fun NavHost(
+    navController: NavHostController,
+    graph: NavGraph,
+    modifier: Modifier,
+    contentAlignment: Alignment,
+    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    sizeTransform: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
+) {
+    NavHost(
+        navController,
+        graph,
+        modifier,
+        contentAlignment,
+        enterTransition,
+        exitTransition,
+        popEnterTransition,
+        popExitTransition,
+        sizeTransform,
+        null
+    )
+}

--- a/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/NavHost.macos.kt
+++ b/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/NavHost.macos.kt
@@ -49,6 +49,7 @@ actual fun NavHost(
         popEnterTransition,
         popExitTransition,
         sizeTransform,
+        null,
         null
     )
 }

--- a/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.macos.kt
+++ b/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.macos.kt
@@ -16,20 +16,4 @@
 
 package androidx.navigation.compose.internal
 
-import androidx.activity.compose.PredictiveBackHandler
-import androidx.compose.runtime.Composable
-import kotlinx.coroutines.flow.Flow
-
-@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-59355
-internal actual typealias LocalViewModelStoreOwner = androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-
-@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-59355
-internal actual typealias BackEventCompat = androidx.activity.BackEventCompat
-
-@Composable
-internal actual fun PredictiveBackHandler(
-    enabled: Boolean,
-    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
-) = PredictiveBackHandler(enabled, onBack)
-
 internal actual typealias DefaultNavTransitions = StandardDefaultNavTransitions

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.unit.Constraints
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.internal.DefaultNavTransitions
+
+@Composable
+actual fun NavHost(
+    navController: NavHostController,
+    graph: NavGraph,
+    modifier: Modifier,
+    contentAlignment: Alignment,
+    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    sizeTransform: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
+) {
+    val iosBlackout = remember(
+        enterTransition, exitTransition, popEnterTransition, popExitTransition, sizeTransform
+    ) {
+        val isDefaultTransition = enterTransition == DefaultNavTransitions.enterTransition &&
+            exitTransition == DefaultNavTransitions.exitTransition &&
+            popEnterTransition == DefaultNavTransitions.popEnterTransition &&
+            popExitTransition == DefaultNavTransitions.popExitTransition &&
+            sizeTransform == DefaultNavTransitions.sizeTransform
+
+        if (isDefaultTransition) {
+            @Composable { isBackAnimation: Boolean, progress: Float ->
+                val blackoutFraction = if (isBackAnimation) 1 - progress else progress
+                Box(
+                    modifier = Modifier
+                        .layout { m, c ->
+                            val placeable = m.measure(
+                                Constraints.fixed(c.maxWidth, c.maxHeight)
+                            )
+                            layout(c.minWidth, c.minHeight) { placeable.place(0, 0) }
+                        }
+                        .drawBehind {
+                            drawRect(Color.Black, alpha = 0.106f * blackoutFraction)
+                        }
+                )
+            }
+        } else {
+            null
+        }
+    }
+
+    NavHost(
+        navController,
+        graph,
+        modifier,
+        contentAlignment,
+        enterTransition,
+        exitTransition,
+        popEnterTransition,
+        popExitTransition,
+        sizeTransform,
+        drawOnBottomEntryDuringAnimation = iosBlackout
+    )
+}

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.uikit.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose.internal
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.navigation.NavBackStackEntry
+
+internal actual object DefaultNavTransitions {
+    actual val enterTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(
+                    durationMillis = 200,
+                    easing = LinearEasing
+                )
+            )
+        }
+    actual val exitTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition  = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.Start,
+                animationSpec = tween(
+                    durationMillis = 200,
+                    easing = LinearEasing
+                ),
+                targetOffset = { fullOffset -> (fullOffset * 0.3f).toInt() }
+            )
+        }
+    actual val popEnterTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
+            slideIntoContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                animationSpec = tween(
+                    durationMillis = 200,
+                    easing = LinearEasing
+                ),
+                initialOffset = { fullOffset -> (fullOffset * 0.3f).toInt() }
+            )
+        }
+    actual val popExitTransition:
+        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
+            slideOutOfContainer(
+                towards = AnimatedContentTransitionScope.SlideDirection.End,
+                animationSpec = tween(
+                    durationMillis = 200,
+                    easing = LinearEasing
+                )
+            )
+        }
+    actual val sizeTransform:
+        (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? = null
+}

--- a/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/NavHost.web.kt
+++ b/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/NavHost.web.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.SizeTransform
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavGraph
+import androidx.navigation.NavHostController
+
+@Composable
+actual fun NavHost(
+    navController: NavHostController,
+    graph: NavGraph,
+    modifier: Modifier,
+    contentAlignment: Alignment,
+    enterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition),
+    popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition),
+    sizeTransform: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
+) {
+    NavHost(
+        navController,
+        graph,
+        modifier,
+        contentAlignment,
+        enterTransition,
+        exitTransition,
+        popEnterTransition,
+        popExitTransition,
+        sizeTransform,
+        null
+    )
+}

--- a/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/NavHost.web.kt
+++ b/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/NavHost.web.kt
@@ -49,6 +49,7 @@ actual fun NavHost(
         popEnterTransition,
         popExitTransition,
         sizeTransform,
+        null,
         null
     )
 }

--- a/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.web.kt
+++ b/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.web.kt
@@ -16,20 +16,4 @@
 
 package androidx.navigation.compose.internal
 
-import androidx.activity.compose.PredictiveBackHandler
-import androidx.compose.runtime.Composable
-import kotlinx.coroutines.flow.Flow
-
-@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-59355
-internal actual typealias LocalViewModelStoreOwner = androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-
-@Suppress("ACTUAL_WITHOUT_EXPECT") // https://youtrack.jetbrains.com/issue/KT-59355
-internal actual typealias BackEventCompat = androidx.activity.BackEventCompat
-
-@Composable
-internal actual fun PredictiveBackHandler(
-    enabled: Boolean,
-    onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
-) = PredictiveBackHandler(enabled, onBack)
-
 internal actual typealias DefaultNavTransitions = StandardDefaultNavTransitions


### PR DESCRIPTION
Implement iOS default NavHost transition animation close to native by default:
 1) if developer changes a NavHost default animation spec then all iOS defaults will be erased
 2) slide animation between screens
 3) dimming of the previous screen
 4) back gesture acts for a single edge depending on the layout direction


https://github.com/user-attachments/assets/92ae4166-2d51-47a9-90dc-46b3e2e297bb


Fixes https://youtrack.jetbrains.com/issue/CMP-4528

## Release Notes
### Features - iOS
- Default `androidx.navigation` transition animation on iOS is as close as possible to the iOS back gesture.
### Known issues - iOS
- _(prerelease fix)_ Back gesture may remain stuck in the middle, the fix will be available in the next pre-release version.