### PR TITLE
Replace deprecated kotlin.system.getTime with TimeSource api

### DIFF
--- a/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/UndoManager.native.kt
+++ b/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/UndoManager.native.kt
@@ -16,4 +16,7 @@
 
 package androidx.compose.foundation.text
 
-internal actual fun timeNowMillis(): Long = kotlin.system.getTimeMillis()
+import kotlin.time.TimeSource
+
+internal actual fun timeNowMillis(): Long =
+    TimeSource.Monotonic.markNow().elapsedNow().inWholeMilliseconds

--- a/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
+++ b/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.yield
  *
  * This value is no longer used by compose runtime.
  */
-@Suppress("DEPRECATION")
 @Deprecated(
     "MonotonicFrameClocks are not globally applicable across platforms. " +
         "Use an appropriate local clock."

--- a/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
+++ b/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.runtime
 
-import kotlin.system.getTimeNanos
+import kotlin.time.TimeSource
 import kotlinx.coroutines.yield
 
 /**
@@ -35,6 +35,6 @@ actual val DefaultMonotonicFrameClock: MonotonicFrameClock = object : MonotonicF
         onFrame: (Long) -> R
     ): R {
         yield()
-        return onFrame(getTimeNanos())
+        return onFrame(TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds)
     }
 }

--- a/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.native.kt
+++ b/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.native.kt
@@ -16,15 +16,13 @@
 
 package androidx.compose.ui
 
-import kotlin.system.getTimeMillis
-import kotlinx.atomicfu.atomic
+import kotlin.time.TimeSource
 
 internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a::class == b::class
 }
 
 internal actual fun currentTimeMillis(): Long {
-    @Suppress("DEPRECATION") // TODO: Avoid using deprecated function
-    return getTimeMillis()
+    return TimeSource.Monotonic.markNow().elapsedNow().inWholeMilliseconds
 }
 


### PR DESCRIPTION
Using Deprecated as Error API is risky, since it can be removed in the next Kotlin versions, making it incompatible with our published klibs. 

## Testing
CI checks

## Release Notes
N/A
