### PR TITLE
[web]: Show the "paste" context menu item even if the permission was denied.

### DIFF
--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
@@ -29,6 +29,7 @@ private const val MIME_TYPE_PLAIN_TEXT = "text/plain"
 
 internal actual suspend fun ClipEntry.readText(): String? {
     if (!this.hasText()) return null
+    if (this.clipboardItems.isEmpty()) return null
     val blob = clipboardItems[0].getType(MIME_TYPE_PLAIN_TEXT).await<Blob>()
     return getTextFromBlob(blob).await<String>().toString()
 }
@@ -45,7 +46,10 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
-    if (this.clipboardItems.isEmpty()) return false
+    // Empty clipboardItems here mean that the read from web clipboard was ended with an error.
+    // The most common reason is that the permission was denied.
+    // In this case we want to show the "paste" menu item anyway.
+    if (this.clipboardItems.isEmpty()) return true
     return doesJsArrayContainValue(this.clipboardItems[0].types, MIME_TYPE_PLAIN_TEXT)
 }
 

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
@@ -30,6 +30,7 @@ private val MIME_TYPE_PLAIN_TEXT_JS = MIME_TYPE_PLAIN_TEXT.toJsString()
 
 internal actual suspend fun ClipEntry.readText(): String? {
     if (!this.hasText()) return null
+    if (this.clipboardItems.length == 0) return null
     val blob = clipboardItems[0]!!.getType(MIME_TYPE_PLAIN_TEXT_JS).await<Blob>()
     return getTextFromBlob(blob).await<JsString>().toString()
 }
@@ -46,7 +47,10 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
-    if (this.clipboardItems.length == 0) return false
+    // Empty clipboardItems here mean that the read from web clipboard was ended with an error.
+    // The most common reason is that the permission was denied.
+    // In this case we want to show the "paste" menu item anyway.
+    if (this.clipboardItems.length == 0) return true
     return doesJsArrayContainValue(this.clipboardItems.get(0)!!.types, MIME_TYPE_PLAIN_TEXT_JS)
 }
 

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
@@ -37,11 +37,7 @@ class JsPlatformClipboard : Clipboard {
             // The most common reason is that the permission was denied
             println("Failed to read from Clipboard: $it")
             emptyClipboardItems
-        }.then {
-            it
         }.await()
-
-        if (items.isEmpty()) return null
         return ClipEntry(items)
     }
 

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
@@ -37,11 +37,7 @@ class WasmPlatformClipboard : Clipboard {
             // The most common reason is that the permission was denied
             println("Failed to read from Clipboard: $it")
             emptyClipboardItems
-        }.then {
-            it
         }.await<JsArray<ClipboardItem>>()
-
-        if (items.length == 0) return null
         return ClipEntry(items)
     }
 


### PR DESCRIPTION
Show the "paste" context menu item even if the permission was denied.

Safari and Firefox ask the clipboard permission on each read action, it means on each frame during the scroll of selected text on mobile web.

## Release Notes
N/A