### PR TITLE
Adjust coordinate space for focusable elements

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -382,9 +382,7 @@ private class AccessibilityRoot(
 
     // UIFocusItemContainerProtocol
 
-    override fun coordinateSpace(): UICoordinateSpaceProtocol {
-        return mediator.view.window ?: mediator.view
-    }
+    override fun coordinateSpace(): UICoordinateSpaceProtocol = mediator.view
 
     override fun focusItemsInRect(rect: CValue<CGRect>): List<*> {
         return if (mediator.isEnabled) {
@@ -664,7 +662,7 @@ private class AccessibilityElement(
         var component: Any? = accessibilityContainer
         while (component != null) {
             when (component) {
-                is UIView -> return component.window ?: component
+                is UIView -> return component
                 is CMPAccessibilityElement -> component = component.accessibilityContainer
                 else -> error("Unexpected coordinate space.")
             }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7907/iOS-Full-Keyboard-access.-Doesnt-work-correctly-inside-dialogs

## Release Notes
### Fixes - iOS
- Fix focus for items within dialogs when full keyboard access is enabled