### PR TITLE
Set ComposeFoundationFlags.isNewContextMenuEnabled=false

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ComposeFoundationFlags.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ComposeFoundationFlags.kt
@@ -77,7 +77,8 @@ object ComposeFoundationFlags {
      * [BasicTextField][androidx.compose.foundation.text.BasicTextField]s. If false, the previous
      * context menu that has no public APIs will be used instead.
      */
-    @Suppress("MutableBareField") @JvmField var isNewContextMenuEnabled = true
+    // TODO: https://youtrack.jetbrains.com/issue/CMP-7757/Adopt-new-context-menu-API
+    @Suppress("MutableBareField") @JvmField var isNewContextMenuEnabled = false
 
     /**
      * Whether to use the new smart selection feature in

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.unit.sp
 import kotlin.math.pow
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
@@ -121,7 +120,6 @@ class BasicTextFieldSelectionHandleTest {
         )
     }
 
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8347
     @Test
     fun coreTextFieldSelectionHandles() = runSkikoComposeUiTest(size = Size(100f, 100f)) {
         val selection = TextRange(1, 3)


### PR DESCRIPTION
Until we've actually implemented the new context menus, disable them.

Fixes https://youtrack.jetbrains.com/issue/CMP-8347

## Testing
Re-enabled `BasicTextFieldSelectionHandleTest.coreTextFieldSelectionHandles`

## Release Notes
N/A