### PR TITLE
Add missed `onPreLayoutNodeReused` implementation

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -403,7 +403,10 @@ internal class RootNodeOwner(
         }
 
         override fun onDetach(node: LayoutNode) {
-            layoutNodes.remove(node.semanticsId)
+            val existing = layoutNodes.remove(node.semanticsId)
+            checkNotNull(existing) {
+                "Invalid usage of Owner.onDetach: layoutNode was not previously attached"
+            }
             measureAndLayoutDelegate.onNodeDetached(node)
             snapshotObserver.clear(node)
             needClearObservations = true
@@ -509,7 +512,13 @@ internal class RootNodeOwner(
 
         override fun onPreLayoutNodeReused(layoutNode: LayoutNode, oldSemanticsId: Int) {
             // Keep the mapping up to date when the semanticsId changes
-            layoutNodes.remove(oldSemanticsId)
+            val existing = layoutNodes.remove(oldSemanticsId)
+            checkNotNull(existing) {
+                "Invalid usage of Owner.onPreLayoutNodeReused: layoutNode is not found"
+            }
+            check(existing == layoutNode) {
+                "Invalid usage of Owner.onPreLayoutNodeReused: previous semanticsId refers another layoutNode"
+            }
             layoutNodes[layoutNode.semanticsId] = layoutNode
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -507,6 +507,12 @@ internal class RootNodeOwner(
         override fun onLayoutNodeDeactivated(layoutNode: LayoutNode) {
         }
 
+        override fun onPreLayoutNodeReused(layoutNode: LayoutNode, oldSemanticsId: Int) {
+            // Keep the mapping up to date when the semanticsId changes
+            layoutNodes.remove(oldSemanticsId)
+            layoutNodes[layoutNode.semanticsId] = layoutNode
+        }
+
         @InternalComposeUiApi
         override fun onInteropViewLayoutChange(view: InteropView) {
             // TODO dispatch platform re-layout


### PR DESCRIPTION
Fix the missed callback implementation that caused a leak. Found during [CMP-6925](https://youtrack.jetbrains.com/issue/CMP-6925) investigation

## Testing
existing tests (new checks), verify benchmarks for now

## Release Notes
### Fixes - Multiple Platforms 
- _(prerelease fix)_ Fix memory leak in some cases of re-usage internal layout nodes
