### PR TITLE
Fix issues zero-duration compose scene resizing

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -65,6 +65,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.native.runtime.GC
 import kotlin.native.runtime.NativeRuntimeApi
 import kotlin.test.assertNotNull
+import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 import kotlinx.cinterop.BetaInteropApi
@@ -366,11 +367,13 @@ internal class ComposeHostingViewController(
     private fun animateSizeTransition(
         transitionCoordinator: UIViewControllerTransitionCoordinatorProtocol
     ) {
+        val duration = transitionCoordinator.transitionDuration.toDuration(DurationUnit.SECONDS)
+        if (duration == Duration.ZERO) return
+
         val displayLinkListener = DisplayLinkListener()
         val sizeTransitionScope = CoroutineScope(
             composeCoroutineContext + displayLinkListener.frameClock
         )
-        val duration = transitionCoordinator.transitionDuration.toDuration(DurationUnit.SECONDS)
         displayLinkListener.start()
 
         val animations = mediator?.prepareAndGetSizeTransitionAnimation()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
@@ -147,13 +147,13 @@ internal class ComposeView(
         scope.launch {
             try {
                 animations()
-            } finally {
-                // Delay mitigates rendering glitches that can occur at the end of the animation.
                 delay(50)
                 isAnimating = false
+            } finally {
+                // Delay mitigates rendering glitches that can occur at the end of the animation.
                 updateLayout()
-                metalView.redrawer.isForcedToPresentWithTransactionEveryFrame = true
-                metalView.redrawer.ongoingInteractionEventsCount++
+                metalView.redrawer.isForcedToPresentWithTransactionEveryFrame = false
+                metalView.redrawer.ongoingInteractionEventsCount--
             }
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
@@ -22,7 +22,6 @@ import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectEqualToRect
@@ -147,11 +146,10 @@ internal class ComposeView(
         scope.launch {
             try {
                 animations()
-                delay(50)
-                isAnimating = false
             } finally {
-                // Delay mitigates rendering glitches that can occur at the end of the animation.
+                isAnimating = false
                 updateLayout()
+                metalView.layoutIfNeeded()
                 metalView.redrawer.isForcedToPresentWithTransactionEveryFrame = false
                 metalView.redrawer.ongoingInteractionEventsCount--
             }


### PR DESCRIPTION
Fix issue where coroutine with cancels too early when animation duration is zero.
Move the delay to the `try` block to allow the `finally` block to be executed when the coroutine is cancelled.

Fixes https://youtrack.jetbrains.com/issue/CMP-7221/iOS-displayCutuotPadding-doesnt-apply-after-opening-the-app-in-landscape-portrait-mode-on-initialization
Fixes https://youtrack.jetbrains.com/issue/CMP-7830/iOS-Gesture-System-gesture-gate-timed-out
Fixes https://youtrack.jetbrains.com/issue/CMP-7378/Dialog-layer-is-not-rendered-if-switched-for-several-times-in-iOS-14

## Release Notes
### Fixes - iOS
- Fix issue where root compose canvas does not resize without animation
- Fix issue where dialog layer may not be shown
