### PR TITLE
Commit text composition on focus changes

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -33,7 +33,6 @@ import java.awt.font.TextHitInfo
 import java.awt.im.InputMethodRequests
 import java.text.AttributedCharacterIterator
 import java.text.AttributedString
-import java.text.CharacterIterator
 import kotlin.math.max
 import kotlin.math.min
 import org.jetbrains.skiko.OS
@@ -117,8 +116,8 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     private fun replaceInputMethodText(event: InputMethodEvent) {
         val input = currentInput ?: return
 
-        val committed = event.text?.toStringUntil(event.committedCharacterCount).orEmpty()
-        val composing = event.text?.toStringFrom(event.committedCharacterCount).orEmpty()
+        val committed = event.committedText
+        val composing = event.composingText
         val ops = mutableListOf<EditCommand>()
 
         if (needToDeletePreviousChar && input.value.selection.min > 0 && composing.isEmpty()) {
@@ -215,28 +214,4 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
                 return AttributedString(committed).iterator
             }
         }
-}
-
-private fun AttributedCharacterIterator.toStringUntil(index: Int): String {
-    val strBuf = StringBuffer()
-    var i = index
-    if (i > 0) {
-        var c: Char = setIndex(0)
-        while (i > 0) {
-            strBuf.append(c)
-            c = next()
-            i--
-        }
-    }
-    return String(strBuf)
-}
-
-private fun AttributedCharacterIterator.toStringFrom(index: Int): String {
-    val strBuf = StringBuffer()
-    var c: Char = setIndex(index)
-    while (c != CharacterIterator.DONE) {
-        strBuf.append(c)
-        c = next()
-    }
-    return String(strBuf)
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
@@ -21,18 +21,20 @@ import java.awt.Point
 import java.awt.im.InputMethodRequests
 
 internal interface PlatformComponent {
-    fun enableInput(inputMethodRequests: InputMethodRequests)
-    fun disableInput()
     // Input service needs to know this information to implement Input Method support
     val locationOnScreen: Point
     val density: Density
 
+    fun enableInput(inputMethodRequests: InputMethodRequests)
+
+    fun disableInput()
+
     companion object {
         val Empty = object : PlatformComponent {
-            override fun enableInput(inputMethodRequests: InputMethodRequests) = Unit
-            override fun disableInput() = Unit
             override val locationOnScreen = Point(0, 0)
             override val density = Density(1f)
+            override fun enableInput(inputMethodRequests: InputMethodRequests) = Unit
+            override fun disableInput() = Unit
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -223,9 +223,10 @@ internal class ComposeContainer(
     override fun windowDeactivated(e: WindowEvent) = Unit
 
     private fun onWindowFocusChanged() {
-        isFocused = window?.isFocused ?: false
-        windowContext.setWindowFocused(isFocused)
-        mediator.onChangeWindowFocus()
+        val isNowFocused = window?.isFocused ?: false
+        isFocused = isNowFocused
+        windowContext.setWindowFocused(isNowFocused)
+        mediator.onWindowFocusChanged()
         layers.fastForEach(DesktopComposeSceneLayer::onWindowFocusChanged)
         updateLifecycleState()
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -621,7 +621,7 @@ internal class ComposeSceneMediator(
         skiaLayerComponent.onRenderApiChanged(action)
     }
 
-    fun onChangeWindowFocus() {
+    fun onWindowFocusChanged() {
         keyboardModifiersRequireUpdate = true
     }
 
@@ -751,6 +751,12 @@ internal class ComposeSceneMediator(
     }
 
     private inner class DesktopPlatformComponent : PlatformComponent {
+        override val locationOnScreen: Point
+            get() = contentComponent.locationOnScreen
+
+        override val density: Density
+            get() = contentComponent.density
+
         override fun enableInput(inputMethodRequests: InputMethodRequests) {
             currentInputMethodRequests = inputMethodRequests
             contentComponent.enableInputMethods(true)
@@ -768,12 +774,6 @@ internal class ComposeSceneMediator(
             // not dynamically
             resetFocus()
         }
-
-        override val locationOnScreen: Point
-            get() = contentComponent.locationOnScreen
-
-        override val density: Density
-            get() = contentComponent.density
     }
 
     @OptIn(InternalComposeUiApi::class)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/InputMethodEndCompositionWorkaround.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/InputMethodEndCompositionWorkaround.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.scene.skia
+
+import java.awt.AWTEvent
+import java.awt.Component
+import java.awt.event.FocusEvent
+import java.awt.im.InputContext
+import java.util.*
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
+
+internal interface InputMethodEndCompositionWorkaround {
+
+    val inputContext: InputContext?
+
+    class CInputMethodWorkaround(
+        val componentInputContext: () -> InputContext?
+    ) : InputMethodEndCompositionWorkaround {
+        override val inputContext: InputContext = object : DelegatingInputContext(componentInputContext) {
+            override fun dispatchEvent(event: AWTEvent) {
+                val componentInputContext = componentInputContext() ?: return
+
+                // Try to end the composition already on focus-lost, but can't do it if some other
+                // component is gaining focus because then it might receive the InputMethodEvent
+                // committing the composition.
+                // Note that this works on JBR (17.0.14), but not on e.g. Corretto, because in
+                // Corretto, by the time CInputMethod.unmarkText is called, there is no
+                // fAwtFocussedComponent.
+                if ((event is FocusEvent) && (event.id == FocusEvent.FOCUS_LOST) && (event.oppositeComponent == null)) {
+                    componentInputContext.endComposition()
+                }
+
+                componentInputContext.dispatchEvent(event)
+
+                if (event.id == FocusEvent.FOCUS_GAINED) {
+                    componentInputContext.endComposition()
+                }
+            }
+        }
+    }
+
+    companion object {
+        fun forCurrentEnvironment(
+            componentInputContext: () -> InputContext?
+        ): InputMethodEndCompositionWorkaround? = when (hostOs) {
+            OS.MacOS -> CInputMethodWorkaround(componentInputContext)
+            else -> null
+        }
+    }
+}
+
+private abstract class DelegatingInputContext(
+    val delegate: () -> InputContext?,
+) : InputContext() {
+
+    override fun dispatchEvent(event: AWTEvent) {
+        delegate()?.dispatchEvent(event)
+    }
+
+    override fun selectInputMethod(locale: Locale?): Boolean {
+        return delegate()?.selectInputMethod(locale) ?: false
+    }
+
+    override fun getLocale(): Locale? {
+        return delegate()?.locale
+    }
+
+    override fun setCharacterSubsets(subsets: Array<out Character.Subset>?) {
+        delegate()?.setCharacterSubsets(subsets)
+    }
+
+    override fun setCompositionEnabled(enable: Boolean) {
+        delegate()?.setCompositionEnabled(enable)
+    }
+
+    override fun isCompositionEnabled(): Boolean {
+        return delegate()?.isCompositionEnabled ?: false
+    }
+
+    override fun reconvert() {
+        delegate()?.reconvert()
+    }
+
+    override fun removeNotify(client: Component?) {
+        delegate()?.removeNotify(client)
+    }
+
+    override fun endComposition() {
+        delegate()?.endComposition()
+    }
+
+    override fun dispose() {
+        delegate()?.dispose()
+    }
+
+    override fun getInputMethodControlObject(): Any? {
+        return delegate()?.inputMethodControlObject
+    }
+}

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/InputMethodEndCompositionWorkaround.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/InputMethodEndCompositionWorkaround.kt
@@ -23,11 +23,26 @@ import java.awt.im.InputContext
 import java.util.*
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
+import org.jetbrains.skiko.SkiaLayer
 
+/**
+ * The interface for a workaround applied to [SkiaLayer] that commits the input method composition
+ * on focus changes.
+ *
+ * See https://github.com/JetBrains/compose-multiplatform-core/pull/2026 for a discussion of the
+ * issue(s) and the fix.
+ */
 internal interface InputMethodEndCompositionWorkaround {
 
+    /**
+     * The [InputContext] that [SkiaLayer.getInputContext] should return; `null` if it should return
+     * the default one.
+     */
     val inputContext: InputContext?
 
+    /**
+     * An implementation of the workaround for [sun.lwawt.macosx.CInputMethod].
+     */
     class CInputMethodWorkaround(
         val componentInputContext: () -> InputContext?
     ) : InputMethodEndCompositionWorkaround {
@@ -55,6 +70,12 @@ internal interface InputMethodEndCompositionWorkaround {
     }
 
     companion object {
+        /**
+         * Returns the workaround for the current JVM/OS.
+         *
+         * @param componentInputContext A function that returns the [SkiaLayer]s original
+         * [InputContext]
+         */
         fun forCurrentEnvironment(
             componentInputContext: () -> InputContext?
         ): InputMethodEndCompositionWorkaround? = when (hostOs) {
@@ -64,6 +85,9 @@ internal interface InputMethodEndCompositionWorkaround {
     }
 }
 
+/**
+ * An [InputContext] that redirects all calls to [delegate].
+ */
 private abstract class DelegatingInputContext(
     val delegate: () -> InputContext?,
 ) : InputContext() {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -52,6 +52,19 @@ internal class SwingSkiaLayerComponent(
                 checkNotNull(mediator.accessible)
             }
         ) {
+            private var endCompositionWorkaround: InputMethodEndCompositionWorkaround? = null
+
+            override fun getInputContext() =
+                endCompositionWorkaround?.inputContext ?: super.getInputContext()
+
+            override fun addNotify() {
+                super.addNotify()
+
+                endCompositionWorkaround = InputMethodEndCompositionWorkaround.forCurrentEnvironment(
+                    componentInputContext = { super.getInputContext() }
+                )
+            }
+
             override fun paint(g: Graphics) {
                 mediator.onChangeDensity()
                 super.paint(g)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -59,6 +59,20 @@ internal class WindowSkiaLayerComponent(
         },
         analytics = skiaLayerAnalytics
     ) {
+
+        private var endCompositionWorkaround: InputMethodEndCompositionWorkaround? = null
+
+        override fun getInputContext() =
+            endCompositionWorkaround?.inputContext ?: super.getInputContext()
+
+        override fun addNotify() {
+            super.addNotify()
+
+            endCompositionWorkaround = InputMethodEndCompositionWorkaround.forCurrentEnvironment(
+                componentInputContext = { super.getInputContext() }
+            )
+        }
+
         override fun paint(g: Graphics) {
             mediator.onChangeDensity()
             super.paint(g)


### PR DESCRIPTION
There is a difference in behavior of CInputMethod in JBR and Corretto (and possibly other JREs).
JBR [ignores calls to `setAWTFocussedComponent` with a `null` component](https://github.com/JetBrains/JetBrainsRuntime/commit/8b9a00915df501ae9778034e882c972a494c2767#diff-01651348382f7df0cfec4fd34fa82401d4bae2f3531c0c7da50974ec15d6308cR285-R290), which allows `endComposition` to work after a component loses focus. This is exactly what happens in the two linked issues; however in [one of them](https://youtrack.jetbrains.com/issue/CMP-7976) it causes a bug while in the [other](https://youtrack.jetbrains.com/issue/CMP-7989) it works around a different bug.

This PR fixes these two issues by:
1. Forcing a call to `endComposition` whenever Compose gains focus.  Note that this also happens when focus switches inside Compose, due to `DesktopPlatformComponent` calling `resetFocus`.
3. Ignoring the extra `InputMethodEvent` that asks us to commit the composition when we receive it as the first event in a text editing session in `DesktopTextInputService2`.

Fixes https://youtrack.jetbrains.com/issue/CMP-7976
Fixes https://youtrack.jetbrains.com/issue/CMP-7989

## Testing
Tested manually on:
```
    Column(
        modifier = Modifier.fillMaxSize().padding(16.dp),
    ) {
        Text("TextField2 1")
        TextField(
            state = rememberTextFieldState(""),
        )

        Spacer(Modifier.height(64.dp))
        Text("TextField2 2")
        TextField(
            state = rememberTextFieldState(""),
        )

        Spacer(Modifier.height(64.dp))
        Text("JTextField")
        SwingPanel(
            factory = {
                JTextField()
            },
            modifier = Modifier
                .size(200.dp, 60.dp)
        )
    }
```

The following tests were performed using 2-Set Korean input in 8 configurations.

1. Type several composite characters in a Compose TextField
2. With a composition in a Compose TextField: Switch to another Compose TextField - composition should be committed. Switch back and press backspace - last character should be deleted.
3. With a composition in a Compose TextField: Switch to a JTextField, switch back and press backspace - last character should be deleted.
4. With a composition in a Compose TextField: Switch to another window - ideally composition should be committed, but not must (doesn't work on Corretto). Switch back - composition should be committed. Press backspace - last character should be deleted.
5. With a live composition in a JTextField: Switch to a Compose TextField, start a composition

The configurations are the combinations of:
1. JBR/Corretto 17.0.14 and JBR/Corretto 21.0.6
6. `WindowSkiaLayerComponent` (via regular `singleWindowApplication`) or `SwingSkiaLayerComponent` with `compose.swing.render.on.graphics=true` (via `ComposePanel` in a `JFrame`).

This should be tested by QA.
It's also a good idea to test whether everything works as before on Windows/Linux.

I discovered an additional bug, only in Corretto:
If, during a composition in a textfield, you switch away from the window and then back, the system completely stops sending mouse-press events to the window. Typing something seems to "shake" the system back into behaving normally. This seems to be caused by the `endComposition` call on focus-gain in `CInputMethodWorkaround`, but it's also present in pure Java (but to trigger it, you have to first press e.g. backspace after switching back to the window).

## Release Notes
### Fixes - Desktop
- [macOS; JBR] Fixed the current composition in a text field being duplicated into another text field when switching focus to it.
- [macOS] Fixed strange glyph being displayed in a text field if window becomes unfocused, then focused again while there's an active composition in the text field (after pressing e.g. backspace).
