### PR TITLE
[web][tests] adopt runApplicationTest / awaitIdle everywhere it makes sense

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/TextTests.kt
@@ -19,13 +19,12 @@ package androidx.compose.ui
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.layout.FirstBaseline
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import kotlin.math.abs
 import kotlin.test.Test
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.test.runTest
 
 class TextTests : OnCanvasTests {
 
@@ -43,9 +42,9 @@ class TextTests : OnCanvasTests {
 
     @Test
     // https://github.com/JetBrains/compose-multiplatform/issues/4078
-    fun baselineShouldBeNotZero() = runTest {
-        val headingOnPositioned = Channel<Float>(10)
-        val subtitleOnPositioned = Channel<Float>(10)
+    fun baselineShouldBeNotZero() = runApplicationTest {
+        val headingOnPositioned = mutableStateOf(10f)
+        val subtitleOnPositioned = mutableStateOf(10f)
 
         createComposeWindow {
             val density = LocalDensity.current.density
@@ -54,7 +53,7 @@ class TextTests : OnCanvasTests {
                     "Heading",
                     modifier = Modifier.alignByBaseline()
                         .onGloballyPositioned {
-                            headingOnPositioned.sendFromScope(it[FirstBaseline] / density)
+                            headingOnPositioned.value = it[FirstBaseline] / density
                         },
                     style = MaterialTheme.typography.h4
                 )
@@ -62,17 +61,16 @@ class TextTests : OnCanvasTests {
                     " — Subtitle",
                     modifier = Modifier.alignByBaseline()
                         .onGloballyPositioned {
-                            subtitleOnPositioned.sendFromScope(it[FirstBaseline] / density)
+                            subtitleOnPositioned.value = it[FirstBaseline] / density
                         },
                     style = MaterialTheme.typography.subtitle1
                 )
             }
         }
 
-        val headingAlignment = headingOnPositioned.receive()
-        val subtitleAlignment = subtitleOnPositioned.receive()
+        awaitIdle()
 
-        assertApproximatelyEqual(29f, headingAlignment)
-        assertApproximatelyEqual(17.5f, subtitleAlignment)
+        assertApproximatelyEqual(29f, headingOnPositioned.value)
+        assertApproximatelyEqual(17.5f, subtitleOnPositioned.value)
     }
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/GesturesTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/GesturesTest.kt
@@ -31,7 +31,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.runTest
@@ -140,7 +141,7 @@ class GesturesTest : OnCanvasTests {
 
     @Test
     // test that both TouchEvent.changedTouches and TouchEvent.targetTouches are handled
-    fun canReceiveTouchEvents() = runTest {
+    fun canReceiveTouchEvents() = runApplicationTest {
         var lastPointerEvent: PointerEvent? = null
 
         createComposeWindow {
@@ -153,23 +154,29 @@ class GesturesTest : OnCanvasTests {
             })
         }
 
-        assertEquals(null, lastPointerEvent)
+        assertNull(lastPointerEvent)
 
         dispatchEvents(
             TouchEvent("touchstart", touchEventInit(createTouch(0, getCanvas(), clientX = 50.0, clientY = 50.0))),
             TouchEvent("touchmove", touchEventInit(createTouch(0, getCanvas(), clientX = 60.0, clientY = 60.0)))
         )
 
-        assertNotEquals(null, lastPointerEvent)
-        assertEquals(1, lastPointerEvent!!.changes.size)
-        assertEquals(PointerEventType.Move, lastPointerEvent!!.type)
+        awaitIdle()
+
+        assertNotNull(lastPointerEvent)
+        assertEquals(1, lastPointerEvent.changes.size)
+        assertEquals(PointerEventType.Move, lastPointerEvent.type)
+
         lastPointerEvent = null
 
         dispatchEvents(
             TouchEvent("touchstart", touchEventWithTargetTouchesInit(createTouch(1, getCanvas(), clientX = 10.0, clientY = 10.0))),
             TouchEvent("touchmove", touchEventWithTargetTouchesInit(createTouch(1, getCanvas(), clientX = 20.0, clientY = 20.0)))
         )
-        assertNotEquals(null, lastPointerEvent)
+
+        awaitIdle()
+
+        assertNotNull(lastPointerEvent)
         assertEquals(1, lastPointerEvent!!.changes.size)
         assertEquals(PointerEventType.Move, lastPointerEvent!!.type)
     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/MouseTextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/MouseTextInputTests.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.TextField
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
@@ -20,10 +21,7 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.browser.document
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import org.w3c.dom.HTMLTextAreaElement
@@ -32,10 +30,8 @@ import org.w3c.dom.events.MouseEventInit
 
 class MouseTextInputTests: OnCanvasTests {
     @Test
-    fun canSelectUsingMouse() = runTest {
-        val syncChannel = Channel<TextRange?>(
-            1, onBufferOverflow = BufferOverflow.DROP_OLDEST
-        )
+    fun canSelectUsingMouse() = runApplicationTest {
+        val textRange = mutableStateOf(TextRange(0, 0))
 
         val focusRequester = FocusRequester()
 
@@ -52,7 +48,7 @@ class MouseTextInputTests: OnCanvasTests {
 
                     LaunchedEffect(textState.selection) {
                         focusRequester.requestFocus()
-                        syncChannel.send(textState.selection)
+                        textRange.value = textState.selection
                     }
                 }
             }
@@ -60,8 +56,8 @@ class MouseTextInputTests: OnCanvasTests {
 
         yield()
 
-        var selection = syncChannel.receive()
-        assertEquals(TextRange(14, 14), selection)
+        awaitIdle()
+        assertEquals(TextRange(14, 14), textRange.value)
         assertTrue(textFieldWidth > 0, "TextField width should be positive")
 
         val canvas = getCanvas()
@@ -71,8 +67,8 @@ class MouseTextInputTests: OnCanvasTests {
         yield()
         canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(clientX = 8, clientY = 20, buttons = 0, button = 1)))
 
-        selection = syncChannel.receive()
-        assertEquals(TextRange(0, 0), selection)
+        awaitIdle()
+        assertEquals(TextRange(0, 0), textRange.value)
 
         val textArea = document.querySelector("textarea")
         assertIs<HTMLTextAreaElement>(textArea)
@@ -102,8 +98,8 @@ class MouseTextInputTests: OnCanvasTests {
         canvas.dispatchEvent(MouseEvent("mousemove", MouseEventInit(clientX = endX, clientY = startY, buttons = 1, button = 1)))
         canvas.dispatchEvent(MouseEvent("mouseup", MouseEventInit(clientX = endX, clientY = startY, buttons = 0, button = 1)))
 
-        selection = syncChannel.receive()
-        assertEquals(TextRange(0, 14), selection)
+        awaitIdle()
+        assertEquals(TextRange(0, 14), textRange.value)
     }
 
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/ScrollTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/ScrollTests.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
@@ -33,29 +34,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionOnScreen
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.sendFromScope
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.test.runTest
 import org.w3c.dom.events.WheelEvent
 import org.w3c.dom.events.WheelEventInit
 
 class ScrollTests : OnCanvasTests {
     @Test
-    fun scrollTillEnd() = runTest {
-        val firstRowScrollPositionResolved = Channel<Boolean>(
-            1, onBufferOverflow = BufferOverflow.DROP_OLDEST
-        )
+    fun scrollTillEnd() = runApplicationTest {
+        val firstRowScrollPositionResolved = mutableStateOf(false)
+        val lastRowScrollPositionResolved = mutableStateOf(false)
 
-        val lastRowScrollPositionResolved = Channel<Boolean>(
-            1, onBufferOverflow = BufferOverflow.DROP_OLDEST
-        )
-
-        val composeWindow = createComposeWindow {
+        createComposeWindow {
             // Setting the density to 2 so the test works correctly on all displays
             CompositionLocalProvider(LocalDensity provides Density(2f)) {
                 Column(
@@ -71,7 +63,7 @@ class ScrollTests : OnCanvasTests {
                             .onGloballyPositioned { coordinates ->
                                 val screenPosition = coordinates.positionOnScreen()
                                 if (screenPosition == Offset(0f, -200f)) {
-                                    firstRowScrollPositionResolved.sendFromScope(true)
+                                    firstRowScrollPositionResolved.value = true
                                 }
                             }
                     )
@@ -100,7 +92,7 @@ class ScrollTests : OnCanvasTests {
                             .background(Color(143, 0, 255)).onGloballyPositioned { coordinates ->
                             val screenPosition = coordinates.positionOnScreen()
                             if (screenPosition == Offset(0f, 1000f)) {
-                                lastRowScrollPositionResolved.sendFromScope(true)
+                                lastRowScrollPositionResolved.value = true
                             }
                         }
                     )
@@ -110,8 +102,10 @@ class ScrollTests : OnCanvasTests {
 
         dispatchEvents(createWheelEvent(clientX = 100, clientY = 100, deltaX = 0.0, deltaY = 200.0))
 
-        assertTrue(firstRowScrollPositionResolved.receive(), "first row scroll position is not resolved")
-        assertTrue(lastRowScrollPositionResolved.receive(), "last row scroll position is not resolved")
+        awaitIdle()
+
+        assertTrue(firstRowScrollPositionResolved.value, "first row scroll position is not resolved")
+        assertTrue(lastRowScrollPositionResolved.value, "last row scroll position is not resolved")
     }
 }
 


### PR DESCRIPTION
As of now we have two approaches for testing recomposable code - one where we wait for recomposition and one where we are relying on channels and then send to this channel something that we later on are checking.

Both approaches are valid but having one approach that solves the issue is better than having two. Apart from that, we're still struggling with flakiness and even if (and this is still can not entirely write off this hypothesis) channels have nothing to do with the flakiness - having one (more universal) approach still makes sense.

## Testing
`gradlew testWeb`


## Release Notes
N/A
