### PR TITLE
Set KOTLIN_2_0 for all configurations

### DIFF
--- a/compose/material3/adaptive/adaptive-layout/src/commonTest/kotlin/androidx/compose/material3/adaptive/layout/PaneMotionTest.kt
+++ b/compose/material3/adaptive/adaptive-layout/src/commonTest/kotlin/androidx/compose/material3/adaptive/layout/PaneMotionTest.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.kruth.assertThat
 import androidx.kruth.assertWithMessage
+import kotlin.test.Ignore
 import kotlin.test.Test
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
@@ -57,6 +58,7 @@ class PaneMotionTest {
         }
     }
 
+    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7979
     @Test
     fun test_allDefaultPaneMotionTransitions() {
         NoMotion.assertTransitions(EnterTransition.None, ExitTransition.None)

--- a/compose/runtime/runtime/api/desktop/runtime.api
+++ b/compose/runtime/runtime/api/desktop/runtime.api
@@ -945,7 +945,6 @@ public class androidx/compose/runtime/snapshots/MutableSnapshot : androidx/compo
 	public fun getReadOnly ()Z
 	public fun getRoot ()Landroidx/compose/runtime/snapshots/Snapshot;
 	public fun hasPendingChanges ()Z
-	public fun setModified (Landroidx/collection/MutableScatterSet;)V
 	public fun takeNestedMutableSnapshot (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Landroidx/compose/runtime/snapshots/MutableSnapshot;
 	public static synthetic fun takeNestedMutableSnapshot$default (Landroidx/compose/runtime/snapshots/MutableSnapshot;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/runtime/snapshots/MutableSnapshot;
 	public fun takeNestedSnapshot (Lkotlin/jvm/functions/Function1;)Landroidx/compose/runtime/snapshots/Snapshot;

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcherUtils.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcherUtils.kt
@@ -16,11 +16,16 @@
 
 package androidx.compose.ui.backhandler
 
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.width
 
 internal fun BackGestureDispatcher.handleBackKeyEvent(
     event: KeyEvent,
@@ -33,4 +38,34 @@ internal fun BackGestureDispatcher.handleBackKeyEvent(
     } else {
         return false
     }
+}
+
+/*
+ FIXME: Figure out why calling [BackEventCompat] constructor from uikitMain causes errors
+  e: Cannot infer type for this parameter. Please specify it explicitly.
+  e: Unresolved reference. None of the following candidates is applicable because of a receiver type mismatch:
+  fun <T, R> DeepRecursiveFunction<T, R>.invoke(value: T): R
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+internal fun backEventCompat(
+    eventOffset: Offset,
+    leftEdge: Boolean,
+    touch: DpOffset,
+    bounds: DpRect
+): BackEventCompat {
+    val progress = if (leftEdge) {
+        touch.x / bounds.width
+    } else {
+        (bounds.width - touch.x) / bounds.width
+    }
+    return BackEventCompat(
+        touchX = eventOffset.x,
+        touchY = eventOffset.y,
+        progress = progress,
+        swipeEdge = if (leftEdge) {
+            BackEventCompat.EDGE_LEFT
+        } else {
+            BackEventCompat.EDGE_RIGHT
+        }
+    )
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/BaseComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/BaseComposeSceneTest.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.test.runTest
 class BaseComposeSceneTest {
 
     @Test
-    fun `test move events consumption`() = runTest(StandardTestDispatcher()) {
+    fun testMoveEventsConsumption() = runTest(StandardTestDispatcher()) {
         val scenes: List<ComposeScene> = listOf(
             PlatformLayersComposeScene(size = IntSize(100, 100)),
             CanvasLayersComposeScene(size = IntSize(100, 100))
@@ -86,7 +86,7 @@ class BaseComposeSceneTest {
     }
 
     @Test
-    fun `cancel all pointers should cancel input coroutines`() = runTest(StandardTestDispatcher()) {
+    fun cancelAllPointersShouldCancelInputCoroutines() = runTest(StandardTestDispatcher()) {
         val scenes: List<ComposeScene> = listOf(
             PlatformLayersComposeScene(size = IntSize(100, 100)),
             CanvasLayersComposeScene(size = IntSize(100, 100))
@@ -108,7 +108,7 @@ class BaseComposeSceneTest {
     }
 
     @Test
-    fun `cancel all pointers should cancel clicks`() = runTest(StandardTestDispatcher()) {
+    fun cancelAllPointersShouldCancelClicks() = runTest(StandardTestDispatcher()) {
         val scenes: List<ComposeScene> = listOf(
             PlatformLayersComposeScene(size = IntSize(100, 100)),
             CanvasLayersComposeScene(size = IntSize(100, 100))

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit
 import kotlinx.cinterop.CValue
+import kotlinx.cinterop.ObjCSignatureOverride
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.MainScope
@@ -77,7 +78,6 @@ private val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
  * Hidden UIView to interact with iOS Keyboard and TextInput system.
  * TODO maybe need to call reloadInputViews() to update UIKit text features?
  */
-@Suppress("CONFLICTING_OVERLOADS")
 internal class IntermediateTextInputUIView(
     private val viewConfiguration: ViewConfiguration
 ) : CMPEditMenuView(frame = CGRectZero.readValue()),
@@ -360,11 +360,13 @@ internal class IntermediateTextInputUIView(
         return (toPosition.position - from.position).toLong()
     }
 
+    @ObjCSignatureOverride
     override fun positionWithinRange(
         range: UITextRange,
         atCharacterOffset: NSInteger
     ): UITextPosition? = null // TODO positionWithinRange
 
+    @ObjCSignatureOverride
     override fun positionWithinRange(
         range: UITextRange,
         farthestInDirection: UITextLayoutDirection

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.sendFromScope
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.unit.Density
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -147,6 +148,7 @@ class TextInputTests : OnCanvasTests  {
         assertEquals("啊X", textInputChannel.receive())
     }
 
+    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-7978
     @Test
     fun compositeInputWebkit() = runTest {
         val textInputChannel = createTextFieldWithChannel()

--- a/navigation/navigation-common/src/androidMain/kotlin/androidx/navigation/NavDestination.android.kt
+++ b/navigation/navigation-common/src/androidMain/kotlin/androidx/navigation/NavDestination.android.kt
@@ -59,7 +59,7 @@ actual constructor(public actual val navigatorName: String) {
         private val hasMatchingAction: Boolean,
         private val mimeTypeMatchLevel: Int
     ) : Comparable<DeepLinkMatch> {
-        override fun compareTo(other: DeepLinkMatch): Int {
+        public actual override fun compareTo(other: DeepLinkMatch): Int {
             // Prefer exact deep links
             if (isExactDeepLink && !other.isExactDeepLink) {
                 return 1

--- a/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/NavDestination.kt
+++ b/navigation/navigation-common/src/commonMain/kotlin/androidx/navigation/NavDestination.kt
@@ -46,6 +46,8 @@ public expect open class NavDestination(navigatorName: String) {
         public val destination: NavDestination
         public val matchingArgs: SavedState?
 
+        public override fun compareTo(other: DeepLinkMatch): Int
+
         /**
          * Returns true if all args from [DeepLinkMatch.matchingArgs] can be found within the
          * [arguments].

--- a/navigation/navigation-common/src/nonAndroidMain/kotlin/androidx/navigation/NavDestination.nonAndroid.kt
+++ b/navigation/navigation-common/src/nonAndroidMain/kotlin/androidx/navigation/NavDestination.nonAndroid.kt
@@ -39,7 +39,7 @@ public actual open class NavDestination actual constructor(
         public actual val matchingArgs: SavedState?,
         private val isExactDeepLink: Boolean,
     ) : Comparable<DeepLinkMatch> {
-        override fun compareTo(other: DeepLinkMatch): Int {
+        public actual override fun compareTo(other: DeepLinkMatch): Int {
             // Prefer exact deep links
             if (isExactDeepLink && !other.isExactDeepLink) {
                 return 1


### PR DESCRIPTION
Drop 1.9 leftovers from #1778
Fixes [CMP-7975](https://youtrack.jetbrains.com/issue/CMP-7975) NPE in K1 PsiElementNode after merging navigation 2.9.0-beta01

## Release Notes
N/A