### PR TITLE
Change properties prefix to jetbrains.androidx.web.tests*

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -37,8 +37,8 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
 
     private val skikoVersion: String
 
-    private val enableChromeTestsProperty = "jetbrains.compose.web.tests.enableChrome"
-    private val enableFirefoxTestsProperty = "jetbrains.compose.web.tests.enableFirefox"
+    private val enableChromeTestsProperty = "jetbrains.androidx.web.tests.enableChrome"
+    private val enableFirefoxTestsProperty = "jetbrains.androidx.web.tests.enableFirefox"
 
     init {
         val toml = Toml.parse(

--- a/gradle.properties
+++ b/gradle.properties
@@ -138,5 +138,5 @@ kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
-jetbrains.compose.web.tests.enableChrome=true
-jetbrains.compose.web.tests.enableFirefox=false
+jetbrains.androidx.web.tests.enableChrome=true
+jetbrains.androidx.web.tests.enableFirefox=false

--- a/mpp/karma.config.d/js/config.js
+++ b/mpp/karma.config.d/js/config.js
@@ -92,10 +92,10 @@ config.customLaunchers = {
 }
 
 config.browsers = [];
-if (process.env["jetbrains.compose.web.tests.enableChrome"]) {
+if (process.env["jetbrains.androidx.web.tests.enableChrome"]) {
     config.browsers.push("ChromeForComposeTests");
 }
-if (process.env["jetbrains.compose.web.tests.enableFirefox"]) {
+if (process.env["jetbrains.androidx.web.tests.enableFirefox"]) {
     config.browsers.push("FirefoxForComposeTests");
 }
 

--- a/mpp/karma.config.d/wasm/config.js
+++ b/mpp/karma.config.d/wasm/config.js
@@ -81,10 +81,10 @@ config.customLaunchers = {
 }
 
 config.browsers = [];
-if (process.env["jetbrains.compose.web.tests.enableChrome"]) {
+if (process.env["jetbrains.androidx.web.tests.enableChrome"]) {
     config.browsers.push("ChromeForComposeTests");
 }
-if (process.env["jetbrains.compose.web.tests.enableFirefox"]) {
+if (process.env["jetbrains.androidx.web.tests.enableFirefox"]) {
     config.browsers.push("FirefoxForComposeTests");
 }
 


### PR DESCRIPTION
This PR corrects names of the flags we are using for resolving browser sets on Teamcity

## Testing
`./gradlew testWeb`

## Release Notes
N/A