### PR TITLE
Save navigator names by type to be able to use it later.

### DIFF
--- a/navigation/navigation-common/src/commonTest/kotlin/androidx/navigation/NavigatorProviderTest.kt
+++ b/navigation/navigation-common/src/commonTest/kotlin/androidx/navigation/NavigatorProviderTest.kt
@@ -88,6 +88,23 @@ class NavigatorProviderTest {
         assertThat(provider.getNavigator<EmptyNavigator>(EmptyNavigator.NAME)).isEqualTo(navigatorB)
     }
 
+    @Test
+    fun replaceNavigatorOfCommonTypeWhenGetByType() {
+        val provider = NavigatorProvider()
+        val navigatorA = EmptyNavigator()
+
+        class EmptyNavigator2 : EmptyNavigator()
+        val navigatorB = EmptyNavigator2()
+
+        assertThat(navigatorA).isNotEqualTo(navigatorB)
+
+        provider.addNavigator(navigatorA)
+        assertThat(provider[EmptyNavigator::class]).isEqualTo(navigatorA)
+
+        provider.addNavigator(navigatorB)
+        assertThat(provider[EmptyNavigator::class]).isEqualTo(navigatorB)
+    }
+
     private val provider = NavigatorProvider()
 
     @Test


### PR DESCRIPTION
There was a bug where two different navigators with the same base type and the name were saved in the provider. In that case we should save only the latest.

## Release Notes
### Fixes - Navigation
- _(prerelease fix)_ Fix custom navigation animation in nested graphs in non-android targets.