### PR TITLE
Wrap a screen content to a Box for the iOS back animation blackout

### DIFF
--- a/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/commonMain/kotlin/androidx/navigation/compose/NavHost.kt
@@ -31,6 +31,8 @@ import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.rememberTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -495,7 +497,7 @@ internal fun NavHost(
     (@JvmSuppressWildcards
     AnimatedContentTransitionScope<NavBackStackEntry>.() -> SizeTransform?)?,
     drawOnBottomEntryDuringAnimation:
-    (@Composable (isBackAnimation: Boolean, progress: Float) -> Unit)?,
+    (@Composable BoxScope.(isBackAnimation: Boolean, progress: Float) -> Unit)?,
     limitBackGestureSwipeEdge: Int?
 ) {
 
@@ -719,28 +721,33 @@ internal fun NavHost(
             // while in the scope of the composable, we provide the navBackStackEntry as the
             // ViewModelStoreOwner and LifecycleOwner
             currentEntry?.LocalOwnersProvider(saveableStateHolder) {
-                (currentEntry.destination as ComposeNavigator.Destination).content(
-                    this,
-                    currentEntry
-                )
-            }
+                val destination = (currentEntry.destination as ComposeNavigator.Destination)
+                if (drawOnBottomEntryDuringAnimation == null) {
+                    destination.content(this, currentEntry)
+                } else {
+                    Box {
+                        with(this@AnimatedContent) {
+                            destination.content(this, currentEntry)
+                        }
 
-            if (currentEntry != null && drawOnBottomEntryDuringAnimation != null) {
-                val currentEntryId = currentEntry.id
-                val initialEntryId = transition.segment.initialState.id
-                val targetEntryId = transition.segment.targetState.id
-                if (
-                    zIndices.contains(currentEntryId) &&
-                    zIndices.contains(initialEntryId) &&
-                    zIndices.contains(targetEntryId)
-                ) {
-                    val currentEntryZ = zIndices[currentEntryId]
-                    val initialEntryZ = zIndices[initialEntryId]
-                    val targetEntryZ = zIndices[targetEntryId]
-                    val isDrawBehind = currentEntryZ < initialEntryZ || currentEntryZ < targetEntryZ
-                    if (isDrawBehind) {
-                        val isGoBack = currentEntryZ == targetEntryZ
-                        drawOnBottomEntryDuringAnimation(isGoBack, transitionState.fraction)
+                        val currentEntryId = currentEntry.id
+                        val initialEntryId = transition.segment.initialState.id
+                        val targetEntryId = transition.segment.targetState.id
+                        if (
+                            zIndices.contains(currentEntryId) &&
+                            zIndices.contains(initialEntryId) &&
+                            zIndices.contains(targetEntryId)
+                        ) {
+                            val currentEntryZ = zIndices[currentEntryId]
+                            val initialEntryZ = zIndices[initialEntryId]
+                            val targetEntryZ = zIndices[targetEntryId]
+                            val isDrawBehind =
+                                currentEntryZ < initialEntryZ || currentEntryZ < targetEntryZ
+                            if (isDrawBehind) {
+                                val isGoBack = currentEntryZ == targetEntryZ
+                                drawOnBottomEntryDuringAnimation(isGoBack, transitionState.fraction)
+                            }
+                        }
                     }
                 }
             }

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
@@ -21,17 +21,15 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.SizeTransform
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.backhandler.BackEventCompat
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavGraph
@@ -58,16 +56,11 @@ actual fun NavHost(
         sizeTransform == DefaultNavTransitions.sizeTransform
 
     if (isDefaultTransition) {
-        val iosBlackout = @Composable { isBackAnimation: Boolean, progress: Float ->
+        val iosBlackout = @Composable fun BoxScope.(isBackAnimation: Boolean, progress: Float) {
             val blackoutFraction = if (isBackAnimation) 1 - progress else progress
             Box(
                 modifier = Modifier
-                    .layout { m, c ->
-                        val placeable = m.measure(
-                            Constraints.fixed(c.maxWidth, c.maxHeight)
-                        )
-                        layout(c.minWidth, c.minHeight) { placeable.place(0, 0) }
-                    }
+                    .matchParentSize()
                     .drawBehind {
                         drawRect(Color.Black, alpha = 0.106f * blackoutFraction)
                     }
@@ -106,7 +99,4 @@ actual fun NavHost(
             null
         )
     }
-
-
-
 }


### PR DESCRIPTION
It fixes a crash when NavHost is located inside a scrollable container and there is no available max size.

The reason is an additional iOS blackout layer.
Simple reproducer:
```kotlin
Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
  NavHost(...)
}
```
Inside the `verticalScroll` it is not possible to measure constrains:
```kotlin
.layout { m, c ->
  val placeable = m.measure(Constraints.fixed(c.maxWidth, c.maxHeight)
  layout(c.minWidth, c.minHeight) { placeable.place(0, 0) }
}
```

So, I wrapped the screen content in an additional Box and use `matchParentSize()` modifier now.

Fixes https://youtrack.jetbrains.com/issue/CMP-8233

## Release Notes
### Fixes - Navigation
- Fix a crash on iOS when a `NavHost` is located in a scrollable container
