### PR TITLE
Remove a debug `println` in `InputMethodSession.getTextLocation`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -168,7 +168,6 @@ private class InputMethodSession(
 
     override fun getTextLocation(offset: TextHitInfo?): Rectangle? {
         val awtRect = request.focusedRectInRoot()?.let {
-            println("focusedRect: $it")
             val centerX = it.topCenter.x
             it.copy(left = centerX, right = centerX).toAwtRectangleRounded(component.density)
         } ?: return null


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

Fixes https://youtrack.jetbrains.com/issue/CMP-8335

## Testing
No testing required.

## Release Notes
N/A