### PR TITLE
Fix MetalView duplication when controller re-enters view hierarchy

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
@@ -73,6 +73,7 @@ internal class ComposeView(
         onLayoutSubviews: () -> Unit = {}
     ) {
         this.metalView?.dispose()
+        this.metalView?.removeFromSuperview()
         this.metalView = metalView
 
         this.onDidMoveToWindow = onDidMoveToWindow


### PR DESCRIPTION
## Release Notes
### Fixes - iOS
- Fix adding extra `MetalView` when Compose controller re-enters view hierarchy
