### PR TITLE
Make backing html input not exceed the canvas bounds and respect the dimensions of the focused rect

### DIFF
--- a/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
+++ b/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
@@ -1,5 +1,6 @@
 package androidx.compose.mpp.demo
 
+import androidx.compose.mpp.demo.bugs.BugsScreen
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -20,6 +21,7 @@ fun main() {
             val app = remember {
                 App(
                     extraScreens = listOf(
+                        BugsScreen,
                         Screen.Example("Web Clipboard API example") {
                             WebClipboardDemo()
                         }

--- a/compose/mpp/demo/src/wasmJsMain/kotlin/androidx/compose/mpp/demo/main.wasm.kt
+++ b/compose/mpp/demo/src/wasmJsMain/kotlin/androidx/compose/mpp/demo/main.wasm.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.mpp.demo.bugs.BugsScreen
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -50,6 +51,7 @@ fun main() {
         val fontsLoaded = remember { mutableStateOf(false) }
         val app = remember { App(
             extraScreens = listOf(
+                BugsScreen,
                 Screen.Example("Web Clipboard API example") {
                     WebClipboardDemo()
                 }

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.mpp.demo.Screen
+
+val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
+    Screen.Example("Text Fields in Scrollable") {
+        TextFieldsInTallScrollableContainer()
+    }
+))

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TextFieldsInScrollable.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/TextFieldsInScrollable.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+
+// https://youtrack.jetbrains.com/issue/CMP-7836/Compose-1.8.0-beta01-weird-scroll-behavior
+@Composable
+fun TextFieldsInTallScrollableContainer() {
+    MaterialTheme {
+        val verticalScrollState = rememberScrollState()
+        Column(modifier = Modifier
+            .verticalScroll(verticalScrollState)
+            .fillMaxSize()
+            .background(Color.LightGray)
+            .padding(vertical = 50.dp, horizontal = 10.dp)
+        ) {
+            var firstTextFieldValue by remember { mutableStateOf(TextFieldValue("first")) }
+            var secondTextFieldValue by remember { mutableStateOf(TextFieldValue("second")) }
+            TextField(
+                enabled = false,
+                value = firstTextFieldValue,
+                onValueChange = { firstTextFieldValue = it }
+            )
+            Spacer(modifier = Modifier.height(2000.dp))
+            TextField(
+                enabled = true,
+                value = secondTextFieldValue,
+                onValueChange = { secondTextFieldValue = it }
+            )
+            Spacer(modifier = Modifier.height(200.dp))
+        }
+    }
+}

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -74,6 +74,11 @@ internal class BackingDomInput(
         backingElement.style.top = "${offset.y}px"
     }
 
+    fun updateHtmlInputGeometry(width: Int, height: Int) {
+        backingElement.style.width = "${width}px"
+        backingElement.style.height = "${height}px"
+    }
+
     fun updateState(textFieldValue: TextFieldValue) {
         inputStrategy.updateState(textFieldValue)
         focus()

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -24,10 +24,20 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.width
 
 internal interface InputAwareInputService {
     fun getOffset(rect: Rect): Offset
     fun processKeyboardEvent(keyboardEvent: KeyEvent): Boolean
+
+    /**
+     * @param rect is the rect in Compose coordinates
+     *
+     * @return a DpRect appropriate for positioning and laying out the HTML backing input
+     */
+    fun getNewGeometryForBackingInput(rect: Rect): DpRect
 }
 
 internal abstract class WebTextInputService : PlatformTextInputService, InputAwareInputService {
@@ -79,8 +89,9 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
     }
 
     override fun notifyFocusedRect(rect: Rect) {
-        super.notifyFocusedRect(rect)
-        backingDomInput?.updateHtmlInputPosition(getOffset(rect))
+        val newRect = getNewGeometryForBackingInput(rect)
+        backingDomInput?.updateHtmlInputPosition(Offset(newRect.left.value, newRect.top.value))
+        backingDomInput?.updateHtmlInputGeometry(newRect.width.value.toInt(), newRect.height.value.toInt())
     }
 
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -53,8 +53,14 @@ import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeSceneDragAndDropNode
 import androidx.compose.ui.scene.ComposeScenePointer
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.height
+import androidx.compose.ui.unit.size
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.width
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -200,6 +206,27 @@ internal class ComposeWindow(
                 val offsetX = viewportRect.left.toFloat().coerceAtLeast(0f) + (rect.left / density.density)
                 val offsetY = viewportRect.top.toFloat().coerceAtLeast(0f) + (rect.top / density.density)
                 return Offset(offsetX, offsetY)
+            }
+
+            override fun getNewGeometryForBackingInput(rect: Rect): DpRect {
+                val viewportRect = canvas.getBoundingClientRect()
+                val dpRect = rect.toDpRect(density)
+                var left = viewportRect.left.toFloat() + dpRect.left.value
+                var top = viewportRect.top.toFloat() + dpRect.top.value
+
+                if (left < viewportRect.left) {
+                    left = viewportRect.left.toFloat()
+                } else if (left + dpRect.width.value > viewportRect.right) {
+                    left = viewportRect.right.toFloat() - dpRect.width.value
+                }
+
+                if (top < viewportRect.top) {
+                    top = viewportRect.top.toFloat()
+                } else if (top + dpRect.height.value > viewportRect.bottom) {
+                    top = viewportRect.bottom.toFloat() - dpRect.height.value
+                }
+
+                return DpRect(DpOffset(left.dp, top.dp), dpRect.size)
             }
 
             override fun processKeyboardEvent(keyEvent: KeyEvent): Boolean {


### PR DESCRIPTION
(Cherry pick from https://github.com/JetBrains/compose-multiplatform-core/pull/2070)

Fixes a second part of https://youtrack.jetbrains.com/issue/CMP-7836

The problem was that a browser tries to bring the backing html input into a view. When the view is beyond the canvas bounds, then it would lead to canvas being partially or completely hidden.

The solution is to not let an html input be positioned anywhere beyond the canvas.


## Testing
Tested manually in a newly added demo-reprdocuer.

This should be tested by QA

## Release Notes
### Fixes - Web
- Fixed the positioning and the dimensions of the backing text input (HTML element). The bug used to lead to unexpected scrolls on the page due to the browser trying to bring the HTML element into a view.
