### PR TITLE
[Cherry-pick] Move TextInputService start/stop calls inside TextInputSession (#2049)

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.SessionMutex
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -34,7 +33,6 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
 import androidx.compose.ui.platform.PlatformDragAndDropSource
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
-import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
@@ -398,13 +396,6 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
             get() = size
     }
 
-    private inner class TestTextInputSession(
-        coroutineScope: CoroutineScope
-    ) : PlatformTextInputSessionScope, CoroutineScope by coroutineScope {
-        override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing =
-            awaitCancellation()
-    }
-
     private inner class TestDragAndDropManager : PlatformDragAndDropManager {
         override val isRequestDragAndDropTransferRequired: Boolean
             get() = true
@@ -443,13 +434,9 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
 
         override val dragAndDropManager: PlatformDragAndDropManager = TestDragAndDropManager()
 
-        private val textInputSessionMutex = SessionMutex<TestTextInputSession>()
-
-        override suspend fun textInputSession(
-            session: suspend PlatformTextInputSessionScope.() -> Nothing
-        ): Nothing = textInputSessionMutex.withSessionCancellingPrevious(
-            sessionInitializer = { TestTextInputSession(it) }, session = session
-        )
+        override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
+            awaitCancellation()
+        }
     }
 }
 

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3506,7 +3506,7 @@ public abstract interface class androidx/compose/ui/platform/PlatformContext {
 	public fun isWindowTransparent ()Z
 	public fun requestFocus ()Z
 	public fun setPointerIcon (Landroidx/compose/ui/input/pointer/PointerIcon;)V
-	public fun textInputSession (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun startInputMethod (Landroidx/compose/ui/platform/PlatformTextInputMethodRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class androidx/compose/ui/platform/PlatformContext$Companion {

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -971,7 +971,7 @@ abstract interface androidx.compose.ui.platform/PlatformContext { // androidx.co
     open fun convertWindowToLocalPosition(androidx.compose.ui.geometry/Offset): androidx.compose.ui.geometry/Offset // androidx.compose.ui.platform/PlatformContext.convertWindowToLocalPosition|convertWindowToLocalPosition(androidx.compose.ui.geometry.Offset){}[0]
     open fun requestFocus(): kotlin/Boolean // androidx.compose.ui.platform/PlatformContext.requestFocus|requestFocus(){}[0]
     open fun setPointerIcon(androidx.compose.ui.input.pointer/PointerIcon) // androidx.compose.ui.platform/PlatformContext.setPointerIcon|setPointerIcon(androidx.compose.ui.input.pointer.PointerIcon){}[0]
-    open suspend fun textInputSession(kotlin.coroutines/SuspendFunction1<androidx.compose.ui.platform/PlatformTextInputSessionScope, kotlin/Nothing>): kotlin/Nothing // androidx.compose.ui.platform/PlatformContext.textInputSession|textInputSession(kotlin.coroutines.SuspendFunction1<androidx.compose.ui.platform.PlatformTextInputSessionScope,kotlin.Nothing>){}[0]
+    open suspend fun startInputMethod(androidx.compose.ui.platform/PlatformTextInputMethodRequest): kotlin/Nothing // androidx.compose.ui.platform/PlatformContext.startInputMethod|startInputMethod(androidx.compose.ui.platform.PlatformTextInputMethodRequest){}[0]
 
     abstract interface RootForTestListener { // androidx.compose.ui.platform/PlatformContext.RootForTestListener|null[0]
         abstract fun onRootForTestCreated(androidx.compose.ui.platform/PlatformRootForTest) // androidx.compose.ui.platform/PlatformContext.RootForTestListener.onRootForTestCreated|onRootForTestCreated(androidx.compose.ui.platform.PlatformRootForTest){}[0]

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -111,9 +111,7 @@ interface PlatformContext {
     val inputModeManager: InputModeManager
     val textInputService: PlatformTextInputService get() = EmptyPlatformTextInputService
 
-    suspend fun textInputSession(
-        session: suspend PlatformTextInputSessionScope.() -> Nothing
-    ): Nothing {
+    suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
         awaitCancellation()
     }
 

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/RootNodeOwnerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/RootNodeOwnerTest.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.node
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.scene.ComposeSceneInputHandler
+import androidx.compose.ui.scene.PointerEventResult
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.PlatformTextInputService
+import androidx.compose.ui.text.input.TextEditingScope
+import androidx.compose.ui.text.input.TextEditorState
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+
+@OptIn(ExperimentalTestApi::class)
+class RootNodeOwnerTest {
+
+    @Test
+    fun textTextInputSession() = runTest {
+        var sessionStarted = false
+        var inputStarted = false
+        var inputStopped = false
+
+        val textInputService = object : PlatformTextInputService {
+            override fun startInput(
+                value: TextFieldValue,
+                imeOptions: ImeOptions,
+                onEditCommand: (List<EditCommand>) -> Unit,
+                onImeActionPerformed: (ImeAction) -> Unit
+            ) {
+            }
+
+            override fun startInput() {
+                inputStarted = true
+            }
+
+            override fun stopInput() {
+                inputStopped = true
+            }
+
+            override fun showSoftwareKeyboard() {}
+            override fun hideSoftwareKeyboard() {}
+            override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) {}
+        }
+        val owner = RootNodeOwner(
+            platformContext = object : PlatformContext by PlatformContext.Empty {
+                override val textInputService: PlatformTextInputService = textInputService
+                override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
+                    sessionStarted = true
+                    awaitCancellation()
+                }
+            }
+        )
+
+        val job = CoroutineScope(coroutineContext).launch(start = CoroutineStart.UNDISPATCHED) {
+            owner.owner.textInputSession {
+                startInputMethod(request = TestInputRequest())
+            }
+        }
+
+        assertTrue(sessionStarted)
+        assertTrue(inputStarted)
+        assertFalse(inputStopped)
+
+        job.cancel()
+
+        assertTrue(sessionStarted)
+        assertTrue(inputStarted)
+        assertTrue(inputStopped)
+    }
+
+    @Test
+    fun textKeyboardShowHide() = runTest {
+        var keyboardShowCalled = false
+        var keyboardHideCalled = false
+
+        val textInputService = object : PlatformTextInputService {
+            override fun startInput(
+                value: TextFieldValue,
+                imeOptions: ImeOptions,
+                onEditCommand: (List<EditCommand>) -> Unit,
+                onImeActionPerformed: (ImeAction) -> Unit
+            ) = error("Should not be called")
+
+            override fun startInput() {}
+            override fun stopInput() {}
+            override fun updateState(oldValue: TextFieldValue?, newValue: TextFieldValue) {}
+            override fun showSoftwareKeyboard() {
+                keyboardShowCalled = true
+            }
+
+            override fun hideSoftwareKeyboard() {
+                keyboardHideCalled = true
+            }
+        }
+        val owner = RootNodeOwner(
+            platformContext = object : PlatformContext by PlatformContext.Empty {
+                override val textInputService: PlatformTextInputService = textInputService
+                override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
+                    awaitCancellation()
+                }
+            }
+        )
+        owner.owner.softwareKeyboardController.show()
+
+        assertFalse(keyboardShowCalled)
+        assertFalse(keyboardHideCalled)
+
+        val job = CoroutineScope(coroutineContext).launch(start = CoroutineStart.UNDISPATCHED) {
+            owner.owner.textInputSession {
+                startInputMethod(request = TestInputRequest())
+            }
+        }
+
+        owner.owner.softwareKeyboardController.show()
+
+        assertTrue(keyboardShowCalled)
+        assertFalse(keyboardHideCalled)
+
+        job.cancel()
+
+        owner.owner.softwareKeyboardController.hide()
+
+        assertTrue(keyboardShowCalled)
+        assertTrue(keyboardHideCalled)
+    }
+}
+
+private fun RootNodeOwner(
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
+    platformContext: PlatformContext = PlatformContext.Empty,
+) = RootNodeOwner(
+    density = Density(1f),
+    layoutDirection = LayoutDirection.Ltr,
+    size = null,
+    coroutineContext = coroutineContext,
+    platformContext = platformContext,
+    snapshotInvalidationTracker = SnapshotInvalidationTracker {},
+    inputHandler = ComposeSceneInputHandler(
+        prepareForPointerInputEvent = {},
+        processPointerInputEvent = { PointerEventResult(false) },
+        cancelPointerInput = {},
+        processKeyEvent = { false },
+    )
+)
+
+@ExperimentalComposeUiApi
+private class TestInputRequest: PlatformTextInputMethodRequest {
+    override val value: () -> TextFieldValue get() = error("Test method")
+    override val state: TextEditorState get() = error("Test method")
+    override val imeOptions: ImeOptions get() = error("Test method")
+    override val onEditCommand: (List<EditCommand>) -> Unit get() = error("Test method")
+    override val onImeAction: ((ImeAction) -> Unit)? get() = error("Test method")
+    override val outputValue: Flow<TextFieldValue> get() = error("Test method")
+    override val textLayoutResult: Flow<TextLayoutResult> get() = error("Test method")
+    override val focusedRectInRoot: Flow<Rect> get() = error("Test method")
+    override val textFieldRectInRoot: Flow<Rect> get() = error("Test method")
+    override val textClippingRectInRoot: Flow<Rect> get() = error("Test method")
+    override val editText: (TextEditingScope.() -> Unit) -> Unit get() = error("Test method")
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.SessionMutex
 import androidx.compose.ui.animation.withAnimationProgress
 import androidx.compose.ui.backhandler.UIKitBackGestureDispatcher
 import androidx.compose.ui.draganddrop.UIKitDragAndDropManager
@@ -54,7 +53,6 @@ import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformScreenReader
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
-import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.platform.UIKitTextInputService
 import androidx.compose.ui.platform.ViewConfiguration
@@ -93,7 +91,6 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.useContents
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -708,57 +705,38 @@ internal class ComposeSceneMediator(
         override val semanticsOwnerListener get() = this@ComposeSceneMediator.semanticsOwnerListener
         override val dragAndDropManager get() = this@ComposeSceneMediator.dragAndDropManager
 
-        private val textInputSessionMutex = SessionMutex<IOSTextInputSession>()
-
-        override suspend fun textInputSession(session: suspend PlatformTextInputSessionScope.() -> Nothing): Nothing =
-            textInputSessionMutex.withSessionCancellingPrevious(
-                sessionInitializer = {
-                    IOSTextInputSession(it)
-                },
-                session = session
-            )
-    }
-
-    private inner class IOSTextInputSession(
-        coroutineScope: CoroutineScope
-    ) : PlatformTextInputSessionScope, CoroutineScope by coroutineScope {
-        private val innerSessionMutex = SessionMutex<Nothing?>()
-
-        override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing =
-            innerSessionMutex.withSessionCancellingPrevious(
-                sessionInitializer = { null }
-            ) {
-                // TODO: Adopt PlatformTextInputService2 (https://youtrack.jetbrains.com/issue/CMP-7832/iOS-Adopt-PlatformTextInputService2)
-                coroutineScope {
-                    launch {
-                        request.outputValue.collect {
-                            textInputService.updateState(oldValue = null, newValue = it)
-                        }
+        override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
+            // TODO: Adopt PlatformTextInputService2 (https://youtrack.jetbrains.com/issue/CMP-7832/iOS-Adopt-PlatformTextInputService2)
+            coroutineScope {
+                launch {
+                    request.outputValue.collect {
+                        textInputService.updateState(oldValue = null, newValue = it)
                     }
-                    launch {
-                        request.textLayoutResult.collect {
-                            textInputService.updateTextLayoutResult(it)
-                        }
+                }
+                launch {
+                    request.textLayoutResult.collect {
+                        textInputService.updateTextLayoutResult(it)
                     }
-                    launch {
-                        request.textFieldRectInRoot.collect {
-                            textInputService.updateTextFrame(it)
-                        }
+                }
+                launch {
+                    request.textFieldRectInRoot.collect {
+                        textInputService.updateTextFrame(it)
                     }
-                    suspendCancellableCoroutine<Nothing> { continuation ->
-                        textInputService.startInput(
-                            value = request.value(),
-                            imeOptions = request.imeOptions,
-                            onEditCommand = request.onEditCommand,
-                            onImeActionPerformed = request.onImeAction ?: {}
-                        )
+                }
+                suspendCancellableCoroutine<Nothing> { continuation ->
+                    textInputService.startInput(
+                        value = request.value(),
+                        imeOptions = request.imeOptions,
+                        onEditCommand = request.onEditCommand,
+                        onImeActionPerformed = request.onImeAction ?: {}
+                    )
 
-                        continuation.invokeOnCancellation {
-                            textInputService.stopInput()
-                        }
+                    continuation.invokeOnCancellation {
+                        textInputService.stopInput()
                     }
                 }
             }
+        }
     }
 }
 

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
-import androidx.compose.ui.SessionMutex
 import androidx.compose.ui.draganddrop.WebDragAndDropManager
 import androidx.compose.ui.events.EventTargetListener
 import androidx.compose.ui.geometry.Offset
@@ -45,7 +44,7 @@ import androidx.compose.ui.platform.DefaultInputModeManager
 import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
-import androidx.compose.ui.platform.PlatformTextInputSessionScope
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.ViewConfiguration
 import androidx.compose.ui.platform.WebTextInputService
 import androidx.compose.ui.platform.WindowInfoImpl
@@ -74,6 +73,7 @@ import kotlinx.browser.window
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.receiveAsFlow
@@ -246,16 +246,12 @@ internal class ComposeWindow(
             }
         }
 
-        private val textInputSessionMutex = SessionMutex<WebTextInputSession>()
-
-        override suspend fun textInputSession(
-            session: suspend PlatformTextInputSessionScope.() -> Nothing
-        ): Nothing = textInputSessionMutex.withSessionCancellingPrevious(
-            sessionInitializer = {
-                WebTextInputSession(it, textInputService)
-            },
-            session = session
-        )
+        override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
+            coroutineScope {
+                WebTextInputSession(this, textInputService)
+                    .startInputMethod(request)
+            }
+        }
     }
 
     private val skiaLayer: SkiaLayer = SkiaLayer().apply {


### PR DESCRIPTION
Due to the incorrect location of TextInputService startInput/stopInput calls, the text input session for keyboard interaction cannot be prevented.

Fixes https://youtrack.jetbrains.com/issue/CMP-7729

## Release Notes
### Fixes - iOS
- Fix an issue where the keyboard would appear after the second tap when the text input session was intercepted.
