### PR TITLE
Simplify the CfW API for navController-browser navigation binding

### DIFF
--- a/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
+++ b/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
@@ -7,10 +7,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import androidx.navigation.ExperimentalBrowserHistoryApi
+import androidx.navigation.bindToBrowserNavigation
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.bindToNavigation
 import org.jetbrains.skiko.wasm.onWasmReady
-import kotlinx.browser.window
 
 @OptIn(ExperimentalComposeUiApi::class)
 @ExperimentalBrowserHistoryApi
@@ -33,7 +32,7 @@ fun main() {
             app.Content(navController)
 
             LaunchedEffect(Unit) {
-                window.bindToNavigation(navController)
+                navController.bindToBrowserNavigation()
             }
         }
     }

--- a/compose/mpp/demo/src/wasmJsMain/kotlin/androidx/compose/mpp/demo/main.wasm.kt
+++ b/compose/mpp/demo/src/wasmJsMain/kotlin/androidx/compose/mpp/demo/main.wasm.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.platform.Font
 import androidx.compose.ui.window.ComposeViewport
 import androidx.navigation.ExperimentalBrowserHistoryApi
+import androidx.navigation.bindToBrowserNavigation
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.bindToNavigation
 import kotlin.wasm.unsafe.UnsafeWasmMemoryApi
 import kotlin.wasm.unsafe.withScopedMemoryAllocator
 import kotlinx.browser.window
@@ -65,7 +65,7 @@ fun main() {
 
             // TODO: possibly suboptimal workaround for https://youtrack.jetbrains.com/issue/CMP-7136/web-Its-non-trivial-to-bind-to-navigation-if-NavHost-is-called-asynchronously
             LaunchedEffect(Unit) {
-                window.bindToNavigation(navController)
+                navController.bindToBrowserNavigation()
             }
         }
 

--- a/navigation/navigation-runtime/api/navigation-runtime.klib.api
+++ b/navigation/navigation-runtime/api/navigation-runtime.klib.api
@@ -116,4 +116,7 @@ final fun androidx.navigation/decodeURIComponent(kotlin/String): kotlin/String /
 final fun androidx.navigation/encodeURIComponent(kotlin/String): kotlin/String // androidx.navigation/encodeURIComponent|encodeURIComponent(kotlin.String){}[0]
 
 // Targets: [js, wasmJs]
+final suspend fun (androidx.navigation/NavController).androidx.navigation/bindToBrowserNavigation(kotlin/Function1<androidx.navigation/NavBackStackEntry, kotlin/String>? = ...) // androidx.navigation/bindToBrowserNavigation|bindToBrowserNavigation@androidx.navigation.NavController(kotlin.Function1<androidx.navigation.NavBackStackEntry,kotlin.String>?){}[0]
+
+// Targets: [js, wasmJs]
 final suspend fun (org.w3c.dom/Window).androidx.navigation/bindToNavigation(androidx.navigation/NavController, kotlin/Function1<androidx.navigation/NavBackStackEntry, kotlin/String>? = ...) // androidx.navigation/bindToNavigation|bindToNavigation@org.w3c.dom.Window(androidx.navigation.NavController;kotlin.Function1<androidx.navigation.NavBackStackEntry,kotlin.String>?){}[0]

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -50,3 +50,5 @@ suspend fun Window.bindToNavigation(
 ) {
     navController.bindToBrowserNavigation(getBackStackEntryRoute)
 }
+
+internal actual fun refBrowserWindow(): BrowserWindow = js("window")

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -41,11 +41,12 @@ import org.w3c.dom.Window
  * @param navController The [NavController] instance to bind to browser window navigation.
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
+@Suppress("UnusedReceiverParameter")
+@Deprecated(message = "Use bindToBrowserNavigation", replaceWith = ReplaceWith("navController.bindToBrowserNavigation(getBackStackEntryRoute)"))
 @ExperimentalBrowserHistoryApi
 suspend fun Window.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    (this as BrowserWindow).bindToNavigation(navController, getBackStackEntryRoute)
+    navController.bindToBrowserNavigation(getBackStackEntryRoute)
 }

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -50,3 +50,5 @@ suspend fun Window.bindToNavigation(
 ) {
     navController.bindToBrowserNavigation(getBackStackEntryRoute)
 }
+
+internal actual fun refBrowserWindow(): BrowserWindow = js("window")

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -42,10 +42,11 @@ import org.w3c.dom.Window
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
 @ExperimentalBrowserHistoryApi
+@Suppress("UnusedReceiverParameter")
+@Deprecated(message = "Use bindToBrowserNavigation", replaceWith = ReplaceWith("navController.bindToBrowserNavigation(getBackStackEntryRoute)"))
 suspend fun Window.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {
-    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
-    (this as BrowserWindow).bindToNavigation(navController, getBackStackEntryRoute)
+    navController.bindToBrowserNavigation(getBackStackEntryRoute)
 }

--- a/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
+++ b/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
@@ -268,4 +268,4 @@ suspend fun NavController.bindToBrowserNavigation(
     refBrowserWindow().bindToNavigation(this, getBackStackEntryRoute)
 }
 
-private fun refBrowserWindow(): BrowserWindow = js("window")
+internal expect fun refBrowserWindow(): BrowserWindow

--- a/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
+++ b/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
@@ -235,3 +235,37 @@ internal external interface BrowserConsole {
 
 external fun decodeURIComponent(str: String): String
 external fun encodeURIComponent(str: String): String
+
+
+/**
+ * Binds the browser window state to the given navigation controller.
+ *
+ * If `getBackStackEntryRoute` is null, then:
+ *  1) if a browser url contains a destination route on a start then navigates to destination
+ *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
+ *
+ * If there is a custom `getBackStackEntryRoute` implementation,
+ * then we don't have knowledge how to parse urls to support direct navigation via browser address input.
+ * In that case, it should be done on the app's side:
+ * ```
+ * window.addEventListener("popstate") { event ->
+ *     event as PopStateEvent
+ *     if (event.state == null) { // empty state means manually entered address
+ *         val url = window.location.toString()
+ *         navController.navigate(...)
+ *     }
+ * }
+ * ```
+ *
+ * @param this The [NavController] instance to bind to browser window navigation.
+ * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
+ */
+@ExperimentalBrowserHistoryApi
+suspend fun NavController.bindToBrowserNavigation(
+    getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
+) {
+    @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")
+    refBrowserWindow().bindToNavigation(this, getBackStackEntryRoute)
+}
+
+private fun refBrowserWindow(): BrowserWindow = js("window")


### PR DESCRIPTION
The function can have fewer parameters: it doesn't need to have a `window` parameter, because it's a singleton, and we can access it implicitly.

This change simplifies the `fun main` common code (k/js and k/wasm), since no need to access w3c `window` API on the client side.

Fixes: https://youtrack.jetbrains.com/issue/CMP-8427

## Release Notes
### Features - Navigation
-  A new API was added to bind the browser navigation state with the `NavController` - `suspend fun NavController.bindToBrowserNavigation`. And the existing function `suspend fun Window.bindToNavigation` is deprecated now.
