### PR TITLE
Actually ignore semantics nodes marked as invisible for a11y

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -227,6 +227,11 @@ internal class AccessibilityController(
      */
     private fun syncNodes() {
         fun SemanticsNode.isValid() = layoutNode.let { it.isPlaced && it.isAttached }
+        fun SemanticsNode.isInvisibleToA11y() = config.let {
+            @Suppress("DEPRECATION")
+            it.contains(SemanticsProperties.InvisibleToUser) ||
+                it.contains(SemanticsProperties.HideFromAccessibility)
+        }
 
         // Build new mapping of ComposeAccessible by node id
         val previous = accessibleByNodeId
@@ -235,6 +240,7 @@ internal class AccessibilityController(
             bfsDeque.add(rootSemanticNode)
         while (bfsDeque.isNotEmpty()) {
             val node = bfsDeque.removeFirst()
+            if (node.isInvisibleToA11y()) continue
 
             val existingAccessible = previous[node.id]
             updated[node.id] = if (existingAccessible != null) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -355,11 +355,8 @@ internal class ComposeAccessible(
             return semanticsNode.size.toAwtDimension()
         }
 
-        @Suppress("DEPRECATION")
         override fun isVisible(): Boolean =
-            !semanticsNode.outerSemanticsNode.requireCoordinator(Nodes.Semantics).isTransparent() &&
-                !semanticsConfig.contains(SemanticsProperties.InvisibleToUser) &&
-                !semanticsConfig.contains(SemanticsProperties.HideFromAccessibility)
+            !semanticsNode.outerSemanticsNode.requireCoordinator(Nodes.Semantics).isTransparent()
 
         override fun isEnabled(): Boolean =
             semanticsConfig.getOrNull(SemanticsProperties.Disabled) == null

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -61,6 +61,7 @@ import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleText
 import javax.accessibility.AccessibleValue
 import kotlin.test.assertEquals
+import kotlin.test.assertFails
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
@@ -184,7 +185,7 @@ class AccessibilityTest {
     }
 
     @Test
-    fun hideFromA11yMakesComponentInvisible() = runDesktopA11yTest {
+    fun hideFromA11yMakesAccessibleUnavailable() = runDesktopA11yTest {
         test.setContent {
             Text(
                 text = "Hello",
@@ -195,8 +196,8 @@ class AccessibilityTest {
             )
         }
 
-        assertFalse("Component should be invisible to accessibility, but isn't") {
-            test.onNodeWithTag("text").fetchAccessibleComponent().isVisible
+        assertFails("Component should be invisible to accessibility, but isn't") {
+            test.onNodeWithTag("text").fetchAccessible()
         }
     }
 
@@ -408,7 +409,7 @@ internal class ComposeA11yTestScope(
             }
         }
 
-        throw AssertionError("Failed: Accessible exists")
+        throw AssertionError("Failed: Accessible does not exist")
     }
 
     fun SemanticsNodeInteraction.fetchAccessibleComponent(): AccessibleComponent =


### PR DESCRIPTION
Actually ignore semantics nodes marked as invisible for a11y; not just report them as invisible.

VoiceOver doesn't skip or ignore accessible components that return `isVisible() = false`.
This PR completely removes from the semantic tree nodes that are marked with `hideFromAccessibility()`.

[Slack discussion](https://jetbrains.slack.com/archives/C076VK0LGH1/p1750930765562089)

## Testing
Adjusted the unit test and also tested manually with VoiceOver with
```
    MaterialTheme {
        Column(
            modifier = Modifier
                .fillMaxSize()
        ) {
            repeat(10) {
                Row(
                    modifier = Modifier.fillMaxWidth()
                        .padding(vertical = 8.dp, horizontal = 16.dp)
                        .semantics(mergeDescendants = true) {
                            if (it % 2 == 1) {
                                hideFromAccessibility()
                            }
                        },
                    verticalAlignment = Alignment.CenterVertically,
                    horizontalArrangement = Arrangement.spacedBy(8.dp)
                ) {
                    Text("Hello $it")
                }
            }
        }
    }
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Elements marked with Modifier.semantics { hideFromAccessibility() } should now be correctly hidden from a11y.
