### PR TITLE
[Cherry-pick] Fix back gesture after modal popup appearance

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -41,7 +41,6 @@ import platform.UIKit.UIRectEdgeLeft
 import platform.UIKit.UIRectEdgeRight
 import platform.UIKit.UIScreenEdgePanGestureRecognizer
 import platform.UIKit.UIView
-import platform.UIKit.UIWindow
 import platform.darwin.NSObject
 
 private const val BACK_GESTURE_SCREEN_SIZE = 0.3
@@ -91,17 +90,10 @@ internal class UIKitBackGestureDispatcher(
             leftEdgePanGestureRecognizer.state in activeGestureStates ||
                 rightEdgePanGestureRecognizer.state in activeGestureStates
 
-    fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
+    fun attachToView(view: UIView?) {
         if (enableBackGesture) {
-            if (window == null) {
-                removeGestureListeners()
-            } else {
-                var view: UIView = composeRootView
-                while (view.superview != window) {
-                    view = requireNotNull(view.superview) {
-                        "Window is not null, but superview is null for ${view.debugDescription}"
-                    }
-                }
+            removeGestureListeners()
+            if (view != null) {
                 addGestureListeners(view)
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -207,7 +207,9 @@ internal class ComposeHostingViewController(
     }
 
     private fun onDidMoveToWindow(window: UIWindow?) {
-        backGestureDispatcher.onDidMoveToWindow(window, rootView)
+        if (mediator != null) {
+            backGestureDispatcher.attachToView(window)
+        }
         val windowContainer = window ?: return
 
         updateInterfaceOrientationState()
@@ -273,6 +275,8 @@ internal class ComposeHostingViewController(
     override fun viewControllerDidEnterWindowHierarchy() {
         super.viewControllerDidEnterWindowHierarchy()
 
+        backGestureDispatcher.attachToView(view.window)
+
         val metalView = MetalView(
             retrieveInteropTransaction = {
                 mediator?.retrieveInteropTransaction() ?: object : UIKitInteropTransaction {
@@ -322,6 +326,8 @@ internal class ComposeHostingViewController(
 
     override fun viewControllerDidLeaveWindowHierarchy() {
         super.viewControllerDidLeaveWindowHierarchy()
+
+        backGestureDispatcher.attachToView(null)
 
         // Store the current state in the next SaveableStateRegistry instance. It is used to
         // provide the saved state to the next compose scene when the view controller re-enters

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.window.MetalView
 import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGPoint
-import platform.UIKit.UIWindow
 
 internal class UIKitComposeSceneLayer(
     private val onClosed: (UIKitComposeSceneLayer) -> Unit,
@@ -72,7 +71,6 @@ internal class UIKitComposeSceneLayer(
         }
 
     val view = UIKitComposeSceneLayerView(
-        ::onDidMoveToWindow,
         ::isInsideInteractionBounds,
         isInterceptingOutsideEvents = { focusable }
     )
@@ -83,7 +81,9 @@ internal class UIKitComposeSceneLayer(
         enableBackGesture = enableBackGesture,
         density = view.density,
         getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
-    )
+    ).also {
+        it.attachToView(view)
+    }
 
     private val mediator = ComposeSceneMediator(
         parentView = view,
@@ -136,10 +136,6 @@ internal class UIKitComposeSceneLayer(
 
     private val scrimPaint = Paint()
 
-    private fun onDidMoveToWindow(window: UIWindow?) {
-        backGestureDispatcher.onDidMoveToWindow(window, view)
-    }
-
     fun render(canvas: Canvas, nanoTime: Long) {
         if (scrimColor != null) {
             val rect = metalView.bounds.asDpRect().toRect(density)
@@ -165,6 +161,7 @@ internal class UIKitComposeSceneLayer(
         view.removeFromSuperview()
         view.dispose()
         interopContainerView.removeFromSuperview()
+        backGestureDispatcher.attachToView(null)
     }
 
     @Composable

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
@@ -27,7 +27,6 @@ import platform.UIKit.UIEvent
 import platform.UIKit.UIEventTypeTouches
 import platform.UIKit.UITouch
 import platform.UIKit.UIView
-import platform.UIKit.UIWindow
 
 /**
  * A backing ComposeSceneLayer view for each Compose scene layer. Its task is to
@@ -39,7 +38,6 @@ import platform.UIKit.UIWindow
  * events that start outside the bounds of the layer content or should let them pass through.
  */
 internal class UIKitComposeSceneLayerView(
-    private var onDidMoveToWindow: (UIWindow?) -> Unit,
     private var isInsideInteractionBounds: (point: CValue<CGPoint>) -> Boolean,
     private var isInterceptingOutsideEvents: () -> Boolean
 ): UIView(frame = CGRectZero.readValue()) {
@@ -121,15 +119,9 @@ internal class UIKitComposeSceneLayerView(
     }
 
     fun dispose() {
-        onDidMoveToWindow = {}
         isInsideInteractionBounds = { false }
         isInterceptingOutsideEvents = { false }
         onOutsidePointerEvent = {}
-    }
-
-    override fun didMoveToWindow() {
-        super.didMoveToWindow()
-        onDidMoveToWindow(window)
     }
 }
 


### PR DESCRIPTION
Add back gesture handler directly on window

Fixes
https://youtrack.jetbrains.com/issue/CMP-7765/iOS-Back-handler.-Doesnt-work-after-opening-video-player-LocalUIViewController

## Release Notes
### Fixes - iOS
- Fix back gesture after modal popup appearance