### PR TITLE
CfW: When Clipboard permission is denied prevent the app from crashing

### DIFF
--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
@@ -29,8 +29,17 @@ class JsPlatformClipboard : Clipboard {
         getW3CClipboard()
     }
 
+    private val emptyClipboardItems = emptyArray<ClipboardItem>()
+
     override suspend fun getClipEntry(): ClipEntry? {
-        val items = nativeClipboard.read().await()
+        val items = nativeClipboard.read().catch {
+            // The most common reason is that the permission was denied
+            println("Failed to read from Clipboard: $it")
+            emptyClipboardItems
+        }.then {
+            it
+        }.await()
+
         if (items.isEmpty()) return null
         return ClipEntry(items)
     }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7716

## Testing
It's not possible to add automated unit-like tests due to permission requirements (the permission request  (Promise) won't resolve without manual input). 

This should be tested by QA

## Release Notes
N/A
