### PR TITLE
Adjust iOS back gesture logic to incorporate touch slope threshold.

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcherUtils.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/backhandler/BackGestureDispatcherUtils.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.width
@@ -51,12 +52,14 @@ internal fun backEventCompat(
     eventOffset: Offset,
     leftEdge: Boolean,
     touch: DpOffset,
-    bounds: DpRect
+    bounds: DpRect,
+    touchSlopeDp: Dp
 ): BackEventCompat {
-    val progress = if (leftEdge) {
-        touch.x / bounds.width
+    val shift = if (leftEdge) touch.x else bounds.width - touch.x
+    val progress = if (shift > touchSlopeDp) {
+        (shift - touchSlopeDp) / (bounds.width - touchSlopeDp)
     } else {
-        (bounds.width - touch.x) / bounds.width
+        0.0f
     }
     return BackEventCompat(
         touchX = eventOffset.x,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/backhandler/UIKitBackGestureDispatcher.kt
@@ -18,11 +18,13 @@ package androidx.compose.ui.backhandler
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
 import androidx.compose.ui.uikit.utils.CMPScreenEdgePanGestureRecognizer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.asDpOffset
 import androidx.compose.ui.unit.asDpRect
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toOffset
 import kotlin.math.abs
 import kotlinx.cinterop.BetaInteropApi
@@ -145,7 +147,8 @@ private class UiKitScreenEdgePanGestureHandler(
                     eventOffset = eventOffset,
                     leftEdge = recognizer.edges == UIRectEdgeLeft,
                     touch = touch,
-                    bounds = view.bounds.asDpRect()
+                    bounds = view.bounds.asDpRect(),
+                    CUPERTINO_TOUCH_SLOP.dp
                 )
 
                 listener?.onProgressed(event)


### PR DESCRIPTION
Added a `touchSlopeDp` parameter to refine back gesture progress calculation, preventing unintended gesture triggers near the screen edge and helping to prerender the previous screen in the navigation.

## Release Notes
N/A
