### PR TITLE
Remove nodes with isClearingSemantics from accessibility tree

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1003,7 +1003,7 @@ internal class AccessibilityMediator(
             beforeBeyondBoundsChildren: ArrayList<SemanticsNode>,
             afterBeyondBoundsChildren: ArrayList<SemanticsNode>
         ) {
-            node.children.fastForEach { child ->
+            node.replacedChildren.fastForEach { child ->
                 if (child.isValid) {
                     if (nodes.contains(child.id)) {
                         semanticsChildren.add(child)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7767/iOS-Accessibility-cannot-leave-traversal-group-inside-LazyColumn

## Release Notes
### Fixes - iOS
- Remove focus on accessibility nodes with clearing semantics