### PR TITLE
Fix initially disabling input methods

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -381,8 +381,6 @@ internal class ComposeSceneMediator(
         container.transferHandler = dragAndDropManager.transferHandler
         container.dropTarget = dragAndDropManager.dropTarget
 
-        // It will be enabled dynamically. See DesktopPlatformComponent
-        contentComponent.enableInputMethods(false)
         contentComponent.focusTraversalKeysEnabled = false
 
         subscribe(contentComponent)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.scene.skia
 import androidx.compose.ui.scene.ComposeSceneMediator
 import java.awt.Dimension
 import java.awt.Graphics
+import java.awt.event.FocusEvent
 import javax.accessibility.Accessible
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
@@ -81,6 +82,23 @@ internal class SwingSkiaLayerComponent(
                 super.getPreferredSize()
             } else {
                 mediator.preferredSize
+            }
+
+            // Workaround for enableInputMethods being ignored until the component is actually focused.
+            // This also controls the default state, without needing it to be set from the outside.
+            private var inputMethodsEnabled = false
+
+            override fun processFocusEvent(e: FocusEvent?) {
+                super.processFocusEvent(e)
+
+                // enableInputMethods is idempotent (and quick when applying the same value),
+                // so it's ok to call it on every event
+                super.enableInputMethods(inputMethodsEnabled)
+            }
+
+            override fun enableInputMethods(enable: Boolean) {
+                inputMethodsEnabled = enable
+                super.enableInputMethods(enable)
             }
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeSceneMediator
 import java.awt.Dimension
 import java.awt.Graphics
+import java.awt.event.FocusEvent
+import java.awt.event.FocusListener
 import javax.accessibility.Accessible
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayer
@@ -60,6 +62,14 @@ internal class WindowSkiaLayerComponent(
         analytics = skiaLayerAnalytics
     ) {
 
+        init {
+            // SkiaLayer never receives focus, only its underlying canvas
+            canvas.addFocusListener(object : FocusListener {
+                override fun focusGained(e: FocusEvent?) = onFocusEvent()
+                override fun focusLost(e: FocusEvent?) = onFocusEvent()
+            })
+        }
+
         private var endCompositionWorkaround: InputMethodEndCompositionWorkaround? = null
 
         override fun getInputContext() =
@@ -89,6 +99,21 @@ internal class WindowSkiaLayerComponent(
             super.getPreferredSize()
         } else {
             mediator.preferredSize
+        }
+
+        // Workaround for enableInputMethods being ignored until the component is actually focused.
+        // This also controls the default state, without needing it to be set from the outside.
+        private var inputMethodsEnabled = false
+
+        private fun onFocusEvent() {
+            // enableInputMethods is idempotent (and quick when applying the same value),
+            // so it's ok to call it on every event
+            super.enableInputMethods(inputMethodsEnabled)
+        }
+
+        override fun enableInputMethods(enable: Boolean) {
+            inputMethodsEnabled = enable
+            super.enableInputMethods(enable)
         }
     }
 


### PR DESCRIPTION
We currently try to disable input methods in `ComposeSceneMediator.init`, but this doesn't work because it's too early. The call `enableInputMethods` is ignored unless the component actually has focus.

This PR adds a local flag in `WindowSkiaLayerComponent` and `SwingSkiaLayerComponent`, and applies it on every focus event.

Fixes https://youtrack.jetbrains.com/issue/CMP-3839

Note that this only fixes the issue for JBR (JetBrains Runtime). For some reason Corretto keeps showing the input method toolbar even when `enableInputMethods` is called correctly. It behaves the same in pure Swing. For example, this code correctly disables the toolbar on JBR, but not on Corretto:

```
    JFrame().apply {
        size = Dimension(800, 600)
        defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE
        isVisible = true
        SwingUtilities.invokeLater {
            focusOwner?.enableInputMethods(false)
        }
    }
```

## Testing
Tested manually on
```
    singleWindowApplication { }
```
using Pinyin - Simplified input method on macOS.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- [macOS] Fix showing the input method toolbar before any text field becomes focused (on JBR only; other runtimes continue to be buggy).
