### PR TITLE
Update androidx.collection version to 1.5.0 (2)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -111,7 +111,7 @@ artifactRedirecting.androidx.compose.material3.common.version=1.0.0-alpha01
 # Look for `COMPOSE_MATERIAL3_ADAPTIVE` in libraryversions.toml
 artifactRedirecting.androidx.compose.material3.adaptive.version=1.1.0-beta01
 # We use artifactRedirecting not only for Compose libs:
-artifactRedirecting.androidx.collection.version=1.5.0-beta01
+artifactRedirecting.androidx.collection.version=1.5.0
 artifactRedirecting.androidx.annotation.version=1.9.1
 artifactRedirecting.androidx.graphics.version=1.0.1
 artifactRedirecting.androidx.lifecycle.version=2.9.0-alpha12


### PR DESCRIPTION
https://github.com/JetBrains/compose-multiplatform-core/pull/1927 doesn't work for `pom` files. We have these dependencies:
```
[INFO] +- org.jetbrains.compose.material3:material3-desktop:jar:9999.0.0-SNAPSHOT:compile
[INFO] |  +- androidx.collection:collection-jvm:jar:1.5.0-beta01:runtime
```

Because:
- material3 depends on `project(":collection:collection")`
- project dependencies are replaced by the redirecting artifact
- `pom` files [don't contain](https://youtrack.jetbrains.com/issue/CMP-7803/collection-compatibility-stub-annotation-compatibility-stub-arent-in-the-dependencies-in-pom-files) any transitive dependencies (comparing to Gradle)

## Testing
The check https://github.com/JetBrains/compose-multiplatform/pull/5258 doesn't fail

## Release Notes
N/A