### PR TITLE
Set ScrollState.viewportSize in BTF2

### DIFF
--- a/compose/foundation/foundation/src/androidInstrumentedTest/kotlin/androidx/compose/foundation/text/input/TextFieldScrollTest.kt
+++ b/compose/foundation/foundation/src/androidInstrumentedTest/kotlin/androidx/compose/foundation/text/input/TextFieldScrollTest.kt
@@ -193,6 +193,32 @@ class TextFieldScrollTest : FocusedWindowTest {
     }
 
     @Test
+    fun textFieldScroll_horizontal_setsViewportSize() {
+        val scrollState = ScrollState(0)
+
+        rule.setupHorizontallyScrollableContent(
+            state = TextFieldState("text"),
+            scrollState = scrollState,
+            modifier = Modifier.size(width = 300.dp, height = 50.dp)
+        )
+
+        rule.runOnIdle { assertThat(scrollState.viewportSize).isGreaterThan(0) }
+    }
+
+    @Test
+    fun textFieldScroll_vertical_setsViewportSize() {
+        val scrollState = ScrollState(0)
+
+        rule.setupVerticallyScrollableContent(
+            state = TextFieldState("text"),
+            scrollState = scrollState,
+            modifier = Modifier.size(width = 300.dp, height = 100.dp)
+        )
+
+        rule.runOnIdle { assertThat(scrollState.viewportSize).isGreaterThan(0) }
+    }
+
+    @Test
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.O)
     fun textField_singleLine_scrolledAndClipped() {
         val parentSize = 200

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldCoreModifier.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldCoreModifier.kt
@@ -353,6 +353,9 @@ internal class TextFieldCoreModifierNode(
         currSelection: TextRange,
         layoutDirection: LayoutDirection
     ) {
+        // update the viewport size
+        scrollState.viewportSize = containerSize
+
         // update the maximum scroll value
         val difference = textLayoutSize - containerSize
         scrollState.maxValue = difference


### PR DESCRIPTION
This cherry-picks the AOSP commit that sets `ScrollState.viewportSize` for BTF2.
This is important for CMP because without it, it's not possible to use scrollbars with the new `TextField(TextFieldState)`.

Fixes https://youtrack.jetbrains.com/issue/CMP-7703

## Testing
```
fun main() = singleWindowApplication {
    Box(
        modifier = Modifier.size(300.dp, 100.dp).border(1.dp, Color.Black)
    ) {
        val textFieldState = rememberTextFieldState()
        val scrollState = rememberScrollState()
        BasicTextField(
            state = textFieldState,
            modifier = Modifier.fillMaxSize().padding(8.dp),
            scrollState = scrollState
        )
        VerticalScrollbar(
            modifier = Modifier.align(Alignment.CenterEnd),
            adapter = rememberScrollbarAdapter(scrollState)
        )
    }
}
```

## Release Notes
### Fixes - Multiple Platforms
- Correctly set `ScrollState.viewportSize` for (Basic)`TextField(TextFieldState)`.
