### PR TITLE
Enable text input for UI Tests and Accessibility

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.kt
@@ -40,7 +40,7 @@ import platform.UIKit.UIAccessibilityTraitUpdatesFrequently
 import platform.UIKit.UIAccessibilityTraits
 
 // Private accessibility trait for text fields
-internal val CMPAccessibilityTraitTextField: UIAccessibilityTraits = 1UL shl 18
+internal val CMPAccessibilityTraitTextView: UIAccessibilityTraits = (1UL shl 18) or (1UL shl 47)
 internal val CMPAccessibilityTraitIsEditing: UIAccessibilityTraits = 1UL shl 21
 
 internal fun SemanticsConfiguration.accessibilityTraits(): UIAccessibilityTraits {
@@ -86,10 +86,11 @@ internal fun SemanticsConfiguration.accessibilityTraits(): UIAccessibilityTraits
         }
     }
 
-    if (contains(SemanticsProperties.EditableText) &&
-        contains(SemanticsActions.SetText)
-    ) {
-        result = result or CMPAccessibilityTraitTextField
+    if (isTextNode) {
+        result = result or CMPAccessibilityTraitTextView
+        if (getOrNull(SemanticsProperties.Focused) == true) {
+            result = result or CMPAccessibilityTraitIsEditing
+        }
     } else if (contains(SemanticsActions.OnClick)) {
         result = result or UIAccessibilityTraitButton
     }
@@ -138,6 +139,9 @@ internal fun SemanticsConfiguration.accessibilityLabel(): String? {
         editableText ?: getOrNull(SemanticsProperties.Text)?.joinToString("\n") { it.text }
     }
 }
+
+internal val SemanticsConfiguration.isTextNode: Boolean get() =
+    contains(SemanticsProperties.EditableText) && contains(SemanticsActions.SetText)
 
 internal fun SemanticsConfiguration.accessibilityValue(): String? {
     getOrNull(SemanticsProperties.StateDescription)?.let {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.kt
@@ -86,7 +86,7 @@ internal fun SemanticsConfiguration.accessibilityTraits(): UIAccessibilityTraits
         }
     }
 
-    if (isTextNode) {
+    if (contains(SemanticsProperties.EditableText)) {
         result = result or CMPAccessibilityTraitTextView
         if (getOrNull(SemanticsProperties.Focused) == true) {
             result = result or CMPAccessibilityTraitIsEditing
@@ -139,9 +139,6 @@ internal fun SemanticsConfiguration.accessibilityLabel(): String? {
         editableText ?: getOrNull(SemanticsProperties.Text)?.joinToString("\n") { it.text }
     }
 }
-
-internal val SemanticsConfiguration.isTextNode: Boolean get() =
-    contains(SemanticsProperties.EditableText) && contains(SemanticsActions.SetText)
 
 internal fun SemanticsConfiguration.accessibilityValue(): String? {
     getOrNull(SemanticsProperties.StateDescription)?.let {


### PR DESCRIPTION
Use `TextView` accessibility traits bitmask for text fields.
Mark text input as `Editing` when text input is focused.

Fixes https://youtrack.jetbrains.com/issue/CMP-7222/Support-accessibility-text-input

## Release Notes

### Features - iOS
- Support accessibility text input
- Support text input for UI Tests