### PR TITLE
Report AccessibleRole.SLIDER for Slider

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -119,7 +119,7 @@ internal class AccessibilityController(
                     SemanticsProperties.TextSelectionRange -> {
                         component.composeAccessibleContext.firePropertyChange(
                             ACCESSIBLE_CARET_PROPERTY,
-                            prev, (entry.value as TextRange).start
+                            (prev as? TextRange)?.start, (entry.value as TextRange).start
                         )
                     }
 
@@ -157,7 +157,7 @@ internal class AccessibilityController(
                         val value = entry.value as ProgressBarRangeInfo
                         component.composeAccessibleContext.firePropertyChange(
                             ACCESSIBLE_VALUE_PROPERTY,
-                            prev,
+                            (prev as? ProgressBarRangeInfo)?.current,
                             value.current
                         )
                     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -46,7 +46,7 @@ import java.awt.FontMetrics
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.event.FocusListener
-import java.util.Locale
+import java.util.*
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleAction
 import javax.accessibility.AccessibleComponent
@@ -61,10 +61,10 @@ import javax.accessibility.AccessibleText
 import javax.accessibility.AccessibleTextSequence
 import javax.accessibility.AccessibleValue
 import javax.swing.text.AttributeSet
-import kotlin.math.roundToInt
-import org.jetbrains.skia.BreakIterator
 import javax.swing.text.SimpleAttributeSet
+import kotlin.math.roundToInt
 import kotlinx.atomicfu.atomic
+import org.jetbrains.skia.BreakIterator
 import org.jetbrains.skiko.nativeInitializeAccessible
 
 private fun <T> SemanticsConfiguration.getFirstOrNull(key: SemanticsPropertyKey<List<T>>): T? {
@@ -432,7 +432,12 @@ internal class ComposeAccessible(
                 scrollBy != null -> AccessibleRole.SCROLL_PANE
                 setText != null -> AccessibleRole.TEXT
                 text != null -> AccessibleRole.LABEL
-                progressBarRangeInfo != null -> AccessibleRole.PROGRESS_BAR
+                progressBarRangeInfo != null -> {
+                    if (semanticsConfig.getOrNull(SemanticsActions.SetProgress) != null)
+                        AccessibleRole.SLIDER
+                    else
+                        AccessibleRole.PROGRESS_BAR
+                }
                 isContainer != null -> AccessibleRole.GROUP_BOX
                 isTraversalGroup != null -> AccessibleRole.GROUP_BOX
                 else -> AccessibleRole.UNKNOWN
@@ -482,6 +487,11 @@ internal class ComposeAccessible(
                         if (selected == true)
                             add(AccessibleState.SELECTED)
                     }
+                }
+
+                if (accessibleRole.let { it == AccessibleRole.SLIDER || it == AccessibleRole.PROGRESS_BAR }) {
+                    // Without this, VoiceOver says "Circular Slider".
+                    add(AccessibleState.HORIZONTAL)
                 }
             }
         }


### PR DESCRIPTION
For nodes with `SemanticsProperties.ProgressBarRangeInfo` that also have a `SemanticsActions.SetProgress` report AWT role as `AccessibleRole.SLIDER`. This indicates to accessibility (specifically VoiceOver) that it should announce the value on every change.

Fixes https://youtrack.jetbrains.com/issue/CMP-8309

## Testing
Tested manually with
```
fun main() = singleWindowApplication {
    Column(
        Modifier.fillMaxSize(),
        horizontalAlignment = Alignment.CenterHorizontally,
        verticalArrangement = Arrangement.Center
    ) {

        var value by remember { mutableStateOf(42f) }
        Slider(
            value = value,
            onValueChange = { value = it },
            valueRange = 0f..100f,
            modifier = Modifier.size(200.dp, 50.dp)
        )

        Spacer(Modifier.height(24.dp))

        LinearProgressIndicator(
            progress = value / 100f,
            modifier = Modifier.width(200.dp)
        )
    }
}
```

This could be tested by QA

## Release Notes
### Fixes - Desktop
- [Accessibility, macOS] Fixed VoiceOver to announce a Slider's value on every change.
