### PR TITLE
Pin lifecycle dependencies to 2.8 in compose/ui

### DIFF
--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -46,7 +46,7 @@ kotlin {
                 implementation(project(":annotation:annotation"))
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
             }
         }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -175,7 +175,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
                 implementation(project(":compose:ui:ui-backhandler"))
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
+                api("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
                 implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4")
                 implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
                 implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4")

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -175,12 +175,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
                 implementation(project(":compose:ui:ui-backhandler"))
-
-                // TODO(igor): figure out how to avoid downgrading runtime to 1.6 in case of project dependencies in mpp demo + pinned lifecycle here
-                implementation(project(":lifecycle:lifecycle-common"))
-                implementation(project(":lifecycle:lifecycle-runtime"))
-                implementation(project(":lifecycle:lifecycle-runtime-compose"))
-                implementation(project(":lifecycle:lifecycle-viewmodel"))
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4")
             }
 
             androidMain.dependencies {


### PR DESCRIPTION
This reverts commit e8e61d6b686bf944b449e3468bfdd7f892433d0e

Fixes https://youtrack.jetbrains.com/issue/CMP-7753

Also,mark `lifecycle-common` as API dependency because it's a part of `LocalLifecycleOwner` signature

## Release Notes
N/A