### PR TITLE
Fix accessibility navigation in Containers mode

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -329,12 +329,8 @@ private sealed interface AccessibilityNode {
 
         override val isAccessibilityElement = false
 
-        override val accessibilityContainerType: UIAccessibilityContainerType
-            get() = if (semanticsNode.isTraversalGroup) {
-                UIAccessibilityContainerTypeSemanticGroup
-            } else {
-                UIAccessibilityContainerTypeNone
-            }
+        override val accessibilityContainerType: UIAccessibilityContainerType =
+            UIAccessibilityContainerTypeSemanticGroup
     }
 }
 
@@ -598,6 +594,9 @@ private class AccessibilityElement(
             super.accessibilityPerformEscape()
         }
     }
+
+    override fun accessibilityContainerType(): UIAccessibilityContainerType =
+        node.accessibilityContainerType
 
     private fun debugContainmentChain() = debugContainmentChain(this)
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7950/Navigation-via-containers-does-not-work

## Release Notes
### Fixes - iOS
- Fix Accessibility navigation through traversal groups in Container mode