### PR TITLE
Extract focusedRectInRoot function.

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -18,14 +18,11 @@ package androidx.compose.foundation.text.input.internal
 
 import androidx.compose.foundation.content.internal.ReceiveContentConfiguration
 import androidx.compose.foundation.text.computeSizeForDefaultText
+import androidx.compose.foundation.text.focusedRectInRoot
 import androidx.compose.foundation.text.input.TextFieldCharSequence
 import androidx.compose.foundation.text.input.setSelectionCoerced
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSession
 import androidx.compose.ui.platform.ViewConfiguration
@@ -35,7 +32,6 @@ import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -132,30 +128,3 @@ private data class SkikoPlatformTextInputMethodRequest(
     override val editProcessor: EditProcessor?,
     override val textLayoutResult: Flow<TextLayoutResult>,
 ): PlatformTextInputMethodRequest
-
-/**
- * Computes the bounds of the area where text editing is in progress, relative to the root.
- */
-// Adapted from TextFieldDelegate.notifyFocusedRect
-// TODO: Move this function into TextFieldDelegate.kt, and call it from both places.
-private fun focusedRectInRoot(
-    layoutResult: TextLayoutResult,
-    layoutCoordinates: LayoutCoordinates,
-    focusOffset: Int,
-    sizeForDefaultText: () -> IntSize
-): Rect {
-    val bbox = when {
-        focusOffset < layoutResult.layoutInput.text.length -> {
-            layoutResult.getBoundingBox(focusOffset)
-        }
-        focusOffset != 0 -> {
-            layoutResult.getBoundingBox(focusOffset - 1)
-        }
-        else -> { // empty text.
-            val size = sizeForDefaultText()
-            Rect(0f, 0f, 1.0f, size.height.toFloat())
-        }
-    }
-    val globalLT = layoutCoordinates.localToRoot(Offset(bbox.left, bbox.top))
-    return Rect(Offset(globalLT.x, globalLT.y), Size(bbox.width, bbox.height))
-}


### PR DESCRIPTION
Extract `focusedRectInRoot` function in `TextFieldDelegate.kt`, and reuse it in `TextInputSession.skiko.kt`.

This is a cherry-pick from AOSP (https://android-review.googlesource.com/c/platform/frameworks/support/+/3495153) and removal the copy of the function from `TextInputSession.skiko.kt`.