### PR TITLE
Fix `artifactRedirection.targetNames` for `window-core` library

### DIFF
--- a/window/window-core/gradle.properties
+++ b/window/window-core/gradle.properties
@@ -15,5 +15,5 @@
 #
 
 # TODO Determine redirection group based on package and remove explicit config
-artifactRedirection.targetNames=android,jvm,iosarm64,iossimulatorarm64,iosx64,linuxarm64,linuxx64,macosarm64,macosx64,tvosarm64,tvossimulatorarm64,tvosx64,watchosarm32,watchosarm64,watchosdevicearm64,watchossimulatorarm64,watchosx64
+artifactRedirection.targetNames=android,desktop,iosarm64,iossimulatorarm64,iosx64,linuxarm64,linuxx64,macosarm64,macosx64,tvosarm64,tvossimulatorarm64,tvosx64,watchosarm32,watchosarm64,watchosdevicearm64,watchossimulatorarm64,watchosx64
 artifactRedirection.groupId=androidx.window


### PR DESCRIPTION
Fixes [CMP-8327](https://youtrack.jetbrains.com/issue/CMP-8327) Could not find org.jetbrains.androidx.window:window-core-desktop:1.4.0-alpha07

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ `Could not find org.jetbrains.androidx.window:window-core-desktop:1.4.0-alpha07` when using `material-adaptive` or `material3-adaptive-navigation-suite`.
