### PR TITLE
Fix overscroll touches assertion when predictive back handler involved

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/IosBugs.kt
@@ -39,5 +39,6 @@ val IosBugs = Screen.Selection(
     ModalMemoryLeak,
     ModalCrash,
     PopupStretching,
+    SwipeBackScrollCrash,
     TransformGesturesBug
 )

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/SwipeBackScrollCrash.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/bugs/SwipeBackScrollCrash.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.mpp.demo.Screen
+import androidx.compose.ui.Modifier
+
+val SwipeBackScrollCrash = Screen.Example("Crash on Swipe Back") {
+    LazyColumn(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
+        items(100) {
+            androidx.compose.material3.Text("Item $it", modifier = Modifier.fillMaxWidth())
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -81,6 +81,16 @@ internal class UIKitBackGestureDispatcher(
         rightEdgePanGestureRecognizer.enabled = listener != null
     }
 
+    private val activeGestureStates = listOf(
+        UIGestureRecognizerStateBegan,
+        UIGestureRecognizerStateChanged
+    )
+
+    val isBackGestureActive: Boolean
+        get() =
+            leftEdgePanGestureRecognizer.state in activeGestureStates ||
+                rightEdgePanGestureRecognizer.state in activeGestureStates
+
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
         if (enableBackGesture) {
             if (window == null) {
@@ -182,7 +192,7 @@ private class UiKitScreenEdgePanGestureHandler(
 
 /**
  * A special gesture recognizer that can cancel touches in the Compose scene.
- * See [androidx.compose.ui.window.UserInputGestureRecognizer.canBePreventedByGestureRecognizer]
+ * See [androidx.compose.ui.window.TouchesGestureRecognizer.canBePreventedByGestureRecognizer]
  */
 internal class UIKitBackGestureRecognizer(
     target: Any?, action: CPointer<out CPointed>?

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -284,7 +284,8 @@ internal class ComposeSceneMediator(
         ::onScrollEvent,
         ::onCancelScroll,
         ::onHoverEvent,
-        ::onKeyboardPresses
+        ::onKeyboardPresses,
+        backGestureDispatcher::isBackGestureActive
     )
 
     /**


### PR DESCRIPTION
Disable Compose touches when `UIKitBackGestureRecognizer` is active.

Fixes https://youtrack.jetbrains.com/issue/CMP-7967/iOS-Crash-when-swiping-screen-with-Predictive-back-feature.

## Release Notes
### Fixes - iOS
- Fix overscroll touches assertion when predictive back handler involved