### PR TITLE
Fix dialogs after modal view controller presentation

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -248,8 +248,9 @@ internal class ComposeHostingViewController(
         configuration.delegate.viewDidAppear(animated)
 
         // Because the container view can change during the modal transition animation,
-        // the gesture handlers are added back when the animation ends.
+        // the gesture handlers and layers view are added back when the animation ends.
         backGestureDispatcher.onDidMoveToWindow(view.window, rootView)
+        layers?.containerView = layersContainerView()
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
Re-add layers to correct container after modal presentation ends

Fixes https://youtrack.jetbrains.com/issue/CMP-8126

## Release Notes
### Fixes - iOS
- Fix dialogs after modal view controller presentation
