### PR TITLE
Fix Text Menu placement for BTF2

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -30,9 +30,6 @@
 
 @property (assign, nonatomic) CGRect targetRect;
 @property (assign, nonatomic) BOOL isEditMenuShown;
-/// Due to the internal implementation of UIEditMenuInteraction, it disappears with animation when a touch is detected.
-/// HACK: Keep tracking incoming touches to show UIEditMenuInteraction again after a short delay.
-@property (assign, nonatomic) BOOL isPossibleTouchDetected;
 
 @property (readwrite) UIEditMenuInteraction* editInteraction API_AVAILABLE(ios(16.0));
 
@@ -67,21 +64,12 @@ id _editInteraction;
     self.isEditMenuShown = YES;
 
     if (@available(iOS 16, *)) {
-        if (self.editInteraction == nil) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                self.editInteraction = [[UIEditMenuInteraction alloc] initWithDelegate:self];
-                [self addInteraction:self.editInteraction];
-                [self presentEditMenuInteraction];
-                self.isPossibleTouchDetected = NO;
-            });
-        } else {
-            if (self.isPossibleTouchDetected || contextMenuItemsChanged) {
-                [self hideEditMenu];
-                [self cancelPresentEditMenuInteraction];
-                [self schedulePresentEditMenuInteraction];
-            } else if (positionChanged) {
-                [self.editInteraction updateVisibleMenuPositionAnimated:NO];
-            }
+        if (self.editInteraction == nil || contextMenuItemsChanged) {
+            [self cancelPresentEditMenuInteraction];
+            NSTimeInterval delay = self.presentInteractionBlock == nil ? 0 : [self editMenuDelay];
+            [self schedulePresentEditMenuInteractionWithDelay:delay];
+        } else if (positionChanged) {
+            [self.editInteraction updateVisibleMenuPositionAnimated:NO];
         }
     } else {
         if (contextMenuItemsChanged || positionChanged) {
@@ -89,11 +77,6 @@ id _editInteraction;
             [self scheduleShowMenuController];
         }
     }
-}
-
-- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event {
-    self.isPossibleTouchDetected = YES;
-    return [super hitTest:point withEvent:event];
 }
 
 - (void)scheduleShowMenuController {
@@ -142,15 +125,18 @@ id _editInteraction;
     [self.editInteraction presentEditMenuWithConfiguration:config];
 }
 
-- (void)schedulePresentEditMenuInteraction API_AVAILABLE(ios(16.0)) {
+- (void)schedulePresentEditMenuInteractionWithDelay:(NSTimeInterval)delay API_AVAILABLE(ios(16.0)) {
     __weak __auto_type weak_self = self;
     self.presentInteractionBlock = dispatch_block_create(0 ,^{
         __auto_type self = weak_self;
+        if (self.editInteraction == nil) {
+            self.editInteraction = [[UIEditMenuInteraction alloc] initWithDelegate:self];
+            [self addInteraction:self.editInteraction];
+        }
         [self presentEditMenuInteraction];
         self.presentInteractionBlock = nil;
-        self.isPossibleTouchDetected = NO;
     });
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)([self editMenuDelay] * NSEC_PER_SEC)),
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
                    dispatch_get_main_queue(),
                    self.presentInteractionBlock);
 }


### PR DESCRIPTION
- Update text menu position when text moved
- Rework UIEditMenuInteraction appearance logic

Fixes https://youtrack.jetbrains.com/issue/CMP-5692/Select-and-Select-All-context-menu-actions-dont-reopen-context-menu
Fixes https://youtrack.jetbrains.com/issue/CMP-7876/iOS-TextField.-Sontext-menu-doesnt-appear

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix Text Menu placement for `TextField(TextFieldState)`