### PR TITLE
Redraw compose scene on appearance

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -216,7 +216,7 @@ internal class ComposeSceneMediator(
 
     private val scene: ComposeScene by lazy {
         composeSceneFactory(
-            ::setNeedsRedraw,
+            redrawer::setNeedsRedraw,
             PlatformContextImpl()
         )
     }
@@ -289,7 +289,7 @@ internal class ComposeSceneMediator(
      */
     private val interopContainer = UIKitInteropContainer(
         root = userInputView,
-        requestRedraw = ::setNeedsRedraw
+        requestRedraw = redrawer::setNeedsRedraw
     )
 
     var interactionBounds = IntRect.Zero
@@ -339,7 +339,7 @@ internal class ComposeSceneMediator(
     private val textInputService: UIKitTextInputService by lazy {
         UIKitTextInputService(
             updateView = {
-                setNeedsRedraw()
+                redrawer.setNeedsRedraw()
                 CATransaction.flush() // clear all animations
             },
             rootView = view,
@@ -630,10 +630,6 @@ internal class ComposeSceneMediator(
         semanticsOwnerListener.dispose()
     }
 
-    private fun setNeedsRedraw() {
-        redrawer.setNeedsRedraw()
-    }
-
     /**
      * Updates the [ComposeScene] with the properties derived from the [view].
      */
@@ -656,6 +652,7 @@ internal class ComposeSceneMediator(
     }
 
     fun sceneDidAppear() {
+        redrawer.setNeedsRedraw()
         keyboardManager.start()
     }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/agiles/153-4000/current?issue=CMP-7265

## Release Notes
### Fixes - iOS
- Fix an issue where Compose would retain the old state when its view was reappeared.