### PR TITLE
Performance degradation fix due to rect tracking

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -447,6 +448,10 @@ internal class RootNodeOwner(
             measureAndLayoutDelegate.onNodeDetached(node)
             snapshotObserver.clear(node)
             needClearObservations = true
+            @OptIn(ExperimentalComposeUiApi::class)
+            if (ComposeUiFlags.isRectTrackingEnabled) {
+                rectManager.remove(node)
+            }
         }
 
         override fun measureAndLayout(sendPointerUpdate: Boolean) {
@@ -474,6 +479,10 @@ internal class RootNodeOwner(
                 // it allows us to not traverse the hierarchy twice.
                 if (!measureAndLayoutDelegate.hasPendingMeasureOrLayout) {
                     measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
+                }
+                @OptIn(ExperimentalComposeUiApi::class)
+                if (ComposeUiFlags.isRectTrackingEnabled) {
+                    rectManager.dispatchCallbacks()
                 }
             }
         }
@@ -545,6 +554,10 @@ internal class RootNodeOwner(
         }
 
         override fun onLayoutNodeDeactivated(layoutNode: LayoutNode) {
+            @OptIn(ExperimentalComposeUiApi::class)
+            if (ComposeUiFlags.isRectTrackingEnabled) {
+                rectManager.remove(layoutNode)
+            }
         }
 
         override fun onPreLayoutNodeReused(layoutNode: LayoutNode, oldSemanticsId: Int) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -251,6 +251,10 @@ internal class RootNodeOwner(
     fun draw(canvas: Canvas) = trace("RootNodeOwner:draw") {
         ownedLayerManager.draw(canvas)
         clearInvalidObservations()
+        @OptIn(ExperimentalComposeUiApi::class)
+        if (ComposeUiFlags.isRectTrackingEnabled) {
+            owner.rectManager.dispatchCallbacks()
+        }
     }
 
     fun setRootModifier(modifier: Modifier) {
@@ -466,6 +470,10 @@ internal class RootNodeOwner(
                         snapshotInvalidationTracker.requestDraw()
                     }
                     measureAndLayoutDelegate.dispatchOnPositionedCallbacks()
+                    @OptIn(ExperimentalComposeUiApi::class)
+                    if (ComposeUiFlags.isRectTrackingEnabled) {
+                       rectManager.dispatchCallbacks()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added forgotten `RectManager` methods calls in analogy of AndroidComposeView (from AOSP  [commit](https://github.com/androidx/androidx/commit/655aebc272ea0b0371b065af7d87a87bd4250928))

Fixes: 
- [CMP-6925](https://youtrack.jetbrains.com/issue/CMP-6925)
- [CMP-6715](https://youtrack.jetbrains.com/issue/CMP-6715)

## Testing
Running the benchmark to ensure that degradation has done

## Release Notes
### Fixes - Multiple Platforms
- Fixed a memory leak and performance degradation when `ComposeUiFlags.isRectTrackingEnabled` set to `true` (default).