### PR TITLE
Remove back gesture handler when hosting view controller becomes invisible

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -259,6 +259,8 @@ internal class ComposeHostingViewController(
         mediator?.sceneWillDisappear()
         layers?.viewWillDisappear()
         configuration.delegate.viewWillDisappear(animated)
+
+        backGestureDispatcher.onDidMoveToWindow(null, rootView)
     }
 
     @Suppress("DEPRECATION")
@@ -320,6 +322,7 @@ internal class ComposeHostingViewController(
             }
         }
 
+        backGestureDispatcher.onDidMoveToWindow(view.window, rootView)
         onAccessibilityChanged()
     }
 
@@ -335,6 +338,7 @@ internal class ComposeHostingViewController(
         )
 
         rootView.updateMetalView(metalView = null)
+        backGestureDispatcher.onDidMoveToWindow(null, rootView)
 
         mediator?.dispose()
         mediator = null


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7765/iOS-Back-handler.-Doesnt-work-after-opening-video-player-LocalUIViewController

## Release Notes
N/A