### PR TITLE
When the window is not yet showing, return Offset.Unspecified when converting to/from screen coordinates.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -72,11 +72,15 @@ internal class PlatformWindowContext {
     fun convertWindowToLocalPosition(container: Component, positionInWindow: Offset) =
         positionInWindow - offsetInWindow(container).toOffset(container.density)
 
-    fun convertLocalToScreenPosition(container: Component, localPosition: Offset): Offset =
-        localPosition + container.locationOnScreen.toOffset(container.density)
+    fun convertLocalToScreenPosition(container: Component, localPosition: Offset): Offset {
+        if (!container.isShowing) return Offset.Unspecified
+        return localPosition + container.locationOnScreen.toOffset(container.density)
+    }
 
-    fun convertScreenToLocalPosition(container: Component, positionOnScreen: Offset): Offset =
-        positionOnScreen - container.locationOnScreen.toOffset(container.density)
+    fun convertScreenToLocalPosition(container: Component, positionOnScreen: Offset): Offset {
+        if (!container.isShowing) return Offset.Unspecified
+        return positionOnScreen - container.locationOnScreen.toOffset(container.density)
+    }
 
     /**
      * Calculates the offset of the given [container] within the window.
@@ -94,7 +98,7 @@ internal class PlatformWindowContext {
     }
 }
 
-private fun Point.toOffset(density: Density): Offset {
+internal fun Point.toOffset(density: Density): Offset {
     val scale = density.density
     return Offset(
         x = x * scale,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
@@ -30,6 +30,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionOnScreen
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
@@ -146,5 +149,25 @@ class ApplicationTest {
 
         awaitIdle()
         assertThat(windowClock).isNotEqualTo(appClock)
+    }
+
+    @Test
+    fun `retrieving screen location immediately does not crash`() = runApplicationTest {
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                Box(
+                    Modifier
+                        .size(100.dp)
+                        .onGloballyPositioned {
+                            it.positionOnScreen()
+                        }
+                        .onPlaced {
+                            it.positionOnScreen()
+                        }
+                )
+            }
+        }
+
+        awaitIdle()
     }
 }


### PR DESCRIPTION
When the window is not shown, `Component.getLocationOnScreen` throws an exception, causing e.g.
```
Modifier.onGloballyPositioned { it.positionOnScreen() }
```
to crash.

Instead of throwing an exception, return `Offset.Unspecified`.

Fixes https://youtrack.jetbrains.com/issue/CMP-7380/Exception-Thrown-in-Desktop-Platform-Context-During-ModifierNode-Placed
Fixes https://youtrack.jetbrains.com/issue/CMP-8323/Material3-Modifier.badgeBounds-crashes-in-1.9.0-alpha01

## Testing
Tested manually, and added a unit test.

## Release Notes
### Fixes - Desktop
- Return `Offset.Unspecified` instead of throwing an exception in `LayoutCoordinates.localToScreen` and `LayoutCoordinates.screenToLocal`.
