### PR TITLE
Fix instrumented tests. Add Tests Launcher for CI.

### DIFF
--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import androidx.build.AndroidXComposePlugin
 import androidx.build.JetbrainsAndroidXPlugin
-import java.util.*
+import java.util.Locale
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
@@ -270,6 +270,8 @@ if (System.getProperty("os.name") == "Mac OS X") {
             throw IllegalStateException("Please run the task from Xcode")
         }
     } else {
+        kotlinBinary.debuggable = true
+        kotlinBinary.optimized = false
         // Otherwise copy the executable into the Xcode output directory.
         tasks.create("packForXCode", Copy::class.java) {
             dependsOn(kotlinBinary.linkTask)

--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -16,7 +16,7 @@
 
 import androidx.build.AndroidXComposePlugin
 import androidx.build.JetbrainsAndroidXPlugin
-import java.util.Locale
+import java.util.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
@@ -270,8 +270,6 @@ if (System.getProperty("os.name") == "Mac OS X") {
             throw IllegalStateException("Please run the task from Xcode")
         }
     } else {
-        kotlinBinary.debuggable = true
-        kotlinBinary.optimized = false
         // Otherwise copy the executable into the Xcode output directory.
         tasks.create("packForXCode", Copy::class.java) {
             dependsOn(kotlinBinary.linkTask)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -583,6 +583,7 @@ class ComponentsAccessibilitySemanticTest {
         }
     }
 
+    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-7030
     @Test
     fun testAccessibilityTraversalGrouping() = runUIKitInstrumentedTest {
         setContent {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
@@ -133,7 +133,7 @@ class BasicInteractionTest {
     fun testTextFieldCallout() = runUIKitInstrumentedTest {
         setContent {
             Column(modifier = Modifier.safeDrawingPadding()) {
-                TextField("Hello-long-long-long-long-long-text", {}, modifier = Modifier.testTag("TextField"))
+                TextField("Hello-long-longlonglong-long-text", {}, modifier = Modifier.testTag("TextField"))
             }
         }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.center
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toDpRect
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -129,6 +130,7 @@ class BasicInteractionTest {
         assertTrue(doubleClicked)
     }
 
+    @Ignore
     @Test
     fun testTextFieldCallout() = runUIKitInstrumentedTest {
         setContent {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
@@ -130,12 +130,12 @@ class BasicInteractionTest {
         assertTrue(doubleClicked)
     }
 
-    @Ignore
+    @Ignore // https://youtrack.jetbrains.com/issue/CMP-8133/Fix-keyboard-dependent-instrumented-tests-on-CI
     @Test
     fun testTextFieldCallout() = runUIKitInstrumentedTest {
         setContent {
             Column(modifier = Modifier.safeDrawingPadding()) {
-                TextField("Hello-long-longlonglong-long-text", {}, modifier = Modifier.testTag("TextField"))
+                TextField("Hello-long-long-long-long-long-text", {}, modifier = Modifier.testTag("TextField"))
             }
         }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.viewinterop.UIKitView
 import androidx.compose.ui.window.KeyboardVisibilityListener
 import androidx.compose.ui.window.KeyboardVisibilityObserver
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -70,6 +71,7 @@ import platform.CoreGraphics.CGRect
 import platform.UIKit.UIView
 import platform.UIKit.UIViewAnimationOptions
 
+@Ignore
 internal class KeyboardInsetsTest {
     @Test
     fun testImeInsetsAnimationFrames_FocusAboveKeyboard() = runUIKitInstrumentedTest {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -71,7 +71,7 @@ import platform.CoreGraphics.CGRect
 import platform.UIKit.UIView
 import platform.UIKit.UIViewAnimationOptions
 
-@Ignore
+@Ignore // https://youtrack.jetbrains.com/issue/CMP-8133/Fix-keyboard-dependent-instrumented-tests-on-CI
 internal class KeyboardInsetsTest {
     @Test
     fun testImeInsetsAnimationFrames_FocusAboveKeyboard() = runUIKitInstrumentedTest {

--- a/compose/ui/ui/src/uikitInstrumentedTest/launcher/Launcher.xcodeproj/project.pbxproj
+++ b/compose/ui/ui/src/uikitInstrumentedTest/launcher/Launcher.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		9928B7FF2D32CD78006277AD /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9928B7FE2D32CD75006277AD /* main.swift */; };
 		9928B8042D330AB6006277AD /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9928B8032D330AB6006277AD /* IOKit.framework */; };
 		9928B82C2D3422C1006277AD /* Launcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9928B82B2D3422C1006277AD /* Launcher.swift */; };
+		99AEE0582DCC020200AAC8AE /* Launcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9928B82B2D3422C1006277AD /* Launcher.swift */; };
+		99AEE05A2DCC020200AAC8AE /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9928B8032D330AB6006277AD /* IOKit.framework */; };
+		99AEE0642DCC06D100AAC8AE /* InstrumentedTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 99AEE0632DCC06D100AAC8AE /* InstrumentedTest.framework */; };
+		99AEE0652DCC06D100AAC8AE /* InstrumentedTest.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 99AEE0632DCC06D100AAC8AE /* InstrumentedTest.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -20,7 +24,28 @@
 			remoteGlobalIDString = 997DFCF92B18E5D3000B56B5;
 			remoteInfo = CMPUIKitUtilsTestApp;
 		};
+		99AEE0552DCC020200AAC8AE /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9975AAC12AEABB5600AF155F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 997DFCF92B18E5D3000B56B5;
+			remoteInfo = CMPUIKitUtilsTestApp;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		99AEE0662DCC06D100AAC8AE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				99AEE0652DCC06D100AAC8AE /* InstrumentedTest.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		9928B7FE2D32CD75006277AD /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -28,6 +53,10 @@
 		9928B82B2D3422C1006277AD /* Launcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Launcher.swift; sourceTree = "<group>"; };
 		997DFCE32B18D99E000B56B5 /* Launcher.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Launcher.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		997DFCFA2B18E5D3000B56B5 /* LauncherHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LauncherHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		99AEE05F2DCC020200AAC8AE /* Launcher-CI.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Launcher-CI.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		99AEE0602DCC061700AAC8AE /* iphonesimulator.xcarchive */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = iphonesimulator.xcarchive; path = "../../../../../../out/androidx/internal-testutils-xctest/build/objc/iphonesimulator.xcarchive"; sourceTree = "<group>"; };
+		99AEE0612DCC067600AAC8AE /* libCMPTestUtils.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libCMPTestUtils.a; path = "../../../../../../out/androidx/internal-testutils-xctest/build/objc/iphonesimulator.xcarchive/Products/usr/local/lib/libCMPTestUtils.a"; sourceTree = "<group>"; };
+		99AEE0632DCC06D100AAC8AE /* InstrumentedTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = InstrumentedTest.framework; path = ../../../../../../out/androidx/compose/ui/ui/build/bin/uikitSimArm64/InstrumentedTestDebugFramework/InstrumentedTest.framework; sourceTree = "<group>"; };
 		99BE84D22C3467B100E43826 /* Launcher.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Launcher.xctestplan; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -47,12 +76,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		99AEE0592DCC020200AAC8AE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				99AEE0642DCC06D100AAC8AE /* InstrumentedTest.framework in Frameworks */,
+				99AEE05A2DCC020200AAC8AE /* IOKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		9928B8002D330AAA006277AD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				99AEE0632DCC06D100AAC8AE /* InstrumentedTest.framework */,
+				99AEE0612DCC067600AAC8AE /* libCMPTestUtils.a */,
+				99AEE0602DCC061700AAC8AE /* iphonesimulator.xcarchive */,
 				9928B8032D330AB6006277AD /* IOKit.framework */,
 			);
 			name = Frameworks;
@@ -74,6 +115,7 @@
 			children = (
 				997DFCE32B18D99E000B56B5 /* Launcher.xctest */,
 				997DFCFA2B18E5D3000B56B5 /* LauncherHost.app */,
+				99AEE05F2DCC020200AAC8AE /* Launcher-CI.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -133,6 +175,25 @@
 			productReference = 997DFCFA2B18E5D3000B56B5 /* LauncherHost.app */;
 			productType = "com.apple.product-type.application";
 		};
+		99AEE0532DCC020200AAC8AE /* Launcher-CI */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 99AEE05C2DCC020200AAC8AE /* Build configuration list for PBXNativeTarget "Launcher-CI" */;
+			buildPhases = (
+				99AEE0572DCC020200AAC8AE /* Sources */,
+				99AEE0592DCC020200AAC8AE /* Frameworks */,
+				99AEE05B2DCC020200AAC8AE /* Resources */,
+				99AEE0662DCC06D100AAC8AE /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				99AEE0542DCC020200AAC8AE /* PBXTargetDependency */,
+			);
+			name = "Launcher-CI";
+			productName = CMPUIKitUtilsTests;
+			productReference = 99AEE05F2DCC020200AAC8AE /* Launcher-CI.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -167,6 +228,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				99AEE0532DCC020200AAC8AE /* Launcher-CI */,
 				997DFCE22B18D99E000B56B5 /* Launcher */,
 				997DFCF92B18E5D3000B56B5 /* LauncherHost */,
 			);
@@ -182,6 +244,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		997DFCF82B18E5D3000B56B5 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		99AEE05B2DCC020200AAC8AE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -228,6 +297,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		99AEE0572DCC020200AAC8AE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				99AEE0582DCC020200AAC8AE /* Launcher.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -235,6 +312,11 @@
 			isa = PBXTargetDependency;
 			target = 997DFCF92B18E5D3000B56B5 /* LauncherHost */;
 			targetProxy = 997DFD082B18E5DC000B56B5 /* PBXContainerItemProxy */;
+		};
+		99AEE0542DCC020200AAC8AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 997DFCF92B18E5D3000B56B5 /* LauncherHost */;
+			targetProxy = 99AEE0552DCC020200AAC8AE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -478,6 +560,67 @@
 			};
 			name = Release;
 		};
+		99AEE05D2DCC020200AAC8AE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = ../../../../../../out/androidx/compose/ui/ui/build/bin/uikitSimArm64/InstrumentedTestDebugFramework/;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inderited)",
+					"CMPUIKitUtils/**",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-L$SRCROOT/../../../../../../out/androidx/internal-testutils-xctest/build/objc/iphonesimulator.xcarchive/Products/usr/local/lib",
+					"-lCMPTestUtils",
+					"-ObjC",
+					"-framework",
+					InstrumentedTest,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = JetBrains.CMPUIKitUtilsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LauncherHost.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LauncherHost";
+			};
+			name = Debug;
+		};
+		99AEE05E2DCC020200AAC8AE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				FRAMEWORK_SEARCH_PATHS = ../../../../../../out/androidx/compose/ui/ui/build/bin/uikitSimArm64/InstrumentedTestDebugFramework/;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inderited)",
+					"CMPUIKitUtils/**",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"-L$SRCROOT/../../../../../../out/androidx/internal-testutils-xctest/build/objc/iphonesimulator.xcarchive/Products/usr/local/lib",
+					"-lCMPTestUtils",
+					"-ObjC",
+					"-framework",
+					InstrumentedTest,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = JetBrains.CMPUIKitUtilsTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LauncherHost.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/LauncherHost";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -504,6 +647,15 @@
 			buildConfigurations = (
 				997DFD062B18E5D4000B56B5 /* Debug */,
 				997DFD072B18E5D4000B56B5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		99AEE05C2DCC020200AAC8AE /* Build configuration list for PBXNativeTarget "Launcher-CI" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				99AEE05D2DCC020200AAC8AE /* Debug */,
+				99AEE05E2DCC020200AAC8AE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Implement dedicated Launcher target for CI.
Ignore `KeyboardInsetsTest`, `BasicInteractionTest. testTextFieldCallout`, `ComponentsAccessibilitySemanticTest. testAccessibilityTraversalGrouping ` to fix later on CI.

## Release Notes
N/A