### PR TITLE
Apply `colorFilter` and `blendMode` from `GraphicsLayerScope`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
@@ -145,6 +145,12 @@ internal class GraphicsLayerOwnerLayer(
         if (maybeChangedFields and Fields.RenderEffect != 0) {
             graphicsLayer.renderEffect = scope.renderEffect
         }
+        if (maybeChangedFields and Fields.ColorFilter != 0) {
+            graphicsLayer.colorFilter = scope.colorFilter
+        }
+        if (maybeChangedFields and Fields.BlendMode != 0) {
+            graphicsLayer.blendMode = scope.blendMode
+        }
         if (maybeChangedFields and Fields.CompositingStrategy != 0) {
             graphicsLayer.compositingStrategy =
                 when (scope.compositingStrategy) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/testutils/ImageAssertions.skiko.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/testutils/ImageAssertions.skiko.kt
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.testutils
+
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Canvas
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Path.Direction
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.test.assertEquals
+
+// A copy from compose/test-utils/src/androidMain/kotlin/androidx/compose/testutils/ImageAssertions.android.kt
+// TODO: commonize compose/test-utils module properly
+
+/**
+ * A helper function to run asserts on [ImageBitmap].
+ *
+ * @param expectedSize The expected size of the bitmap. Leave null to skip the check.
+ * @param expectedColorProvider Returns the expected color for the provided pixel position. The
+ *   returned color is then asserted as the expected one on the given bitmap.
+ * @throws AssertionError if size or colors don't match.
+ */
+fun ImageBitmap.assertPixels(
+    expectedSize: IntSize? = null,
+    expectedColorProvider: (pos: IntOffset) -> Color?,
+) {
+    if (expectedSize != null) {
+        if (width != expectedSize.width || height != expectedSize.height) {
+            throw AssertionError(
+                "Bitmap size is wrong! Expected '$expectedSize' but got " + "'$width x $height'"
+            )
+        }
+    }
+
+    val pixel = toPixelMap()
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            val pxPos = IntOffset(x, y)
+            val expectedClr = expectedColorProvider(pxPos)
+            if (expectedClr != null) {
+                pixel.assertPixelColor(expectedClr, x, y)
+            }
+        }
+    }
+}
+
+/** Asserts that the color at a specific pixel in the bitmap at ([x], [y]) is [expected]. */
+fun PixelMap.assertPixelColor(
+    expected: Color,
+    x: Int,
+    y: Int,
+    error: (Color) -> String = { color -> "Pixel($x, $y) expected to be $expected, but was $color" },
+) {
+    val actual = this[x, y]
+    val errorString = error(actual)
+    assertEquals(expected.red, actual.red, 0.02f, errorString)
+    assertEquals(expected.green, actual.green, 0.02f, errorString)
+    assertEquals(expected.blue, actual.blue, 0.02f, errorString)
+    assertEquals(expected.alpha, actual.alpha, 0.02f, errorString)
+}
+
+/**
+ * Asserts that the expected color is present in this bitmap.
+ *
+ * @throws AssertionError if the expected color is not present.
+ */
+fun ImageBitmap.assertContainsColor(expectedColor: Color): ImageBitmap {
+    if (!containsColor(expectedColor)) {
+        throw AssertionError("The given color $expectedColor was not found in the bitmap.")
+    }
+    return this
+}
+
+fun ImageBitmap.assertDoesNotContainColor(unexpectedColor: Color): ImageBitmap {
+    if (containsColor(unexpectedColor)) {
+        throw AssertionError("The given color $unexpectedColor was found in the bitmap.")
+    }
+    return this
+}
+
+private fun ImageBitmap.containsColor(expectedColor: Color): Boolean {
+    val pixels = this.toPixelMap()
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            val color = pixels[x, y]
+            if (color == expectedColor) {
+                return true
+            }
+        }
+    }
+    return false
+}
+
+/**
+ * Asserts that the given [shape] is drawn in the bitmap in the color [shapeColor] on a background
+ * of [backgroundColor].
+ *
+ * The whole background of the bitmap should be filled with the [backgroundColor]. The [shape]'s
+ * size is that of the bitmap, minus the [horizontalPadding] and [verticalPadding] on all sides. The
+ * shape must be aligned in the center.
+ *
+ * To avoid the pixels on the edge of a shape, where anti-aliasing means the pixel is neither the
+ * shape color nor the background color, a gap size can be given with [antiAliasingGap]. Pixels that
+ * are close to the border of the shape are not checked. A larger [antiAliasingGap] means more
+ * pixels are left unchecked, and a gap of 0 pixels means all pixels are tested.
+ *
+ * @param density current [Density] or the screen
+ * @param shape the [Shape] of the foreground
+ * @param shapeColor the color of the foreground shape
+ * @param backgroundColor the color of the background shape
+ * @param antiAliasingGap The size of the border area from the shape outline to leave it untested as
+ *   it is likely anti-aliased. Only works for convex shapes. The default is 1 pixel
+ */
+fun ImageBitmap.assertShape(
+    density: Density,
+    horizontalPadding: Dp,
+    verticalPadding: Dp,
+    backgroundColor: Color,
+    shapeColor: Color,
+    shape: Shape = RectangleShape,
+    antiAliasingGap: Float = with(density) { 1.dp.toPx() },
+) =
+    assertShape(
+        density = density,
+        shape = shape,
+        shapeColor = shapeColor,
+        backgroundColor = backgroundColor,
+        backgroundShape = RectangleShape,
+        shapeSize =
+            Size(
+                width - with(density) { horizontalPadding.toPx() * 2 },
+                height - with(density) { verticalPadding.toPx() * 2 },
+            ),
+        antiAliasingGap = antiAliasingGap,
+    )
+
+/**
+ * Asserts that the given [shape] and [backgroundShape] are drawn in the bitmap according to the
+ * given parameters.
+ *
+ * The [shape]'s bounding box should have size [shapeSize] and be centered at [shapeCenter]. The
+ * [backgroundShape]'s bounding box should have size [backgroundSize] and be centered at
+ * [backgroundCenter].
+ *
+ * Pixels that are outside the background area are not checked. Pixels that are outside the [shape]
+ * and inside the [backgroundShape] must be [backgroundColor]. Pixels that are inside the [shape]
+ * must be [shapeColor].
+ *
+ * If [backgroundColor] is `null`, only pixels inside the [shape] are checked.
+ *
+ * Because pixels on the edge of a shape are anti-aliased, pixels that are close the shape's edges
+ * are not checked. Use [antiAliasingGap] to ignore more (or less) pixels around the shape's edges.
+ * A larger [antiAliasingGap] means more pixels are left unchecked, and a gap of 0 pixels means all
+ * pixels are tested.
+ */
+// TODO (mount, malkov) : to investigate why it flakes when shape is not rect
+fun ImageBitmap.assertShape(
+    density: Density,
+    shape: Shape,
+    shapeColor: Color,
+    shapeSize: Size = Size(width.toFloat(), height.toFloat()),
+    shapeCenter: Offset = Offset(width / 2f, height / 2f),
+    backgroundShape: Shape = RectangleShape,
+    backgroundColor: Color?,
+    backgroundSize: Size = Size(width.toFloat(), height.toFloat()),
+    backgroundCenter: Offset = Offset(width / 2f, height / 2f),
+    antiAliasingGap: Float = with(density) { 1.dp.toPx() },
+) {
+    val pixels = toPixelMap()
+
+    // the bounding box of the foreground shape in the bitmap
+    val shapeBounds =
+        Rect(
+            left = shapeCenter.x - shapeSize.width / 2f,
+            top = shapeCenter.y - shapeSize.height / 2f,
+            right = shapeCenter.x + shapeSize.width / 2f,
+            bottom = shapeCenter.y + shapeSize.height / 2f,
+        )
+    // the bounding box of the background shape in the bitmap
+    val backgroundBounds =
+        Rect(
+            left = backgroundCenter.x - backgroundSize.width / 2f,
+            top = backgroundCenter.y - backgroundSize.height / 2f,
+            right = backgroundCenter.x + backgroundSize.width / 2f,
+            bottom = backgroundCenter.y + backgroundSize.height / 2f,
+        )
+
+    // Convert the shapes into a paths
+    val foregroundPath = shape.asPath(shapeBounds, density)
+    val backgroundPath = backgroundShape.asPath(backgroundBounds, density)
+
+    forEachPixelIn(shapeBounds, backgroundBounds, antiAliasingGap) { x, y, inFgBounds, inBgBounds ->
+        if (inFgBounds && !inBgBounds) {
+            // Only consider the foreground shape
+            if (foregroundPath.contains(x, y, shapeCenter, antiAliasingGap)) {
+                pixels.assertPixelColor(shapeColor, x, y)
+            }
+        } else if (inBgBounds && !inFgBounds) {
+            // Only consider the background shape, if there is one
+            if (
+                backgroundColor != null &&
+                    backgroundPath.contains(x, y, backgroundCenter, antiAliasingGap)
+            ) {
+                pixels.assertPixelColor(backgroundColor, x, y)
+            }
+        } else if (inFgBounds /* && inBgBounds */) {
+            // Need to consider both the foreground and background (if there is one)
+            if (foregroundPath.contains(x, y, shapeCenter, antiAliasingGap)) {
+                pixels.assertPixelColor(shapeColor, x, y)
+            } else if (
+                backgroundColor != null &&
+                    foregroundPath.notContains(x, y, shapeCenter, antiAliasingGap) &&
+                    backgroundPath.contains(x, y, backgroundCenter, antiAliasingGap)
+            ) {
+                pixels.assertPixelColor(backgroundColor, x, y)
+            }
+        }
+    }
+}
+
+private fun ImageBitmap.forEachPixelIn(
+    shapeBounds: Rect,
+    backgroundBounds: Rect,
+    margin: Float,
+    block: (x: Int, y: Int, inShapeBounds: Boolean, inBackgroundBounds: Boolean) -> Unit,
+) {
+    // Iterate over all pixels in the background. Usually that's all we have to do.
+    for (y in rowIndices(backgroundBounds)) {
+        for (x in columnIndices(backgroundBounds)) {
+            block.invoke(x, y, shapeBounds.contains(x, y, margin), true)
+        }
+    }
+    // While checking the background area, we potentially checked a lot of foreground area at the
+    // same time. Try to avoid checking pixels again.
+    val shapeBoundsToCheck = shapeBounds.subtract(backgroundBounds)
+    for (y in rowIndices(shapeBoundsToCheck)) {
+        for (x in columnIndices(shapeBoundsToCheck)) {
+            // Anything contained in the background is already checked
+            if (!backgroundBounds.contains(x, y, margin)) {
+                block.invoke(x, y, true, false)
+            }
+        }
+    }
+}
+
+private fun ImageBitmap.rowIndices(bounds: Rect): IntRange =
+    bounds.top.coerceAtLeast(0f) until bounds.bottom.coerceAtMost(height.toFloat())
+
+private fun ImageBitmap.columnIndices(bounds: Rect): IntRange =
+    bounds.left.coerceAtLeast(0f) until bounds.right.coerceAtMost(width.toFloat())
+
+private infix fun Float.until(until: Float): IntRange {
+    val from = this.roundToInt()
+    val to = until.roundToInt()
+    if (from <= Int.MIN_VALUE) return IntRange.EMPTY
+    return from until to
+}
+
+private fun Shape.asPath(bounds: Rect, density: Density): Path {
+    return Path().apply {
+        addOutline(createOutline(bounds.size, LayoutDirection.Ltr, density))
+        // Translate only modifies segments already added, so call it after addOutline
+        translate(bounds.topLeft)
+    }
+}
+
+private fun Path.contains(x: Int, y: Int, center: Offset, margin: Float): Boolean =
+    contains(pointFartherFromAnchor(x, y, center, margin))
+
+private fun Path.notContains(x: Int, y: Int, center: Offset, margin: Float): Boolean =
+    !contains(pointCloserToAnchor(x, y, center, margin))
+
+/**
+ * Tests to see if the given point is within the path. (That is, whether the point would be in the
+ * visible portion of the path if the path was used with [Canvas.clipPath].)
+ *
+ * The `point` argument is interpreted as an offset from the origin.
+ *
+ * Returns true if the point is in the path, and false otherwise.
+ */
+@VisibleForTesting
+internal fun Path.contains(offset: Offset): Boolean {
+    val path = Path()
+    path.addRect(
+        rect = Rect(
+            left = offset.x - 0.01f,
+            top = offset.y - 0.01f,
+            right = offset.x + 0.01f,
+            bottom = offset.y + 0.01f,
+        ),
+        direction = Direction.CounterClockwise,
+    )
+    if (op(path, this, PathOperation.Intersect)) {
+        return !path.isEmpty
+    }
+    return false
+}
+
+private fun pointCloserToAnchor(x: Int, y: Int, anchor: Offset, delta: Float): Offset {
+    val xx =
+        when {
+            x > anchor.x -> max(x - delta, anchor.x)
+            x < anchor.x -> min(x + delta, anchor.x)
+            else -> x.toFloat()
+        }
+    val yy =
+        when {
+            y > anchor.y -> max(y - delta, anchor.y)
+            y < anchor.y -> min(y + delta, anchor.y)
+            else -> y.toFloat()
+        }
+    return Offset(xx, yy)
+}
+
+private fun pointFartherFromAnchor(x: Int, y: Int, anchor: Offset, delta: Float): Offset {
+    val xx =
+        when {
+            x > anchor.x -> x + delta
+            x < anchor.x -> x - delta
+            else -> x.toFloat()
+        }
+    val yy =
+        when {
+            y > anchor.y -> y + delta
+            y < anchor.y -> y - delta
+            else -> y.toFloat()
+        }
+    return Offset(xx, yy)
+}
+
+private fun Rect.contains(x: Int, y: Int, margin: Float): Boolean =
+    left <= x + margin && top <= y + margin && right >= x - margin && bottom >= y - margin
+
+private fun Rect.subtract(other: Rect): Rect {
+    // Subtraction can only happen if the other rect is overlapping entirely in a dimension
+    if (other.left <= this.left && other.right >= this.right) {
+        // Other rect potentially overlaps over entire width
+        return if (other.top <= this.top && other.bottom >= this.bottom) {
+            // Subtract everything
+            Rect.Zero
+        } else if (other.top <= this.top && other.bottom > this.top) {
+            // Subtract from the top
+            Rect(this.left, other.bottom, this.right, this.bottom)
+        } else if (other.top < this.bottom && other.bottom >= this.bottom) {
+            // Subtract from the bottom
+            Rect(this.left, this.top, this.right, other.top)
+        } else {
+            // Subtract nothing
+            this
+        }
+    } else if (other.top <= this.top && other.bottom >= this.bottom) {
+        // Other rect potentially overlaps over entire height
+        return if (other.left <= this.left && other.right > this.left) {
+            // Subtract from the left
+            Rect(other.right, this.top, this.right, this.bottom)
+        } else if (other.left < this.right && other.right >= this.right) {
+            // Subtract from the right
+            Rect(this.left, this.top, other.left, this.bottom)
+        } else {
+            // Subtract nothing
+            this
+        }
+    } else {
+        // Subtract nothing
+        return this
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/Assert.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/Assert.kt
@@ -16,6 +16,9 @@
 
 package androidx.compose.ui
 
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -36,4 +39,41 @@ internal fun AssertThat<*>.containsExactly(vararg varargs: Any?) {
 
 internal fun <T> assertThat(t: T): AssertThat<T> {
     return AssertThat(t)
+}
+
+internal fun assertColorsEqual(
+    expected: Color,
+    actual: Color,
+    alphaTolerance: Float = 0.05f,
+    error: () -> String = { "$expected and $actual are not similar!" },
+) {
+    val errorString = error()
+    assertEquals(expected.red, actual.red, alphaTolerance, errorString)
+    assertEquals(expected.green, actual.green, alphaTolerance, errorString)
+    assertEquals(expected.blue, actual.blue, alphaTolerance, errorString)
+    assertEquals(expected.alpha, actual.alpha, alphaTolerance, errorString)
+}
+
+internal fun assertOffsetEqual(
+    expected: Offset,
+    actual: Offset,
+    alphaTolerance: Float = 0.05f,
+    error: () -> String = { "$expected and $actual are not similar!" },
+) {
+    val errorString = error()
+    assertEquals(expected.x, actual.x, alphaTolerance, errorString)
+    assertEquals(expected.y, actual.y, alphaTolerance, errorString)
+}
+
+internal fun assertRectEqual(
+    expected: Rect,
+    actual: Rect,
+    alphaTolerance: Float = 0.05f,
+    error: () -> String = { "$expected and $actual are not similar!" },
+) {
+    val errorString = error()
+    assertEquals(expected.left, actual.left, alphaTolerance, errorString)
+    assertEquals(expected.right, actual.right, alphaTolerance, errorString)
+    assertEquals(expected.top, actual.top, alphaTolerance, errorString)
+    assertEquals(expected.bottom, actual.bottom, alphaTolerance, errorString)
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/LayoutTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/LayoutTestUtils.kt
@@ -47,18 +47,6 @@ import org.jetbrains.skia.Bitmap
 
 // A copy from androidInstrumentedTest/kotlin/androidx/compose/ui/AndroidLayoutDrawTest.kt
 
-fun assertColorsEqual(
-    expected: Color,
-    color: Color,
-    error: () -> String = { "$expected and $color are not similar!" },
-) {
-    val errorString = error()
-    assertEquals(expected.red, color.red, 0.05f, errorString)
-    assertEquals(expected.green, color.green, 0.05f, errorString)
-    assertEquals(expected.blue, color.blue, 0.05f, errorString)
-    assertEquals(expected.alpha, color.alpha, 0.05f, errorString)
-}
-
 @Composable
 fun AtLeastSize(size: Int, modifier: Modifier = Modifier, content: @Composable () -> Unit = {}) {
     Layout(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/LayoutTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/LayoutTestUtils.kt
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.constrainHeight
+import androidx.compose.ui.unit.constrainWidth
+import androidx.compose.ui.unit.offset
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.test.assertEquals
+import org.jetbrains.skia.Bitmap
+
+// A copy from androidInstrumentedTest/kotlin/androidx/compose/ui/AndroidLayoutDrawTest.kt
+
+fun assertColorsEqual(
+    expected: Color,
+    color: Color,
+    error: () -> String = { "$expected and $color are not similar!" },
+) {
+    val errorString = error()
+    assertEquals(expected.red, color.red, 0.05f, errorString)
+    assertEquals(expected.green, color.green, 0.05f, errorString)
+    assertEquals(expected.blue, color.blue, 0.05f, errorString)
+    assertEquals(expected.alpha, color.alpha, 0.05f, errorString)
+}
+
+@Composable
+fun AtLeastSize(size: Int, modifier: Modifier = Modifier, content: @Composable () -> Unit = {}) {
+    Layout(
+        measurePolicy = { measurables, constraints ->
+            val newConstraints =
+                Constraints(
+                    minWidth = max(size, constraints.minWidth),
+                    maxWidth =
+                        if (constraints.hasBoundedWidth) {
+                            max(size, constraints.maxWidth)
+                        } else {
+                            Constraints.Infinity
+                        },
+                    minHeight = max(size, constraints.minHeight),
+                    maxHeight =
+                        if (constraints.hasBoundedHeight) {
+                            max(size, constraints.maxHeight)
+                        } else {
+                            Constraints.Infinity
+                        },
+                )
+            val placeables = measurables.map { m -> m.measure(newConstraints) }
+            var maxWidth = size
+            var maxHeight = size
+            placeables.forEach { child ->
+                maxHeight = max(child.height, maxHeight)
+                maxWidth = max(child.width, maxWidth)
+            }
+            layout(maxWidth, maxHeight) { placeables.forEach { child -> child.place(0, 0) } }
+        },
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@Composable
+fun FixedSize(size: Int, modifier: Modifier = Modifier, content: @Composable () -> Unit = {}) {
+    Layout(content = content, modifier = modifier) { measurables, _ ->
+        val newConstraints = Constraints.fixed(size, size)
+        val placeables = measurables.map { m -> m.measure(newConstraints) }
+        layout(size, size) { placeables.forEach { child -> child.placeRelative(0, 0) } }
+    }
+}
+
+@Composable
+fun Align(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Layout(
+        modifier = modifier,
+        measurePolicy = { measurables, constraints ->
+            val newConstraints =
+                Constraints(
+                    minWidth = 0,
+                    maxWidth = constraints.maxWidth,
+                    minHeight = 0,
+                    maxHeight = constraints.maxHeight,
+                )
+            val placeables = measurables.map { m -> m.measure(newConstraints) }
+            var maxWidth = constraints.minWidth
+            var maxHeight = constraints.minHeight
+            placeables.forEach { child ->
+                maxHeight = max(child.height, maxHeight)
+                maxWidth = max(child.width, maxWidth)
+            }
+            layout(maxWidth, maxHeight) {
+                placeables.forEach { child -> child.placeRelative(0, 0) }
+            }
+        },
+        content = content,
+    )
+}
+
+@Composable
+internal fun Padding(size: Int, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Layout(
+        modifier = modifier,
+        measurePolicy = { measurables, constraints ->
+            val totalDiff = size * 2
+            val targetMinWidth = constraints.minWidth - totalDiff
+            val targetMaxWidth =
+                if (constraints.hasBoundedWidth) {
+                    constraints.maxWidth - totalDiff
+                } else {
+                    Constraints.Infinity
+                }
+            val targetMinHeight = constraints.minHeight - totalDiff
+            val targetMaxHeight =
+                if (constraints.hasBoundedHeight) {
+                    constraints.maxHeight - totalDiff
+                } else {
+                    Constraints.Infinity
+                }
+            val newConstraints =
+                Constraints(
+                    minWidth = targetMinWidth.coerceAtLeast(0),
+                    maxWidth = targetMaxWidth.coerceAtLeast(0),
+                    minHeight = targetMinHeight.coerceAtLeast(0),
+                    maxHeight = targetMaxHeight.coerceAtLeast(0),
+                )
+            val placeables = measurables.map { m -> m.measure(newConstraints) }
+            var maxWidth = size
+            var maxHeight = size
+            placeables.forEach { child ->
+                maxHeight = max(child.height + totalDiff, maxHeight)
+                maxWidth = max(child.width + totalDiff, maxWidth)
+            }
+            layout(maxWidth, maxHeight) {
+                placeables.forEach { child -> child.placeRelative(size, size) }
+            }
+        },
+        content = content,
+    )
+}
+
+@Composable
+fun Wrap(
+    modifier: Modifier = Modifier,
+    minWidth: Int = 0,
+    minHeight: Int = 0,
+    content: @Composable () -> Unit = {},
+) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        val placeables = measurables.map { it.measure(constraints) }
+        val width = max(placeables.maxByOrNull { it.width }?.width ?: 0, minWidth)
+        val height = max(placeables.maxByOrNull { it.height }?.height ?: 0, minHeight)
+        layout(width, height) { placeables.forEach { it.placeRelative(0, 0) } }
+    }
+}
+
+@Composable
+fun Scroller(
+    modifier: Modifier = Modifier,
+    onScrollPositionChanged: (position: Int, maxPosition: Int) -> Unit,
+    offset: State<Int>,
+    content: @Composable () -> Unit,
+) {
+    val maxPosition = remember { mutableStateOf(Constraints.Infinity) }
+    ScrollerLayout(
+        modifier = modifier,
+        maxPosition = maxPosition.value,
+        onMaxPositionChanged = {
+            maxPosition.value = 0
+            onScrollPositionChanged(offset.value, 0)
+        },
+        content = content,
+    )
+}
+
+@Composable
+private fun ScrollerLayout(
+    modifier: Modifier = Modifier,
+    @Suppress("UNUSED_PARAMETER") maxPosition: Int,
+    onMaxPositionChanged: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        val childConstraints =
+            constraints.copy(maxHeight = constraints.maxHeight, maxWidth = Constraints.Infinity)
+        val childMeasurable = measurables.first()
+        val placeable = childMeasurable.measure(childConstraints)
+        val width = min(placeable.width, constraints.maxWidth)
+        layout(width, placeable.height) {
+            onMaxPositionChanged()
+            placeable.placeRelative(0, 0)
+        }
+    }
+}
+
+@Composable
+fun WrapForceRelayout(
+    model: State<Int>,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        val placeables = measurables.map { it.measure(constraints) }
+        val width = placeables.maxByOrNull { it.width }?.width ?: 0
+        val height = placeables.maxByOrNull { it.height }?.height ?: 0
+        layout(width, height) {
+            model.value
+            placeables.forEach { it.placeRelative(0, 0) }
+        }
+    }
+}
+
+@Composable
+fun SimpleRow(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        var width = 0
+        var height = 0
+        val placeables =
+            measurables.map {
+                it.measure(constraints.copy(maxWidth = constraints.maxWidth - width)).also {
+                    width += it.width
+                    height = max(height, it.height)
+                }
+            }
+        layout(width, height) {
+            var currentWidth = 0
+            placeables.forEach {
+                it.placeRelative(currentWidth, 0)
+                currentWidth += it.width
+            }
+        }
+    }
+}
+
+@Composable
+fun JustConstraints(modifier: Modifier, content: @Composable () -> Unit) {
+    Layout(content, modifier) { _, constraints ->
+        layout(constraints.minWidth, constraints.minHeight) {}
+    }
+}
+
+fun Modifier.padding(padding: Int) = this.then(PaddingModifier(padding, padding, padding, padding))
+
+private data class PaddingModifier(val left: Int, val top: Int, val right: Int, val bottom: Int) :
+    LayoutModifier {
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable =
+            measurable.measure(
+                constraints.offset(horizontal = -left - right, vertical = -top - bottom)
+            )
+        return layout(
+            constraints.constrainWidth(left + placeable.width + right),
+            constraints.constrainHeight(top + placeable.height + bottom),
+        ) {
+            placeable.placeRelative(left, top)
+        }
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int,
+    ): Int =
+        measurable.minIntrinsicWidth((height - (top + bottom)).coerceAtLeast(0)) + (left + right)
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurable: IntrinsicMeasurable,
+        height: Int,
+    ): Int =
+        measurable.maxIntrinsicWidth((height - (top + bottom)).coerceAtLeast(0)) + (left + right)
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurable: IntrinsicMeasurable,
+        width: Int,
+    ): Int =
+        measurable.minIntrinsicHeight((width - (left + right)).coerceAtLeast(0)) + (top + bottom)
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurable: IntrinsicMeasurable,
+        width: Int,
+    ): Int =
+        measurable.maxIntrinsicHeight((width - (left + right)).coerceAtLeast(0)) + (top + bottom)
+}
+
+internal val AlignTopLeft =
+    object : LayoutModifier {
+        override fun MeasureScope.measure(
+            measurable: Measurable,
+            constraints: Constraints,
+        ): MeasureResult {
+            val placeable = measurable.measure(constraints.copyMaxDimensions())
+            return layout(constraints.maxWidth, constraints.maxHeight) {
+                placeable.placeRelative(0, 0)
+            }
+        }
+    }
+
+@Stable
+class SquareModel(
+    size: Int = 10,
+    outerColor: Color = Color(0xFF000080),
+    innerColor: Color = Color(0xFFFFFFFF),
+) {
+    var size: Int by mutableStateOf(size)
+    var outerColor: Color by mutableStateOf(outerColor)
+    var innerColor: Color by mutableStateOf(innerColor)
+}
+
+fun Modifier.background(color: Color) = drawBehind { drawRect(color) }
+
+fun Modifier.background(model: SquareModel, isInner: Boolean) = drawBehind {
+    drawRect(if (isInner) model.innerColor else model.outerColor)
+}
+
+class LayoutAndDrawModifier(val color: Color) : LayoutModifier, DrawModifier {
+
+    override fun MeasureScope.measure(
+        measurable: Measurable,
+        constraints: Constraints,
+    ): MeasureResult {
+        val placeable = measurable.measure(Constraints.fixed(10, 10))
+        return layout(constraints.maxWidth, constraints.maxHeight) {
+            placeable.placeRelative(
+                (constraints.maxWidth - placeable.width) / 2,
+                (constraints.maxHeight - placeable.height) / 2,
+            )
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        drawRect(color)
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.FixedSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.Padding
 import androidx.compose.ui.assertColorsEqual
+import androidx.compose.ui.assertOffsetEqual
+import androidx.compose.ui.assertRectEqual
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.background
 import androidx.compose.ui.draw.drawBehind
@@ -315,10 +317,10 @@ class CommonGraphicsLayerTest {
         }
 
         onRoot().apply {
-            assertEquals(Offset(15f, 5f), coords2!!.localPositionOf(coords1!!, Offset.Zero))
-            assertEquals(Offset(-5f, 5f), coords2!!.localPositionOf(coords1!!, Offset(20f, 0f)))
-            assertEquals(Rect(-5f, -5f, 15f, 5f), coords2!!.localBoundingBoxOf(coords1!!, false))
-            assertEquals(Rect(0f, 0f, 10f, 5f), coords2!!.localBoundingBoxOf(coords1!!, true))
+            assertOffsetEqual(Offset(15f, 5f), coords2!!.localPositionOf(coords1!!, Offset.Zero))
+            assertOffsetEqual(Offset(-5f, 5f), coords2!!.localPositionOf(coords1!!, Offset(20f, 0f)))
+            assertRectEqual(Rect(-5f, -5f, 15f, 5f), coords2!!.localBoundingBoxOf(coords1!!, false))
+            assertRectEqual(Rect(0f, 0f, 10f, 5f), coords2!!.localBoundingBoxOf(coords1!!, true))
         }
     }
 
@@ -1285,7 +1287,7 @@ class CommonGraphicsLayerTest {
             }
         }
 
-        runOnIdle { assertThat(bounds).isEqualTo(Rect(0f, 0f, 10f, 10f)) }
+        runOnIdle { assertRectEqual(bounds, Rect(0f, 0f, 10f, 10f)) }
     }
 
     @Test
