### PR TITLE
Fix overscroll when RTL is enabled

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Overscroll.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/Overscroll.uikit.kt
@@ -21,9 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalAccessorScope
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.LayoutDirection
 
 @Composable
 internal actual fun rememberPlatformOverscrollEffect(): OverscrollEffect? =
@@ -32,24 +30,21 @@ internal actual fun rememberPlatformOverscrollEffect(): OverscrollEffect? =
 @Composable
 internal fun rememberOverscrollEffect(applyClip: Boolean): OverscrollEffect {
     val density = LocalDensity.current.density
-    val layoutDirection = LocalLayoutDirection.current
 
-    return remember(density, layoutDirection) {
-        CupertinoOverscrollEffect(density, layoutDirection, applyClip)
+    return remember(density) {
+        CupertinoOverscrollEffect(density, applyClip)
     }
 }
 
 internal actual fun CompositionLocalAccessorScope.defaultOverscrollFactory(): OverscrollFactory? {
     val density = LocalDensity.currentValue
-    val layoutDirection = LocalLayoutDirection.currentValue
-    return CupertinoOverscrollEffectFactory(density, layoutDirection)
+    return CupertinoOverscrollEffectFactory(density)
 }
 
 private data class CupertinoOverscrollEffectFactory(
-    private val density: Density,
-    private val layoutDirection: LayoutDirection
+    private val density: Density
 ) : OverscrollFactory {
     override fun createOverscrollEffect(): OverscrollEffect {
-        return CupertinoOverscrollEffect(density.density, layoutDirection, applyClip = false)
+        return CupertinoOverscrollEffect(density.density, applyClip = false)
     }
 }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/cupertino/CupertinoOverscrollEffect.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.toOffset
@@ -96,7 +95,6 @@ private data class CupertinoOverscrollAvailableDelta(
  */
 internal class CupertinoOverscrollEffect(
     private val density: Float,
-    layoutDirection: LayoutDirection,
     val applyClip: Boolean
 ) : OverscrollEffect {
     /*
@@ -110,12 +108,6 @@ internal class CupertinoOverscrollEffect(
      * received delta.
      */
     private var direction: CupertinoOverscrollDirection = CupertinoOverscrollDirection.UNKNOWN
-
-    private val reverseHorizontal =
-        when (layoutDirection) {
-            LayoutDirection.Ltr -> false
-            LayoutDirection.Rtl -> true
-        }
 
     /*
      * Size of container is taking into consideration when computing rubber banding
@@ -141,7 +133,7 @@ internal class CupertinoOverscrollEffect(
 
     private var lastFlingUnconsumedDelta: Offset = Offset.Zero
     private val visibleOverscrollOffset: IntOffset
-        get() = overscrollOffsetState.value.reverseHorizontalIfNeeded().rubberBanded().round()
+        get() = overscrollOffsetState.value.rubberBanded().round()
 
     override val isInProgress: Boolean
         get() =
@@ -433,12 +425,6 @@ internal class CupertinoOverscrollEffect(
 
         return currentVelocity
     }
-
-    private fun Offset.reverseHorizontalIfNeeded(): Offset =
-        Offset(
-            if (reverseHorizontal) -x else x,
-            y
-        )
 
     private fun Offset.rubberBanded(): Offset {
         if (scrollSize.width == 0f || scrollSize.height == 0f) {


### PR DESCRIPTION
Remove redundant coordinates flipping when RTL enabled.

Fixes https://youtrack.jetbrains.com/issue/CMP-8039/iOS.-Overscroll-doesnt-react-on-RTL-LocalLayoutDirection

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix overscroll when RTL is enabled