### PR TITLE
Match Composable actual uikit API with expected one

### DIFF
--- a/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
+++ b/compose/foundation/foundation-layout/src/uikitMain/kotlin/androidx/compose/foundation/layout/WindowInsets.uikit.kt
@@ -131,7 +131,9 @@ actual val WindowInsets.Companion.tappableElement: WindowInsets
  * The insets for the curved areas in a waterfall display.
  * It is useless for iOS.
  */
-actual val WindowInsets.Companion.waterfall: WindowInsets get() = ZeroInsets
+actual val WindowInsets.Companion.waterfall: WindowInsets
+    @Composable
+    get() = ZeroInsets
 
 /**
  * The insets that include areas where content may be covered by other drawn content.


### PR DESCRIPTION
Add Composable annotation to the `WindowInsets.Companion.waterfall` getter to match the expected API

## Release Notes
### Breaking Changes - iOS
- Add Composable annotation to the `WindowInsets.Companion.waterfall` getter to match the expected API