### PR TITLE
[Cherry-pick] Fix memory leak in ComposeUIViewController (#2072)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -69,13 +69,13 @@ internal class UIKitTextInputService(
     private val view: UIView,
     private val viewConfiguration: ViewConfiguration,
     private val focusStack: FocusStack?,
-    private val onInputStarted: () -> Unit,
+    private var onInputStarted: () -> Unit,
     /**
      * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
      * Erasure happens due to K/N not supporting Obj-C lightweight generics.
      */
-    private val onKeyboardPresses: (Set<*>) -> Unit,
-    private val focusManager: () -> ComposeSceneFocusManager
+    private var onKeyboardPresses: (Set<*>) -> Unit,
+    private var focusManager: () -> ComposeSceneFocusManager?
 ) : PlatformTextInputService, TextToolbar {
 
     private var currentOnEditCommand: ((List<EditCommand>) -> Unit)? = null
@@ -180,8 +180,7 @@ internal class UIKitTextInputService(
     override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) {
         val internalOldValue = sessionEditProcessor?.toTextFieldValue()
         val textChanged = internalOldValue == null || internalOldValue.text != newValue.text
-        val selectionChanged =
-            textChanged || internalOldValue == null || internalOldValue.selection != newValue.selection
+        val selectionChanged = textChanged || internalOldValue.selection != newValue.selection
         if (textChanged) {
             textUIView?.textWillChange()
         }
@@ -246,7 +245,7 @@ internal class UIKitTextInputService(
 
     private fun handleEscape(event: KeyEvent): Boolean {
         return if (sessionEditProcessor != null && event.type == KeyEventType.KeyUp) {
-            focusManager().releaseFocus()
+            focusManager()?.releaseFocus()
             true
         } else {
             false
@@ -374,7 +373,7 @@ internal class UIKitTextInputService(
         detachIntermediateTextInputView()
         showMenuOrUpdatePosition = {}
         textUIView = IntermediateTextInputUIView(
-            viewConfiguration = viewConfiguration
+            doubleTapTimeoutMillis = viewConfiguration.doubleTapTimeoutMillis
         ).also {
             it.setAutoresizingMask(
                 UIViewAutoresizingFlexibleWidth or UIViewAutoresizingFlexibleHeight
@@ -399,6 +398,13 @@ internal class UIKitTextInputService(
             }
         }
         textUIView = null
+    }
+
+    fun dispose() {
+        stopInput()
+        onInputStarted = { }
+        onKeyboardPresses = { }
+        focusManager = { null }
     }
 
     private fun createSkikoInput() = object : IOSSkikoInput {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.platform.EmptyInputTraits
 import androidx.compose.ui.platform.IOSSkikoInput
 import androidx.compose.ui.platform.SkikoUITextInputTraits
 import androidx.compose.ui.platform.TextActions
-import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.uikit.utils.CMPEditMenuView
 import androidx.compose.ui.unit.DpOffset
@@ -79,7 +78,7 @@ private val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
  * TODO maybe need to call reloadInputViews() to update UIKit text features?
  */
 internal class IntermediateTextInputUIView(
-    private val viewConfiguration: ViewConfiguration
+    private val doubleTapTimeoutMillis: Long
 ) : CMPEditMenuView(frame = CGRectZero.readValue()),
     UIKeyInputProtocol, UITextInputProtocol {
     private var _inputDelegate: UITextInputDelegateProtocol? = null
@@ -505,7 +504,7 @@ internal class IntermediateTextInputUIView(
     override fun isUserInteractionEnabled(): Boolean = false // disable clicks
 
     override fun editMenuDelay(): Double =
-        viewConfiguration.doubleTapTimeoutMillis.milliseconds.toDouble(DurationUnit.SECONDS)
+        doubleTapTimeoutMillis.milliseconds.toDouble(DurationUnit.SECONDS)
 
     /**
      * Show copy/paste text menu


### PR DESCRIPTION
In Kotlin the `IntermediateTextInputUIView` is captured by UIKit during text input and will not be released until the next input session begins. The change eliminates unnecessary references to allow ComposeUIViewController and other classes to be deallocated.

Fixes https://youtrack.jetbrains.com/issue/CMP-8111/Memory-leak-in-ComposeHostingViewController-after-text-input


## Release Notes
### Fixes - iOS
- Fix a memory leak in `ComposeUIViewController` when text input starts