### PR TITLE
KeyCommand.DELETE_PREV_CHAR correctly deletes chars (2)

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -184,6 +184,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 implementation(project(":internal-testutils-runtime"))
                 implementation("androidx.activity:activity-compose:1.3.1")
                 implementation("androidx.core:core:1.9.0")
+                implementation("androidx.emoji2:emoji2-bundled:1.5.0")
 
                 implementation(libs.testUiautomator)
                 implementation(libs.testRules)

--- a/compose/foundation/foundation/src/androidInstrumentedTest/kotlin/androidx/compose/foundation/text/test/EmojiCompatHelper.kt
+++ b/compose/foundation/foundation/src/androidInstrumentedTest/kotlin/androidx/compose/foundation/text/test/EmojiCompatHelper.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.test
+
+import android.content.Context
+import androidx.emoji2.bundled.BundledEmojiCompatConfig
+import androidx.emoji2.text.EmojiCompat
+import com.google.common.truth.Truth.assertThat
+import java.util.concurrent.Executor
+
+internal fun withEmojiCompat(context: Context, enabled: Boolean = true, block: () -> Unit) {
+    if (!enabled) {
+        block()
+        return
+    }
+
+    try {
+        val synchronousExecutor = Executor { runnable -> runnable.run() }
+        EmojiCompat.init(BundledEmojiCompatConfig(context, synchronousExecutor))
+        assertThat(EmojiCompat.get().loadState).isEqualTo(EmojiCompat.LOAD_STATE_SUCCEEDED)
+        block()
+    } finally {
+        EmojiCompat.reset(null)
+    }
+}

--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/StringHelpers.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/StringHelpers.android.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.foundation.text.input.internal.findCodePointBefore
+import androidx.compose.foundation.text.input.internal.selection.TextFieldPreparedSelection.Companion.NoCharacterFound
 import androidx.emoji2.text.EmojiCompat
 import java.text.BreakIterator
 
@@ -36,6 +38,18 @@ internal actual fun String.findFollowingBreak(index: Int): Int {
     val it = BreakIterator.getCharacterInstance()
     it.setText(this)
     return it.following(index)
+}
+
+internal actual fun String.findCodePointOrEmojiStartBefore(index: Int): Int {
+    if (index <= 0) return NoCharacterFound
+
+    val emojiCompat = getEmojiCompatIfLoaded()
+    if (emojiCompat == null) return findCodePointBefore(index)
+
+    val emojiStart = emojiCompat.getEmojiStart(this, index - 1)
+    if (emojiStart < 0) return findCodePointBefore(index)
+
+    return emojiStart
 }
 
 private fun getEmojiCompatIfLoaded(): EmojiCompat? =

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/StringHelpers.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/StringHelpers.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.foundation.text.input.internal.selection.TextFieldPreparedSelection.Companion.NoCharacterFound
 import androidx.compose.ui.text.TextRange
 
 /** StringBuilder.appendCodePoint is already defined on JVM so it's called appendCodePointX. */
@@ -29,6 +30,13 @@ internal expect fun String.findPrecedingBreak(index: Int): Int
  * breaks before the end of the string.
  */
 internal expect fun String.findFollowingBreak(index: Int): Int
