### PR TITLE
Fix `:mpp:publishComposeJb` fail

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -9,6 +9,11 @@ buildscript {
     }
 }
 
+// this module depends on all other modules info, so we need to initialize them first
+(rootProject.allprojects - project).forEach {
+    evaluationDependsOn(it.path)
+}
+
 open class ComposePublishingTask : AbstractComposePublishingTask() {
     override fun dependsOnComposeTask(task: String) {
         dependsOn(task)


### PR DESCRIPTION
`:mpp:publishComposeJb` fails on CI:
```
A problem occurred configuring project ':mpp'.
> Could not create task ':mpp:publishComposeJb'.
   > Please specify any of these properties in the root `gradle.properties`:
     artifactRedirection.version.compose-multiplatform-core.compose.animation.animation, artifactRedirection.version.compose-multiplatform-core.compose.animation, artifactRedirection.version.compose-multiplatform-core.compose, artifactRedirection.version.compose-multiplatform-core
     Or disable redirection by overriding `artifactRedirection.targetNames=` in
     `D:\Work\compose-multiplatform-core\compose\animation\animation\gradle.properties`
```

(`publishComposeJb` doesn't fail)

We call `artifactRedirection` to early, before group is changed by Androidx plugin. The fix is always evaluate `mpp` module in the end.

Besides this issue, there could be other issues, as this module depends on a lot of info from other modules.

Fixes https://youtrack.jetbrains.com/issue/CMP-7851/gradlew-mpppublishComposeJb-fails

## Details
If we call `mpp:publishComposeJb`:
```
mpp/build.gradle -> publishMultiplatform -> eachProject.artifactRedirection, eachProject.configure -> change groupId
```

If we call `publishComposeJb`:
```
eachProject.configure -> change groupId -> mpp/build.gradle -> publishMultiplatform -> eachProject.artifactRedirection
```

## Testing
`gradlew publishComposeJb`, `gradlew :mpp:publishComposeJb` don't fail

## Release Notes
N/A