### PR TITLE
Avoid pasteboard permissions alert when pasting text in TextField

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
@@ -35,4 +35,4 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
     return ClipEntry.withPlainText(this.text)
 }
 
-internal actual fun ClipEntry?.hasText(): Boolean = this?.getPlainText() != null
+internal actual fun ClipEntry?.hasText(): Boolean = this?.hasPlainText() ?: false

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.uikit.kt
@@ -19,13 +19,16 @@ package androidx.compose.ui.platform
 import androidx.compose.ui.ExperimentalComposeUiApi
 import platform.UIKit.UIPasteboard
 
-actual typealias NativeClipboard = platform.UIKit.UIPasteboard
+actual typealias NativeClipboard = UIPasteboard
 
 internal class UiKitPlatformClipboard internal constructor() : Clipboard {
     override suspend fun getClipEntry(): ClipEntry? {
-        if (nativeClipboard.items.isEmpty()) return null
+        if (nativeClipboard.numberOfItems() == 0L) return null
         return ClipEntry().apply {
-            plainText = nativeClipboard.string
+            getPlainText = {
+                nativeClipboard.string
+            }
+            hasPlainText = nativeClipboard.hasStrings
         }
     }
 
@@ -33,7 +36,7 @@ internal class UiKitPlatformClipboard internal constructor() : Clipboard {
         if (clipEntry == null) {
             nativeClipboard.items = emptyList<Map<String, Any>>()
         } else {
-            nativeClipboard.string = clipEntry.plainText
+            nativeClipboard.string = clipEntry.getPlainText()
         }
     }
 
@@ -59,15 +62,22 @@ actual class ClipEntry internal constructor() {
     actual val clipMetadata: ClipMetadata
         get() = TODO("ClipMetadata is not implemented. Consider using nativeClipboard")
 
-    internal var plainText: String? = null
+    internal var getPlainText: () -> String? = { null }
+    internal var hasPlainText: Boolean = false
 
     @ExperimentalComposeUiApi
-    fun getPlainText(): String? = plainText
+    fun getPlainText(): String? = getPlainText.invoke()
+
+    @ExperimentalComposeUiApi
+    fun hasPlainText(): Boolean {
+        return hasPlainText
+    }
 
     companion object {
         @ExperimentalComposeUiApi
         fun withPlainText(text: String): ClipEntry = ClipEntry().apply {
-            plainText = text
+            getPlainText = { text }
+            hasPlainText = true
         }
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.uikit.kt
@@ -25,7 +25,7 @@ internal class UiKitPlatformClipboard internal constructor() : Clipboard {
     override suspend fun getClipEntry(): ClipEntry? {
         if (nativeClipboard.numberOfItems() == 0L) return null
         return ClipEntry().apply {
-            getPlainText = {
+            getPlainTextLambda = {
                 nativeClipboard.string
             }
             hasPlainText = nativeClipboard.hasStrings
@@ -62,11 +62,11 @@ actual class ClipEntry internal constructor() {
     actual val clipMetadata: ClipMetadata
         get() = TODO("ClipMetadata is not implemented. Consider using nativeClipboard")
 
-    internal var getPlainText: () -> String? = { null }
+    internal var getPlainTextLambda: () -> String? = { null }
     internal var hasPlainText: Boolean = false
 
     @ExperimentalComposeUiApi
-    fun getPlainText(): String? = getPlainText.invoke()
+    fun getPlainText(): String? = getPlainTextLambda.invoke()
 
     @ExperimentalComposeUiApi
     fun hasPlainText(): Boolean {
@@ -76,7 +76,7 @@ actual class ClipEntry internal constructor() {
     companion object {
         @ExperimentalComposeUiApi
         fun withPlainText(text: String): ClipEntry = ClipEntry().apply {
-            getPlainText = { text }
+            getPlainTextLambda = { text }
             hasPlainText = true
         }
     }


### PR DESCRIPTION
Postpone reading text content from `UIPasteboard` until the moment it's being requested.

Fixes https://youtrack.jetbrains.com/issue/CMP-7713/UIPasteboard-access-alert-for-BTF2

## Release Notes
### Fixes - iOS
- Removed permissions alert when pasting text into a `TextField`