### PR TITLE
[Cherry-pick] Fix out of the bounds handling for multiple layers, remove extra view (#2069)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -104,9 +104,6 @@ internal class ComposeHostingViewController(
         transparentForTouches = false,
         useOpaqueConfiguration = configuration.opaque,
     )
-    private val interopContainerView = UIView().also {
-        rootView.embedSubview(it)
-    }
     private var mediator: ComposeSceneMediator? = null
     private val windowContext = PlatformWindowContext()
     private var layers: UIKitComposeSceneLayersHolder? = null
@@ -290,7 +287,6 @@ internal class ComposeHostingViewController(
                 mediator?.render(canvas.asComposeCanvas(), nanoTime)
             }
         )
-        rootView.updateMetalView(metalView, ::onDidMoveToWindow)
         metalView.canBeOpaque = configuration.opaque
 
         val layers = UIKitComposeSceneLayersHolder(windowContext, configuration.parallelRendering)
@@ -298,8 +294,6 @@ internal class ComposeHostingViewController(
         this.layers = layers
 
         mediator = ComposeSceneMediator(
-            parentView = rootView,
-            interopContainerView = interopContainerView,
             onFocusBehavior = configuration.onFocusBehavior,
             focusStack = focusStack,
             windowContext = windowContext,
@@ -310,6 +304,10 @@ internal class ComposeHostingViewController(
             },
             backGestureDispatcher = backGestureDispatcher
         ).also { mediator ->
+            rootView.embedSubview(mediator.inputView)
+            rootView.updateMetalView(metalView, ::onDidMoveToWindow)
+            rootView.embedSubview(mediator.overlayView)
+
             mediator.updateInteractionRect()
             mediator.setContent {
                 ProvideContainerCompositionLocals(content)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -64,7 +64,6 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.uikit.LocalKeyboardOverlapHeight
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.uikit.density
-import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntRect
@@ -183,8 +182,6 @@ private class SemanticsOwnerListenerImpl(
 }
 
 internal class ComposeSceneMediator(
-    parentView: UIView,
-    interopContainerView: UIView,
     private val onFocusBehavior: OnFocusBehavior,
     private val focusStack: FocusStack?,
     private val windowContext: PlatformWindowContext,
@@ -269,9 +266,9 @@ internal class ComposeSceneMediator(
     /**
      * View wrapping the hierarchy managed by this Mediator.
      */
-    private val view = UIKitTransparentContainerView(
-        onLayoutSubviews = ::updateLayout
-    )
+    private val _overlayView = UIKitTransparentContainerView(onLayoutSubviews = ::updateLayout)
+
+    val overlayView: UIView get() = _overlayView
 
     /**
      * View that handles the user input events and hosts interop views.
@@ -287,6 +284,8 @@ internal class ComposeSceneMediator(
         ::onKeyboardPresses,
         backGestureDispatcher::isBackGestureActive
     )
+
+    val inputView: UIView get() = userInputView
 
     /**
      * Container for managing UIKitView and UIKitViewController
@@ -309,11 +308,11 @@ internal class ComposeSceneMediator(
      * @param point Point in the interaction view coordinate space.
      */
     private fun isPointInsideInteractionBounds(point: CValue<CGPoint>) =
-        interactionBounds.contains(point.asDpOffset().toOffset(view.density).round())
+        interactionBounds.contains(point.asDpOffset().toOffset(_overlayView.density).round())
 
     private val semanticsOwnerListener by lazy {
         SemanticsOwnerListenerImpl(
-            view = view,
+            view = _overlayView,
             coroutineContext = coroutineContext,
             performEscape = {
                 val down = onKeyboardEvent(KeyEvent(Key.Escape, KeyEventType.KeyDown))
@@ -330,7 +329,7 @@ internal class ComposeSceneMediator(
 
     private val keyboardManager by lazy {
         ComposeSceneKeyboardOffsetManager(
-            view = view,
+            view = _overlayView,
             keyboardOverlapHeightChanged = { height ->
                 if (keyboardOverlapHeight != height) {
                     animateKeyboardOffsetChanges = false
@@ -346,7 +345,7 @@ internal class ComposeSceneMediator(
                 redrawer.setNeedsRedraw()
                 CATransaction.flush() // clear all animations
             },
-            view = view,
+            view = _overlayView,
             viewConfiguration = viewConfiguration,
             focusStack = focusStack,
             onInputStarted = {
@@ -479,7 +478,7 @@ internal class ComposeSceneMediator(
                 pressure = touch.force.toFloat(),
                 historical = event?.historicalChangesForTouch(
                     touch,
-                    view,
+                    _overlayView,
                     density.density
                 ) ?: emptyList()
             )
@@ -509,11 +508,6 @@ internal class ComposeSceneMediator(
     private var previousButtonMask: Long = 0L
     private var previousTouchEventKind: TouchesEventKind? = null
 
-    init {
-        parentView.embedSubview(view)
-        interopContainerView.embedSubview(userInputView)
-    }
-
     private var lastFocusedRect: Rect? = null
     private fun getFocusedRect(): Rect? {
         return scene.focusManager.getFocusRect()?.also {
@@ -522,7 +516,7 @@ internal class ComposeSceneMediator(
     }
 
     fun setContent(content: @Composable () -> Unit) {
-        view.runOnceOnAppeared {
+        _overlayView.runOnceOnAppeared {
             focusStack?.pushAndFocus(userInputView)
 
             scene.setContent {
@@ -549,12 +543,12 @@ internal class ComposeSceneMediator(
                     withAnimationProgress(duration) { progress ->
                         layoutMargins = lerp(
                             start = initialLayoutMargins,
-                            stop = view.layoutMargins.toPlatformInsets(),
+                            stop = _overlayView.layoutMargins.toPlatformInsets(),
                             fraction = progress
                         )
                         safeArea = lerp(
                             start = initialSafeArea,
-                            stop = view.safeAreaInsets.toPlatformInsets(),
+                            stop = _overlayView.safeAreaInsets.toPlatformInsets(),
                             fraction = progress
                         )
                         size = lerp(
@@ -620,14 +614,14 @@ internal class ComposeSceneMediator(
         onPreviewKeyEvent = { false }
         onKeyEvent = { false }
 
-        view.dispose()
+        _overlayView.dispose()
         textInputService.stopInput()
         applicationForegroundStateListener.dispose()
         focusStack?.popUntilNext(userInputView)
         keyboardManager.dispose()
         userInputView.dispose()
 
-        view.removeFromSuperview()
+        _overlayView.removeFromSuperview()
         userInputView.removeFromSuperview()
 
         scene.close()
@@ -636,23 +630,23 @@ internal class ComposeSceneMediator(
     }
 
     /**
-     * Updates the [ComposeScene] with the properties derived from the [view].
+     * Updates the [ComposeScene] with the properties derived from the [_overlayView].
      */
     private fun updateLayout() {
-        density = view.density
+        density = _overlayView.density
 
         if (isLayoutTransitionAnimating) {
             return
         }
-        layoutMargins = view.layoutMargins.toPlatformInsets()
-        safeArea = view.safeAreaInsets.toPlatformInsets()
+        layoutMargins = _overlayView.layoutMargins.toPlatformInsets()
+        safeArea = _overlayView.safeAreaInsets.toPlatformInsets()
 
         size = currentViewSize.roundToIntSize()
     }
 
     private val currentViewSize: Size get() {
         return with(density) {
-            view.frame.useContents { size.asDpSize() }.toSize()
+            _overlayView.frame.useContents { size.asDpSize() }.toSize()
         }
     }
 
@@ -696,16 +690,16 @@ internal class ComposeSceneMediator(
         override val screenReader: PlatformScreenReader get() = platformScreenReader
 
         override fun convertLocalToWindowPosition(localPosition: Offset): Offset =
-            windowContext.convertLocalToWindowPosition(view, localPosition)
+            windowContext.convertLocalToWindowPosition(_overlayView, localPosition)
 
         override fun convertWindowToLocalPosition(positionInWindow: Offset): Offset =
-            windowContext.convertWindowToLocalPosition(view, positionInWindow)
+            windowContext.convertWindowToLocalPosition(_overlayView, positionInWindow)
 
         override fun convertLocalToScreenPosition(localPosition: Offset): Offset =
-            windowContext.convertLocalToScreenPosition(view, localPosition)
+            windowContext.convertLocalToScreenPosition(_overlayView, localPosition)
 
         override fun convertScreenToLocalPosition(positionOnScreen: Offset): Offset =
-            windowContext.convertScreenToLocalPosition(view, positionOnScreen)
+            windowContext.convertScreenToLocalPosition(_overlayView, positionOnScreen)
 
         override val viewConfiguration get() = this@ComposeSceneMediator.viewConfiguration
         override val inputModeManager = DefaultInputModeManager(InputMode.Touch)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.uikit.density
+import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -45,6 +46,7 @@ import androidx.compose.ui.window.MetalView
 import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGPoint
+import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 
 internal class UIKitComposeSceneLayer(
@@ -71,23 +73,21 @@ internal class UIKitComposeSceneLayer(
             }
         }
 
-    val view = UIKitComposeSceneLayerView(
+    val interactionView = UIKitComposeSceneLayerView(
         ::onDidMoveToWindow,
         ::isInsideInteractionBounds,
         isInterceptingOutsideEvents = { focusable }
     )
 
-    val interopContainerView = UIKitTransparentContainerView()
+    val overlayView: UIView get() = mediator.overlayView
 
     private val backGestureDispatcher = UIKitBackGestureDispatcher(
         enableBackGesture = enableBackGesture,
-        density = view.density,
+        density = interactionView.density,
         getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
     )
 
     private val mediator = ComposeSceneMediator(
-        parentView = view,
-        interopContainerView = interopContainerView,
         onFocusBehavior = onFocusBehavior,
         focusStack = focusStack,
         windowContext = windowContext,
@@ -95,10 +95,12 @@ internal class UIKitComposeSceneLayer(
         redrawer = metalView.redrawer,
         composeSceneFactory = ::createComposeScene,
         backGestureDispatcher = backGestureDispatcher
-    )
+    ).also {
+        interactionView.embedSubview(it.inputView)
+    }
 
     private fun isInsideInteractionBounds(point: CValue<CGPoint>): Boolean =
-        boundsInWindow.contains(point.asDpOffset().toOffset(view.density).round())
+        boundsInWindow.contains(point.asDpOffset().toOffset(interactionView.density).round())
     
     private fun createComposeScene(
         invalidate: () -> Unit,
@@ -137,7 +139,7 @@ internal class UIKitComposeSceneLayer(
     private val scrimPaint = Paint()
 
     private fun onDidMoveToWindow(window: UIWindow?) {
-        backGestureDispatcher.onDidMoveToWindow(window, view)
+        backGestureDispatcher.onDidMoveToWindow(window, interactionView)
     }
 
     fun render(canvas: Canvas, nanoTime: Long) {
@@ -162,9 +164,8 @@ internal class UIKitComposeSceneLayer(
 
     internal fun dispose() {
         mediator.dispose()
-        view.removeFromSuperview()
-        view.dispose()
-        interopContainerView.removeFromSuperview()
+        interactionView.removeFromSuperview()
+        interactionView.dispose()
     }
 
     @Composable
@@ -193,7 +194,7 @@ internal class UIKitComposeSceneLayer(
     override fun setOutsidePointerEventListener(
         onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)?
     ) {
-        view.onOutsidePointerEvent = {
+        interactionView.onOutsidePointerEvent = {
             onOutsidePointerEvent?.invoke(it, null)
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayerView.kt
@@ -117,7 +117,7 @@ internal class UIKitComposeSceneLayerView(
             }
         }
 
-        return null
+        return result
     }
 
     fun dispose() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -124,9 +124,9 @@ internal class UIKitComposeSceneLayersHolder(
         val isFirstLayer = layers.isEmpty()
 
         layers.add(layer)
-        view.insertSubview(layer.interopContainerView, belowSubview = metalView)
-        layer.interopContainerView.addLayoutConstraintsToMatch(view)
-        view.embedSubview(layer.view)
+        view.insertSubview(layer.interactionView, belowSubview = metalView)
+        layer.interactionView.addLayoutConstraintsToMatch(view)
+        view.embedSubview(layer.overlayView)
 
         if (isFirstLayer) {
             containerView?.embedSubview(view)


### PR DESCRIPTION
Move out of the bounds tap handling logic from the overlay view to the interaction view. This change also enables the removal of the extra container view, with the ComposeSceneMediator.view being used instead.

Fixes
https://youtrack.jetbrains.com/issue/CMP-8075/iOS-MBS-inside-NavHost-dialog-destination-doesnt-react-to-gestures

## Release Notes
### Fixes - iOS
- Fix issue where `androidx.compose.material3.ModalBottomSheet` closes after any tap
