### PR TITLE
Correct casing for `nonJvmMain` in build.gradle config.

### DIFF
--- a/lifecycle/lifecycle-runtime/build.gradle
+++ b/lifecycle/lifecycle-runtime/build.gradle
@@ -100,7 +100,7 @@ androidXMultiplatform {
             }
         }
 
-        nonjvmMain {
+        nonJvmMain {
             dependsOn(commonMain)
         }
         nonJvmTest {
@@ -108,7 +108,7 @@ androidXMultiplatform {
         }
 
         nativeMain {
-            dependsOn(nonjvmMain)
+            dependsOn(nonJvmMain)
 
             // Required for WeakReference usage
             languageSettings.optIn("kotlin.experimental.ExperimentalNativeApi")
@@ -119,7 +119,7 @@ androidXMultiplatform {
         }
 
         webMain {
-            dependsOn(nonjvmMain)
+            dependsOn(nonJvmMain)
         }
 
         webTest {

--- a/lifecycle/lifecycle-viewmodel/build.gradle
+++ b/lifecycle/lifecycle-viewmodel/build.gradle
@@ -107,11 +107,11 @@ androidXMultiplatform {
         }
 
         desktopMain.dependsOn(jvmMain)
-        nonjvmMain.dependsOn(commonMain)
-        nativeMain.dependsOn(nonjvmMain)
+        nonJvmMain.dependsOn(commonMain)
+        nativeMain.dependsOn(nonJvmMain)
         darwinMain.dependsOn(nativeMain)
         linuxMain.dependsOn(nativeMain)
-        webMain.dependsOn(nonjvmMain)
+        webMain.dependsOn(nonJvmMain)
 
         targets.configureEach { target ->
             if (target.platformType == KotlinPlatformType.native) {


### PR DESCRIPTION
Updated all occurrences of `nonjvmMain` to `nonJvmMain` to ensure consistent casing in module dependencies. This fixes build issues on linux CI agents with a case-sensitive file system.

## Release Notes
N/A