### PR TITLE
Optimize usage of NSDateFormatter in Darwin source set

### DIFF
--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
@@ -51,7 +51,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     ): String {
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
-        return getCachedDateFormatterForPattern(pattern, cache).stringFromDate(nsDate)
+        return getCachedDateFormatterForPattern(pattern, true, cache).stringFromDate(nsDate)
     }
 
     actual fun formatWithSkeleton(
@@ -61,7 +61,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     ): String {
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
-        return getCachedDateFormatterForSkeleton(skeleton, cache).stringFromDate(nsDate)
+        return getCachedDateFormatterForSkeleton(skeleton = skeleton, cache = cache).stringFromDate(nsDate)
     }
 
     actual fun parse(
@@ -71,7 +71,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         cache: MutableMap<String, Any>
     ): CalendarDate? {
         // TODO https://youtrack.jetbrains.com/issue/CMP-7146/Properly-use-locale-in-CalendarModel.parse-implementations
-        val nsDate = getCachedDateFormatterForPattern(pattern, cache).dateFromString(date) ?: return null
+        val nsDate = getCachedDateFormatterForPattern(pattern = pattern, useLocale = false, cache = cache).dateFromString(date) ?: return null
 
         return Instant
             .fromEpochMilliseconds((nsDate.timeIntervalSince1970 * 1000).toLong())
@@ -108,26 +108,36 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
             ?.contains('a') == false
     }
 
