### PR TITLE
Add UIKit instrumented test for scrolls

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.DpRectZero
 import androidx.compose.ui.test.utils.dpRectInWindow
@@ -541,6 +543,7 @@ internal class ScrollTest {
                     .height(100.dp)
                     .background(Color.Red)
                     .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                    .testTag("Red Box")
                 )
 
                 UIKitView(
@@ -554,7 +557,8 @@ internal class ScrollTest {
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(200.dp)
-                        .onGloballyPositioned { labelRect = it.boundsInWindow().toDpRect(density) },
+                        .onGloballyPositioned { labelRect = it.boundsInWindow().toDpRect(density) }
+                        .testTag("UIKit.UILabel"),
                     onReset = { /* Just to make it reusable */ }
                 )
 
@@ -566,8 +570,11 @@ internal class ScrollTest {
             }
         }
 
-        // start at center.y of the UILabel and drag upwards
-        touchDown(DpOffset(screenSize.center.x, 250.dp))
+        val initialBoxRect = boxRect.copy()
+        val initialLabelRect = labelRect.copy()
+
+        findNodeWithTag("UIKit.UILabel")
+            .touchDown()
             .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
@@ -576,18 +583,15 @@ internal class ScrollTest {
         assertEquals(DpRect(DpOffset(x = 0.dp, y = 0.dp), DpSize(screenSize.width, 100.dp)), boxRect)
         assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), labelRect)
 
-        // start at center.y of the red box and drag downwards
-        touchDown(DpOffset(screenSize.center.x, 50.dp))
+        findNodeWithTag("Red Box")
+            .touchDown()
             .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
         waitForIdle()
 
-        // frames should be at their initial positions
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 100.dp)), boxRect)
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), labelRect)
-
-        waitForIdle()
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 100.dp)), initialBoxRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), initialLabelRect)
     }
 
     @Test
@@ -682,7 +686,7 @@ internal class ScrollTest {
     @Test
     fun testOverscrollForUIKitHorizontalScrollViewAtTop() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRectZero()
+        var uiKitViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -691,12 +695,12 @@ internal class ScrollTest {
                 screenSize = screenSize,
                 topContentHeight = 0.dp,
                 uiKitScrollViewHeight = 200.dp,
-                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
                 uiKitContentOffset = { contentOffset = it }
             )
         }
 
-        val initialUIKitViewRect = uiKitViewRect.copy()
+        val initialUIKitViewRect = uiKitViewRect().copy()
 
         assertEquals(DpRect(DpOffset(x = 0.dp, y = 0.dp), DpSize(screenSize.width, 200.dp)), initialUIKitViewRect)
 
@@ -705,22 +709,22 @@ internal class ScrollTest {
 
         waitForIdle()
 
-        assertTrue(uiKitViewRect.top > 0.dp)
-        assertTrue(uiKitViewRect.top < (50 + CUPERTINO_TOUCH_SLOP).dp)
+        assertTrue(uiKitViewRect().top > 0.dp)
+        assertTrue(uiKitViewRect().top < (50 + CUPERTINO_TOUCH_SLOP).dp)
 
         assertEquals(DpOffset(x = 0.dp, y = 0.dp), contentOffset())
 
         touch.up()
         waitForIdle()
 
-        assertEquals(initialUIKitViewRect, uiKitViewRect)
+        assertEquals(initialUIKitViewRect, uiKitViewRect())
         assertEquals(0 * density.density, state.value.toFloat())
     }
 
     @Test
     fun testVerticalComposeScrollsWhenDraggingFromUIKitHorizontalScroll() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRectZero()
+        var uiKitViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -729,7 +733,7 @@ internal class ScrollTest {
                 screenSize = screenSize,
                 topContentHeight = 200.dp,
                 uiKitScrollViewHeight = 200.dp,
-                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
                 uiKitContentOffset = { contentOffset = it }
             )
         }
@@ -741,7 +745,7 @@ internal class ScrollTest {
         waitForIdle()
 
         assertEquals(100 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
         assertEquals(DpOffset(x = 0.dp, y = 0.dp), contentOffset())
     }
 
@@ -753,7 +757,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeScroll_HorizontalDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRectZero()
+        var uiKitViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -762,7 +766,7 @@ internal class ScrollTest {
                 screenSize = screenSize,
                 topContentHeight = 200.dp,
                 uiKitScrollViewHeight = 200.dp,
-                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
                 uiKitContentOffset = { contentOffset = it }
             )
         }
@@ -774,7 +778,7 @@ internal class ScrollTest {
         waitForIdle()
 
         assertEquals(0 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
         assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
     }
 
@@ -786,7 +790,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeVerticalScroll_VerticalDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRectZero()
+        var uiKitViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -795,7 +799,7 @@ internal class ScrollTest {
                 screenSize = screenSize,
                 topContentHeight = 200.dp,
                 uiKitScrollViewHeight = 200.dp,
-                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
                 uiKitContentOffset = { contentOffset = it }
             )
         }
@@ -807,7 +811,7 @@ internal class ScrollTest {
         waitForIdle()
 
         assertEquals(50 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 150.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 150.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
         assertEquals(DpOffset.Zero, contentOffset())
     }
 
@@ -822,7 +826,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeVerticalScroll_MixedDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRectZero()
+        var uiKitViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -831,7 +835,7 @@ internal class ScrollTest {
                 screenSize = screenSize,
                 topContentHeight = 200.dp,
                 uiKitScrollViewHeight = 200.dp,
-                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
                 uiKitContentOffset = { contentOffset = it }
             )
         }
@@ -846,7 +850,7 @@ internal class ScrollTest {
         waitForIdle()
 
         assertEquals(0 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
         assertEquals(DpOffset(x = 100.dp, y = 0.dp), contentOffset())
     }
 
@@ -860,7 +864,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeVerticalScroll_VerticalAndSmallHorizontalDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRectZero()
+        var uiKitViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -869,7 +873,7 @@ internal class ScrollTest {
                 screenSize = screenSize,
                 topContentHeight = 200.dp,
                 uiKitScrollViewHeight = 200.dp,
-                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
                 uiKitContentOffset = { contentOffset = it }
             )
         }
@@ -884,7 +888,7 @@ internal class ScrollTest {
 
         // verify that only Compose scroll state changed but UIScrollView content offset stayed the same
         assertEquals(100 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
         assertEquals(DpOffset.Zero, contentOffset())
     }
 }
