### PR TITLE
Use cross-fade animation when rotating screen with interop views

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -226,7 +226,14 @@ internal class ComposeHostingViewController(
         super.viewWillTransitionToSize(size, withTransitionCoordinator)
 
         updateInterfaceOrientationState()
-        animateSizeTransition(withTransitionCoordinator)
+
+        if (mediator?.hasInteropViews == true || layers?.hasInteropViews == true) {
+            // Heavy interop views may slow down the animation of per-frame screen rotation.
+            // For these cases, a cross-fade transition will be used instead.
+            crossFadeSizeTransition(withTransitionCoordinator)
+        } else {
+            animateSizeTransition(withTransitionCoordinator)
+        }
     }
 
     @Suppress("DEPRECATION")
@@ -409,6 +416,27 @@ internal class ComposeHostingViewController(
             completion = {
                 sizeTransitionScope.cancel()
                 displayLinkListener.invalidate()
+            }
+        )
+    }
+
+    private fun crossFadeSizeTransition(
+        transitionCoordinator: UIViewControllerTransitionCoordinatorProtocol
+    ) {
+        val duration = transitionCoordinator.transitionDuration.toDuration(DurationUnit.SECONDS)
+        if (duration == Duration.ZERO) return
+
+        val transitionScope = CoroutineScope(composeCoroutineContext)
+        val viewAnimationClosure = rootView.animateCrossFadeTransition(transitionScope)
+        val layersAnimationClosure = layers?.animateCrossFadeTransition(transitionScope)
+
+        transitionCoordinator.animateAlongsideTransition(
+            animation = {
+                viewAnimationClosure()
+                layersAnimationClosure?.invoke()
+            },
+            completion = {
+                transitionScope.cancel()
             }
         )
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -250,6 +250,8 @@ internal class ComposeSceneMediator(
             }
         }
 
