### PR TITLE
Fix Compose usage in non-Gradle Desktop projects

### DIFF
--- a/compose/animation/animation-core/build.gradle
+++ b/compose/animation/animation-core/build.gradle
@@ -97,7 +97,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":compose:ui:ui"))
                 implementation(project(":compose:ui:ui-unit"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(libs.kotlinCoroutinesCore)
             }
 

--- a/compose/animation/animation-graphics/build.gradle
+++ b/compose/animation/animation-graphics/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         api("androidx.compose.ui:ui-geometry:1.2.1")
 
         implementation("androidx.compose.ui:ui-util:1.2.1")
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation("androidx.core:core-ktx:1.5.0")
 
         testImplementation(libs.testRules)
@@ -80,7 +80,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
 
                 api(project(":compose:animation:animation"))

--- a/compose/animation/animation/build.gradle
+++ b/compose/animation/animation/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         api("androidx.compose.ui:ui-geometry:1.2.1")
 
         implementation("androidx.compose.ui:ui-util:1.2.1")
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
 
         testImplementation(libs.testRules)
         testImplementation(libs.testRunner)
@@ -81,7 +81,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
 
                 api(project(":compose:animation:animation-core"))

--- a/compose/benchmark-utils/build.gradle
+++ b/compose/benchmark-utils/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     api(projectOrArtifact(":compose:test-utils"))
     api(androidxArtifact(":benchmark:benchmark-junit4"))
 
-    implementation(libs.kotlinStdlibCommon)
+    implementation(libs.kotlinStdlib)
     implementation(projectOrArtifact(":compose:runtime:runtime"))
     implementation(projectOrArtifact(":compose:ui:ui"))
     implementation(libs.testRules)

--- a/compose/desktop/desktop/build.gradle
+++ b/compose/desktop/desktop/build.gradle
@@ -44,7 +44,7 @@ kotlin {
     if (desktopEnabled) {
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":compose:ui:ui-util"))
                 api(project(":compose:foundation:foundation"))
                 api(project(":compose:material:material"))

--- a/compose/foundation/foundation-layout/build.gradle
+++ b/compose/foundation/foundation-layout/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         implementation("androidx.compose.ui:ui-util:1.2.1")
         implementation("androidx.core:core:1.7.0")
         implementation("androidx.compose.animation:animation-core:1.2.1")
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
 
         testImplementation(libs.testRules)
         testImplementation(libs.testRunner)
@@ -87,7 +87,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":annotation:annotation"))
                 implementation(project(":collection:collection"))
 

--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -44,7 +44,7 @@ dependencies {
         api(project(":compose:runtime:runtime"))
         api(project(":compose:ui:ui"))
 
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation(project(":compose:foundation:foundation-layout"))
         implementation("androidx.emoji2:emoji2:1.4.0")
         implementation("androidx.compose.ui:ui-graphics:1.2.1")
@@ -105,7 +105,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":annotation:annotation"))
                 implementation(project(":collection:collection"))
                 implementation(project(":performance:performance-annotation"))