@@ -1300,7 +1302,7 @@ class CommonGraphicsLayerTest {
             }
         }
 
-        runOnIdle { assertThat(bounds).isEqualTo(Rect(0f, 0f, 9f, 9f)) }
+        runOnIdle { assertRectEqual(bounds, Rect(0f, 0f, 9f, 9f)) }
     }
 
     @Test
@@ -1320,7 +1322,7 @@ class CommonGraphicsLayerTest {
             }
         }
 
-        runOnIdle { assertThat(bounds).isEqualTo(Rect(10f, 10f, 20f, 20f)) }
+        runOnIdle { assertRectEqual(bounds, Rect(10f, 10f, 20f, 20f)) }
     }
 
     @Test

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/CommonGraphicsLayerTest.kt
@@ -1,0 +1,1434 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.graphics
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReusableContent
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.movableContentOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.testutils.assertPixelColor
+import androidx.compose.testutils.assertPixels
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.FixedSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Padding
+import androidx.compose.ui.assertColorsEqual
+import androidx.compose.ui.assertThat
+import androidx.compose.ui.background
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.inset
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.isEqualTo
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.padding
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
+import kotlin.math.roundToInt
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import org.jetbrains.skia.Bitmap
+
+// A copy from androidInstrumentedTest/kotlin/androidx/compose/ui/draw/GraphicsLayerTest.kt
+
+@OptIn(ExperimentalTestApi::class)
+class CommonGraphicsLayerTest {
+
+    @Test
+    fun testLayerBoundsPosition() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            FixedSize(
+                30,
+                Modifier.padding(10).graphicsLayer().onGloballyPositioned { coords = it },
+            ) { /* no-op */
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            assertEquals(Offset(10f, 10f), layoutCoordinates.positionInRoot())
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(10f, 10f, 40f, 40f), bounds)
+            val global = layoutCoordinates.boundsInWindow()
+            val position = layoutCoordinates.positionInWindow()
+            assertEquals(position.x, global.left)
+            assertEquals(position.y, global.top)
+            assertEquals(30f, global.width)
+            assertEquals(30f, global.height)
+        }
+    }
+
+    @Test
+    fun testScale() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(
+                    10,
+                    Modifier.graphicsLayer(scaleX = 2f, scaleY = 3f).onGloballyPositioned {
+                        coords = it
+                    },
+                ) {}
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(5f, 0f, 25f, 30f), bounds)
+            assertEquals(Offset(5f, 0f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testScaleConvenienceXY() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(
+                    10,
+                    Modifier.scale(scaleX = 2f, scaleY = 3f).onGloballyPositioned { coords = it },
+                ) {}
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(5f, 0f, 25f, 30f), bounds)
+            assertEquals(Offset(5f, 0f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testScaleConvenienceUniform() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(10, Modifier.scale(scale = 2f).onGloballyPositioned { coords = it }) {}
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(5f, 5f, 25f, 25f), bounds)
+            assertEquals(Offset(5f, 5f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testRotation() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(
+                    10,
+                    Modifier.graphicsLayer(scaleY = 3f, rotationZ = 90f).onGloballyPositioned {
+                        coords = it
+                    },
+                ) {}
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(0f, 10f, 30f, 20f), bounds)
+            assertEquals(Offset(30f, 10f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testRotationConvenience() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(10, Modifier.rotate(90f).onGloballyPositioned { coords = it }) {}
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(10.0f, 10f, 20f, 20f), bounds)
+            assertEquals(Offset(20f, 10f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testRotationPivot() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(
+                    10,
+                    Modifier.graphicsLayer(
+                            rotationZ = 90f,
+                            transformOrigin = TransformOrigin(1.0f, 1.0f),
+                        )
+                        .onGloballyPositioned { coords = it },
+                )
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(20f, 10f, 30f, 20f), bounds)
+            assertEquals(Offset(30f, 10f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testTranslationXY() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(
+                    10,
+                    Modifier.graphicsLayer(translationX = 5.0f, translationY = 8.0f)
+                        .onGloballyPositioned { coords = it },
+                )
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(15f, 18f, 25f, 28f), bounds)
+            assertEquals(Offset(15f, 18f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testClip() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(10, Modifier.graphicsLayer(clip = true)) {
+                    FixedSize(
+                        10,
+                        Modifier.graphicsLayer(scaleX = 2f).onGloballyPositioned { coords = it },
+                    ) {}
+                }
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            assertEquals(Rect(10f, 10f, 20f, 20f), bounds)
+            // Positions aren't clipped
+            assertEquals(Offset(5f, 10f), layoutCoordinates.positionInRoot())
+        }
+    }
+
+    @Test
+    fun testSiblingComparisons() = runComposeUiTest {
+        var coords1: LayoutCoordinates? = null
+        var coords2: LayoutCoordinates? = null
+        setContent {
+            with(LocalDensity.current) {
+                Box(Modifier.requiredSize(25.toDp()).graphicsLayer(rotationZ = 30f, clip = true)) {
+                    Box(
+                        Modifier.graphicsLayer(
+                                rotationZ = 90f,
+                                transformOrigin = TransformOrigin(0f, 1f),
+                                clip = true,
+                            )
+                            .requiredSize(20.toDp(), 10.toDp())
+                            .align(AbsoluteAlignment.TopLeft)
+                            .onGloballyPositioned { coords1 = it }
+                    )
+                    Box(
+                        Modifier.graphicsLayer(
+                                rotationZ = -90f,
+                                transformOrigin = TransformOrigin(0f, 1f),
+                                clip = true,
+                            )
+                            .requiredSize(10.toDp())
+                            .align(AbsoluteAlignment.BottomRight)
+                            .onGloballyPositioned { coords2 = it }
+                    )
+                }
+            }
+        }
+
+        onRoot().apply {
+            assertEquals(Offset(15f, 5f), coords2!!.localPositionOf(coords1!!, Offset.Zero))
+            assertEquals(Offset(-5f, 5f), coords2!!.localPositionOf(coords1!!, Offset(20f, 0f)))
+            assertEquals(Rect(-5f, -5f, 15f, 5f), coords2!!.localBoundingBoxOf(coords1!!, false))
+            assertEquals(Rect(0f, 0f, 10f, 5f), coords2!!.localBoundingBoxOf(coords1!!, true))
+        }
+    }
+
+    @Test
+    fun testCameraDistanceWithRotationY() = runComposeUiTest {
+        val testTag = "parent"
+        setContent {
+            Box(modifier = Modifier.testTag(testTag).wrapContentSize()) {
+                Box(
+                    modifier =
+                        Modifier.requiredSize(100.dp)
+                            .background(Color.Gray)
+                            .graphicsLayer(rotationY = 25f, cameraDistance = 1.0f)
+                            .background(Color.Red)
+                ) {
+                    Box(modifier = Modifier.requiredSize(100.dp))
+                }
+            }
+        }
+
+        onNodeWithTag(testTag).captureToImage().asSkiaBitmap().apply {
+            assertEquals(Color.Red.toArgb(), getColor(0, 0))
+            assertEquals(Color.Red.toArgb(), getColor(0, height - 1))
+            assertEquals(Color.Red.toArgb(), getColor(width / 2 - 10, height / 2))
+            assertEquals(Color.Gray.toArgb(), getColor(width - 1 - 10, height / 2))
+            assertEquals(Color.Gray.toArgb(), getColor(width - 1, 0))
+            assertEquals(Color.Gray.toArgb(), getColor(width - 1, height - 1))
+        }
+    }
+
+    @Test
+    fun testEmptyClip() = runComposeUiTest {
+        val EmptyRectangle =
+            object : Shape {
+                override fun createOutline(
+                    size: Size,
+                    layoutDirection: LayoutDirection,
+                    density: Density,
+                ) = Outline.Rectangle(Rect.Zero)
+            }
+        val tag = "testTag"
+        setContent {
+            Box(modifier = Modifier.testTag(tag).requiredSize(100.dp).background(Color.Blue)) {
+                Box(
+                    modifier =
+                        Modifier.matchParentSize()
+                            .graphicsLayer(clip = true, shape = EmptyRectangle)
+                            .background(Color.Red)
+                )
+            }
+        }
+
+        // Results should match background color of parent. Because the child Box is clipped to
+        // an empty rectangle, no red pixels from its background should be visible
+        onNodeWithTag(tag).captureToImage().assertPixels { Color.Blue }
+    }
+
+    @Test
+    fun testTotalClip() = runComposeUiTest {
+        var coords: LayoutCoordinates? = null
+        setContent {
+            Padding(10) {
+                FixedSize(10, Modifier.graphicsLayer(clip = true)) {
+                    FixedSize(10, Modifier.padding(20).onGloballyPositioned { coords = it }) {}
+                }
+            }
+        }
+
+        onRoot().apply {
+            val layoutCoordinates = coords!!
+            val bounds = layoutCoordinates.boundsInRoot()
+            // should be completely clipped out
+            assertEquals(0f, bounds.width)
+            assertEquals(0f, bounds.height)
+        }
+    }
+
+    @Test
+    fun testColorFilter() = runComposeUiTest {
+        val testTag = "colorFilterTag"
+        setContent {
+            Box(modifier = Modifier.testTag(testTag).wrapContentSize()) {
+                Box(modifier = Modifier.requiredSize(10.dp).background(Color.Green))
+                Box(
+                    modifier =
+                        Modifier.requiredSize(10.dp)
+                            .graphicsLayer(
+                                colorFilter = LightingColorFilter(Color.White, Color.Red)
+                            )
+                            .background(Color.Black)
+                )
+            }
+        }
+
+        onNodeWithTag(testTag).captureToImage().asSkiaBitmap().apply {
+            assertColor(Color.Red, 0, 0)
+            assertColor(Color.Red, 0, height - 1)
+            assertColor(Color.Red, width / 2 - 10, height / 2)
+        }
+    }
+
+    @Test
+    fun testColorFilterAsScope() = runComposeUiTest {
+        val testTag = "colorFilterTag"
+        setContent {
+            Box(modifier = Modifier.testTag(testTag).wrapContentSize()) {
+                Box(modifier = Modifier.requiredSize(10.dp).background(Color.Green))
+                Box(
+                    modifier =
+                        Modifier.requiredSize(10.dp)
+                            .graphicsLayer {
+                                colorFilter = LightingColorFilter(Color.White, Color.Red)
+                            }
+                            .background(Color.Black)
+                )
+            }
+        }
+
+        onNodeWithTag(testTag).captureToImage().asSkiaBitmap().apply {
+            assertColor(Color.Red, 0, 0)
+            assertColor(Color.Red, 0, height - 1)
+            assertColor(Color.Red, width / 2 - 10, height / 2)
+        }
+    }
+
+    @Test
+    fun testBlendMode() = runComposeUiTest {
+        val testTag = "blendModeTag"
+        setContent {
+            Box(modifier = Modifier.testTag(testTag).wrapContentSize()) {
+                Box(modifier = Modifier.requiredSize(10.dp).background(Color.Yellow))
+                Box(
+                    modifier =
+                        Modifier.requiredSize(10.dp)
+                            .graphicsLayer(blendMode = BlendMode.Dst)
+                            .background(Color.Blue)
+                )
+            }
+        }
+
+        onNodeWithTag(testTag).captureToImage().asSkiaBitmap().apply {
+            assertColor(Color.Yellow, 0, 0)
+            assertColor(Color.Yellow, 0, height - 1)
+            assertColor(Color.Yellow, width / 2 - 10, height / 2)
+        }
+    }
+
+    @Test
+    fun testBlendModeAsScope() = runComposeUiTest {
+        val testTag = "blendModeTag"
+        setContent {
+            Box(modifier = Modifier.testTag(testTag).wrapContentSize()) {
+                Box(modifier = Modifier.requiredSize(10.dp).background(Color.Yellow))
+                Box(
+                    modifier =
+                        Modifier.requiredSize(10.dp)
+                            .graphicsLayer { blendMode = BlendMode.Dst }
+                            .background(Color.Blue)
+                )
+            }
+        }
+
+        onNodeWithTag(testTag).captureToImage().asSkiaBitmap().apply {
+            assertColor(Color.Yellow, 0, 0)
+            assertColor(Color.Yellow, 0, height - 1)
+            assertColor(Color.Yellow, width / 2 - 10, height / 2)
+        }
+    }
+
+    @Composable
+    fun BoxBlur(tag: String, size: Float, blurRadius: Float) {
+        BoxRenderEffect(
+            tag,
+            (size / LocalDensity.current.density).dp,
+            ({ BlurEffect(blurRadius, blurRadius, TileMode.Decal) }),
+        ) {
+            inset(blurRadius, blurRadius) { drawRect(Color.Blue) }
+        }
+    }
+
+    @Composable
+    fun BoxRenderEffect(
+        tag: String,
+        size: Dp,
+        renderEffectCreator: () -> RenderEffect,
+        drawBlock: DrawScope.() -> Unit,
+    ) {
+        Box(
+            Modifier.testTag(tag)
+                .size(size)
+                .background(Color.Black)
+                .graphicsLayer { renderEffect = renderEffectCreator() }
+                .drawBehind(drawBlock)
+        )
+    }
+
+    @Test
+    fun testBlurEffect() = runComposeUiTest {
+        val tag = "blurTag"
+        val size = 100f
+        val blurRadius = 10f
+        setContent { BoxBlur(tag, size, blurRadius) }
+        onNodeWithTag(tag).captureToImage().apply {
+            val pixelMap = toPixelMap()
+            var nonPureBlueCount = 0
+            for (x in (blurRadius).toInt() until (width - (blurRadius)).toInt()) {
+                for (y in (blurRadius).toInt() until (height - (blurRadius)).toInt()) {
+                    val pixelColor = pixelMap[x, y]
+                    if (pixelColor.red > 0 || pixelColor.green > 0) {
+                        fail("Only blue colors are expected. Pixel at [$x, $y] $pixelColor")
+                    }
+                    if (pixelColor.blue > 0 && pixelColor.blue < 1f) {
+                        nonPureBlueCount++
+                    }
+                }
+            }
+            assertTrue(nonPureBlueCount > 0)
+        }
+    }
+
+    @Test
+    fun testZeroRadiusBlurDoesNotCrash() = runComposeUiTest {
+        val tag = "blurTag"
+        val size = 100f
+        setContent { BoxBlur(tag, size, 0f) }
+    }
+
+    @Test
+    fun testOffsetEffect() = runComposeUiTest {
+        val tag = "blurTag"
+        val size = 100f
+        setContent {
+            BoxRenderEffect(
+                tag,
+                (size / LocalDensity.current.density).dp,
+                { OffsetEffect(20f, 20f) },
+            ) {
+                drawRect(Color.Blue, size = Size(this.size.width - 20, this.size.height - 20))
+            }
+        }
+        onNodeWithTag(tag).captureToImage().apply {
+            val pixelMap = toPixelMap()
+            for (x in 0 until width) {
+                for (y in 0 until height) {
+                    if (x >= 20f && y >= 20f) {
+                        assertEquals(Color.Blue, pixelMap[x, y], "Index $x, $y should be blue")
+                    } else {
+                        assertEquals(Color.Black, pixelMap[x, y], "Index $x, $y should be black")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun invalidateWhenWeHaveSemanticModifierAfterLayer() = runComposeUiTest {
+        var color by mutableStateOf(Color.Red)
+        setContent { FixedSize(5, Modifier.graphicsLayer().testTag("tag").background(color)) }
+
+        runOnIdle { color = Color.Green }
+
+        onNodeWithTag("tag").captureToImage().assertPixels { color }
+    }
+
+    @Test
+    fun testDpPixelConversions() = runComposeUiTest {
+        var density: Density? = null
+        var testDpConversion = 0f
+        var testFontScaleConversion = 0f
+        setContent {
+            density = LocalDensity.current
+            // Verify that the current density is passed to the graphics layer
+            // implementation and that density dependent methods are consuming it
+            Box(
+                modifier =
+                    Modifier.graphicsLayer {
+                        testDpConversion = 2.dp.toPx()
+                        testFontScaleConversion = 3.dp.toSp().toPx()
+                    }
+            )
+        }
+
+        runOnIdle {
+            with(density!!) {
+                assertEquals(2.dp.toPx(), testDpConversion)
+                assertEquals(3.dp.toSp().toPx(), testFontScaleConversion)
+            }
+        }
+    }
+
+    @Test
+    fun testClickOnScaledElement() = runComposeUiTest {
+        var firstClicked = false
+        var secondClicked = false
+        setContent {
+            Layout(
+                content = {
+                    Box(Modifier.fillMaxSize().clickable { firstClicked = true })
+                    Box(Modifier.fillMaxSize().clickable { secondClicked = true })
+                },
+                modifier = Modifier.testTag("layout"),
+            ) { measurables, _ ->
+                val itemConstraints = Constraints.fixed(100, 100)
+                val first = measurables[0].measure(itemConstraints)
+                val second = measurables[1].measure(itemConstraints)
+                layout(100, 200) {
+                    val layer: GraphicsLayerScope.() -> Unit = {
+                        scaleX = 0.5f
+                        scaleY = 0.5f
+                    }
+                    first.placeWithLayer(0, 0, layerBlock = layer)
+                    second.placeWithLayer(0, 100, layerBlock = layer)
+                }
+            }
+        }
+
+        onNodeWithTag("layout").performTouchInput { click(position = Offset(50f, 170f)) }
+
+        runOnIdle {
+            assertFalse(firstClicked, "First element is clicked")
+            assertTrue(secondClicked, "Second element is not clicked")
+        }
+    }
+
+    @Test
+    fun usingNestedDerivedStateInGraphicsLayerBlock() = runComposeUiTest {
+        val mutableState = mutableStateOf(1f)
+        val derivedState by derivedStateOf { mutableState.value }
+        val nestedDerivedState by derivedStateOf { derivedState }
+        var valueReadInGraphicsLayer = Float.MIN_VALUE
+
+        setContent {
+            Box(
+                Modifier.layout { measurable, constraints ->
+                        // update the state during the measure pass
+                        mutableState.value = 2f
+
+                        val placeable = measurable.measure(constraints)
+                        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+                    }
+                    .graphicsLayer {
+                        // read during updateLayerParameters
+                        valueReadInGraphicsLayer = nestedDerivedState
+                    }
+            )
+        }
+
+        runOnIdle { assertEquals(2f, valueReadInGraphicsLayer) }
+    }
+
+    @Test
+    fun testCompositingStrategyModulateAlpha() = runComposeUiTest {
+        val tag = "testTag"
+        val dimen = 200
+        setContent {
+            Canvas(
+                modifier =
+                    Modifier.testTag(tag)
+                        .size((dimen / LocalDensity.current.density).dp)
+                        .background(Color.Black)
+                        .graphicsLayer(
+                            alpha = 0.5f,
+                            compositingStrategy = CompositingStrategy.ModulateAlpha,
+                        )
+            ) {
+                inset(0f, 0f, size.width / 3, size.height / 3) { drawRect(color = Color.Red) }
+                inset(size.width / 3, size.height / 3, 0f, 0f) { drawRect(color = Color.Blue) }
+            }
+        }
+
+        onNodeWithTag(tag).captureToImage().apply {
+            with(toPixelMap()) {
+                val redWithAlpha = Color.Red.copy(alpha = 0.5f)
+                val blueWithAlpha = Color.Blue.copy(alpha = 0.5f)
+                val bg = Color.Black
+                val expectedTopLeft = redWithAlpha.compositeOver(bg)
+                val expectedBottomRight = blueWithAlpha.compositeOver(bg)
+                val expectedCenter = blueWithAlpha.compositeOver(redWithAlpha).compositeOver(bg)
+                assertPixelColor(expectedTopLeft, 0, 0)
+                assertPixelColor(Color.Black, width - 1, 0)
+                assertPixelColor(expectedBottomRight, width - 1, height - 1)
+                assertPixelColor(Color.Black, 0, height - 1)
+                assertPixelColor(expectedCenter, width / 2, height / 2)
+            }
+        }
+    }
+
+    @Test
+    fun testCompositingStrategyAlways() = runComposeUiTest {
+        val tag = "testTag"
+        val dimen = 200
+        setContent {
+            Canvas(
+                modifier =
+                    Modifier.testTag(tag)
+                        .size((dimen / LocalDensity.current.density).dp)
+                        .background(Color.LightGray)
+                        .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+            ) {
+                inset(0f, 0f, size.width / 3, size.height / 3) { drawRect(color = Color.Red) }
+                inset(size.width / 3, size.height / 3, 0f, 0f) {
+                    drawRect(color = Color.Blue, blendMode = BlendMode.Xor)
+                }
+            }
+        }
+
+        onNodeWithTag(tag).captureToImage().apply {
+            with(toPixelMap()) {
+                assertPixelColor(Color.Red, 0, 0)
+                assertPixelColor(Color.LightGray, width - 1, 0)
+                assertPixelColor(Color.Blue, width - 1, height - 1)
+                assertPixelColor(Color.LightGray, 0, height - 1)
+                assertPixelColor(Color.LightGray, width / 2, height / 2)
+            }
+        }
+    }
+
+    @Test
+    fun testCompositingStrategyAuto() = runComposeUiTest {
+        val tag = "testTag"
+        val dimen = 200
+        setContent {
+            Canvas(
+                modifier =
+                    Modifier.testTag(tag)
+                        .size((dimen / LocalDensity.current.density).dp)
+                        .background(Color.Black)
+                        .graphicsLayer(alpha = 0.5f, compositingStrategy = CompositingStrategy.Auto)
+            ) {
+                inset(0f, 0f, size.width / 3, size.height / 3) { drawRect(color = Color.Red) }
+                inset(size.width / 3, size.height / 3, 0f, 0f) { drawRect(color = Color.Blue) }
+            }
+        }
+
+        onNodeWithTag(tag).captureToImage().apply {
+            with(toPixelMap()) {
+                val redWithAlpha = Color.Red.copy(alpha = 0.5f)
+                val blueWithAlpha = Color.Blue.copy(alpha = 0.5f)
+                val bg = Color.Black
+                val expectedTopLeft = redWithAlpha.compositeOver(bg)
+                val expectedBottomRight = blueWithAlpha.compositeOver(bg)
+                val expectedCenter = blueWithAlpha.compositeOver(bg)
+                assertPixelColor(expectedTopLeft, 0, 0)
+                assertPixelColor(Color.Black, width - 1, 0)
+                assertPixelColor(expectedBottomRight, width - 1, height - 1)
+                assertPixelColor(Color.Black, 0, height - 1)
+                assertPixelColor(expectedCenter, width / 2, height / 2)
+            }
+        }
+    }
+
+    @Test
+    fun testGraphicsLayerScopeSize() = runComposeUiTest {
+        val widthDp = 200.dp
+        val heightDp = 500.dp
+
+        var graphicsLayerWidth = 0f
+        var graphicsLayerHeight = 0f
+        var drawScopeWidth = -1f
+        var drawScopeHeight = -1f
+        setContent {
+            Box(
+                modifier =
+                    Modifier.size(widthDp, heightDp)
+                        .graphicsLayer {
+                            graphicsLayerWidth = size.width
+                            graphicsLayerHeight = size.height
+                        }
+                        .drawBehind {
+                            drawScopeWidth = size.width
+                            drawScopeHeight = size.height
+                        }
+            )
+        }
+        runOnIdle {
+            assertEquals(drawScopeWidth, graphicsLayerWidth)
+            assertEquals(drawScopeHeight, graphicsLayerHeight)
+        }
+    }
+
+    @Test
+    fun testGraphicsLayerSizeAfterRelayout() = runComposeUiTest {
+        var composableSize by mutableStateOf(20.dp)
+        var graphicsLayerWidth = -1f
+        var graphicsLayerHeight = -1f
+        var drawScopeWidth = 0f
+        var drawScopeHeight = 0f
+
+        var density: Density? = null
+
+        setContent {
+            density = LocalDensity.current
+            Box(
+                modifier =
+                    Modifier.size(composableSize, composableSize)
+                        .graphicsLayer {
+                            graphicsLayerWidth = size.width
+                            graphicsLayerHeight = size.height
+                        }
+                        .drawBehind {
+                            drawScopeWidth = size.width
+                            drawScopeHeight = size.height
+                        }
+            )
+        }
+
+        waitForIdle()
+
+        assertNotNull(density)
+
+        var sizePx = with(density!!) { ceil(composableSize.toPx()) }
+        assertEquals(sizePx, graphicsLayerWidth)
+        assertEquals(sizePx, graphicsLayerHeight)
+        assertEquals(sizePx, drawScopeWidth)
+        assertEquals(sizePx, drawScopeHeight)
+
+        composableSize = 40.dp
+
+        waitForIdle()
+
+        sizePx = with(density!!) { ceil(composableSize.toPx()) }
+        assertEquals(sizePx, graphicsLayerWidth)
+        assertEquals(sizePx, graphicsLayerHeight)
+        assertEquals(sizePx, drawScopeWidth)
+        assertEquals(sizePx, drawScopeHeight)
+    }
+
+    @Test
+    fun removingGraphicsLayerInvalidatesParentLayer() = runComposeUiTest {
+        var toggle by mutableStateOf(true)
+        val size = 100
+        setContent {
+            val sizeDp = with(LocalDensity.current) { size.toDp() }
+            LazyColumn(Modifier.testTag("lazy").background(Color.Blue)) {
+                items(4) {
+                    Box(
+                        Modifier.then(if (toggle) Modifier.graphicsLayer(alpha = 0f) else Modifier)
+                            .background(Color.Red)
+                            .size(sizeDp)
+                    )
+                }
+            }
+        }
+
+        onNodeWithTag("lazy").captureToImage().asSkiaBitmap().apply {
+            assertEquals(Color.Blue.toArgb(), getColor(10, (size * 1.5f).roundToInt()))
+            assertEquals(Color.Blue.toArgb(), getColor(10, (size * 2.5f).roundToInt()))
+        }
+
+        runOnIdle { toggle = !toggle }
+
+        onNodeWithTag("lazy").captureToImage().asSkiaBitmap().apply {
+            assertEquals(Color.Red.toArgb(), getColor(10, (size * 1.5f).roundToInt()))
+            assertEquals(Color.Red.toArgb(), getColor(10, (size * 2.5f).roundToInt()))
+        }
+    }
+
+    // Repro test for b/298520326. Unfortunately, this test does not successfully reproduce the
+    // issue prior to the "fix", so is not a valid regression test. The act of calling
+    // `captureToImage()` causes the bug to disappear.
+    @Test
+    fun removingGraphicsLayerInvalidatesParentLayer2() = runComposeUiTest {
+        var toggle by mutableStateOf(false)
+        val size = 100
+        setContent {
+            val sizeDp = with(LocalDensity.current) { size.toDp() }
+            Box(
+                Modifier.testTag("outer")
+                    .layout { measurable, constraints ->
+                        val placeable = measurable.measure(constraints)
+                        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+                    }
+                    .then(
+                        if (toggle)
+                            Modifier.graphicsLayer(scaleX = 1f).layout { measurable, constraints ->
+                                val placeable = measurable.measure(constraints)
+                                layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+                            }
+                        else Modifier
+                    )
+            ) {
+                Box(Modifier.Companion.background(Color.Red).size(sizeDp))
+            }
+        }
+
+        val pt = (size * 0.5f).roundToInt()
+
+        onNodeWithTag("outer").captureToImage().asSkiaBitmap().apply {
+            assertEquals(Color.Red.toArgb(), getColor(pt, pt))
+        }
+
+        runOnIdle { toggle = !toggle }
+
+        onNodeWithTag("outer").captureToImage().asSkiaBitmap().apply {
+            assertEquals(Color.Red.toArgb(), getColor(pt, pt))
+        }
+
+        runOnIdle { toggle = !toggle }
+
+        onNodeWithTag("outer").captureToImage().asSkiaBitmap().apply {
+            assertEquals(Color.Red.toArgb(), getColor(pt, pt))
+        }
+    }
+
+    @Test
+    fun removingGraphicsLayerModifierResetsItsAction() = runComposeUiTest {
+        var addGraphicsLayer by mutableStateOf(true)
+        lateinit var coordinates: LayoutCoordinates
+        setContent {
+            Box(
+                if (addGraphicsLayer) {
+                    Modifier.graphicsLayer(translationX = 10f)
+                } else {
+                    Modifier
+                }
+            ) {
+                Layout(Modifier.onGloballyPositioned { coordinates = it }) { _, _ ->
+                    layout(10, 10) {}
+                }
+            }
+        }
+
+        runOnIdle {
+            assertEquals(Rect(10f, 0f, 20f, 10f), coordinates.boundsInRoot())
+            addGraphicsLayer = false
+        }
+
+        runOnIdle { assertEquals(Rect(0f, 0f, 10f, 10f), coordinates.boundsInRoot()) }
+    }
+
+    @Test
+    fun invalidationAfterMovingMovableContentWithLayer() = runComposeUiTest {
+        var moveContent by mutableStateOf(false)
+        var counter by mutableStateOf(0)
+        var counterReadInDrawing = -1
+        val content = movableContentOf {
+            Box(Modifier.size(5.dp).graphicsLayer().drawBehind { counterReadInDrawing = counter })
+        }
+
+        setContent {
+            if (moveContent) {
+                Box(Modifier.size(5.dp)) { content() }
+            } else {
+                Box(Modifier.size(10.dp)) { content() }
+            }
+        }
+
+        runOnIdle { moveContent = true }
+
+        runOnIdle {
+            assertThat(counterReadInDrawing).isEqualTo(counter)
+            counter++
+        }
+
+        runOnIdle { assertThat(counterReadInDrawing).isEqualTo(counter) }
+    }
+
+    @Test
+    fun updatingLayerPropertiesAfterMovingMovableContent() = runComposeUiTest {
+        var moveContent by mutableStateOf(false)
+        var counter by mutableStateOf(0)
+        var counterReadInLayerBlock = -1
+        val content = movableContentOf {
+            Box(Modifier.size(5.dp).graphicsLayer { counterReadInLayerBlock = counter })
+        }
+
+        setContent {
+            if (moveContent) {
+                Box(Modifier.size(5.dp)) { content() }
+            } else {
+                Box(Modifier.size(10.dp)) { content() }
+            }
+        }
+
+        runOnIdle { moveContent = true }
+
+        runOnIdle {
+            assertThat(counterReadInLayerBlock).isEqualTo(counter)
+            counter++
+        }
+
+        runOnIdle { assertThat(counterReadInLayerBlock).isEqualTo(counter) }
+    }
+
+    @Test
+    fun updatingValueIsNotCausingRemeasureOrRelayout() = runComposeUiTest {
+        var translationX by mutableStateOf(0f)
+        lateinit var coordinates: LayoutCoordinates
+        var remeasureCount = 0
+        var relayoutCount = 0
+        val layoutModifier =
+            Modifier.layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                remeasureCount++
+                layout(placeable.width, placeable.height) {
+                    relayoutCount++
+                    placeable.place(0, 0)
+                }
+            }
+        setContent {
+            Box(Modifier.graphicsLayer(translationX = translationX).then(layoutModifier)) {
+                Layout(Modifier.onGloballyPositioned { coordinates = it }) { _, _ ->
+                    layout(10, 10) {}
+                }
+            }
+        }
+
+        runOnIdle {
+            assertEquals(0f, coordinates.boundsInRoot().left)
+            // reset counters
+            remeasureCount = 0
+            relayoutCount = 0
+            // update translation
+            translationX = 10f
+        }
+
+        runOnIdle {
+            assertEquals(10f, coordinates.boundsInRoot().left)
+            assertEquals(0, remeasureCount)
+            assertEquals(0, relayoutCount)
+        }
+    }
+
+    @Test
+    fun updatingLambdaIsNotCausingRemeasureOrRelayout() = runComposeUiTest {
+        var lambda by mutableStateOf<GraphicsLayerScope.() -> Unit>({})
+        lateinit var coordinates: LayoutCoordinates
+        var remeasureCount = 0
+        var relayoutCount = 0
+        val layoutModifier =
+            Modifier.layout { measurable, constraints ->
+                val placeable = measurable.measure(constraints)
+                remeasureCount++
+                layout(placeable.width, placeable.height) {
+                    relayoutCount++
+                    placeable.place(0, 0)
+                }
+            }
+        setContent {
+            Box(Modifier.graphicsLayer(lambda).then(layoutModifier)) {
+                Layout(Modifier.onGloballyPositioned { coordinates = it }) { _, _ ->
+                    layout(10, 10) {}
+                }
+            }
+        }
+
+        runOnIdle {
+            assertEquals(0f, coordinates.boundsInRoot().left)
+            // reset counters
+            remeasureCount = 0
+            relayoutCount = 0
+            // update lambda
+            lambda = { translationX = 10f }
+        }
+
+        runOnIdle {
+            assertEquals(10f, coordinates.boundsInRoot().left)
+            assertEquals(0, remeasureCount)
+            assertEquals(0, relayoutCount)
+        }
+    }
+
+    @Test
+    fun addingLayerForChildDoesntTriggerChildRelayout() = runComposeUiTest {
+        var relayoutCount = 0
+        var modifierRelayoutCount = 0
+        var needLayer by mutableStateOf(false)
+        var layerBlockCalled = false
+        setContent {
+            Layout(
+                content = {
+                    Layout(
+                        modifier =
+                            Modifier.layout { measurable, constraints ->
+                                val placeable = measurable.measure(constraints)
+                                layout(placeable.width, placeable.height) {
+                                    modifierRelayoutCount++
+                                    placeable.place(0, 0)
+                                }
+                            }
+                    ) { _, _ ->
+                        layout(10, 10) { relayoutCount++ }
+                    }
+                }
+            ) { measurables, constraints ->
+                val placeable = measurables[0].measure(constraints)
+                layout(placeable.width, placeable.height) {
+                    if (needLayer) {
+                        placeable.placeWithLayer(0, 0) { layerBlockCalled = true }
+                    } else {
+                        placeable.place(0, 0)
+                    }
+                }
+            }
+        }
+
+        runOnIdle {
+            relayoutCount = 0
+            modifierRelayoutCount = 0
+            needLayer = true
+        }
+
+        runOnIdle {
+            assertEquals(0, relayoutCount)
+            assertTrue(layerBlockCalled)
+            assertEquals(0, modifierRelayoutCount)
+        }
+    }
+
+    @Test
+    fun movingChildsLayerDoesntTriggerChildRelayout() = runComposeUiTest {
+        var relayoutCount = 0
+        var modifierRelayoutCount = 0
+        var position by mutableStateOf(0)
+        setContent {
+            Layout(
+                content = {
+                    Layout(
+                        modifier =
+                            Modifier.layout { measurable, constraints ->
+                                val placeable = measurable.measure(constraints)
+                                layout(placeable.width, placeable.height) {
+                                    modifierRelayoutCount++
+                                    placeable.place(0, 0)
+                                }
+                            }
+                    ) { _, _ ->
+                        layout(10, 10) { relayoutCount++ }
+                    }
+                }
+            ) { measurables, constraints ->
+                val placeable = measurables[0].measure(constraints)
+                layout(placeable.width, placeable.height) { placeable.placeWithLayer(position, 0) }
+            }
+        }
+
+        runOnIdle {
+            relayoutCount = 0
+            modifierRelayoutCount = 0
+            position = 10
+        }
+
+        runOnIdle {
+            assertEquals(0, relayoutCount)
+            assertEquals(0, modifierRelayoutCount)
+        }
+    }
+
+    @Test
+    fun placingWithExplicitLayerDraws() = runComposeUiTest {
+        setContent {
+            val layer = rememberGraphicsLayer()
+            Canvas(
+                modifier =
+                    Modifier.testTag("tag").layout { measurable, _ ->
+                        val placeable = measurable.measure(Constraints.fixed(10, 10))
+                        layout(placeable.width, placeable.height) {
+                            placeable.placeWithLayer(0, 0, layer)
+                        }
+                    }
+            ) {
+                drawRect(Color.Blue)
+            }
+        }
+
+        onNodeWithTag("tag").captureToImage().assertPixels(IntSize(10, 10)) { Color.Blue }
+    }
+
+    @Test
+    fun placingWithExplicitLayerSetsCorrectSizeAndOffset() = runComposeUiTest {
+        lateinit var layer: GraphicsLayer
+        setContent {
+            layer = rememberGraphicsLayer()
+            Canvas(
+                modifier =
+                    Modifier.layout { measurable, _ ->
+                        val placeable = measurable.measure(Constraints.fixed(20, 20))
+                        layout(placeable.width, placeable.height) {
+                            placeable.placeWithLayer(10, 10, layer)
+                        }
+                    }
+            ) {
+                drawRect(Color.Blue)
+            }
+        }
+
+        runOnIdle {
+            assertThat(layer.size.width).isEqualTo(20)
+            assertThat(layer.size.height).isEqualTo(20)
+            assertThat(layer.topLeft.x).isEqualTo(10)
+            assertThat(layer.topLeft.y).isEqualTo(10)
+        }
+    }
+
+    @Test
+    fun layerIsNotReleasedWhenWeStopPlacingIt() = runComposeUiTest {
+        lateinit var layer: GraphicsLayer
+        var needChild by mutableStateOf(true)
+        setContent {
+            layer = rememberGraphicsLayer()
+            if (needChild) {
+                Canvas(
+                    modifier =
+                        Modifier.layout { measurable, constraints ->
+                            val placeable = measurable.measure(constraints)
+                            layout(placeable.width, placeable.height) {
+                                placeable.placeWithLayer(1, 0, layer)
+                            }
+                        }
+                ) {
+                    drawRect(Color.Blue)
+                }
+            }
+        }
+
+        runOnIdle { needChild = false }
+
+        runOnIdle { assertFalse(layer.isReleased) }
+    }
+
+    @Test
+    fun switchingFromExplicitLayerToImplicit() = runComposeUiTest {
+        var useExplicitLayer by mutableStateOf(true)
+        setContent {
+            val layer =
+                if (useExplicitLayer) {
+                    rememberGraphicsLayer()
+                } else {
+                    null
+                }
+            Canvas(
+                modifier =
+                    Modifier.testTag("tag")
+                        .layout { measurable, _ ->
+                            val placeable = measurable.measure(Constraints.fixed(10, 10))
+                            layout(placeable.width, placeable.height) {
+                                if (layer != null) {
+                                    placeable.placeWithLayer(0, 0, layer)
+                                } else {
+                                    placeable.place(0, 0)
+                                }
+                            }
+                        }
+                        .then(if (layer != null) Modifier else Modifier.graphicsLayer())
+            ) {
+                drawRect(Color.Blue)
+            }
+        }
+
+        runOnIdle { useExplicitLayer = false }
+
+        onNodeWithTag("tag").captureToImage().assertPixels(IntSize(10, 10)) { Color.Blue }
+    }
+
+    @Test
+    fun centerPivotIsUsedWhenWeCalculateBoundsBeforeLayerWasFirstDrawn() = runComposeUiTest {
+        var bounds: Rect = Rect.Zero
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                Box(
+                    modifier =
+                        Modifier.size(10.dp).rotate(180f).onPlaced { bounds = it.boundsInRoot() }
+                )
+            }
+        }
+
+        runOnIdle { assertThat(bounds).isEqualTo(Rect(0f, 0f, 10f, 10f)) }
+    }
+
+    @Test
+    fun centerPivotIsCorrectlyCalculatedForOddSize() = runComposeUiTest {
+        var bounds: Rect = Rect.Zero
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                Box(
+                    modifier =
+                        Modifier.size(9.dp).rotate(180f).onPlaced { bounds = it.boundsInRoot() }
+                )
+            }
+        }
+
+        runOnIdle { assertThat(bounds).isEqualTo(Rect(0f, 0f, 9f, 9f)) }
+    }
+
+    @Test
+    fun customPivotIsCalculatedCorrectlyWhenWeCalculateBoundsBeforeLayerWasFirstDrawn() = runComposeUiTest {
+        var bounds: Rect = Rect.Zero
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                Box(
+                    modifier =
+                        Modifier.size(10.dp)
+                            .graphicsLayer(
+                                rotationZ = 180f,
+                                transformOrigin = TransformOrigin(1f, 1f),
+                            )
+                            .onPlaced { bounds = it.boundsInRoot() }
+                )
+            }
+        }
+
+        runOnIdle { assertThat(bounds).isEqualTo(Rect(10f, 10f, 20f, 20f)) }
+    }
+
+    @Test
+    fun reusedLayerIsRedrawn() = runComposeUiTest {
+        val drawRed = mutableStateOf(true)
+        setContent {
+            Box(Modifier.graphicsLayer().testTag("content")) {
+                ReusableContent(drawRed.value) {
+                    val thirtyPixelsInDp = with(LocalDensity.current) { 30.toDp() }
+                    Box(Modifier.size(thirtyPixelsInDp).graphicsLayer()) {
+                        if (drawRed.value) {
+                            Box(Modifier.fillMaxSize().background(Color.Red))
+                        } else {
+                            Box(Modifier.fillMaxSize().background(Color.Blue))
+                        }
+                    }
+                }
+            }
+        }
+        onNodeWithTag("content").captureToImage().asSkiaBitmap().apply {
+            assertThat(width).isEqualTo(30)
+            assertThat(height).isEqualTo(30)
+            assertThat(getColor(15, 15)).isEqualTo(Color.Red.toArgb())
+        }
+        drawRed.value = false
+        waitForIdle()
+        onNodeWithTag("content").captureToImage().asSkiaBitmap().apply {
+            assertThat(width).isEqualTo(30)
+            assertThat(height).isEqualTo(30)
+            assertThat(getColor(15, 15)).isEqualTo(Color.Blue.toArgb())
+        }
+    }
+
+    @Test
+    fun layerIsCorrectlyRecreatedWithClipAppliedAfterReuse() = runComposeUiTest {
+        var switch by mutableStateOf(true)
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                Box(Modifier.testTag("tag").background(Color.Blue)) {
+                    ReusableContent(switch) {
+                        Canvas(
+                            modifier = Modifier.padding(5.dp).size(5.dp).graphicsLayer(clip = true)
+                        ) {
+                            drawRect(Color.Red, Offset(-5f, -5f), Size(15f, 15f))
+                        }
+                    }
+                }
+            }
+        }
+
+        fun assertPixels() {
+            onNodeWithTag("tag").captureToImage().assertPixels(IntSize(15, 15)) {
+                if (it.x in 5 until 10 && it.y in 5 until 10) {
+                    Color.Red
+                } else {
+                    Color.Blue
+                }
+            }
+        }
+
+        assertPixels()
+
+        runOnIdle { switch = !switch }
+
+        assertPixels()
+    }
+
+    @Test
+    fun layerIsCorrectlyRecreatedWithClipAppliedWhenMoved() = runComposeUiTest {
+        var switch by mutableStateOf(true)
+        val moveable = movableContentOf {
+            Canvas(modifier = Modifier.padding(5.dp).size(5.dp).graphicsLayer(clip = true)) {
+                drawRect(Color.Red, Offset(-5f, -5f), Size(15f, 15f))
+            }
+        }
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(1f)) {
+                Box(Modifier.testTag("tag").background(Color.Blue)) {
+                    if (switch) {
+                        moveable()
+                    } else {
+                        moveable()
+                    }
+                }
+            }
+        }
+
+        fun assertPixels() {
+            onNodeWithTag("tag").captureToImage().assertPixels(IntSize(15, 15)) {
+                if (it.x in 5 until 10 && it.y in 5 until 10) {
+                    Color.Red
+                } else {
+                    Color.Blue
+                }
+            }
+        }
+
+        assertPixels()
+
+        runOnIdle { switch = !switch }
+
+        assertPixels()
+    }
+}
+
+fun Bitmap.assertColor(expectedColor: Color, x: Int, y: Int) {
+    val pixel = Color(getColor(x, y))
+    assertColorsEqual(expectedColor, pixel) {
+        "Pixel [$x, $y] is expected to be $expectedColor, but was $pixel"
+    }
+}

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
@@ -50,8 +50,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 
-@ExperimentalTestApi
-class GraphicsLayerTest {
+@OptIn(ExperimentalTestApi::class)
+class GraphicsLayerRegressionTest {
 
     // Bug: https://youtrack.jetbrains.com/issue/CMP-6660
     @Test


### PR DESCRIPTION
Fixes [CMP-7609](https://youtrack.jetbrains.com/issue/CMP-7609) Adopt adding blendMode and colorFilter to layers

## Release Notes
### Fixes - Multiple Platforms
- _(prerelease fix)_ Fix applying `colorFilter` and `blendMode` from `GraphicsLayerScope` to `GraphicsLayer`