-    private fun getCachedDateFormatterForSkeleton(skeleton: String, cache: MutableMap<String, Any>): NSDateFormatter {
-        return cache.getOrPut("S:$skeleton${this@PlatformDateFormat.locale.localeIdentifier}") {
+    private fun getCachedDateFormatterForSkeleton(
+        skeleton: String,
+        cache: MutableMap<String, Any>
+    ): NSDateFormatter {
+        return cache.getOrPut("S:$skeleton${locale.localeIdentifier}") {
             createBaseFormatter().apply {
                 setLocalizedDateFormatFromTemplate(skeleton)
             }
         } as NSDateFormatter
     }
 
-    private fun getCachedDateFormatterForPattern(pattern: String, cache: MutableMap<String, Any>): NSDateFormatter {
-        return cache.getOrPut("P:$pattern${this@PlatformDateFormat.locale.localeIdentifier}") {
-            createBaseFormatter().apply {
+    private fun getCachedDateFormatterForPattern(
+        pattern: String,
+        useLocale: Boolean,
+        cache: MutableMap<String, Any>
+    ): NSDateFormatter {
+        val localeKey = if (useLocale) locale.localeIdentifier else "NO_LOC"
+        return cache.getOrPut("P:$pattern:$localeKey") {
+            createBaseFormatter(useLocale).apply {
                 setDateFormat(pattern)
             }
         } as NSDateFormatter
     }
 
-    private fun createBaseFormatter(): NSDateFormatter {
+    private fun createBaseFormatter(useLocale: Boolean = true): NSDateFormatter {
         return NSDateFormatter().apply {
             setTimeZone(TimeZone.UTC.toNSTimeZone())
-            setLocale(this@PlatformDateFormat.locale)
+            if (useLocale) {
+                setLocale(locale)
+            }
         }
     }
 }

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
@@ -25,9 +25,21 @@ import platform.Foundation.NSDate
 import platform.Foundation.NSDateFormatter
 import platform.Foundation.NSDateFormatterShortStyle
 import platform.Foundation.dateWithTimeIntervalSince1970
+import platform.Foundation.localeIdentifier
 import platform.Foundation.timeIntervalSince1970
 
 internal actual class PlatformDateFormat actual constructor(private val locale: CalendarLocale) {
+
+    private val baseDateFormatter by lazy {
+        createBaseFormatter()
+    }
+
+    private val shortDateFormatter by lazy {
+        NSDateFormatter().apply {
+            setLocale(this@PlatformDateFormat.locale)
+            setDateStyle(NSDateFormatterShortStyle)
+        }
+    }
 
     actual val firstDayOfWeek: Int
         get() = firstDayOfWeek()
@@ -35,37 +47,31 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     actual fun formatWithPattern(
         utcTimeMillis: Long,
         pattern: String,
+        cache: MutableMap<String, Any>
     ): String {
-
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
-        return NSDateFormatter().apply {
-            setTimeZone(TimeZone.UTC.toNSTimeZone())
-            setLocale(this@PlatformDateFormat.locale)
-            setDateFormat(pattern)
-        }.stringFromDate(nsDate)
+        return getCachedDateFormatterForPattern(pattern, cache).stringFromDate(nsDate)
     }
 
     actual fun formatWithSkeleton(
         utcTimeMillis: Long,
         skeleton: String,
+        cache: MutableMap<String, Any>
     ): String {
-
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
-        return NSDateFormatter().apply {
-            setTimeZone(TimeZone.UTC.toNSTimeZone())
-            setLocale(this@PlatformDateFormat.locale)
-            setLocalizedDateFormatFromTemplate(skeleton)
-        }.stringFromDate(nsDate)
+        return getCachedDateFormatterForSkeleton(skeleton, cache).stringFromDate(nsDate)
     }
 
-    actual fun parse(date: String, pattern: String, locale: CalendarLocale): CalendarDate? {
+    actual fun parse(
+        date: String,
+        pattern: String,
+        locale: CalendarLocale,
+        cache: MutableMap<String, Any>
+    ): CalendarDate? {
         // TODO https://youtrack.jetbrains.com/issue/CMP-7146/Properly-use-locale-in-CalendarModel.parse-implementations
-        val nsDate = NSDateFormatter().apply {
-            setTimeZone(TimeZone.UTC.toNSTimeZone())
-            setDateFormat(pattern)
-        }.dateFromString(date) ?: return null
+        val nsDate = getCachedDateFormatterForPattern(pattern, cache).dateFromString(date) ?: return null
 
         return Instant
             .fromEpochMilliseconds((nsDate.timeIntervalSince1970 * 1000).toLong())
@@ -73,20 +79,14 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     }
 
     actual fun getDateInputFormat(): DateInputFormat {
-
-        val pattern = NSDateFormatter().apply {
-            setLocale(this@PlatformDateFormat.locale)
-            setDateStyle(NSDateFormatterShortStyle)
-        }.dateFormat
+        val pattern = shortDateFormatter.dateFormat
 
         return datePatternAsInputFormat(pattern)
     }
 
     @Suppress("UNCHECKED_CAST")
     actual val weekdayNames: List<Pair<String, String>> get() {
-        val formatter = NSDateFormatter().apply {
-            setLocale(this@PlatformDateFormat.locale)
-        }
+        val formatter = baseDateFormatter
 
         val fromSundayToSaturday = formatter.standaloneWeekdaySymbols
             .zip(formatter.veryShortStandaloneWeekdaySymbols) as List<Pair<String, String>>
@@ -106,5 +106,28 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         return NSDateFormatter
             .dateFormatFromTemplate("j", 0UL, locale)
             ?.contains('a') == false
+    }
+
+    private fun getCachedDateFormatterForSkeleton(skeleton: String, cache: MutableMap<String, Any>): NSDateFormatter {
+        return cache.getOrPut("S:$skeleton${this@PlatformDateFormat.locale.localeIdentifier}") {
+            createBaseFormatter().apply {
+                setLocalizedDateFormatFromTemplate(skeleton)
+            }
+        } as NSDateFormatter
+    }
+
+    private fun getCachedDateFormatterForPattern(pattern: String, cache: MutableMap<String, Any>): NSDateFormatter {
+        return cache.getOrPut("P:$pattern${this@PlatformDateFormat.locale.localeIdentifier}") {
+            createBaseFormatter().apply {
+                setDateFormat(pattern)
+            }
+        } as NSDateFormatter
+    }
+
+    private fun createBaseFormatter(): NSDateFormatter {
+        return NSDateFormatter().apply {
+            setTimeZone(TimeZone.UTC.toNSTimeZone())
+            setLocale(this@PlatformDateFormat.locale)
+        }
     }
 }

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
@@ -51,7 +51,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     ): String {
         val nsDate = NSDate.dateWithTimeIntervalSince1970(utcTimeMillis / 1000.0)
 
-        return getCachedDateFormatterForPattern(pattern, true, cache).stringFromDate(nsDate)
+        return getCachedDateFormatterForPattern(pattern = pattern, useLocale = true, cache = cache).stringFromDate(nsDate)
     }
 
     actual fun formatWithSkeleton(

--- a/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
+++ b/compose/material3/material3/src/darwinMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.darwin.kt
@@ -112,7 +112,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         skeleton: String,
         cache: MutableMap<String, Any>
     ): NSDateFormatter {
-        return cache.getOrPut("S:$skeleton${locale.localeIdentifier}") {
+        return cache.getOrPut("S:$skeleton${this@PlatformDateFormat.locale.localeIdentifier}") {
             createBaseFormatter().apply {
                 setLocalizedDateFormatFromTemplate(skeleton)
             }
@@ -124,7 +124,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         useLocale: Boolean,
         cache: MutableMap<String, Any>
     ): NSDateFormatter {
-        val localeKey = if (useLocale) locale.localeIdentifier else "NO_LOC"
+        val localeKey = if (useLocale) this@PlatformDateFormat.locale.localeIdentifier else "NO_LOC"
         return cache.getOrPut("P:$pattern:$localeKey") {
             createBaseFormatter(useLocale).apply {
                 setDateFormat(pattern)
@@ -136,7 +136,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         return NSDateFormatter().apply {
             setTimeZone(TimeZone.UTC.toNSTimeZone())
             if (useLocale) {
-                setLocale(locale)
+                setLocale(this@PlatformDateFormat.locale)
             }
         }
     }

--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.desktop.kt
@@ -39,13 +39,15 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     actual fun formatWithPattern(
         utcTimeMillis: Long,
         pattern: String,
+        cache: MutableMap<String, Any>
     ): String {
         return delegate.formatWithPattern(utcTimeMillis, pattern, locale)
     }
 
     actual fun formatWithSkeleton(
         utcTimeMillis: Long,
-        skeleton: String
+        skeleton: String,
+        cache: MutableMap<String, Any>
     ): String {
         // Note: there is no equivalent in Java for Android's DateFormat.getBestDateTimePattern.
         // The JDK SimpleDateFormat expects a pattern, so the results for unrecognized skeletons will be "2023Jan7",
@@ -70,10 +72,15 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
             DatePickerDefaults.YearMonthSkeleton -> "LLLL yyyy" // L is a pattern for standalone month (without day)
             else -> skeleton
         }
-        return formatWithPattern(utcTimeMillis, pattern)
+        return formatWithPattern(utcTimeMillis, pattern, cache)
     }
 
-    actual fun parse(date: String, pattern: String, locale: CalendarLocale): CalendarDate? {
+    actual fun parse(
+        date: String,
+        pattern: String,
+        locale: CalendarLocale,
+        cache: MutableMap<String, Any>
+    ): CalendarDate? {
         return delegate.parse(date, pattern, locale)
     }
 

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/CalendarModel.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/CalendarModel.skiko.kt
@@ -34,5 +34,6 @@ internal actual fun formatWithSkeleton(
     return PlatformDateFormat(locale).formatWithSkeleton(
         utcTimeMillis = utcTimeMillis,
         skeleton = skeleton,
+        cache = cache
     )
 }

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/KotlinxDatetimeCalendarModel.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/KotlinxDatetimeCalendarModel.kt
@@ -121,11 +121,11 @@ internal class KotlinxDatetimeCalendarModel(locale: CalendarLocale) : CalendarMo
         pattern: String,
         locale: CalendarLocale
     ): String {
-        return platformDateFormat.formatWithPattern(utcTimeMillis, pattern)
+        return platformDateFormat.formatWithPattern(utcTimeMillis, pattern, formatterCache)
     }
 
     override fun parse(date: String, pattern: String, locale: CalendarLocale): CalendarDate? {
-        return platformDateFormat.parse(date, pattern, locale)
+        return platformDateFormat.parse(date, pattern, locale, formatterCache)
     }
 
     private fun Instant.toCalendarMonth(

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.kt
@@ -27,14 +27,21 @@ internal expect class PlatformDateFormat(locale: CalendarLocale) {
     fun formatWithPattern(
         utcTimeMillis: Long,
         pattern: String,
+        cache: MutableMap<String, Any>
     ): String
 
     fun formatWithSkeleton(
         utcTimeMillis: Long,
         skeleton: String,
+        cache: MutableMap<String, Any>
     ): String
 
-    fun parse(date: String, pattern: String, locale: CalendarLocale): CalendarDate?
+    fun parse(
+        date: String,
+        pattern: String,
+        locale: CalendarLocale,
+        cache: MutableMap<String, Any>
+    ): CalendarDate?
 
     fun getDateInputFormat(): DateInputFormat
 

--- a/compose/material3/material3/src/webCommonW3C/kotlin/androidx/compose/material3/internal/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/webCommonW3C/kotlin/androidx/compose/material3/internal/PlatformDateFormat.jsWasm.kt
@@ -54,6 +54,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     actual fun formatWithPattern(
         utcTimeMillis: Long,
         pattern: String,
+        cache: MutableMap<String, Any>
     ): String {
 
         val date = Instant
@@ -91,6 +92,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     actual fun formatWithSkeleton(
         utcTimeMillis: Long,
         skeleton: String,
+        cache: MutableMap<String, Any>
     ): String {
         val jsDate = Date(utcTimeMillis.toDouble())
 
@@ -140,7 +142,12 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     }
 
     @OptIn(FormatStringsInDatetimeFormats::class)
-    actual fun parse(date: String, pattern: String, locale: CalendarLocale): CalendarDate? {
+    actual fun parse(
+        date: String,
+        pattern: String,
+        locale: CalendarLocale,
+        cache: MutableMap<String, Any>
+    ): CalendarDate? {
         // TODO https://youtrack.jetbrains.com/issue/CMP-7146/Properly-use-locale-in-CalendarModel.parse-implementations
         return try {
             LocalDate.parse(


### PR DESCRIPTION
This PR optimizes the creation and use of `NSDateFormatter` instances to improve performance. Previously, new `NSDateFormatter` instances were created on each method call. This PR implements a caching mechanism to reuse the formatters.

Fixes - https://youtrack.jetbrains.com/issue/CMP-8052

## Release Notes

N/A
