### PR TITLE
Fix wrong position of context menu in textfield on modal screens

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -103,6 +103,11 @@ internal class IntermediateTextInputUIView(
 
     override fun canBecomeFirstResponder() = true
 
+    override fun resignFirstResponder(): Boolean {
+        hideTextMenu()
+        return super.resignFirstResponder()
+    }
+
     override fun beginFloatingCursorAtPoint(point: CValue<CGPoint>) {
         input?.beginFloatingCursor(point.useContents { DpOffset(x.dp, y.dp) })
     }


### PR DESCRIPTION
Partially fixes: https://youtrack.jetbrains.com/issue/CMP-7951/iOS-TextField-wrong-selection-carret-and-context-menu-behavior-with-TextField-inside-Dialog

## Testing
Manual by using code from the task.
This should be tested by QA

## Release Notes
### Fixes - iOS
Fixed the behavior of a context menu in the textfields inside modally presented screens