### PR TITLE
Fix overscroll animation freeze when pull-to-refresh is triggered

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -229,7 +229,7 @@ internal class CupertinoOverscrollEffect(
             }
 
             CupertinoScrollSource.FLING -> {
-                // If unconsumedDelta is not Zero, [CupertinoFlingEffect] will cancel fling and
+                // If unconsumedDelta is not Zero, [CupertinoOverscrollEffect] will cancel fling and
                 // start spring animation instead
                 lastFlingUnconsumedDelta = unconsumedDelta
                 delta - unconsumedDelta
@@ -260,8 +260,13 @@ internal class CupertinoOverscrollEffect(
         val velocityConsumedByFling = performFling(availableFlingVelocity)
         val postFlingVelocity = availableFlingVelocity - velocityConsumedByFling
 
+        val unconsumedDelta = lastFlingUnconsumedDelta.toFloat()
+        if (unconsumedDelta == 0f && overscrollOffset == Offset.Zero) {
+            return
+        }
+
         playSpringAnimation(
-            lastFlingUnconsumedDelta.toFloat(),
+            unconsumedDelta,
             postFlingVelocity.toFloat(),
             CupertinoSpringAnimationReason.POSSIBLE_SPRING_IN_THE_END
         )


### PR DESCRIPTION
Do not run spring animation when overscroll effect was interrupted by scroll effect.

Fixes https://youtrack.jetbrains.com/issue/CMP-6739/Overscroll-interfere-with-pull-to-refresh

## Release Notes
### Fixes - iOS
- Fix overscroll animation freeze when pull-to-refresh is triggered