### PR TITLE
Update androidx.collection version to 1.5.0

### DIFF
--- a/collection/collection-compatibility-stub/build.gradle
+++ b/collection/collection-compatibility-stub/build.gradle
@@ -66,7 +66,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                api("androidx.collection:collection:1.5.0-beta02")
+                api("androidx.collection:collection:1.5.0")
             }
         }
 


### PR DESCRIPTION
androidx.collection 1.5.0 is already available - https://maven.google.com/web/index.html?q=collect#androidx.collection:collection:1.5.0


Closes https://youtrack.jetbrains.com/issue/CMP-7742, also closes https://youtrack.jetbrains.com/issue/CMP-7570


## Release Notes
N/A