### PR TITLE
Optimize some (fairly used) paths to use fast extension function

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/PointerMatcher.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastAny
 
 /**
  * [PointerMatcher] represents a single condition or a set of conditions which a [PointerEvent] has to match
@@ -100,7 +101,7 @@ fun interface PointerMatcher {
 
         private class CombinedPointerMatcher(val sources: List<PointerMatcher>) : PointerMatcher {
             override fun matches(event: PointerEvent): Boolean {
-                return sources.any { it.matches(event) }
+                return sources.fastAny { it.matches(event) }
             }
         }
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.ui.text
 
-import androidx.compose.ui.util.fastForEach
+
 import org.jetbrains.skiko.currentNanoTime
 
 // Extremely simple Cache interface which is enough for ui.text needs

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
@@ -55,11 +55,12 @@ internal class ExpireAfterAccessCache<K, V>(
 
     private fun checkEvicted(now: Long) {
         val expireTime = now - expireAfterNanos
-        accessTime.keys.takeWhile {
-            accessTime[it]!! < expireTime
-        }.fastForEach {
-            map.remove(it)
-            accessTime.remove(it)
+        val iterator = accessTime.entries.iterator()
+        for (entry in iterator) {
+            if (entry.value < expireTime) {
+                map.remove(entry.key)
+                iterator.remove()
+            } else break
         }
     }
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.text
 
+import androidx.compose.ui.util.fastForEach
 import org.jetbrains.skiko.currentNanoTime
 
 // Extremely simple Cache interface which is enough for ui.text needs
@@ -56,7 +57,7 @@ internal class ExpireAfterAccessCache<K, V>(
         val expireTime = now - expireAfterNanos
         accessTime.keys.takeWhile {
             accessTime[it]!! < expireTime
-        }.forEach {
+        }.fastForEach {
             map.remove(it)
             accessTime.remove(it)
         }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.text
 
-
 import org.jetbrains.skiko.currentNanoTime
 
 // Extremely simple Cache interface which is enough for ui.text needs

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.util.fastAny
 import kotlin.math.abs
 import org.jetbrains.skia.paragraph.LineMetrics
 import org.jetbrains.skia.paragraph.Paragraph
@@ -151,7 +152,7 @@ internal class ParagraphLayouter(
             // but we have to invalidate it because it's backed into skia's paragraph.
             // Since it affects only [ShaderBrush] we can keep the cache if it's not used.
             if (builder.textStyle.brush is ShaderBrush ||
-                builder.annotations.any {
+                builder.annotations.fastAny {
                     it.item is SpanStyle && // TODO(ivan): Verify that we need only [SpanStyle] here
                     it.item.brush is ShaderBrush }) {
                 invalidateParagraph(onlyForeground = true)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -31,7 +31,9 @@ import androidx.compose.ui.text.font.GenericFontFamily
 import androidx.compose.ui.text.font.LoadedFontFamily
 import androidx.compose.ui.text.font.Typeface
 import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.util.fastFilteredMap
 import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMapNotNull
 import org.jetbrains.skia.FontMgrWithFallback
 import org.jetbrains.skia.paragraph.FontCollection
 import org.jetbrains.skia.paragraph.TypefaceFontProviderWithFallback
@@ -331,9 +333,12 @@ internal class FontCache {
     private fun ensureRegistered(fontFamily: FontFamily): List<String> =
         when (fontFamily) {
             is FontListFontFamily -> {
-                val fonts = fontFamily.fonts.filterIsInstance<SystemFont>()
+                val fonts = fontFamily.fonts.fastMapNotNull {
+                    if (it is SystemFont) it.identity
+                    else null
+                }
                 if (fonts.size == fontFamily.fonts.size) {
-                    fonts.fastMap { it.identity }
+                    fonts
                 } else {
                     // not supported
                     throw IllegalArgumentException(
@@ -341,11 +346,13 @@ internal class FontCache {
                     )
                 }
             }
+
             is LoadedFontFamily -> {
                 val typeface = fontFamily.typeface as SkiaBackedTypeface
                 ensureRegistered(typeface.nativeTypeface, typeface.alias)
                 listOf(typeface.alias)
             }
+
             is GenericFontFamily -> fontFamily.aliases
             is DefaultFontFamily -> FontFamily.SansSerif.aliases
             else -> throw IllegalArgumentException("Unknown font family type: $fontFamily")
@@ -376,10 +383,15 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
             mapOf(
                 FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans", "Arial"),
                 FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
-                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono", "Consolas"),
+                FontFamily.Monospace.name to listOf(
+                    "Noto Sans Mono",
+                    "DejaVu Sans Mono",
+                    "Consolas"
+                ),
                 // better alternative?
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
+
         Platform.Windows ->
             mapOf(
                 // Segoe UI is the Windows system font, so try it first.
@@ -389,15 +401,29 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Consolas"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
+
         Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS ->
             mapOf(
                 // .AppleSystem* aliases is the only legal way to get default SF and NY fonts.
-                FontFamily.SansSerif.name to listOf(".AppleSystemUIFont", "Helvetica Neue", "Helvetica"),
-                FontFamily.Serif.name to listOf(".AppleSystemUIFontSerif", "Times", "Times New Roman"),
-                FontFamily.Monospace.name to listOf(".AppleSystemUIFontMonospaced", "Menlo", "Courier"),
+                FontFamily.SansSerif.name to listOf(
+                    ".AppleSystemUIFont",
+                    "Helvetica Neue",
+                    "Helvetica"
+                ),
+                FontFamily.Serif.name to listOf(
+                    ".AppleSystemUIFontSerif",
+                    "Times",
+                    "Times New Roman"
+                ),
+                FontFamily.Monospace.name to listOf(
+                    ".AppleSystemUIFontMonospaced",
+                    "Menlo",
+                    "Courier"
+                ),
                 // Safari "font-family: cursive" real font names from macOS and iOS.
                 FontFamily.Cursive.name to listOf("Apple Chancery", "Snell Roundhand")
             )
+
         Platform.Android -> // https://m3.material.io/styles/typography/fonts
             mapOf(
                 FontFamily.SansSerif.name to listOf("Roboto", "Noto Sans"),
@@ -405,6 +431,7 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Roboto Mono", "Noto Sans Mono"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
+
         Platform.Unknown ->
             mapOf(
                 FontFamily.SansSerif.name to listOf("Arial"),

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -346,13 +346,11 @@ internal class FontCache {
                     )
                 }
             }
-
             is LoadedFontFamily -> {
                 val typeface = fontFamily.typeface as SkiaBackedTypeface
                 ensureRegistered(typeface.nativeTypeface, typeface.alias)
                 listOf(typeface.alias)
             }
-
             is GenericFontFamily -> fontFamily.aliases
             is DefaultFontFamily -> FontFamily.SansSerif.aliases
             else -> throw IllegalArgumentException("Unknown font family type: $fontFamily")
@@ -383,15 +381,10 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
             mapOf(
                 FontFamily.SansSerif.name to listOf("Noto Sans", "DejaVu Sans", "Arial"),
                 FontFamily.Serif.name to listOf("Noto Serif", "DejaVu Serif", "Times New Roman"),
-                FontFamily.Monospace.name to listOf(
-                    "Noto Sans Mono",
-                    "DejaVu Sans Mono",
-                    "Consolas"
-                ),
+                FontFamily.Monospace.name to listOf("Noto Sans Mono", "DejaVu Sans Mono", "Consolas"),
                 // better alternative?
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-
         Platform.Windows ->
             mapOf(
                 // Segoe UI is the Windows system font, so try it first.
@@ -401,29 +394,15 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Consolas"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-
         Platform.MacOS, Platform.IOS, Platform.TvOS, Platform.WatchOS ->
             mapOf(
                 // .AppleSystem* aliases is the only legal way to get default SF and NY fonts.
-                FontFamily.SansSerif.name to listOf(
-                    ".AppleSystemUIFont",
-                    "Helvetica Neue",
-                    "Helvetica"
-                ),
-                FontFamily.Serif.name to listOf(
-                    ".AppleSystemUIFontSerif",
-                    "Times",
-                    "Times New Roman"
-                ),
-                FontFamily.Monospace.name to listOf(
-                    ".AppleSystemUIFontMonospaced",
-                    "Menlo",
-                    "Courier"
-                ),
+                FontFamily.SansSerif.name to listOf(".AppleSystemUIFont", "Helvetica Neue", "Helvetica"),
+                FontFamily.Serif.name to listOf(".AppleSystemUIFontSerif", "Times", "Times New Roman"),
+                FontFamily.Monospace.name to listOf(".AppleSystemUIFontMonospaced", "Menlo", "Courier"),
                 // Safari "font-family: cursive" real font names from macOS and iOS.
                 FontFamily.Cursive.name to listOf("Apple Chancery", "Snell Roundhand")
             )
-
         Platform.Android -> // https://m3.material.io/styles/typography/fonts
             mapOf(
                 FontFamily.SansSerif.name to listOf("Roboto", "Noto Sans"),
@@ -431,7 +410,6 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
                 FontFamily.Monospace.name to listOf("Roboto Mono", "Noto Sans Mono"),
                 FontFamily.Cursive.name to listOf("Comic Sans MS")
             )
-
         Platform.Unknown ->
             mapOf(
                 FontFamily.SansSerif.name to listOf("Arial"),

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.GenericFontFamily
 import androidx.compose.ui.text.font.LoadedFontFamily
 import androidx.compose.ui.text.font.Typeface
 import androidx.compose.ui.text.font.createFontFamilyResolver
+import androidx.compose.ui.util.fastMap
 import org.jetbrains.skia.FontMgrWithFallback
 import org.jetbrains.skia.paragraph.FontCollection
 import org.jetbrains.skia.paragraph.TypefaceFontProviderWithFallback
@@ -332,7 +333,7 @@ internal class FontCache {
             is FontListFontFamily -> {
                 val fonts = fontFamily.fonts.filterIsInstance<SystemFont>()
                 if (fonts.size == fontFamily.fonts.size) {
-                    fonts.map { it.identity }
+                    fonts.fastMap { it.identity }
                 } else {
                     // not supported
                     throw IllegalArgumentException(
@@ -415,7 +416,7 @@ private val GenericFontFamiliesMapping: Map<String, List<String>> by lazy {
 }
 
 internal fun FontVariation.Settings.toSkiaFontVariationList(): List<org.jetbrains.skia.FontVariation> {
-    return settings.map { setting ->
+    return settings.fastMap { setting ->
         org.jetbrains.skia.FontVariation(setting.axisName, setting.toVariationValue(null))
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMaxOfOrNull
 import androidx.compose.ui.window.LocalWindow
 
 /**
@@ -60,8 +61,8 @@ internal fun WindowContentLayout(
                 }
             }
 
-            val contentWidth = contentPlaceables.maxOfOrNull { it.measuredWidth } ?: 0
-            val contentHeight = contentPlaceables.maxOfOrNull { it.measuredHeight } ?: 0
+            val contentWidth = contentPlaceables.fastMaxOfOrNull { it.measuredWidth } ?: 0
+            val contentHeight = contentPlaceables.fastMaxOfOrNull { it.measuredHeight } ?: 0
             layout(contentWidth, contentHeight) {
                 contentPlaceables.fastForEach { placeable ->
                     placeable.place(0, 0)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/WindowContentLayout.desktop.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMaxOfOrDefault
 import androidx.compose.ui.util.fastMaxOfOrNull
 import androidx.compose.ui.window.LocalWindow
 
@@ -61,8 +62,8 @@ internal fun WindowContentLayout(
                 }
             }
 
-            val contentWidth = contentPlaceables.fastMaxOfOrNull { it.measuredWidth } ?: 0
-            val contentHeight = contentPlaceables.fastMaxOfOrNull { it.measuredHeight } ?: 0
+            val contentWidth = contentPlaceables.fastMaxOfOrDefault(0) { it.measuredWidth }
+            val contentHeight = contentPlaceables.fastMaxOfOrDefault(0) { it.measuredHeight }
             layout(contentWidth, contentHeight) {
                 contentPlaceables.fastForEach { placeable ->
                     placeable.place(0, 0)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.skiko.OverlayRenderDecorator
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.window.Dialog
@@ -519,7 +520,7 @@ internal class ComposeContainer(
     }
 
     private inner class FocusableLayerEventFilter : AwtEventFilter() {
-        private val noFocusableLayers get() = layers.all { !it.focusable }
+        private val noFocusableLayers get() = layers.fastAll { !it.focusable }
 
         override fun shouldSendMouseEvent(event: AwtMouseEvent): Boolean = noFocusableLayers
         override fun shouldSendKeyEvent(event: AwtKeyEvent): Boolean = noFocusableLayers

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -19,7 +19,9 @@ package androidx.compose.ui.input.pointer
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.scene.PointerEventResult
 import androidx.compose.ui.scene.merging
+import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastMap
 
 /**
  * Compose or user code can't work well if we miss some events.
@@ -211,7 +213,7 @@ internal class SyntheticEventSender(
 
     private fun PointerInputEvent.isSamePosition(previousEvent: PointerInputEvent?): Boolean {
         val previousIdToPosition = previousEvent?.pointers?.associate { it.id to it.position }
-        return pointers.all {
+        return pointers.fastAll {
             val previousPosition = previousIdToPosition?.get(it.id)
             previousPosition == null || it.position == previousPosition
         }
@@ -224,7 +226,7 @@ internal class SyntheticEventSender(
         copyPointer: (PointerInputEventData) -> PointerInputEventData,
     ) = PointerInputEvent(
         eventType = type,
-        pointers = pointers.map(copyPointer),
+        pointers = pointers.fastMap(copyPointer),
         uptime = uptime,
         nativeEvent = null,
         buttons = buttons,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OverlayLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OverlayLayout.skiko.kt
@@ -18,6 +18,9 @@ package androidx.compose.ui.layout
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrNull
 
 /**
  * Creates an overlay layout that places the content on top of each other.
@@ -30,12 +33,12 @@ internal fun OverlayLayout(modifier: Modifier, content: @Composable () -> Unit) 
     content = content,
     modifier = modifier,
     measurePolicy = { measurables, constraints ->
-        val placeables = measurables.map { it.measure(constraints) }
+        val placeables = measurables.fastMap { it.measure(constraints) }
         layout(
-            placeables.maxOfOrNull { it.width } ?: constraints.minWidth,
-            placeables.maxOfOrNull { it.height } ?: constraints.minHeight
+            placeables.fastMaxOfOrNull { it.width } ?: constraints.minWidth,
+            placeables.fastMaxOfOrNull { it.height } ?: constraints.minHeight
         ) {
-            placeables.forEach {
+            placeables.fastForEach {
                 it.place(0, 0)
             }
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OverlayLayout.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OverlayLayout.skiko.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrDefault
 import androidx.compose.ui.util.fastMaxOfOrNull
 
 /**
@@ -35,8 +36,8 @@ internal fun OverlayLayout(modifier: Modifier, content: @Composable () -> Unit) 
     measurePolicy = { measurables, constraints ->
         val placeables = measurables.fastMap { it.measure(constraints) }
         layout(
-            placeables.fastMaxOfOrNull { it.width } ?: constraints.minWidth,
-            placeables.fastMaxOfOrNull { it.height } ?: constraints.minHeight
+            placeables.fastMaxOfOrDefault(constraints.minWidth) { it.width },
+            placeables.fastMaxOfOrDefault(constraints.minHeight) { it.height }
         ) {
             placeables.fastForEach {
                 it.place(0, 0)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -96,6 +96,7 @@ import androidx.compose.ui.unit.toRect
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrDefault
 import androidx.compose.ui.util.fastMaxOfOrNull
 import androidx.compose.ui.util.trace
 import androidx.compose.ui.viewinterop.InteropPointerInputModifier
@@ -206,8 +207,8 @@ internal class RootNodeOwner(
             // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
             val children = owner.root.children
             return IntSize(
-                width = children.fastMaxOfOrNull { it.outerCoordinator.measuredWidth } ?: 0,
-                height = children.fastMaxOfOrNull { it.outerCoordinator.measuredHeight } ?: 0,
+                width = children.fastMaxOfOrDefault(0) { it.outerCoordinator.measuredWidth },
+                height = children.fastMaxOfOrDefault(0) { it.outerCoordinator.measuredHeight },
             )
         } finally {
             measureAndLayoutDelegate.updateRootConstraintsWithInfinityCheck(constraints)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -94,6 +94,9 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toIntRect
 import androidx.compose.ui.unit.toRect
 import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrNull
 import androidx.compose.ui.util.trace
 import androidx.compose.ui.viewinterop.InteropPointerInputModifier
 import androidx.compose.ui.viewinterop.InteropView
@@ -203,8 +206,8 @@ internal class RootNodeOwner(
             // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
             val children = owner.root.children
             return IntSize(
-                width = children.maxOfOrNull { it.outerCoordinator.measuredWidth } ?: 0,
-                height = children.maxOfOrNull { it.outerCoordinator.measuredHeight } ?: 0,
+                width = children.fastMaxOfOrNull { it.outerCoordinator.measuredWidth } ?: 0,
+                height = children.fastMaxOfOrNull { it.outerCoordinator.measuredHeight } ?: 0,
             )
         } finally {
             measureAndLayoutDelegate.updateRootConstraintsWithInfinityCheck(constraints)
@@ -230,10 +233,10 @@ internal class RootNodeOwner(
                 Offset(x = width, y = 0f),
                 Offset(x = 0f, y = height),
                 Offset(x = width, y = height)
-            ).map {
+            ).fastMap {
                 platformContext.convertLocalToScreenPosition(it)
             }
-        if (corners.any { it.isUnspecified }) null else corners
+        if (corners.fastAny { it.isUnspecified }) null else corners
     }
 
     fun invalidatePositionOnScreen() {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.platform.makeSynchronizedObject
 import androidx.compose.ui.internal.getCurrentThreadId
 import androidx.compose.ui.platform.synchronized
+import androidx.compose.ui.util.fastForEach
 import kotlinx.atomicfu.atomic
 
 /**
@@ -141,7 +142,7 @@ private class CommandList(
             listCopy.addAll(list)
             list.clear()
         }
-        listCopy.forEach { it.invoke() }
+        listCopy.fastForEach { it.invoke() }
         listCopy.clear()
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.round
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
+import androidx.compose.ui.util.fastLastOrNull
 import androidx.compose.ui.viewinterop.InteropView
 import androidx.compose.ui.window.getDialogScrimBlendMode
 import kotlin.coroutines.CoroutineContext
@@ -275,7 +276,7 @@ private class CanvasLayersComposeSceneImpl(
      */
     private fun hoveredOwner(event: PointerInputEvent): RootNodeOwner {
         val position = event.pointers.first().position
-        return layers.lastOrNull { it.isInBounds(position) }?.owner ?: mainOwner
+        return layers.fastLastOrNull { it.isInBounds(position) }?.owner ?: mainOwner
     }
 
     /**
@@ -474,7 +475,7 @@ private class CanvasLayersComposeSceneImpl(
 
     private fun releaseFocus(layer: AttachedComposeSceneLayer) {
         if (layer == focusedLayer) {
-            focusedLayer = layers.lastOrNull { it.focusable }
+            focusedLayer = layers.fastLastOrNull { it.focusable }
 
             // Enter event to new focusedOwner will be sent via synthetic event on next frame
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.input.pointer.SyntheticEventSender
 import androidx.compose.ui.input.pointer.areAnyPressed
 import androidx.compose.ui.input.pointer.copy
 import androidx.compose.ui.node.RootNodeOwner
+import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.trace
 import org.jetbrains.skiko.currentNanoTime
 
@@ -162,7 +163,7 @@ internal class ComposeSceneInputHandler(
         val iterator = pointerPositions.iterator()
         while (iterator.hasNext()) {
             val pointerId = iterator.next().key
-            val pointer = event.pointers.find { it.id == pointerId } ?: continue
+            val pointer = event.pointers.fastFirstOrNull { it.id == pointerId } ?: continue
             if ((pointer.type != PointerType.Mouse && !pointer.down) ||
                 (pointer.type == PointerType.Mouse && event.eventType == PointerEventType.Exit)
             ) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventData
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.util.fastMap
 import kotlin.jvm.JvmInline
 
 /**
@@ -127,7 +128,7 @@ internal fun PointerInputEvent(
 ) = PointerInputEvent(
     eventType = eventType,
     uptime = timeMillis,
-    pointers = pointers.map {
+    pointers = pointers.fastMap {
         PointerInputEventData(
             id = it.id,
             uptime = timeMillis,

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.size
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.width
+import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.viewinterop.InteropViewGroup
 import androidx.compose.ui.viewinterop.TrackInteropPlacementContainer
 import androidx.lifecycle.Lifecycle
@@ -423,11 +424,12 @@ internal class ComposeWindow(
         canvas.style.width = "${boxSize.width}px"
         canvas.style.height = "${boxSize.height}px"
 
-        _windowInfo.containerSize = IntSize(width, height)
+        val containerSize = IntSize(width, height)
+        _windowInfo.containerSize = containerSize
 
         // TODO: Align with Container/Mediator architecture
         skiaLayer.attachTo(canvas)
-        scene.size = IntSize(width, height)
+        scene.size = containerSize
         skiaLayer.needRedraw()
     }
 
@@ -476,7 +478,7 @@ internal class ComposeWindow(
         } else {
             event.changedTouches.asList()
         }
-        val pointers = touches.map { touch ->
+        val pointers = touches.fastMap { touch ->
             ComposeScenePointer(
                 id = PointerId(touch.identifier.toLong()),
                 position = Offset(


### PR DESCRIPTION
This is a fairly simple pr to make internal code use fast* extension functions from module ui-utils (fastForEach, fastMap, fastAny, fastLastOrNull, etc). These fast extension functions do not allocate an iterator and they are inlined so in theory it should be more performant than normal Iterator extension functions. I tried also moving roundTo extension functions, but they do not throw exceptions (fastRoundToInt returns 0 on Unspecified) and i wasn't sure if i was gonna break something and so i didnt go with it.

I also added a minichange in ComposeWindow.web.kt, so that on every resize it creates less allocations (IntSize was being created twice while being the same, small but resize is called a lot of times)

This should lead to better performance overall (to Skiko targets) but maybe its barely noticeable. Should any problem arise (it shouldnt since we are doing less), feel free to rollback!

## Testing
Ideally it should be tested with multiplatform benchmarks

## Release Notes
N/A
