### PR TITLE
Update wasm Demo and js Demo run configurations

### DIFF
--- a/.run/mpp/demo/js-Demo.run.xml
+++ b/.run/mpp/demo/js-Demo.run.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="jsRun" />
+          <option value="jsBrowserDevelopmentRun" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.run/mpp/demo/wasm-Demo.run.xml
+++ b/.run/mpp/demo/wasm-Demo.run.xml
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="wasmJsBrowserRun" />
+          <option value="wasmJsBrowserDevelopmentRun" />
         </list>
       </option>
       <option name="vmOptions" />


### PR DESCRIPTION
After an update to kotlin 2.1.21 the previous task names became ambiguous, so we specify it preciesly now.



## Testing
N/A

## Release Notes
N/A