### PR TITLE
[web] Update backing input position and geometry via CSS 

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -31,7 +31,10 @@ internal interface ComposeCommandCommunicator {
     fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean
 }
 
-private fun setGlobalCssProperty(property: String, value: Float): Unit = js("document.documentElement.style.setProperty(property, value)")
+private fun setBackingInputLeft(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-left\", value)")
+private fun setBackingInputTop(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-top\", value)")
+private fun setBackingInputWidth(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-width\", value)")
+private fun setBackingInputHeight(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-height\", value)")
 
 /**
  * The purpose of this entity is to isolate synchronization between a TextFieldValue
@@ -48,17 +51,11 @@ internal class BackingDomInput(
     )
 
     private companion object {
-        private const val leftPropertyName = "--compose-internal-web-backing-input-left"
-        private const val topPropertyName = "--compose-internal-web-backing-input-top"
-        private const val widthPropertyName = "--compose-internal-web-backing-input-width"
-        private const val heightPropertyName = "--compose-internal-web-backing-input-height"
-
-
         init {
-            setGlobalCssProperty(leftPropertyName, 0f)
-            setGlobalCssProperty(topPropertyName, 0f)
-            setGlobalCssProperty(widthPropertyName, 0f)
-            setGlobalCssProperty(heightPropertyName, 0f)
+            setBackingInputLeft(0f)
+            setBackingInputTop(0f)
+            setBackingInputWidth(0f)
+            setBackingInputHeight(0f)
         }
     }
 
@@ -85,13 +82,13 @@ internal class BackingDomInput(
     }
 
     fun updateHtmlInputPosition(offset: Offset) {
-        setGlobalCssProperty(leftPropertyName, offset.x)
-        setGlobalCssProperty(topPropertyName, offset.y)
+        setBackingInputLeft(offset.x)
+        setBackingInputTop(offset.y)
     }
 
     fun updateHtmlInputGeometry(width: Float, height: Float) {
-        setGlobalCssProperty(widthPropertyName, width)
-        setGlobalCssProperty(heightPropertyName, height)
+        setBackingInputWidth(width)
+        setBackingInputHeight(height)
     }
 
     fun updateState(textFieldValue: TextFieldValue) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.browser.document
 import kotlinx.browser.window
 
-
 internal interface ComposeCommandCommunicator {
     fun sendEditCommand(commands: List<EditCommand>)
     fun sendEditCommand(command: EditCommand) = sendEditCommand(listOf(command))
@@ -32,6 +31,7 @@ internal interface ComposeCommandCommunicator {
     fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean
 }
 
+private fun setGlobalCssProperty(property: String, value: Float): Unit = js("document.documentElement.style.setProperty(property, value)")
 
 /**
  * The purpose of this entity is to isolate synchronization between a TextFieldValue
@@ -46,6 +46,21 @@ internal class BackingDomInput(
         imeOptions,
         composeCommunicator
     )
+
+    private companion object {
+        private const val leftPropertyName = "--compose-internal-web-backing-input-left"
+        private const val topPropertyName = "--compose-internal-web-backing-input-top"
+        private const val widthPropertyName = "--compose-internal-web-backing-input-width"
+        private const val heightPropertyName = "--compose-internal-web-backing-input-height"
+
+
+        init {
+            setGlobalCssProperty(leftPropertyName, 0f)
+            setGlobalCssProperty(topPropertyName, 0f)
+            setGlobalCssProperty(widthPropertyName, 0f)
+            setGlobalCssProperty(heightPropertyName, 0f)
+        }
+    }
 
     private val backingElement = inputStrategy.htmlInput
 
@@ -70,13 +85,13 @@ internal class BackingDomInput(
     }
 
     fun updateHtmlInputPosition(offset: Offset) {
-        backingElement.style.left = "${offset.x}px"
-        backingElement.style.top = "${offset.y}px"
+        setGlobalCssProperty(leftPropertyName, offset.x)
+        setGlobalCssProperty(topPropertyName, offset.y)
     }
 
-    fun updateHtmlInputGeometry(width: Int, height: Int) {
-        backingElement.style.width = "${width}px"
-        backingElement.style.height = "${height}px"
+    fun updateHtmlInputGeometry(width: Float, height: Float) {
+        setGlobalCssProperty(widthPropertyName, width)
+        setGlobalCssProperty(heightPropertyName, height)
     }
 
     fun updateState(textFieldValue: TextFieldValue) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeOptions
@@ -31,10 +30,12 @@ internal interface ComposeCommandCommunicator {
     fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean
 }
 
-private fun setBackingInputLeft(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-left\", value)")
-private fun setBackingInputTop(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-top\", value)")
-private fun setBackingInputWidth(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-width\", value)")
-private fun setBackingInputHeight(value: Float): Unit = js("document.documentElement.style.setProperty(\"--compose-internal-web-backing-input-height\", value)")
+private fun setBackingInputBox(left: Float, top: Float, width: Float, height: Float) { js("""
+    document.documentElement.style.setProperty("--compose-internal-web-backing-input-left", left);
+    document.documentElement.style.setProperty("--compose-internal-web-backing-input-top", top);
+    document.documentElement.style.setProperty("--compose-internal-web-backing-input-width", width);
+    document.documentElement.style.setProperty("--compose-internal-web-backing-input-height", height)
+""") }
 
 /**
  * The purpose of this entity is to isolate synchronization between a TextFieldValue
@@ -52,10 +53,7 @@ internal class BackingDomInput(
 
     private companion object {
         init {
-            setBackingInputLeft(0f)
-            setBackingInputTop(0f)
-            setBackingInputWidth(0f)
-            setBackingInputHeight(0f)
+            setBackingInputBox(0f, 0f, 0f, 0f)
         }
     }
 
@@ -81,14 +79,8 @@ internal class BackingDomInput(
         backingElement.blur()
     }
 
-    fun updateHtmlInputPosition(offset: Offset) {
-        setBackingInputLeft(offset.x)
-        setBackingInputTop(offset.y)
-    }
-
-    fun updateHtmlInputGeometry(width: Float, height: Float) {
-        setBackingInputWidth(width)
-        setBackingInputHeight(height)
+    fun updateHtmlInputBox(left: Float, top: Float, width: Float, height: Float) {
+        setBackingInputBox(left, top, width, height)
     }
 
     fun updateState(textFieldValue: TextFieldValue) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -230,7 +230,7 @@ private fun ImeOptions.createDomElement(): HTMLElement {
         setProperty("white-space", "pre-wrap")
         setProperty("align-content", "center")
         setProperty("top", "calc(min(var(--compose-internal-web-backing-input-top) * 1px, 100vh - var(--compose-internal-web-backing-input-height) * 1px))")
-        setProperty("left", "calc(var(--compose-internal-web-backing-input-left) * 1px")
+        setProperty("left", "calc(min(var(--compose-internal-web-backing-input-left) * 1px, 100vw - var(--compose-internal-web-backing-input-width) * 1px))")
         setProperty("width", "calc(var(--compose-internal-web-backing-input-width) * 1px")
         setProperty("height", "calc(var(--compose-internal-web-backing-input-height) * 1px")
         setProperty("padding", "0")

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -222,14 +222,17 @@ private fun ImeOptions.createDomElement(): HTMLElement {
     htmlElement.setAttribute("inputmode", inputMode)
     htmlElement.setAttribute("enterkeyhint", enterKeyHint)
 
+
     htmlElement.style.apply {
         setProperty("position", "absolute")
         setProperty("user-select", "none")
         setProperty("forced-color-adjust", "none")
         setProperty("white-space", "pre-wrap")
         setProperty("align-content", "center")
-        setProperty("top", "0")
-        setProperty("left", "0")
+        setProperty("top", "calc(min(var(--compose-internal-web-backing-input-top) * 1px, 100vh - var(--compose-internal-web-backing-input-height) * 1px))")
+        setProperty("left", "calc(var(--compose-internal-web-backing-input-left) * 1px")
+        setProperty("width", "calc(var(--compose-internal-web-backing-input-width) * 1px")
+        setProperty("height", "calc(var(--compose-internal-web-backing-input-height) * 1px")
         setProperty("padding", "0")
         setProperty("opacity", "0")
         setProperty("color", "transparent")

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -101,7 +101,7 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
     ) {
         val newRect = getNewGeometryForBackingInput(innerTextFieldBounds)
         backingDomInput?.updateHtmlInputPosition(Offset(newRect.left.value, newRect.top.value))
-        backingDomInput?.updateHtmlInputGeometry(newRect.width.value.toInt(), newRect.height.value.toInt())
+        backingDomInput?.updateHtmlInputGeometry(newRect.width.value, newRect.height.value)
     }
 
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -91,19 +91,6 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         backingDomInput?.updateState(newValue)
     }
 
-    override fun updateTextLayoutResult(
-        textFieldValue: TextFieldValue,
-        offsetMapping: OffsetMapping,
-        textLayoutResult: TextLayoutResult,
-        textFieldToRootTransform: (Matrix) -> Unit,
-        innerTextFieldBounds: Rect,
-        decorationBoxBounds: Rect
-    ) {
-        val newRect = getNewGeometryForBackingInput(innerTextFieldBounds)
-        backingDomInput?.updateHtmlInputBox(newRect.left.value, newRect.top.value, newRect.width.value, newRect.height.value)
-    }
-
-
     override fun notifyFocusedRect(rect: Rect) {
         val newRect = getNewGeometryForBackingInput(rect)
         backingDomInput?.updateHtmlInputBox(newRect.left.value, newRect.top.value, newRect.width.value, newRect.height.value)

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -103,4 +103,9 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         backingDomInput?.updateHtmlInputBox(newRect.left.value, newRect.top.value, newRect.width.value, newRect.height.value)
     }
 
+
+    override fun notifyFocusedRect(rect: Rect) {
+        val newRect = getNewGeometryForBackingInput(rect)
+        backingDomInput?.updateHtmlInputBox(newRect.left.value, newRect.top.value, newRect.width.value, newRect.height.value)
+    }
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -100,8 +100,7 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         decorationBoxBounds: Rect
     ) {
         val newRect = getNewGeometryForBackingInput(innerTextFieldBounds)
-        backingDomInput?.updateHtmlInputPosition(Offset(newRect.left.value, newRect.top.value))
-        backingDomInput?.updateHtmlInputGeometry(newRect.width.value, newRect.height.value)
+        backingDomInput?.updateHtmlInputBox(newRect.left.value, newRect.top.value, newRect.width.value, newRect.height.value)
     }
 
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -211,20 +211,8 @@ internal class ComposeWindow(
             override fun getNewGeometryForBackingInput(rect: Rect): DpRect {
                 val viewportRect = canvas.getBoundingClientRect()
                 val dpRect = rect.toDpRect(density)
-                var left = viewportRect.left.toFloat() + dpRect.left.value
-                var top = viewportRect.top.toFloat() + dpRect.top.value
-
-                if (left < viewportRect.left) {
-                    left = viewportRect.left.toFloat()
-                } else if (left + dpRect.width.value > viewportRect.right) {
-                    left = viewportRect.right.toFloat() - dpRect.width.value
-                }
-
-                if (top < viewportRect.top) {
-                    top = viewportRect.top.toFloat()
-                } else if (top + dpRect.height.value > viewportRect.bottom) {
-                    top = viewportRect.bottom.toFloat() - dpRect.height.value
-                }
+                val left = viewportRect.left.toFloat() + dpRect.left.value
+                val top = viewportRect.top.toFloat() + dpRect.top.value
 
                 return DpRect(DpOffset(left.dp, top.dp), dpRect.size)
             }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/MouseTextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/MouseTextInputTests.kt
@@ -83,7 +83,6 @@ class MouseTextInputTests: OnCanvasTests {
         // We expect the canvas to be on the top despite the coordinates match the textarea.
         // So it will be the first to process all the point inputs
         assertEquals(canvas, elementsAtPos[0], "First element under mouse supposed to be canvas")
-        assertTrue(elementsAtPos.toList().any { it == textArea }) // such a weird check to make the test common for js and wasm
         withContext(Dispatchers.Default) {
             delay(250) // to separate the mouse events
         }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -134,11 +134,23 @@ abstract class TextInputTests : OnCanvasTests {
         focusRequester.requestFocus()
         awaitIdle()
 
-        val clientRectSticky= currentHtmlInput().getBoundingClientRect()
+        var clientRectSticky= currentHtmlInput().getBoundingClientRect()
         val expectedTopValue = window.innerHeight - clientRectSticky.height
 
         // TODO: In Firefox there's a 0.5 delta - may be this can be accounted precisely somehow
-        assertTrue((clientRectSticky.top - expectedTopValue).absoluteValue < 1.0, "top position sticky")
+        val topDelta = clientRectSticky.top - expectedTopValue
+        assertTrue(topDelta.absoluteValue < 1.0, "top position sticky $topDelta")
+
+        // intentionally huge, will never grow over viewport nevertheless
+        leftState = 10000000.dp
+
+        focusRequester.requestFocus()
+        awaitIdle()
+
+        clientRectSticky= currentHtmlInput().getBoundingClientRect()
+        val expectedLeftValue = window.innerWidth - clientRectSticky.width
+        val leftDelta = clientRectSticky.left - expectedLeftValue
+        assertTrue(leftDelta.absoluteValue < 1.0, "left position sticky $leftDelta")
     }
 
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -139,7 +139,8 @@ abstract class TextInputTests : OnCanvasTests {
 
         // TODO: In Firefox there's a 0.5 delta - may be this can be accounted precisely somehow
         val topDelta = clientRectSticky.top - expectedTopValue
-        assertTrue(topDelta.absoluteValue < 1.0, "top position sticky $topDelta")
+        val deltaThreshold = 1.01
+        assertTrue(topDelta.absoluteValue < deltaThreshold, "top position sticky $topDelta")
 
         // intentionally huge, will never grow over viewport nevertheless
         leftState = 10000000.dp
@@ -150,7 +151,7 @@ abstract class TextInputTests : OnCanvasTests {
         clientRectSticky= currentHtmlInput().getBoundingClientRect()
         val expectedLeftValue = window.innerWidth - clientRectSticky.width
         val leftDelta = clientRectSticky.left - expectedLeftValue
-        assertTrue(leftDelta.absoluteValue < 1.0, "left position sticky $leftDelta")
+        assertTrue(leftDelta.absoluteValue < deltaThreshold, "left position sticky $leftDelta")
     }
 
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -128,7 +128,7 @@ abstract class TextInputTests : OnCanvasTests {
         focusRequester.requestFocus()
         awaitIdle()
 
-        // intentionally huge, will never grow over virewport nevertheless
+        // intentionally huge, will never grow over viewport nevertheless
         topState = 10000000.dp
 
         focusRequester.requestFocus()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -16,11 +16,15 @@
 
 package androidx.compose.ui.input
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.TestInputState
@@ -31,10 +35,15 @@ import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import kotlin.math.absoluteValue
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import kotlinx.browser.document
+import kotlinx.browser.window
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -86,7 +95,54 @@ abstract class TextInputTests : OnCanvasTests {
     }
 
     @Test
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-8094
+    fun positionInput() = runApplicationTest {
+        val focusRequester = FocusRequester()
+        val inputHolder = createTestInputState()
+
+        var leftState by mutableStateOf(0.dp)
+        var topState by mutableStateOf(0.dp)
+
+        createComposeWindow {
+            Box(modifier = Modifier.padding(horizontal = leftState, vertical = topState)) {
+                inputHolder.createBasicTextField(focusRequester)
+            }
+        }
+
+        focusRequester.requestFocus()
+        waitForHtmlInput()
+
+        sendToHtmlInput(keyEvent("a"), keyEvent("b"), keyEvent("c"))
+
+        inputHolder.awaitAndAssertTextEquals("abc")
+
+        val clientRectInitial = currentHtmlInput().getBoundingClientRect()
+
+        leftState = 50.dp
+        focusRequester.requestFocus()
+        awaitIdle()
+
+        val clientRectUpdated = currentHtmlInput().getBoundingClientRect()
+
+        assertEquals(50.0, clientRectUpdated.left - clientRectInitial.left, "left position updated")
+
+        focusRequester.requestFocus()
+        awaitIdle()
+
+        // intentionally huge, will never grow over virewport nevertheless
+        topState = 10000000.dp
+
+        focusRequester.requestFocus()
+        awaitIdle()
+
+        val clientRectSticky= currentHtmlInput().getBoundingClientRect()
+        val expectedTopValue = window.innerHeight - clientRectSticky.height
+
+        // TODO: In Firefox there's a 0.5 delta - may be this can be accounted precisely somehow
+        assertTrue((clientRectSticky.top - expectedTopValue).absoluteValue < 1.0, "top position sticky")
+    }
+
+
+    @Test
     fun regularInput() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
 


### PR DESCRIPTION
This is rebased version of 
https://github.com/JetBrains/compose-multiplatform-core/pull/2128
See https://youtrack.jetbrains.com/issue/CMP-7997/Position-backing-HTML-text-field-via-CSS-variables

## Testing
`gradlew testWeb`

## Release Notes
N/A