+    val hasInteropViews: Boolean get() = interopContainer.hasInteropViews
+
     private val applicationForegroundStateListener =
         ApplicationForegroundStateListener { _ ->
             // Sometimes the application can trigger animation and go background before the animation is

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -154,6 +154,8 @@ internal class UIKitComposeSceneLayer(
 
     fun retrieveInteropTransaction() = mediator.retrieveInteropTransaction()
 
+    val hasInteropViews: Boolean get() = mediator.hasInteropViews
+
     fun prepareAndGetSizeTransitionAnimation() = mediator.prepareAndGetSizeTransitionAnimation()
 
     override fun close() {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayersHolder.uikit.kt
@@ -102,6 +102,8 @@ internal class UIKitComposeSceneLayersHolder(
         }
     }
 
+    fun animateCrossFadeTransition(scope: CoroutineScope) = view.animateCrossFadeTransition(scope)
+
     fun dispose(hasViewAppeared: Boolean) {
         // `dispose` is called instead of `close`, because `close` is also used imperatively
         // to remove the layer from the array based on user interaction.
@@ -174,6 +176,17 @@ internal class UIKitComposeSceneLayersHolder(
         this.layers.fastForEach {
             it.sceneWillDisappear()
         }
+    }
+
+    val hasInteropViews: Boolean get() {
+        layersCache.withCopy { layers ->
+            layers.fastForEach {
+                if (it.hasInteropViews) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropContainer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropContainer.uikit.kt
@@ -32,6 +32,8 @@ internal class UIKitInteropContainer(
     private var interopViews = mutableMapOf<InteropView, InteropViewHolder>()
     private var transaction = UIKitInteropMutableTransaction(isInteropActive = false)
 
+    val hasInteropViews: Boolean get() = interopViews.isNotEmpty()
+
     // TODO: Android reuses `owner.snapshotObserver`. We should probably do the same with RootNodeOwner.
     /**
      * Snapshot observer that is used by underlying [InteropViewHolder] to observe changes in

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.uikit.kt
@@ -33,6 +33,7 @@ import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectIntersection
 import platform.CoreGraphics.CGRectIsEmpty
+import platform.UIKit.UIView
 
 internal abstract class UIKitInteropElementHolder<T : InteropView>(
     factory: () -> T,
@@ -119,7 +120,9 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
                 .asCGRect()
 
             container.scheduleUpdate {
-                group.setFrame(groupFrame)
+                UIView.performWithoutAnimation {
+                    group.setFrame(groupFrame)
+                }
             }
         }
 
@@ -145,7 +148,9 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
                         .asCGRect()
 
                 container.scheduleUpdate {
-                    userComponentCGRect = newUserComponentCGRect
+                    UIView.performWithoutAnimation {
+                        userComponentCGRect = newUserComponentCGRect
+                    }
                 }
 
                 currentUserComponentRect = userComponentRect

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeView.uikit.kt
@@ -22,6 +22,7 @@ import kotlinx.cinterop.CValue
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectEqualToRect
@@ -29,9 +30,13 @@ import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIColor
 import platform.UIKit.UIEvent
+import platform.UIKit.UIGraphicsImageRenderer
+import platform.UIKit.UIImage
+import platform.UIKit.UIImageView
 import platform.UIKit.UITraitCollection
 import platform.UIKit.UIUserInterfaceStyle
 import platform.UIKit.UIView
+import platform.UIKit.UIViewContentMode
 import platform.UIKit.UIWindow
 
 internal class ComposeView(
@@ -103,7 +108,9 @@ internal class ComposeView(
     private var isAnimating: Boolean = false
 
     override fun layoutSubviews() {
-        super.layoutSubviews()
+        performWithoutAnimation {
+            super.layoutSubviews()
+        }
 
         onLayoutSubviews()
         updateLayout()
@@ -127,18 +134,40 @@ internal class ComposeView(
                 max(oldSize.height.value, newSize.height.value).toDouble()
             )
             if (!CGRectEqualToRect(metalView.frame, targetRect)) {
-                UIView.performWithoutAnimation {
+                performWithoutAnimation {
                     metalView.setFrame(targetRect)
                     metalView.setNeedsSynchronousDrawOnNextLayout()
                 }
             }
         } else {
             if (!CGRectEqualToRect(metalView.frame, bounds)) {
-                UIView.performWithoutAnimation {
+                performWithoutAnimation {
                     metalView.setFrame(bounds)
                     metalView.setNeedsSynchronousDrawOnNextLayout()
                 }
             }
+        }
+    }
+
+    fun animateCrossFadeTransition(scope: CoroutineScope): () -> Unit {
+        val image = viewContentImage()
+        val imageView = UIImageView(frame = bounds).also(::addSubview)
+        imageView.image = image
+        imageView.setContentMode(UIViewContentMode.UIViewContentModeScaleToFill)
+
+        setClipsToBounds(false)
+
+        scope.launch {
+            try {
+                awaitCancellation()
+            } finally {
+                setClipsToBounds(true)
+                imageView.removeFromSuperview()
+            }
+        }
+
+        return {
+            imageView.alpha = 0.0
         }
     }
 
@@ -163,5 +192,12 @@ internal class ComposeView(
 
     override fun hitTest(point: CValue<CGPoint>, withEvent: UIEvent?): UIView? {
         return super.hitTest(point, withEvent).takeUnless { transparentForTouches && it == this }
+    }
+
+    private fun viewContentImage(): UIImage {
+        val renderer = UIGraphicsImageRenderer(bounds = bounds)
+        return renderer.imageWithActions { context ->
+            this.drawViewHierarchyInRect(bounds, false)
+        }
     }
 }


### PR DESCRIPTION
Heavy interop views may slow down the animation of per-frame screen rotation.
For these cases, a cross-fade transition will be used instead.

Fixes https://youtrack.jetbrains.com/issue/CMP-8114/iOS.-Interop-View-big-delay-after-changing-orientation

## Release Notes
### Fixes - iOS
- Use the cross-fade animation effect when rotating the screen with Interop views.

