### PR TITLE
Fix TextInputTests::keyboardEventPassedToTextField test

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.events.InputEventInit
 import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.sendFromScope
 import kotlin.test.Ignore
 import kotlin.test.Test
@@ -43,7 +42,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.yield
 import org.w3c.dom.HTMLTextAreaElement
 import org.w3c.dom.events.CompositionEvent
 import org.w3c.dom.events.CompositionEventInit


### PR DESCRIPTION
In all keyboardEventPassedToTextField we have no other TextInputTests rather then just wait for an element we need in a Selenium-like fashion - that is - just waiting for it

## Testing
run `./gradlew testWeb`

## Release Notes
N/A
