### PR TITLE
TextFieldKeyEventHandler for iOS 

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldKeyEventHandler.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldKeyEventHandler.android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,5 @@
 
 package androidx.compose.foundation.text.input.internal
 
-import androidx.compose.ui.input.key.KeyEvent
-
-/**
- * Factory function to create a platform specific [TextFieldKeyEventHandler].
- */
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-741/Implement-createTextFieldKeyEventHandler
-internal fun createSkikoTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}
-
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-1361/Implement-isFromSoftKeyboard
-/**
- * Returns whether this key event is created by the software keyboard.
- */
-internal actual val KeyEvent.isFromSoftKeyboard: Boolean
-    get() = false
+/** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
+internal actual fun createTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.desktop.kt
@@ -17,4 +17,4 @@
 package androidx.compose.foundation.text.input.internal
 
 /** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
-internal actual fun createTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}
+internal actual fun createTextFieldKeyEventHandler() = createSkikoTextFieldKeyEventHandler()

--- a/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.jsWasm.kt
+++ b/compose/foundation/foundation/src/jsWasmMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.jsWasm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,5 @@
 
 package androidx.compose.foundation.text.input.internal
 
-import androidx.compose.ui.input.key.KeyEvent
-
-/**
- * Factory function to create a platform specific [TextFieldKeyEventHandler].
- */
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-741/Implement-createTextFieldKeyEventHandler
-internal fun createSkikoTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}
-
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-1361/Implement-isFromSoftKeyboard
-/**
- * Returns whether this key event is created by the software keyboard.
- */
-internal actual val KeyEvent.isFromSoftKeyboard: Boolean
-    get() = false
+/** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
+internal actual fun createTextFieldKeyEventHandler() = createSkikoTextFieldKeyEventHandler()

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.jvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,5 @@
 
 package androidx.compose.foundation.text.input.internal
 
-import androidx.compose.ui.input.key.KeyEvent
-
-/**
- * Factory function to create a platform specific [TextFieldKeyEventHandler].
- */
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-741/Implement-createTextFieldKeyEventHandler
-internal fun createSkikoTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}
-
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-1361/Implement-isFromSoftKeyboard
-/**
- * Returns whether this key event is created by the software keyboard.
- */
-internal actual val KeyEvent.isFromSoftKeyboard: Boolean
-    get() = false
+/** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
+internal actual fun createTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.macos.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,5 @@
 
 package androidx.compose.foundation.text.input.internal
 
-import androidx.compose.ui.input.key.KeyEvent
-
-/**
- * Factory function to create a platform specific [TextFieldKeyEventHandler].
- */
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-741/Implement-createTextFieldKeyEventHandler
-internal fun createSkikoTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}
-
-// TODO https://youtrack.jetbrains.com/issue/COMPOSE-1361/Implement-isFromSoftKeyboard
-/**
- * Returns whether this key event is created by the software keyboard.
- */
-internal actual val KeyEvent.isFromSoftKeyboard: Boolean
-    get() = false
+/** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
+internal actual fun createTextFieldKeyEventHandler() = createSkikoTextFieldKeyEventHandler()

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.skiko.kt
@@ -16,13 +16,57 @@
 
 package androidx.compose.foundation.text.input.internal
 
+import androidx.compose.foundation.text.KeyCommand
+import androidx.compose.foundation.text.commonKeyMapping
+import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
 
 /**
  * Factory function to create a platform specific [TextFieldKeyEventHandler].
  */
 // TODO https://youtrack.jetbrains.com/issue/COMPOSE-741/Implement-createTextFieldKeyEventHandler
 internal fun createSkikoTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {}
