### PR TITLE
Fix freeze when scrolling is cancelled during overscroll

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -485,6 +485,7 @@ private class CupertinoOverscrollNode(
                 pointersDown++
             } else if (pointerEvent.type == PointerEventType.Release) {
                 pointersDown--
+                assert(pointersDown >= 0) { "pointersDown cannot be negative" }
             }
         }
     }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -33,6 +33,9 @@ import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.drawscope.clipRect
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
@@ -40,6 +43,7 @@ import androidx.compose.ui.node.DelegatableNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
 import androidx.compose.ui.node.LayoutModifierNode
+import androidx.compose.ui.node.PointerInputModifierNode
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -126,12 +130,18 @@ internal class CupertinoOverscrollEffect(
      * It will be mapped to the actual visible offset using the rubber banding rule inside
      * [Modifier.offset] within [effectModifier]
      */
-    private var overscrollOffset: Offset by mutableStateOf(Offset.Zero)
+    private var overscrollOffsetState = mutableStateOf(Offset.Zero)
+    private var overscrollOffset: Offset
+        get () = overscrollOffsetState.value
+        set(value) {
+            overscrollOffsetState.value = value
+            drawCallScheduledByOffsetChange = true
+        }
+    private var drawCallScheduledByOffsetChange = true
 
     private var lastFlingUnconsumedDelta: Offset = Offset.Zero
     private val visibleOverscrollOffset: IntOffset
-        get() =
-            overscrollOffset.reverseHorizontalIfNeeded().rubberBanded().round()
+        get() = overscrollOffsetState.value.reverseHorizontalIfNeeded().rubberBanded().round()
 
     override val isInProgress: Boolean
         get() =
@@ -139,11 +149,23 @@ internal class CupertinoOverscrollEffect(
             // this effect is considered to be in progress
             visibleOverscrollOffset.toOffset().getDistance() > 0.5f
 
-    override val node: DelegatableNode = CupertinoOverscrollNode(
+    private val overscrollNode = CupertinoOverscrollNode(
         offset = { visibleOverscrollOffset },
         onNodeRemeasured = { scrollSize = it.toSize() },
+        onDraw = ::onDraw,
         applyClip = applyClip
     )
+    override val node: DelegatableNode get() = overscrollNode
+
+    private fun onDraw() {
+        // Fix an issue where scrolling was cancelled but the overscroll effect was not completed.
+        // Reset the overscroll effect when no ongoing animation or interaction is applied.
+        if (!drawCallScheduledByOffsetChange && isInProgress && overscrollNode.pointersDown == 0) {
+            overscrollOffsetState.value = Offset.Zero
+        }
+
+        drawCallScheduledByOffsetChange = false
+    }
 
     private fun NestedScrollSource.toCupertinoScrollSource(): CupertinoScrollSource? =
         when (this) {
@@ -442,11 +464,37 @@ internal class CupertinoOverscrollEffect(
 private class CupertinoOverscrollNode(
     val offset: Density.() -> IntOffset,
     val onNodeRemeasured: (IntSize) -> Unit,
+    val onDraw: () -> Unit,
     val applyClip: Boolean
-): LayoutModifierNode, LayoutAwareModifierNode, DrawModifierNode, Modifier.Node() {
+) : Modifier.Node(),
+    LayoutModifierNode,
+    LayoutAwareModifierNode,
+    DrawModifierNode,
+    PointerInputModifierNode {
     override fun onRemeasured(size: IntSize) = onNodeRemeasured(size)
 
+    var pointersDown by mutableStateOf(0)
+
+    override fun onPointerEvent(
+        pointerEvent: PointerEvent,
+        pass: PointerEventPass,
+        bounds: IntSize
+    ) {
+        if (pass == PointerEventPass.Final) {
+            if (pointerEvent.type == PointerEventType.Press) {
+                pointersDown++
+            } else if (pointerEvent.type == PointerEventType.Release) {
+                pointersDown--
+            }
+        }
+    }
+
+    override fun onCancelPointerInput() {
+        pointersDown = 0
+    }
+
     override fun ContentDrawScope.draw() {
+        onDraw()
         if (applyClip) {
             val bounds = Rect(-offset().toOffset(), size)
             val rect = size.toRect().intersect(bounds)
@@ -460,7 +508,6 @@ private class CupertinoOverscrollNode(
             this@draw.drawContent()
         }
     }
-
 
     override fun MeasureScope.measure(
         measurable: Measurable,


### PR DESCRIPTION
Reset the overscroll effect when no ongoing animation or interaction is applied.

Fixes https://youtrack.jetbrains.com/issue/CMP-7099/iOS-Content-in-a-scrollable-container-becomes-non-focusable-after-calling-focusManager.clearFocus

## Release Notes
### Fixes - iOS
- Fix freeze where scrolling was cancelled but the overscroll effect was not completed