### PR TITLE
CMP-8165: fix redirection for runtime-annotations 

### DIFF
--- a/compose/runtime/runtime-annotation/gradle.properties
+++ b/compose/runtime/runtime-annotation/gradle.properties
@@ -14,5 +14,5 @@
 # limitations under the License.
 #
 
-artifactRedirection.targetNames=android,jvm,iosarm64,iossimulatorarm64,iosx64,linuxarm64,linuxx64,macosarm64,macosx64,tvosarm64,tvossimulatorarm64,tvosx64,watchosarm32,watchosarm64,watchosdevicearm64,watchossimulatorarm64,watchosx64
+artifactRedirection.targetNames=android,jvm,uikitX64,uikitArm64,uikitSimArm64,linuxarm64,linuxx64,macosarm64,macosx64,tvosarm64,tvossimulatorarm64,tvosx64,watchosarm32,watchosarm64,watchosdevicearm64,watchossimulatorarm64,watchosx64
 artifactRedirection.groupId=androidx.compose.runtime


### PR DESCRIPTION
## Proposed Changes

  - fix redirection target names to match target names defined for `runtime-annotation` module in `compose/runtime/runtime-annotation/build.gradle` via `androidXComposeMultiplatform { ... darwin() ... }`

this is needed because those targets defined as "uikitX64, uikitArm64, uikitSimArm64" instead of "iosarm64,iossimulatorarm64,iosx64" in https://github.com/JetBrains/compose-multiplatform-core/blob/f5d4ced953790f7a2c375bc6328194cea79b8b6d/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt#L205

thanks @eymar for finding solution!

## Testing

Test: tested against sample project from https://youtrack.jetbrains.com/issue/CMP-8165

## Issues Fixed

Fixes: [CMP-8165](https://youtrack.jetbrains.com/issue/CMP-8165)

## Release Notes
N/A