### PR TITLE
Fix keyboard insets tests

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -23,7 +23,16 @@ Run tests for Web:
 
 Run tests for UIKit:
 ```bash
-./gradlew :mpp:testUIKit -PiosSimulatorName='iPhone 15'
+./gradlew :mpp:testUIKit'
+```
+
+Run iOS instrumented tests:
+```bash
+defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
+
+cd compose/ui/ui/src/uikitInstrumentedTest/launcher
+
+xcodebuild test -scheme Launcher -project Launcher.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 16'
 ```
 
 ### API checks

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -26,8 +26,12 @@ Run tests for UIKit:
 ./gradlew :mpp:testUIKit'
 ```
 
-Run iOS instrumented tests:
+Run iOS instrumented tests.
+Note: To ensure the test runs on an iOS simulator with a detached hardware keyboard,
+we must shut down all simulators and update the ConnectHardwareKeyboard flag.
 ```bash
+xcrun simctl shutdown all
+
 defaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false
 
 cd compose/ui/ui/src/uikitInstrumentedTest/launcher

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui
 
-import androidx.compose.ui.keyboard.KeyboardInsetsTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui
 
-import androidx.compose.test.interaction.BasicInteractionTest
+import androidx.compose.ui.keyboard.KeyboardInsetsTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite
@@ -29,6 +29,6 @@ fun testSuite(): XCTestSuite = setupXCTestSuite(
     // LayersAccessibilityTest::class,
 
     // Run test cases from a test
-     BasicInteractionTest::testTextFieldCallout,
+    // BasicInteractionTest::testTextFieldCallout,
     // LayersAccessibilityTest::testLayersAppearanceOrder
 )

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -19,20 +19,30 @@ package androidx.compose.ui.keyboard
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.TextField
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.dpRectInWindow
 import androidx.compose.ui.test.utils.forEachWithPrevious
@@ -40,48 +50,58 @@ import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.asDpRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.min
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.viewinterop.UIKitView
-import kotlin.test.Ignore
+import androidx.compose.ui.window.KeyboardVisibilityListener
+import androidx.compose.ui.window.KeyboardVisibilityObserver
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.TimeSource
-import kotlin.time.TimeSource.Monotonic.ValueTimeMark
+import kotlinx.cinterop.CValue
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreGraphics.CGRect
 import platform.UIKit.UIView
+import platform.UIKit.UIViewAnimationOptions
 
