### PR TITLE
Cancel compose scene interaction when back gesture is detected

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toOffset
 import kotlin.math.abs
 import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.CPointed
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.useContents
 import platform.Foundation.NSSelectorFromString
@@ -58,14 +60,14 @@ internal class UIKitBackGestureDispatcher(
         getListener = { activeListener }
     )
 
-    private val leftEdgePanGestureRecognizer = UIScreenEdgePanGestureRecognizer(
+    private val leftEdgePanGestureRecognizer = UIKitBackGestureRecognizer(
         target = iosGestureHandler,
         action = NSSelectorFromString(UiKitScreenEdgePanGestureHandler::handleEdgePan.name + ":")
     ).apply {
         edges = UIRectEdgeLeft
     }
 
-    private val rightEdgePanGestureRecognizer = UIScreenEdgePanGestureRecognizer(
+    private val rightEdgePanGestureRecognizer = UIKitBackGestureRecognizer(
         target = iosGestureHandler,
         action = NSSelectorFromString(UiKitScreenEdgePanGestureHandler::handleEdgePan.name + ":")
     ).apply {
@@ -189,3 +191,11 @@ private class UiKitScreenEdgePanGestureHandler(
         }
     }
 }
+
+/**
+ * A special gesture recognizer that can cancel touches in the Compose scene.
+ * See [androidx.compose.ui.window.UserInputGestureRecognizer.canBePreventedByGestureRecognizer]
+ */
+internal class UIKitBackGestureRecognizer(
+    target: Any?, action: CPointer<out CPointed>?
+) : UIScreenEdgePanGestureRecognizer(target = target, action = action)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.backhandler.UIKitBackGestureRecognizer
 import androidx.compose.ui.scene.PointerEventResult
 import androidx.compose.ui.uikit.utils.CMPGestureRecognizer
 import androidx.compose.ui.viewinterop.InteropView
@@ -48,8 +49,6 @@ import platform.UIKit.UIScrollView
 import platform.UIKit.UITouch
 import platform.UIKit.UIView
 import platform.UIKit.setState
-import platform.darwin.dispatch_async
-import platform.darwin.dispatch_get_main_queue
 
 /**
  * A reason for why touches are sent to Compose
@@ -229,7 +228,10 @@ internal class UserInputGestureRecognizer(
     override fun canBePreventedByGestureRecognizer(
         preventingGestureRecognizer: UIGestureRecognizer
     ): Boolean {
-        return if (canIgnoreDragGesture(preventingGestureRecognizer)) {
+        return if (preventingGestureRecognizer is UIKitBackGestureRecognizer) {
+            cancelAllTrackedTouches()
+            true
+        } else if (canIgnoreDragGesture(preventingGestureRecognizer)) {
             false
         } else if (preventingGestureRecognizer is UserInputGestureRecognizer
             && preventingGestureRecognizer.state.isOngoing) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7632/iOS-Back-gesture-doesnt-cancel-touch-events

## Release Notes

### Fixes - iOS
- Fixed a bug where touches could be handled by back gesture and composable content at the same time