### PR TITLE
Fix accessibility for popups of modal view controller

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -212,7 +212,7 @@ internal class ComposeHostingViewController(
 
         updateInterfaceOrientationState()
 
-        layers?.window = window
+        layers?.containerView = layersContainerView()
         windowContext.setWindowContainer(windowContainer)
         updateMotionSpeed()
     }
@@ -289,7 +289,7 @@ internal class ComposeHostingViewController(
         metalView.canBeOpaque = configuration.opaque
 
         val layers = UIKitComposeSceneLayersHolder(windowContext, configuration.parallelRendering)
-        layers.window = rootView.window
+        layers.containerView = layersContainerView()
         this.layers = layers
 
         mediator = ComposeSceneMediator(
@@ -347,6 +347,21 @@ internal class ComposeHostingViewController(
     override fun didReceiveMemoryWarning() {
         GC.collect()
         super.didReceiveMemoryWarning()
+    }
+
+    // The Layers view is a full screen overlay of the current content. To do this, the layers
+    // container view should be placed as close as possible to the current UIWindow.
+    // If another view controller is presented modaly, UIWindow changes accessibility elements,
+    // so the layers view can't be accessed by the iOS accessibility engine.
+    // Find the next view in the hierarchy. This view is unique to the root and each modal
+    // view controller.
+    private fun layersContainerView(): UIView? {
+        val window = view.window ?: return null
+        var iteratingView = view.superview
+        while (iteratingView != null && iteratingView.superview != window) {
+            iteratingView = iteratingView.superview
+        }
+        return iteratingView
     }
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.Canvas
-import platform.UIKit.UIWindow
+import platform.UIKit.UIView
 
 /**
  * A class responsible for managing and rendering [UIKitComposeSceneLayer]s.
@@ -72,7 +72,7 @@ internal class UIKitComposeSceneLayersHolder(
         )
     }
 
-    var window: UIWindow? = null
+    var containerView: UIView? = null
         set(value) {
             if (field != value) {
                 field = value
@@ -117,6 +117,7 @@ internal class UIKitComposeSceneLayersHolder(
 
         view.updateMetalView(metalView = null)
         view.removeFromSuperview()
+        containerView = null
     }
 
     fun attach(layer: UIKitComposeSceneLayer, hasViewAppeared: Boolean) {
@@ -128,7 +129,7 @@ internal class UIKitComposeSceneLayersHolder(
         view.embedSubview(layer.view)
 
         if (isFirstLayer) {
-            window?.embedSubview(view)
+            containerView?.embedSubview(view)
         }
 
         if (hasViewAppeared) {


### PR DESCRIPTION
The Compose Layers view is a full screen overlay of the current content. To do this, the Layers container view should be placed as close as possible to the current UIWindow.
If another view controller is presented modaly, UIWindow changes accessibility elements, so the Compose Layers View can't be accessed by the iOS accessibility engine.
Find the next view in the hierarchy. This view is unique to the root and each modal view controller.

Fixes https://youtrack.jetbrains.com/issue/CMP-7907/iOS-Full-Keyboard-access.-Doesnt-work-correctly-inside-dialogs

## Release Notes
N/A
