### PR TITLE
CMP-7543 Retain AnnotatedString in ClipEntries on Desktop

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
@@ -16,20 +16,30 @@
 
 package androidx.compose.foundation.internal
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.NativeClipboard
 import androidx.compose.ui.text.AnnotatedString
+import java.awt.datatransfer.Clipboard
+import java.awt.datatransfer.ClipboardOwner
 import java.awt.datatransfer.DataFlavor
-import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
 import java.io.IOException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+// This implementation detail is used by Jewel.
+// When removing it, please provide an alternative of retrieving an annotated string,
+// and notify a Jewel developer that they need to change the implementation.
+private val annotatedStringFlavor: DataFlavor =
+    DataFlavor(AnnotatedString::class.java, "AnnotatedString")
+
 internal actual suspend fun ClipEntry.readText(): String? {
     if (!hasText()) return null
 
+    val transferable = nativeClipEntry as? Transferable
     return withContext(Dispatchers.IO) {
-        val transferable = nativeClipEntry as? java.awt.datatransfer.Transferable
         try {
             transferable?.getTransferData(DataFlavor.stringFlavor) as? String
         } catch (_: IOException) {
@@ -39,21 +49,38 @@ internal actual suspend fun ClipEntry.readText(): String? {
     }
 }
 
-// TODO: https://youtrack.jetbrains.com/issue/CMP-7543/Support-styled-text-in-PlatformClipboard-implementations
 internal actual suspend fun ClipEntry.readAnnotatedString(): AnnotatedString? {
-    return readText()?.let { AnnotatedString(it) }
+    if (!hasAnnotatedString()) {
+        if (!hasText()) return null
+        return readText()?.let { AnnotatedString(it) }
+    }
+
+    val transferable = nativeClipEntry as? Transferable
+    return withContext(Dispatchers.IO) {
+        try {
+            transferable?.getTransferData(annotatedStringFlavor) as? AnnotatedString
+        } catch (_: IOException) {
+            // the data is no longer available in the requested flavor
+            null
+        }
+    }
 }
 
-// TODO: https://youtrack.jetbrains.com/issue/CMP-7543/Support-styled-text-in-PlatformClipboard-implementations
 internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
     if (this == null) return null
-    val transferable = StringSelection(this.text)
+    val transferable = AnnotatedStringTransferable(this)
     return ClipEntry(transferable)
+}
+
+internal fun ClipEntry?.hasAnnotatedString(): Boolean {
+    if (this == null) return false
+    val transferable = nativeClipEntry as? Transferable ?: return false
+    return transferable.isDataFlavorSupported(annotatedStringFlavor)
 }
 
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
-    val transferable = nativeClipEntry as? java.awt.datatransfer.Transferable ?: return false
+    val transferable = nativeClipEntry as? Transferable ?: return false
     return transferable.isDataFlavorSupported(DataFlavor.stringFlavor)
 }
 
