### PR TITLE
Refactor default iOS transition logic in NavHost.

### DIFF
--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
@@ -57,52 +57,56 @@ actual fun NavHost(
         popExitTransition == DefaultNavTransitions.popExitTransition &&
         sizeTransform == DefaultNavTransitions.sizeTransform
 
-    val iosBlackout: (@Composable (isBackAnimation: Boolean, progress: Float) -> Unit)? =
-        remember(isDefaultTransition) {
-            if (isDefaultTransition) {
-                return@remember @Composable{ isBackAnimation: Boolean, progress: Float ->
-                    val blackoutFraction = if (isBackAnimation) 1 - progress else progress
-                    Box(
-                        modifier = Modifier
-                            .layout { m, c ->
-                                val placeable = m.measure(
-                                    Constraints.fixed(c.maxWidth, c.maxHeight)
-                                )
-                                layout(c.minWidth, c.minHeight) { placeable.place(0, 0) }
-                            }
-                            .drawBehind {
-                                drawRect(Color.Black, alpha = 0.106f * blackoutFraction)
-                            }
-                    )
-                }
-            } else {
-                return@remember null
-            }
+    if (isDefaultTransition) {
+        val iosBlackout = @Composable { isBackAnimation: Boolean, progress: Float ->
+            val blackoutFraction = if (isBackAnimation) 1 - progress else progress
+            Box(
+                modifier = Modifier
+                    .layout { m, c ->
+                        val placeable = m.measure(
+                            Constraints.fixed(c.maxWidth, c.maxHeight)
+                        )
+                        layout(c.minWidth, c.minHeight) { placeable.place(0, 0) }
+                    }
+                    .drawBehind {
+                        drawRect(Color.Black, alpha = 0.106f * blackoutFraction)
+                    }
+            )
         }
 
-    val layoutDirection = LocalLayoutDirection.current
-    val backEventEdge = remember(isDefaultTransition, layoutDirection) {
-        if (isDefaultTransition) {
-            when (layoutDirection) {
-                LayoutDirection.Ltr -> BackEventCompat.EDGE_LEFT
-                LayoutDirection.Rtl -> BackEventCompat.EDGE_RIGHT
-            }
-        } else {
-            null
+        val backEventEdge = when (LocalLayoutDirection.current) {
+            LayoutDirection.Ltr -> BackEventCompat.EDGE_LEFT
+            LayoutDirection.Rtl -> BackEventCompat.EDGE_RIGHT
         }
+        NavHost(
+            navController,
+            graph,
+            modifier,
+            contentAlignment,
+            enterTransition,
+            exitTransition,
+            popEnterTransition,
+            popExitTransition,
+            sizeTransform,
+            drawOnBottomEntryDuringAnimation = iosBlackout,
+            limitBackGestureSwipeEdge = backEventEdge
+        )
+    } else {
+        NavHost(
+            navController,
+            graph,
+            modifier,
+            contentAlignment,
+            enterTransition,
+            exitTransition,
+            popEnterTransition,
+            popExitTransition,
+            sizeTransform,
+            null,
+            null
+        )
     }
 
-    NavHost(
-        navController,
-        graph,
-        modifier,
-        contentAlignment,
-        enterTransition,
-        exitTransition,
-        popEnterTransition,
-        popExitTransition,
-        sizeTransform,
-        drawOnBottomEntryDuringAnimation = iosBlackout,
-        limitBackGestureSwipeEdge = backEventEdge
-    )
+
+
 }


### PR DESCRIPTION
Refactor default iOS transition logic in NavHost.

Fixes a type resolve in metadata compiler:
```
> Task :navigation:navigation-compose:compileUikitMainKotlinMetadata FAILED
e: file:///../compose-multiplatform-core/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt:61:9 Type inference failed. Expected type mismatch: inferred type is ((Boolean, Float) -> Unit)? but @Composable() ((Boolean, Float) -> Unit)? was expected

```

## Release Notes
N/A