### PR TITLE
Revert "Pin lifecycle dependencies to 2.8 in compose/ui"

### DIFF
--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -46,7 +46,7 @@ kotlin {
                 implementation(project(":annotation:annotation"))
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
             }
         }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -175,10 +175,12 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
                 implementation(project(":compose:ui:ui-backhandler"))
-                api("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4")
+
+                // TODO(igor): figure out how to avoid downgrading runtime to 1.6 in case of project dependencies in mpp demo + pinned lifecycle here
+                implementation(project(":lifecycle:lifecycle-common"))
+                implementation(project(":lifecycle:lifecycle-runtime"))
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel"))
             }
 
             androidMain.dependencies {


### PR DESCRIPTION
Reverts JetBrains/compose-multiplatform-core#1912

It fails the full pipeline. The fix is WIP in https://youtrack.jetbrains.com/issue/CMP-7761/1.8.0dev2186-doesnt-work-with-JPS-and-Maven

## Release Notes
N/A