### PR TITLE
[Cherry-pick] Fix caret placement near complex unicode glyphs with non-spacing marks

### DIFF
--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/CharHelpers.jvm.kt
@@ -38,6 +38,9 @@ internal actual fun CodePoint.isNeutralDirection(): Boolean =
         else -> false
     }
 
+internal actual fun CodePoint.isNonSpacingMark(): Boolean =
+    getDirectionality() == CharDirectionality.NONSPACING_MARK
+
 /**
  * Get the Unicode directionality of a character.
  */

--- a/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/CharHelpers.native.kt
+++ b/compose/ui/ui-text/src/jsNativeMain/kotlin/androidx/compose/ui/text/CharHelpers.native.kt
@@ -40,3 +40,6 @@ internal actual fun CodePoint.isNeutralDirection(): Boolean =
 
         else -> false
     }
+
+internal actual fun CodePoint.isNonSpacingMark(): Boolean =
+    CharDirection.of(this) == CharDirection.DIR_NON_SPACING_MARK

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/CharHelpers.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/CharHelpers.skiko.kt
@@ -72,6 +72,7 @@ internal fun CodePoint.isSupplementaryCodePoint(): Boolean =
 
 internal expect fun CodePoint.strongDirectionType(): StrongDirectionType
 internal expect fun CodePoint.isNeutralDirection(): Boolean
+internal expect fun CodePoint.isNonSpacingMark(): Boolean
 
 /**
  * Determine direction based on the first strong directional character.

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -392,7 +392,26 @@ internal class SkiaParagraph(
         }
 
     override fun getOffsetForPosition(position: Offset): Int {
-        val glyphPosition = paragraph.getGlyphPositionAtCoordinate(position.x, position.y).position
+        val initialGlyphPosition = paragraph.getGlyphPositionAtCoordinate(position.x, position.y).position
+
+        // Check if the position is inside a complex character with non-spacing marks
+        // If it is, adjust the position to the next possible space
+        var glyphPosition = initialGlyphPosition
+        if (glyphPosition in 0 until text.length) {
+            // Check if the current position has a non-spacing mark
+            val isNonSpacingMark = text.codePointAt(glyphPosition).isNonSpacingMark()
+
+            if (isNonSpacingMark) {
+                // Find the boundaries of the complex character
+                val precedingBreak = text.findPrecedingBreak(glyphPosition)
+                val followingBreak = text.findFollowingBreak(glyphPosition)
+
+                // If we're inside a complex character, jump to the end of it
+                if (precedingBreak != glyphPosition && followingBreak != glyphPosition) {
+                    glyphPosition = followingBreak
+                }
+            }
+        }
 
         // Below we apply a workaround for skiko/skia issue:
         //
@@ -436,6 +455,23 @@ internal class SkiaParagraph(
         val rightX = rects?.lastOrNull()?.rect?.right ?: expectedLine.right.toFloat()
 
         if (leftX == rightX) {
+            return glyphPosition
+        }
+
+        // Check if the last character of the line is a non-spacing mark
+        val hasNonSpacingMarkAtEnd = if (isNotEmptyLine && expectedLine.endExcludingWhitespaces > 0) {
+            val lastCharIndex = expectedLine.endExcludingWhitespaces - 1
+            if (lastCharIndex >= 0 && lastCharIndex < text.length) {
+                text.codePointAt(lastCharIndex).isNonSpacingMark()
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+
+        // If the line ends with a non-spacing mark, don't apply the workaround
+        if (hasNonSpacingMarkAtEnd) {
             return glyphPosition
         }
 

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.text
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
@@ -25,6 +26,7 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
 
 // Adopted tests from text/text/src/androidTest/java/androidx/compose/ui/text/android/selection/WordBoundaryTest.kt
 class SkikoParagraphTest {
@@ -375,6 +377,49 @@ class SkikoParagraphTest {
         val paragraph = simpleParagraph("", TextStyle(textAlign = TextAlign.End))
         val cursorHorizontalPosition = paragraph.getHorizontalPosition(0, false)
         assertEquals(maxWidthConstraint.toFloat(), cursorHorizontalPosition)
+    }
+
+    @Test
+    fun getOffsetForPosition_insideComplexCharacter_shouldJumpToEnd() {
+        val text = "abc\u0915\u094D abc" // "abcक् abc"
+        val paragraph = simpleParagraph(text)
+
+        val complexCharStart = 3 // Index of 'क'
+        val complexCharBox = paragraph.getBoundingBox(complexCharStart)
+
+        // Try to position the caret inside the complex character
+        val insideOffset =
+            Offset(complexCharBox.left + complexCharBox.width / 2, complexCharBox.center.y)
+        val position = paragraph.getOffsetForPosition(insideOffset)
+
+        assertEquals(
+            5, // after 'क्'
+            position,
+            message = "The position should be at the end of the complex character, not inside it"
+        )
+    }
+
+    /**
+     * Test that the caret can be placed at the end of a line when a complex character
+     * is the last character in the line.
+     */
+    @Test
+    fun getOffsetForPosition_endOfLineWithComplexCharacter_shouldPositionCorrectly() {
+        val text = "abc\u0915\u094D" // "abcक्"
+        val paragraph = simpleParagraph(text)
+
+        val complexCharStart = 3
+        val complexCharBox = paragraph.getBoundingBox(complexCharStart)
+
+        val afterOffset = Offset(complexCharBox.right + 5, complexCharBox.center.y)
+        val position = paragraph.getOffsetForPosition(afterOffset)
+
+
+        assertEquals(
+            5,
+            position,
+            message = "The position should be at the end of the text"
+        )
     }
 
 


### PR DESCRIPTION
Added check for a non-space mark in the getOffsetByPosition, which is being used to determine caret position in text.
There were two problems: it was possible to manually place the caret between parts of complex glyph, and layout calculation incorrectly worked with non-space marks at the end of the line, placing the caret between parts of the symbol.

Fixes: https://youtrack.jetbrains.com/issue/CMP-8054/

## Testing
This should be tested by QA

The test case is available on the related issue for iOS

Additional test case: try to click right at the `क्` character (or move the caret by long-tap), and try to type. This symbol shouldn't be divided by typed text

## Release Notes
### Fixes - Multiple Platforms
Fixed caret placement near glyphs if glyphs are compound symbols and part of them are non-spacing marks