### PR TITLE
Fix material ripple misplacement on resized composables

### DIFF
--- a/compose/material/material-ripple/src/commonMain/kotlin/androidx/compose/material/ripple/RippleAnimation.kt
+++ b/compose/material/material-ripple/src/commonMain/kotlin/androidx/compose/material/ripple/RippleAnimation.kt
@@ -60,9 +60,10 @@ internal class RippleAnimation(
     private val radius: Float,
     private val bounded: Boolean
 ) {
-    private var startRadius: Float? = null
 
-    private var targetCenter: Offset? = null
+    private val isUnspecifiedOrigin : Boolean = origin == null
+
+    private var startRadius: Float? = null
 
     private val animatedAlpha = Animatable(0f)
     private val animatedRadiusPercent = Animatable(0f)
@@ -123,12 +124,12 @@ internal class RippleAnimation(
         if (startRadius == null) {
             startRadius = getRippleStartRadius(size)
         }
-        if (origin == null) {
+        if (isUnspecifiedOrigin) {
             origin = center
         }
-        if (targetCenter == null) {
-            targetCenter = Offset(size.width / 2.0f, size.height / 2.0f)
-        }
+
+        val targetX = size.width / 2.0f
+        val targetY = size.height / 2.0f
 
         val alpha =
             if (finishRequested && !finishedFadingIn) {
@@ -141,8 +142,8 @@ internal class RippleAnimation(
         val radius = lerp(startRadius!!, radius, animatedRadiusPercent.value)
         val centerOffset =
             Offset(
-                lerp(origin!!.x, targetCenter!!.x, animatedCenterPercent.value),
-                lerp(origin!!.y, targetCenter!!.y, animatedCenterPercent.value),
+                lerp(origin!!.x, targetX, animatedCenterPercent.value),
+                lerp(origin!!.y, targetY, animatedCenterPercent.value),
             )
 
         val modulatedColor = color.copy(alpha = color.alpha * alpha)

--- a/compose/material/material-ripple/src/commonMain/kotlin/androidx/compose/material/ripple/RippleAnimation.kt
+++ b/compose/material/material-ripple/src/commonMain/kotlin/androidx/compose/material/ripple/RippleAnimation.kt
@@ -56,13 +56,10 @@ import kotlinx.coroutines.launch
  * @param bounded If true the effect should be clipped by the target layout bounds.
  */
 internal class RippleAnimation(
-    private var origin: Offset?,
+    private val origin: Offset?,
     private val radius: Float,
     private val bounded: Boolean
 ) {
-
-    private val isUnspecifiedOrigin : Boolean = origin == null
-
     private var startRadius: Float? = null
 
     private val animatedAlpha = Animatable(0f)
@@ -124,9 +121,8 @@ internal class RippleAnimation(
         if (startRadius == null) {
             startRadius = getRippleStartRadius(size)
         }
-        if (isUnspecifiedOrigin) {
-            origin = center
-        }
+
+        val originOffset = origin ?: center
 
         val targetX = size.width / 2.0f
         val targetY = size.height / 2.0f
@@ -142,8 +138,8 @@ internal class RippleAnimation(
         val radius = lerp(startRadius!!, radius, animatedRadiusPercent.value)
         val centerOffset =
             Offset(
-                lerp(origin!!.x, targetX, animatedCenterPercent.value),
-                lerp(origin!!.y, targetY, animatedCenterPercent.value),
+                lerp(originOffset.x, targetX, animatedCenterPercent.value),
+                lerp(originOffset.y, targetY, animatedCenterPercent.value),
             )
 
         val modulatedColor = color.copy(alpha = color.alpha * alpha)


### PR DESCRIPTION
Fixes https://github.com/JetBrains/compose-multiplatform/issues/3064

This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Fixed material ripple indication misplacement on composables resized during the animation (such as Material3 `Switch` thumb)
