### PR TITLE
[Cherry-pick] Fix usage of runtime experimental annotation (#2031)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -19,7 +19,6 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,7 +90,7 @@ import platform.UIKit.UIWindow
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
-@OptIn(BetaInteropApi::class, ExperimentalComposeApi::class)
+@OptIn(BetaInteropApi::class)
 @ExportObjCClass
 internal class ComposeHostingViewController(
     private val configuration: ComposeUIViewControllerConfiguration,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.uikit
 
-import androidx.compose.runtime.ExperimentalComposeApi
 import androidx.compose.ui.ExperimentalComposeUiApi
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
@@ -47,7 +46,7 @@ class ComposeUIViewControllerConfiguration {
      * Determines whether the Compose view should have an opaque background.
      * Warning: disabling opaque layer may affect performance.
      */
-    @ExperimentalComposeApi
+    @ExperimentalComposeUiApi
     var opaque: Boolean = true
 
     /**
@@ -72,7 +71,7 @@ class ComposeUIViewControllerConfiguration {
     /**
      * A flag to enable or disable iOS BackGesture recognizer.
      */
-    @ExperimentalComposeApi
+    @ExperimentalComposeUiApi
     var enableBackGesture: Boolean = true
 }
 


### PR DESCRIPTION
Address missed feedback from
https://github.com/JetBrains/compose-multiplatform-core/pull/1694#discussion_r1856576561

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Change runtime experimental annotations to proper "ui" experimental annotations for a few fields inside `ComposeUIViewControllerConfiguration`

