### PR TITLE
Add a flag to disable iOS back gesture detection

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -53,6 +53,7 @@ private const val BACK_GESTURE_VELOCITY = 100
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal class UIKitBackGestureDispatcher(
+    private val enableBackGesture: Boolean,
     density: Density,
     getTopLeftOffsetInWindow: () -> IntOffset
 ) : BackGestureDispatcher() {
@@ -83,16 +84,18 @@ internal class UIKitBackGestureDispatcher(
     }
 
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
-        if (window == null) {
-            removeGestureListeners()
-        } else {
-            var view: UIView = composeRootView
-            while (view.superview != window) {
-                view = requireNotNull(view.superview) {
-                    "Window is not null, but superview is null for ${view.debugDescription}"
+        if (enableBackGesture) {
+            if (window == null) {
+                removeGestureListeners()
+            } else {
+                var view: UIView = composeRootView
+                while (view.superview != window) {
+                    view = requireNotNull(view.superview) {
+                        "Window is not null, but superview is null for ${view.debugDescription}"
+                    }
                 }
+                addGestureListeners(view)
             }
-            addGestureListeners(view)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -121,6 +121,7 @@ internal class ComposeHostingViewController(
     )
 
     private val backGestureDispatcher = UIKitBackGestureDispatcher(
+        enableBackGesture = configuration.enableBackGesture,
         density = rootView.density,
         getTopLeftOffsetInWindow = { IntOffset.Zero } //full screen
     )
@@ -416,7 +417,8 @@ internal class ComposeHostingViewController(
                     focusStack = if (focusable) focusStack else null,
                     windowContext = windowContext,
                     compositionContext = compositionContext,
-                    coroutineContext = composeCoroutineContext
+                    coroutineContext = composeCoroutineContext,
+                    enableBackGesture = configuration.enableBackGesture,
                 )
 
                 attachLayer(layer)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -59,7 +59,8 @@ internal class UIKitComposeSceneLayer(
     focusStack: FocusStack?,
     windowContext: PlatformWindowContext,
     compositionContext: CompositionContext,
-    private val coroutineContext: CoroutineContext
+    private val coroutineContext: CoroutineContext,
+    private val enableBackGesture: Boolean,
 ) : ComposeSceneLayer {
 
     override var focusable: Boolean = focusStack != null
@@ -79,6 +80,7 @@ internal class UIKitComposeSceneLayer(
     val interopContainerView = UIKitTransparentContainerView()
 
     private val backGestureDispatcher = UIKitBackGestureDispatcher(
+        enableBackGesture = enableBackGesture,
         density = view.density,
         getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
     )

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -68,6 +68,12 @@ class ComposeUIViewControllerConfiguration {
      */
     @ExperimentalComposeUiApi
     var parallelRendering: Boolean = false
+
+    /**
+     * A flag to enable or disable iOS BackGesture recognizer.
+     */
+    @ExperimentalComposeApi
+    var enableBackGesture: Boolean = true
 }
 
 /**


### PR DESCRIPTION
On Android users can enable/disable the BackHandler via the Manifest: https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#opt-predictive

The difference is the flag is enabled by default in the Compose iOS.

Fixes [CMP-7842](https://youtrack.jetbrains.com/issue/CMP-7842)

## Release Notes
### Fixes - Navigation
- _(prerelease fix)_ Add a flag to disable iOS back gesture detection.