### PR TITLE
Replace `focusedRectInRoot` with a simpler computation

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldDelegate.kt
@@ -213,6 +213,7 @@ internal class TextFieldDelegate {
             textInputSession.notifyFocusedRect(
                 focusedRectInRoot(
                     layoutResult = textLayoutResult,
+                    layoutCoordinates = layoutCoordinates,
                     focusOffset = offsetMapping.originalToTransformed(value.selection.max),
                     sizeForDefaultText = {
                         computeSizeForDefaultText(
@@ -220,8 +221,7 @@ internal class TextFieldDelegate {
                             textDelegate.density,
                             textDelegate.fontFamilyResolver
                         )
-                    },
-                    convertLocalToRoot = layoutCoordinates::localToRoot
+                    }
                 )
             )
         }
@@ -432,8 +432,8 @@ internal class TextFieldDelegate {
 /** Computes the bounds of the area where text editing is in progress, relative to the root. */
 internal fun focusedRectInRoot(
     layoutResult: TextLayoutResult,
+    layoutCoordinates: LayoutCoordinates,
     focusOffset: Int,
-    convertLocalToRoot: (Offset) -> Offset,
     sizeForDefaultText: () -> IntSize
 ): Rect {
     val bbox =
@@ -449,6 +449,6 @@ internal fun focusedRectInRoot(
                 Rect(0f, 0f, 1.0f, size.height.toFloat())
             }
         }
-    val globalLT = convertLocalToRoot(Offset(bbox.left, bbox.top))
+    val globalLT = layoutCoordinates.localToRoot(Offset(bbox.left, bbox.top))
     return Rect(Offset(globalLT.x, globalLT.y), Size(bbox.width, bbox.height))
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -16,8 +16,6 @@
 
 package androidx.compose.foundation.text.input.internal
 
-import androidx.compose.foundation.text.computeSizeForDefaultText
-import androidx.compose.foundation.text.focusedRectInRoot
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -102,16 +100,8 @@ internal actual fun legacyTextInputServiceAdapterAndService():
                 val matrix = Matrix().also { textFieldToRootTransform(it) }
                 textFieldRectInRoot = matrix.map(decorationBoxBounds)
                 textClippingRectInRoot = matrix.map(innerTextFieldBounds)
-                focusedRectInRoot = focusedRectInRoot(
-                    layoutResult = textLayoutResult,
-                    focusOffset = offsetMapping.originalToTransformed(textFieldValue.selection.max),
-                    sizeForDefaultText = {
-                        textLayoutResult.layoutInput.let {
-                            computeSizeForDefaultText(it.style, it.density, it.fontFamilyResolver)
-                        }
-                    },
-                    convertLocalToRoot = matrix::map
-                )
+                val cursorOffset = offsetMapping.originalToTransformed(textFieldValue.selection.max)
+                focusedRectInRoot = matrix.map(textLayoutResult.getCursorRect(cursorOffset))
             }
 
             override fun startStylusHandwriting() {}

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -17,8 +17,6 @@
 package androidx.compose.foundation.text.input.internal
 
 import androidx.compose.foundation.content.internal.ReceiveContentConfiguration
-import androidx.compose.foundation.text.computeSizeForDefaultText
-import androidx.compose.foundation.text.focusedRectInRoot
 import androidx.compose.foundation.text.input.TextFieldBuffer
 import androidx.compose.foundation.text.input.TextFieldCharSequence
 import androidx.compose.foundation.text.input.delete
@@ -26,6 +24,7 @@ import androidx.compose.foundation.text.input.setSelectionCoerced
 import androidx.compose.foundation.text.offsetByCodePoints
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
@@ -103,16 +102,9 @@ internal actual suspend fun PlatformTextInputSession.platformSpecificTextInputSe
         val focusedRectInRootFlow = snapshotFlow {
             val layoutResult = layoutState.layoutResult ?: return@snapshotFlow null
             val layoutCoords = layoutState.textLayoutNodeCoordinates ?: return@snapshotFlow null
-            focusedRectInRoot(
-                layoutResult = layoutResult,
-                focusOffset = state.visualText.selection.max,
-                sizeForDefaultText = {
-                    layoutResult.layoutInput.let {
-                        computeSizeForDefaultText(it.style, it.density, it.fontFamilyResolver)
-                    }
-                },
-                convertLocalToRoot = layoutCoords::localToRoot,
-            )
+            layoutResult
+                .getCursorRect(state.visualText.selection.max)
+                .translate(layoutCoords.localToRoot(Offset.Zero))
         }.filterNotNull()
 
         val textFieldRectInRoot = snapshotFlow {
@@ -242,7 +234,6 @@ private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScop
         buffer.cursor = newCursorInBuffer
     }
 }
