### PR TITLE
Fix TextField crash when selection start removed while selecting

### DIFF
--- a/compose/foundation/foundation/src/androidInstrumentedTest/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldLongPressTest.kt
+++ b/compose/foundation/foundation/src/androidInstrumentedTest/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldLongPressTest.kt
@@ -34,10 +34,12 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -46,9 +48,13 @@ import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.swipeLeft
 import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.LayoutDirection
@@ -385,6 +391,42 @@ class TextFieldLongPressTest : FocusedWindowTest {
         }
 
         rule.runOnIdle { assertThat(state.selection).isEqualTo(TextRange(4, 23)) }
+    }
+
+    @OptIn(ExperimentalTestApi::class)
+    @Test
+    fun deleteWhileDraggingSelection() {
+        lateinit var textLayoutResult: TextLayoutResult
+        val state = TextFieldState("Hello")
+        rule.setContent {
+            BasicTextField(
+                state = state,
+                modifier = Modifier.testTag(TAG),
+                onTextLayout = { textLayoutResult = it()!! }
+            )
+        }
+
+        fun positionForOffset(offset: Int) =
+            Offset(
+                x = textLayoutResult.getHorizontalPosition(offset, usePrimaryDirection = true),
+                y = textLayoutResult.size.height / 2f
+            )
+
+        rule.onNodeWithTag(TAG).apply {
+            performMouseInput {
+                moveTo(positionForOffset(5))
+                press()
+                moveTo(positionForOffset(4))
+            }
+            assertThat(state.selection).isEqualTo(TextRange(4, 5))
+
+            performKeyInput { pressKey(Key.Backspace) }
+            assertThat(state.selection).isEqualTo(TextRange(4, 4))
+
+            performMouseInput { moveTo(positionForOffset(3)) }
+            assertThat(state.selection).isEqualTo(TextRange(3, 4))
+            performMouseInput { release() }
+        }
     }
 
     // region RTL

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -79,6 +79,7 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.unit.Density
@@ -621,7 +622,11 @@ internal class TextFieldSelectionState(
         private var dragBeginPosition: Offset = Offset.Unspecified
 
         override fun onStart(downPosition: Offset, adjustment: SelectionAdjustment): Boolean {
-            if (!enabled || textFieldState.visualText.isEmpty()) return false
+            val layoutResult = textLayoutState.layoutResult
+            if (!enabled || layoutResult == null || textFieldState.visualText.isEmpty()) {
+                return false
+            }
+
             logDebug { "Mouse.onStart" }
             directDragGestureInitiator = InputType.Mouse
 
@@ -631,30 +636,40 @@ internal class TextFieldSelectionState(
             dragBeginOffsetInText = -1
             dragBeginPosition = downPosition
 
-            val newSelection = updateSelection(downPosition, adjustment, isStartOfSelection = true)
+            val newSelection =
+                updateSelection(downPosition, adjustment, layoutResult, isStartOfSelection = true)
             dragBeginOffsetInText = newSelection.start
 
             return true
         }
 
         override fun onDrag(dragPosition: Offset, adjustment: SelectionAdjustment): Boolean {
-            if (!enabled || textFieldState.visualText.isEmpty()) return false
+            val layoutResult = textLayoutState.layoutResult
+            if (!enabled || layoutResult == null || textFieldState.visualText.isEmpty()) {
+                return false
+            }
+
             logDebug { "Mouse.onDrag $dragPosition" }
-            updateSelection(dragPosition, adjustment, isStartOfSelection = false)
+            updateSelection(dragPosition, adjustment, layoutResult, isStartOfSelection = false)
             return true
         }
 
         private fun updateSelection(
             dragPosition: Offset,
             adjustment: SelectionAdjustment,
+            layoutResult: TextLayoutResult,
             isStartOfSelection: Boolean,
         ): TextRange {
+            val textLength = layoutResult.layoutInput.text.length
             val startOffset: Int =
-                dragBeginOffsetInText.takeIf { it >= 0 }
-                    ?: textLayoutState.getOffsetForPosition(
+                if (0 <= dragBeginOffsetInText && dragBeginOffsetInText <= textLength) {
+                    dragBeginOffsetInText
+                } else {
+                    textLayoutState.getOffsetForPosition(
                         position = dragBeginPosition,
                         coerceInVisibleBounds = false
                     )
+                }
 
             val endOffset: Int =
                 textLayoutState.getOffsetForPosition(


### PR DESCRIPTION
This is a cherry-pick of https://android-review.googlesource.com/c/platform/frameworks/support/+/3561283

Fixes https://youtrack.jetbrains.com/issue/CMP-7792

## Release Notes
### Fixes - Multiple Platforms
- Fixed crash when dragging selection in `TextField(TextFieldState)` while also editing the text, such as by pressing Backspace.
