### PR TITLE
Add ComposeSceneMediator crash test

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.integrations
+
+import androidx.compose.ui.backhandler.UIKitBackGestureDispatcher
+import androidx.compose.ui.platform.PlatformWindowContext
+import androidx.compose.ui.scene.ComposeSceneMediator
+import androidx.compose.ui.scene.PlatformLayersComposeScene
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.uikit.OnFocusBehavior
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.center
+import androidx.compose.ui.viewinterop.UIKitInteropAction
+import androidx.compose.ui.viewinterop.UIKitInteropTransaction
+import androidx.compose.ui.window.MetalRedrawer
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import platform.CoreGraphics.CGRectMake
+import platform.QuartzCore.CAMetalLayer
+
+class ComposeSceneMediatorTest {
+    @Test
+    fun testDisposedMediatorShouldNotCrash() = runBlocking {
+        val mediator = makeMediator()
+        mediator.setContent {}
+        mediator.dispose()
+
+        mediator.density = Density(2f)
+        mediator.layoutDirection = LayoutDirection.Rtl
+        mediator.compositionLocalContext = null
+        mediator.interactionBounds = IntRect.Companion.Zero
+        mediator.isAccessibilityEnabled = true
+        mediator.prepareAndGetSizeTransitionAnimation().invoke(10.milliseconds)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testDisposedViewControllerTapNoCrash() = runUIKitInstrumentedTest {
+        setContent {}
+
+        hostingViewController.viewControllerDidLeaveWindowHierarchy()
+
+        tap(screenSize.center)
+
+        waitForIdle()
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testDisposedViewControllerResizeNoCrash() = runUIKitInstrumentedTest {
+        setContent {}
+
+        hostingViewController.viewControllerDidLeaveWindowHierarchy()
+
+        hostingViewController.view.setFrame(CGRectMake(0.0, 0.0, 100.0, 100.0))
+        hostingViewController.view.layoutIfNeeded()
+
+        waitForIdle()
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun makeMediator(): ComposeSceneMediator {
+        val mediator = ComposeSceneMediator(
+            onFocusBehavior = OnFocusBehavior.DoNothing,
+            focusStack = null,
+            windowContext = PlatformWindowContext(),
+            coroutineContext = Dispatchers.Main,
+            redrawer = MetalRedrawer(
+                metalLayer = CAMetalLayer(),
+                retrieveInteropTransaction = {
+                    object : UIKitInteropTransaction {
+                        override val actions: List<UIKitInteropAction> = emptyList()
+                        override val isInteropActive: Boolean = false
+                    }
+                },
+                useSeparateRenderThreadWhenPossible = false,
+                render = { _, _ -> }
+            ),
+            backGestureDispatcher = UIKitBackGestureDispatcher(
+                enableBackGesture = false,
+                density = Density(1f),
+                getTopLeftOffsetInWindow = { IntOffset.Companion.Zero }
+            ),
+            composeSceneFactory = { invalidate, platformContext ->
+                PlatformLayersComposeScene(
+                    density = Density(1f)
+                )
+            },
+        )
+        return mediator
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -91,7 +91,7 @@ internal class UIKitInstrumentedTest {
     val keyboardHeight: Dp get() =
         KeyboardVisibilityListener.keyboardFrame.useContents { size.height.dp }
     val screenSize: DpSize = screen.bounds().useContents { DpSize(size.width.dp, size.height.dp) }
-    private lateinit var hostingViewController: ComposeHostingViewController
+    internal lateinit var hostingViewController: ComposeHostingViewController
 
     private val infiniteAnimationPolicy = object : InfiniteAnimationPolicy {
         override suspend fun <R> onInfiniteOperation(block: suspend () -> R): R {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -378,7 +378,7 @@ internal class ComposeSceneMediator(
             }
         }
 
-    fun onScrollEvent(
+    private fun onScrollEvent(
         position: DpOffset,
         delta: DpOffset,
         event: UIEvent?,
@@ -407,7 +407,7 @@ internal class ComposeSceneMediator(
         )
     }
 
-    fun onHoverEvent(
+    private fun onHoverEvent(
         position: DpOffset,
         event: UIEvent?,
         eventKind: TouchesEventKind
@@ -434,7 +434,7 @@ internal class ComposeSceneMediator(
         )
     }
 
-    fun onCancelScroll() {
+    private fun onCancelScroll() {
         redrawer.ongoingInteractionEventsCount -= 1
         scene.cancelPointerInput()
     }


### PR DESCRIPTION
Cover scenarios in which the ComposeSceneMediator may crash.

Fixes https://youtrack.jetbrains.com/issue/CMP-1516/iOS-write-integrated-tests-when-they-are-supported

## Release Notes
N/A