### PR TITLE
Make coroutines an api dependency of compose runtime

### DIFF
--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -115,7 +115,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         sourceSets {
             commonMain.dependencies {
                 implementation(libs.kotlinStdlib)
-                implementation(libs.kotlinCoroutinesCore)
+                api(libs.kotlinCoroutinesCore)
                 implementation(project(":annotation:annotation"))
                 implementation(project(":collection:collection"))
                 implementation(project(":performance:performance-annotation"))


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5803

It's already api() in AOSP. https://android-review.googlesource.com/c/platform/frameworks/support/+/3443339
Probably we didn't get this change yet. 

## Testing
N/A

## Release Notes
### Fixes - Multiple Platforms
- Compose runtime module now exposes its dependency on Kotlin Coroutines API (changed from `implementation()` to `api()`)