### PR TITLE
Do not map-to-untransformed the selection and composition from EditProcessor

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -57,20 +57,18 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
             value = state.untransformedText.toTextFieldValue(),
             textInputSession = null
         )
-
         val newValue = editProcessor.apply(commands)
 
         state.replaceAll(newValue.text)
         state.editUntransformedTextAsUser {
-            val untransformedSelection = state.mapFromTransformed(newValue.selection)
-            setSelectionCoerced(untransformedSelection.start, untransformedSelection.end)
+            val selection = newValue.selection
+            setSelectionCoerced(selection.start, selection.end)
 
             val composition = newValue.composition
             if (composition == null) {
                 commitComposition()
             } else {
-                val untransformedComposition = state.mapFromTransformed(composition)
-                setComposition(untransformedComposition.start, untransformedComposition.end)
+                setComposition(composition.start, composition.end)
             }
         }
     }


### PR DESCRIPTION
In `PlatformTextInputSession.platformSpecificTextInputSession`, don't map-to-untransformed the selection and composition returned by the EditProcessor, as they are already untransformed.

## Testing
Tested manually with e.g.
```
TextField(
    state = rememberTextFieldState(),
    outputTransformation = {
        insert(0, "---")
    }
}
```

## Release Notes
N/A