### PR TITLE
Replace the text inside editUntransformedTextAsUser

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -59,11 +59,15 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         )
         val newValue = editProcessor.apply(commands)
 
-        state.replaceAll(newValue.text)
         state.editUntransformedTextAsUser {
+            // Update text
+            replace(0, length, newValue.text)
+
+            // Update selection
             val selection = newValue.selection
             setSelectionCoerced(selection.start, selection.end)
 
+            // Update composition
             val composition = newValue.composition
             if (composition == null) {
                 commitComposition()


### PR DESCRIPTION
Replace the text inside editUntransformedTextAsUser in onEditCommand (PlatformTextInputSession).

This is a minor change - it's just cleaner and makes the entire change in one (`TextFieldState`) commit, rather than two.

## Release Notes
N/A
