### PR TITLE
Align `actual val KeyEvent.isTypedEvent` visibility with `expect` declaration

### DIFF
--- a/compose/foundation/foundation/api/desktop/foundation.api
+++ b/compose/foundation/foundation/api/desktop/foundation.api
@@ -1895,10 +1895,6 @@ public final class androidx/compose/foundation/text/TextAutoSizeDefaults {
 public final class androidx/compose/foundation/text/TextContextMenu$Companion {
 }
 
-public final class androidx/compose/foundation/text/TextFieldKeyInput_desktopKt {
-	public static final fun isTypedEvent-ZmokQxo (Ljava/lang/Object;)Z
-}
-
 public final class androidx/compose/foundation/text/contextmenu/builder/TextContextMenuBuilderScope {
 	public static final field $stable I
 	public final fun separator ()V

--- a/compose/foundation/foundation/api/foundation.klib.api
+++ b/compose/foundation/foundation/api/foundation.klib.api
@@ -1738,8 +1738,6 @@ final val androidx.compose.foundation.text/androidx_compose_foundation_text_Text
 final val androidx.compose.foundation.text/androidx_compose_foundation_text_TextRangeLayoutModifier$stableprop // androidx.compose.foundation.text/androidx_compose_foundation_text_TextRangeLayoutModifier$stableprop|#static{}androidx_compose_foundation_text_TextRangeLayoutModifier$stableprop[0]
 final val androidx.compose.foundation.text/androidx_compose_foundation_text_UndoManager$stableprop // androidx.compose.foundation.text/androidx_compose_foundation_text_UndoManager$stableprop|#static{}androidx_compose_foundation_text_UndoManager$stableprop[0]
 final val androidx.compose.foundation.text/androidx_compose_foundation_text_defaultSkikoKeyMapping$stableprop // androidx.compose.foundation.text/androidx_compose_foundation_text_defaultSkikoKeyMapping$stableprop|#static{}androidx_compose_foundation_text_defaultSkikoKeyMapping$stableprop[0]
-final val androidx.compose.foundation.text/isTypedEvent // androidx.compose.foundation.text/isTypedEvent|@androidx.compose.ui.input.key.KeyEvent{}isTypedEvent[0]
-    final fun (androidx.compose.ui.input.key/KeyEvent).<get-isTypedEvent>(): kotlin/Boolean // androidx.compose.foundation.text/isTypedEvent.<get-isTypedEvent>|<get-isTypedEvent>@androidx.compose.ui.input.key.KeyEvent(){}[0]
 final val androidx.compose.foundation.v2/androidx_compose_foundation_v2_LazyGridScrollbarAdapter$stableprop // androidx.compose.foundation.v2/androidx_compose_foundation_v2_LazyGridScrollbarAdapter$stableprop|#static{}androidx_compose_foundation_v2_LazyGridScrollbarAdapter$stableprop[0]
 final val androidx.compose.foundation.v2/androidx_compose_foundation_v2_LazyLineContentAdapter$stableprop // androidx.compose.foundation.v2/androidx_compose_foundation_v2_LazyLineContentAdapter$stableprop|#static{}androidx_compose_foundation_v2_LazyLineContentAdapter$stableprop[0]
 final val androidx.compose.foundation.v2/androidx_compose_foundation_v2_LazyLineContentAdapter_VisibleLine$stableprop // androidx.compose.foundation.v2/androidx_compose_foundation_v2_LazyLineContentAdapter_VisibleLine$stableprop|#static{}androidx_compose_foundation_v2_LazyLineContentAdapter_VisibleLine$stableprop[0]
@@ -2387,3 +2385,7 @@ final fun androidx.compose.foundation/androidx_compose_foundation_PlatformMagnif
 
 // Targets: [ios]
 final fun androidx.compose.foundation/androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter(): kotlin/Int // androidx.compose.foundation/androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter|androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter(){}[0]
+
+// Targets: [js, wasmJs]
+final val androidx.compose.foundation.text/isTypedEvent // androidx.compose.foundation.text/isTypedEvent|@androidx.compose.ui.input.key.KeyEvent{}isTypedEvent[0]
+    final fun (androidx.compose.ui.input.key/KeyEvent).<get-isTypedEvent>(): kotlin/Boolean // androidx.compose.foundation.text/isTypedEvent.<get-isTypedEvent>|<get-isTypedEvent>@androidx.compose.ui.input.key.KeyEvent(){}[0]

--- a/compose/foundation/foundation/api/foundation.klib.api
+++ b/compose/foundation/foundation/api/foundation.klib.api
@@ -2385,7 +2385,3 @@ final fun androidx.compose.foundation/androidx_compose_foundation_PlatformMagnif
 
 // Targets: [ios]
 final fun androidx.compose.foundation/androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter(): kotlin/Int // androidx.compose.foundation/androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter|androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter(){}[0]
-
-// Targets: [js, wasmJs]
-final val androidx.compose.foundation.text/isTypedEvent // androidx.compose.foundation.text/isTypedEvent|@androidx.compose.ui.input.key.KeyEvent{}isTypedEvent[0]
-    final fun (androidx.compose.ui.input.key/KeyEvent).<get-isTypedEvent>(): kotlin/Boolean // androidx.compose.foundation.text/isTypedEvent.<get-isTypedEvent>|<get-isTypedEvent>@androidx.compose.ui.input.key.KeyEvent(){}[0]

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
@@ -27,6 +27,6 @@ private fun Char.isPrintable(): Boolean {
         block != Character.UnicodeBlock.SPECIALS
 }
 
-actual val KeyEvent.isTypedEvent: Boolean
+internal actual val KeyEvent.isTypedEvent: Boolean
     get() = awtEventOrNull?.id == java.awt.event.KeyEvent.KEY_TYPED &&
         awtEventOrNull?.keyChar?.isPrintable() == true

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text
 
+import androidx.compose.foundation.InternalFoundationApi
 import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.input.key.KeyEvent
 
@@ -27,6 +28,10 @@ private fun Char.isPrintable(): Boolean {
         block != Character.UnicodeBlock.SPECIALS
 }
 
-internal actual val KeyEvent.isTypedEvent: Boolean
+// This API was never supposed to be public, but currently there are some external usages of it,
+// so it cannot be removed from the public right now.
+// However, starting with 1.9 it's marked as NOT a public-stable API with compatibility guarantees.
+@InternalFoundationApi
+actual val KeyEvent.isTypedEvent: Boolean
     get() = awtEventOrNull?.id == java.awt.event.KeyEvent.KEY_TYPED &&
         awtEventOrNull?.keyChar?.isPrintable() == true

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.macos.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.key.utf16CodePoint
 
-actual val KeyEvent.isTypedEvent: Boolean
+internal actual val KeyEvent.isTypedEvent: Boolean
     get() = type == KeyEventType.KeyDown &&
         !isISOControl(utf16CodePoint) &&
         !isAppKitReserved(utf16CodePoint) &&

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.uikit.kt
@@ -18,5 +18,5 @@ package androidx.compose.foundation.text
 
 import androidx.compose.ui.input.key.KeyEvent
 
-actual val KeyEvent.isTypedEvent: Boolean
+internal actual val KeyEvent.isTypedEvent: Boolean
     get() = false // on UIKit physical keyboard not handled as text input

--- a/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
+++ b/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
@@ -16,7 +16,7 @@
 
 package androidx.compose.foundation.text
 
-import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.InternalFoundationApi
 import androidx.compose.ui.dom.domEventOrNull
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -25,7 +25,7 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.type
 import org.w3c.dom.events.KeyboardEvent
 
-@VisibleForTesting // TODO: Remove from public at all
+@InternalFoundationApi // TODO: Remove from public at all
 actual val KeyEvent.isTypedEvent: Boolean
     get() = type == KeyEventType.KeyDown
         && !isMetaPressed

--- a/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
+++ b/compose/foundation/foundation/src/webCommonW3C/kotlin/androidx/compose/foundation/text/TextFieldKeyInput.js.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.dom.domEventOrNull
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
@@ -24,6 +25,7 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.type
 import org.w3c.dom.events.KeyboardEvent
 
+@VisibleForTesting // TODO: Remove from public at all
 actual val KeyEvent.isTypedEvent: Boolean
     get() = type == KeyEventType.KeyDown
         && !isMetaPressed
@@ -33,4 +35,3 @@ actual val KeyEvent.isTypedEvent: Boolean
 private fun KeyboardEvent.isPrintable(): Boolean {
     return key.firstOrNull()?.toString() == key
 }
-

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/IsTypedEventTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/IsTypedEventTests.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.input
 
+import androidx.compose.foundation.InternalFoundationApi
 import androidx.compose.foundation.text.isTypedEvent
 import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.input.key.toComposeEvent
@@ -24,6 +25,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.w3c.dom.events.KeyboardEvent
 
+@OptIn(InternalFoundationApi::class)
 class IsTypedEventTests {
     private fun KeyboardEvent.assertIsTyped(message: String? = null) {
         val composeEvent = toComposeEvent()


### PR DESCRIPTION
`val KeyEvent.isTypedEvent` was never supposed as a public API + `expect` declaration is internal

## Release Notes
N/A