+
+internal fun createIOSTextFieldKeyEventHandler() = object : TextFieldKeyEventHandler() {
+    override fun onKeyEvent(
+        event: KeyEvent,
+        textFieldState: TransformedTextFieldState,
+        textLayoutState: TextLayoutState,
+        textFieldSelectionState: TextFieldSelectionState,
+        clipboardKeyCommandsHandler: ClipboardKeyCommandsHandler,
+        editable: Boolean,
+        singleLine: Boolean,
+        onSubmit: () -> Unit
+    ): Boolean {
+        return when(commonKeyMapping{
+            event.isShiftPressed && event.isMetaPressed
+        }.map(event)) {
+            // iOS has its own Key Input handler for these keys:
+            KeyCommand.LEFT_CHAR,
+            KeyCommand.RIGHT_CHAR,
+            KeyCommand.UP,
+            KeyCommand.DOWN,
+            KeyCommand.SELECT_LEFT_CHAR,
+            KeyCommand.SELECT_RIGHT_CHAR,
+            KeyCommand.SELECT_UP,
+            KeyCommand.SELECT_DOWN -> return false
+            else -> {
+                super.onKeyEvent(
+                    event,
+                    textFieldState,
+                    textLayoutState,
+                    textFieldSelectionState,
+                    clipboardKeyCommandsHandler,
+                    editable,
+                    singleLine,
+                    onSubmit
+                )
+            }
+        }
+    }
+}
 
 // TODO https://youtrack.jetbrains.com/issue/COMPOSE-1361/Implement-isFromSoftKeyboard
 /**

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.uikit.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.input.internal
+
+import androidx.compose.foundation.text.KeyCommand
+import androidx.compose.foundation.text.commonKeyMapping
+import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.isShiftPressed
+
+/** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
+internal actual fun createTextFieldKeyEventHandler(): TextFieldKeyEventHandler = object : TextFieldKeyEventHandler() {
+    override fun onKeyEvent(
+        event: KeyEvent,
+        textFieldState: TransformedTextFieldState,
+        textLayoutState: TextLayoutState,
+        textFieldSelectionState: TextFieldSelectionState,
+        clipboardKeyCommandsHandler: ClipboardKeyCommandsHandler,
+        editable: Boolean,
+        singleLine: Boolean,
+        onSubmit: () -> Unit
+    ): Boolean {
+        return when(commonKeyMapping{
+            event.isShiftPressed && event.isMetaPressed
+        }.map(event)) {
+            // iOS has its own Key Input handler for these keys:
+            KeyCommand.LEFT_CHAR,
+            KeyCommand.RIGHT_CHAR,
+            KeyCommand.UP,
+            KeyCommand.DOWN,
+            KeyCommand.SELECT_LEFT_CHAR,
+            KeyCommand.SELECT_RIGHT_CHAR,
+            KeyCommand.SELECT_UP,
+            KeyCommand.SELECT_DOWN -> return false
+            else -> {
+                super.onKeyEvent(
+                    event,
+                    textFieldState,
+                    textLayoutState,
+                    textFieldSelectionState,
+                    clipboardKeyCommandsHandler,
+                    editable,
+                    singleLine,
+                    onSubmit
+                )
+            }
+        }
+    }
+}

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.uikit.kt
@@ -16,49 +16,5 @@
 
 package androidx.compose.foundation.text.input.internal
 
-import androidx.compose.foundation.text.KeyCommand
-import androidx.compose.foundation.text.commonKeyMapping
-import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState
-import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
-
 /** Factory function to create a platform specific [TextFieldKeyEventHandler]. */
-internal actual fun createTextFieldKeyEventHandler(): TextFieldKeyEventHandler = object : TextFieldKeyEventHandler() {
-    override fun onKeyEvent(
-        event: KeyEvent,
-        textFieldState: TransformedTextFieldState,
-        textLayoutState: TextLayoutState,
-        textFieldSelectionState: TextFieldSelectionState,
-        clipboardKeyCommandsHandler: ClipboardKeyCommandsHandler,
-        editable: Boolean,
-        singleLine: Boolean,
-        onSubmit: () -> Unit
-    ): Boolean {
-        return when(commonKeyMapping{
-            event.isShiftPressed && event.isMetaPressed
-        }.map(event)) {
-            // iOS has its own Key Input handler for these keys:
-            KeyCommand.LEFT_CHAR,
-            KeyCommand.RIGHT_CHAR,
-            KeyCommand.UP,
-            KeyCommand.DOWN,
-            KeyCommand.SELECT_LEFT_CHAR,
-            KeyCommand.SELECT_RIGHT_CHAR,
-            KeyCommand.SELECT_UP,
-            KeyCommand.SELECT_DOWN -> return false
-            else -> {
-                super.onKeyEvent(
-                    event,
-                    textFieldState,
-                    textLayoutState,
-                    textFieldSelectionState,
-                    clipboardKeyCommandsHandler,
-                    editable,
-                    singleLine,
-                    onSubmit
-                )
-            }
-        }
-    }
-}
+internal actual fun createTextFieldKeyEventHandler(): TextFieldKeyEventHandler = createIOSTextFieldKeyEventHandler()


### PR DESCRIPTION
Implemented TextFieldKeyEventHandler for iOS target to avoid sending multiple EditCommands via using hardware keyboard on device / simulator in BTF2

Fixes: https://youtrack.jetbrains.com/issue/CMP-7893/Shiftarrow-up-does-not-select-on-BTF2

## Testing
Manual, use a hardware keyboard and try to select the text with Shift + Arrows, and just use arrows for navigation

## Release Notes
### Fixes - iOS
Fixed incorrect selection and navigation by arrow keys from a hardware keyboard in `BasicTextField(TextFieldState)`