+
+/**
+ * @return If the index is within an emoji, returns the index of the start of the emoji. If the
+ *   index is not an emoji, returns the code point before the given [index], or [NoCharacterFound]
+ *   if there is no code point before [index].
+ */
+internal expect fun String.findCodePointOrEmojiStartBefore(index: Int): Int
 
 internal fun CharSequence.findParagraphStart(startIndex: Int): Int {
     for (index in startIndex downTo 1) {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.kt
@@ -125,10 +125,11 @@ internal class TextFieldKeyInput(
                 KeyCommand.END -> moveCursorToEnd()
                 KeyCommand.DELETE_PREV_CHAR ->
                     deleteIfSelectedOr {
-                            DeleteSurroundingTextCommand(
-                                selection.end - getPrecedingCharacterIndex(),
-                                0
-                            )
+                            val precedingCodePointIndex = getPrecedingCodePointOrEmojiStartIndex()
+                            if (precedingCodePointIndex == NoCharacterFound) {
+                                return@deleteIfSelectedOr null
+                            }
+                            DeleteSurroundingTextCommand(selection.end - precedingCodePointIndex, 0)
                         }
                         ?.apply()
                 KeyCommand.DELETE_NEXT_CHAR -> {

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/CodepointHelpers.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/CodepointHelpers.kt
@@ -16,8 +16,16 @@
 
 package androidx.compose.foundation.text.input.internal
 
+import androidx.compose.foundation.text.input.internal.selection.TextFieldPreparedSelection.Companion.NoCharacterFound
+
 internal expect fun CharSequence.codePointAt(index: Int): Int
 
 internal expect fun charCount(codePoint: Int): Int
 
 internal expect fun CharSequence.codePointBefore(index: Int): Int
+
+/**
+ * @return the code point before the given [index], or [NoCharacterFound] if there is no code point
+ *   before [index].
+ */
+internal expect fun CharSequence.findCodePointBefore(index: Int): Int

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.kt
@@ -178,7 +178,7 @@ internal abstract class TextFieldKeyEventHandler {
                 KeyCommand.LINE_RIGHT -> moveCursorToLineRightSide()
                 KeyCommand.HOME -> moveCursorToHome()
                 KeyCommand.END -> moveCursorToEnd()
-                KeyCommand.DELETE_PREV_CHAR -> moveCursorPrevByChar().deleteMovement()
+                KeyCommand.DELETE_PREV_CHAR -> moveCursorPrevByCodePointOrEmoji().deleteMovement()
                 KeyCommand.DELETE_NEXT_CHAR -> moveCursorNextByChar().deleteMovement()
                 KeyCommand.DELETE_PREV_WORD -> moveCursorPrevByWord().deleteMovement()
                 KeyCommand.DELETE_NEXT_WORD -> moveCursorNextByWord().deleteMovement()

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextPreparedSelection.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextPreparedSelection.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation.text.input.internal.selection
 
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.text.findCodePointOrEmojiStartBefore
 import androidx.compose.foundation.text.findFollowingBreak
 import androidx.compose.foundation.text.findParagraphEnd
 import androidx.compose.foundation.text.findParagraphStart
@@ -213,6 +214,10 @@ internal class TextFieldPreparedSelection(
                 wedgeAffinity = newWedgeAffinity
             }
         }
+
+    fun moveCursorPrevByCodePointOrEmoji() = moveCursorTo {
+        text.findCodePointOrEmojiStartBefore(selection.end)
+    }
 
     fun moveCursorPrevByChar() = moveCursorTo { text.findPrecedingBreak(selection.end) }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextPreparedSelection.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextPreparedSelection.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation.text.selection
 
 import androidx.compose.foundation.text.TextLayoutResultProxy
+import androidx.compose.foundation.text.findCodePointOrEmojiStartBefore
 import androidx.compose.foundation.text.findFollowingBreak
 import androidx.compose.foundation.text.findParagraphEnd
 import androidx.compose.foundation.text.findParagraphStart
@@ -133,6 +134,14 @@ internal abstract class BaseTextPreparedSelection<T : BaseTextPreparedSelection<
             }
         }
     }
+
+    /**
+     * Returns the index of the code point preceding the end of [selection], or [NoCharacterFound]
+     * if there is no preceding code point. If the character is within an emoji, it returns the
+     * start of the emoji instead.
+     */
+    fun getPrecedingCodePointOrEmojiStartIndex() =
+        annotatedString.text.findCodePointOrEmojiStartBefore(selection.end)
 
     /** Returns the index of the character break preceding the end of [selection]. */
     fun getPrecedingCharacterIndex() = annotatedString.text.findPrecedingBreak(selection.end)

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/StringHelpers.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/StringHelpers.jsNative.kt
@@ -20,3 +20,6 @@ internal actual fun StringBuilder.appendCodePointX(codePoint: Int): StringBuilde
     appendCodePoint(codePoint)
     return this
 }
+
+internal actual fun String.findCodePointOrEmojiStartBefore(index: Int): Int =
+    implementedInJetBrainsFork()

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/StringHelpers.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/StringHelpers.jsNative.kt
@@ -21,5 +21,3 @@ internal actual fun StringBuilder.appendCodePointX(codePoint: Int): StringBuilde
     return this
 }
 
-internal actual fun String.findCodePointOrEmojiStartBefore(index: Int): Int =
-    implementedInJetBrainsFork()

--- a/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/input/internal/CodepointHelpers.jsNative.kt
+++ b/compose/foundation/foundation/src/jsNativeMain/kotlin/androidx/compose/foundation/text/input/internal/CodepointHelpers.jsNative.kt
@@ -19,6 +19,8 @@ package androidx.compose.foundation.text.input.internal
 import androidx.compose.foundation.text.codePointAt as _codePointAt
 import androidx.compose.foundation.text.codePointBefore as _codePointBefore
 import androidx.compose.foundation.text.charCount
