### PR TITLE
Fix default NavHost animation

### DIFF
--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -139,9 +139,9 @@ public fun NavHost(
     exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         DefaultNavTransitions.exitTransition,
     popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        DefaultNavTransitions.popEnterTransition,
+        enterTransition,
     popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        DefaultNavTransitions.popExitTransition,
+        exitTransition,
     builder: NavGraphBuilder.() -> Unit
 ) {
     NavHost(
@@ -197,11 +197,11 @@ public fun NavHost(
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        DefaultNavTransitions.popEnterTransition,
+        enterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        DefaultNavTransitions.popExitTransition,
+        exitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
@@ -265,11 +265,11 @@ public fun NavHost(
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        DefaultNavTransitions.popEnterTransition,
+        enterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        DefaultNavTransitions.popExitTransition,
+        exitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
@@ -333,11 +333,11 @@ public fun NavHost(
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        DefaultNavTransitions.popEnterTransition,
+        enterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        DefaultNavTransitions.popExitTransition,
+        exitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =
@@ -413,9 +413,9 @@ public fun NavHost(
     exitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
         DefaultNavTransitions.exitTransition,
     popEnterTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        DefaultNavTransitions.popEnterTransition,
+        enterTransition,
     popExitTransition: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        DefaultNavTransitions.popExitTransition,
+        exitTransition,
 ) {
     NavHost(
         navController,
@@ -462,11 +462,11 @@ public expect fun NavHost(
     popEnterTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition) =
-        DefaultNavTransitions.popEnterTransition,
+        enterTransition,
     popExitTransition:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition) =
-        DefaultNavTransitions.popExitTransition,
+        exitTransition,
     sizeTransform:
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? =

--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.kt
@@ -48,8 +48,6 @@ internal expect fun PredictiveBackHandler(
 internal expect object DefaultNavTransitions {
     val enterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
     val exitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
-    val popEnterTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition
-    val popExitTransition: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition
     val sizeTransform: (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?
 }
 
@@ -62,10 +60,6 @@ internal object StandardDefaultNavTransitions {
         AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
         fadeOut(animationSpec = tween(700))
     }
-    val popEnterTransition:
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = enterTransition
-    val popExitTransition:
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = exitTransition
     val sizeTransform:
         (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? = null
 }

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
@@ -53,8 +53,8 @@ actual fun NavHost(
 ) {
     val isDefaultTransition = enterTransition == DefaultNavTransitions.enterTransition &&
         exitTransition == DefaultNavTransitions.exitTransition &&
-        popEnterTransition == DefaultNavTransitions.popEnterTransition &&
-        popExitTransition == DefaultNavTransitions.popExitTransition &&
+        popEnterTransition == DefaultNavTransitions.enterTransition &&
+        popExitTransition == DefaultNavTransitions.exitTransition &&
         sizeTransform == DefaultNavTransitions.sizeTransform
 
     if (isDefaultTransition) {

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/internal/NavHostInternals.uikit.kt
@@ -46,27 +46,6 @@ internal actual object DefaultNavTransitions {
                 targetOffset = { fullOffset -> (fullOffset * 0.3f).toInt() }
             )
         }
-    actual val popEnterTransition:
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
-            slideIntoContainer(
-                towards = AnimatedContentTransitionScope.SlideDirection.End,
-                animationSpec = tween(
-                    durationMillis = 200,
-                    easing = LinearEasing
-                ),
-                initialOffset = { fullOffset -> (fullOffset * 0.3f).toInt() }
-            )
-        }
-    actual val popExitTransition:
-        AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
-            slideOutOfContainer(
-                towards = AnimatedContentTransitionScope.SlideDirection.End,
-                animationSpec = tween(
-                    durationMillis = 200,
-                    easing = LinearEasing
-                )
-            )
-        }
     actual val sizeTransform:
         (AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)? = null
 }


### PR DESCRIPTION
Use custom enter/exit as default for popEnter/popExit.
(The same as on Android)

Fixes https://youtrack.jetbrains.com/issue/CMP-7826

## Release Notes
### Fixes - Navigation
- _(prerelease fix)_ Fixed default pop `NavHost` animations if enter/exit animations are customized only.
