### PR TITLE
Fix popup platform insets

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -444,7 +444,6 @@ private fun PopupLayout(
     content: @Composable () -> Unit
 ) {
     val currentContent by rememberUpdatedState(content)
-    val platformInsets = properties.platformInsets
     var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
     EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
     val layer = rememberComposeSceneLayer(
@@ -453,6 +452,7 @@ private fun PopupLayout(
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     layer.Content {
+        val platformInsets = properties.platformInsets
         val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@Content
         val containerSize = LocalWindowInfo.current.containerSize
         val layoutDirection = LocalLayoutDirection.current


### PR DESCRIPTION
Use popup platform insets provided by the current layer instead of the insets provided by the root or parent compose scene.
Align the `usePlatformInsets` behavior with Dialog.

Fixes https://youtrack.jetbrains.com/issue/CMP-6555

## Release Notes
### Fixes - iOS
- Fix popup safe drawing padding when `usePlatformInsets = true`.