### PR TITLE
Report AccessibleRole.CHECKBOX for Switch.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -419,14 +419,11 @@ internal class ComposeAccessible(
             AccessibilityController.AccessibilityUsage.notifyInUse()
             val fromSemanticRole = when (semanticsConfig.getOrNull(SemanticsProperties.Role)) {
                 Role.Button -> AccessibleRole.PUSH_BUTTON
-                Role.Checkbox -> AccessibleRole.CHECK_BOX
+                Role.Checkbox, Role.Switch -> AccessibleRole.CHECK_BOX
                 Role.RadioButton -> AccessibleRole.RADIO_BUTTON
                 Role.Tab -> AccessibleRole.PAGE_TAB
                 Role.DropdownList -> AccessibleRole.COMBO_BOX
                 else -> null
-                // ?
-                //  Role.Switch ->
-                //  Role.Image ->
             }
 
             return when {
@@ -474,7 +471,7 @@ internal class ComposeAccessible(
                 when (semanticsConfig.getOrNull(SemanticsProperties.Role)) {
                     // Note that this is not executed on macOS (for checkboxes or radio buttons),
                     // where the system inspects the value returned by getAccessibleValue instead.
-                    Role.Checkbox -> addCheckedStateForCheckbox()
+                    Role.Checkbox, Role.Switch -> addCheckedStateForCheckboxOrSwitch()
                     Role.RadioButton -> addCheckedStateForRadioButton()
                     else -> {  // Default case, for other (possibly null) roles
                         addDefaultStateForToggleableState()
@@ -489,8 +486,10 @@ internal class ComposeAccessible(
             }
         }
 
-        private fun AccessibleStateSet.addCheckedStateForCheckbox() {
+        private fun AccessibleStateSet.addCheckedStateForCheckboxOrSwitch() {
             // Checkbox uses Modifier.triStateToggleable, which sets
+            // SemanticsPropertyReceiver.toggleableState
+            // Switch uses Modifier.toggleable, which also sets
             // SemanticsPropertyReceiver.toggleableState
             addDefaultStateForToggleableState()
         }


### PR DESCRIPTION
We currently don't report any AWT `AccessibleRole` for Compose's `Role.Switch`.
Unfortunately AWT doesn't have a role for switches, but they are similar enough to checkboxes, that I think it's better to report them as such than not at all.

Fixes https://youtrack.jetbrains.com/issue/CMP-8008

## Testing
Tested manually.

This could be tested by QA

## Release Notes
### Features - Desktop
- Add accessibility role for `Switch`, reporting it as a checkbox.
