### PR TITLE
Implement ContextMenuArea for BTF2

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -27,13 +27,16 @@ import androidx.compose.foundation.LocalContextMenuRepresentation
 import androidx.compose.foundation.contextMenuOpenDetector
 import androidx.compose.foundation.internal.nativeClipboardHasText
 import androidx.compose.foundation.text.TextContextMenu.TextManager
+import androidx.compose.foundation.text.input.getSelectedText
 import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState
+import androidx.compose.foundation.text.selection.SelectionAdjustment
 import androidx.compose.foundation.text.selection.SelectionManager
 import androidx.compose.foundation.text.selection.TextFieldSelectionManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
@@ -46,6 +49,9 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.getSelectedText
 import java.awt.Component
 import javax.swing.JPopupMenu
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -64,8 +70,17 @@ internal actual fun ContextMenuArea(
     enabled: Boolean,
     content: @Composable () -> Unit
 ) {
-    // TODO: Implement merged from Compose 1.7.0 overload
-    content()
+    if (!enabled) {
+        content()
+        return
+    }
+
+    val state = remember { ContextMenuState() }
+    val coroutineScope = rememberCoroutineScope()
+    val textManager = remember(selectionState, coroutineScope) {
+        selectionState.textManager(coroutineScope)
+    }
+    LocalTextContextMenu.current.Area(textManager, state, content)
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -127,6 +142,56 @@ private val TextFieldSelectionManager.textManager: TextManager get() = object : 
 
     override fun selectWordAtPositionIfNotAlreadySelected(offset: Offset) {
         this@textManager.selectWordAtPositionIfNotAlreadySelected(offset)
+    }
+}
+
+private fun TextFieldSelectionState.textManager(coroutineScope: CoroutineScope): TextManager {
+    return object : TextManager {
+
+        override val selectedText
+            get() = AnnotatedString(textFieldState.visualText.getSelectedText().toString())
+
+        private fun launchUndispatched(block: suspend CoroutineScope.() -> Unit) {
+            coroutineScope.launch(start = CoroutineStart.UNDISPATCHED, block = block)
+        }
+
+        private fun cutImpl() = launchUndispatched { cut() }
+
+        private fun copyImpl() = launchUndispatched { copy() }
+
+        private fun pasteImpl() = launchUndispatched { paste() }
+
+        override val cut: (() -> Unit)?
+            get() = if (canCut()) ::cutImpl else null
+
+        override val copy: (() -> Unit)?
+            get() = if (canCopy()) ::copyImpl else null
+
+        override val paste: (() -> Unit)?
+            get() {
+                launchUndispatched { updateClipboardEntry() }
+                return if (canPaste()) ::pasteImpl else null
+            }
+
+        override val selectAll: (() -> Unit)?
+            get() = if (canSelectAll()) ::selectAll else null
+
+        override fun selectWordAtPositionIfNotAlreadySelected(offset: Offset) {
+            if (!textLayoutState.isPositionOnText(offset)) return
+            val index = textLayoutState.getOffsetForPosition(offset, coerceInVisibleBounds = false)
+            if (index == -1) return
+
+            if (index !in textFieldState.visualText.selection) {
+                val selection = updateSelection(
+                    textFieldCharSequence = textFieldState.visualText,
+                    startOffset = index,
+                    endOffset = index,
+                    isStartHandle = false,
+                    adjustment = SelectionAdjustment.Word,
+                )
+                textFieldState.selectCharsIn(selection)
+            }
+        }
     }
 }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -17,9 +17,9 @@
 package androidx.compose.foundation
 
 import androidx.compose.foundation.copyPasteAndroidTests.lazy.list.assertIsNotPlaced
-import androidx.compose.foundation.internal.toClipEntry
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -28,9 +28,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
-import androidx.compose.ui.platform.ClipboardManager
 import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalLocalization
 import androidx.compose.ui.platform.NativeClipboard
 import androidx.compose.ui.platform.PlatformLocalization
@@ -46,7 +44,6 @@ import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import java.awt.datatransfer.StringSelection
 import kotlin.test.assertEquals
@@ -96,9 +93,19 @@ class ContextMenuTest {
         assertEquals(1, childrenCount)
     }
 
-    // https://youtrack.jetbrains.com/issue/CMP-7083/Context-menu-on-desktop-shows-incorrect-items-after-the-second-showing
     @Test
-    fun `different items for different selections in textfield`() = runContextMenuTest {
+    fun `different items for different selections in btf`() =
+        `different items for different selections in textfield`(useBtf2 = false)
+
+    @Test
+    fun `different items for different selections in btf2`() =
+        `different items for different selections in textfield`(useBtf2 = true)
+
+
+    // https://youtrack.jetbrains.com/issue/CMP-7083/Context-menu-on-desktop-shows-incorrect-items-after-the-second-showing
+    private fun `different items for different selections in textfield`(
+        useBtf2: Boolean
+    ) = runContextMenuTest {
         val localization = object : PlatformLocalization {
             override val copy = "copy"
             override val cut = "cut"
@@ -131,7 +138,11 @@ class ContextMenuTest {
                 LocalLocalization provides localization,
                 LocalClipboard provides clipboard
             ) {
-                BasicTextField("Text", {}, Modifier.testTag("textfield"))
+                if (useBtf2) {
+                    BasicTextField(rememberTextFieldState("Text"), Modifier.testTag("textfield"))
+                } else {
+                    BasicTextField("Text", {}, Modifier.testTag("textfield"))
+                }
             }
         }
 


### PR DESCRIPTION
Implement ContextMenuArea for `BasicTextField(TextFieldState)` (aka BTF2).

Fixes https://youtrack.jetbrains.com/issue/CMP-8332/State-based-BasicTextField-is-missing-context-menu-on-desktop

## Testing
Run `different items for different selections in textfield` on both kinds of text fields.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Implemented a context menu for `BasicTextField(TextFieldState)`
