### PR TITLE
Fix text menu opening after Select All

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -75,16 +75,12 @@ id _editInteraction;
                 self.isPossibleTouchDetected = NO;
             });
         } else {
-            if (self.isPossibleTouchDetected) {
+            if (self.isPossibleTouchDetected || contextMenuItemsChanged) {
+                [self hideEditMenu];
                 [self cancelPresentEditMenuInteraction];
                 [self schedulePresentEditMenuInteraction];
-            } else {
-                if (contextMenuItemsChanged) {
-                    [self.editInteraction reloadVisibleMenu];
-                }
-                if (positionChanged) {
-                    [self.editInteraction updateVisibleMenuPositionAnimated:NO];
-                }
+            } else if (positionChanged) {
+                [self.editInteraction updateVisibleMenuPositionAnimated:NO];
             }
         }
     } else {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-5692/Select-and-Select-All-context-menu-actions-dont-reopen-context-menu

## Release Notes
### Fixes - iOS
- Fix Text Menu opening after Select All action tap
