### PR TITLE
Bump pinned lifecycle version

### DIFF
--- a/compose/desktop/desktop/samples/build.gradle
+++ b/compose/desktop/desktop/samples/build.gradle
@@ -39,7 +39,7 @@ kotlin {
             implementation(libs.skikoCurrentOs)
             implementation(project(":compose:desktop:desktop"))
 
-            implementation("org.jetbrains.compose.material:material-icons-core:1.6.11") {
+            implementation("org.jetbrains.compose.material:material-icons-core:1.7.3") {
                 // exclude dependencies, because they override local projects when we build 0.0.0-* version
                 // (see https://repo1.maven.org/maven2/org/jetbrains/compose/material/material-icons-core-desktop/1.6.11/material-icons-core-desktop-1.6.11.module)
                 exclude group: "org.jetbrains.compose.runtime"

--- a/compose/desktop/desktop/samples/build.gradle
+++ b/compose/desktop/desktop/samples/build.gradle
@@ -37,6 +37,7 @@ kotlin {
 
         jvmMain.dependencies {
             implementation(libs.skikoCurrentOs)
+            implementation(project(":collection:collection"))
             implementation(project(":compose:desktop:desktop"))
 
             implementation("org.jetbrains.compose.material:material-icons-core:1.7.3") {

--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -173,7 +173,7 @@ kotlin {
                 implementation(libs.kotlinCoroutinesCore)
                 api(libs.kotlinSerializationCore)
 
-                implementation("org.jetbrains.compose.material:material-icons-core:1.6.11") {
+                implementation("org.jetbrains.compose.material:material-icons-core:1.7.3") {
                     // exclude dependencies, because they override local projects when we build 0.0.0-* version
                     // (see https://repo1.maven.org/maven2/org/jetbrains/compose/material/material-icons-core-desktop/1.6.11/material-icons-core-desktop-1.6.11.module)
                     exclude("org.jetbrains.compose.runtime")

--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -96,7 +96,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             commonMain.dependencies {
                 implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
                 api(project(":compose:runtime:runtime"))
                 api("org.jetbrains.androidx.savedstate:savedstate-compose:1.3.0")
             }

--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -46,7 +46,7 @@ kotlin {
                 implementation(project(":annotation:annotation"))
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
             }
         }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -170,10 +170,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-text")
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
-                api("org.jetbrains.androidx.lifecycle:lifecycle-common:2.8.4")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.8.4")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.8.4")
+                api("org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.1")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.9.1")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.1")
+                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.1")
             }
 
             androidMain.dependencies {


### PR DESCRIPTION
Required to fix compatibility with savedstate 1.3

Also fixes missing collection ref in desktop samples and latest `material-icons-core` in demo

## Release Notes
N/A
