### PR TITLE
FunctionKeyMeta: Revert AnnotationRetention to 'AnnotationRetention.RUNTIME'

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/FunctionKeyMeta.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/FunctionKeyMeta.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.ComposeCompilerApi
  */
 @ComposeCompilerApi
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.BINARY)
+@Retention(AnnotationRetention.RUNTIME)
 @Repeatable
 annotation class FunctionKeyMeta(val key: Int, val startOffset: Int, val endOffset: Int)
 


### PR DESCRIPTION
Cherry-pick of https://android-review.googlesource.com/c/platform/frameworks/support/+/3662394, to receive it faster to fix hot reload in the dev builds. Asked by @sellmair

## Release Notes
N/A