### PR TITLE
Add readable error for invalid bitmap size

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaImageAsset.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaImageAsset.skiko.kt
@@ -49,6 +49,7 @@ internal actual fun ActualImageBitmap(
     hasAlpha: Boolean,
     colorSpace: ColorSpace
 ): ImageBitmap {
+    require(width > 0 && height > 0) { "width and height must be > 0" }
     val colorType = config.toSkiaColorType()
     val alphaType = if (hasAlpha) ColorAlphaType.PREMUL else ColorAlphaType.OPAQUE
     val skiaColorSpace = colorSpace.toSkiaColorSpace()


### PR DESCRIPTION
More readable error (like on Android) instead of 
```
java.lang.RuntimeException: Failed to Image::makeFromBitmap Bitmap(_ptr=0x6000002ee740)
	at org.jetbrains.skia.Image$Companion.makeFromBitmap(Image.kt:114)
	at androidx.compose.ui.graphics.SkiaBackedCanvas.drawImageRect-cI72Soc(SkiaBackedCanvas.skiko.kt:225)
	at androidx.compose.ui.graphics.SkiaBackedCanvas.drawImage-d-4ec7I(SkiaBackedCanvas.skiko.kt:189)
	at androidx.compose.ui.graphics.drawscope.CanvasDrawScope.drawImage-gbVJVH8(CanvasDrawScope.kt:211)
	at androidx.compose.ui.node.LayoutNodeDrawScope.drawImage-gbVJVH8(LayoutNodeDrawScope.kt)
	at androidx.compose.ui.graphics.drawscope.DrawScope.drawImage-gbVJVH8$default(DrawScope.kt:476)
	at androidx.compose.ui.graphics.shadow.DropShadowRenderer.onDrawShadow-MLmccfk(DropShadowPainter.kt:206)
	at androidx.compose.ui.graphics.shadow.ShadowRenderer.drawShadow-erFMhIw(ShadowRenderer.kt:81)
	at androidx.compose.ui.graphics.shadow.DropShadowPainter.onDraw(DropShadowPainter.kt:81)
```

## Release Notes
N/A
