### PR TITLE
Fix Popup appearance for pointer input

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -158,6 +158,7 @@ internal class UIKitComposeSceneLayer(
     internal fun dispose() {
         mediator.dispose()
         view.removeFromSuperview()
+        view.dispose()
     }
 
     @Composable


### PR DESCRIPTION
Use only touches to send Outside Bounds pointer events.

Fixes https://youtrack.jetbrains.com/issue/CMP-7733/Cannot-open-popup-with-trackpad

## Release Notes
### Fixes - iOS
- Fixed an issue where it wasn't possible to open a popup using pointer input devices.