+import androidx.compose.foundation.text.input.internal.selection.TextFieldPreparedSelection.Companion.NoCharacterFound
+import androidx.compose.foundation.text.offsetByCodePoints
 
 internal actual fun CharSequence.codePointAt(index: Int): Int =
     _codePointAt(index)
@@ -28,3 +30,12 @@ internal actual fun charCount(codePoint: Int): Int =
 
 internal actual fun CharSequence.codePointBefore(index: Int): Int =
     _codePointBefore(index)
+
+/**
+ * @return the code point before the given [index], or [NoCharacterFound] if there is no code point
+ *   before [index].
+ */
+internal actual fun CharSequence.findCodePointBefore(index: Int): Int {
+    if (index <= 0) return NoCharacterFound
+    return offsetByCodePoints(index, offset = -1)
+}

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/input/internal/CodepointHelpers.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/input/internal/CodepointHelpers.jvm.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.foundation.text.input.internal
 
+import androidx.compose.foundation.text.input.internal.selection.TextFieldPreparedSelection.Companion.NoCharacterFound
+
 internal actual fun CharSequence.codePointAt(index: Int): Int =
     java.lang.Character.codePointAt(this, index)
 
@@ -23,3 +25,7 @@ internal actual fun charCount(codePoint: Int): Int = java.lang.Character.charCou
 
 internal actual fun CharSequence.codePointBefore(index: Int): Int =
     java.lang.Character.codePointBefore(this, index)