--- a/compose/material/material-ripple/build.gradle
+++ b/compose/material/material-ripple/build.gradle
@@ -39,7 +39,7 @@ dependencies {
         api("androidx.compose.foundation:foundation:1.2.1")
         api("androidx.compose.runtime:runtime:1.2.1")
 
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation("androidx.compose.animation:animation:1.2.1")
         implementation("androidx.compose.ui:ui-util:1.2.1")
 
@@ -72,7 +72,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
                 api(project(":compose:foundation:foundation"))
                 api(project(":compose:runtime:runtime"))

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         api("androidx.compose.ui:ui:1.2.1")
         api("androidx.compose.ui:ui-text:1.2.1")
 
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation("androidx.compose.animation:animation:1.2.1")
         implementation("androidx.compose.foundation:foundation-layout:1.2.1")
         implementation("androidx.compose.ui:ui-util:1.2.1")
@@ -95,7 +95,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:animation:animation-core"))
                 api(project(":compose:foundation:foundation"))
                 api("org.jetbrains.compose.material:material-icons-core:1.6.11") {

--- a/compose/material3/adaptive/adaptive-layout/build.gradle
+++ b/compose/material3/adaptive/adaptive-layout/build.gradle
@@ -49,7 +49,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:material3:adaptive:adaptive"))
                 api(project(":compose:animation:animation-core"))
                 api(project(":compose:ui:ui"))

--- a/compose/material3/adaptive/adaptive-navigation/build.gradle
+++ b/compose/material3/adaptive/adaptive-navigation/build.gradle
@@ -49,7 +49,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:material3:adaptive:adaptive-layout"))
                 implementation(project(":compose:foundation:foundation"))
                 implementation(project(":compose:ui:ui-util"))

--- a/compose/material3/adaptive/adaptive/build.gradle
+++ b/compose/material3/adaptive/adaptive/build.gradle
@@ -49,7 +49,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:foundation:foundation"))
                 api(project(":compose:ui:ui-geometry"))
                 api("org.jetbrains.androidx.window:window-core:1.3.1")

--- a/compose/material3/material3-adaptive-navigation-suite/build.gradle
+++ b/compose/material3/material3-adaptive-navigation-suite/build.gradle
@@ -48,7 +48,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":compose:material3:material3"))
                 implementation(project(":compose:material3:adaptive:adaptive"))
                 implementation(project(":compose:ui:ui"))

--- a/compose/material3/material3-common/build.gradle
+++ b/compose/material3/material3-common/build.gradle
@@ -41,7 +41,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":compose:ui:ui-util"))
                 api(project(":compose:foundation:foundation"))
                 api(project(":compose:foundation:foundation-layout"))

--- a/compose/material3/material3-window-size-class/build.gradle
+++ b/compose/material3/material3-window-size-class/build.gradle
@@ -40,7 +40,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":compose:ui:ui-util"))
                 api(project(":compose:runtime:runtime"))
                 api(project(":compose:ui:ui"))

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -38,7 +38,7 @@ dependencies {
          * When updating dependencies, make sure to make the an an analogous update in the
          * corresponding block below
          */
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation("androidx.activity:activity-compose:1.5.0")
         implementation("androidx.compose.animation:animation-core:1.3.1")
         implementation(project(":compose:foundation:foundation-layout"))
@@ -96,7 +96,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":compose:animation:animation-core"))
 
                 api(project(":compose:foundation:foundation"))

--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -96,7 +96,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             corresponding block above */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
 
                 api project(":compose:runtime:runtime")

--- a/compose/runtime/runtime-test-utils/build.gradle
+++ b/compose/runtime/runtime-test-utils/build.gradle
@@ -53,7 +53,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.kotlinStdlibCommon)
+            implementation(libs.kotlinStdlib)
             implementation(projectOrArtifact(":compose:runtime:runtime"))
             implementation kotlin("test")
             implementation(libs.kotlinCoroutinesTest)

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -114,7 +114,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinCoroutinesCore)
                 implementation(project(":annotation:annotation"))
                 implementation(project(":collection:collection"))

--- a/compose/runtime/runtime/integration-tests/build.gradle
+++ b/compose/runtime/runtime/integration-tests/build.gradle
@@ -32,7 +32,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinCoroutinesCore)
                 implementation(projectOrArtifact(":compose:ui:ui"))
             }

--- a/compose/test-utils/build.gradle
+++ b/compose/test-utils/build.gradle
@@ -32,7 +32,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(projectOrArtifact(":compose:runtime:runtime"))
                 implementation(projectOrArtifact(":compose:ui:ui-unit"))
                 implementation(projectOrArtifact(":compose:ui:ui-graphics"))

--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -41,7 +41,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinCoroutinesCore)
                 implementation(project(":annotation:annotation"))
                 implementation(project(":compose:runtime:runtime"))

--- a/compose/ui/ui-geometry/build.gradle
+++ b/compose/ui/ui-geometry/build.gradle
@@ -64,7 +64,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
 
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -41,7 +41,7 @@ if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
         implementation("androidx.compose.runtime:runtime:1.2.1")
         implementation(project(":compose:ui:ui-util"))
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
 
         testImplementation(libs.testRules)
         testImplementation(libs.testRunner)
