### PR TITLE
Fix all `Int.subtractConstraintSafely` methods to `coerceAtLeast(0)`

### DIFF
--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/OutlinedTextField.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/OutlinedTextField.kt
@@ -966,7 +966,7 @@ private class OutlinedTextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == LeadingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -976,7 +976,7 @@ private class OutlinedTextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == TrailingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -1008,11 +1008,11 @@ private class OutlinedTextFieldMeasurePolicy(
     }
 }
 
-private fun Int.substractConstraintSafely(from: Int): Int {
+private fun Int.subtractConstraintSafely(other: Int): Int {
     if (this == Constraints.Infinity) {
         return this
     }
-    return this - from
+    return (this - other).coerceAtLeast(0)
 }
 
 /**

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/TextField.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/TextField.kt
@@ -914,7 +914,7 @@ private class TextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == LeadingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -924,7 +924,7 @@ private class TextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == TrailingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -956,11 +956,11 @@ private class TextFieldMeasurePolicy(
     }
 }
 
-private fun Int.substractConstraintSafely(from: Int): Int {
+private fun Int.subtractConstraintSafely(other: Int): Int {
     if (this == Constraints.Infinity) {
         return this
     }
-    return this - from
+    return (this - other).coerceAtLeast(0)
 }
 
 private fun calculateWidth(

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ListItem.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ListItem.kt
@@ -721,9 +721,9 @@ private fun verticalPadding(listItemType: ListItemType): Dp =
         else -> ListItemVerticalPadding
     }
 
-private fun Int.subtractConstraintSafely(n: Int): Int {
+private fun Int.subtractConstraintSafely(other: Int): Int {
     if (this == Constraints.Infinity) {
         return this
     }
-    return this - n
+    return (this - other).coerceAtLeast(0)
 }

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/OutlinedTextField.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/OutlinedTextField.kt
@@ -854,7 +854,7 @@ private class OutlinedTextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == LeadingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -864,7 +864,7 @@ private class OutlinedTextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == TrailingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -881,7 +881,7 @@ private class OutlinedTextFieldMeasurePolicy(
                 ?.let {
                     val height = intrinsicMeasurer(it, remainingWidth)
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     height
@@ -892,7 +892,7 @@ private class OutlinedTextFieldMeasurePolicy(
                 ?.let {
                     val height = intrinsicMeasurer(it, remainingWidth)
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     height
@@ -928,11 +928,11 @@ private class OutlinedTextFieldMeasurePolicy(
     }
 }
 
-private fun Int.substractConstraintSafely(from: Int): Int {
+private fun Int.subtractConstraintSafely(other: Int): Int {
     if (this == Constraints.Infinity) {
         return this
     }
-    return this - from
+    return (this - other).coerceAtLeast(0)
 }
 
 /**

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TextField.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TextField.kt
@@ -838,7 +838,7 @@ private class TextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == LeadingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -848,7 +848,7 @@ private class TextFieldMeasurePolicy(
                 .fastFirstOrNull { it.layoutId == TrailingId }
                 ?.let {
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     intrinsicMeasurer(it, width)
@@ -864,7 +864,7 @@ private class TextFieldMeasurePolicy(
                 ?.let {
                     val height = intrinsicMeasurer(it, remainingWidth)
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     height
@@ -875,7 +875,7 @@ private class TextFieldMeasurePolicy(
                 ?.let {
                     val height = intrinsicMeasurer(it, remainingWidth)
                     remainingWidth =
-                        remainingWidth.substractConstraintSafely(
+                        remainingWidth.subtractConstraintSafely(
                             it.maxIntrinsicWidth(Constraints.Infinity)
                         )
                     height
@@ -910,11 +910,11 @@ private class TextFieldMeasurePolicy(
     }
 }
 
-private fun Int.substractConstraintSafely(from: Int): Int {
+private fun Int.subtractConstraintSafely(other: Int): Int {
     if (this == Constraints.Infinity) {
         return this
     }
-    return this - from
+    return (this - other).coerceAtLeast(0)
 }
 
 private fun calculateWidth(


### PR DESCRIPTION
Fix all `Int.subtractConstraintSafely` methods to apply `coerceAtLeast(0)` to result.

This has also been fixed upstream (https://android-review.googlesource.com/c/platform/frameworks/support/+/3463981 and https://android-review.googlesource.com/c/platform/frameworks/support/+/3527848), but it's not possible to cherry-pick these without creating merge conflicts down the line. So I've chosen to make the minimal fixes in `jb-main` instead.

Fixes https://youtrack.jetbrains.com/issue/CMP-6784/IllegalArgumentException-maxWidth-28-must-be-than-minWidth0

## Testing
Tests added in AOSP.

## Release Notes
### Fixes - Multiple Platforms
- Fixed `IllegalArgumentException: maxWidth(value) must be >= than minWidth(0)` crashes when a `TextField` with `trailingIcon` is too narrow.
