### PR TITLE
Properly transform caret position in legacyTextInputServiceAdapterAndService

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -104,7 +104,7 @@ internal actual fun legacyTextInputServiceAdapterAndService():
                 textClippingRectInRoot = matrix.map(innerTextFieldBounds)
                 focusedRectInRoot = focusedRectInRoot(
                     layoutResult = textLayoutResult,
-                    focusOffset = textFieldValue.selection.max,
+                    focusOffset = offsetMapping.originalToTransformed(textFieldValue.selection.max),
                     sizeForDefaultText = {
                         textLayoutResult.layoutInput.let {
                             computeSizeForDefaultText(it.style, it.density, it.fontFamilyResolver)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/TextFieldTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TextFieldTest {
+    @Test
+    fun selectionWithVisualTransformation() = runComposeUiTest {
+        val rawText = "abcde"
+        val transformedText = "bcde"
+
+        val visualTransformation = object : VisualTransformation {
+            val offsetMapping = object : OffsetMapping {
+                override fun originalToTransformed(offset: Int) = (offset - 1).coerceAtLeast(0)
+                override fun transformedToOriginal(offset: Int) = offset + 1
+            }
+            override fun filter(text: AnnotatedString) = TransformedText(
+                text = AnnotatedString(transformedText),
+                offsetMapping = offsetMapping,
+            )
+        }
+
+        var selection by mutableStateOf(TextRange(0, 0))
+        setContent {
+            val focusRequester = remember { FocusRequester() }
+            BasicTextField(
+                value = TextFieldValue(rawText, selection = selection),
+                onValueChange = {},
+                visualTransformation = visualTransformation,
+                modifier = Modifier
+                    .focusRequester(focusRequester)
+                    .testTag("textField"),
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+
+        onNodeWithTag("textField").assertTextEquals(transformedText)
+
+        // Try all valid selections; just check there's no crash
+        for (i in 0 .. rawText.length) {
+            for (j in i .. rawText.length) {
+                selection = TextRange(i, j)
+                waitForIdle()
+            }
+        }
+    }
+}


### PR DESCRIPTION
When determining the `focusedRectInRoot`, `legacyTextInputServiceAdapterAndService` needs to transform the position of the caret according to the `offsetMapping`.

Fixes https://youtrack.jetbrains.com/issue/CMP-8170

## Testing
Added a new test, and tested manually with
```
private const val TEXT_ORIGINAL = "XTest"
private const val TEXT_TRANSFORMED = "Test"

val visualTransformation = object : VisualTransformation {
    val offsetMapping = object : OffsetMapping {
        override fun originalToTransformed(offset: Int) = (offset - 1).coerceAtLeast(0)
        override fun transformedToOriginal(offset: Int) = offset + 1
    }
    override fun filter(text: AnnotatedString) = TransformedText(
        text = AnnotatedString(TEXT_TRANSFORMED),
        offsetMapping = offsetMapping,
    )
}

fun main() = singleWindowApplication {
    Box(
        modifier = Modifier.padding(8.dp),
    ) {
        BasicTextField(
            value = TEXT_ORIGINAL,
            onValueChange = {},
            textStyle = TextStyle(fontSize = 52.sp),
            visualTransformation = visualTransformation,
            modifier = Modifier
                .border(1.dp, Color.Black)
                .padding(4.dp)
        )
    }
}
```

This could be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Fixed `TextField(TextFieldValue)` when used with a visual transformation with a non-identity offset mapping (potentially even crashing).