@@ -83,7 +83,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
 
                 api(project(":compose:ui:ui-unit"))
                 implementation(project(":compose:runtime:runtime"))

--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -43,7 +43,7 @@ dependencies {
         api("androidx.activity:activity:1.2.1")
         api(libs.junit)
         api(libs.kotlinStdlib)
-        api(libs.kotlinStdlibCommon)
+        api(libs.kotlinStdlib)
         api(libs.testExtJunit)
 
         implementation("androidx.compose.runtime:runtime-saveable:1.2.1")
@@ -102,7 +102,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             jvmMain.dependencies {
                 api(libs.junit)
                 api(libs.kotlinStdlib)
-                api(libs.kotlinStdlibCommon)
+                api(libs.kotlinStdlib)
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -54,7 +54,7 @@ dependencies {
         api(libs.kotlinCoroutinesCore)
         api(libs.kotlinCoroutinesTest)
         api(libs.kotlinStdlib)
-        api(libs.kotlinStdlibCommon)
+        api(libs.kotlinStdlib)
 
         implementation(project(":compose:ui:ui-util"))
         implementation("androidx.annotation:annotation:1.1.0")
@@ -111,7 +111,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api(project(":compose:runtime:runtime"))
                 api(libs.kotlinCoroutinesCore)
                 api(libs.kotlinCoroutinesTest)
-                api(libs.kotlinStdlibCommon)
+                api(libs.kotlinStdlib)
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -36,7 +36,7 @@ if(!AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          * When updating dependencies, make sure to make the an analogous update in the
          * corresponding block below
          */
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation(libs.kotlinCoroutinesCore)
 
         api(project(":compose:ui:ui-graphics"))
@@ -102,7 +102,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinCoroutinesCore)
 
                 api(project(":compose:ui:ui-graphics"))

--- a/compose/ui/ui-tooling-preview/build.gradle
+++ b/compose/ui/ui-tooling-preview/build.gradle
@@ -37,7 +37,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:runtime:runtime"))
             }
         }

--- a/compose/ui/ui-tooling/build.gradle
+++ b/compose/ui/ui-tooling/build.gradle
@@ -36,7 +36,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:ui:ui-tooling-preview"))
                 api(project(":compose:runtime:runtime"))
                 api(project(":compose:ui:ui"))

--- a/compose/ui/ui-unit/build.gradle
+++ b/compose/ui/ui-unit/build.gradle
@@ -74,7 +74,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 api(project(":compose:ui:ui-geometry"))
 
                 implementation(project(":annotation:annotation"))

--- a/compose/ui/ui-util/build.gradle
+++ b/compose/ui/ui-util/build.gradle
@@ -60,7 +60,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
          */
         sourceSets {
             commonMain.dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
             }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -50,7 +50,7 @@ dependencies {
          * When updating dependencies, make sure to make the an an analogous update in the
          * corresponding block below
          */
-        implementation(libs.kotlinStdlibCommon)
+        implementation(libs.kotlinStdlib)
         implementation(libs.kotlinCoroutinesCore)
         implementation(libs.atomicFu)
 
@@ -162,7 +162,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":annotation:annotation"))
                 implementation(project(":collection:collection"))
                 implementation(project(":performance:performance-annotation"))
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinCoroutinesCore)
 
                 // when updating the runtime version please also update the runtime-saveable version

--- a/graphics/graphics-shapes/build.gradle
+++ b/graphics/graphics-shapes/build.gradle
@@ -69,7 +69,7 @@ kotlin {
 
         commonMain {
             dependencies {
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation("org.jetbrains.compose.collection-internal:collection:1.7.1")
                 implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
             }

--- a/kruth/kruth/build.gradle
+++ b/kruth/kruth/build.gradle
@@ -61,7 +61,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(libs.kotlinStdlibCommon)
+                api(libs.kotlinStdlib)
                 api(libs.kotlinTestCommon)
             }
         }

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -73,7 +73,7 @@ kotlin {
                 api project(":navigation:navigation-runtime")
                 api "org.jetbrains.androidx.savedstate:savedstate:1.2.2"
 
-                implementation(libs.kotlinStdlibCommon)
+                implementation(libs.kotlinStdlib)
                 implementation(libs.kotlinSerializationCore)
             }
         }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7471/Fix-Maven-Test-project-on-CI

