### PR TITLE
Update defaultLocale to use preferredLanguages in darwin

### DIFF
--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
@@ -19,11 +19,13 @@ package androidx.compose.material3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import platform.Foundation.NSLocale
-import platform.Foundation.currentLocale
+import platform.Foundation.preferredLanguages
 
 
 actual typealias CalendarLocale = NSLocale
 
 @Composable
 @ReadOnlyComposable
-internal actual fun defaultLocale(): CalendarLocale = NSLocale.currentLocale()
+internal actual fun defaultLocale(): CalendarLocale = NSLocale(
+    NSLocale.preferredLanguages.first() as String
+)


### PR DESCRIPTION
Replaces NSLocale.currentLocale with NSLocale.preferredLanguages.first for determining the default locale. This aligns locale selection with user language preferences on darwin platforms.

## Release Notes
N/A