### PR TITLE
Add failure requirements for TouchesGestureRecognizer

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -32,6 +32,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer;
 
+- (BOOL)shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer;
+
+- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.h
@@ -34,8 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer;
 
-- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -42,4 +42,12 @@
     return [super canBePreventedByGestureRecognizer:preventingGestureRecognizer];
 }
 
+- (BOOL)shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return [super shouldRequireFailureOfGestureRecognizer:otherGestureRecognizer];
+}
+
+- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    return [super shouldRequireFailureOfGestureRecognizer:otherGestureRecognizer];
+}
+
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPGestureRecognizer.m
@@ -46,8 +46,4 @@
     return [super shouldRequireFailureOfGestureRecognizer:otherGestureRecognizer];
 }
 
-- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-    return [super shouldRequireFailureOfGestureRecognizer:otherGestureRecognizer];
-}
-
 @end

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -281,6 +281,13 @@ private class TouchesGestureRecognizer(
         }
     }
 
+    override fun shouldRequireFailureOfGestureRecognizer(
+        otherGestureRecognizer: UIGestureRecognizer
+    ): Boolean {
+        return (otherGestureRecognizer is UIKitBackGestureRecognizer) ||
+            super.shouldRequireFailureOfGestureRecognizer(otherGestureRecognizer)
+    }
+
     /**
      * Checks if compose can get priority over interop view with UIScrollView on it.
      *


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7632/iOS-Back-gesture-doesnt-cancel-touch-events

## Release Notes
N/A