@@ -948,7 +952,7 @@ private fun VerticalScrollWithHorizontalUIKitScroll(
     topContentHeight: Dp,
     uiKitScrollViewHeight: Dp,
     uiKitScrollViewContentWidth: Double = 1000.0,
-    onUIKitViewGloballyPositioned: (androidx.compose.ui.layout.LayoutCoordinates) -> Unit = {},
+    uiKitScrollViewRectInWindow: (() -> DpRect) -> Unit = {},
     uiKitContentOffset: (() -> DpOffset) -> Unit = { },
 ) {
     Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -966,13 +970,13 @@ private fun VerticalScrollWithHorizontalUIKitScroll(
                 val scrollView = UIScrollView()
                 scrollView.setContentSize(CGSizeMake(uiKitScrollViewContentWidth, uiKitScrollViewHeight.value.toDouble()))
                 scrollView.backgroundColor = UIColor.lightGrayColor
+                uiKitScrollViewRectInWindow({ scrollView.dpRectInWindow() })
                 uiKitContentOffset({ scrollView.contentOffset.asDpOffset() })
                 scrollView
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .height(uiKitScrollViewHeight)
-                .onGloballyPositioned(onUIKitViewGloballyPositioned),
+                .height(uiKitScrollViewHeight),
             update = {}
         )
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.unit.center
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.viewinterop.UIKitView
-import kotlin.math.abs
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -182,7 +182,7 @@ internal class ScrollTest {
             if (i > 1) {
                 try {
                     assertEquals(currentDiff, previousDiff, 5e-5f)
-                } catch (e: AssertionError) {
+                } catch (_: AssertionError) {
                     assertTrue(currentDiff < previousDiff)
                 }
             }
@@ -237,7 +237,7 @@ internal class ScrollTest {
             if (i > 1) {
                 try {
                     assertEquals(currentDiff, previousDiff, 5e-5f)
-                } catch (e: AssertionError) {
+                } catch (_: AssertionError) {
                     assertTrue(currentDiff > previousDiff)
                 }
             }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -172,8 +172,8 @@ internal class ScrollTest {
         var previousBoxTop = boxRect.top
         var previousDiff = 0f
 
-        for (i in 1..11) {
-            touch.dragBy(dy = 20.dp, duration = 0.1.seconds)
+        repeat(10) { i ->
+            touch.dragBy(dy = 20.dp, duration = 100.milliseconds)
             waitForIdle()
 
             val currentBoxTop = boxRect.top
@@ -226,7 +226,7 @@ internal class ScrollTest {
         var previousBoxTop = boxRect.top
         var previousDiff = 0f
 
-        for (i in 1..10) {
+        repeat(10) { i ->
             touch.dragBy(dy = -20.dp, duration = 0.1.seconds)
             waitForIdle()
 
@@ -259,7 +259,7 @@ internal class ScrollTest {
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
-                for (index in 0 until 10) {
+                repeat(10) { index ->
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -44,7 +44,9 @@ import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.DpRectZero
+import androidx.compose.ui.test.utils.dpRectInWindow
 import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
@@ -588,114 +590,97 @@ internal class ScrollTest {
         waitForIdle()
     }
 
-    @OptIn(ExperimentalForeignApi::class)
     @Test
-    fun testUIKitScrollViewInsideComposeScrollViewInteractions() = runUIKitInstrumentedTest {
+    fun testUIKitScrollViewInsideComposeScrollView_DragFromUIKitScrollView() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRectZero()
+        var uiScrollViewRect: () -> DpRect = { DpRectZero() }
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
-            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
-                Box(modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .background(Color.Blue)
-                )
-
-                Box(modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .background(Color.Red)
-                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
-                )
-
-                var scrollViewSize by mutableStateOf(DpSize.Zero)
-                UIKitView(
-                    factory = {
-                        val scrollView = UIScrollView()
-                        scrollView.setContentSize(
-                            CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
-                        )
-                        contentOffset = { scrollView.contentOffset.asDpOffset() }
-                        scrollView.backgroundColor = UIColor.lightGrayColor
-                        scrollView
-                    },
-                    update = { scrollView ->
-                        scrollView.setContentSize(
-                            CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
-                        )
-                    },
-                    modifier = Modifier.fillMaxWidth().height(400.dp).onSizeChanged {
-                        scrollViewSize = with(density) {
-                            DpSize(it.width.toDp(), it.height.toDp())
-                        }
-                    }
-                )
-
-                Box(modifier = Modifier
-                    .fillMaxWidth()
-                    .height(screenSize.height)
-                    .background(Color.White)
-                )
-            }
+            VerticalUIKitScrollInsideVerticalScroll(
+                state = state,
+                screenSize = screenSize,
+                density = density,
+                topContentHeight = 400.dp,
+                uiKitScrollViewHeight = 400.dp,
+                uiKitScrollViewRectInWindow = { uiScrollViewRect = it },
+                uiKitContentOffset = { contentOffset = it }
+            )
         }
 
-        // start in red box and drag upwards
-        touchDown(DpOffset(screenSize.center.x, 250.dp))
-            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
-
-        waitForIdle()
-
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), boxRect)
-
         // start in UIScrollView and drag upwards
-        touchDown(DpOffset(screenSize.center.x, 400.dp))
+        touchDown(DpOffset(screenSize.center.x, 450.dp))
             .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
         waitForIdle()
 
         // red box should remain at the same position
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), boxRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 400.dp), DpSize(screenSize.width, 400.dp)), uiScrollViewRect())
         assertEquals(DpOffset(x = 0.dp, y = 100.dp), contentOffset())
+    }
 
-        // drag back to initial position
-        touchDown(DpOffset(screenSize.center.x, 50.dp))
-            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testUIKitScrollViewInsideComposeScrollView_DragFromCompose() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiScrollViewRect: () -> DpRect = { DpRectZero() }
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalUIKitScrollInsideVerticalScroll(
+                state = state,
+                screenSize = screenSize,
+                density = density,
+                topContentHeight = 400.dp,
+                uiKitScrollViewHeight = 400.dp,
+                uiKitScrollViewRectInWindow = { uiScrollViewRect = it },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 200.dp))
+            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
         waitForIdle()
 
-        // start in red box and flick upwards
-        touchDown(DpOffset(screenSize.center.x, 150.dp))
-            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp, duration = 100.milliseconds)
-            .up()
-
-        // wait for the flick to be in the deceleration phase
-        delay(800)
-
-        // start in the UIScrollView and drag down while flick animation is still in progress
-        touchDown(DpOffset(screenSize.center.x, 100.dp))
-            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
-
-        waitForIdle()
-
-        // UIScrollView content offset should still be the same
-        assertEquals(DpOffset(x = 0.dp, y = 100.dp), contentOffset())
-
-        // drag up in UIScrollView from idle position
-        touchDown(DpOffset(screenSize.center.x, 300.dp))
-            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
-
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 300.dp), DpSize(screenSize.width, 400.dp)), uiScrollViewRect())
         assertEquals(DpOffset.Zero, contentOffset())
     }
 
     @Test
