### PR TITLE
Fix TimePicker not respecting user's 24-hour clock setting on iOS

### DIFF
--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
@@ -19,6 +19,7 @@ package androidx.compose.material3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import platform.Foundation.NSLocale
+import platform.Foundation.autoupdatingCurrentLocale
 import platform.Foundation.preferredLanguages
 
 
@@ -26,6 +27,4 @@ actual typealias CalendarLocale = NSLocale
 
 @Composable
 @ReadOnlyComposable
-internal actual fun defaultLocale(): CalendarLocale = NSLocale(
-    NSLocale.preferredLanguages.first() as String
-)
+internal actual fun defaultLocale(): CalendarLocale = NSLocale.autoupdatingCurrentLocale()

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import platform.Foundation.NSLocale
 import platform.Foundation.autoupdatingCurrentLocale
-import platform.Foundation.preferredLanguages
 
 
 actual typealias CalendarLocale = NSLocale

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import platform.Foundation.NSLocale
 import platform.Foundation.autoupdatingCurrentLocale
+import platform.Foundation.preferredLanguages
 
 
 actual typealias CalendarLocale = NSLocale

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/CalendarLocale.darwin.kt
@@ -19,7 +19,6 @@ package androidx.compose.material3
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import platform.Foundation.NSLocale
-import platform.Foundation.autoupdatingCurrentLocale
 import platform.Foundation.preferredLanguages
 
 
@@ -27,4 +26,6 @@ actual typealias CalendarLocale = NSLocale
 
 @Composable
 @ReadOnlyComposable
-internal actual fun defaultLocale(): CalendarLocale = NSLocale.autoupdatingCurrentLocale()
+internal actual fun defaultLocale(): CalendarLocale = NSLocale(
+    NSLocale.preferredLanguages.first() as String
+)

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
@@ -24,6 +24,8 @@ import platform.Foundation.NSCalendar
 import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSDateFormatterShortStyle
+import platform.Foundation.NSLocale
+import platform.Foundation.autoupdatingCurrentLocale
 import platform.Foundation.dateWithTimeIntervalSince1970
 import platform.Foundation.timeIntervalSince1970
 
@@ -106,8 +108,11 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     // 'j' template requests the preferred hour format for the locale.
     // 'a' is a pattern for AM\PM symbol. Presence of this symbol means that locale has 12h format.
     actual fun is24HourFormat(): Boolean {
+        // Use autoupdatingCurrentLocale so the result reflects the user's current system settings.
+        val currentLocale = NSLocale.autoupdatingCurrentLocale()
+
         return NSDateFormatter
-            .dateFormatFromTemplate("j", 0UL, locale)
+            .dateFormatFromTemplate("j", 0UL, currentLocale)
             ?.contains('a') == false
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the TimePicker did not respect the user’s 12h/24h clock preference set in iOS Settings. This is because the `is24HourFormat` function was based on a manually constructed `defaultLocale` using `preferredLanguages.first`, which does not reflect user-specific system settings.

This PR uses `NSLocale.autoupdatingCurrent` as `defaultLocale`, which ensures that the platform date formatter reflects both the current region settings and the user's system preferences.

Note: There is a difference in behavior between initializing `NSLocale` with an identifier and using `NSLocale.autoupdatingCurrent` (`NSLocale.current`) even if the identifiers are the same. 
- the former applies default date formatting rules based language-region combination defined by the identifier
- the latter reflects the actual **iOS settings** which is desired in this case.

Note: we use `NSLocale.autoupdatingCurrent` instead of `NSLocale.current` so that any changes to user preferences are updated immediately. This can be changed in this PR if preferred.

Note: the previous behavior was introduced in https://github.com/JetBrains/compose-multiplatform-core/pull/1914 and I am not entirely sure why that change was necessary, @terrakok can you please share a bit more context?

Fixes (partially) - https://youtrack.jetbrains.com/issue/CMP-7870/

## Release Notes
### Fixes - iOS
- Fix TimePicker not respecting user's 24-hour clock setting on iOS
