### PR TITLE
[Cherry-pick] Fix context menu appearance after triple-tap (#2068)

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -64,8 +64,9 @@ id _editInteraction;
 
     if (@available(iOS 16, *)) {
         if (self.editInteraction == nil || contextMenuItemsChanged || !self.isEditMenuShown) {
+            BOOL isFirstMenuPresentation = self.presentInteractionBlock == nil;
             [self cancelPresentEditMenuInteraction];
-            NSTimeInterval delay = self.presentInteractionBlock == nil ? 0 : [self editMenuDelay];
+            NSTimeInterval delay = isFirstMenuPresentation ? 0 : [self editMenuDelay];
             [self schedulePresentEditMenuInteractionWithDelay:delay];
         } else if (positionChanged) {
             [self.editInteraction updateVisibleMenuPositionAnimated:NO];
@@ -134,7 +135,6 @@ id _editInteraction;
             [self addInteraction:self.editInteraction];
         }
         [self presentEditMenuInteraction];
-        self.presentInteractionBlock = nil;
     });
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)),
                    dispatch_get_main_queue(),
@@ -144,6 +144,7 @@ id _editInteraction;
 - (void)cancelPresentEditMenuInteraction API_AVAILABLE(ios(16.0)) {
     if (self.presentInteractionBlock != nil) {
         dispatch_block_cancel(self.presentInteractionBlock);
+        self.presentInteractionBlock = nil;
     }
 }
 


### PR DESCRIPTION
Update the logic in the pop-up code so that the pop-up is updated with a delay until the 'hide' command is executed.

Fixes
https://youtrack.jetbrains.com/issue/CMP-7953/iOS-TextField.-Sontext-menu-sometimes-doesnt-appear-when-using-triple-tap

## Release Notes
### Fixes - iOS
- Fix context menu appearance after triple-tap