### PR TITLE
Improve error warning in BrowserHistory navigation handler

### DIFF
--- a/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
+++ b/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
@@ -187,7 +187,11 @@ private fun NavController.tryToNavigateToUrlFragment(localWindow: BrowserWindow)
         try {
             navigate(route)
         } catch (e: IllegalArgumentException) {
-            localWindow.console.warn("Can't navigate to '$route'")
+            localWindow.console.warn("""
+                Can't navigate to '$route'! Error: ${e.message}
+                Check that the NavGraph is set up already in the NavController.
+                A typical mistake is to call `bindToNavigation` before the NavHost function is called.
+            """.trimIndent())
         }
     }
 }


### PR DESCRIPTION
Extended the warning message for navigation errors to include the exception message and additional guidance. This helps developers diagnose common issues like incorrect NavGraph setup or premature `bindToNavigation` calls.

Fixes https://youtrack.jetbrains.com/issue/CMP-8150

## Release Notes
N/A