### PR TITLE
Compose 1.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -105,8 +105,8 @@ jetbrains.compose.compiler.version=1.5.14.1
 #   artifactRedirection.version.<redirectionGroup>.<redirectionModule>
 #   covers all sub-module projects
 #   (artifactRedirection.version.androidx.compose covers androidx.compose.*:*)
-artifactRedirection.version.androidx.compose=1.8.0-rc03
-artifactRedirection.version.androidx.compose.material.material-navigation=1.8.0-rc03
+artifactRedirection.version.androidx.compose=1.8.0
+artifactRedirection.version.androidx.compose.material.material-navigation=1.8.0
 artifactRedirection.version.androidx.compose.material3=1.3.2
 artifactRedirection.version.androidx.compose.material3.common=1.0.0-alpha01
 artifactRedirection.version.androidx.compose.material3.adaptive=1.1.0


### PR DESCRIPTION
No diff in `compose`:
```
$ git diff androidx/compose-ui/1.8.0-rc03 androidx/compose-ui/1.8.0
diff --git a/libraryversions.toml b/libraryversions.toml
index c72c512c424..3ee8d57b3f2 100644
--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -21,12 +21,12 @@ CAMERA_VIEWFINDER = "1.4.0-alpha12"
 CARDVIEW = "1.1.0-alpha01"
 CAR_APP = "1.8.0-alpha01"
 COLLECTION = "1.5.0-beta03"
-COMPOSE = "1.8.0-rc03"
+COMPOSE = "1.8.0"
 COMPOSE_MATERIAL3 = "1.4.0-alpha07"
 COMPOSE_MATERIAL3_ADAPTIVE = "1.1.0-beta01"
 COMPOSE_MATERIAL3_COMMON = "1.0.0-alpha01"
 COMPOSE_MATERIAL3_XR = "1.0.0-alpha02"
-COMPOSE_RUNTIME = "1.8.0-rc03"
+COMPOSE_RUNTIME = "1.8.0"
 CONSTRAINTLAYOUT = "2.3.0-alpha01"
 CONSTRAINTLAYOUT_COMPOSE = "1.2.0-alpha01"
 CONSTRAINTLAYOUT_CORE = "1.2.0-alpha01"
```

So, changing only the redirect version.

## Release Notes
N/A