### PR TITLE
(WIP) Fixed caret placement near glyphs

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
@@ -20,9 +20,8 @@ package androidx.compose.ui.text
  * Get strong (R, L or AL) direction type.
  * See https://www.unicode.org/reports/tr9/
  */
-internal actual fun CodePoint.strongDirectionType(): StrongDirectionType {
-    val directionality = getDirectionality()
-    return when (directionality) {
+internal actual fun CodePoint.strongDirectionType(): StrongDirectionType =
+    when (getDirectionality()) {
         CharDirectionality.LEFT_TO_RIGHT -> StrongDirectionType.Ltr
 
         CharDirectionality.RIGHT_TO_LEFT,
@@ -30,7 +29,6 @@ internal actual fun CodePoint.strongDirectionType(): StrongDirectionType {
 
         else -> StrongDirectionType.None
     }
-}
 internal actual fun CodePoint.isNeutralDirection(): Boolean =
     when (getDirectionality()) {
         CharDirectionality.OTHER_NEUTRALS,

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
@@ -20,8 +20,9 @@ package androidx.compose.ui.text
  * Get strong (R, L or AL) direction type.
  * See https://www.unicode.org/reports/tr9/
  */
-internal actual fun CodePoint.strongDirectionType(): StrongDirectionType =
-    when (getDirectionality()) {
+internal actual fun CodePoint.strongDirectionType(): StrongDirectionType {
+    val directionality = getDirectionality()
+    return when (directionality) {
         CharDirectionality.LEFT_TO_RIGHT -> StrongDirectionType.Ltr
 
         CharDirectionality.RIGHT_TO_LEFT,
@@ -29,6 +30,7 @@ internal actual fun CodePoint.strongDirectionType(): StrongDirectionType =
 
         else -> StrongDirectionType.None
     }
+}
 internal actual fun CodePoint.isNeutralDirection(): Boolean =
     when (getDirectionality()) {
         CharDirectionality.OTHER_NEUTRALS,
@@ -37,6 +39,9 @@ internal actual fun CodePoint.isNeutralDirection(): Boolean =
 
         else -> false
     }
+
+internal actual fun CodePoint.isNonSpacingMark(): Boolean =
+    getDirectionality() == CharDirectionality.NONSPACING_MARK
 
 /**
  * Get the Unicode directionality of a character.

--- a/compose/ui/ui-text/src/nonJvmMain/kotlin/androidx/compose/ui/text/CharHelpers.nonJvm.kt
+++ b/compose/ui/ui-text/src/nonJvmMain/kotlin/androidx/compose/ui/text/CharHelpers.nonJvm.kt
@@ -40,3 +40,6 @@ internal actual fun CodePoint.isNeutralDirection(): Boolean =
 
         else -> false
     }
+
+internal actual fun CodePoint.isNonSpacingMark(): Boolean =
+    CharDirection.of(this) == CharDirection.DIR_NON_SPACING_MARK

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/CharHelpers.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/CharHelpers.skiko.kt
@@ -74,6 +74,7 @@ internal fun CodePoint.isSupplementaryCodePoint(): Boolean =
 
 internal expect fun CodePoint.strongDirectionType(): StrongDirectionType
 internal expect fun CodePoint.isNeutralDirection(): Boolean
+internal expect fun CodePoint.isNonSpacingMark(): Boolean
 
 /**
  * Determine direction based on the first strong directional character.

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -439,6 +439,23 @@ internal class SkiaParagraph(
             return glyphPosition
         }
 
+        // Check if the last character of the line is a non-spacing mark
+        val hasNonSpacingMarkAtEnd = if (isNotEmptyLine && expectedLine.endExcludingWhitespaces > 0) {
+            val lastCharIndex = expectedLine.endExcludingWhitespaces - 1
+            if (lastCharIndex >= 0 && lastCharIndex < text.length) {
+                text.codePointAt(lastCharIndex).isNonSpacingMark()
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+
+        // If the line ends with a non-spacing mark, don't apply the workaround
+        if (hasNonSpacingMarkAtEnd) {
+            return glyphPosition
+        }
+
         var correctedGlyphPosition = glyphPosition
 
         if (position.x <= leftX) { // when clicked to the left of a text line


### PR DESCRIPTION
 Fixed caret placement near glyphs if glyphs are compound symbols and part of them treated like an RTL sequence

Fixes: https://youtrack.jetbrains.com/issue/CMP-8054/TextField.-Some-characters-arent-deleted-correctly-or-cant-be-fully-removed

## Testing
Manual, by the steps to reproduce from a related issue
This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
Fixed caret placement near glyphs if glyphs are compound symbols and part of them are non-spacing marks