### PR TITLE
Polish `ComposeScene` kdocs and API a bit

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicLayerBugTest.desktop.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/GraphicLayerBugTest.desktop.kt
@@ -84,14 +84,13 @@ class GraphicLayerBugDesktopTest {
                 coroutineException = throwable
             }
         ) {
-            CanvasLayersComposeScene(coroutineContext = coroutineContext).apply {
-                body(this)
-                close()
+            CanvasLayersComposeScene(coroutineContext = coroutineContext).use {
+                body(it)
             }
         }
 
         if (coroutineException != null) {
-            throw coroutineException!!
+            throw coroutineException
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -51,7 +51,7 @@ import kotlinx.coroutines.withContext
  * It provides a base implementation for managing composition, input events, and rendering.
  *
  * @property composeSceneContext the object that used to share "context" between multiple scenes
- * on the screen. Also, it provides a way for platform interaction that required within a scene.
+ * on the screen. Also, it provides a way for platform interaction that is required within a scene.
  */
 @OptIn(InternalComposeUiApi::class)
 internal abstract class BaseComposeScene(
@@ -228,7 +228,6 @@ internal abstract class BaseComposeScene(
         }
     }
 
-    // TODO(demin): return Boolean (when it is consumed)
     // TODO(demin) verify that pressure is the same on Android and iOS
     override fun sendPointerEvent(
         eventType: PointerEventType,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.draganddrop.DragAndDropNode
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
@@ -47,7 +48,6 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.viewinterop.InteropView
 import androidx.compose.ui.viewinterop.pointerInteropFilter
-import org.jetbrains.skiko.currentNanoTime
 
 /**
  * Represents a static [CompositionLocal] key for a [ComposeScene] in Jetpack Compose.
@@ -68,9 +68,12 @@ internal val LocalComposeScene = staticCompositionLocalOf<ComposeScene?> { null 
  * (such as application, runComposeUiTest, ComposeWindow). While it can be used by
  * third-party users for integrating Compose into other platforms, it does not come
  * with any guarantee of stability.
+ *
+ * @see PlatformLayersComposeScene
+ * @see CanvasLayersComposeScene
  */
 @InternalComposeUiApi
-interface ComposeScene {
+sealed interface ComposeScene : AutoCloseable {
 
     /**
      * Density of the content which will be used to convert [Dp] units.
@@ -122,12 +125,12 @@ interface ComposeScene {
      * Close all resources and subscriptions. Not calling this method when [ComposeScene] is no
      * longer needed will cause a memory leak.
      *
-     * All effects launched via [LaunchedEffect] or [rememberCoroutineScope] will be cancelled
+     * All effects launched via [LaunchedEffect] or [rememberCoroutineScope] will be canceled
      * (but not immediately).
      *
      * After calling this method, you cannot call any other method of this [ComposeScene].
      */
-    fun close()
+    override fun close()
 
     /**
      * Returns the current content size (in pixels) in infinity constraints.
@@ -200,7 +203,7 @@ interface ComposeScene {
         eventType: PointerEventType,
         position: Offset,
         scrollDelta: Offset = Offset.Zero,
-        timeMillis: Long = currentTimeForEvent(),
+        timeMillis: Long = currentTimeMillis(),
         type: PointerType = PointerType.Mouse,
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
@@ -235,7 +238,7 @@ interface ComposeScene {
         buttons: PointerButtons = PointerButtons(),
         keyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers(),
         scrollDelta: Offset = Offset.Zero,
-        timeMillis: Long = currentTimeForEvent(),
+        timeMillis: Long = currentTimeMillis(),
         nativeEvent: Any? = null,
         button: PointerButton? = null,
     ): PointerEventResult
@@ -265,7 +268,7 @@ interface ComposeScene {
     fun sendRotaryScrollEvent(
         verticalScrollPixels: Float,
         horizontalScrollPixels: Float,
-        timeMillis: Long = currentTimeForEvent(),
+        timeMillis: Long = currentTimeMillis(),
     ): Boolean
 
     /**
@@ -282,6 +285,3 @@ interface ComposeScene {
      */
     suspend fun withMonotonicFrameClock(block: suspend () -> Unit)
 }
-
-private fun currentTimeForEvent(): Long =
-    (currentNanoTime() / 1E6).toLong()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -111,7 +111,7 @@ interface ComposeSceneLayer {
 
     /**
      * Update the composition with the content described by the [content] composable. After this
-     * has been called the changes to produce the initial composition has been calculated and
+     * has been called, the changes to produce the initial composition have been calculated and
      * applied to the composition.
      *
      * Will throw an [IllegalStateException] if the composition has been disposed.
@@ -164,7 +164,10 @@ interface ComposeSceneLayer {
  * the current [ComposeScene]. This layer can be utilized to display content
  * as a new [LayoutNode] tree.
  *
- * @param focusable Indicates whether the layer is focusable. Default value is false.
+ * @see Popup
+ * @see Dialog
+ *
+ * @param focusable Indicates whether the layer is focusable. The default value is false.
  * @return The created [ComposeSceneLayer].
  */
 @Composable

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/CanvasLayersComposeSceneTest.kt
@@ -36,19 +36,16 @@ class CanvasLayersComposeSceneTest {
     @Test
     fun sceneSizeChangeTriggersInvalidation() = runTest(StandardTestDispatcher()) {
         var invalidationCount = 0
-        val scene = CanvasLayersComposeScene(
+        CanvasLayersComposeScene(
             size = IntSize(100, 100),
             coroutineContext = coroutineContext,
             invalidate = { invalidationCount++ }
-        )
-        try {
+        ).use { scene ->
             scene.setContent { Box(Modifier.fillMaxSize()) }
 
             assertEquals(1, invalidationCount)
             scene.size = IntSize(120, 120)
             assertEquals(2, invalidationCount)
-        } finally {
-            scene.close()
         }
     }
 
@@ -56,11 +53,10 @@ class CanvasLayersComposeSceneTest {
     fun cancelClickForGestureOwner() = runTest(StandardTestDispatcher()) {
         var rootCancelled = false
         var popupCancelled = false
-        val scene = CanvasLayersComposeScene(
+        CanvasLayersComposeScene(
             size = IntSize(100, 100),
             coroutineContext = coroutineContext,
-        )
-        try {
+        ).use { scene ->
             scene.setContent {
                 Box(modifier = Modifier.fillMaxSize().onCancel { rootCancelled = true })
 
@@ -74,8 +70,6 @@ class CanvasLayersComposeSceneTest {
 
             assertFalse(rootCancelled)
             assertTrue(popupCancelled)
-        } finally {
-            scene.close()
         }
     }
 }


### PR DESCRIPTION
- Remove usage of `org.jetbrains.skiko.currentNanoTime` for events time
- Make `ComposeScene` `sealed` and `AutoCloseable`
- Polish a few comments

## Release Notes
N/A