### PR TITLE
Fix navigator registration with the correct name

### DIFF
--- a/navigation/navigation-common/src/nonAndroidMain/kotlin/androidx/navigation/NavigatorProvider.nonAndroid.kt
+++ b/navigation/navigation-common/src/nonAndroidMain/kotlin/androidx/navigation/NavigatorProvider.nonAndroid.kt
@@ -78,7 +78,7 @@ public actual open class NavigatorProvider actual constructor() {
         navigator: Navigator<out NavDestination>
     ): Navigator<out NavDestination>? {
         require(validateName(name)) { "Navigator name cannot be an empty string" }
-        _typeToNavigatorName[navigator::class] = navigator.name
+        _typeToNavigatorName[navigator::class] = name
         val previousNavigator = _namedNavigators[name]
         if (previousNavigator == navigator) {
             return navigator


### PR DESCRIPTION
Previously, the navigator's name property was being used instead of the provided `name` argument, which could lead to a null exception.

## Release Notes
N/A