+
+internal actual fun CharSequence.findCodePointBefore(index: Int): Int =
+    if (index <= 0) NoCharacterFound
+    else java.lang.Character.offsetByCodePoints(this, index, /* codePointOffset= */ -1)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldInputTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldInputTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.foundation.assertThat
+import androidx.compose.foundation.isEqualTo
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextInputSelection
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.performTextReplacement
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TextFieldInputTest {
+    @Test
+    fun textField_backspace_withDiacritic() = runTextFieldInputTest {
+        onTextField {
+            setTextAndPlaceCursorAtEnd("e\u0301f") // e + combining acute accent + f
+            performKeyInput {
+                pressKey(Key.Backspace)
+                assertTextEquals("e\u0301")
+                pressKey(Key.Backspace) // Should remove the accent, not the base character
+                assertTextEquals("e")
+                pressKey(Key.Backspace)
+                assertTextEquals("")
+                pressKey(Key.Backspace) // Shouldn't crash
+                assertTextEquals("")
+            }
+        }
+    }
+
+    private fun TextFieldInputTestScope.backspace_withEmoji(emoji: String) {
+        onTextField {
+            setTextAndPlaceCursorAtEnd(emoji)
+            performKeyInput {
+                pressKey(Key.Backspace)
+                assertTextEquals("")
+            }
+        }
+    }
+
+    @Test
+    fun textField_backspace_withEmoji() = runTextFieldInputTest {
+        backspace_withEmoji("")
+        backspace_withEmoji("✅")
+        backspace_withEmoji("😉")
+        backspace_withEmoji("🥺")
+        backspace_withEmoji("♥️")
+        backspace_withEmoji("🇮🇱")  // flag
+        backspace_withEmoji("🏴󠁧󠁢󠁥󠁮󠁧󠁿")  // Scotland flag (14 characters)
+        backspace_withEmoji("✌\uD83C\uDFFD")  // victory hand: medium skin tone
+        backspace_withEmoji("👩‍❤️‍💋‍👩")  // 👩 ❤️ 💋‍ 👩 (joined with zero-width-joiner)
+    }
+}
+
+@OptIn(ExperimentalTestApi::class)
+private abstract class TextFieldInputTestScope(
+    val uiTest: ComposeUiTest,
+) : SemanticsNodeInteractionsProvider by uiTest {
+    protected val textFieldTag = "TextField"
+
+    abstract val text: String
+
+    @Composable
+    abstract fun TextField()
+
+    fun assertTextEquals(expected: String) {
+        assertThat(text).isEqualTo(expected)
+    }
+
+    fun onTextField(block: SemanticsNodeInteraction.() -> Unit) =
+        with(onNodeWithTag(textFieldTag)) {
+            block()
+        }
+
+    fun SemanticsNodeInteraction.setTextAndPlaceCursorAtEnd(text: String) {
+        performTextReplacement(text)
+        performTextInputSelection(TextRange(text.length))
+    }
+}
+
+@OptIn(ExperimentalTestApi::class)
+private class TextField1InputTestScope(
+    uiTest: ComposeUiTest,
+): TextFieldInputTestScope(uiTest) {
+    private var textFieldValue by mutableStateOf(TextFieldValue())
+
+    override val text: String
+        get() = textFieldValue.text
+
+    @Composable
+    override fun TextField() {
+        val focusRequester = FocusRequester()
+        BasicTextField(
+            value = textFieldValue,
+            onValueChange = { textFieldValue = it },
+            modifier = Modifier
+                .focusRequester(focusRequester)
+                .testTag(textFieldTag)
+        )
+
+        LaunchedEffect(focusRequester) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    override fun toString() = "TextField1"
+}
+
+@OptIn(ExperimentalTestApi::class)
+private class TextField2InputTestScope(
+    uiTest: ComposeUiTest,
+): TextFieldInputTestScope(uiTest) {
+    private var textFieldState by mutableStateOf(TextFieldState())
+
+    override val text: String
+        get() = textFieldState.text.toString()
+
+    @Composable
+    override fun TextField() {
+        val focusRequester = FocusRequester()
+        BasicTextField(
+            state = textFieldState,
+            modifier = Modifier
+                .focusRequester(focusRequester)
+                .testTag(textFieldTag)
+        )
+
+        LaunchedEffect(focusRequester) {
+            focusRequester.requestFocus()
+        }
+    }
+
+    override fun toString() = "TextField2"
+}
+
+@OptIn(ExperimentalTestApi::class)
+private fun runTextFieldInputTest(
+    scopeBuilders: List<(ComposeUiTest) -> TextFieldInputTestScope> = listOf(
+        ::TextField1InputTestScope,
+        ::TextField2InputTestScope,
+    ),
+    block: TextFieldInputTestScope.() -> Unit
+) {
+    for (scopeBuilder in scopeBuilders) {
+        runComposeUiTest {
+            with(scopeBuilder(this)) {
+                setContent {
+                    TextField()
+                }
+                block()
+            }
+        }
+    }
+}

--- a/compose/ui/ui-util/src/nonJvmMain/kotlin/androidx/compose/ui/util/InlineClassHelper.nonJvm.kt
+++ b/compose/ui/ui-util/src/nonJvmMain/kotlin/androidx/compose/ui/util/InlineClassHelper.nonJvm.kt
@@ -27,3 +27,5 @@ actual inline fun doubleFromBits(bits: Long): Double = Double.fromBits(bits)
 actual inline fun Float.fastRoundToInt(): Int = roundToInt()
 
 actual inline fun Double.fastRoundToInt(): Int = roundToInt()
+
+internal actual fun CharSequence.findCodePointBefore(index: Int): Int = implementedInJetBrainsFork()

--- a/compose/ui/ui-util/src/nonJvmMain/kotlin/androidx/compose/ui/util/InlineClassHelper.nonJvm.kt
+++ b/compose/ui/ui-util/src/nonJvmMain/kotlin/androidx/compose/ui/util/InlineClassHelper.nonJvm.kt
@@ -27,5 +27,3 @@ actual inline fun doubleFromBits(bits: Long): Double = Double.fromBits(bits)
 actual inline fun Float.fastRoundToInt(): Int = roundToInt()
 
 actual inline fun Double.fastRoundToInt(): Int = roundToInt()
-
-internal actual fun CharSequence.findCodePointBefore(index: Int): Int = implementedInJetBrainsFork()


### PR DESCRIPTION
Before, the command was deleting to the previous character break. Now, it will correctly delete a code point instead so that diacritic marks are removed off a glyph instead of deleting the entire glyph. An exception is carved out for emojis, where the entire emoji will be deleted instead of a single code point, which would decompose emojis to their parts if deleting a single 
code point.

Note that this is a cherry-pick of https://android-review.googlesource.com/c/platform/frameworks/support/+/3501992 with adaptations for CMP.

This PR is a re-application of https://github.com/JetBrains/compose-multiplatform-core/pull/1869.

Fixes https://youtrack.jetbrains.com/issue/CMP-7478

## Testing
- Added new tests
- Manual testing

This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Changes pressing backspace in a textfield to delete diacritic marks, if any, rather than the entire character.