### PR TITLE
Fix input and deleting text in BTF2 with transformation on iOS

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -94,13 +94,8 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
     coroutineScope {
         val outputValueFlow = callbackFlow {
             state.collectImeNotifications { _, _, _ ->
-                /* This is required for iOS
-                *  This logic runs after any changes made in `onEditCommand` if any, ensuring the internal value
-                *  in UIKitTextInputService remains up-to-date and always sends a new position
-                *  which was changed by caret movement (tapping / long tapping).
-                *  Currently, iOS doesn't handle any touches directly, they handled on Compose side,
-                *  so it's necessary to forward selection changes explicitly (like BTF1 does in TextFieldDelegate.skiko.kt)
-                *  */
+                // SkikoPlatformTextInputMethodRequest should work with an untransformed text on all platforms
+                // This updates platform text input services after changing the state with latest value in onEditCommand
                 trySend(state.untransformedText.toTextFieldValue())
             }
         }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -95,11 +95,12 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         val outputValueFlow = callbackFlow {
             state.collectImeNotifications { _, _, _ ->
                 /* This is required for iOS
-                *  It allows to iOS text input to know about any selection changes made by tap / long tap
-                *  Currently, iOS doesn't handle touches, it made on Compose side, so it's necessary to forward
-                *  selection changes explicitly (like BTF1 does in TextFieldDelegate.skiko.kt)
-                *  Without this, iOS will send EditCommands using last-know position which was changed
-                *  by text edition, not caret movement
+                *  It allows the iOS text input to detect selection changes made by tapping / long tapping
+                *  Currently, iOS doesn't handle touches directly, they handled on Compose side,
+                *  so it's necessary to forward selection changes explicitly (like BTF1 does in TextFieldDelegate.skiko.kt).
+                *  This logic runs after any changes made in `onEditCommand` if any, ensuring the internal value
+                *  in UIKitTextInputService remains up-to-date and always sends a new position
+                *  which was changed by caret movement
                 *  */
                 trySend(state.untransformedText.toTextFieldValue())
             }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -93,8 +93,15 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
 
     coroutineScope {
         val outputValueFlow = callbackFlow {
-            state.collectImeNotifications { _, newValue, _ ->
-                trySend(newValue.toTextFieldValue())
+            state.collectImeNotifications { _, _, _ ->
+                /* This is required for iOS
+                *  It allows to iOS text input to know about any selection changes made by tap / long tap
+                *  Currently, iOS doesn't handle touches, it made on Compose side, so it's necessary to forward
+                *  selection changes explicitly (like BTF1 does in TextFieldDelegate.skiko.kt)
+                *  Without this, iOS will send EditCommands using last-know position which was changed
+                *  by text edition, not caret movement
+                *  */
+                trySend(state.untransformedText.toTextFieldValue())
             }
         }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -95,12 +95,11 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         val outputValueFlow = callbackFlow {
             state.collectImeNotifications { _, _, _ ->
                 /* This is required for iOS
-                *  It allows the iOS text input to detect selection changes made by tapping / long tapping
-                *  Currently, iOS doesn't handle touches directly, they handled on Compose side,
-                *  so it's necessary to forward selection changes explicitly (like BTF1 does in TextFieldDelegate.skiko.kt).
                 *  This logic runs after any changes made in `onEditCommand` if any, ensuring the internal value
                 *  in UIKitTextInputService remains up-to-date and always sends a new position
-                *  which was changed by caret movement
+                *  which was changed by caret movement (tapping / long tapping).
+                *  Currently, iOS doesn't handle any touches directly, they handled on Compose side,
+                *  so it's necessary to forward selection changes explicitly (like BTF1 does in TextFieldDelegate.skiko.kt)
                 *  */
                 trySend(state.untransformedText.toTextFieldValue())
             }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -298,6 +298,7 @@ internal class UIKitTextInputService(
         }
 
     private fun sendEditCommand(vararg commands: EditCommand) {
+        _tempCurrentInputSession?.apply(commands.toList())
         editCommandsBatch.addAll(commands)
         flushEditCommandsIfNeeded()
     }
@@ -308,9 +309,6 @@ internal class UIKitTextInputService(
             editCommandsBatch.clear()
 
             currentInput?.onEditCommand?.invoke(commandList)
-
-            val newValue = _tempCurrentInputSession?.toTextFieldValue() ?: return
-            updateState(oldValue = null, newValue = newValue)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -153,7 +153,9 @@ internal class UIKitTextInputService(
         onImeActionPerformed: (ImeAction) -> Unit
     ) {
         currentInput = CurrentInput(value, onEditCommand)
-        _tempCurrentInputSession = editProcessor
+        _tempCurrentInputSession = editProcessor?.apply {
+            reset(value, null)
+        }
         currentImeOptions = imeOptions
         currentImeActionHandler = onImeActionPerformed
 
@@ -296,7 +298,7 @@ internal class UIKitTextInputService(
         }
 
     private fun sendEditCommand(vararg commands: EditCommand) {
-        _tempCurrentInputSession?.apply(commands.toList())
+//        _tempCurrentInputSession?.apply(commands.toList()) // should be obsolete
 
         editCommandsBatch.addAll(commands)
         flushEditCommandsIfNeeded()
@@ -308,6 +310,9 @@ internal class UIKitTextInputService(
             editCommandsBatch.clear()
 
             currentInput?.onEditCommand?.invoke(commandList)
+
+            val newValue = _tempCurrentInputSession?.toTextFieldValue() ?: return
+            updateState(oldValue = null, newValue = newValue)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -153,7 +153,7 @@ internal class UIKitTextInputService(
         onImeActionPerformed: (ImeAction) -> Unit
     ) {
         currentInput = CurrentInput(value, onEditCommand)
-        _tempCurrentInputSession = editProcessor?.apply {
+        _tempCurrentInputSession = EditProcessor().apply {
             reset(value, null)
         }
         currentImeOptions = imeOptions

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -299,6 +299,7 @@ internal class UIKitTextInputService(
 
     private fun sendEditCommand(vararg commands: EditCommand) {
         _tempCurrentInputSession?.apply(commands.toList())
+
         editCommandsBatch.addAll(commands)
         flushEditCommandsIfNeeded()
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -298,8 +298,6 @@ internal class UIKitTextInputService(
         }
 
     private fun sendEditCommand(vararg commands: EditCommand) {
-//        _tempCurrentInputSession?.apply(commands.toList()) // should be obsolete
-
         editCommandsBatch.addAll(commands)
         flushEditCommandsIfNeeded()
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -736,6 +736,11 @@ internal class ComposeSceneMediator(
                 // TODO: Adopt PlatformTextInputService2 (https://youtrack.jetbrains.com/issue/CMP-7832/iOS-Adopt-PlatformTextInputService2)
                 coroutineScope {
                     launch {
+                        request.outputValue.collect {
+                            textInputService.updateState(oldValue = null, newValue = it)
+                        }
+                    }
+                    launch {
                         request.textLayoutResult.collect {
                             textInputService.updateTextLayoutResult(it)
                         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -736,11 +736,6 @@ internal class ComposeSceneMediator(
                 // TODO: Adopt PlatformTextInputService2 (https://youtrack.jetbrains.com/issue/CMP-7832/iOS-Adopt-PlatformTextInputService2)
                 coroutineScope {
                     launch {
-                        request.outputValue.collect {
-                            textInputService.updateState(oldValue = null, newValue = it)
-                        }
-                    }
-                    launch {
                         request.textLayoutResult.collect {
                             textInputService.updateTextLayoutResult(it)
                         }


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

Fixes: https://youtrack.jetbrains.com/issue/CMP-6633/iOS.-BTF2.-Output-transformation.-Insert-method-doesnt-move-caret-position

## Testing
Manual (see a related task)
This should be tested by QA

## Release Notes
### Fixes - iOS
Fixed text editing behavior (typing / deleting) in `BasicTextField(TextFieldState)` with applied `OutputTransformation`

