### PR TITLE
Re-add back gesture handler after end of transition animation

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -93,17 +93,14 @@ internal class UIKitBackGestureDispatcher(
 
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
         if (enableBackGesture) {
-            if (window == null) {
-                removeGestureListeners()
-            } else {
-                var view: UIView = composeRootView
-                while (view.superview != window) {
-                    view = requireNotNull(view.superview) {
-                        "Window is not null, but superview is null for ${view.debugDescription}"
-                    }
+            removeGestureListeners()
+            var view: UIView = composeRootView
+            while (view.superview != window) {
+                view = requireNotNull(view.superview) {
+                    "Window is not null, but superview is null for ${view.debugDescription}"
                 }
-                addGestureListeners(view)
             }
+            addGestureListeners(view)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -94,13 +94,15 @@ internal class UIKitBackGestureDispatcher(
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
         if (enableBackGesture) {
             removeGestureListeners()
-            var view: UIView = composeRootView
-            while (view.superview != window) {
-                view = requireNotNull(view.superview) {
-                    "Window is not null, but superview is null for ${view.debugDescription}"
+            if (window != null) {
+                var view: UIView = composeRootView
+                while (view.superview != window) {
+                    view = requireNotNull(view.superview) {
+                        "Window is not null, but superview is null for ${view.debugDescription}"
+                    }
                 }
+                addGestureListeners(view)
             }
-            addGestureListeners(view)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -246,6 +246,10 @@ internal class ComposeHostingViewController(
         mediator?.sceneDidAppear()
         layers?.viewDidAppear()
         configuration.delegate.viewDidAppear(animated)
+
+        // Because the container view can change during the modal transition animation,
+        // the gesture handlers are added back when the animation ends.
+        backGestureDispatcher.onDidMoveToWindow(view.window, rootView)
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
Due to iOS specifics, it changes container view that used for back gesture handling after the end of modal transition animation.

Fixes https://youtrack.jetbrains.com/issue/CMP-7765/iOS-Back-handler.-Doesnt-work-after-opening-video-player-LocalUIViewController

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix back gesture handling after modal view controller dismissal