### PR TITLE
Filter out unprintable characters received in InputMethodEvent

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -112,8 +112,8 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     private fun replaceInputMethodText(event: InputMethodEvent) {
         val input = currentInput ?: return
 
-        val committed = event.text.printableSubstringOrEmpty(0, event.committedCharacterCount)
-        val composing = event.text.printableSubstringOrEmpty(event.committedCharacterCount, null)
+        val committed = event.text.substringSuitableForTextFieldOrEmpty(0, event.committedCharacterCount)
+        val composing = event.text.substringSuitableForTextFieldOrEmpty(event.committedCharacterCount, null)
         val ops = mutableListOf<EditCommand>()
 
         if (needToDeletePreviousChar && input.value.selection.min > 0 && composing.isEmpty()) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -112,8 +112,8 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     private fun replaceInputMethodText(event: InputMethodEvent) {
         val input = currentInput ?: return
 
-        val committed = event.text.substringSuitableForTextFieldOrEmpty(0, event.committedCharacterCount)
-        val composing = event.text.substringSuitableForTextFieldOrEmpty(event.committedCharacterCount, null)
+        val committed = event.committedText
+        val composing = event.composingText
         val ops = mutableListOf<EditCommand>()
 
         if (needToDeletePreviousChar && input.value.selection.min > 0 && composing.isEmpty()) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -33,7 +33,6 @@ import java.awt.font.TextHitInfo
 import java.awt.im.InputMethodRequests
 import java.text.AttributedCharacterIterator
 import java.text.AttributedString
-import java.text.CharacterIterator
 import kotlin.math.max
 import kotlin.math.min
 import org.jetbrains.skiko.OS
@@ -113,8 +112,8 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     private fun replaceInputMethodText(event: InputMethodEvent) {
         val input = currentInput ?: return
 
-        val committed = event.text?.toStringUntil(event.committedCharacterCount).orEmpty()
-        val composing = event.text?.toStringFrom(event.committedCharacterCount).orEmpty()
+        val committed = event.text.printableSubstringOrEmpty(0, event.committedCharacterCount)
+        val composing = event.text.printableSubstringOrEmpty(event.committedCharacterCount, null)
         val ops = mutableListOf<EditCommand>()
 
         if (needToDeletePreviousChar && input.value.selection.min > 0 && composing.isEmpty()) {
@@ -211,28 +210,4 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
                 return AttributedString(committed).iterator
             }
         }
-}
-
-private fun AttributedCharacterIterator.toStringUntil(index: Int): String {
-    val strBuf = StringBuffer()
-    var i = index
-    if (i > 0) {
-        var c: Char = setIndex(0)
-        while (i > 0) {
-            strBuf.append(c)
-            c = next()
-            i--
-        }
-    }
-    return String(strBuf)
-}
-
-private fun AttributedCharacterIterator.toStringFrom(index: Int): String {
-    val strBuf = StringBuffer()
-    var c: Char = setIndex(index)
-    while (c != CharacterIterator.DONE) {
-        strBuf.append(c)
-        c = next()
-    }
-    return String(strBuf)
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -183,8 +183,8 @@ private class InputMethodRequestsImpl(
     }
 
     fun replaceInputMethodText(event: InputMethodEvent) {
-        val committed = event.text.printableSubstringOrEmpty(0, event.committedCharacterCount)
-        val composing = event.text.printableSubstringOrEmpty(event.committedCharacterCount, null)
+        val committed = event.text.substringSuitableForTextFieldOrEmpty(0, event.committedCharacterCount)
+        val composing = event.text.substringSuitableForTextFieldOrEmpty(event.committedCharacterCount, null)
 
         editText {
             if (needToDeletePreviousChar && selection.min > 0 && composing.isEmpty()) {
@@ -204,12 +204,12 @@ private class InputMethodRequestsImpl(
  * Returns the substring between [start] (inclusive) and [end] (exclusive, or the end of the
  * iterator, if `null`) of the given [AttributedCharacterIterator].
  *
- * Only printable characters are returned.
- * The reason unprintable characters need to be filtered is that the system sometimes sends
- * unprintable ones (e.g. backspace.) in an [InputMethodEvent].
+ * Only characters suitable to be present in a text field are returned.
+ * The reason the characters need to be filtered is that the system sometimes sends ones that
+ * should not be added to a text field (e.g. the backspace character) in an [InputMethodEvent].
  * See https://youtrack.jetbrains.com/issue/CMP-7989
  */
-internal fun AttributedCharacterIterator?.printableSubstringOrEmpty(
+internal fun AttributedCharacterIterator?.substringSuitableForTextFieldOrEmpty(
     start: Int,
     end: Int? = null
 ) : String {
@@ -219,7 +219,7 @@ internal fun AttributedCharacterIterator?.printableSubstringOrEmpty(
         index = start
         var c: Char = current()
         while ((c != CharacterIterator.DONE) && ((end == null) || (index < end))) {
-            if (!c.isISOControl())
+            if ((c == '\r') || (c == '\n') || (c == '\t') || !c.isISOControl())
                 append(c)
             c = next()
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -183,8 +183,8 @@ private class InputMethodRequestsImpl(
     }
 
     fun replaceInputMethodText(event: InputMethodEvent) {
-        val committed = event.text.substringSuitableForTextFieldOrEmpty(0, event.committedCharacterCount)
-        val composing = event.text.substringSuitableForTextFieldOrEmpty(event.committedCharacterCount, null)
+        val committed = event.committedText
+        val composing = event.composingText
 
         editText {
             if (needToDeletePreviousChar && selection.min > 0 && composing.isEmpty()) {
@@ -201,6 +201,20 @@ private class InputMethodRequestsImpl(
 }
 
 /**
+ * The committed text specified by the event, or an empty string if none.
+ */
+internal val InputMethodEvent.committedText: String
+    get() = text.substringSuitableForTextFieldOrEmpty(0, committedCharacterCount)
+
+
+/**
+ * The composing text specified by the event, or an empty string if none.
+ */
+internal val InputMethodEvent.composingText: String
+    get() = text.substringSuitableForTextFieldOrEmpty(committedCharacterCount, null)
+
+
+/**
  * Returns the substring between [start] (inclusive) and [end] (exclusive, or the end of the
  * iterator, if `null`) of the given [AttributedCharacterIterator].
  *
@@ -209,7 +223,7 @@ private class InputMethodRequestsImpl(
  * should not be added to a text field (e.g. the backspace character) in an [InputMethodEvent].
  * See https://youtrack.jetbrains.com/issue/CMP-7989
  */
-internal fun AttributedCharacterIterator?.substringSuitableForTextFieldOrEmpty(
+private fun AttributedCharacterIterator?.substringSuitableForTextFieldOrEmpty(
     start: Int,
     end: Int? = null
 ) : String {


### PR DESCRIPTION
Ignore unprintable characters sent to us in `InputMethodEvent`s.

In some cases, the text in an `InputMethodEvent` contains unprintable characters. For example:
1. Type something using composite input, and have a live composition in a text field.
2. Switch to a different window and back.
3. Press the "backspace" key.
4. The JRE sends an `InputMethodEvent` asking to commit literally the ASCII backspace character: '\b'.

Fixes https://youtrack.jetbrains.com/issue/CMP-7989

## Testing
Tested manually.

## Release Notes
### Fixes - Desktop
- [macOS] Fixed bad characters being added to a text field if switching away and back to a Compose window while composing text in the text field.