### PR TITLE
Support keyboard text input

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -55,6 +55,7 @@ import kotlin.time.measureTime
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
+import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -76,6 +77,7 @@ import platform.CoreGraphics.CGRectGetMinX
 import platform.CoreGraphics.CGRectGetMinY
 import platform.CoreGraphics.CGRectIntersectsRect
 import platform.CoreGraphics.CGRectIsEmpty
+import platform.CoreGraphics.CGRectZero
 import platform.UIKit.NSStringFromCGRect
 import platform.UIKit.UIAccessibilityContainerType
 import platform.UIKit.UIAccessibilityContainerTypeNone
@@ -632,7 +634,8 @@ private class AccessibilityElement(
 
     override fun focusItemContainer(): UIFocusItemContainerProtocol = this
 
-    override fun frame(): CValue<CGRect> = accessibilityFrame()
+    var focusFrame: CValue<CGRect> = CGRectZero.readValue()
+    override fun frame(): CValue<CGRect> = focusFrame
 
     override fun parentFocusEnvironment(): UIFocusEnvironmentProtocol? =
         accessibilityContainer as? UIFocusEnvironmentProtocol
@@ -884,6 +887,10 @@ internal class AccessibilityMediator(
         return view.convertRect(rect.toDpRect(view.density).asCGRect(), toView = null)
     }
 
+    private fun convertToRootViewCGRect(rect: Rect): CValue<CGRect> {
+        return rect.toDpRect(view.density).asCGRect()
+    }
+
     fun notifyScrollCompleted(
         scrollResult: AccessibilityScrollEventResult,
         delay: Long,
@@ -961,6 +968,7 @@ internal class AccessibilityMediator(
         if (!CGRectEqualToRect(accessibilityFrame, element.accessibilityFrame)) {
             element.setAccessibilityFrame(accessibilityFrame)
         }
+        element.focusFrame = convertToRootViewCGRect(frame)
         return element
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.uikit.LocalInterfaceOrientation
 import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.uikit.PlistSanityCheck
 import androidx.compose.ui.uikit.density
+import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.uikit.utils.CMPViewController
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -83,6 +84,7 @@ import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UITraitCollection
 import platform.UIKit.UIUserInterfaceLayoutDirection
 import platform.UIKit.UIUserInterfaceStyle
+import platform.UIKit.UIView
 import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
 import platform.UIKit.UIWindow
 import platform.darwin.dispatch_async
@@ -102,6 +104,9 @@ internal class ComposeHostingViewController(
         transparentForTouches = false,
         useOpaqueConfiguration = configuration.opaque,
     )
+    private val interopContainerView = UIView().also {
+        rootView.embedSubview(it)
+    }
     private var mediator: ComposeSceneMediator? = null
     private val windowContext = PlatformWindowContext()
     private var layers: UIKitComposeSceneLayersHolder? = null
@@ -278,6 +283,7 @@ internal class ComposeHostingViewController(
                 mediator?.render(canvas.asComposeCanvas(), nanoTime)
             }
         )
+        rootView.updateMetalView(metalView, ::onDidMoveToWindow)
         metalView.canBeOpaque = configuration.opaque
 
         val layers = UIKitComposeSceneLayersHolder(windowContext, configuration.parallelRendering)
@@ -286,6 +292,7 @@ internal class ComposeHostingViewController(
 
         mediator = ComposeSceneMediator(
             parentView = rootView,
+            interopContainerView = interopContainerView,
             onFocusBehavior = configuration.onFocusBehavior,
             focusStack = focusStack,
             windowContext = windowContext,
@@ -308,7 +315,6 @@ internal class ComposeHostingViewController(
             }
         }
 
-        rootView.updateMetalView(metalView, ::onDidMoveToWindow)
         onAccessibilityChanged()
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -267,7 +267,7 @@ internal class ComposeSceneMediator(
     /**
      * View wrapping the hierarchy managed by this Mediator.
      */
-    private val view = ComposeSceneMediatorView(
+    private val view = UIKitTransparentContainerView(
         onLayoutSubviews = ::updateLayout
     )
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -117,12 +117,12 @@ import platform.UIKit.UIView
 /**
  * iOS specific-implementation of [PlatformContext.SemanticsOwnerListener] used to track changes in [SemanticsOwner].
  *
- * @property rootView The UI container associated with the semantics owner.
+ * @property view The UI container associated with the semantics owner.
  * @property coroutineContext The coroutine context to use for handling semantics changes.
  * @property performEscape A lambda to delegate accessibility escape operation. Returns true if the escape was handled, false otherwise.
  */
 private class SemanticsOwnerListenerImpl(
-    private val rootView: UIView,
+    private val view: UIView,
     private val coroutineContext: CoroutineContext,
     private val performEscape: () -> Boolean,
     private val onKeyboardPresses: (Set<*>) -> Unit,
@@ -140,7 +140,7 @@ private class SemanticsOwnerListenerImpl(
     override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
         if (accessibilityMediator == null) {
             accessibilityMediator = AccessibilityMediator(
-                rootView,
+                view,
                 semanticsOwner,
                 coroutineContext,
                 performEscape,
@@ -182,6 +182,7 @@ private class SemanticsOwnerListenerImpl(
 
 internal class ComposeSceneMediator(
     parentView: UIView,
+    interopContainerView: UIView,
     private val onFocusBehavior: OnFocusBehavior,
     private val focusStack: FocusStack?,
     private val windowContext: PlatformWindowContext,
@@ -309,7 +310,7 @@ internal class ComposeSceneMediator(
 
     private val semanticsOwnerListener by lazy {
         SemanticsOwnerListenerImpl(
-            rootView = parentView,
+            view = view,
             coroutineContext = coroutineContext,
             performEscape = {
                 val down = onKeyboardEvent(KeyEvent(Key.Escape, KeyEventType.KeyDown))
@@ -342,7 +343,7 @@ internal class ComposeSceneMediator(
                 setNeedsRedraw()
                 CATransaction.flush() // clear all animations
             },
-            rootView = view,
+            view = view,
             viewConfiguration = viewConfiguration,
             focusStack = focusStack,
             onInputStarted = {
@@ -507,7 +508,7 @@ internal class ComposeSceneMediator(
 
     init {
         parentView.embedSubview(view)
-        view.embedSubview(userInputView)
+        interopContainerView.embedSubview(userInputView)
     }
 
     private var lastFocusedRect: Rect? = null
@@ -736,6 +737,11 @@ internal class ComposeSceneMediator(
                     launch {
                         request.textLayoutResult.collect {
                             textInputService.updateTextLayoutResult(it)
+                        }
+                    }
+                    launch {
+                        request.textFieldRectInRoot.collect {
+                            textInputService.updateTextFrame(it)
                         }
                     }
                     suspendCancellableCoroutine<Nothing> { continuation ->

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.window.MetalView
 import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGPoint
-import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 
 internal class UIKitComposeSceneLayer(
@@ -77,7 +76,7 @@ internal class UIKitComposeSceneLayer(
         isInterceptingOutsideEvents = { focusable }
     )
 
-    val interopContainerView = UIView()
+    val interopContainerView = UIKitTransparentContainerView()
 
     private val backGestureDispatcher = UIKitBackGestureDispatcher(
         density = view.density,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.window.MetalView
 import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGPoint
+import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 
 internal class UIKitComposeSceneLayer(
@@ -76,6 +77,8 @@ internal class UIKitComposeSceneLayer(
         isInterceptingOutsideEvents = { focusable }
     )
 
+    val interopContainerView = UIView()
+
     private val backGestureDispatcher = UIKitBackGestureDispatcher(
         density = view.density,
         getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
@@ -83,6 +86,7 @@ internal class UIKitComposeSceneLayer(
 
     private val mediator = ComposeSceneMediator(
         parentView = view,
+        interopContainerView = interopContainerView,
         onFocusBehavior = onFocusBehavior,
         focusStack = focusStack,
         windowContext = windowContext,
@@ -159,6 +163,7 @@ internal class UIKitComposeSceneLayer(
         mediator.dispose()
         view.removeFromSuperview()
         view.dispose()
+        interopContainerView.removeFromSuperview()
     }
 
     @Composable

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
@@ -117,7 +117,7 @@ internal class UIKitComposeSceneLayerView(
             }
         }
 
-        return result
+        return null
     }
 
     fun dispose() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -122,8 +122,8 @@ internal class UIKitComposeSceneLayersHolder(
         val isFirstLayer = layers.isEmpty()
 
         layers.add(layer)
+        view.insertSubview(layer.interopContainerView, belowSubview = metalView)
         view.embedSubview(layer.view)
-        view.bringSubviewToFront(metalView)
 
         if (isFirstLayer) {
             // The content of previous layers drawn on the Metal view should be cleared and

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.scene
 
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.platform.PlatformWindowContext
+import androidx.compose.ui.uikit.addLayoutConstraintsToMatch
 import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.viewinterop.UIKitInteropTransaction
@@ -123,6 +124,7 @@ internal class UIKitComposeSceneLayersHolder(
 
         layers.add(layer)
         view.insertSubview(layer.interopContainerView, belowSubview = metalView)
+        layer.interopContainerView.addLayoutConstraintsToMatch(view)
         view.embedSubview(layer.view)
 
         if (isFirstLayer) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitTransparentContainerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitTransparentContainerView.kt
@@ -24,8 +24,8 @@ import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIEvent
 import platform.UIKit.UIView
 
-internal class ComposeSceneMediatorView(
-    var onLayoutSubviews: () -> Unit
+internal class UIKitTransparentContainerView(
+    var onLayoutSubviews: () -> Unit = {}
 ) : UIView(CGRectZero.readValue()) {
     private var onAppeared: (() -> Unit)? = null
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/LayoutConstraints.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/LayoutConstraints.uikit.kt
@@ -16,50 +16,22 @@
 
 package androidx.compose.ui.uikit
 
-import kotlinx.cinterop.CValue
-import kotlinx.cinterop.useContents
-import platform.CoreGraphics.CGSize
 import platform.UIKit.NSLayoutConstraint
 import platform.UIKit.UIView
 
-internal fun UIView.embedSubview(subview: UIView): List<NSLayoutConstraint> {
+internal fun UIView.embedSubview(subview: UIView) {
     addSubview(subview)
-    subview.translatesAutoresizingMaskIntoConstraints = false
-    return subview.layoutConstraintsToMatch(this).also {
-        NSLayoutConstraint.activateConstraints(it)
-    }
+    subview.addLayoutConstraintsToMatch(this)
 }
 
-internal fun UIView.layoutConstraintsToMatch(other: UIView) =
+internal fun UIView.addLayoutConstraintsToMatch(other: UIView) {
+    translatesAutoresizingMaskIntoConstraints = false
     listOf(
         leftAnchor.constraintEqualToAnchor(other.leftAnchor),
         rightAnchor.constraintEqualToAnchor(other.rightAnchor),
         topAnchor.constraintEqualToAnchor(other.topAnchor),
         bottomAnchor.constraintEqualToAnchor(other.bottomAnchor)
-    )
-
-internal fun UIView.layoutConstraintsToCenterInParent(parent: UIView, size: CValue<CGSize>) =
-    size.useContents {
-        listOf(
-            centerXAnchor.constraintEqualToAnchor(parent.centerXAnchor),
-            centerYAnchor.constraintEqualToAnchor(parent.centerYAnchor),
-            widthAnchor.constraintEqualToConstant(width),
-            heightAnchor.constraintEqualToConstant(height)
-        )
-    }
-
-/**
- * A box for a list of constraints which deactivates the old constraints and activates the new ones
- * when new value is set.
- */
-internal class ExclusiveLayoutConstraints {
-    private var constraints: List<NSLayoutConstraint> = emptyList()
-
-    fun set(value: List<NSLayoutConstraint>) {
-        if (constraints.isNotEmpty()) {
-            NSLayoutConstraint.deactivateConstraints(constraints)
-        }
-        constraints = value
-        NSLayoutConstraint.activateConstraints(constraints)
+    ).also {
+        NSLayoutConstraint.activateConstraints(it)
     }
 }


### PR DESCRIPTION
Support keyboard focus for text fields.
Align IntermediateTextInputUIView frame with the TextField bounds.
Reorder view hierarchy inside ComposeHostingViewController to place accessibility container view on top of MetalView.

Fixes https://youtrack.jetbrains.com/issue/CMP-7556/Support-text-input-for-Full-Keyboard-access

## Release Notes
### Features - iOS
- Support text input when Full Keyboard Access is enabled