### PR TITLE
[Cherry-pick] Show error message when UIKitViewController inside Popup or Dialog (#2099)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitViewController.uikit.kt
@@ -56,6 +56,11 @@ fun <T : UIViewController> UIKitViewController(
     val interopContainer = LocalInteropContainer.current
     val parentViewController = LocalUIViewController.current
 
+    val isDescendant = interopContainer.root.isDescendantOfView(parentViewController.view)
+    assert(isDescendant) {
+        "Currently, UIKitViewController cannot be used within Popups or Dialogs"
+    }
+
     InteropView(
         factory = { compositeKeyHash ->
             UIKitInteropViewControllerHolder(


### PR DESCRIPTION
The UIKitViewController is currently not supported inside pop-ups or dialogues.
Display a meaningful error message when UIKitViewController is used outside of the main composable.

Fixes https://youtrack.jetbrains.com/issue/CMP-8135

## Release Notes
### Fixes - iOS
- Show an error message when `UIKitViewController` inside `Popup` or `Dialog`
