### PR TITLE
Concatenate child text and content description with Modifier.semantics(mergeDescendants = true)

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -67,10 +67,6 @@ import kotlinx.atomicfu.atomic
 import org.jetbrains.skia.BreakIterator
 import org.jetbrains.skiko.nativeInitializeAccessible
 
-private fun <T> SemanticsConfiguration.getFirstOrNull(key: SemanticsPropertyKey<List<T>>): T? {
-    return getOrNull(key)?.firstOrNull()
-}
-
 private typealias ActionKey = SemanticsPropertyKey<AccessibilityAction<() -> Boolean>>
 
 /**
@@ -139,11 +135,8 @@ internal class ComposeAccessible(
         val setSelection
             get() = semanticsConfig.getOrNull(SemanticsActions.SetSelection)
         val text
-            // TODO should we concatenate the texts instead of getting only the first one
-            // Concatenation seems to be reasonable eg, for button with two text nodes inside
-            // but conflicts with setText action
             get() = semanticsConfig.getOrNull(SemanticsProperties.EditableText)
-                ?: semanticsConfig.getFirstOrNull(SemanticsProperties.Text)
+                ?: semanticsConfig.getOrNull(SemanticsProperties.Text)?.mergeText()
 
         val textLayoutResult: TextLayoutResult?
             get() {
@@ -255,9 +248,9 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleDescription(): String? {
-            // TODO concatenate values?
             return semanticsConfig
-                .getFirstOrNull(SemanticsProperties.ContentDescription)
+                .getOrNull(SemanticsProperties.ContentDescription)
+                ?.mergeText()
         }
 
         override fun getAccessibleParent(): Accessible? {
@@ -870,6 +863,8 @@ internal class ComposeAccessible(
         override fun doAccessibleAction(i: Int): Boolean {
             return accessibleAction?.doAccessibleAction(i) ?: false
         }
+
+        private fun List<CharSequence>.mergeText() = joinToString(", ")
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.platform
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
@@ -61,6 +62,7 @@ import javax.accessibility.AccessibleText
 import javax.accessibility.AccessibleValue
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -300,7 +302,26 @@ class AccessibilityTest {
         test.onNodeWithTag("box").fetchAccessibleComponent().let {
             assertEquals(size, it.size.toDpSize())
         }
-   }
+    }
+
+    @Test
+    fun mergeDescendantsMergesText() = runDesktopA11yTest {
+        test.setContent {
+            Row(
+                Modifier
+                    .testTag("text")
+                    .semantics(mergeDescendants = true) {}
+            ) {
+                Text("Hello")
+                Text("World")
+            }
+        }
+
+        test.onNodeWithTag("text").apply {
+            assertTextContains("Hello")
+            assertTextContains("World")
+        }
+    }
 
 }
 
@@ -442,5 +463,14 @@ internal class ComposeA11yTestScope(
             actual = fetchAccessible().accessibleContext!!.accessibleValue.currentAccessibleValue,
             message = "Current accessible value expected to, but does not equal: $number",
         )
+    }
+
+    /**
+     * Asserts that the text of the accessible
+     */
+    fun SemanticsNodeInteraction.assertTextContains(value: String) {
+        val text = fetchAccessible().composeAccessibleContext.text
+        assertNotNull(text, "Text is null")
+        assertTrue(value in text, "Text does not contain $value")
     }
 }


### PR DESCRIPTION
Concatenate child text and content description with Modifier.semantics(mergeDescendants = true)

Fixes https://youtrack.jetbrains.com/issue/CMP-2111/Accessibility-semanticsmergeDescendants-true-does-not-merge-semantics-of-descendants

## Testing
Tested manually with VoiceOver, and added a new unit test.

## Release Notes
### Fixes - Desktop
- `SemanticsProperties.Text` and `SemanticsProperties.ContentDescription` values will now be correctly concatenated when `Modifier.semantics(mergeDescendants = true)` is used.
