### PR TITLE
Revert localToWindow conversion in CfW and position interop container exactly at Canvas' position

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.wasmJs.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.wasmJs.kt
@@ -54,9 +54,16 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
         interopContainer = interopContainer,
         interopWrapper =
             (document.createElement("div") as HTMLDivElement)
-                .apply { style.position = "absolute" },
+                .apply {
+                    style.position = "absolute"
+                    // hide it until it's properly positioned,
+                    // otherwise it can briefly flash at 0,0
+                    toggleVisibility(this, isHidden = true)
+                },
         compositeKeyHash = compositeKeyHash
     )
+
+    private var isPositioned = false
 
     private var isHidden: Boolean = false
 
@@ -88,14 +95,18 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
         if (!clippedRect.isEmpty) {
             setSizeAndPosition(
                 interopWrapper,
-                newPosition.x.toDouble(),
-                newPosition.y.toDouble(),
+                newPosition.x.toDouble() / density.density,
+                newPosition.y.toDouble() / density.density,
                 unclippedRect.width,
                 unclippedRect.height
             )
             updateClipPath(clippedRect, unclippedRect)
+            if (!isPositioned) {
+                isPositioned = true
+                toggleVisibility(interopWrapper, isHidden = false)
+            }
         } else if (!isHidden) {
-            toggleVisibility(interopWrapper, true)
+            toggleVisibility(interopWrapper, isHidden = true)
             isHidden = true
         }
     }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -89,6 +89,7 @@ import org.jetbrains.skiko.SkikoRenderDelegate
 import org.w3c.dom.AddEventListenerOptions
 import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
+import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.HTMLTitleElement
@@ -176,6 +177,7 @@ internal class DefaultWindowState(private val viewportContainer: Element) : Comp
 @OptIn(InternalComposeApi::class)
 internal class ComposeWindow(
     private val canvas: HTMLCanvasElement,
+    private val interopContainerElement: HTMLDivElement,
     content: @Composable () -> Unit,
     private val state: ComposeWindowState
 ) : LifecycleOwner, ViewModelStoreOwner {
@@ -210,19 +212,23 @@ internal class ComposeWindow(
             }
         }
 
+        @Suppress("RedundantOverride")
         override fun convertLocalToWindowPosition(localPosition: Offset): Offset {
-            val (canvasX, canvasY) = getCanvasCoordinates()
-            return Offset(
-                x = (canvasX + localPosition.x / density.density).toFloat(),
-                y = (canvasY + localPosition.y / density.density).toFloat()
-            )
+            // TODO (o.karpovich): Currently, CfW uses AttachedComposeSceneLayer, so
+            // Window Rect == Canvas Rect, although a canvas might take only a portion of the browser's
+            // viewport: Window Rect > Canvas Rect.
+            // Update this implementation when implementing https://youtrack.jetbrains.com/issue/CMP-8359
+            // The implementation will have to rely on the <canvas> of a particular layer.
+            return super.convertLocalToWindowPosition(localPosition)
         }
 
