### PR TITLE
Don't call dispatchOnPositionedCallbacks if the actual position on screen has not changed.

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
@@ -264,4 +264,32 @@ class ApplicationTest {
         exitTestApplication()
     }
 
+    @Test
+    fun `onGloballyPositioned is not called repeatedly with same position on screen`() = runApplicationTest(useDelay = true) {
+        lateinit var window: ComposeWindow
+        val positionsOnScreen = mutableListOf<Offset>()
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                window = this@Window.window
+                Box(
+                    Modifier
+                        .size(100.dp)
+                        .onGloballyPositioned {
+                            positionsOnScreen.add(it.positionOnScreen())
+                        }
+                )
+            }
+        }
+        awaitIdle()
+
+        window.location = Point(window.x + 100, window.y + 100)
+        awaitIdle()
+
+        assertTrue(
+            positionsOnScreen.zipWithNext().none { it.first == it.second },
+            message = "onGloballyPositioned is called repeatedly with same positionOnScreen: $positionsOnScreen"
+        )
+    }
+
+
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -155,6 +155,7 @@ internal class RootNodeOwner(
     private val pointerInputEventProcessor = PointerInputEventProcessor(owner.root)
     private val measureAndLayoutDelegate = MeasureAndLayoutDelegate(owner.root)
     private var isDisposed = false
+    private var currentPositionOnScreen: Offset = positionOnScreen()
 
     init {
         snapshotObserver.startObserving()
@@ -219,8 +220,14 @@ internal class RootNodeOwner(
         onLightingInfoChanged()
     }
 
+    private fun positionOnScreen() = platformContext.convertLocalToScreenPosition(Offset.Zero) 
+
     fun invalidatePositionOnScreen() {
-        measureAndLayoutDelegate.dispatchOnPositionedCallbacks(forceDispatch = true)
+        val positionOnScreen = positionOnScreen()
+        if (positionOnScreen != currentPositionOnScreen) {
+            measureAndLayoutDelegate.dispatchOnPositionedCallbacks(forceDispatch = true)
+            currentPositionOnScreen = positionOnScreen
+        }
     }
 
     fun draw(canvas: Canvas) = trace("RootNodeOwner:draw") {


### PR DESCRIPTION
Avoid calling `Modifier.onGloballyPositioned` repeatedly when the actual position of the window has not changed.

## Testing
Added a new unit test.

## Release Notes
N/A