### PR TITLE
In DesktopTextInputService, ignore call to `stopInput()`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -76,6 +76,10 @@ internal class DesktopTextInputService(private val component: PlatformComponent)
     }
 
     override fun stopInput() {
+        // We may have been "started" with startInput() (with no arguments), but it's not a real
+        // session in this case, so let's not call component.disableInput()
+        if (currentInput == null) return
+
         component.disableInput()
         currentInput = null
     }


### PR DESCRIPTION
https://github.com/JetBrains/compose-multiplatform-core/pull/1974, adds calls of `startInput()` (no-argument version) and `stopInput` to `DesktopTextInputService`.

Unfortunately, `DesktopTextInputService` was not prepared for this scenario, as it never expected `startInput()` (the version without arguments) to be called. It would then call `PlatformComponent.disableInput()` on `stopInput()`, causing this to be called twice (another time by `DesktopTextInputService2`).

This PR fixes `DesktopTextInputService` to ignore `stopInput` calls unless the correct `startInput` function was called.

## Release Notes
N/A