### PR TITLE
Implement WebTextInputSession and initialize textInputSession

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.SessionMutex
 import androidx.compose.ui.draganddrop.WebDragAndDropManager
 import androidx.compose.ui.events.EventTargetListener
 import androidx.compose.ui.geometry.Offset
@@ -43,6 +44,7 @@ import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.WindowInfoImpl
@@ -214,6 +216,17 @@ internal class ComposeWindow(
                 canvas.style.cursor = pointerIcon.id
             }
         }
+
+        private val textInputSessionMutex = SessionMutex<WebTextInputSession>()
+
+        override suspend fun textInputSession(
+            session: suspend PlatformTextInputSessionScope.() -> Nothing
+        ): Nothing = textInputSessionMutex.withSessionCancellingPrevious(
+            sessionInitializer = {
+                WebTextInputSession(it, textInputService)
+            },
+            session = session
+        )
     }
 
     private val skiaLayer: SkiaLayer = SkiaLayer().apply {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebTextInputSession.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebTextInputSession.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.SessionMutex
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.platform.PlatformTextInputSessionScope
+import androidx.compose.ui.platform.WebTextInputService
+import androidx.compose.ui.text.input.TextFieldValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+internal class WebTextInputSession(
+    coroutineScope: CoroutineScope,
+    private val webTextInputService: WebTextInputService
+) : PlatformTextInputSessionScope, CoroutineScope by coroutineScope {
+
+    private val innerSessionMutex = SessionMutex<Nothing?>()
+
+    override suspend fun startInputMethod(request: PlatformTextInputMethodRequest) =
+        innerSessionMutex.withSessionCancellingPrevious(
+            // This session has no data, just init/dispose tasks.
+            sessionInitializer = { null }
+        ) {
+            (suspendCancellableCoroutine<Nothing> { continuation ->
+                webTextInputService.startInput(
+                    value = request.state,
+                    imeOptions = request.imeOptions,
+                    onEditCommand = request.onEditCommand,
+                    onImeActionPerformed = request.onImeAction ?: {}
+                )
+
+                continuation.invokeOnCancellation {
+                    webTextInputService.stopInput()
+                }
+            })
+        }
+
+    @ExperimentalComposeUiApi
+    override fun updateSelectionState(newState: TextFieldValue) {
+        webTextInputService.updateState(oldValue = null, newState)
+    }
+
+    @ExperimentalComposeUiApi
+    override fun notifyFocusedRect(rect: Rect) {
+        webTextInputService.notifyFocusedRect(rect)
+    }
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -16,21 +16,33 @@
 
 package androidx.compose.ui.input
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.TextField
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.sendFromScope
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlinx.browser.document
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 import org.w3c.dom.HTMLTextAreaElement
 
 class TextInputTests : OnCanvasTests  {
@@ -93,5 +105,27 @@ class TextInputTests : OnCanvasTests  {
         )
 
         assertEquals("step2", textInputChannel.receive())
+    }
+
+    @Test
+    fun basicTextField2HasBackingHtmlTextAreaElement() = runTest {
+        val focusRequester = FocusRequester()
+
+        createComposeWindow {
+            val textFieldState2 = remember { TextFieldState("I am TextField 2") }
+            BasicTextField(
+                textFieldState2,
+                Modifier.padding(16.dp).fillMaxWidth().focusRequester(focusRequester)
+            )
+        }
+
+        var textArea = document.querySelector("textarea")
+        assertNull(textArea)
+
+        focusRequester.requestFocus()
+
+        yield()
+        textArea = document.querySelector("textarea")
+        assertIs<HTMLTextAreaElement>(textArea)
     }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7499

## Testing
This should be tested by QA

## Release Notes

### Fixes - Web
- Mobile browsers: the virtual keyboard is shown when the `TextField` is clicked/receives focus


