### PR TITLE
Check Release Notes GitHub workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,36 +14,7 @@ Describe how you tested your changes. If possible and needed:
 This should be tested by QA
 
 ## Release Notes
-<!--
-If we definitely shouldn't add Release Notes, add only N/A.
-
-Or enumerate sections, subsections and all changes.
-
-Possible sections:
-- Highlights             // major features
-- Known Issues           // issues planned to be fixed, with possible workarounds
-- Breaking Changes       // incompatible changes without deprecation cycle
-- Migration Notes        // deprecations, removals, minimal version increases, defined behavior changes
-- Features               // minor features
-- Fixes                  // bug fixes, undefined behavior changes
-
-Possible subsections:
-- Multiple Platforms     // any module, 2 or more platform changes
-- iOS                    // any module, iOS-only changes
-- Desktop                // any module, Desktop-only changes
-- Web                    // any module, Web-only changes
-- Android                // any module, Android-only changes
-- Resources              // specific module, prefer it over the platform ones
-- Gradle Plugin          // specific module, prefer it over the platform ones
-- Lifecycle              // specific module, prefer it over the platform ones
-- Navigation             // specific module, prefer it over the platform ones
--->
-### Section - Subsection
-- Describe a change for adding it to https://github.com/JetBrains/compose-multiplatform/blob/master/CHANGELOG.md
-- _(prerelease fix)_ Fix some bug that introduced in a prerelease version (dev/beta). It will be included in a dev/beta changelog, but excluded from a stable changelog
-
-### Section - Subsection
-- Describe another change if needed
+See the format in https://github.com/JetBrains/compose-multiplatform/blob/master/tools/changelog/PR_FORMAT.md
 
 ## Google CLA
 You need to sign the Google Contributor’s License Agreement at https://cla.developers.google.com/.

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -13,4 +13,6 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: JetBrains/compose-multiplatform/tools/changelog/check-release-notes-github-action@master
+      - uses: JetBrains/compose-multiplatform/tools/changelog/check-release-notes-github-action@igordmn-patch-7
+        with:
+          checkout_ref: 'igordmn-patch-7'

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -13,6 +13,4 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: JetBrains/compose-multiplatform/tools/changelog/check-release-notes-github-action@igordmn-patch-7
-        with:
-          checkout_ref: 'igordmn-patch-7'
+      - uses: JetBrains/compose-multiplatform/tools/changelog/check-release-notes-github-action@master

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -1,0 +1,16 @@
+# Checks Release Notes in the PR description when:
+#   opened - PR is opened
+#   edited - The title/description are changed
+#   synchronize - New commits appeared.
+#                 We don't use the new content, but we still need to mark this commit Green/Red in GitHub UI
+
+name: Check Release Notes in the description
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: JetBrains/compose-multiplatform/tools/changelog/check-release-notes-github-action@master


### PR DESCRIPTION
Similar to [compose-multiplatform](https://github.com/JetBrains/compose-multiplatform/pull/5251) by reusing workflow from there

## Testing
CI successes with Release Notes, fails without it

## Release Notes
N/A
