### PR TITLE
Fix non-interactive UI after interop view tap

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -281,10 +281,16 @@ private class TouchesGestureRecognizer(
         }
     }
 
+    private val activeGestureStates = listOf(
+        UIGestureRecognizerStatePossible,
+        UIGestureRecognizerStateBegan,
+        UIGestureRecognizerStateChanged
+    )
     override fun shouldRequireFailureOfGestureRecognizer(
         otherGestureRecognizer: UIGestureRecognizer
     ): Boolean {
-        return (otherGestureRecognizer is UIKitBackGestureRecognizer) ||
+        return (otherGestureRecognizer is UIKitBackGestureRecognizer &&
+            otherGestureRecognizer.state in activeGestureStates) ||
             super.shouldRequireFailureOfGestureRecognizer(otherGestureRecognizer)
     }
 


### PR DESCRIPTION
Update condition for touches gesture handler when cancelling it.

Fixes https://youtrack.jetbrains.com/issue/CMP-7632

## Release Notes
### Fixes - iOS
-  _(prerelease fix)_ Fix non-interactive UI after interop view tap