### PR TITLE
Depend on collection/annotation `project` instead of an artifact

### DIFF
--- a/collection/collection/build.gradle
+++ b/collection/collection/build.gradle
@@ -66,7 +66,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                implementation(project(":annotation:annotation"))
                 implementation(libs.atomicFu)
             }
         }

--- a/compose/material3/adaptive/adaptive-layout/build.gradle
+++ b/compose/material3/adaptive/adaptive-layout/build.gradle
@@ -66,7 +66,7 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.kotlinTest)
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
                 implementation(project(":kruth:kruth"))
             }
         }

--- a/compose/material3/material3-adaptive-navigation-suite/build.gradle
+++ b/compose/material3/material3-adaptive-navigation-suite/build.gradle
@@ -53,7 +53,7 @@ kotlin {
                 implementation(project(":compose:material3:adaptive:adaptive"))
                 implementation(project(":compose:ui:ui"))
                 implementation("org.jetbrains.androidx.window:window-core:1.3.1")
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
             }
         }
 

--- a/graphics/graphics-shapes/build.gradle
+++ b/graphics/graphics-shapes/build.gradle
@@ -70,8 +70,8 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(libs.kotlinStdlib)
-                implementation("org.jetbrains.compose.collection-internal:collection:1.7.1")
-                implementation("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                implementation(project(":collection:collection"))
+                implementation(project(":annotation:annotation"))
             }
         }
 

--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -52,7 +52,7 @@ androidXMultiplatform {
             dependencies {
                 api(libs.kotlinStdlib)
                 api(libs.kotlinCoroutinesCore)
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
             }
         }
 

--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -61,7 +61,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
                 implementation(project(":lifecycle:lifecycle-common"))
                 api project(":lifecycle:lifecycle-runtime")
                 api("org.jetbrains.compose.runtime:runtime:1.7.1")

--- a/lifecycle/lifecycle-runtime/build.gradle
+++ b/lifecycle/lifecycle-runtime/build.gradle
@@ -37,7 +37,7 @@ androidXMultiplatform {
             dependencies {
                 api(libs.kotlinStdlib)
                 api(project(":lifecycle:lifecycle-common"))
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
             }
         }
 

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -46,7 +46,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain {
             dependencies {
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
                 api(project(":savedstate:savedstate"))
                 api(project(":lifecycle:lifecycle-viewmodel"))
                 api(libs.kotlinStdlib)

--- a/lifecycle/lifecycle-viewmodel/build.gradle
+++ b/lifecycle/lifecycle-viewmodel/build.gradle
@@ -56,7 +56,7 @@ androidXMultiplatform {
 
         commonMain {
             dependencies {
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
                 api(libs.kotlinStdlib)
                 api(libs.kotlinCoroutinesCore)
             }

--- a/savedstate/savedstate/build.gradle
+++ b/savedstate/savedstate/build.gradle
@@ -31,7 +31,7 @@ androidXMultiplatform {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
                 api(projectOrArtifact(":lifecycle:lifecycle-common"))
                 api(libs.kotlinCoroutinesCore)
                 api(libs.kotlinSerializationCore)

--- a/window/window-core/build.gradle
+++ b/window/window-core/build.gradle
@@ -66,7 +66,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                api("org.jetbrains.compose.annotation-internal:annotation:1.7.1")
+                api(project(":annotation:annotation"))
             }
         }
 


### PR DESCRIPTION
1. `:graphics:graphics-shapes:compileKotlinLinuxX64` currently fails:
```
> Task :graphics:graphics-shapes:compileKotlinLinuxX64 FAILED
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/CornerRounding.kt:19:17 Unresolved reference 'annotation'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/CornerRounding.kt:53:6 Unresolved reference 'FloatRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/CornerRounding.kt:54:6 Unresolved reference 'FloatRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/PolygonMeasure.kt:19:17 Unresolved reference 'annotation'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/PolygonMeasure.kt:83:10 Unresolved reference 'FloatRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/PolygonMeasure.kt:84:10 Unresolved reference 'FloatRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/RoundedPolygon.kt:19:17 Unresolved reference 'annotation'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/RoundedPolygon.kt:283:6 Illegal annotation class 'IntRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/Shapes.kt:19:17 Unresolved reference 'annotation'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/Shapes.kt:20:17 Unresolved reference 'annotation'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/Shapes.kt:38:6 Illegal annotation class 'IntRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/Shapes.kt:273:6 Unresolved reference 'FloatRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/Shapes.kt:278:6 Unresolved reference 'FloatRange'.
e: file:///D:/Work/compose-multiplatform-core/graphics/graphics-shapes/src/commonMain/kotlin/androidx/graphics/shapes/Shapes.kt:279:6 Unresolved reference 'FloatRange'.
```
This task is called on `klibApiCheck` task (used in https://youtrack.jetbrains.com/issue/CMP-6675/Run-binary-compatibility-validator-for-iOS), even if there is a redirection (seems a bug in the redirected androidx.annotation:1.8.0, which is fixed in 1.8.2)

2. We need to exclude all dependencies on artifacts because someday it won't be compatible with `androidx`. If we start to depend on it now, 1.8.0 will be compatible at the moment we remove internal dependencies

## Testing
1. CI checks

2. `:graphics:graphics-shapes:compileKotlinLinuxX64` doesn't fail

## Release Notes
N/A