### PR TITLE
CfW: Apply negative z-index to backing text area to avoid interference with pointer input

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingTextArea.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingTextArea.kt
@@ -177,6 +177,8 @@ internal class BackingTextArea(
             setProperty("resize", "none")
             setProperty("text-shadow", "none")
             setProperty("z-index", "-1")
+            // TODO: do we need pointer-events: none
+            //setProperty("pointer-events", "none")
         }
 
         initEvents(htmlInput)

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingTextArea.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingTextArea.kt
@@ -176,6 +176,7 @@ internal class BackingTextArea(
             setProperty("border", "none")
             setProperty("resize", "none")
             setProperty("text-shadow", "none")
+            setProperty("z-index", "-1")
         }
 
         initEvents(htmlInput)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -201,11 +201,8 @@ class TextInputTests : OnCanvasTests  {
         // Try to select the text using mouse:
         val clientY = textAreaRect.top.toInt() + 8
         canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56, clientY = clientY, buttons = 1, button = 1)))
-        yield()
         canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(clientX = 56, clientY = clientY, buttons = 1, button = 1)))
-        yield()
         canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 1, button = 1)))
-        yield()
         canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 0, button = 1)))
 
         selection = syncChannel.receive()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -197,8 +197,11 @@ class TextInputTests : OnCanvasTests  {
             delay(250) // to separate the mouse events
         }
 
+
         // Try to select the text using mouse:
         val clientY = textAreaRect.top.toInt() + 8
+        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56, clientY = clientY, buttons = 1, button = 1)))
+        yield()
         canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(clientX = 56, clientY = clientY, buttons = 1, button = 1)))
         yield()
         canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 1, button = 1)))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -193,7 +193,9 @@ class TextInputTests : OnCanvasTests  {
         // So it will be the first to process all the point inputs
         assertEquals(canvas, elementsAtPos[0])
         assertTrue(elementsAtPos.toList().any { it == textArea }) // such a weird check to make the test common for js and wasm
-        yield()
+        withContext(Dispatchers.Default) {
+            delay(250) // to separate the mouse events
+        }
 
         // Try to select the text using mouse:
         val clientY = textAreaRect.top.toInt() + 8

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -31,21 +31,17 @@ import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.sendFromScope
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.browser.document
-import kotlinx.browser.window
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -142,7 +138,7 @@ class TextInputTests : OnCanvasTests  {
     }
 
     @Test
-    fun canSelectAWordUsingMouse() = runTest {
+    fun canSelectUsingMouse() = runTest {
         val syncChannel = Channel<TextRange?>(
             1, onBufferOverflow = BufferOverflow.DROP_OLDEST
         )
@@ -199,16 +195,15 @@ class TextInputTests : OnCanvasTests  {
 
 
         // Try to select the text using mouse:
-        val clientY = textAreaRect.top.toInt() + 8
-        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56, clientY = clientY, buttons = 1, button = 1)))
-        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(clientX = 56, clientY = clientY, buttons = 1, button = 1)))
-        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 1, button = 1)))
-        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 0, button = 1)))
+        val startX = textAreaRect.left.toInt() + 1
+        val startY = textAreaRect.top.toInt() + 8
+        val endX = textAreaRect.right.toInt() - 1
+        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = startX, clientY = startY, buttons = 1, button = 1)))
+        canvas.dispatchEvent(MouseEvent("mousedown", MouseEventInit(clientX = startX, clientY = startY, buttons = 1, button = 1)))
+        canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = endX, clientY = startY, buttons = 1, button = 1)))
+        canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(clientX = endX, clientY = startY, buttons = 0, button = 1)))
 
-        do {
-            selection = syncChannel.receive()
-        } while (selection != TextRange(6, 13))
-
-        assertEquals(TextRange(6, 13), selection)
+        selection = syncChannel.receive()
+        assertEquals(TextRange(0, 14), selection)
     }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -205,7 +205,10 @@ class TextInputTests : OnCanvasTests  {
         canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 1, button = 1)))
         canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(clientX = 56 * 2, clientY = clientY, buttons = 0, button = 1)))
 
-        selection = syncChannel.receive()
+        do {
+            selection = syncChannel.receive()
+        } while (selection != TextRange(6, 13))
+
         assertEquals(TextRange(6, 13), selection)
     }
 }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7238

## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- Fix text selection with mouse in `TextField`
