### PR TITLE
[Cherry-pick] Fix size during pivot calculation (#2080)

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
@@ -347,8 +347,8 @@ internal class GraphicsLayerOwnerLayer(
             val pivotX: Float
             val pivotY: Float
             if (pivotOffset.isUnspecified) {
-                pivotX = size.width / 2f
-                pivotY = size.height / 2f
+                pivotX = this@GraphicsLayerOwnerLayer.size.width / 2f
+                pivotY = this@GraphicsLayerOwnerLayer.size.height / 2f
             } else {
                 pivotX = pivotOffset.x
                 pivotY = pivotOffset.y

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/OwnerLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/OwnerLayerTest.kt
@@ -299,6 +299,23 @@ class OwnerLayerTest {
     }
 
     @Test
+    fun rotationZ_unspecified_origin() {
+        layer.resize(IntSize(100, 10))
+        layer.updateProperties(
+            rotationZ = 90f
+        )
+
+        assertMapping(
+            from = Offset(50f, 5f),
+            to = Offset(50f, 5f)
+        )
+        assertMapping(
+            from = Offset(45f, 10f),
+            to = Offset(55f, 10f)
+        )
+    }
+
+    @Test
     fun translation_scale_left_top_origin() {
         layer.resize(IntSize(100, 10))
         layer.updateProperties(


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8129 (1.8.0 regression)

## Release Notes
### Fixes - Multiple Platforms
- Fix incorrect pointer position calculation with rotation around unspecified pivot