### PR TITLE
Support Compose scene recreation

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.h
@@ -18,7 +18,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@protocol CMPViewControllerLifecycleDelegate
+
+- (void)viewControllerWillAppear;
+- (void)viewControllerDidDisappear;
+- (void)viewControllerWillDealloc;
+
+@end
+
 @interface CMPViewController : UIViewController
+
+- (id)initWithLifecycleDelegate:(id<CMPViewControllerLifecycleDelegate> _Nullable)delegate;
 
 /// Indicates that view controller is considered alive in terms of structural containment.
 /// Overriding classes should call super.

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/Utils/XCTestCase.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/Utils/XCTestCase.swift
@@ -20,8 +20,8 @@ extension XCTestCase {
     /// Awaits for expectation without blocking UI thread.
     @MainActor
     func expect(        
-        timeout: TimeInterval,
-        line: Int,
+        timeout: TimeInterval = 5.0,
+        line: Int = #line,
         expectation: @escaping () -> Bool
     ) async {
         let start = Date()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitLifecycleOwner.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitLifecycleOwner.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+
+internal class IOSLifecycleOwner: LifecycleOwner, ViewModelStoreOwner {
+    override val lifecycle = LifecycleRegistry(this)
+    override val viewModelStore = ViewModelStore()
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -200,6 +200,7 @@ internal class ComposeHostingViewController(
 
         updateInterfaceOrientationState()
 
+        layers?.window = window
         windowContext.setWindowContainer(windowContainer)
         updateMotionSpeed()
     }
@@ -397,6 +398,7 @@ internal class ComposeHostingViewController(
         metalView.canBeOpaque = configuration.opaque
 
         val layers = UIKitComposeSceneLayersHolder(windowContext, configuration.parallelRendering)
+        layers.window = rootView.window
         this.layers = layers
 
         mediator = ComposeSceneMediator(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -73,7 +73,7 @@ internal class UIKitComposeSceneLayersHolder(
 
     var window: UIWindow? = null
         set(value) {
-            if (field != window) {
+            if (field != value) {
                 field = value
 
                 view.removeFromSuperview()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -62,12 +62,27 @@ internal class UIKitComposeSceneLayersHolder(
     }
 
     private val view = ComposeView(
-        onDidMoveToWindow = {},
-        onLayoutSubviews = { windowContext.updateWindowContainerSize() },
         useOpaqueConfiguration = false,
         transparentForTouches = true,
-        metalView = metalView
-    )
+    ).also {
+        it.updateMetalView(
+            metalView = metalView,
+            onLayoutSubviews = { windowContext.updateWindowContainerSize() }
+        )
+    }
+
+    var window: UIWindow? = null
+        set(value) {
+            if (field != window) {
+                field = value
+
+                view.removeFromSuperview()
+                if (layers.isNotEmpty()) {
+                    value?.embedSubview(view)
+                    value?.layoutIfNeeded()
+                }
+            }
+        }
 
     fun animateSizeTransition(scope: CoroutineScope, duration: Duration) {
         if (this.layers.isEmpty()) {
@@ -87,8 +102,6 @@ internal class UIKitComposeSceneLayersHolder(
     }
 
     fun dispose(hasViewAppeared: Boolean) {
-        metalView.dispose()
-
         // `dispose` is called instead of `close`, because `close` is also used imperatively
         // to remove the layer from the array based on user interaction.
         while (this.layers.isNotEmpty()) {
@@ -101,15 +114,14 @@ internal class UIKitComposeSceneLayersHolder(
             layer.dispose()
         }
 
-        view.dispose()
+        view.updateMetalView(metalView = null)
         view.removeFromSuperview()
     }
 
-    fun attach(window: UIWindow, layer: UIKitComposeSceneLayer, hasViewAppeared: Boolean) {
-        val isFirstLayer = this.layers.isEmpty()
+    fun attach(layer: UIKitComposeSceneLayer, hasViewAppeared: Boolean) {
+        val isFirstLayer = layers.isEmpty()
 
-        this.layers.add(layer)
-
+        layers.add(layer)
         view.embedSubview(layer.view)
         view.bringSubviewToFront(metalView)
 
@@ -119,8 +131,8 @@ internal class UIKitComposeSceneLayersHolder(
 
             metalView.setNeedsSynchronousDrawOnNextLayout()
 
-            window.embedSubview(view)
-            window.layoutIfNeeded()
+            window?.embedSubview(view)
+            window?.layoutIfNeeded()
         }
 
         if (hasViewAppeared) {
@@ -149,7 +161,6 @@ internal class UIKitComposeSceneLayersHolder(
 
             // Redraw content with layer removed
             metalView.redrawer.setNeedsRedraw()
-
         }
     }
 
@@ -187,8 +198,8 @@ internal class UIKitComposeSceneLayersHolder(
 
         // Some layers may be removed during rendering, because recomposition will happen in the
         // process, so we need to make a temporary copy of the list
-        layersCache.withCopy {
-            it.fastForEach {
+        layersCache.withCopy { layers ->
+            layers.fastForEach {
                 it.render(composeCanvas, nanoTime)
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerLifecycleDelegate.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ViewControllerLifecycleDelegate.uikit.kt
@@ -23,7 +23,8 @@ import platform.Foundation.NSNotificationCenter
 import platform.darwin.NSObject
 
 internal class ViewControllerLifecycleDelegate(
-    private val lifecycleOwner: IOSLifecycleOwner
+    private val lifecycleOwner: IOSLifecycleOwner,
+    notificationCenter: NSNotificationCenter = NSNotificationCenter.defaultCenter
 ): NSObject(), CMPViewControllerLifecycleDelegateProtocol {
 
     private var isViewAppeared = false
@@ -32,13 +33,13 @@ internal class ViewControllerLifecycleDelegate(
     private var isDisposed = false
 
     private val applicationForegroundStateListener =
-        ApplicationForegroundStateListener(NSNotificationCenter.defaultCenter) { isForeground ->
+        ApplicationForegroundStateListener(notificationCenter) { isForeground ->
             isAppForeground = isForeground
             updateLifecycleState()
         }
 
     private val applicationActiveStateListener =
-        ApplicationActiveStateListener(NSNotificationCenter.defaultCenter) { isActive ->
+        ApplicationActiveStateListener(notificationCenter) { isActive ->
             isAppActive = isActive
             updateLifecycleState()
         }


### PR DESCRIPTION
Support Compose scene recreation when ComposeHostingViewController appears

Fixes https://youtrack.jetbrains.com/issue/CMP-7111/Consider-to-re-create-Compose-Scene-after-disposal
Fixes https://youtrack.jetbrains.com/issue/CMP-7536/iOS-Dialog-crash-with-Cannot-attach-layer-if-the-view-is-not-in-the-window-hierarchy

## Release Notes
### Features - iOS
- Add ability to recreate Composable after `ComposeUIViewController` leaves view controller hierarchy