-    fun testOverscrollWhenUIKitHorizontalScrollViewIsAtTop() = runUIKitInstrumentedTest {
+    fun testUIKitScrollViewInsideComposeScrollView_DragFromUIScrollView() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiScrollViewRect: () -> DpRect = { DpRectZero() }
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalUIKitScrollInsideVerticalScroll(
+                state = state,
+                screenSize = screenSize,
+                density = density,
+                topContentHeight = 400.dp,
+                uiKitScrollViewHeight = 400.dp,
+                uiKitScrollViewRectInWindow = { uiScrollViewRect = it },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        val initialUIScrollViewRect = uiScrollViewRect()
+
+        touchDown(DpOffset(screenSize.center.x, 450.dp))
+            .dragBy(dy = -(150 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(initialUIScrollViewRect, uiScrollViewRect())
+        assertEquals(DpOffset(x = 0.dp, y = 150.dp), contentOffset())
+    }
+
+    @Test
+    fun testOverscrollForUIKitHorizontalScrollViewAtTop() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
         var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
@@ -712,6 +697,7 @@ internal class ScrollTest {
         }
 
         val initialUIKitViewRect = uiKitViewRect.copy()
+
         assertEquals(DpRect(DpOffset(x = 0.dp, y = 0.dp), DpSize(screenSize.width, 200.dp)), initialUIKitViewRect)
 
         val touch = touchDown(DpOffset(screenSize.center.x, 100.dp))
@@ -729,30 +715,6 @@ internal class ScrollTest {
 
         assertEquals(initialUIKitViewRect, uiKitViewRect)
         assertEquals(0 * density.density, state.value.toFloat())
-
-        // Horizontal drag to verify UIKit scroll reacts
-        touchDown(DpOffset(screenSize.center.x, 100.dp))
-            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
-
-        waitForIdle()
-
-        // Horizontal content offset should change, but vertical position stays the same
-        assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
-        assertEquals(initialUIKitViewRect, uiKitViewRect)
-
-        // Combined gesture - start with downward overscroll then horizontal
-        touchDown(DpOffset(screenSize.center.x, 100.dp))
-            .dragBy(dy = (50 + CUPERTINO_TOUCH_SLOP).dp)
-            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp, dy = 0.dp)
-            .up()
-
-        waitForIdle()
-
-        // View should return to original position after overscroll
-        assertEquals(initialUIKitViewRect, uiKitViewRect)
-        // Horizontal content should not change
-        assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
     }
 
     @Test
@@ -927,6 +889,56 @@ internal class ScrollTest {
     }
 }
 
+@Composable
+private fun VerticalUIKitScrollInsideVerticalScroll(
+    state: ScrollState,
+    screenSize: DpSize,
+    density: Density,
+    topContentHeight: Dp,
+    uiKitScrollViewHeight: Dp,
+    uiKitScrollViewRectInWindow: (() -> DpRect) -> Unit = {},
+    uiKitContentOffset: (() -> DpOffset) -> Unit = { },
+) {
+    Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(topContentHeight)
+                .background(Color.Red)
+        )
+
+        var scrollViewSize by mutableStateOf(DpSize.Zero)
+        UIKitView(
+            factory = {
+                val scrollView = UIScrollView()
+                scrollView.setContentSize(
+                    CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
+                )
+                scrollView.backgroundColor = UIColor.lightGrayColor
+                uiKitScrollViewRectInWindow({ scrollView.dpRectInWindow() })
+                uiKitContentOffset({ scrollView.contentOffset.asDpOffset() })
+                scrollView
+            },
+            update = { scrollView ->
+                scrollView.setContentSize(
+                    CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
+                )
+            },
+            modifier = Modifier.fillMaxWidth().height(uiKitScrollViewHeight).onSizeChanged {
+                scrollViewSize = with(density) {
+                    DpSize(it.width.toDp(), it.height.toDp())
+                }
+            }
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(screenSize.height)
+                .background(Color.White)
+        )
+    }
+}
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -654,36 +654,6 @@ internal class ScrollTest {
     }
 
     @Test