@@ -63,6 +90,32 @@ internal actual fun ClipEntry?.hasText(): Boolean {
 // Note: the name can't be just `hasText` because NativeClipboard is a typealias to Any,
 // so it would conflict with ClipEntry?.hasText declaration. Therefore, we need a unique name.
 internal fun NativeClipboard.nativeClipboardHasText(): Boolean {
-    val awtClipboard = this as? java.awt.datatransfer.Clipboard ?: return false
+    val awtClipboard = this as? Clipboard ?: return false
     return awtClipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)
+}
+
+// Derived from StringSelection
+@VisibleForTesting
+internal class AnnotatedStringTransferable(
+    private val data: AnnotatedString
+) : Transferable, ClipboardOwner {
+    override fun getTransferDataFlavors(): Array<DataFlavor?> = supportedFlavors
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+        flavor in supportedFlavors
+
+    override fun getTransferData(flavor: DataFlavor): Any =
+        when (flavor) {
+            annotatedStringFlavor -> data
+            DataFlavor.stringFlavor -> data.text
+            else -> throw UnsupportedFlavorException(flavor)
+        }
+
+    override fun lostOwnership(clipboard: Clipboard?, contents: Transferable?) {
+        // Empty
+    }
+
+    companion object {
+        private val supportedFlavors = arrayOf(annotatedStringFlavor, DataFlavor.stringFlavor)
+    }
 }

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/internal/ClipboardUtilsTest.desktop.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/internal/ClipboardUtilsTest.desktop.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.internal
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import com.google.common.truth.Truth.assertThat
+import java.awt.Image
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.awt.datatransfer.UnsupportedFlavorException
+import java.awt.image.BufferedImage
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ClipboardUtilsTest {
+
+    @Test
+    fun `should not say a ClipEntry contains plain text when it doesn't`() {
+        val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+        val clipEntry = ClipEntry(ImageTransferable(image))
+        assertThat(clipEntry.hasText()).isFalse()
+    }
+
+    @Test
+    fun `should say a ClipEntry contains plain text when it only contains plain text`() {
+        val clipEntry = ClipEntry(StringSelection("Hello"))
+        assertThat(clipEntry.hasText()).isTrue()
+    }
+
+    @Test
+    fun `should say a ClipEntry contains plain text when it is an AnnotatedStringTransferable`() {
+        val clipEntry = ClipEntry(AnnotatedStringTransferable(AnnotatedString("Hello")))
+        assertThat(clipEntry.hasText()).isTrue()
+    }
+
+    @Test
+    fun `should not say a ClipEntry contains an AnnotatedString when it doesn't contain any text`() {
+        val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+        val clipEntry = ClipEntry(ImageTransferable(image))
+        assertThat(clipEntry.hasAnnotatedString()).isFalse()
+    }
+
+    @Test
+    fun `should not say a ClipEntry contains an AnnotatedString when it contains only plain text`() {
+        val clipEntry = ClipEntry(StringSelection("Hello"))
+        assertThat(clipEntry.hasAnnotatedString()).isFalse()
+    }
+
+    @Test
+    fun `should say a ClipEntry contains an AnnotatedString when it does`() {
+        val clipEntry = ClipEntry(AnnotatedStringTransferable(AnnotatedString("Hello")))
+        assertThat(clipEntry.hasAnnotatedString()).isTrue()
+    }
+
+    @Test
+    fun `should return null when trying to read plain text from a ClipEntry with no text`() {
+        val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+        val clipEntry = ClipEntry(ImageTransferable(image))
+        assertThat(runBlocking { clipEntry.readText() }).isNull()
+    }
+
+    @Test
+    fun `should return the right plain text when trying to read plain text from a ClipEntry with only plain text`() {
+        val clipEntry = ClipEntry(StringSelection("Hello"))
+        val text = runBlocking { clipEntry.readText() }
+        assertThat(text).isNotNull()
+        assertThat(text).isEqualTo("Hello")
+    }
+
+    @Test
+    fun `should return the right plain text when trying to read plain text from a ClipEntry with an AnnotatedString`() {
+        val clipEntry = ClipEntry(AnnotatedStringTransferable(AnnotatedString("Hello")))
+        val text = runBlocking { clipEntry.readText() }
+        assertThat(text).isNotNull()
+        assertThat(text).isEqualTo("Hello")
+    }
+
+    @Test
+    fun `should return null when trying to read an AnnotatedString from a ClipEntry with no text`() {
+        val image = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+        val clipEntry = ClipEntry(ImageTransferable(image))
+        assertThat(runBlocking { clipEntry.readAnnotatedString() }).isNull()
+    }
+
+    @Test
+    fun `should return an AnnotatedString wrapping the plain text when trying to read an AnnotatedString from a ClipEntry with only plain text`() {
+        val clipEntry = ClipEntry(StringSelection("Hello"))
+        val annotatedString = runBlocking { clipEntry.readAnnotatedString() }
+        assertThat(annotatedString).isNotNull()
+        assertThat(annotatedString).isEqualTo(AnnotatedString("Hello"))
+    }
+
+    @Test
+    fun `should return an AnnotatedString when trying to read an AnnotatedString from a ClipEntry with an AnnotatedString`() {
+        val clipEntry = ClipEntry(AnnotatedStringTransferable(AnnotatedString("Hello")))
+        assertThat(runBlocking { clipEntry.readAnnotatedString() }).isNotNull()
+    }
+
+    @Test
+    fun `should retain annotations when transforming an AnnotatedString to a ClipEntry`() {
+        val original = buildAnnotatedString {
+            append("Hello, ")
+            withStyle(SpanStyle(color = Color.Blue)) {
+                append("World!")
+            }
+        }
+
+        val clipEntry = original.toClipEntry()
+        assertThat(clipEntry).isNotNull()
+        assertThat(clipEntry!!.hasAnnotatedString()).isTrue()
+
+        val clipEntryString = runBlocking { clipEntry.readAnnotatedString() }
+        assertThat(clipEntryString).isNotNull()
+        assertThat(clipEntryString!!).isEqualTo(original)
+    }
+
+    @Test
+    fun `should allow obtaining the plain text when transforming an AnnotatedString to a ClipEntry`() {
+        val original = buildAnnotatedString {
+            append("Hello, ")
+            withStyle(SpanStyle(color = Color.Blue)) {
+                append("World!")
+            }
+        }
+
+        val clipEntry = original.toClipEntry()
+        assertThat(clipEntry).isNotNull()
+        assertThat(clipEntry!!.hasText()).isTrue()
+
+        val clipEntryString = runBlocking { clipEntry.readText() }
+        assertThat(clipEntryString).isNotNull()
+        assertThat(clipEntryString!!).isEqualTo(original.text)
+    }
+}
+
+private class ImageTransferable(
+    private val image: Image
+) : Transferable {
+    override fun getTransferDataFlavors(): Array<DataFlavor?> = supportedFlavors
+
+    override fun isDataFlavorSupported(flavor: DataFlavor): Boolean =
+        flavor in supportedFlavors
+
+    override fun getTransferData(flavor: DataFlavor): Any =
+        when (flavor) {
+            DataFlavor.imageFlavor -> image
+            else -> throw UnsupportedFlavorException(flavor)
+        }
+
+    companion object {
+        private val supportedFlavors = arrayOf(DataFlavor.imageFlavor)
+    }
+}

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/platform/DesktopFont.desktop.kt
@@ -15,15 +15,20 @@
  */
 package androidx.compose.ui.text.platform
 
