### PR TITLE
Separate `material-navigation` versioning

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -63,6 +63,7 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 `-Pjetbrains.publication.version.CORE_BUNDLE`,
 `-Pjetbrains.publication.version.CORE_URI`,
 `-Pjetbrains.publication.version.COMPOSE`,
+`-Pjetbrains.publication.version.COMPOSE_MATERIAL_NAVIGATION`,
 `-Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE`,
 `-Pjetbrains.publication.version.LIFECYCLE`,
 `-Pjetbrains.publication.version.NAVIGATION`,
@@ -72,7 +73,7 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 The default value for the version is `0.0.0-SNAPSHOT`
 
 And library groups:
-`-Pjetbrains.publication.libraries=CORE_BUNDLE,CORE_URI,COMPOSE,COMPOSE_MATERIAL3_ADAPTIVE,LIFECYCLE,NAVIGATION,SAVEDSTATE,WINDOW`
+`-Pjetbrains.publication.libraries=CORE_BUNDLE,CORE_URI,COMPOSE,COMPOSE_MATERIAL_NAVIGATION,COMPOSE_MATERIAL3_ADAPTIVE,LIFECYCLE,NAVIGATION,SAVEDSTATE,WINDOW`
 
 The default value includes all libraries.
 

--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -85,10 +85,8 @@ kotlin {
 androidx {
     name = "Compose Material Navigation"
     type = LibraryType.PUBLISHED_LIBRARY
-    mavenVersion = LibraryVersions.COMPOSE
     inceptionYear = "2024"
     description = "Compose Material integration with Navigation"
-//    samples(projectOrArtifact(":compose:material:material-navigation-samples"))
 }
 
 android {

--- a/gradle.properties
+++ b/gradle.properties
@@ -101,7 +101,12 @@ jetbrains.compose.compiler.version=1.5.14.1
 # in fact `android.compose` is used.
 #
 # Versions should equal the last merged to the branch
+# Format:
+#   artifactRedirection.version.<redirectionGroup>.<redirectionModule>
+#   covers all sub-module projects
+#   (artifactRedirection.version.androidx.compose covers androidx.compose.*:*)
 artifactRedirection.version.androidx.compose=1.8.0-rc02
+artifactRedirection.version.androidx.compose.material.material-navigation=1.8.0-rc02
 artifactRedirection.version.androidx.compose.material3=1.3.1
 artifactRedirection.version.androidx.compose.material3.common=1.0.0-alpha01
 artifactRedirection.version.androidx.compose.material3.adaptive=1.1.0

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -20,6 +20,7 @@ CARDVIEW = "1.1.0-alpha01"
 CAR_APP = "1.7.0-beta02"
 COLLECTION = "1.5.0-alpha03"
 COMPOSE = "1.8.0-rc02"
+COMPOSE_MATERIAL_NAVIGATION = "1.8.0-rc02"
 COMPOSE_MATERIAL3 = "1.3.1"
 COMPOSE_MATERIAL3_ADAPTIVE = "1.1.0"
 COMPOSE_MATERIAL3_COMMON = "1.0.0-alpha01"
@@ -315,6 +316,7 @@ ANNOTATION_JETBRAINS = { group = "org.jetbrains.compose.annotation-internal", at
 COLLECTION_JETBRAINS = { group = "org.jetbrains.compose.collection-internal", atomicGroupVersion = "versions.COMPOSE", overrideInclude = [ ":collection:collection" ] }
 COMPOSE_COMPILER = { group = "org.jetbrains.compose.compiler", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_DESKTOP = { group = "org.jetbrains.compose.desktop", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_MATERIAL_NAVIGATION = { group = "org.jetbrains.compose.material", atomicGroupVersion = "versions.COMPOSE_MATERIAL_NAVIGATION", overrideInclude = [ ":compose:material:material-navigation" ] }
 COMPOSE_MATERIAL3_COMMON = { group = "org.jetbrains.compose.material3.common", atomicGroupVersion = "versions.COMPOSE_MATERIAL3_COMMON", overrideInclude = [ ":compose:material3:material3-common" ] }
 
 GRAPHICS_SHAPES_JETBRAINS = { group = "org.jetbrains.androidx.graphics", atomicGroupVersion = "versions.GRAPHICS_SHAPES", overrideInclude = [ ":graphics:graphics-shapes" ] }

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -39,7 +39,6 @@ val libraryToComponents = mapOf(
         ComposeComponent(":compose:material3:material3"),
         //ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
-        ComposeComponent(":compose:material:material-navigation"),
         ComposeComponent(":compose:material3:material3-window-size-class"),
         ComposeComponent(":compose:material3:material3-adaptive-navigation-suite"),
         ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),
@@ -72,6 +71,9 @@ val libraryToComponents = mapOf(
         ),
         ComposeComponent(":compose:ui:ui-unit"),
         ComposeComponent(":compose:ui:ui-util"),
+    ),
+    "COMPOSE_MATERIAL_NAVIGATION" to listOf(
+        ComposeComponent(":compose:material:material-navigation"),
     ),
     "COMPOSE_MATERIAL3_COMMON" to listOf(
         ComposeComponent(":compose:material3:material3-common"),


### PR DESCRIPTION
`material-navigation` won't be released as stable at the time the main Compose will be stable. Because `navigation` itself won't be stable

Fixes https://youtrack.jetbrains.com/issue/CMP-7885

CI change: https://jetbrains.team/p/ui/reviews/22/timeline

## Testing
```
./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=COMPOSE -Pjetbrains.publication.version.COMPOSE=0.1.0

./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=COMPOSE,COMPOSE_MATERIAL_NAVIGATION -Pjetbrains.publication.version.COMPOSE=0.3.0 -Pjetbrains.publication.version.COMPOSE_MATERIAL_NAVIGATION=0.2.0
```

## Release Notes
N/A