### PR TITLE
Fix accessibility elements rects when compose scene is shifted

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -881,7 +881,7 @@ internal class AccessibilityMediator(
     val hasPendingInvalidations: Boolean get() = !invalidationChannel.isEmpty
 
     private fun convertToAppWindowCGRect(rect: Rect): CValue<CGRect> {
-        return rect.toDpRect(view.density).asCGRect()
+        return view.convertRect(rect.toDpRect(view.density).asCGRect(), toView = null)
     }
 
     fun notifyScrollCompleted(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -304,6 +304,7 @@ internal class ComposeHostingViewController(
         }
 
         rootView.updateMetalView(metalView, ::onDidMoveToWindow)
+        onAccessibilityChanged()
     }
 
     override fun viewControllerDidLeaveWindowHierarchy() {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7722/Accessibility-elements-have-incorrect-frame-when-compose-scene-is-shifted

## Release Notes
### Fixes - iOS
- Fix accessibility elements rects when `ComposeUIViewController` is shifted