-    fun testUIKitScrollViewInsideComposeScrollView_DragFromUIScrollView() = runUIKitInstrumentedTest {
-        val state = ScrollState(0)
-        var uiScrollViewRect: () -> DpRect = { DpRectZero() }
-        var contentOffset: () -> DpOffset = { DpOffset.Zero }
-
-        setContent {
-            VerticalUIKitScrollInsideVerticalScroll(
-                state = state,
-                screenSize = screenSize,
-                density = density,
-                topContentHeight = 400.dp,
-                uiKitScrollViewHeight = 400.dp,
-                uiKitScrollViewRectInWindow = { uiScrollViewRect = it },
-                uiKitContentOffset = { contentOffset = it }
-            )
-        }
-
-        val initialUIScrollViewRect = uiScrollViewRect()
-
-        touchDown(DpOffset(screenSize.center.x, 450.dp))
-            .dragBy(dy = -(150 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
-
-        waitForIdle()
-
-        assertEquals(initialUIScrollViewRect, uiScrollViewRect())
-        assertEquals(DpOffset(x = 0.dp, y = 150.dp), contentOffset())
-    }
-
-    @Test
     fun testOverscrollForUIKitHorizontalScrollViewAtTop() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
         var uiKitViewRect: () -> DpRect = { DpRectZero() }
@@ -719,34 +689,6 @@ internal class ScrollTest {
 
         assertEquals(initialUIKitViewRect, uiKitViewRect())
         assertEquals(0 * density.density, state.value.toFloat())
-    }
-
-    @Test
-    fun testVerticalComposeScrollsWhenDraggingFromUIKitHorizontalScroll() = runUIKitInstrumentedTest {
-        val state = ScrollState(0)
-        var uiKitViewRect: () -> DpRect = { DpRectZero() }
-        var contentOffset: () -> DpOffset = { DpOffset.Zero }
-
-        setContent {
-            VerticalScrollWithHorizontalUIKitScroll(
-                state = state,
-                screenSize = screenSize,
-                topContentHeight = 200.dp,
-                uiKitScrollViewHeight = 200.dp,
-                uiKitScrollViewRectInWindow = { uiKitViewRect = it },
-                uiKitContentOffset = { contentOffset = it }
-            )
-        }
-
-        touchDown(DpOffset(screenSize.center.x, 300.dp))
-            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
-
-        waitForIdle()
-
-        assertEquals(100 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
-        assertEquals(DpOffset(x = 0.dp, y = 0.dp), contentOffset())
     }
 
     /**

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -558,8 +558,7 @@ internal class ScrollTest {
                         .fillMaxWidth()
                         .height(200.dp)
                         .onGloballyPositioned { labelRect = it.boundsInWindow().toDpRect(density) }
-                        .testTag("UIKit.UILabel"),
-                    onReset = { /* Just to make it reusable */ }
+                        .testTag("UIKit.UILabel")
                 )
 
                 Box(modifier = Modifier

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -180,11 +180,12 @@ internal class ScrollTest {
             val currentDiff = (currentBoxTop - previousBoxTop).value
 
             // skip the first two iterations as we don't want to take into account the first drag position
-            if (i > 2) {
-                val epsilon = 5e-5f
-                val isDiffZero = abs(abs(currentDiff) - abs(previousDiff)) <= epsilon
-                val isDiffDecreasing = abs(currentDiff) < abs(previousDiff)
-                assertTrue(isDiffDecreasing || isDiffZero)
+            if (i > 1) {
+                try {
+                    assertEquals(currentDiff, previousDiff, 5e-5f)
+                } catch (e: AssertionError) {
+                    assertTrue(currentDiff < previousDiff)
+                }
             }
 
             previousBoxTop = currentBoxTop
@@ -234,11 +235,12 @@ internal class ScrollTest {
             val currentDiff = (currentBoxTop - previousBoxTop).value
 
             // skip the first two iterations as we don't want to take into account the first drag position
-            if (i > 2) {
-                val epsilon = 5e-5f
-                val isDiffZero = abs(abs(currentDiff) - abs(previousDiff)) <= epsilon
-                val isDiffDecreasing = abs(currentDiff) < abs(previousDiff)
-                assertTrue(isDiffDecreasing || isDiffZero)
+            if (i > 1) {
+                try {
+                    assertEquals(currentDiff, previousDiff, 5e-5f)
+                } catch (e: AssertionError) {
+                    assertTrue(currentDiff > previousDiff)
+                }
             }
 
             previousBoxTop = currentBoxTop

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -1,0 +1,1012 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.scroll
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.DpRectZero
+import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.asDpOffset
+import androidx.compose.ui.unit.center
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.viewinterop.UIKitView
+import kotlin.math.abs
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRectZero
+import platform.CoreGraphics.CGSizeMake
+import platform.UIKit.UIColor
+import platform.UIKit.UILabel
+import platform.UIKit.UIScrollView
+
+internal class ScrollTest {
+
+    /**
+     * Tests that a drag of the same value as the touch slop threshold will not trigger overscroll behavior
+     * in a vertically scrollable Column.
+     **/
+    @Test
+    fun testExactTouchSlopDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.Blue)
+                )
+            }
+        }
+
+        waitForIdle()
+
+        val initialBoxRect = boxRect.copy()
+        val dyExact = CUPERTINO_TOUCH_SLOP.dp
+
+        touchDown(screenSize.center)
+            .dragBy(dy = dyExact)
+
+        waitForIdle()
+
+        assertEquals(initialBoxRect, boxRect)
+    }
+
+    /**
+     * Tests that a drag just over the touch slop threshold will trigger overscroll behavior
+     * in a vertically scrollable Column.
+     **/
+    @Test
+    fun testJustOverTouchSlopDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.White)
+                )
+            }
+        }
+
+        val dyJustOver = CUPERTINO_TOUCH_SLOP.dp + 1.dp
+
+        touchDown(screenSize.center)
+            .dragBy(dy = dyJustOver)
+
+        waitForIdle()
+
+        assertTrue(boxRect.top > 0.dp)
+        // Scroll state remains at 0 despite visual overscroll
+        assertEquals(0 * density.density, state.value.toFloat())
+    }
+
+    @Test
+    fun testTopOverscrollDragResistance() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned {
+                        boxRect = it.boundsInWindow().toDpRect(density)
+                    }
+                )
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height.times(2))
+                    .background(Color.White)
+                )
+            }
+        }
+
+        waitForIdle()
+        val touch = touchDown(screenSize.center)
+        var previousBoxTop = boxRect.top
+        var previousDiff = 0f
+
+        for (i in 1..11) {
+            touch.dragBy(dy = 20.dp, duration = 0.1.seconds)
+            waitForIdle()
+
+            val currentBoxTop = boxRect.top
+            val currentDiff = (currentBoxTop - previousBoxTop).value
+
+            // skip the first two iterations as we don't want to take into account the first drag position
+            if (i > 2) {
+                val epsilon = 5e-5f
+                val isDiffZero = abs(abs(currentDiff) - abs(previousDiff)) <= epsilon
+                val isDiffDecreasing = abs(currentDiff) < abs(previousDiff)
+                assertTrue(isDiffDecreasing || isDiffZero)
+            }
+
+            previousBoxTop = currentBoxTop
+            previousDiff = currentDiff
+        }
+
+        waitForIdle()
+        touch.up()
+        waitForIdle()
+        // stabilizes back at the original position
+        assertEquals(DpRect(DpOffset.Zero, DpSize(screenSize.width, 100.dp)), boxRect)
+    }
+
+    @Test
+    fun testBottomOverscrollDragResistance() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        val boxHeight = 100.0
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.White)
+                )
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(boxHeight.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned {
+                        boxRect = it.boundsInWindow().toDpRect(density)
+                    }
+                )
+            }
+        }
+
+        waitForIdle()
+        val touch = touchDown(screenSize.center)
+        var previousBoxTop = boxRect.top
+        var previousDiff = 0f
+
+        for (i in 1..10) {
+            touch.dragBy(dy = -20.dp, duration = 0.1.seconds)
+            waitForIdle()
+
+            val currentBoxTop = boxRect.top
+            val currentDiff = (currentBoxTop - previousBoxTop).value
+
+            // skip the first two iterations as we don't want to take into account the first drag position
+            if (i > 2) {
+                val epsilon = 5e-5f
+                val isDiffZero = abs(abs(currentDiff) - abs(previousDiff)) <= epsilon
+                val isDiffDecreasing = abs(currentDiff) < abs(previousDiff)
+                assertTrue(isDiffDecreasing || isDiffZero)
+            }
+
+            previousBoxTop = currentBoxTop
+            previousDiff = currentDiff
+        }
+
+        waitForIdle()
+        touch.up()
+        waitForIdle()
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = screenSize.height - boxHeight.dp), DpSize(width = screenSize.width, height = boxHeight.dp)), boxRect)
+    }
+
+    @Test
+    fun testOverscrollAndFlick() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        val boxHeight = 100.0
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                for (index in 0 until 10) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(boxHeight.dp)
+                            .background(if (index % 2 == 0) Color.Blue else Color.Red)
+                            .then(
+                                if (index == 0) {
+                                    Modifier.onGloballyPositioned {
+                                        boxRect = it.boundsInWindow().toDpRect(density)
+                                    }
+                                } else {
+                                    Modifier
+                                }
+                            )
+                    )
+                }
+            }
+        }
+
+        // overscroll
+        val touch = touchDown(screenSize.center)
+            .dragBy(dy = boxHeight.dp)
+
+        // rubber band effect is applied
+        assertTrue(0.dp < boxRect.top && boxRect.top < boxHeight.dp)
+        // overscroll does not alter scroll state
+        assertEquals(0 * density.density, state.value.toFloat())
+
+        // flick up
+        touch
+            .dragBy(dy = -(boxHeight + 50).dp, duration = 100.milliseconds)
+            .up()
+
+        waitForIdle()
+
+        // top box is out of visible bounds
+        assertEquals(DpRectZero(), boxRect)
+        // scroll state is updated
+        assertTrue(state.value > boxHeight)
+    }
+
+    /**
+     * Verifies that drag gestures smaller than the touch slop threshold
+     * don't trigger scrolling behavior in a vertically scrollable Column.
+     */
+    @Test
+    fun testNotScrollingForSmallDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.White)
+                )
+            }
+        }
+
+
+        val dySmall = 5.dp
+        assertTrue(dySmall.value < CUPERTINO_TOUCH_SLOP)
+
+        // downward drag - overscroll
+        touchDown(screenSize.center)
+            .dragBy(dy = dySmall)
+        waitForIdle()
+
+        val initialBoxRect = DpRect(DpOffset.Zero, DpSize(screenSize.width, 100.dp))
+
+        // expect no changes
+        assertEquals(0 * density.density, state.value.toFloat())
+        assertEquals(initialBoxRect, boxRect)
+
+        // upward drag - scroll
+        touchDown(screenSize.center)
+            .dragBy(dy = -dySmall)
+        waitForIdle()
+
+        // expect no changes
+        assertEquals(0 * density.density, state.value.toFloat())
+        assertEquals(initialBoxRect, boxRect)
+    }
+
+    @Test
+    fun testOverscrollForContentSmallerThanScreenSize() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Green)
+                )
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+            }
+        }
+
+        val initialBoxRect = DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 100.dp))
+
+        waitForIdle()
+        assertEquals(initialBoxRect, boxRect)
+
+        touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dy = 50.dp)
+
+        waitForIdle()
+        assertEquals(initialBoxRect, boxRect)
+    }
+
+    @Test
+    fun testOverscrollForContentSizeOfScreenSize() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.Green)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+            }
+        }
+
+        val initialBoxRect = DpRect(DpOffset.Zero, screenSize)
+
+        waitForIdle()
+        assertEquals(initialBoxRect, boxRect)
+
+        touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dy = 50.dp)
+
+        waitForIdle()
+        assertEquals(initialBoxRect, boxRect)
+    }
+
+    @Test
+    fun testHorizontalScrollWithRTL() = runUIKitInstrumentedTest {
+        val itemSize = 150
+        val lazyRowState = LazyListState()
+        val totalScrollOffset = { lazyRowState.firstVisibleItemIndex * itemSize + lazyRowState.firstVisibleItemScrollOffset }
+
+        setContent {
+            HorizontalScrollContent(
+                itemSize = itemSize.dp,
+                lazyRowState = lazyRowState,
+                layoutDirection = LayoutDirection.Rtl
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dx = (150 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(150, totalScrollOffset())
+    }
+
+    @Test
+    fun testHorizontalScrollWithLTR() = runUIKitInstrumentedTest {
+        val itemSize = 150
+        val lazyRowState = LazyListState()
+        val totalScrollOffset = { lazyRowState.firstVisibleItemIndex * itemSize + lazyRowState.firstVisibleItemScrollOffset }
+
+        setContent {
+            HorizontalScrollContent(
+                itemSize = itemSize.dp,
+                lazyRowState = lazyRowState,
+                layoutDirection = LayoutDirection.Ltr
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dx = -(150 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(150, totalScrollOffset())
+    }
+
+    @Test
+    fun testHorizontalOverscrollWithRTL() = runUIKitInstrumentedTest {
+        val itemSize = 150
+        val itemCount = 20
+        val lazyRowState = LazyListState()
+        val totalScrollOffset = { lazyRowState.firstVisibleItemIndex * itemSize + lazyRowState.firstVisibleItemScrollOffset }
+        var firstBoxRect = DpRectZero()
+
+        setContent {
+            HorizontalScrollContent(
+                itemSize = itemSize.dp,
+                itemCount = itemCount,
+                lazyRowState = lazyRowState,
+                layoutDirection = LayoutDirection.Rtl,
+                onFirstBoxGloballyPositioned = { firstBoxRect = it.boundsInWindow().toDpRect(density) }
+            )
+        }
+
+        val touch = touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+
+        assertTrue(firstBoxRect.right < screenSize.width)
+        assertTrue(firstBoxRect.right > screenSize.width - 50.dp)
+
+        touch.up()
+
+        waitForIdle()
+
+        assertEquals(screenSize.width, firstBoxRect.right)
+        assertEquals(0, totalScrollOffset())
+    }
+
+    @Test
+    fun testHorizontalOverscrollWithLTR() = runUIKitInstrumentedTest {
+        val itemSize = 150
+        val lazyRowState = LazyListState()
+        val totalScrollOffset = { lazyRowState.firstVisibleItemIndex * itemSize + lazyRowState.firstVisibleItemScrollOffset }
+        var firstBoxRect = DpRectZero()
+
+        setContent {
+            HorizontalScrollContent(
+                itemSize = itemSize.dp,
+                lazyRowState = lazyRowState,
+                layoutDirection = LayoutDirection.Ltr,
+                onFirstBoxGloballyPositioned = { firstBoxRect = it.boundsInWindow().toDpRect(density) }
+            )
+        }
+
+        val touch = touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dx = (50 + CUPERTINO_TOUCH_SLOP).dp)
+
+        assertTrue(firstBoxRect.left > 0.dp)
+        assertTrue(firstBoxRect.left < 50.dp)
+
+        touch.up()
+
+        waitForIdle()
+
+        assertEquals(0.dp, firstBoxRect.left)
+        assertEquals(0, totalScrollOffset())
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testDragWithTouchStartInUIKitViewAndComposeView() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var labelRect = DpRect(DpOffset.Zero, DpSize.Zero)
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Blue)
+                )
+
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+
+                UIKitView(
+                    factory = {
+                        val label = UILabel(frame = CGRectZero.readValue())
+                        label.text = "UIKit.UILabel"
+                        label.textColor = UIColor.blackColor
+                        label.backgroundColor = UIColor.redColor
+                        label
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .onGloballyPositioned { labelRect = it.boundsInWindow().toDpRect(density) },
+                    onReset = { /* Just to make it reusable */ }
+                )
+
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.White)
+                )
+            }
+        }
+
+        // start at center.y of the UILabel and drag upwards
+        touchDown(DpOffset(screenSize.center.x, 250.dp))
+            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 0.dp), DpSize(screenSize.width, 100.dp)), boxRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), labelRect)
+
+        // start at center.y of the red box and drag downwards
+        touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        // frames should be at their initial positions
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 100.dp)), boxRect)
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), labelRect)
+
+        waitForIdle()
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testUIKitScrollViewInsideComposeScrollViewInteractions() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .background(Color.Blue)
+                )
+
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .background(Color.Red)
+                    .onGloballyPositioned { boxRect = it.boundsInWindow().toDpRect(density) }
+                )
+
+                var scrollViewSize by mutableStateOf(DpSize.Zero)
+                UIKitView(
+                    factory = {
+                        val scrollView = UIScrollView()
+                        scrollView.setContentSize(
+                            CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
+                        )
+                        contentOffset = { scrollView.contentOffset.asDpOffset() }
+                        scrollView.backgroundColor = UIColor.lightGrayColor
+                        scrollView
+                    },
+                    update = { scrollView ->
+                        scrollView.setContentSize(
+                            CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth().height(400.dp).onSizeChanged {
+                        scrollViewSize = with(density) {
+                            DpSize(it.width.toDp(), it.height.toDp())
+                        }
+                    }
+                )
+
+                Box(modifier = Modifier
+                    .fillMaxWidth()
+                    .height(screenSize.height)
+                    .background(Color.White)
+                )
+            }
+        }
+
+        waitForIdle()
+
+        // start in red box and drag upwards
+        touchDown(DpOffset(screenSize.center.x, 250.dp))
+            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), boxRect)
+
+        // start in UIScrollView and drag upwards
+        touchDown(DpOffset(screenSize.center.x, 400.dp))
+            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        // red box should remain at the same position
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), boxRect)
+        assertEquals(DpOffset(x = 0.dp, y = 100.dp), contentOffset())
+
+        // drag back to initial position
+        touchDown(DpOffset(screenSize.center.x, 50.dp))
+            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        // start in red box and flick upwards
+        touchDown(DpOffset(screenSize.center.x, 150.dp))
+            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp, duration = 100.milliseconds)
+            .up()
+
+        // wait for the flick to be in the deceleration phase
+        delay(800)
+
+        // start in the UIScrollView and drag down while flick animation is still in progress
+        touchDown(DpOffset(screenSize.center.x, 100.dp))
+            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        // UIScrollView content offset should still be the same
+        assertEquals(DpOffset(x = 0.dp, y = 100.dp), contentOffset())
+
+        // drag up in UIScrollView from idle position
+        touchDown(DpOffset(screenSize.center.x, 300.dp))
+            .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        assertEquals(DpOffset.Zero, contentOffset())
+    }
+
+    @Test
+    fun testOverscrollWhenUIKitHorizontalScrollViewIsAtTop() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalScrollWithHorizontalUIKitScroll(
+                state = state,
+                screenSize = screenSize,
+                topContentHeight = 0.dp,
+                uiKitScrollViewHeight = 200.dp,
+                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        val initialUIKitViewRect = uiKitViewRect.copy()
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 0.dp), DpSize(screenSize.width, 200.dp)), initialUIKitViewRect)
+
+        val touch = touchDown(DpOffset(screenSize.center.x, 100.dp))
+            .dragBy(dy = (50 + CUPERTINO_TOUCH_SLOP).dp)
+
+        waitForIdle()
+
+        assertTrue(uiKitViewRect.top > 0.dp)
+        assertTrue(uiKitViewRect.top < (50 + CUPERTINO_TOUCH_SLOP).dp)
+
+        assertEquals(DpOffset(x = 0.dp, y = 0.dp), contentOffset())
+
+        touch.up()
+        waitForIdle()
+
+        assertEquals(initialUIKitViewRect, uiKitViewRect)
+        assertEquals(0 * density.density, state.value.toFloat())
+
+        // Horizontal drag to verify UIKit scroll reacts
+        touchDown(DpOffset(screenSize.center.x, 100.dp))
+            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        // Horizontal content offset should change, but vertical position stays the same
+        assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
+        assertEquals(initialUIKitViewRect, uiKitViewRect)
+
+        // Combined gesture - start with downward overscroll then horizontal
+        touchDown(DpOffset(screenSize.center.x, 100.dp))
+            .dragBy(dy = (50 + CUPERTINO_TOUCH_SLOP).dp)
+            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp, dy = 0.dp)
+            .up()
+
+        waitForIdle()
+
+        // View should return to original position after overscroll
+        assertEquals(initialUIKitViewRect, uiKitViewRect)
+        // Horizontal content should not change
+        assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
+    }
+
+    @Test
+    fun testVerticalComposeScrollsWhenDraggingFromUIKitHorizontalScroll() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalScrollWithHorizontalUIKitScroll(
+                state = state,
+                screenSize = screenSize,
+                topContentHeight = 200.dp,
+                uiKitScrollViewHeight = 200.dp,
+                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 300.dp))
+            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(100 * density.density, state.value.toFloat())
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpOffset(x = 0.dp, y = 0.dp), contentOffset())
+    }
+
+    /**
+     * Tests horizontal UIScrollView scrolling behavior when:
+     * - Touch interaction starts inside the UIScrollView
+     * - Drag gesture continues horizontally
+     */
+    @Test
+    fun testHorizontalUIScrollViewInComposeScroll_HorizontalDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalScrollWithHorizontalUIKitScroll(
+                state = state,
+                screenSize = screenSize,
+                topContentHeight = 200.dp,
+                uiKitScrollViewHeight = 200.dp,
+                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 250.dp))
+            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(0 * density.density, state.value.toFloat())
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
+    }
+
+    /**
+     * Tests horizontal UIScrollView scrolling behavior when:
+     * - Touch interaction starts inside the UIScrollView
+     * - Drag gesture continues vertically
+     */
+    @Test
+    fun testHorizontalUIScrollViewInComposeVerticalScroll_VerticalDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalScrollWithHorizontalUIKitScroll(
+                state = state,
+                screenSize = screenSize,
+                topContentHeight = 200.dp,
+                uiKitScrollViewHeight = 200.dp,
+                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 250.dp))
+            .dragBy(dy = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(50 * density.density, state.value.toFloat())
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 150.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpOffset.Zero, contentOffset())
+    }
+
+    /**
+     * Tests drag gestures that include both horizontal and vertical
+     * components when interacting with a horizontal UIKit scroll view embedded in a vertical
+     * Compose scroll container. Verifies proper gesture disambiguation and handling when:
+     * 1. Drag gestures change direction mid-interaction
+     * 2. Mixed horizontal and vertical movements occur simultaneously
+     * 3. Drag gestures extend beyond the bounds of the UIKit view
+     */
+    @Test
+    fun testHorizontalUIScrollViewInComposeVerticalScroll_MixedDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalScrollWithHorizontalUIKitScroll(
+                state = state,
+                screenSize = screenSize,
+                topContentHeight = 200.dp,
+                uiKitScrollViewHeight = 200.dp,
+                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        touchDown(DpOffset(screenSize.center.x, 250.dp))
+            .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp, dy = -50.dp)
+            .dragBy(dx = 20.dp, dy = -50.dp)
+            .dragBy(dx = -70.dp, dy = 50.dp)
+            .dragBy(dy = -150.dp)
+            .up()
+
+        waitForIdle()
+
+        assertEquals(0 * density.density, state.value.toFloat())
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpOffset(x = 100.dp, y = 0.dp), contentOffset())
+    }
+
+    /**
+     * Tests the resolution of ambiguous drag gestures between a horizontal UIKit scroll view
+     * and a vertical Compose scroll container. Specifically:
+     * 1. When drag starts with primarily vertical movement, Compose scroll takes precedence
+     * 2. Small horizontal movements during a primarily vertical drag don't trigger UIKit scroll
+     * 3. Direction disambiguation happens early in the gesture
+     */
+    @Test
+    fun testHorizontalUIScrollViewInComposeVerticalScroll_VerticalAndSmallHorizontalDrag() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var contentOffset: () -> DpOffset = { DpOffset.Zero }
+
+        setContent {
+            VerticalScrollWithHorizontalUIKitScroll(
+                state = state,
+                screenSize = screenSize,
+                topContentHeight = 200.dp,
+                uiKitScrollViewHeight = 200.dp,
+                onUIKitViewGloballyPositioned = { uiKitViewRect = it.boundsInWindow().toDpRect(density) },
+                uiKitContentOffset = { contentOffset = it }
+            )
+        }
+
+        // start inside UIScrollView and drag slightly to the side and upwards
+        touchDown(DpOffset(screenSize.center.x, 250.dp))
+            .dragBy(dx = -(5 + CUPERTINO_TOUCH_SLOP).dp, dy = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+            .dragBy(dx = -50.dp, dy = -50.dp)
+            .up()
+
+        waitForIdle()
+
+        // verify that only Compose scroll state changed but UIScrollView content offset stayed the same
+        assertEquals(100 * density.density, state.value.toFloat())
+        assertEquals(DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect)
+        assertEquals(DpOffset.Zero, contentOffset())
+    }
+}
+
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+private fun VerticalScrollWithHorizontalUIKitScroll(
+    state: ScrollState,
+    screenSize: DpSize,
+    topContentHeight: Dp,
+    uiKitScrollViewHeight: Dp,
+    uiKitScrollViewContentWidth: Double = 1000.0,
+    onUIKitViewGloballyPositioned: (androidx.compose.ui.layout.LayoutCoordinates) -> Unit = {},
+    uiKitContentOffset: (() -> DpOffset) -> Unit = { },
+) {
+    Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+        if (topContentHeight > 0.dp) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(topContentHeight)
+                    .background(Color.Red)
+            )
+        }
+
+        UIKitView(
+            factory = {
+                val scrollView = UIScrollView()
+                scrollView.setContentSize(CGSizeMake(uiKitScrollViewContentWidth, uiKitScrollViewHeight.value.toDouble()))
+                scrollView.backgroundColor = UIColor.lightGrayColor
+                uiKitContentOffset({ scrollView.contentOffset.asDpOffset() })
+                scrollView
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(uiKitScrollViewHeight)
+                .onGloballyPositioned(onUIKitViewGloballyPositioned),
+            update = {}
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(screenSize.height)
+                .background(Color.White)
+        )
+    }
+}
+
+@Composable
+private fun HorizontalScrollContent(
+    itemSize: Dp,
+    itemCount: Int = 20,
+    lazyRowState: LazyListState,
+    layoutDirection: LayoutDirection,
+    onFirstBoxGloballyPositioned: (androidx.compose.ui.layout.LayoutCoordinates) -> Unit = {}
+) {
+    CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            LazyRow(modifier = Modifier.height(itemSize), state = lazyRowState) {
+                items(itemCount) {
+                    Box(
+                        Modifier
+                            .size(itemSize, itemSize)
+                            .background(remember { Color(Random.nextInt()) })
+                            .then(
+                                if (it == 0) Modifier.onGloballyPositioned(onFirstBoxGloballyPositioned) else Modifier
+                            )
+                    ) {
+                        Text("Text ${it}")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -374,7 +374,6 @@ internal class ScrollTest {
 
         val initialBoxRect = DpRect(DpOffset(x = 0.dp, y = 100.dp), DpSize(screenSize.width, 100.dp))
 
-        waitForIdle()
         assertEquals(initialBoxRect, boxRect)
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -79,7 +79,7 @@ internal class ScrollTest {
     @Test
     fun testExactTouchSlopDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -115,7 +115,7 @@ internal class ScrollTest {
     @Test
     fun testJustOverTouchSlopDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -148,7 +148,7 @@ internal class ScrollTest {
     @Test
     fun testTopOverscrollDragResistance() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -202,7 +202,7 @@ internal class ScrollTest {
     fun testBottomOverscrollDragResistance() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
         val boxHeight = 100.0
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -255,7 +255,7 @@ internal class ScrollTest {
     fun testOverscrollAndFlick() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
         val boxHeight = 100.0
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -308,7 +308,7 @@ internal class ScrollTest {
     @Test
     fun testNotScrollingForSmallDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -354,7 +354,7 @@ internal class ScrollTest {
     @Test
     fun testOverscrollForContentSmallerThanScreenSize() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -386,7 +386,7 @@ internal class ScrollTest {
     @Test
     fun testOverscrollForContentSizeOfScreenSize() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -522,8 +522,8 @@ internal class ScrollTest {
     @Test
     fun testDragWithTouchStartInUIKitViewAndComposeView() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
-        var labelRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
+        var labelRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
@@ -591,7 +591,7 @@ internal class ScrollTest {
     @Test
     fun testUIKitScrollViewInsideComposeScrollViewInteractions() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var boxRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var boxRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -696,7 +696,7 @@ internal class ScrollTest {
     @Test
     fun testOverscrollWhenUIKitHorizontalScrollViewIsAtTop() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -757,7 +757,7 @@ internal class ScrollTest {
     @Test
     fun testVerticalComposeScrollsWhenDraggingFromUIKitHorizontalScroll() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -790,7 +790,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeScroll_HorizontalDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -823,7 +823,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeVerticalScroll_VerticalDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -859,7 +859,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeVerticalScroll_MixedDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {
@@ -897,7 +897,7 @@ internal class ScrollTest {
     @Test
     fun testHorizontalUIScrollViewInComposeVerticalScroll_VerticalAndSmallHorizontalDrag() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
-        var uiKitViewRect = DpRect(DpOffset.Zero, DpSize.Zero)
+        var uiKitViewRect = DpRectZero()
         var contentOffset: () -> DpOffset = { DpOffset.Zero }
 
         setContent {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -612,16 +612,17 @@ internal class ScrollTest {
             )
         }
 
-        // start in UIScrollView and drag upwards
-        touchDown(DpOffset(screenSize.center.x, 450.dp))
-            .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+        val initialUIScrollViewRect = uiScrollViewRect()
+
+        findNodeWithTag("UIKit.UIScrollView")
+            .touchDown()
+            .dragBy(dy = -(250 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
         waitForIdle()
 
-        // red box should remain at the same position
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 400.dp), DpSize(screenSize.width, 400.dp)), uiScrollViewRect())
-        assertEquals(DpOffset(x = 0.dp, y = 100.dp), contentOffset())
+        assertEquals(initialUIScrollViewRect, uiScrollViewRect())
+        assertEquals(DpOffset(x = 0.dp, y = 250.dp), contentOffset())
     }
 
     @OptIn(ExperimentalForeignApi::class)
@@ -643,7 +644,8 @@ internal class ScrollTest {
             )
         }
 
-        touchDown(DpOffset(screenSize.center.x, 200.dp))
+        findNodeWithTag("Top Box")
+            .touchDown()
             .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
@@ -713,14 +715,17 @@ internal class ScrollTest {
             )
         }
 
-        touchDown(DpOffset(screenSize.center.x, 250.dp))
+        val initialUIKitViewRect = uiKitViewRect().copy()
+
+        findNodeWithTag("UIKit.UIScrollView")
+            .touchDown()
             .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
         waitForIdle()
 
         assertEquals(0 * density.density, state.value.toFloat())
-        assertEquals(DpRect(DpOffset(x = 0.dp, y = 200.dp), DpSize(screenSize.width, 200.dp)), uiKitViewRect())
+        assertEquals(initialUIKitViewRect, uiKitViewRect())
         assertEquals(DpOffset(x = 50.dp, y = 0.dp), contentOffset())
     }
 
@@ -746,7 +751,8 @@ internal class ScrollTest {
             )
         }
 
-        touchDown(DpOffset(screenSize.center.x, 250.dp))
+        findNodeWithTag("UIKit.UIScrollView")
+            .touchDown()
             .dragBy(dy = -(50 + CUPERTINO_TOUCH_SLOP).dp)
             .up()
 
@@ -820,8 +826,8 @@ internal class ScrollTest {
             )
         }
 
-        // start inside UIScrollView and drag slightly to the side and upwards
-        touchDown(DpOffset(screenSize.center.x, 250.dp))
+        findNodeWithTag("UIKit.UIScrollView")
+            .touchDown()
             .dragBy(dx = -(5 + CUPERTINO_TOUCH_SLOP).dp, dy = -(50 + CUPERTINO_TOUCH_SLOP).dp)
             .dragBy(dx = -50.dp, dy = -50.dp)
             .up()
@@ -851,6 +857,7 @@ private fun VerticalUIKitScrollInsideVerticalScroll(
                 .fillMaxWidth()
                 .height(topContentHeight)
                 .background(Color.Red)
+                .testTag("Top Box")
         )
 
         var scrollViewSize by mutableStateOf(DpSize.Zero)
@@ -870,7 +877,11 @@ private fun VerticalUIKitScrollInsideVerticalScroll(
                     CGSizeMake(scrollViewSize.width.value.toDouble(), 1000.0)
                 )
             },
-            modifier = Modifier.fillMaxWidth().height(uiKitScrollViewHeight).onSizeChanged {
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("UIKit.UIScrollView")
+                .height(uiKitScrollViewHeight)
+                .onSizeChanged {
                 scrollViewSize = with(density) {
                     DpSize(it.width.toDp(), it.height.toDp())
                 }
@@ -918,7 +929,8 @@ private fun VerticalScrollWithHorizontalUIKitScroll(
             },
             modifier = Modifier
                 .fillMaxWidth()
-                .height(uiKitScrollViewHeight),
+                .height(uiKitScrollViewHeight)
+                .testTag("UIKit.UIScrollView"),
             update = {}
         )
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -97,8 +97,6 @@ internal class ScrollTest {
             }
         }
 
-        waitForIdle()
-
         val initialBoxRect = boxRect.copy()
         val dyExact = CUPERTINO_TOUCH_SLOP.dp
 
@@ -170,7 +168,6 @@ internal class ScrollTest {
             }
         }
 
-        waitForIdle()
         val touch = touchDown(screenSize.center)
         var previousBoxTop = boxRect.top
         var previousDiff = 0f
@@ -225,7 +222,6 @@ internal class ScrollTest {
             }
         }
 
-        waitForIdle()
         val touch = touchDown(screenSize.center)
         var previousBoxTop = boxRect.top
         var previousDiff = 0f
@@ -406,7 +402,6 @@ internal class ScrollTest {
 
         val initialBoxRect = DpRect(DpOffset.Zero, screenSize)
 
-        waitForIdle()
         assertEquals(initialBoxRect, boxRect)
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
@@ -645,8 +640,6 @@ internal class ScrollTest {
                 )
             }
         }
-
-        waitForIdle()
 
         // start in red box and drag upwards
         touchDown(DpOffset(screenSize.center.x, 250.dp))

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -205,6 +205,14 @@ internal class UIKitInstrumentedTest {
     }
 
     /**
+     * Simulates a touch-down event at the center of a given AccessibilityTestNode.
+     */
+    fun AccessibilityTestNode.touchDown(): UITouch {
+        val frame = frame ?: error("Internal error. Frame is missing.")
+        return touchDown(frame.center())
+    }
+
+    /**
      * Simulates a drag gesture on the screen, moving the touch from its current location to a specified position
      * over a given duration.
      *


### PR DESCRIPTION
Add set of instrumented tests to validate scroll interactions in Compose for iOS, including vertical, horizontal, and interop behaviors.

Scenarios covered

- touch slop thresholds
- overscroll resistance
- RTL/LTR + scroll / overscroll
- integration with `UIScrollView`s
- gesture disambiguation for nested scrolls

Fixes - https://youtrack.jetbrains.com/issue/CMP-143

## Release Notes
N/A
