### PR TITLE
Fix POM when there is dependency on an artifact with redirection

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
@@ -234,7 +234,6 @@ internal fun Project.originalToRedirectedDependency(
         .orEmpty()
         .associateBy { DefaultModuleIdentifier.newId(it.moduleGroup, it.moduleName) }
         .mapValuesNotNull { it.value.findRedirectedDependencyHeuristically()?.module?.id }
-//configurations.filter { it.name.contains("mingw") }.mapNotNull { try { it.name to it.resolvedConfiguration } catch (e: Exception) { null } }
 
     return projectDefined + externalWithHeuristic
 }

--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetbrainsAndroidXRedirectingPublicationHelpers.kt
@@ -16,22 +16,27 @@
 
 package androidx.build.jetbrains
 
+import androidx.build.getProjectsMap
+import com.android.utils.mapValuesNotNull
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
-import org.gradle.api.attributes.Usage
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.capabilities.Capability
 import org.gradle.api.component.ComponentWithCoordinates
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.component.SoftwareComponent
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.publish.maven.MavenPublication
@@ -150,4 +155,86 @@ internal class CustomRootComponent(
             )
         )
     }
+}
+
+internal fun Project.originalToRedirectedDependency(
+    componentName: String
+): Map<ModuleIdentifier, ModuleVersionIdentifier> {
+    /**
+     * Find a redirect to another group and version.
+     *
+     * Use heuristic method that compares modules names. Example:
+     *   [first-level-dependency] org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4 ->
+     *   [artifact-with-the-same-name] androidx.lifecycle:lifecycle-runtime:2.8.5 ->
+     *   [artifact-with-the-same-name-plus-suffix] androidx.lifecycle:lifecycle-runtime-desktop:2.8.5
+     *
+     * The first dependency redirects to the last one.
+     */
+    fun ResolvedDependency.findRedirectedDependencyHeuristically() =
+        children
+            .find { it.moduleName == moduleName }
+            ?.children
+            // don't check `it.moduleName == "moduleName-$target"` here,
+            // as it can be resolved to any other suitable target
+            // (for example, to jvm, or any other custom)
+            ?.find { it.moduleName.startsWith(moduleName) }
+
+    /**
+     * Extract redirections from project configuration
+     *
+     * Example for compose:ui
+     * org.jetbrains.androidx.performance:performance-annotation-iosarm64=androidx.performance:performance-annotation-iosarm64:1.0.0-alpha01
+     * org.jetbrains.androidx.performance:performance-annotation-jvm=androidx.performance:performance-annotation-jvm:1.0.0-alpha01
+     * org.jetbrains.compose.annotation-internal:annotation-jvm=androidx.annotation:annotation-jvm:1.9.1
+     * org.jetbrains.compose.collection-internal:collection-jvm=androidx.collection:collection-jvm:1.5.0-beta01
+     * ...
+     */
+    val projectDefined =
+        getProjectsMap()
+            .values
+            .mapNotNull { project.findProject(it) }
+            .flatMap { project ->
+                val redirecting = project.artifactRedirecting()
+                redirecting.targetNames.filter { it.isNotEmpty() }.map {
+                    val group = project.group.toString()
+                    val name = project.name.toString()
+                    val target = it
+                    val original = DefaultModuleIdentifier.newId(group, "$name-$target")
+                    val redirected = DefaultModuleVersionIdentifier.newId(
+                        redirecting.groupId,
+                        "$name-$target",
+                        redirecting.versionForTargetOrDefault(target)
+                    )
+                    original to redirected
+                }
+            }
+            .associate { it }
+
+    fun mainConfiguration() =
+        configurations.find { it.name == "${componentName}RuntimeClasspath" } ?:
+        configurations.find { it.name == "${componentName}CompileKlibraries" }!!
+
+    /**
+     * Extract redirections for dependencies using heuristic method (for both project, and external)
+     *
+     * Example for compose:ui
+     * org.jetbrains.compose.annotation-internal:annotation=androidx.annotation:annotation-jvm:1.9.1
+     * org.jetbrains.compose.collection-internal:collection=androidx.collection:collection-jvm:1.5.0-beta02
+     * org.jetbrains.androidx.lifecycle:lifecycle-common=androidx.lifecycle:lifecycle-common-jvm:2.8.5
+     * org.jetbrains.androidx.lifecycle:lifecycle-runtime=androidx.lifecycle:lifecycle-runtime-desktop:2.8.5
+     * org.jetbrains.androidx.lifecycle:lifecycle-viewmodel=androidx.lifecycle:lifecycle-viewmodel-desktop:2.8.5
+     *
+     * It is workaround for
+     * https://youtrack.jetbrains.com/issue/CMP-7764/Redirection-of-artifacts-breaks-poms-for-multiplatform-libraries-that-use-them
+     * After it is resolved, externalWithHeuristic shouldn't be needed.
+     */
+    val externalWithHeuristic = mainConfiguration()
+        .resolvedConfiguration
+        .firstLevelModuleDependencies
+        .orEmpty()
+        .associateBy { DefaultModuleIdentifier.newId(it.moduleGroup, it.moduleName) }
+        .mapValuesNotNull { it.value.findRedirectedDependencyHeuristically()?.module?.id }
+//configurations.filter { it.name.contains("mingw") }.mapNotNull { try { it.name to it.resolvedConfiguration } catch (e: Exception) { null } }
+
+    return projectDefined + externalWithHeuristic
 }

