### PR TITLE
[Cherry-pick] Fix keyboard jumps when switching between text fields (#2062)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -58,6 +58,11 @@ import platform.UIKit.UIView
 import platform.UIKit.UIViewAutoresizingFlexibleHeight
 import platform.UIKit.UIViewAutoresizingFlexibleWidth
 
+// Due to unexpected delays between the commands to show/hide the keyboard,
+// it may jump when switching between text fields.
+// Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
+private val CLEAR_FOCUS_DELAY: Long = 10L
+
 internal class UIKitTextInputService(
     private val updateView: () -> Unit,
     private val view: UIView,
@@ -167,7 +172,7 @@ internal class UIKitTextInputService(
 
     override fun hideSoftwareKeyboard() {
         textUIView?.let {
-            focusStack?.popUntilNext(it)
+            focusStack?.popUntilNext(it, delayMillis = CLEAR_FOCUS_DELAY)
         }
     }
 
@@ -388,6 +393,7 @@ internal class UIKitTextInputService(
 
             view.resetOnKeyboardPressesCallback()
             mainScope.launch {
+                delay(CLEAR_FOCUS_DELAY)
                 view.removeFromSuperview()
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -50,6 +50,7 @@ import kotlin.math.absoluteValue
 import kotlin.math.min
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.CoreGraphics.CGRectMake

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/FocusStack.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/FocusStack.uikit.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.window
 
 import androidx.compose.ui.util.fastForEachReversed
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import platform.UIKit.UIView
 
@@ -40,13 +41,14 @@ internal class FocusStack {
      * Pop all elements until some element. Also pop this element too.
      * Last remaining element in Stack will be focused.
      */
-    fun popUntilNext(view: UIView) {
+    fun popUntilNext(view: UIView, delayMillis: Long = 0) {
         if (activeViews.contains(view)) {
             val index = activeViews.indexOf(view)
             resignedViews += activeViews.subList(index, activeViews.size)
             activeViews = activeViews.subList(0, index)
 
             mainScope.launch {
+                delay(delayMillis)
                 resignedViews.fastForEachReversed {
                     it.resignFirstResponder()
                 }


### PR DESCRIPTION
Add extra delay to postpone the hide keyboard function call.

Fixes
https://youtrack.jetbrains.com/issue/CMP-8046/Keyboard-jumps-when-TF-refocuses-programmatically

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix keyboard jumps when switching between text fields