### PR TITLE
Update `SwingInteropContainer.placeInteropAbove` when the renderApi changes

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -167,12 +167,18 @@ internal class ComposeSceneMediator(
         get() = renderApi == GraphicsApi.METAL && contentComponent !is SkiaSwingLayer
 
     /**
+     * Whether to place interop components above non-interop components.
+     */
+    private val shouldPlaceInteropAbove: Boolean
+        get() = !useInteropBlending || metalOrderHack
+
+    /**
      * A container that controls interop views/components. It is used to add and remove
      * native views/components to [container].
      */
     private val interopContainer = SwingInteropContainer(
         root = container,
-        placeInteropAbove = !useInteropBlending || metalOrderHack,
+        placeInteropAbove = shouldPlaceInteropAbove,
         requestRedraw = ::onComposeInvalidation
     )
 
@@ -362,6 +368,9 @@ internal class ComposeSceneMediator(
         // Because interopContainer.root == container, add a listener only after adding
         // [invisibleComponent] and [contentComponent] to react only on changes with [interopLayer].
         interopContainer.root.addContainerListener(interopContainerListener)
+        onRenderApiChanged {
+            interopContainer.placeInteropAbove = shouldPlaceInteropAbove
+        }
 
         // AwtDragAndDropManager support
         container.transferHandler = dragAndDropManager.transferHandler

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropContainer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropContainer.skiko.kt
@@ -105,6 +105,28 @@ internal fun InteropContainer.countInteropComponentsBelow(holder: InteropViewHol
 }
 
 /**
+ * Sort the given interop components by their order in the container.
+ *
+ * @param holders The list to sort.
+ * @return The sorted list.
+ */
+internal fun InteropContainer.interopComponentsSortedByDrawOrder(
+    holders: Collection<InteropViewHolder>
+): List<InteropViewHolder> {
+    val remainingHolders = holders.toMutableSet()
+    val result = mutableListOf<InteropViewHolder>()
+    rootModifier?.traverseDescendantsInDrawOrder {
+        val holder = it.interopViewHolder
+        if ((holder != null) && remainingHolders.remove(holder)) {
+            result.add(holder)
+        }
+        true
+    }
+    check(remainingHolders.isEmpty()) { "Some interop view holders not found in interop container" }
+    return result
+}
+
+/**
  * Wrapper of Compose content that might contain interop views. It adds a helper modifier to root
  * that allows traversing interop views in the tree with the right order.
  *


### PR DESCRIPTION
When `renderApi` changes, update `SwingInteropContainer.placeInteropAbove` and possibly reposition the interop views accordingly.

Fixes https://youtrack.jetbrains.com/issue/CMP-7746/SwingPanels-placed-incorrectly-on-Windows-if-Direct3D-is-unsupported

## Testing
Tested manually by making `renderApi` mutable and then putting
```
init {
    thread {
        while (true) {
            Thread.sleep(5000)
            println("Setting render API to OpenGL")
            renderApi = GraphicsApi.OPENGL
            Thread.sleep(5000)
            println("Setting render API to Direct3D")
            renderApi = GraphicsApi.DIRECT3D
        }
    }
}
```
in `ComposeSceneMediator.desktop.kt`.
Then running the InteropOrder demo and playing with the colored squares (don't forget to also set `compose.interop.blending=true`).

## Release Notes
### Fixes - Desktop
- [Swing Interop] Fixed `compose.interop.blending=true` completely breaking Swing interop on Windows when Direct3D is unsupported. Note that interop blending is still supported on Windows only if Direct3D is available.
