### PR TITLE
Fix the first layer appearance freeze

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -628,6 +628,7 @@ internal class ComposeSceneMediator(
         userInputView.dispose()
 
         view.removeFromSuperview()
+        userInputView.removeFromSuperview()
 
         scene.close()
         interopContainer.dispose()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -128,13 +128,7 @@ internal class UIKitComposeSceneLayersHolder(
         view.embedSubview(layer.view)
 
         if (isFirstLayer) {
-            // The content of previous layers drawn on the Metal view should be cleared and
-            // redrawn synchronously after the new layer is attached to avoid flickering.
-
-            metalView.setNeedsSynchronousDrawOnNextLayout()
-
             window?.embedSubview(view)
-            window?.layoutIfNeeded()
         }
 
         if (hasViewAppeared) {
@@ -157,6 +151,9 @@ internal class UIKitComposeSceneLayersHolder(
             view.removeFromSuperview()
 
             transaction.actions.fastForEach { it.invoke() }
+
+            // If the layers list is empty, the draw call will clear the canvas.
+            metalView.redrawer.draw(waitUntilCompletion = false)
         } else {
             // It wasn't the last layer, pending transactions should be added to the list
             removedLayersTransactions.add(transaction)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -285,12 +285,12 @@ internal class MetalRedrawer(
     /**
      * Immediately dispatch draw and block the thread until it's finished and presented on the screen.
      */
-    fun drawSynchronously() {
+    fun draw(waitUntilCompletion: Boolean) {
         if (caDisplayLink == null) {
             return
         }
 
-        draw(waitUntilCompletion = true, CACurrentMediaTime())
+        draw(waitUntilCompletion, CACurrentMediaTime())
     }
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalView.uikit.kt
@@ -124,7 +124,7 @@ internal class MetalView(
         }
 
         if (needsSynchronousDraw) {
-            redrawer.drawSynchronously()
+            redrawer.draw(waitUntilCompletion = true)
 
             needsSynchronousDraw = false
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/UserInputView.uikit.kt
@@ -59,6 +59,7 @@ import platform.UIKit.UIScrollTypeMaskAll
 import platform.UIKit.UIScrollView
 import platform.UIKit.UITouch
 import platform.UIKit.UIView
+import platform.UIKit.endEditing
 import platform.UIKit.setState
 
 /**
@@ -587,6 +588,7 @@ internal class UserInputView(
      * can be caused by implicit capture of the view by UIKit objects (such as UIEvent).
      */
     fun dispose() {
+        endEditing(force = true)
         removeGestureRecognizer(touchesGestureRecognizer)
         touchesGestureRecognizer.dispose()
         scrollGestureRecognizer?.let {


### PR DESCRIPTION
Fix issue when first layer appears with 1 second drawing freeze.
Attempt to mitigate `System gesture gate timed out` error when removing the last layer.

Fixes https://youtrack.jetbrains.com/issue/CMP-7830/iOS-Gesture-System-gesture-gate-timed-out

## Release Notes
### Fixes - iOS
- Fix the first layer appearance freeze
