### PR TITLE
Throttle accessibility tree reload when focus changes

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -940,11 +940,10 @@ internal class AccessibilityMediator(
         accessibilityElementsMap.clear()
     }
 
-    private var focusedScrollableParentsIdsUpdateJob = Job()
+    private var focusedScrollableParentsIdsUpdateJob: Job? = null
     private fun scheduleFocusedScrollableParentsIdsUpdate() {
-        focusedScrollableParentsIdsUpdateJob.cancel()
-        focusedScrollableParentsIdsUpdateJob = Job()
-        CoroutineScope(coroutineContext + focusedScrollableParentsIdsUpdateJob).launch {
+        focusedScrollableParentsIdsUpdateJob?.cancel()
+        focusedScrollableParentsIdsUpdateJob = coroutineScope.launch {
             // Throttle the recalculation of scrollable parent node IDs to avoid unnecessary
             // reloading of the accessibility tree when the focusMode changes quickly.
             delay(10)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7947/Investigate-A11y-issues-in-KotlinConf-app

## Release Notes
### Fixes - iOS
- Fixes an issue where the accessibility engine could leave a scrollable list without reading it to the end