### PR TITLE
Optionally allow run tests in Firefox

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -37,6 +37,9 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
 
     private val skikoVersion: String
 
+    private val enableChromeTestsProperty = "jetbrains.compose.web.tests.enableChrome"
+    private val enableFirefoxTestsProperty = "jetbrains.compose.web.tests.enableFirefox"
+
     init {
         val toml = Toml.parse(
             project.rootProject.projectDir.resolve("gradle/libs.versions.toml").toPath()
@@ -75,6 +78,13 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         js(KotlinJsCompilerType.IR) {
             browser {
                 testTask {
+                    if (project.findProperty(enableChromeTestsProperty)?.toString()?.toBoolean() == true) {
+                        it.environment(enableChromeTestsProperty, "1")
+                    }
+                    if (project.findProperty(enableFirefoxTestsProperty)?.toString()?.toBoolean() == true) {
+                        it.environment(enableFirefoxTestsProperty, "1")
+                    }
+
                     it.useKarma {
                         // We need to set up at least one browser here due to kotlin tooling limitations
                         // Actual browser configuration is set in mpp/karma.config.d/js/config.js
@@ -129,6 +139,13 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
         wasmJs {
             browser {
                 testTask {
+                    if (project.findProperty(enableChromeTestsProperty)?.toString()?.toBoolean() == true) {
+                        it.environment(enableChromeTestsProperty, "1")
+                    }
+                    if (project.findProperty(enableFirefoxTestsProperty)?.toString()?.toBoolean() == true) {
+                        it.environment(enableFirefoxTestsProperty, "1")
+                    }
+
                     it.useKarma {
                         // We need to set up at least one browser here due to kotlin tooling limitations
                         // Actual browser configuration is set in mpp/karma.config.d/wasm/config.js

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -79,6 +79,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
                         // We need to set up at least one browser here due to kotlin tooling limitations
                         // Actual browser configuration is set in mpp/karma.config.d/js/config.js
                         useChrome()
+                        useFirefox()
                         useConfigDirectory(
                             project.rootProject.projectDir.resolve("mpp/karma.config.d/js")
                         )
@@ -132,6 +133,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
                         // We need to set up at least one browser here due to kotlin tooling limitations
                         // Actual browser configuration is set in mpp/karma.config.d/wasm/config.js
                         useChrome()
+                        useFirefox()
                         useConfigDirectory(
                             project.rootProject.projectDir.resolve("mpp/karma.config.d/wasm")
                         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -136,3 +136,7 @@ artifactRedirection.modulesForKNativeManifest=\
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
+
+# In which browsers run web tests
+jetbrains.compose.web.tests.enableChrome=true
+jetbrains.compose.web.tests.enableFirefox=false

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -82,10 +82,17 @@ config.customLaunchers = {
     ChromeForComposeTests: {
         base: "Chrome",
         flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
+    },
+    FirefoxWithTouchEvents: {
+        base: "Firefox",
+        prefs: {
+ 		'dom.w3c_touch_events.enabled': 1
+       }
     }
 }
 
-config.browsers = ["ChromeForComposeTests"];
+console.log(process.env);
+config.browsers = ["FirefoxWithTouchEvents"];
 
 // A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
 (function() {

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -83,7 +83,7 @@ config.customLaunchers = {
         base: "Chrome",
         flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
     },
-    FirefoxWithTouchEvents: {
+    FirefoxForComposeTests: {
         base: "Firefox",
         prefs: {
  		'dom.w3c_touch_events.enabled': 1
@@ -91,8 +91,10 @@ config.customLaunchers = {
     }
 }
 
-console.log(process.env);
-config.browsers = ["FirefoxWithTouchEvents"];
+config.browsers = ["ChromeForComposeTests"];
+if (process.env.COMPOSE_WEB_TESTS_FIREFOX) {
+    config.browsers.push("FirefoxForComposeTests");
+}
 
 // A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
 (function() {

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -46,7 +46,7 @@ function KarmaWebpackOutputFramework(config) {
             "Webpack has not instantiated controller yet.\n" +
             "Check if you have enabled webpack preprocessor and framework before this framework"
         )
-        returns
+        return
     }
 
     config.files.push({
@@ -91,8 +91,11 @@ config.customLaunchers = {
     }
 }
 
-config.browsers = ["ChromeForComposeTests"];
-if (process.env.COMPOSE_WEB_TESTS_FIREFOX) {
+config.browsers = [];
+if (process.env["jetbrains.compose.web.tests.enableChrome"]) {
+    config.browsers.push("ChromeForComposeTests");
+}
+if (process.env["jetbrains.compose.web.tests.enableFirefox"]) {
     config.browsers.push("FirefoxForComposeTests");
 }
 

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -72,7 +72,7 @@ config.customLaunchers = {
         base: "Chrome",
         flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
     },
-    FirefoxWithTouchEvents: {
+    FirefoxForComposeTests: {
         base: "Firefox",
         prefs: {
  		'dom.w3c_touch_events.enabled': 1
@@ -80,7 +80,10 @@ config.customLaunchers = {
     }
 }
 
-config.browsers = ["FirefoxWithTouchEvents"];
+config.browsers = ["ChromeForComposeTests"];
+if (process.env.COMPOSE_WEB_TESTS_FIREFOX) {
+    config.browsers.push("FirefoxForComposeTests");
+}
 
 // A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
 (function() {

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -71,10 +71,16 @@ config.customLaunchers = {
     ChromeForComposeTests: {
         base: "Chrome",
         flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
+    },
+    FirefoxWithTouchEvents: {
+        base: "Firefox",
+        prefs: {
+ 		'dom.w3c_touch_events.enabled': 1
+       }
     }
 }
 
-config.browsers = ["ChromeForComposeTests"];
+config.browsers = ["FirefoxWithTouchEvents"];
 
 // A workaround from https://android-review.googlesource.com/c/platform/frameworks/support/+/3413540
 (function() {

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -80,8 +80,11 @@ config.customLaunchers = {
     }
 }
 
-config.browsers = ["ChromeForComposeTests"];
-if (process.env.COMPOSE_WEB_TESTS_FIREFOX) {
+config.browsers = [];
+if (process.env["jetbrains.compose.web.tests.enableChrome"]) {
+    config.browsers.push("ChromeForComposeTests");
+}
+if (process.env["jetbrains.compose.web.tests.enableFirefox"]) {
     config.browsers.push("FirefoxForComposeTests");
 }
 


### PR DESCRIPTION
The goal of this PR is make it possible to run Firefox tests optionally 
This is the part of work that is required to be done in framework of https://youtrack.jetbrains.com/issue/CMP-8115

## Testing
`./gradlew testWeb -Pjetbrains.androidx.web.tests.enableFirefox=true -Pjetbrains.androidx.web.tests.enableChrome=false`

## Release Notes
N/A
