### PR TITLE
Back navigation fixes

### DIFF
--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -534,17 +534,19 @@ internal fun NavHost(
                 val goodEdge =
                     limitBackGestureSwipeEdge == null || it.swipeEdge == limitBackGestureSwipeEdge
 
-                if (currentBackStack.size > 1 && goodEdge) {
+                if (currentBackStack.size > 1) {
                     inPredictiveBack = true
-                    progress = it.progress
+                    if (goodEdge) {
+                        progress = it.progress
+                    }
                 }
             }
-            if (currentBackStack.size > 1 && inPredictiveBack) {
+            if (currentBackStack.size > 1) {
                 inPredictiveBack = false
                 composeNavigator.popBackStack(currentBackStackEntry!!, false)
             }
         } catch (e: CancellationException) {
-            if (currentBackStack.size > 1 && inPredictiveBack) {
+            if (currentBackStack.size > 1) {
                 inPredictiveBack = false
             }
         }


### PR DESCRIPTION
Fix the back navigation handler on iOS and Desktop.

Fixes https://youtrack.jetbrains.com/issue/CMP-7712
## Release Notes
### Fixes - Navigation
- _(prerelease fix)_ Fix a desktop back navigation when Esc button clicked.
- _(prerelease fix)_ Fix an iOS back navigation after a swipe on disallowed edge.