### PR TITLE
Add linuxMain source set

### DIFF
--- a/annotation/annotation-compatibility-stub/build.gradle
+++ b/annotation/annotation-compatibility-stub/build.gradle
@@ -35,9 +35,7 @@ androidXComposeMultiplatform {
     js()
     wasm()
     darwin()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/annotation/annotation/build.gradle
+++ b/annotation/annotation/build.gradle
@@ -19,9 +19,7 @@ androidXComposeMultiplatform {
     js()
     wasm()
     darwin()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -206,8 +206,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         iosArm64("uikitArm64")
         iosSimulatorArm64("uikitSimArm64")
 
-        val commonMain = sourceSets.getByName("commonMain")
-        val nativeMain = sourceSets.create("nativeMain")
+        val nativeMain = getOrCreateNativeMain()
         val darwinMain = sourceSets.create("darwinMain")
         val macosMain = sourceSets.create("macosMain")
         val macosX64Main = sourceSets.getByName("macosX64Main")
@@ -216,7 +215,6 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         val uikitX64Main = sourceSets.getByName("uikitX64Main")
         val uikitArm64Main = sourceSets.getByName("uikitArm64Main")
         val uikitSimArm64Main = sourceSets.getByName("uikitSimArm64Main")
-        nativeMain.dependsOn(commonMain)
         darwinMain.dependsOn(nativeMain)
         macosMain.dependsOn(darwinMain)
         macosX64Main.dependsOn(macosMain)
@@ -226,8 +224,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         uikitArm64Main.dependsOn(uikitMain)
         uikitSimArm64Main.dependsOn(uikitMain)
 
-        val commonTest = sourceSets.getByName("commonTest")
-        val nativeTest = sourceSets.create("nativeTest")
+        val nativeTest = getOrCreateNativeTest()
         val darwinTest = sourceSets.create("darwinTest")
         val macosTest = sourceSets.create("macosTest")
         val macosX64Test = sourceSets.getByName("macosX64Test")
@@ -236,7 +233,6 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         val uikitX64Test = sourceSets.getByName("uikitX64Test")
         val uikitArm64Test = sourceSets.getByName("uikitArm64Test")
         val uikitSimArm64Test = sourceSets.getByName("uikitSimArm64Test")
-        nativeTest.dependsOn(commonTest)
         darwinTest.dependsOn(nativeTest)
         macosTest.dependsOn(darwinTest)
         macosX64Test.dependsOn(macosTest)
@@ -247,12 +243,25 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         uikitSimArm64Test.dependsOn(uikitTest)
     }
 
-    override fun linuxX64(): Unit = multiplatformExtension.run {
+    override fun linux(): Unit = multiplatformExtension.run {
         linuxX64()
-    }
-
-    override fun linuxArm64(): Unit = multiplatformExtension.run {
         linuxArm64()
+
+        val nativeMain = getOrCreateNativeMain()
+        val linuxMain = sourceSets.create("linuxMain")
+        val linuxX64Main = sourceSets.getByName("linuxX64Main")
+        val linuxArm64Main = sourceSets.getByName("linuxArm64Main")
+        linuxMain.dependsOn(nativeMain)
+        linuxX64Main.dependsOn(linuxMain)
+        linuxArm64Main.dependsOn(linuxMain)
+
+        val nativeTest = getOrCreateNativeTest()
+        val linuxTest = sourceSets.create("linuxTest")
+        val linuxX64Test = sourceSets.getByName("linuxX64Test")
+        val linuxArm64Test = sourceSets.getByName("linuxArm64Test")
+        linuxTest.dependsOn(nativeTest)
+        linuxX64Test.dependsOn(linuxTest)
+        linuxArm64Test.dependsOn(linuxTest)
     }
 
     private fun getOrCreateJvmMain(): KotlinSourceSet =
@@ -260,6 +269,12 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
 
     private fun getOrCreateJvmTest(): KotlinSourceSet =
         getOrCreateSourceSet("jvmTest", "commonTest")
+
+    private fun getOrCreateNativeMain(): KotlinSourceSet =
+        getOrCreateSourceSet("nativeMain", "commonMain")
+
+    private fun getOrCreateNativeTest(): KotlinSourceSet =
+        getOrCreateSourceSet("nativeTest", "commonTest")
 
     private fun getOrCreateSourceSet(
         name: String,

--- a/buildSrc/public/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtension.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtension.kt
@@ -56,15 +56,9 @@ abstract class AndroidXComposeMultiplatformExtension {
 
     /**
      * Provides the default target configuration and source set dependencies
-     * for all linuxX64 native targets.
+     * for all linux native targets.
      */
-    abstract fun linuxX64(): Unit
-
-    /**
-     * Provides the default target configuration and source set dependencies
-     * for all linuxArm64 native targets.
-     */
-    abstract fun linuxArm64(): Unit
+    abstract fun linux(): Unit
 
     /**
      * Configures native compilation tasks with flags to link required frameworks

--- a/collection/collection-compatibility-stub/build.gradle
+++ b/collection/collection-compatibility-stub/build.gradle
@@ -35,9 +35,7 @@ androidXComposeMultiplatform {
     js()
     wasm()
     darwin()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/collection/collection/build.gradle
+++ b/collection/collection/build.gradle
@@ -35,9 +35,7 @@ androidXComposeMultiplatform {
     js()
     wasm()
     darwin()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/compose/runtime/runtime-annotation/build.gradle
+++ b/compose/runtime/runtime-annotation/build.gradle
@@ -41,9 +41,7 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -73,9 +73,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         darwin()
         js()
         wasm()
-
-        linuxX64()
-        linuxArm64()
+        linux()
     }
 
     kotlin {

--- a/compose/runtime/runtime-test-utils/build.gradle
+++ b/compose/runtime/runtime-test-utils/build.gradle
@@ -37,8 +37,7 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -69,9 +69,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
         js()
         wasm()
         darwin()
-
-        linuxX64()
-        linuxArm64()
+        linux()
     }
 
     kotlin {

--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -43,9 +43,7 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {

--- a/savedstate/savedstate-compose/build.gradle
+++ b/savedstate/savedstate-compose/build.gradle
@@ -44,9 +44,7 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
-
-    linuxX64()
-    linuxArm64()
+    linux()
 }
 
 kotlin {


### PR DESCRIPTION
This PR creates a new `linuxMain` source set which depends on `nativeMain`. It can be created with `linux()`, this is similar to how it is done for other targets.

Replaced individual `linuxX64()`/`linuxArm64()` targets with this new `linux()` call. I did not add linux support to any new modules, this PR is so the actual PR supporting Linux for Compose UI will be a bit smaller. The additional linuxMain source set is required for that.

## Testing
N/A

## Release Notes
N/A