-import org.jetbrains.skia.FontStyle as SkFontStyle
-import org.jetbrains.skia.Typeface as SkTypeface
 import androidx.compose.ui.text.ExperimentalTextApi
-import androidx.compose.ui.text.font.*
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontLoadingStrategy
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
 import java.io.File
 import org.jetbrains.skia.Data
 import org.jetbrains.skia.FontMgr
 import org.jetbrains.skia.FontSlant
+import org.jetbrains.skia.FontStyle as SkFontStyle
 import org.jetbrains.skia.FontWidth
+import org.jetbrains.skia.Typeface as SkTypeface
 
 actual sealed class PlatformFont : Font {
     actual abstract val identity: String
@@ -201,7 +206,6 @@ internal actual fun loadTypeface(font: Font): SkTypeface {
     }
     val typeface = when (font) {
         is ResourceFont -> typefaceResource(font.name)
-        // TODO: replace with FontMgr.makeFromFile(font.file.toString())
         is FileFont -> FontMgr.default.makeFromFile(font.file.toString())
         is LoadedFont -> FontMgr.default.makeFromData(Data.makeFromBytes(font.getData()))
         is SystemFont -> FontMgr.default.matchFamilyStyle(font.identity, font.skFontStyle)

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3637,6 +3637,7 @@ public final class androidx/compose/ui/platform/JvmActuals_jvmKt {
 }
 
 public final class androidx/compose/ui/platform/PlatformClipboard_desktopKt {
+	public static final fun getAnnotatedStringFlavor (Landroidx/compose/ui/text/AnnotatedString$Companion;)Ljava/awt/datatransfer/DataFlavor;
 	public static final fun getAsAwtTransferable (Landroidx/compose/ui/platform/ClipEntry;)Ljava/awt/datatransfer/Transferable;
 	public static final fun getAwtClipboard (Landroidx/compose/ui/platform/Clipboard;)Ljava/awt/datatransfer/Clipboard;
 }

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3637,7 +3637,6 @@ public final class androidx/compose/ui/platform/JvmActuals_jvmKt {
 }
 
 public final class androidx/compose/ui/platform/PlatformClipboard_desktopKt {
-	public static final fun getAnnotatedStringFlavor (Landroidx/compose/ui/text/AnnotatedString$Companion;)Ljava/awt/datatransfer/DataFlavor;
 	public static final fun getAsAwtTransferable (Landroidx/compose/ui/platform/ClipEntry;)Ljava/awt/datatransfer/Transferable;
 	public static final fun getAwtClipboard (Landroidx/compose/ui/platform/Clipboard;)Ljava/awt/datatransfer/Clipboard;
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
@@ -17,7 +17,9 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import java.awt.HeadlessException
 import java.awt.Toolkit
+import java.awt.datatransfer.ClipboardOwner
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
@@ -29,7 +31,7 @@ internal class AwtPlatformClipboard internal constructor() : Clipboard {
     private val systemClipboard by lazy {
         try {
             Toolkit.getDefaultToolkit().systemClipboard
-        } catch (e: java.awt.HeadlessException) {
+        } catch (_: HeadlessException) {
             null
         }
     }
@@ -44,8 +46,8 @@ internal class AwtPlatformClipboard internal constructor() : Clipboard {
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
         val transferable = clipEntry?.nativeClipEntry as? Transferable
         systemClipboard?.setContents(
-            transferable ?: EmptyTransferable,
-            null
+            /* contents = */ transferable ?: EmptyTransferable,
+            /* owner = */ transferable as? ClipboardOwner,
         )
     }
 
@@ -67,11 +69,12 @@ val Clipboard.awtClipboard: java.awt.datatransfer.Clipboard?
     get() = nativeClipboard as? java.awt.datatransfer.Clipboard
 
 /**
- * A wrapper for platform clip entry instance which can be used to access or set the Clipboard content.
- * The actual implementation may vary depending on the underlying GUI toolkit
- * and on the actual implementation of Clipboard.nativeClipboard.
+ * A wrapper for platform clip entry instance which can be used to access
+ * or set the Clipboard content. The actual implementation may vary
+ * depending on the underlying GUI toolkit and on the actual implementation
+ * of Clipboard.nativeClipboard.
  *
- * See [asAwtTransferable] to access [java.awt.datatransfer.Transferable].
+ * See [asAwtTransferable] to access [Transferable].
  */
 actual class ClipEntry(val nativeClipEntry: Any) {
     // TODO https://youtrack.jetbrains.com/issue/CMP-1260/ClipboardManager.-Implement-getClip-getClipMetadata-setClip
@@ -80,8 +83,8 @@ actual class ClipEntry(val nativeClipEntry: Any) {
 }
 
 /**
- * Returns [Transferable] instance if ClipEntry.nativeClipEntry type is [Transferable].
- * Otherwise, it returns null.
+ * Returns a [Transferable] instance if the [ClipEntry.nativeClipEntry]
+ * type is [Transferable]. Otherwise, it returns null.
  */
 @ExperimentalComposeUiApi
 val ClipEntry.asAwtTransferable: Transferable?


### PR DESCRIPTION
Prior to this, the implementation of `ClipboardUtils.desktop.kt` would "flatten" `AnnotatedString`s into their plaintext representation. This means that if you implemented a custom `Clipboard`, it would only receive the plaintext representation of the copied text in `setEntry`. With this change, the `AnnotatedString` is actually preserved when copying, so `Clipboard` can access the rich text and serialize it as it prefers.

It should not change the observed behaviour when using the default `Clipboard`, but allows users to create custom ones which can do things like [JEWEL-815](https://youtrack.jetbrains.com/issue/JEWEL-815).

PS: this removes the `withContext` calls from `ClipboardUtils.desktop.kt` since they optimise for rare cases (extremely large content in the clipboard, probably O(100MB) or more) which are going to clog on the AWT side or during composition anyway. It can cause a small perf degradation in the overwhelmingly more common scenarios of tiny-to-large clipboard contents due to the dispatching of the coroutine to the IO dispatcher. This was discussed with someone from the Compose Text team.

## Testing
Ran tests, smoke tested by hand. 

## Release Notes
### Features - Desktop
- Full `AnnotatedString` is available as a data flavor in `ClipEntry`, instead of only its text.
