### PR TITLE
Make PointerEventResult aware of anyChangeConsumed state besides anyMovementConsumed

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -290,7 +290,7 @@ internal class RootNodeOwner(
             IdentityPositionCalculator,
             isInBounds = isInBounds
         )
-        return PointerEventResult(result.anyMovementConsumed)
+        return PointerEventResult(value = result.value)
     }
 
     fun onKeyEvent(keyEvent: KeyEvent): Boolean {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerInputEventData
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -151,12 +152,35 @@ internal fun PointerInputEvent(
 /**
  * The result of processing a pointer event.
  *
- * @property anyMovementConsumed Indicates whether any pointer movement was consumed during event
- * processing.
+ * @property value is a bitmask indicating the properties of the result.
+ * Use [anyMovementConsumed] and [anyChangeConsumed] to read those properties.
+ *
+ * The value is the same as in [androidx.compose.ui.input.pointer.ProcessResult],
+ * but we can't just reuse it because it's internal.
  */
 @InternalComposeUiApi
 @JvmInline
-value class PointerEventResult(val anyMovementConsumed: Boolean)
+value class PointerEventResult(val value: Int) {
+
+    constructor(
+        anyMovementConsumed: Boolean = false,
+        anyChangeConsumed: Boolean = false
+    ) : this(
+        value = (anyMovementConsumed.toInt() shl 1) or
+            (anyChangeConsumed.toInt() shl 2)
+    )
+
+    /** It's true when [PointerInputChange] was consumed and Pointer's position was changed */
+    internal val anyMovementConsumed
+        inline get() = (value and 0x2) != 0
+
+    /** It's true when any [PointerInputChange] was consumed. */
+    internal val anyChangeConsumed
+        inline get() = (value and 0x4) != 0
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun Boolean.toInt() = if (this) 1 else 0
 
 // TODO: Rewrite to vararg after https://youtrack.jetbrains.com/issue/KT-33565/Allow-vararg-parameter-of-inline-class-type
 internal fun PointerEventResult.merging(
@@ -164,8 +188,5 @@ internal fun PointerEventResult.merging(
     result2: PointerEventResult? = null,
     result3: PointerEventResult? = null
 ) = PointerEventResult(
-    anyMovementConsumed = anyMovementConsumed ||
-        result1.anyMovementConsumed ||
-        result2?.anyMovementConsumed ?: false ||
-        result3?.anyMovementConsumed ?: false
+    value = this.value or result1.value or (result2?.value ?: 0) or (result3?.value ?: 0)
 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -160,7 +160,7 @@ internal fun PointerInputEvent(
  */
 @InternalComposeUiApi
 @JvmInline
-value class PointerEventResult internal constructor(val value: Int) {
+value class PointerEventResult internal constructor(internal val value: Int) {
 
     constructor(
         anyMovementConsumed: Boolean = false,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -160,7 +160,7 @@ internal fun PointerInputEvent(
  */
 @InternalComposeUiApi
 @JvmInline
-value class PointerEventResult(val value: Int) {
+value class PointerEventResult internal constructor(val value: Int) {
 
     constructor(
         anyMovementConsumed: Boolean = false,

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/PointerEventResultTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/PointerEventResultTest.kt
@@ -112,4 +112,67 @@ class PointerEventResultTest {
             assertTrue(result.anyChangeConsumed)
         }
     }
+
+    @Test
+    fun testMergingWithMultipleParams() {
+        // Test with two parameters (this, result1)
+        PointerEventResult(value = 1).merging(
+            result1 = PointerEventResult(value = 2)
+        ).let { result ->
+            assertEquals(3, result.value)
+        }
+
+        // Test with three parameters (this, result1, result2)
+        PointerEventResult(value = 1).merging(
+            result1 = PointerEventResult(value = 2),
+            result2 = PointerEventResult(value = 4)
+        ).let { result ->
+            assertEquals(7, result.value)
+        }
+
+        // Test with four parameters (this, result1, result2, result3)
+        PointerEventResult(value = 1).merging(
+            result1 = PointerEventResult(value = 2),
+            result2 = PointerEventResult(value = 4),
+            result3 = PointerEventResult(value = 7)
+        ).let { result ->
+            assertEquals(7, result.value)
+        }
+
+        // Test with null parameters
+        PointerEventResult(value = 1).merging(
+            result1 = PointerEventResult(value = 2),
+            result2 = null,
+            result3 = null
+        ).let { result ->
+            assertEquals(3, result.value)
+        }
+
+        PointerEventResult(value = 1).merging(
+            result1 = PointerEventResult(value = 2),
+            result2 = PointerEventResult(value = 4),
+            result3 = null
+        ).let { result ->
+            assertEquals(7, result.value)
+        }
+
+        // Test with zero values
+        PointerEventResult(value = 0).merging(
+            result1 = PointerEventResult(value = 0),
+            result2 = PointerEventResult(value = 0),
+            result3 = PointerEventResult(value = 0)
+        ).let { result ->
+            assertEquals(0, result.value)
+        }
+
+        // Test with a mix of values
+        PointerEventResult(value = 1).merging(
+            result1 = PointerEventResult(value = 0),
+            result2 = PointerEventResult(value = 2),
+            result3 = PointerEventResult(value = 1)
+        ).let { result ->
+            assertEquals(3, result.value)
+        }
+    }
+
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/PointerEventResultTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/PointerEventResultTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.scene
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PointerEventResultTest {
+
+    @Test
+    fun testSecondaryConstructor() {
+        PointerEventResult().let {
+            assertEquals(0, it.value)
+            assertFalse(it.anyMovementConsumed)
+            assertFalse(it.anyChangeConsumed)
+        }
+
+        PointerEventResult(anyMovementConsumed = true).let {
+            assertEquals(2, it.value)
+            assertTrue(it.anyMovementConsumed)
+            assertFalse(it.anyChangeConsumed)
+        }
+
+        PointerEventResult(anyChangeConsumed = true).let {
+            assertEquals(4, it.value)
+            assertFalse(it.anyMovementConsumed)
+            assertTrue(it.anyChangeConsumed)
+        }
+
+        PointerEventResult(anyMovementConsumed = true, anyChangeConsumed = true).let {
+            assertEquals(6, it.value)
+            assertTrue(it.anyMovementConsumed)
+            assertTrue(it.anyChangeConsumed)
+        }
+    }
+
+    @Test
+    fun testMapping() {
+        androidx.compose.ui.input.pointer.ProcessResult(
+            dispatchedToAPointerInputModifier = false,
+            anyMovementConsumed = false,
+            anyChangeConsumed = false
+        ).let {
+            PointerEventResult(it.value)
+        }.let { result ->
+            assertEquals(0, result.value)
+            assertFalse(result.anyMovementConsumed)
+            assertFalse(result.anyChangeConsumed)
+        }
+
+        androidx.compose.ui.input.pointer.ProcessResult(
+            dispatchedToAPointerInputModifier = true,
+            anyMovementConsumed = false,
+            anyChangeConsumed = false
+        ).let {
+            PointerEventResult(it.value)
+        }.let { result ->
+            assertEquals(1, result.value)
+            assertFalse(result.anyMovementConsumed)
+            assertFalse(result.anyChangeConsumed)
+        }
+
+        androidx.compose.ui.input.pointer.ProcessResult(
+            dispatchedToAPointerInputModifier = true,
+            anyMovementConsumed = true,
+            anyChangeConsumed = false
+        ).let {
+            PointerEventResult(it.value)
+        }.let { result ->
+            assertEquals(3, result.value)
+            assertTrue(result.anyMovementConsumed)
+            assertFalse(result.anyChangeConsumed)
+        }
+
+        androidx.compose.ui.input.pointer.ProcessResult(
+            dispatchedToAPointerInputModifier = true,
+            anyMovementConsumed = false,
+            anyChangeConsumed = true
+        ).let {
+            PointerEventResult(it.value)
+        }.let { result ->
+            assertEquals(5, result.value)
+            assertFalse(result.anyMovementConsumed)
+            assertTrue(result.anyChangeConsumed)
+        }
+
+        androidx.compose.ui.input.pointer.ProcessResult(
+            dispatchedToAPointerInputModifier = true,
+            anyMovementConsumed = true,
+            anyChangeConsumed = true
+        ).let {
+            PointerEventResult(it.value)
+        }.let { result ->
+            assertEquals(7, result.value)
+            assertTrue(result.anyMovementConsumed)
+            assertTrue(result.anyChangeConsumed)
+        }
+    }
+}

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -566,8 +566,7 @@ internal class ComposeWindow(
             button = event.composeButton,
         )
 
-        // TODO: anyMovementConsumed is always false
-        // if (result.anyMovementConsumed) event.preventDefault()
+        if (result.anyChangeConsumed) event.preventDefault()
     }
 
     private val MouseEvent.offset get() = Offset(


### PR DESCRIPTION
Change `PointerEventResult` (marked as `@InternalComposeUiApi`) implementation to include the information about `anyChangeConsumed` besides `anyMovementConsumed` using the bitmask.

This fix is possible now after https://android-review.googlesource.com/c/platform/frameworks/support/+/3633065 is merged to our fork.

Fixes https://youtrack.jetbrains.com/issue/CMP-7520/CfW-back-gesture-interferes-with-Horizontal-Scroll

## Testing
Added the tests for new properties. 

## Release Notes
### Fixes - Web
- Fixed an unexpected back gesture after a horizontal scroll.