Needed for using inside IntelliJ.

## 1. Fix  `Could not resolve version conflict` 

See `MavenUploadHelper` change.

A regression after updating to Kotlin 2.1. [Reported in Kotlin](https://youtrack.jetbrains.com/issue/KT-75512/pom-in-a-Multiplatform-project-with-a-customized-withXml-is-not-correct).

Sequence:
- Compose modifies pom, adding version restriction via `[]`:
```
    <dependency>
      <groupId>org.jetbrains.compose.ui</groupId>
      <artifactId>ui-backhandler</artifactId>
      <version>[9999.0.0-SNAPSHOT]</version>
      <scope>compile</scope>
    </dependency>
```
- Kotlin should modifies pom to adapt it multiplatform:
```
    <dependency>
      <groupId>org.jetbrains.compose.ui</groupId>
      <artifactId>ui-backhandler-desktop</artifactId>
      <version>[9999.0.0-SNAPSHOT]</version>
      <scope>compile</scope>
    </dependency>
```
- but fails to do so because we modified pom ourselves. The result is:
```
    <dependency>
      <groupId>org.jetbrains.compose.ui</groupId>
      <artifactId>ui-backhandler</artifactId>
      <version>[9999.0.0-SNAPSHOT]</version>
      <scope>compile</scope>
    </dependency>
```
- it causes some Android dependencies leaked into desktop dependencies:
```
org.jetbrains.compose.ui:ui-desktop:jar:9999.0.0-SNAPSHOT ->
 org.jetbrains.compose.ui:ui-backhandler:jar:[9999.0.0-SNAPSHOT,9999.0.0-SNAPSHOT] ->
 org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:jar:9999.0.0-SNAPSHOT ->
 androidx.lifecycle:lifecycle-runtime-compose:jar:2.9.0-alpha03 ->
 androidx.lifecycle:lifecycle-runtime-compose-android:aar
```

Fixing the issue by removing the feature "assignSingleVersionDependenciesInGroupForPom":
- it was added in https://android-review.googlesource.com/c/platform/frameworks/support/+/931551
- probably it is added to enforce the same version between sub-modules like `ui`, `ui-graphics`
- but enforcing it breaks a supported case using Compose Material 1.7 with Compose UI 1.6, as it doesn't distinguish modules and submodules
- because it is `pom`, it works only for non-Gradle projects. Gradle uses a Gradle module metadata (according only my experience - `pom` was broken 2 years ago, but compose-multiplatform-desktop-template worked)

Alternative to it is to use this [workaround](https://youtrack.jetbrains.com/issue/KT-75512/pom-in-a-Multiplatform-project-with-a-customized-withXml-is-not-correct#focus=Comments-27-11612114.0-0)

As a consequence of more changes of publication logic, I created https://youtrack.jetbrains.com/issue/CMP-7471/Fix-Maven-Test-project-on-CI

## Fix `Could not find artifact org.jetbrains.kotlin:kotlin-stdlib-common`

See `build.gradle` changes.

Error:
```
Could not resolve dependencies for project org.example:maven-test-project:jar:1.0-SNAPSHOT: Could not find artifact org.jetbrains.kotlin:kotlin-stdlib-common:jar:2.1.10 in mavenCentral (https://repo1.maven.org/maven2/)
```
It was because kotlinStdlibCommon is [deprecated](https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common/2.1.0) and doesn't contain `jar`. Changed to `kotlinStdlib` as recommended in the description.

## Testing
The reproducer from the issue works now

# Release Notes
## Fixes - Desktop
- _(prerelease fix)_ Fix "Could not resolve version conflict" in non-Gradle projects
