### PR TITLE
iOS back handler fixes.

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcherUtils.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcherUtils.kt
@@ -16,16 +16,21 @@
 
 package androidx.compose.ui.backhandler
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 
-@OptIn(ExperimentalComposeUiApi::class)
-internal class DesktopBackGestureDispatcher : BackGestureDispatcher() {
-    fun onKeyEvent(event: KeyEvent): Boolean {
-        return handleBackKeyEvent(event, activeListener)
+internal fun BackGestureDispatcher.handleBackKeyEvent(
+    event: KeyEvent,
+    listener: BackGestureListener?
+): Boolean {
+    if (listener != null && event.type == KeyEventType.KeyDown && event.key == Key.Escape) {
+        listener.onStarted()
+        listener.onCompleted()
+        return true
+    } else {
+        return false
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -107,16 +107,7 @@ internal class UIKitBackGestureDispatcher(
     }
 
     fun onKeyEvent(event: KeyEvent): Boolean {
-        if (event.type == KeyEventType.KeyUp && event.key == Key.Escape) {
-            activeListener?.let {
-                it.onStarted()
-                it.onCompleted()
-            }
-
-            return true
-        } else {
-            return false
-        }
+        return handleBackKeyEvent(event, activeListener)
     }
 }
 
@@ -169,7 +160,8 @@ private class UiKitScreenEdgePanGestureHandler(
                     translation.useContents {
                         view.bounds.useContents {
                             val edge = recognizer.edges
-                            val velX = if (edge == UIRectEdgeLeft) this@velocity.x else -this@velocity.x
+                            val velX =
+                                if (edge == UIRectEdgeLeft) this@velocity.x else -this@velocity.x
                             when {
                                 //if movement is fast in the right direction
                                 velX > BACK_GESTURE_VELOCITY -> listener?.onCompleted()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -126,13 +126,15 @@ private class UiKitScreenEdgePanGestureHandler(
     private val getTopLeftOffsetInWindow: () -> IntOffset,
     private val getListener: () -> BackGestureListener?
 ) : NSObject() {
+    private var listener: BackGestureListener? = null
+
     @ObjCAction
     fun handleEdgePan(recognizer: UIScreenEdgePanGestureRecognizer) {
-        val listener = getListener() ?: return
         val view = recognizer.view ?: return
         when (recognizer.state) {
             UIGestureRecognizerStateBegan -> {
-                listener.onStarted()
+                listener = getListener()
+                listener?.onStarted()
             }
 
             UIGestureRecognizerStateChanged -> {
@@ -155,7 +157,7 @@ private class UiKitScreenEdgePanGestureHandler(
                             }
                         )
 
-                        listener.onProgressed(event)
+                        listener?.onProgressed(event)
                     }
                 }
             }
@@ -170,25 +172,28 @@ private class UiKitScreenEdgePanGestureHandler(
                             val velX = if (edge == UIRectEdgeLeft) this@velocity.x else -this@velocity.x
                             when {
                                 //if movement is fast in the right direction
-                                velX > BACK_GESTURE_VELOCITY -> listener.onCompleted()
+                                velX > BACK_GESTURE_VELOCITY -> listener?.onCompleted()
                                 //if movement is backward
-                                velX < -10 -> listener.onCancelled()
+                                velX < -10 -> listener?.onCancelled()
                                 //if there is no movement, or the movement is slow,
                                 //but the touch is already more than BACK_GESTURE_SCREEN_SIZE
-                                abs(x) >= size.width * BACK_GESTURE_SCREEN_SIZE -> listener.onCompleted()
-                                else -> listener.onCancelled()
+                                abs(x) >= size.width * BACK_GESTURE_SCREEN_SIZE -> listener?.onCompleted()
+                                else -> listener?.onCancelled()
                             }
                         }
                     }
                 }
+                listener = null
             }
 
             UIGestureRecognizerStateCancelled -> {
-                listener.onCancelled()
+                listener?.onCancelled()
+                listener = null
             }
 
             UIGestureRecognizerStateFailed -> {
-                listener.onCancelled()
+                listener?.onCancelled()
+                listener = null
             }
         }
     }

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -538,6 +538,10 @@ internal fun NavHost(
                     inPredictiveBack = true
                     if (goodEdge) {
                         progress = it.progress
+                    } else {
+                        throw CancellationException(
+                            "The current edge is not allowed to perform back gesture."
+                        )
                     }
                 }
             }


### PR DESCRIPTION
1) Cancel back handler for invalid back gesture edge in NavHost. Otherwise, it is possible to complete the gesture and call popBackStack.
2) Refactor the iOS back gesture handler to keep the listener instance while the gesture is in progress.
3) Extract back key event handling into a utility function to reduce duplication across platform-specific back gesture dispatchers.

## Release Notes
N/A