### PR TITLE
In `platformSpecificTextInputSession` call `editUntransformedTextAsUser(restartImeIfContentChanges = false)`

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -65,7 +65,7 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         )
         val newValue = editProcessor.apply(commands)
 
-        state.editUntransformedTextAsUser {
+        state.editUntransformedTextAsUser(restartImeIfContentChanges = false) {
             // Update text
             replace(0, length, newValue.text)
 
@@ -84,7 +84,7 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
     }
 
     fun editText(block: TextEditingScope.() -> Unit) {
-        state.editUntransformedTextAsUser {
+        state.editUntransformedTextAsUser(restartImeIfContentChanges = false) {
             with(TextEditingScope(this)) {
                 block()
             }


### PR DESCRIPTION
In `PlatformTextInputSession.platformSpecificTextInputSession`, when calling `editUntransformedTextAsUser`, pass `restartImeIfContentChanges = false`, as this is, according to the documentation, exactly the case when it should be false.

I'm not sure what exactly this affects, but it seems the right thing to do.

## Release Notes
N/A