--- a/buildSrc/public/src/main/kotlin/androidx/build/jetbrains/ArtifactRedirecting.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/jetbrains/ArtifactRedirecting.kt
@@ -22,7 +22,11 @@ data class ArtifactRedirecting(
     val groupId: String,
     val defaultVersion: String,
     val targetNames: Set<String>,
-    val targetVersions: Map<String, String>
+
+    /**
+     * Versions for specific targets. If not specified, [defaultVersion] is used.
+     */
+    val targetVersions: Map<String, String> = emptyMap()
 ) {
     fun versionForTargetOrDefault(target: String): String {
         return targetVersions[target.lowercase()] ?: defaultVersion


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7761/1.8.0dev2186-doesnt-work-with-JPS-and-Maven

The issue was that `pom` points to a root artifact, not to `-desktop` artifact. :
```
    <dependency>
      <groupId>org.jetbrains.androidx.lifecycle</groupId>
      <artifactId>lifecycle-runtime</artifactId>
      <version>2.8.4</version>
      <scope>runtime</scope>
    </dependency>
```

It is broken because lifecycle-runtime has a redirection, and KGP can't handle it properly.

We already had the fix for `project` dependencies in https://github.com/JetBrains/compose-multiplatform-core/pull/1171, but the issue also exist if we depend on an already published library. In this PR, we apply the fix for such libraries. 

To dermine redirection, we use some heuristic by comparing module names. If we encounter this
```
[first-level-dependency] org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4 ->
[artifact-with-the-same-name] androidx.lifecycle:lifecycle-runtime:2.8.5 ->
[artifact-with-the-same-name-plus-suffix] androidx.lifecycle:lifecycle-runtime-desktop:2.8.5
```
it means there is a redirection. If it was determined wrongly, integration tests should fail.

## Testing

### Method 1
1. Perform `./gradlew publishComposeJbToMavenLocal`
2. `mvn install exec:java -Dexec.mainClass="MainKt" -Dkotlin.version=2.1.0 -Dcompose.version=9999.0.0-SNAPSHOT` in https://github.com/JetBrains/compose-multiplatform/tree/master/ci/templates/maven-test-project works

### Method 2
1. Perform `gradlew publishComposeJbToMavenLocal -Pcompose.platforms=all` for the state before the fix and after the fix
2. See the diff for [~/.m2/repository/org/jetbrains](https://github.com/JetBrains/compose-multiplatform-core/commit/ab4561c91a3c9f64c5985a5e4539c937e2edf3ad). Only pinned dependencies should change

## Release Notes
N/A