### PR TITLE
Fix backing html input focusing logic

### DIFF
--- a/compose/mpp/demo/src/jsMain/resources/styles.css
+++ b/compose/mpp/demo/src/jsMain/resources/styles.css
@@ -40,3 +40,11 @@ body:has(textarea) {
 body:has(textarea:focus) {
     background-color: #eaffe3;
 }
+
+body:has(input) {
+    background-color: aliceblue;
+}
+
+body:has(input:focus) {
+    background-color: #eaffe3;
+}

--- a/compose/mpp/demo/src/wasmJsMain/resources/styles.css
+++ b/compose/mpp/demo/src/wasmJsMain/resources/styles.css
@@ -40,3 +40,12 @@ body:has(textarea) {
 body:has(textarea:focus) {
     background-color: #eaffe3;
 }
+
+body:has(input) {
+    background-color: aliceblue;
+}
+
+body:has(input:focus) {
+    background-color: #eaffe3;
+}
+

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.browser.document
+import kotlinx.browser.window
 
 
 internal interface ComposeCommandCommunicator {
@@ -53,7 +54,9 @@ internal class BackingDomInput(
     }
 
     fun focus() {
-        backingElement.focus()
+        window.requestAnimationFrame {
+            backingElement.focus()
+        }
     }
 
     fun blur() {
@@ -63,12 +66,11 @@ internal class BackingDomInput(
     fun updateHtmlInputPosition(offset: Offset) {
         backingElement.style.left = "${offset.x}px"
         backingElement.style.top = "${offset.y}px"
-
-        focus()
     }
 
     fun updateState(textFieldValue: TextFieldValue) {
         inputStrategy.updateState(textFieldValue)
+        focus()
     }
 
     fun dispose() {


### PR DESCRIPTION
Cherry-pick of https://github.com/JetBrains/compose-multiplatform-core/pull/1991


- no need to focus the input after its position is udpated - it keeps the focus anyway
- request focus on value update - otherwise the change of cursor position makes the input unfocues

Fixes https://youtrack.jetbrains.com/issue/CMP-7836

## Testing
This should be tested by QA

## Release Notes
N/A
