### PR TITLE
In InputMethodSession.getTextLocation, scale focusRect size according to density too

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.awt
 
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntRect
@@ -45,17 +46,37 @@ internal fun Component.isParentOf(component: Component?): Boolean {
     return false
 }
 
-internal fun IntRect.toAwtRectangle(density: Density): Rectangle {
-    val left = floor(left / density.density).toInt()
-    val top = floor(top / density.density).toInt()
-    val right = ceil(right / density.density).toInt()
-    val bottom = ceil(bottom / density.density).toInt()
-    val width = right - left
-    val height = bottom - top
-    return Rectangle(
-        left, top, width, height
-    )
+internal fun toAwtRectangle(
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float,
+    density: Float
+): Rectangle {
+    val rleft = floor(left / density).toInt()
+    val rtop = floor(top / density).toInt()
+    val rright = ceil(right / density).toInt()
+    val rbottom = ceil(bottom / density).toInt()
+    val rwidth = rright - rleft
+    val rheight = rbottom - rtop
+    return Rectangle(rleft, rtop, rwidth, rheight)
 }
+
+internal fun IntRect.toAwtRectangle(density: Density = Density(1f)) = toAwtRectangle(
+    left = left.toFloat(),
+    top = top.toFloat(),
+    right = right.toFloat(),
+    bottom = bottom.toFloat(),
+    density = density.density
+)
+
+internal fun Rect.toAwtRectangle(density: Density) = toAwtRectangle(
+    left = left,
+    top = top,
+    right = right,
+    bottom = bottom,
+    density = density.density
+)
 
 internal fun Color.toAwtColor() = java.awt.Color(red, green, blue, alpha)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.ui.awt.toAwtRectangle
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.ImeOptions
@@ -147,13 +148,13 @@ private class InputMethodRequestsImpl(
     }
 
     override fun getTextLocation(offset: TextHitInfo?): Rectangle? {
-        return focusedRect?.let {
-            val x = (it.right / component.density.density).toInt() +
-                component.locationOnScreen.x
-            val y = (it.top / component.density.density).toInt() +
-                component.locationOnScreen.y
-            Rectangle(x, y, it.width.toInt(), it.height.toInt())
-        }
+        val awtRect = focusedRect?.let {
+            it.copy(left = it.right).toAwtRectangle(component.density)
+        } ?: return null
+
+        val locationOnScreen = component.locationOnScreen
+        awtRect.translate(locationOnScreen.x, locationOnScreen.y)
+        return awtRect
     }
 
     override fun getCommittedText(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -170,7 +170,9 @@ open class BaseWindowTextFieldTest {
                     val focusRequester = FocusRequester()
                     BasicTextField(
                         value = textFieldValue,
-                        onValueChange = { textFieldValue = it },
+                        onValueChange = {
+                            textFieldValue = it
+                        },
                         modifier = Modifier.focusRequester(focusRequester)
                     )
 


### PR DESCRIPTION
**This is a cherry-pick of https://github.com/JetBrains/compose-multiplatform-core/pull/2118 into `release/1.8`.**

The `focusRect` size needs to be scaled according to the density, too.

Fixes https://youtrack.jetbrains.com/issue/CMP-8176/Input-Method-toolbar-too-far-from-text

## Testing
Tested manually with
```
TextField(
    state = rememberTextFieldState(""),
    textStyle = LocalTextStyle.current.copy(fontSize = 64.sp),
)
```

This could be tested by QA

## Release Notes
### Fixes - Desktop
- Fix the positioning of the IME popup being too far away from the text, on screens with density greater than `1.0`.
