### PR TITLE
Fix extra draw invalidations during scrolling

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
@@ -45,9 +45,24 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 
+/**
+ * A class representing a layer that owns and manages a `GraphicsLayer` for composable rendering.
+ *
+ * This layer is responsible for managing graphical properties, transformations, and rendering
+ * tasks associated with a `GraphicsLayer`. It provides mechanisms for updating layer properties,
+ * triggering invalidations, resizing, and mapping offsets or bounds using transformation matrices.
+ *
+ * @constructor
+ * @param graphicsLayer The initial `GraphicsLayer` for this layer.
+ * @param context The graphics context responsible for managing this layer, or `null` if externally
+ *   managed. When context is not null, it means the object is created internally, and we need to
+ *   release it during disposal.
+ * @param layerManager The manager responsible for handling the ownership and lifecycle of this layer.
+ * @param drawBlock The lambda function invoked to perform custom drawing on the canvas.
+ * @param invalidateParentLayer Callback to invalidate the parent layer when necessary.
+ */
 internal class GraphicsLayerOwnerLayer(
     graphicsLayer: GraphicsLayer,
-    // when we have a context it means the object is created by us and we need to release it
     private val context: GraphicsContext?,
     private val layerManager: OwnedLayerManager,
     drawBlock: (canvas: Canvas, parentLayer: GraphicsLayer?) -> Unit,
@@ -179,6 +194,9 @@ internal class GraphicsLayerOwnerLayer(
         }
     }
 
+    /**
+     * Triggers redrawing of Compose content during the next frame.
+     */
     private fun triggerRepaint() {
         layerManager.invalidate()
     }
@@ -240,6 +258,9 @@ internal class GraphicsLayerOwnerLayer(
         }
     }
 
+    /**
+     * Marks content as dirty and triggers redrawing.
+     */
     override fun invalidate() {
         if (isDestroyed) return
         isDirty = true

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/GraphicsLayerOwnerLayer.skiko.kt
@@ -175,8 +175,12 @@ internal class GraphicsLayerOwnerLayer(
 
         mutatedFields = scope.mutatedFields
         if (maybeChangedFields != 0 || outlineChanged) {
-            invalidate()
+            triggerRepaint()
         }
+    }
+
+    private fun triggerRepaint() {
+        layerManager.invalidate()
     }
 
     private fun updateOutline() {
@@ -197,7 +201,7 @@ internal class GraphicsLayerOwnerLayer(
 
     override fun move(position: IntOffset) {
         graphicsLayer.topLeft = position
-        invalidate()
+        triggerRepaint()
     }
 
     override fun resize(size: IntSize) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/OwnedLayerManager.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/OwnedLayerManager.kt
@@ -39,5 +39,8 @@ internal interface OwnedLayerManager {
 
     fun notifyLayerIsDirty(layer: OwnedLayer, isDirty: Boolean)
 
+    /**
+     * Triggers redrawing of Compose content during the next frame.
+     */
     fun invalidate()
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/GraphicLayerBugTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/GraphicLayerBugTest.kt
@@ -18,9 +18,14 @@ package androidx.compose.ui.platform
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Scaffold
@@ -28,53 +33,90 @@ import androidx.compose.material.TextField
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 // Tests for fixed bugs
+@OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class)
 class GraphicLayerBugTest {
     // https://github.com/JetBrains/compose-multiplatform/issues/4681
-    @OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class)
     @Test
-    fun draw_invalidates_inside_complex_layout() =
-        runComposeUiTest {
-            var valueForDraw by mutableStateOf(0f)
-            var lastDrawnValue = -1f
+    fun draw_invalidates_inside_complex_layout() = runComposeUiTest {
+        var valueForDraw by mutableStateOf(0f)
+        var lastDrawnValue = -1f
 
-            setContent {
-                val pagerState = rememberPagerState { 1 }
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    topBar = {
-                        Spacer(Modifier.drawBehind { pagerState.targetPage })
-                    },
-                ) {
-                    HorizontalPager(modifier = Modifier.fillMaxSize(), state = pagerState) {
-                        var value by remember { mutableStateOf("") }
-                        TextField(
-                            value = value,
-                            onValueChange = { value = it },
-                        )
+        setContent {
+            val pagerState = rememberPagerState { 1 }
+            Scaffold(
+                modifier = Modifier.fillMaxSize(),
+                topBar = {
+                    Spacer(Modifier.drawBehind { pagerState.targetPage })
+                },
+            ) {
+                HorizontalPager(modifier = Modifier.fillMaxSize(), state = pagerState) {
+                    var value by remember { mutableStateOf("") }
+                    TextField(
+                        value = value,
+                        onValueChange = { value = it },
+                    )
 
-                        Canvas(Modifier.size(40.dp)) {
-                            lastDrawnValue = valueForDraw
-                        }
+                    Canvas(Modifier.size(40.dp)) {
+                        lastDrawnValue = valueForDraw
                     }
                 }
             }
-
-            waitForIdle()
-            assertThat(lastDrawnValue).isEqualTo(0f)
-
-            valueForDraw = 1f
-            waitForIdle()
-            assertThat(lastDrawnValue).isEqualTo(1f)
         }
+
+        waitForIdle()
+        assertThat(lastDrawnValue).isEqualTo(0f)
+
+        valueForDraw = 1f
+        waitForIdle()
+        assertThat(lastDrawnValue).isEqualTo(1f)
+    }
+
+    // https://youtrack.jetbrains.com/issue/CMP-8491
+    @Test
+    fun draw_invalidates_inside_scroll() = runSkikoComposeUiTest(Size(100f, 200f)) {
+        class ItemState(
+            var value: Int = 0
+        )
+        val data = List(50) { ItemState(0) }
+        lateinit var lazyListState: LazyListState
+        lateinit var scope: CoroutineScope
+        setContent {
+            lazyListState = rememberLazyListState()
+            scope = rememberCoroutineScope()
+            LazyColumn(Modifier.fillMaxSize(), lazyListState) {
+                items(items = data, key = { it }) {
+                    Box(Modifier.size(100.dp).drawWithContent {
+                        it.value++
+                        this@drawWithContent.drawContent()
+                    })
+                }
+            }
+        }
+
+        scope.launch {
+            repeat(50) {
+                lazyListState.animateScrollToItem(it)
+            }
+        }
+
+        waitForIdle()
+        assertThat(data.map { it.value }).isEqualTo(List(50) { 1 })
+    }
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/OwnerLayerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/OwnerLayerTest.kt
@@ -22,12 +22,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
-import androidx.compose.ui.assertThat
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.layer.GraphicsLayer
-import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest


### PR DESCRIPTION
Fixes [CMP-8491](https://youtrack.jetbrains.com/issue/CMP-8491) Compose 1.8 triggers extra drawing invalidations of unchanged items during scroll

## Release Notes
### Fixes - Multiple Platforms
- Fix extra draw invalidations during scrolling (1.8 regression)