### PR TITLE
Cherry pick a deadlock fix in Recomposer

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
@@ -433,14 +433,15 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
      * @return `true` if the frame has work to do (e.g. [hasFrameWorkLocked])
      */
     private fun recordComposerModifications(): Boolean {
+        var compositions: List<ControlledComposition> = emptyList()
         val changes =
             synchronized(stateLock) {
                 if (snapshotInvalidations.isEmpty()) return hasFrameWorkLocked
+                compositions = knownCompositionsLocked()
                 snapshotInvalidations.wrapIntoSet().also {
                     snapshotInvalidations = MutableScatterSet()
                 }
             }
-        val compositions = knownCompositions()
         var complete = false
         try {
             run {
@@ -452,7 +453,6 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
                     if (_state.value <= State.ShuttingDown) return@run
                 }
             }
-            synchronized(stateLock) { snapshotInvalidations = MutableScatterSet() }
             complete = true
         } finally {
             if (!complete) {

--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/Recomposer.kt
@@ -215,17 +215,6 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
     private var closeCause: Throwable? = null
     private val _knownCompositions = mutableListOf<ControlledComposition>()
     private var _knownCompositionsCache: List<ControlledComposition>? = null
-    private val knownCompositions
-        get() =
-            _knownCompositionsCache
-                ?: run {
-                    val compositions = _knownCompositions
-                    val newCache =
-                        if (compositions.isEmpty()) emptyList() else ArrayList(compositions)
-                    _knownCompositionsCache = newCache
-                    newCache
-                }
-
     private var snapshotInvalidations = MutableScatterSet<Any>()
     private val compositionInvalidations = mutableVectorOf<ControlledComposition>()
     private val compositionsAwaitingApply = mutableListOf<ControlledComposition>()
@@ -390,16 +379,14 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
             get() = synchronized(stateLock) { this@Recomposer.errorState }
 
         fun invalidateGroupsWithKey(key: Int) {
-            val compositions: List<ControlledComposition> =
-                synchronized(stateLock) { knownCompositions }
+            val compositions: List<ControlledComposition> = knownCompositions()
             compositions
                 .fastMapNotNull { it as? CompositionImpl }
                 .fastForEach { it.invalidateGroupsWithKey(key) }
         }
 
         fun saveStateAndDisposeForHotReload(): List<HotReloadable> {
-            val compositions: List<ControlledComposition> =
-                synchronized(stateLock) { knownCompositions }
+            val compositions: List<ControlledComposition> = knownCompositions()
             return compositions
                 .fastMapNotNull { it as? CompositionImpl }
                 .fastMap { HotReloadable(it).apply { clearContent() } }
@@ -453,7 +440,7 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
                     snapshotInvalidations = MutableScatterSet()
                 }
             }
-        val compositions = synchronized(stateLock) { knownCompositions }
+        val compositions = knownCompositions()
         var complete = false
         try {
             run {
@@ -494,7 +481,7 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
                 }
                 .wrapIntoSet()
         if (changes.isNotEmpty()) {
-            knownCompositions.fastForEach { composition ->
+            knownCompositionsLocked().fastForEach { composition ->
                 composition.recordModificationsOf(changes)
             }
         }
@@ -634,7 +621,7 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
                         // composition that was otherwise valid.
                         if (modifiedValues.isNotEmpty() || compositionInvalidations.isNotEmpty()) {
                             synchronized(stateLock) {
-                                knownCompositions.fastForEach { value ->
+                                knownCompositionsLocked().fastForEach { value ->
                                     if (
                                         value !in alreadyComposed &&
                                             value.observesAnyOf(modifiedValuesSet)
@@ -782,10 +769,28 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
         }
     }
 
+    /**
+     * Returns a cached copy of the list of known compositions that can be iterated safely without
+     * holding the `stateLock`.
+     */
+    private fun knownCompositions(): List<ControlledComposition> {
+        return synchronized(stateLock) { knownCompositionsLocked() }
+    }
+
+    private fun knownCompositionsLocked(): List<ControlledComposition> {
+        val cache = _knownCompositionsCache
+        if (cache != null) return cache
+
+        val compositions = _knownCompositions
+        val newCache = if (compositions.isEmpty()) emptyList() else ArrayList(compositions)
+        _knownCompositionsCache = newCache
+        return newCache
+    }
+
     @OptIn(ExperimentalComposeRuntimeApi::class)
     private fun clearKnownCompositionsLocked() {
         registrationObservers?.forEach { observer ->
-            knownCompositions.forEach { composition ->
+            knownCompositionsLocked().forEach { composition ->
                 observer.onCompositionUnregistered(this, composition)
             }
         }
@@ -1067,7 +1072,7 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
             try {
                 // Invalidate all registered composers when we start since we weren't observing
                 // snapshot changes on their behalf. Assume anything could have changed.
-                synchronized(stateLock) { knownCompositions }.fastForEach { it.invalidateAll() }
+                knownCompositions().fastForEach { it.invalidateAll() }
 
                 coroutineScope { block(parentFrameClock) }
             } finally {
@@ -1142,7 +1147,7 @@ class Recomposer(effectCoroutineContext: CoroutineContext) : CompositionContext(
 
         synchronized(stateLock) {
             if (_state.value > State.ShuttingDown) {
-                if (composition !in knownCompositions) {
+                if (composition !in knownCompositionsLocked()) {
                     addKnownCompositionLocked(composition)
                 }
             }


### PR DESCRIPTION
Cherry-pick these CLs from AOSP:
https://android-review.googlesource.com/c/platform/frameworks/support/+/3638708
https://android-review.googlesource.com/c/platform/frameworks/support/+/3638709

Fixes https://youtrack.jetbrains.com/issue/CMP-8239/Cherry-pick-changes-in-Recomposer-to-fix-race-condition-causing-missing-snapshot-invalidations

## Release Notes
N/A