-
 
 @OptIn(ExperimentalComposeUiApi::class)
 internal data class SkikoPlatformTextInputMethodRequest(

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
@@ -114,7 +114,7 @@ class LegacyPlatformTextInputServiceAdapterTest {
         assertThat(outputValue?.text).isEqualTo("abc")
         assertThat(outputValue?.selection).isEqualTo(TextRange(3, 3))
         assertThat(textLayoutResult?.layoutInput?.text?.text).isEqualTo("abc")
-        assertThat(focusedRectInRoot?.isEmpty).isFalse()
+        assertThat(focusedRectInRoot).isNotNull()
         assertThat(textFieldRectInRoot?.isEmpty).isFalse()
         assertThat(textClippingRectInRoot?.isEmpty).isFalse()
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -31,6 +31,7 @@ import javax.swing.JFrame
 import javax.swing.JLayeredPane
 import kotlin.math.ceil
 import kotlin.math.floor
+import kotlin.math.roundToInt
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
@@ -70,13 +71,19 @@ internal fun IntRect.toAwtRectangle(density: Density = Density(1f)) = toAwtRecta
     density = density.density
 )
 
-internal fun Rect.toAwtRectangle(density: Density) = toAwtRectangle(
-    left = left,
-    top = top,
-    right = right,
-    bottom = bottom,
-    density = density.density
-)
+/**
+ * Returns a [java.awt.Rectangle] corresponding to this [Rect], in the given density.
+ *
+ * The coordinates are rounded to the nearest integer.
+ */
+internal fun Rect.toAwtRectangleRounded(density: Density): Rectangle {
+    val densityValue = density.density
+    val left = (this.left / densityValue).roundToInt()
+    val top = (this.top / densityValue).roundToInt()
+    val right = (this.right / densityValue).roundToInt()
+    val bottom = (this.bottom / densityValue).roundToInt()
+    return Rectangle(left, top, right - left, bottom - top)
+}
 
 internal fun Color.toAwtColor() = java.awt.Color(red, green, blue, alpha)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.awt.toAwtRectangle
+import androidx.compose.ui.awt.toAwtRectangleRounded
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.scene.ComposeSceneMediator
 import androidx.compose.ui.text.TextRange
@@ -180,7 +180,8 @@ private class InputMethodSession(
 
     override fun getTextLocation(offset: TextHitInfo?): Rectangle? {
         val awtRect = focusedRect?.let {
-            it.copy(left = it.right).toAwtRectangle(component.density)
+            val centerX = it.topCenter.x
+            it.copy(left = centerX, right = centerX).toAwtRectangleRounded(component.density)
         } ?: return null
 
         val locationOnScreen = component.locationOnScreen

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -18,10 +18,13 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
+import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpRect
@@ -88,8 +91,15 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         backingDomInput?.updateState(newValue)
     }
 
-    override fun notifyFocusedRect(rect: Rect) {
-        val newRect = getNewGeometryForBackingInput(rect)
+    override fun updateTextLayoutResult(
+        textFieldValue: TextFieldValue,
+        offsetMapping: OffsetMapping,
+        textLayoutResult: TextLayoutResult,
+        textFieldToRootTransform: (Matrix) -> Unit,
+        innerTextFieldBounds: Rect,
+        decorationBoxBounds: Rect
+    ) {
+        val newRect = getNewGeometryForBackingInput(innerTextFieldBounds)
         backingDomInput?.updateHtmlInputPosition(Offset(newRect.left.value, newRect.top.value))
         backingDomInput?.updateHtmlInputGeometry(newRect.width.value.toInt(), newRect.height.value.toInt())
     }


### PR DESCRIPTION
Instead of the common `focusedRectInRoot`, just compute and transform the cursor position.
This also reverts the changes to `TextFieldDelegate` from https://github.com/JetBrains/compose-multiplatform-core/pull/1974, making upstreaming unnecessary.

## Testing
Tested manually.

## Release Notes
N/A