+        @Suppress("RedundantOverride")
         override fun convertWindowToLocalPosition(positionInWindow: Offset): Offset {
-            val (canvasX, canvasY) = getCanvasCoordinates()
-            val localX = (positionInWindow.x - canvasX) * density.density
-            val localY = (positionInWindow.y - canvasY) * density.density
-            return Offset(x = localX.toFloat(), y = localY.toFloat())
+            // TODO (o.karpovich): Currently, CfW uses AttachedComposeSceneLayer, so
+            // Window Rect == Canvas Rect, although a canvas might take only a portion of the browser's
+            // viewport: Window Rect > Canvas Rect.
+            // Update this implementation when implementing https://youtrack.jetbrains.com/issue/CMP-8359
+            return super.convertWindowToLocalPosition(positionInWindow)
         }
 
         override val textInputService = object : WebTextInputService() {
@@ -382,8 +388,6 @@ internal class ComposeWindow(
 
         scene.density = density
 
-        val interopContainerElement = document.createElement("div") as HTMLElement
-        document.body!!.appendChild(interopContainerElement)
         val interopContainer = WebInteropContainer(InteropViewGroup(interopContainerElement))
 
         scene.setContent {
@@ -586,6 +590,7 @@ private const val defaultCanvasElementId = "ComposeTarget"
  * This can be turned off by setting [applyDefaultStyles] to false.
  */
 @ExperimentalComposeUiApi
+@Deprecated("CanvasBasedWindow doesn't support HTML interop via WebElementView API. Use ComposeViewport API instead")
 fun CanvasBasedWindow(
     title: String? = null,
     canvasElementId: String = defaultCanvasElementId,
@@ -619,6 +624,8 @@ fun CanvasBasedWindow(
 
     ComposeWindow(
         canvas = canvas,
+        // a detached container
+        interopContainerElement = document.createElement("div") as HTMLDivElement,
         content = content,
         state = if (requestResize == null) DefaultWindowState(document.documentElement!!) else ComposeWindowState.createFromLambda(requestResize)
     )
@@ -653,10 +660,29 @@ fun ComposeViewport(
     val canvas = document.createElement("canvas") as HTMLCanvasElement
     canvas.setAttribute("tabindex", "0")
 
-    viewportContainer.appendChild(canvas)
+    // Create a common container (parent html element) for canvas and the interop container
+    // to position at the same place - the interop container is position at 0,0 relative to <canvas>.
+    // It simplifies the positioning of the interop views in the container.
+    val layerRoot = document.createElement("div") as HTMLElement
+    layerRoot.style.apply {
+        position = "relative"
+    }
+
+    viewportContainer.appendChild(layerRoot)
+    layerRoot.appendChild(canvas)
+
+    val interopContainerElement = document.createElement("div") as HTMLDivElement
+    layerRoot.appendChild(interopContainerElement)
+
+    interopContainerElement.style.apply {
+        position = "absolute"
+        top = "0"
+        left = "0"
+    }
 
     ComposeWindow(
         canvas = canvas,
+        interopContainerElement = interopContainerElement,
         content = content,
         state = DefaultWindowState(viewportContainer)
     )

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -21,10 +21,12 @@ import androidx.compose.runtime.Recomposer
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.window.ComposeViewport
+import kotlin.coroutines.suspendCoroutine
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.browser.document
+import kotlinx.browser.window
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -74,8 +76,17 @@ internal interface OnCanvasTests {
         return canvas
     }
 
-    fun createComposeWindow(content: @Composable () -> Unit) {
+    suspend fun createComposeWindow(content: @Composable () -> Unit) {
         ComposeViewport(containerId, content = content)
+
+        suspendCoroutine { continuation ->
+            // This helps reduce the flakiness.
+            // A potential cause of flakiness: the default Coroutine Dispatcher regularly postpones
+            // the resumption of the tasks in its queue to the next frame.
+            // (it does so to let the event loop run / release the single thread)
+            // I don't expect any issue from doing this, since a test will suspend and won't do anything.
+            window.requestAnimationFrame { continuation.resumeWith(Result.success(it)) }
+        }
     }
 
     fun dispatchEvents(vararg events: Event) {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/ComposeWindowLifecycleTest.kt
@@ -29,7 +29,7 @@ import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.test.runTest
-
+import org.w3c.dom.HTMLDivElement
 
 class ComposeWindowLifecycleTest : OnCanvasTests {
     @Test
@@ -40,6 +40,7 @@ class ComposeWindowLifecycleTest : OnCanvasTests {
 
         val lifecycleOwner = ComposeWindow(
             canvas = canvas,
+            interopContainerElement = document.createElement("div") as HTMLDivElement,
             content = {},
             state = DefaultWindowState(document.documentElement!!)
         )

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/KeyEventTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/KeyEventTests.kt
@@ -39,11 +39,12 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
 
 class KeyEventTests : OnCanvasTests {
     @Test
     // https://github.com/JetBrains/compose-multiplatform/issues/3644
-    fun keyMappingIsValid() {
+    fun keyMappingIsValid() = runTest {
         val fr = FocusRequester()
         var mapping = ""
         var k: Key? = null
@@ -89,7 +90,7 @@ class KeyEventTests : OnCanvasTests {
 
     @Test
     // https://github.com/JetBrains/compose-multiplatform/issues/2296
-    fun onPreviewKeyEventShouldWork() {
+    fun onPreviewKeyEventShouldWork() = runTest {
 
         val fr = FocusRequester()
         val textValue = mutableStateOf("")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/PreventDefaultTest.kt
@@ -29,11 +29,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
 
 class PreventDefaultTest : OnCanvasTests {
 
     @Test
-    fun testPreventDefault() {
+    fun testPreventDefault() = runTest {
         val fr = FocusRequester()
         var changedValue = ""
         createComposeWindow {


### PR DESCRIPTION
- The new positioning of interop container required a change ComposeWindow initialization
- Updated the tests initialization a bit, since the initialization of ComposeWindow got a bit heavier

The revert of `localToWindow` conversion fixes a non-released bug with incorrect position of Popup layouts (such as selection handles). See the attached video - interop views are properly positioned and the handles are at correct position too.

https://github.com/user-attachments/assets/a1bfe04b-de1c-4087-8f67-83476b303d6a

## Release Notes
N/A