-// TODO: https://youtrack.jetbrains.com/issue/CMP-7991 Does not work with new Launcher. Rework the test.
-@Ignore
 internal class KeyboardInsetsTest {
-    companion object {
-        // Maximum duration of a frame that is not considered as a frame drop.
-        // Warning: The test can be flaky on slow agents. Consider increasing the duration or
-        // using multiple retries in this case.
-        val maxFrameDuration = 1.seconds / 60 * 1.7
-    }
-
     @Test
-    fun testImeInsetsAnimationFrames() = runUIKitInstrumentedTest {
+    fun testImeInsetsAnimationFrames_FocusAboveKeyboard() = runUIKitInstrumentedTest {
         val contentFrames = mutableListOf<DpRect>()
         var lastContentFrame = DpRect(DpOffset.Unspecified, DpSize.Unspecified)
+        var focusManager: FocusManager? = null
+        val focusRequester = FocusRequester()
 
-        setContent {
-            Box(Modifier
-                .fillMaxSize()
-                .imePadding()
-                .onGloballyPositioned { coordinates ->
-                    // Since you can have multiple layouts per render cycle, remember the last
-                    // one and add it for further analysis during the render phase.
-                    lastContentFrame = coordinates.boundsInWindow().toDpRect(density)
-                }
-                .drawWithContent {
-                    contentFrames.add(lastContentFrame)
-                }
-            )
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            focusManager = LocalFocusManager.current
+            Box(
+                Modifier
+                    .fillMaxSize()
+                    .imePadding()
+                    .onGloballyPositioned { coordinates ->
+                        // Since you can have multiple layouts per render cycle, remember the last
+                        // one and add it for further analysis during the render phase.
+                        lastContentFrame = coordinates.boundsInWindow().toDpRect(density)
+                    }
+                    .drawWithContent {
+                        contentFrames.add(lastContentFrame)
+                    }
+            ) {
+                TextField(
+                    value = "",
+                    onValueChange = {},
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .align(Alignment.BottomCenter)
+                )
+            }
         }
 
         val screenRect = DpRect(origin = DpOffset.Zero, size = screenSize)
@@ -90,7 +110,7 @@ internal class KeyboardInsetsTest {
         assertTrue(contentFrames.all { it == screenRect })
 
         // Show keyboard with animation
-        // showKeyboard(animated = true)
+        focusRequester.requestFocus()
         contentFrames.clear()
         waitForIdle()
 
@@ -118,6 +138,7 @@ internal class KeyboardInsetsTest {
         }
 
         // Hide keyboard with animation
+        focusManager?.clearFocus()
         contentFrames.clear()
         waitForIdle()
 
@@ -138,192 +159,409 @@ internal class KeyboardInsetsTest {
         }
     }
 
-    @Ignore // Became flaky. TODO: Investigate performance problem.
     @Test
-    fun testImeInsetsAnimationFrameRate() = runUIKitInstrumentedTest {
-        val refreshTimings = mutableListOf<ValueTimeMark>()
+    fun testImeInsetsAnimationFrames_DoNothing() = runUIKitInstrumentedTest {
+        val contentFrames = mutableListOf<DpRect>()
+        var lastContentFrame = DpRect(DpOffset.Unspecified, DpSize.Unspecified)
+        var focusManager: FocusManager? = null
+        val focusRequester = FocusRequester()
 
-        setContent {
-            Box(Modifier
-                .fillMaxSize()
-                .imePadding()
-                .drawWithContent {
-                    refreshTimings.add(TimeSource.Monotonic.markNow())
-                }
-            )
-        }
-
-        // Show keyboard with animation
-        refreshTimings.clear()
-        waitForIdle()
-
-        refreshTimings.forEachWithPrevious { previous, next ->
-            assertTrue(next - previous < maxFrameDuration)
-        }
-
-        // Hide keyboard with animation
-        refreshTimings.clear()
-        waitForIdle()
-
-        refreshTimings.forEachWithPrevious { previous, next ->
-            assertTrue(next - previous < maxFrameDuration)
-        }
-    }
-
-    @Ignore // Became flaky. TODO: Investigate performance problem.
-    @Test
-    fun testImeInsetsAnimationFrameRateWithFocusedTextField() =
-        runUIKitInstrumentedTest {
-            // Maximum duration of a frame that is not considered as a frame drop
-            // Warning: The test can be flaky on slow agents. Consider using multiple retries
-            // in this case scenario
-            val maxFrameDuration = 1.seconds / 60 * 1.7
-
-            val refreshTimings = mutableListOf<ValueTimeMark>()
-            val focusRequester = FocusRequester()
-
-            setContent {
-                Box(Modifier
+        setContent({
+            onFocusBehavior = OnFocusBehavior.DoNothing
+        }) {
+            focusManager = LocalFocusManager.current
+            Box(
+                Modifier
                     .fillMaxSize()
                     .imePadding()
-                    .drawWithContent {
-                        refreshTimings.add(TimeSource.Monotonic.markNow())
+                    .onGloballyPositioned { coordinates ->
+                        // Since you can have multiple layouts per render cycle, remember the last
+                        // one and add it for further analysis during the render phase.
+                        lastContentFrame = coordinates.boundsInWindow().toDpRect(density)
                     }
-                ) {
-                    TextField(
-                        value = "",
-                        onValueChange = {},
-                        modifier = Modifier
-                            .focusRequester(focusRequester)
-                            .align(Alignment.BottomCenter)
-                    )
-                }
-            }
-
-            // Show keyboard with animation
-            focusRequester.requestFocus()
-            // showKeyboard(animated = true)
-            refreshTimings.clear()
-            waitForIdle()
-
-            refreshTimings.forEachWithPrevious { previous, next ->
-                assertTrue(next - previous < maxFrameDuration)
-            }
-
-            // Hide keyboard with animation
-            focusRequester.freeFocus()
-            refreshTimings.clear()
-            waitForIdle()
-
-            refreshTimings.forEachWithPrevious { previous, next ->
-                assertTrue(next - previous < maxFrameDuration)
-            }
-        }
-
-    @Test
-    fun testFocusableAboveKeyboardOffsetBehavior() =
-        runUIKitInstrumentedTest {
-            var textRectInWindow: DpRect? = null
-            var textRectInRoot: DpRect? = null
-            val bottomPadding = 100.dp
-            val interopView = UIView()
-
-            val focusRequester = FocusRequester()
-            setContent({
-                onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
-            }) {
-                Box(Modifier.padding(bottom = bottomPadding)) {
-                    UIKitView(
-                        factory = { interopView },
-                        modifier = Modifier.fillMaxSize()
-                    )
-                    TextField(
-                        value = "",
-                        onValueChange = {},
-                        modifier = Modifier
-                            .focusRequester(focusRequester)
-                            .align(Alignment.BottomCenter)
-                            .onGloballyPositioned { coordinates ->
-                                textRectInWindow = coordinates.boundsInWindow().toDpRect(density)
-                                textRectInRoot = coordinates.boundsInRoot().toDpRect(density)
-                            }
-                    )
-                }
-
-                LaunchedEffect(Unit) {
-                    focusRequester.requestFocus()
-                    // showKeyboard(animated = false)
-                }
-            }
-
-            assertEquals(screenSize.height - keyboardHeight, textRectInWindow?.bottom)
-            assertEquals(screenSize.height - keyboardHeight, textRectInRoot?.bottom)
-            assertEquals(screenSize.height - keyboardHeight, interopView.dpRectInWindow().bottom)
-
-            focusRequester.freeFocus()
-
-            waitForIdle()
-            assertEquals(screenSize.height - bottomPadding, textRectInWindow?.bottom)
-            assertEquals(screenSize.height - bottomPadding, textRectInRoot?.bottom)
-            assertEquals(screenSize.height - bottomPadding, interopView.dpRectInWindow().bottom)
-        }
-
-    @Test
-    fun testFocusableAboveKeyboardRefocusBehavior() =
-        runUIKitInstrumentedTest {
-            var text1RectInWindow: DpRect? = null
-            var text2RectInWindow: DpRect? = null
-            var text3RectInWindow: DpRect? = null
-
-            val focusRequester1 = FocusRequester()
-            val focusRequester2 = FocusRequester()
-            val focusRequester3 = FocusRequester()
-            setContent({
-                onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
-            }) {
-                @Composable
-                fun TestTextField(
-                    requester: FocusRequester,
-                    onPositionInWindowChanged: (DpRect) -> Unit
-                ) = TextField(
+                    .drawWithContent {
+                        contentFrames.add(lastContentFrame)
+                    }
+            ) {
+                TextField(
                     value = "",
                     onValueChange = {},
                     modifier = Modifier
-                        .focusRequester(requester)
-                        .onGloballyPositioned {
-                            onPositionInWindowChanged(it.boundsInWindow().toDpRect(density))
+                        .focusRequester(focusRequester)
+                        .align(Alignment.BottomCenter)
+                )
+            }
+        }
+
+        val screenRect = DpRect(origin = DpOffset.Zero, size = screenSize)
+
+        assertEquals(screenRect, contentFrames.last())
+        assertTrue(contentFrames.all { it == screenRect })
+
+        // Show keyboard with animation
+        focusRequester.requestFocus()
+        contentFrames.clear()
+        waitForIdle()
+
+        val visibleRect = DpRect(
+            left = 0.dp,
+            top = 0.dp,
+            right = screenSize.width,
+            bottom = screenSize.height - keyboardHeight
+        )
+
+        assertTrue(contentFrames.count() > 5, "Animation should produce large number of frames")
+        assertEquals(visibleRect, contentFrames.last(), "")
+        contentFrames.forEach {
+            assertEquals(0.dp, it.top, "Content must be top-aligned")
+        }
+        contentFrames.forEachWithPrevious { previousFrame, nextFrame ->
+            assertTrue(
+                nextFrame.bottom <= previousFrame.bottom,
+                "Content must shrink up on every frame"
+            )
+            assertTrue(
+                nextFrame.height <= previousFrame.height,
+                "Content size must decrease on every frame"
+            )
+        }
+
+        // Hide keyboard with animation
+        focusManager?.clearFocus()
+        contentFrames.clear()
+        waitForIdle()
+
+        assertTrue(contentFrames.count() > 5, "Animation should produce large number of frames")
+        assertEquals(screenRect, contentFrames.last())
+        contentFrames.forEach {
+            assertEquals(0.dp, it.top, "Content must be top-aligned")
+        }
+        contentFrames.forEachWithPrevious { previousFrame, nextFrame ->
+            assertTrue(
+                actual = nextFrame.bottom >= previousFrame.bottom,
+                "Content must expand down on every frame"
+            )
+            assertTrue(
+                actual = nextFrame.height >= previousFrame.height,
+                "Content size must increase on every frame"
+            )
+        }
+    }
+
+    @Test
+    fun testFocusableAboveKeyboardOffsetBehavior() = runUIKitInstrumentedTest {
+        var textRectInWindow: DpRect? = null
+        var textRectInRoot: DpRect? = null
+        val bottomPadding = 100.dp
+        val interopView = UIView()
+        var focusManager: FocusManager? = null
+
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            focusManager = LocalFocusManager.current
+            val focusRequester = remember { FocusRequester() }
+            Box(Modifier.padding(bottom = bottomPadding)) {
+                UIKitView(
+                    factory = { interopView },
+                    modifier = Modifier.fillMaxSize()
+                )
+                TextField(
+                    value = "",
+                    onValueChange = {},
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .align(Alignment.BottomCenter)
+                        .onGloballyPositioned { coordinates ->
+                            textRectInWindow = coordinates.boundsInWindow().toDpRect(density)
+                            textRectInRoot = coordinates.boundsInRoot().toDpRect(density)
                         }
                 )
-
-                Column(Modifier.fillMaxSize()) {
-                    Spacer(modifier = Modifier.weight(1f))
-                    TestTextField(focusRequester1) { text1RectInWindow = it }
-                    TestTextField(focusRequester2) { text2RectInWindow = it }
-                    TestTextField(focusRequester3) { text3RectInWindow = it }
-                }
-
-                LaunchedEffect(Unit) {
-                    focusRequester1.requestFocus()
-                    // showKeyboard(animated = false)
-                }
             }
 
-            assertEquals(screenSize.height - keyboardHeight, text1RectInWindow?.bottom)
-            assertNotEquals(screenSize.height - keyboardHeight, text2RectInWindow?.bottom)
-            assertNotEquals(screenSize.height - keyboardHeight, text3RectInWindow?.bottom)
-
-            focusRequester2.requestFocus()
-            waitForIdle()
-
-            assertNotEquals(screenSize.height - keyboardHeight, text1RectInWindow?.bottom)
-            assertEquals(screenSize.height - keyboardHeight, text2RectInWindow?.bottom)
-            assertNotEquals(screenSize.height - keyboardHeight, text3RectInWindow?.bottom)
-
-            focusRequester3.requestFocus()
-            waitForIdle()
-
-            assertNotEquals(screenSize.height - keyboardHeight, text1RectInWindow?.bottom)
-            assertNotEquals(screenSize.height - keyboardHeight, text2RectInWindow?.bottom)
-            assertEquals(screenSize.height - keyboardHeight, text3RectInWindow?.bottom)
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
         }
+
+        assertEquals(screenSize.height - keyboardHeight, textRectInWindow?.bottom)
+        assertEquals(screenSize.height - keyboardHeight, textRectInRoot?.bottom)
+        assertEquals(screenSize.height - keyboardHeight, interopView.dpRectInWindow().bottom)
+
+        focusManager?.clearFocus()
+        waitForIdle()
+
+        assertEquals(screenSize.height - bottomPadding, textRectInWindow?.bottom)
+        assertEquals(screenSize.height - bottomPadding, textRectInRoot?.bottom)
+        assertEquals(screenSize.height - bottomPadding, interopView.dpRectInWindow().bottom)
+    }
+
+    @Test
+    fun testFocusableAboveKeyboardRefocusBehavior() = runUIKitInstrumentedTest {
+        var text1RectInWindow: DpRect? = null
+        var text2RectInWindow: DpRect? = null
+        var text3RectInWindow: DpRect? = null
+
+        val focusRequester1 = FocusRequester()
+        val focusRequester2 = FocusRequester()
+        val focusRequester3 = FocusRequester()
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            @Composable
+            fun TestTextField(
+                requester: FocusRequester,
+                onPositionInWindowChanged: (DpRect) -> Unit
+            ) = TextField(
+                value = "",
+                onValueChange = {},
+                modifier = Modifier
+                    .focusRequester(requester)
+                    .onGloballyPositioned {
+                        onPositionInWindowChanged(it.boundsInWindow().toDpRect(density))
+                    }
+            )
+
+            Column(Modifier.fillMaxSize()) {
+                Spacer(modifier = Modifier.weight(1f))
+                TestTextField(focusRequester1) { text1RectInWindow = it }
+                TestTextField(focusRequester2) { text2RectInWindow = it }
+                TestTextField(focusRequester3) { text3RectInWindow = it }
+            }
+
+            LaunchedEffect(Unit) {
+                focusRequester1.requestFocus()
+            }
+        }
+
+        assertEquals(screenSize.height - keyboardHeight, text1RectInWindow?.bottom)
+        assertNotEquals(screenSize.height - keyboardHeight, text2RectInWindow?.bottom)
+        assertNotEquals(screenSize.height - keyboardHeight, text3RectInWindow?.bottom)
+
+        focusRequester2.requestFocus()
+        waitForIdle()
+
+        assertNotEquals(screenSize.height - keyboardHeight, text1RectInWindow?.bottom)
+        assertEquals(screenSize.height - keyboardHeight, text2RectInWindow?.bottom)
+        assertNotEquals(screenSize.height - keyboardHeight, text3RectInWindow?.bottom)
+
+        focusRequester3.requestFocus()
+        waitForIdle()
+
+        assertNotEquals(screenSize.height - keyboardHeight, text1RectInWindow?.bottom)
+        assertNotEquals(screenSize.height - keyboardHeight, text2RectInWindow?.bottom)
+        assertEquals(screenSize.height - keyboardHeight, text3RectInWindow?.bottom)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testRefocusKeyboardSizeNotChanges() = runUIKitInstrumentedTest {
+        val keyboardFrames = mutableListOf<DpRect>()
+        val contentFrames = mutableListOf<DpRect>()
+        val observer = object : KeyboardVisibilityObserver {
+            override fun keyboardWillShow(
+                targetFrame: CValue<CGRect>,
+                duration: Double,
+                animationOptions: UIViewAnimationOptions
+            ) {
+            }
+
+            override fun keyboardWillHide(
+                targetFrame: CValue<CGRect>,
+                duration: Double,
+                animationOptions: UIViewAnimationOptions
+            ) {
+            }
+
+            override fun keyboardWillChangeFrame(
+                targetFrame: CValue<CGRect>,
+                duration: Double,
+                animationOptions: UIViewAnimationOptions
+            ) {
+                keyboardFrames.add(targetFrame.asDpRect())
+            }
+        }
+        KeyboardVisibilityListener.addObserver(observer)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().imePadding().onGloballyPositioned {
+                contentFrames.add(it.boundsInRoot().toDpRect(density))
+            }) {
+                Spacer(Modifier.weight(100f))
+                TextField(
+                    value = "",
+                    onValueChange = {},
+                    modifier = Modifier.testTag("TF1")
+                )
+                TextField(
+                    value = "",
+                    onValueChange = {},
+                    modifier = Modifier.testTag("TF2")
+                )
+            }
+        }
+
+        findNodeWithTag("TF1").tap()
+        waitForIdle()
+
+        assertFalse(keyboardFrames.isEmpty(), "No keyboard frame changes detected")
+        assertFalse(contentFrames.emptyOrAllEqual(), "No content size changes due to ime height changes detected")
+        // Remove frame changes during the keyboard appearance
+        keyboardFrames.clear()
+        contentFrames.clear()
+
+        // Switch between text fields
+        findNodeWithTag("TF2").tap()
+        waitForIdle()
+        findNodeWithTag("TF1").tap()
+        waitForIdle()
+        KeyboardVisibilityListener.removeObserver(observer)
+
+        // Verify that nor keyboard or content size changed and keyboard presents on the screen.
+        assertTrue(keyboardFrames.emptyOrAllEqual())
+        assertTrue(contentFrames.emptyOrAllEqual())
+        assertNotEquals(0.dp, keyboardHeight)
+    }
+
+    @Test
+    fun testFocusableAboveKeyboardLargeTextField() = runUIKitInstrumentedTest {
+        var lastTextFieldFrame = DpRect(DpOffset.Unspecified, DpSize.Unspecified)
+        val topOffset = 100.dp
+
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            val focusRequester = remember { FocusRequester() }
+            BasicTextField(
+                value = "test Focusable AboveKeyboard Large Text Field".repeat(200),
+                onValueChange = {},
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .padding(top = topOffset)
+                    .fillMaxSize()
+                    .onGloballyPositioned { coordinates ->
+                        lastTextFieldFrame = coordinates.boundsInWindow().toDpRect(density)
+                    }
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        val expectedTextField = DpRect(
+            left = 0.dp,
+            top = 0.dp,
+            right = screenSize.width,
+            bottom = screenSize.height - min(topOffset, keyboardHeight)
+        )
+        assertEquals(expectedTextField, lastTextFieldFrame)
+    }
+
+    @Test
+    fun testFocusableAboveKeyboardWithIMEInsetsLargeTextField() = runUIKitInstrumentedTest {
+        var lastTextFieldFrame = DpRect(DpOffset.Unspecified, DpSize.Unspecified)
+        val topOffset = 100.dp
+
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            val focusRequester = remember { FocusRequester() }
+            BasicTextField(
+                value = "test Focusable AboveKeyboard Large Text Field".repeat(200),
+                onValueChange = {},
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .fillMaxSize()
+                    .padding(top = topOffset)
+                    .imePadding()
+                    .onGloballyPositioned { coordinates ->
+                        lastTextFieldFrame = coordinates.boundsInWindow().toDpRect(density)
+                    }
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        val expectedTextField = DpRect(
+            left = 0.dp,
+            top = topOffset,
+            right = screenSize.width,
+            bottom = screenSize.height - keyboardHeight
+        )
+        assertEquals(expectedTextField, lastTextFieldFrame)
+    }
+
+    @Test
+    fun testFocusBehaviorDoNothingLargeTextField() = runUIKitInstrumentedTest {
+        var lastTextFieldFrame = DpRect(DpOffset.Unspecified, DpSize.Unspecified)
+
+        setContent({
+            onFocusBehavior = OnFocusBehavior.DoNothing
+        }) {
+            val focusRequester = remember { FocusRequester() }
+            BasicTextField(
+                value = "test Focusable AboveKeyboard Large Text Field".repeat(200),
+                onValueChange = {},
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .fillMaxSize()
+                    .onGloballyPositioned { coordinates ->
+                        lastTextFieldFrame = coordinates.boundsInWindow().toDpRect(density)
+                    }
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        val expectedTextField = DpRect(
+            left = 0.dp,
+            top = 0.dp,
+            right = screenSize.width,
+            bottom = screenSize.height
+        )
+        assertEquals(expectedTextField, lastTextFieldFrame)
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun testFocusableAboveKeyboardInModalBottomSheet() = runUIKitInstrumentedTest {
+        var lastTextFieldFrame = DpRect(DpOffset.Unspecified, DpSize.Unspecified)
+
+        setContent({
+            onFocusBehavior = OnFocusBehavior.FocusableAboveKeyboard
+        }) {
+            val focusRequester = remember { FocusRequester() }
+            ModalBottomSheet(
+                onDismissRequest = {},
+                contentWindowInsets = { WindowInsets.ime }
+            ) {
+                TextField(
+                    value = "",
+                    onValueChange = {},
+                    modifier = Modifier
+                        .focusRequester(focusRequester)
+                        .onGloballyPositioned { coordinates ->
+                            lastTextFieldFrame = coordinates.boundsInWindow().toDpRect(density)
+                        }
+                )
+            }
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        assertEquals(screenSize.height - keyboardHeight, lastTextFieldFrame.bottom)
+    }
+}
+
+private fun List<*>.emptyOrAllEqual(): Boolean {
+    var allItemsEqual = true
+    forEachWithPrevious { prev, next ->
+        if (prev != next) {
+            allItemsEqual = false
+        }
+    }
+    return allItemsEqual
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.platform.accessibility.CMPAccessibilityTraitIsEditing
 import androidx.compose.ui.platform.accessibility.CMPAccessibilityTraitTextView
 import androidx.compose.ui.test.utils.DpRectZero
 import androidx.compose.ui.test.utils.intersect
-import androidx.compose.ui.test.utils.toDpRect
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.asDpRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
@@ -111,7 +111,7 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
             identifier = (element as? UIAccessibilityElement)?.accessibilityIdentifier,
             label = element.accessibilityLabel,
             value = element.accessibilityValue,
-            frame = element.accessibilityFrame.toDpRect(),
+            frame = element.accessibilityFrame.asDpRect(),
             children = children,
             traits = allAccessibilityTraits.keys.filter {
                 element.accessibilityTraits and it != 0.toULong()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.scene.ComposeHostingViewController
 import androidx.compose.ui.test.utils.center
 import androidx.compose.ui.test.utils.moveToLocationOnWindow
 import androidx.compose.ui.test.utils.toCGPoint
-import androidx.compose.ui.test.utils.toDpOffset
 import androidx.compose.ui.test.utils.touchDown
 import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
@@ -54,6 +53,7 @@ import platform.UIKit.UIScreen
 import platform.UIKit.UITouch
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
+import platform.UIKit.endEditing
 import platform.UIKit.systemBackgroundColor
 import platform.darwin.NSObject
 
@@ -120,6 +120,10 @@ internal class UIKitInstrumentedTest {
     }
 
     fun tearDown() {
+        // Stop text editing and hide keyboard if any
+        hostingViewController.view.endEditing(force = true)
+        waitForIdle()
+
         appDelegate.cleanUp()
     }
 
@@ -254,7 +258,7 @@ internal class UIKitInstrumentedTest {
 
     val UITouch.location: DpOffset
         get() {
-        return locationInView(hostingViewController.view).toDpOffset()
+        return locationInView(hostingViewController.view).asDpOffset()
     }
 }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/DpRect+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/DpRect+Utils.kt
@@ -24,10 +24,8 @@ import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.min
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.useContents
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGPointMake
-import platform.CoreGraphics.CGRect
 import platform.UIKit.UIView
 
 @OptIn(ExperimentalForeignApi::class)
@@ -45,19 +43,6 @@ internal fun DpRect.intersect(other: DpRect): DpRect {
         top = max(top, other.top),
         right = min(right, other.right),
         bottom = min(bottom, other.bottom)
-    )
-}
-
-@OptIn(ExperimentalForeignApi::class)
-internal fun CValue<CGPoint>.toDpOffset(): DpOffset = useContents { DpOffset(x.dp, y.dp) }
-
-@OptIn(ExperimentalForeignApi::class)
-internal fun CValue<CGRect>.toDpRect() = useContents {
-    DpRect(
-        left = origin.x.dp,
-        top = origin.y.dp,
-        right = origin.x.dp + size.width.dp,
-        bottom = origin.y.dp + size.height.dp,
     )
 }
 


### PR DESCRIPTION
Test IME insets for `FocusableAboveKeyboard` and `DoNothing` behavior modes.
Test insets for large text fields.
Remove duplicated converting methods.
Update MULTIPLATFORM.md.

Fixes https://youtrack.jetbrains.com/agiles/153-4000/current?issue=CMP-7991

## Release Notes
N/A