### PR TITLE
Keep all nodes with TestTag in accessibility hierarchy

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/semantics/SemanticsOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/semantics/SemanticsOwner.skiko.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.roundToIntRect
 internal fun SemanticsNode.isImportantForAccessibility() =
     !isHidden &&
         (unmergedConfig.isMergingSemanticsOfDescendants ||
+            unmergedConfig.contains(SemanticsProperties.TestTag) ||
             unmergedConfig.containsImportantForAccessibility())
 
 @Suppress("DEPRECATION")


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/CMP-7902/Traversal-groups-with-test-tag-not-reachable-in-accessibility-tree

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix an issue where traversal group nodes with test tag are missing in the accessibility tree