### PR TITLE
[Cherry-pick] Fix savedstate compilation for mingw

### DIFF
--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -117,8 +117,8 @@ val libraryToComponents = mapOf(
         ComposeComponent(":performance:performance-annotation", viewModelPlatforms),
     ),
     "SAVEDSTATE" to listOf(
-        ComposeComponent(":savedstate:savedstate", viewModelPlatforms),
-        ComposeComponent(":savedstate:savedstate-compose"),
+        ComposeComponent(":savedstate:savedstate", supportedPlatforms = ComposePlatforms.ALL_AOSP),
+        ComposeComponent(":savedstate:savedstate-compose", supportedPlatforms = ComposePlatforms.ALL),
     ),
     "WINDOW" to listOf(
         ComposeComponent(":window:window-core", viewModelPlatforms),

--- a/savedstate/savedstate-compose/api/savedstate-compose.klib.api
+++ b/savedstate/savedstate-compose/api/savedstate-compose.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64.uikitArm64, iosSimulatorArm64.uikitSimArm64, iosX64.uikitX64, js, macosArm64, macosX64, wasmJs]
+// Targets: [iosArm64.uikitArm64, iosSimulatorArm64.uikitSimArm64, iosX64.uikitX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/savedstate/savedstate-compose/build.gradle
+++ b/savedstate/savedstate-compose/build.gradle
@@ -44,9 +44,21 @@ androidXComposeMultiplatform {
     darwin()
     js()
     wasm()
+
+    linuxX64()
+    linuxArm64()
 }
 
 kotlin {
+    watchosArm64()
+    watchosArm32()
+    watchosX64()
+    watchosSimulatorArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+    mingwX64()
+
     sourceSets {
         commonMain {
             dependencies {

--- a/savedstate/savedstate/api/savedstate.klib.api
+++ b/savedstate/savedstate/api/savedstate.klib.api
@@ -1,5 +1,5 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64, watchosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/savedstate/savedstate/build.gradle
+++ b/savedstate/savedstate/build.gradle
@@ -8,6 +8,8 @@
 
 import androidx.build.LibraryType
 import androidx.build.PlatformIdentifier
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.konan.target.Family
 
 plugins {
     id("AndroidXPlugin")
@@ -112,20 +114,28 @@ androidXMultiplatform {
             dependsOn(nonAndroidTest)
         }
 
-        darwinMain {
+        unixMain {
             dependsOn(nativeMain)
+        }
+
+        unixTest {
+            dependsOn(nativeTest)
+        }
+
+        darwinMain {
+            dependsOn(unixMain)
         }
 
         darwinTest {
-            dependsOn(nativeTest)
+            dependsOn(unixTest)
         }
 
         linuxMain {
-            dependsOn(nativeMain)
+            dependsOn(unixMain)
         }
 
         linuxTest {
-            dependsOn(nativeTest)
+            dependsOn(unixTest)
         }
 
         webMain {
@@ -137,29 +147,18 @@ androidXMultiplatform {
         }
 
         targets.configureEach { target ->
-            if (target.platformType == org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.native) {
-                target.compilations["main"].defaultSourceSet {
-                    def konanTargetFamily = target.konanTarget.family
-                    if (konanTargetFamily.appleFamily) {
-                        dependsOn(darwinMain)
-                    } else if (konanTargetFamily == org.jetbrains.kotlin.konan.target.Family.LINUX) {
-                        dependsOn(linuxMain)
-                    } else {
-                        throw new GradleException("unknown native target ${target}")
-                    }
+            if (target.platformType == KotlinPlatformType.native) {
+                if (target.konanTarget.family.appleFamily) {
+                    target.compilations["main"].defaultSourceSet.dependsOn(darwinMain)
+                    target.compilations["test"].defaultSourceSet.dependsOn(darwinTest)
+                } else if (target.konanTarget.family == Family.LINUX) {
+                    target.compilations["main"].defaultSourceSet.dependsOn(linuxMain)
+                    target.compilations["test"].defaultSourceSet.dependsOn(linuxTest)
+                } else {
+                    target.compilations["main"].defaultSourceSet.dependsOn(nativeMain)
+                    target.compilations["test"].defaultSourceSet.dependsOn(nativeTest)
                 }
-                target.compilations["test"].defaultSourceSet {
-                    def konanTargetFamily = target.konanTarget.family
-                    if (konanTargetFamily.appleFamily) {
-                        dependsOn(darwinTest)
-                    } else if (konanTargetFamily == org.jetbrains.kotlin.konan.target.Family.LINUX) {
-                        dependsOn(linuxTest)
-                    } else {
-                        throw new GradleException("unknown native target ${target}")
-                    }
-                }
-            } else if (target.platformType == org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.js ||
-                    target.platformType == org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType.wasm) {
+            } else if (target.platformType in [KotlinPlatformType.js, KotlinPlatformType.wasm]) {
                 target.compilations["main"].defaultSourceSet.dependsOn(webMain)
                 target.compilations["test"].defaultSourceSet.dependsOn(webTest)
             }
@@ -175,6 +174,7 @@ kotlin {
     tvosArm64()
     tvosX64()
     tvosSimulatorArm64()
+    mingwX64()
 }
 
 android {

--- a/savedstate/savedstate/src/mingwX64Main/kotlin/androidx/savedstate/internal/SynchronizedObject.native.mingwX64.kt
+++ b/savedstate/savedstate/src/mingwX64Main/kotlin/androidx/savedstate/internal/SynchronizedObject.native.mingwX64.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.savedstate.internal
+
+import kotlinx.cinterop.Arena
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.ptr
+import platform.posix.pthread_mutex_destroy
+import platform.posix.pthread_mutex_init
+import platform.posix.pthread_mutex_lock
+import platform.posix.pthread_mutex_tVar
+import platform.posix.pthread_mutex_unlock
+import platform.posix.pthread_mutexattr_destroy
+import platform.posix.pthread_mutexattr_init
+import platform.posix.pthread_mutexattr_settype
+import platform.posix.pthread_mutexattr_tVar
+
+internal actual val PTHREAD_MUTEX_RECURSIVE: Int = platform.posix.PTHREAD_MUTEX_RECURSIVE
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual class SynchronizedObjectImpl {
+    private val arena = Arena()
+    private val attr: pthread_mutexattr_tVar = arena.alloc()
+    private val mutex: pthread_mutex_tVar = arena.alloc()
+
+    init {
+        pthread_mutexattr_init(attr.ptr)
+        pthread_mutexattr_settype(attr.ptr, PTHREAD_MUTEX_RECURSIVE)
+        pthread_mutex_init(mutex.ptr, attr.ptr)
+    }
+
+    internal actual fun lock(): Int = pthread_mutex_lock(mutex.ptr)
+
+    internal actual fun unlock(): Int = pthread_mutex_unlock(mutex.ptr)
+
+    internal actual fun dispose() {
+        pthread_mutex_destroy(mutex.ptr)
+        pthread_mutexattr_destroy(attr.ptr)
+        arena.clear()
+    }
+}

--- a/savedstate/savedstate/src/nativeMain/kotlin/androidx/savedstate/internal/SynchronizedObject.native.kt
+++ b/savedstate/savedstate/src/nativeMain/kotlin/androidx/savedstate/internal/SynchronizedObject.native.kt
@@ -13,74 +13,50 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package androidx.savedstate.internal
 
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.createCleaner
-import kotlinx.cinterop.Arena
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.alloc
-import kotlinx.cinterop.ptr
-import platform.posix.pthread_mutex_destroy
-import platform.posix.pthread_mutex_init
-import platform.posix.pthread_mutex_lock
-import platform.posix.pthread_mutex_t
-import platform.posix.pthread_mutex_unlock
-import platform.posix.pthread_mutexattr_destroy
-import platform.posix.pthread_mutexattr_init
-import platform.posix.pthread_mutexattr_settype
-import platform.posix.pthread_mutexattr_t
 
 /**
  * Wrapper for platform.posix.PTHREAD_MUTEX_RECURSIVE which is represented as kotlin.Int on darwin
- * platforms and kotlin.UInt on linuxX64 See: // https://youtrack.jetbrains.com/issue/KT-41509
+ * platforms and kotlin.UInt on linuxX64
+ * See: https://youtrack.jetbrains.com/issue/KT-41509
  */
 internal expect val PTHREAD_MUTEX_RECURSIVE: Int
 
-internal actual class SynchronizedObject actual constructor() {
+internal expect class SynchronizedObjectImpl() {
+    internal fun lock(): Int
+    internal fun unlock(): Int
+    internal fun dispose()
+}
 
-    private val resource = Resource()
+internal actual class SynchronizedObject actual constructor() {
+    private val impl = SynchronizedObjectImpl()
 
     @Suppress("unused") // The returned Cleaner must be assigned to a property
-    @OptIn(ExperimentalStdlibApi::class, ExperimentalNativeApi::class)
-    private val cleaner = createCleaner(resource, Resource::dispose)
+    @OptIn(ExperimentalNativeApi::class)
+    private val cleaner = createCleaner(impl, SynchronizedObjectImpl::dispose)
 
     fun lock() {
-        resource.lock()
+        impl.lock()
     }
 
     fun unlock() {
-        resource.unlock()
-    }
-
-    @OptIn(ExperimentalForeignApi::class)
-    private class Resource {
-        private val arena: Arena = Arena()
-        private val attr: pthread_mutexattr_t = arena.alloc()
-        private val mutex: pthread_mutex_t = arena.alloc()
-
-        init {
-            pthread_mutexattr_init(attr.ptr)
-            pthread_mutexattr_settype(attr.ptr, PTHREAD_MUTEX_RECURSIVE)
-            pthread_mutex_init(mutex.ptr, attr.ptr)
-        }
-
-        fun lock(): Int = pthread_mutex_lock(mutex.ptr)
-
-        fun unlock(): Int = pthread_mutex_unlock(mutex.ptr)
-
-        fun dispose() {
-            pthread_mutex_destroy(mutex.ptr)
-            pthread_mutexattr_destroy(attr.ptr)
-            arena.clear()
-        }
+        impl.unlock()
     }
 }
 
+@OptIn(ExperimentalContracts::class)
 internal actual inline fun <T> synchronizedImpl(
     lock: SynchronizedObject,
     crossinline action: () -> T
 ): T {
+    contract { callsInPlace(action, InvocationKind.EXACTLY_ONCE) }
     lock.lock()
     return try {
         action()

--- a/savedstate/savedstate/src/unixMain/kotlin/androidx/savedstate/internal/SynchronizedObject.unix.kt
+++ b/savedstate/savedstate/src/unixMain/kotlin/androidx/savedstate/internal/SynchronizedObject.unix.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.savedstate.internal
+
+import kotlinx.cinterop.Arena
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.ptr
+import platform.posix.pthread_mutex_destroy
+import platform.posix.pthread_mutex_init
+import platform.posix.pthread_mutex_lock
+import platform.posix.pthread_mutex_t
+import platform.posix.pthread_mutex_unlock
+import platform.posix.pthread_mutexattr_destroy
+import platform.posix.pthread_mutexattr_init
+import platform.posix.pthread_mutexattr_settype
+import platform.posix.pthread_mutexattr_t
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual class SynchronizedObjectImpl actual constructor() {
+    private val arena: Arena = Arena()
+    private val attr: pthread_mutexattr_t = arena.alloc()
+    private val mutex: pthread_mutex_t = arena.alloc()
+
+    init {
+        pthread_mutexattr_init(attr.ptr)
+        pthread_mutexattr_settype(attr.ptr, PTHREAD_MUTEX_RECURSIVE)
+        pthread_mutex_init(mutex.ptr, attr.ptr)
+    }
+
+    internal actual fun lock(): Int = pthread_mutex_lock(mutex.ptr)
+
+    internal actual fun unlock(): Int = pthread_mutex_unlock(mutex.ptr)
+
+    internal actual fun dispose() {
+        pthread_mutex_destroy(mutex.ptr)
+        pthread_mutexattr_destroy(attr.ptr)
+        arena.clear()
+    }
+}


### PR DESCRIPTION
This change backports adding more publication targets for `savedstate` and `savedstate-compose` modules. It will required to make upcoming savedstate 1.3.0 compatiable with future compose-runtime changes (ability to pin to this version) and prevents conflicts with following cherry pick of #2075

## Release Notes
N/A
