### PR TITLE
[Cherry-pick] Re-add back gesture handler after end of transition animation (#2046)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -93,9 +93,8 @@ internal class UIKitBackGestureDispatcher(
 
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
         if (enableBackGesture) {
-            if (window == null) {
-                removeGestureListeners()
-            } else {
+            removeGestureListeners()
+            if (window != null) {
                 var view: UIView = composeRootView
                 while (view.superview != window) {
                     view = requireNotNull(view.superview) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -246,6 +246,10 @@ internal class ComposeHostingViewController(
         mediator?.sceneDidAppear()
         layers?.viewDidAppear()
         configuration.delegate.viewDidAppear(animated)
+
+        // Because the container view can change during the modal transition animation,
+        // the gesture handlers are added back when the animation ends.
+        backGestureDispatcher.onDidMoveToWindow(view.window, rootView)
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
Due to iOS specifics, it changes container view that used for back gesture handling after the end of modal transition animation.

Fixes
https://youtrack.jetbrains.com/issue/CMP-7765/iOS-Back-handler.-Doesnt-work-after-opening-video-player-LocalUIViewController

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix back gesture handling after modal view controller dismissal
