### PR TITLE
Fix DesktopTextInputService2.commitEventWorkaroundShouldIgnoreEvent

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -42,6 +42,8 @@ internal class DesktopTextInputService2(
 
     private var receivedInputMethodEventsSinceStartInput = false
 
+    private var composingText: String = ""
+
     fun startInput(request: PlatformTextInputMethodRequest) {
         receivedInputMethodEventsSinceStartInput = false
         component.enableInput(
@@ -92,14 +94,12 @@ internal class DesktopTextInputService2(
         val isFirstEventAfterStartInput = !receivedInputMethodEventsSinceStartInput
         receivedInputMethodEventsSinceStartInput = true
 
-        // Note that we need to handle two cases:
-        // - Focus moves between Compose text fields.
-        // - Focus moves from a Swing text component into a Compose text field
-        // The 2nd case is why we can't have a more surgical check here, i.e. check that the
-        // previous composition matches the committed text.
-        // But this check is hopefully good enough; the IME should not be asking to immediately
-        // commit something without putting it into a composition first.
-        return isFirstEventAfterStartInput && event.committedText.isNotEmpty()
+        val currentComposingText = composingText
+        composingText = event.composingText
+
+        return isFirstEventAfterStartInput &&
+            event.committedText == currentComposingText &&
+            event.composingText.isEmpty()
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -749,23 +749,34 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
     }
 
     @Theory
-    internal fun macOsAccentedCharacterByLongPressInput(textFieldKind: TextFieldKind<*>) = runTextFieldTest(
-        name = "ç, macOS",
-        textFieldKind = textFieldKind,
-    ) {
-        if (!isMacOs) return@runTextFieldTest  // Assume.assumeTrue doesn't work with @Theory
+    internal fun macOsAccentedCharacterByLongPressInput(textFieldKind: TextFieldKind<*>) =
+        runTextFieldTest(
+            name = "ç, macOS",
+            textFieldKind = textFieldKind,
+        ) {
+            if (!isMacOs) return@runTextFieldTest  // Assume.assumeTrue doesn't work with @Theory
 
-        window.sendKeyEvent('c'.code, 'c', KEY_PRESSED)
-        window.sendKeyTypedEvent('c')
-        // This triggers the "needToDeletePreviousChar" hack in DesktopTextInputService(2).
-        // If the implementation of this ever changes, this test will need to change as well.
-        // Note that using java.awt.Robot to test this doesn't appear to work, as the accented
-        // characters toolbar isn't displayed.
-        window.focusOwner.inputMethodRequests.getSelectedText(null)
-        window.sendKeyEvent('c'.code, 'c', KEY_RELEASED)
-        assertStateEquals("c", selection = TextRange(1), composition = null)
+            window.sendKeyEvent('c'.code, 'c', KEY_PRESSED)
+            window.sendKeyTypedEvent('c')
+            // This triggers the "needToDeletePreviousChar" hack in DesktopTextInputService(2).
+            // If the implementation of this ever changes, this test will need to change as well.
+            // Note that using java.awt.Robot to test this doesn't appear to work, as the accented
+            // characters toolbar isn't displayed.
+            window.focusOwner.inputMethodRequests.getSelectedText(null)
+            window.sendKeyEvent('c'.code, 'c', KEY_RELEASED)
+            assertStateEquals("c", selection = TextRange(1), composition = null)
 
-        window.sendInputMethodEvent("ç", 1)
-        assertStateEquals("ç", selection = TextRange(1), composition = null)
-    }
+            window.sendInputMethodEvent("ç", 1)
+            assertStateEquals("ç", selection = TextRange(1), composition = null)
+        }
+
+    @Theory
+    internal fun committedTextEventSentImmediatelyCommitsText(textFieldKind: TextFieldKind<*>) =
+        runTextFieldTest(
+            name = "first InputMethodEvent commits text",
+            textFieldKind = textFieldKind,
+        ) {
+            window.sendInputMethodEvent("·", committedCharacterCount = 1)
+            assertStateEquals("·", selection = TextRange(1), composition = null)
+        }
 }


### PR DESCRIPTION
Implement it more surgically by comparing the composition with the committed text.

Note that this breaks the case of focus moving from a Swing text field to a Compose text field (with an ongoing composition) in Corretto (but not JBR, because of `InputMethodEndCompositionWorkaround`).
However, because this is a relatively less frequent case than the one reported in CMP-8384, we'll have to live with it.

Fixes https://youtrack.jetbrains.com/issue/CMP-8384

## Testing
Tested manually, and added a unit test.

## Release Notes
### Fixes - Desktop
- Fixed the case when the IME's first event to a text field is to commit a composition.
