### PR TITLE
Move disabling window shadows from skiko to avoid mixing view and windows properties 

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -250,6 +250,9 @@ class ComposeDialog : JDialog {
         get() = composePanel.isWindowTransparent
         set(value) {
             composePanel.isWindowTransparent = value
+
+            // Disable macOS shadow for undecorated windows
+            rootPane.putClientProperty("Window.shadow", !value)
         }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -186,7 +186,14 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
      * Transparency should be set only if window is not showing and `isUndecorated` is set to
      * `true`, otherwise AWT will throw an exception.
      */
-    var isTransparent: Boolean by composePanel::isWindowTransparent
+    var isTransparent: Boolean
+        get() = composePanel.isWindowTransparent
+        set(value) {
+            composePanel.isWindowTransparent = value
+
+            // Disable macOS shadow for undecorated windows
+            rootPane.putClientProperty("Window.shadow", !value)
+        }
 
     var placement: WindowPlacement
         get() = when {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -71,6 +71,10 @@ internal class WindowComposeSceneLayer(
             isWindowTransparent = transparent,
             renderApi = composeContainer.renderApi
         )
+        if (transparent) {
+            // Disable macOS shadow for undecorated windows
+            it.rootPane.putClientProperty("Window.shadow", false)
+        }
     }
     private val container = object : JLayeredPaneWithTransparencyHack() {
         override fun addNotify() {


### PR DESCRIPTION
Restore behaviour after [skiko change](https://github.com/JetBrains/skiko/pull/1034)

Fixes [CMP-7752](https://youtrack.jetbrains.com/issue/CMP-7752) Interop blending should not disable window shadows on macOS

## Testing

Try to create windows with `compose.interop.blending`/transparency with various combinations. On macOS shadows should be disabled only for transparent windows.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix missing window shadows on macOS in case of usage `compose.interop.blending` flag
