### PR TITLE
CfW: Switch to shadow DOM for canvas and interop elements hosting

### DIFF
--- a/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
+++ b/compose/mpp/demo/src/jsMain/kotlin/androidx/compose/mpp/demo/main.js.kt
@@ -35,5 +35,7 @@ fun main() {
                 navController.bindToBrowserNavigation()
             }
         }
+
+        setupBackingTextAreaDebugHints()
     }
 }

--- a/compose/mpp/demo/src/wasmJsMain/kotlin/androidx/compose/mpp/demo/main.wasm.kt
+++ b/compose/mpp/demo/src/wasmJsMain/kotlin/androidx/compose/mpp/demo/main.wasm.kt
@@ -84,6 +84,7 @@ fun main() {
         }
 
     }
+    setupBackingTextAreaDebugHints()
 }
 
 private suspend fun loadResAsync(url: String): Deferred<ArrayBuffer> {

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
@@ -17,7 +17,52 @@
 package androidx.compose.mpp.demo
 
 import androidx.compose.ui.platform.ClipEntry
+import kotlinx.browser.document
+import org.w3c.dom.HTMLElement
 
 expect suspend fun ClipEntry?.getPlainText(): String?
 
 expect fun createClipEntryWithPlainText(text: String): ClipEntry
+
+// Setting the colors to indicate the presence of the backing textarea or input, and its focus state
+internal fun setupBackingTextAreaDebugHints() {
+    val sr = document.getElementById("composeApplication")!!.shadowRoot!!
+
+    val srStyle = document.createElement("style").apply {
+        // language=css
+        textContent = """
+            :host {
+                --my-variable: transparent;
+            }
+            :host:has(textarea) {
+                --my-variable: aliceblue;
+            }
+            :host:has(input) {
+                --my-variable: aliceblue;
+            }
+            :host:has(textarea:focus) {
+                --my-variable: #eaffe3;
+            }
+            :host:has(input:focus) {
+                --my-variable: #eaffe3;
+            }
+            #debugBackingInputIndicator {
+                background-color: var(--my-variable);
+                position: absolute;
+                top: 0;
+                left: 0;
+                margin: 0;
+                width: 100%;
+                height: 100%;
+                z-index: -10;
+            }
+        """.trimIndent()
+    }
+
+    val firstChild = sr.children.item(0) as HTMLElement
+    sr.insertBefore(srStyle, firstChild)
+
+    sr.appendChild(document.createElement("div").apply {
+        id = "debugBackingInputIndicator"
+    })
+}

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlinx.browser.document
 import kotlinx.browser.window
+import org.w3c.dom.HTMLElement
 
 internal interface ComposeCommandCommunicator {
     fun sendEditCommand(commands: List<EditCommand>)
@@ -30,11 +31,11 @@ internal interface ComposeCommandCommunicator {
     fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean
 }
 
-private fun setBackingInputBox(left: Float, top: Float, width: Float, height: Float) { js("""
-    document.documentElement.style.setProperty("--compose-internal-web-backing-input-left", left);
-    document.documentElement.style.setProperty("--compose-internal-web-backing-input-top", top);
-    document.documentElement.style.setProperty("--compose-internal-web-backing-input-width", width);
-    document.documentElement.style.setProperty("--compose-internal-web-backing-input-height", height)
+private fun setBackingInputBox(container: HTMLElement, left: Float, top: Float, width: Float, height: Float) { js("""
+    container.style.setProperty("--compose-internal-web-backing-input-left", left);
+    container.style.setProperty("--compose-internal-web-backing-input-top", top);
+    container.style.setProperty("--compose-internal-web-backing-input-width", width);
+    container.style.setProperty("--compose-internal-web-backing-input-height", height)
 """) }
 
 /**
@@ -43,6 +44,7 @@ private fun setBackingInputBox(left: Float, top: Float, width: Float, height: Fl
  * the virtual keyboard.
  */
 internal class BackingDomInput(
+    val inputContainer: HTMLElement,
     imeOptions: ImeOptions,
     composeCommunicator : ComposeCommandCommunicator,
 ) {
@@ -51,16 +53,11 @@ internal class BackingDomInput(
         composeCommunicator
     )
 
-    private companion object {
-        init {
-            setBackingInputBox(0f, 0f, 0f, 0f)
-        }
-    }
-
     private val backingElement = inputStrategy.htmlInput
 
     fun register() {
-        document.body?.appendChild(backingElement)
+        setBackingInputBox(container = inputContainer, 0f, 0f, 0f, 0f)
+        inputContainer.appendChild(backingElement)
     }
 
     fun focus() {
@@ -85,7 +82,7 @@ internal class BackingDomInput(
         // Apparently when the width is 0px and the selection index is large enough (big text length),
         // the lags become more noticeable.
         // I assume it has something to do with text layout. Read more in the comments of the linked issue.
-        setBackingInputBox(left, top, width.coerceAtLeast(1f), height)
+        setBackingInputBox(container = inputContainer, left, top, width.coerceAtLeast(1f), height)
     }
 
     fun updateState(textFieldValue: TextFieldValue) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -16,23 +16,19 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Matrix
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.width
+import org.w3c.dom.HTMLElement
 
 internal interface InputAwareInputService {
-    fun getOffset(rect: Rect): Offset
     fun processKeyboardEvent(keyboardEvent: KeyEvent): Boolean
 
     /**
@@ -51,6 +47,11 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
             field = value
         }
 
+    /**
+     * This container will host the actual hidden HTML input element.
+     */
+    abstract val backingDomInputContainer: HTMLElement
+
     override fun startInput(
         value: TextFieldValue,
         imeOptions: ImeOptions,
@@ -68,7 +69,8 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
                     override fun sendEditCommand(commands: List<EditCommand>) {
                         onEditCommand(commands)
                     }
-                }
+                },
+                inputContainer = backingDomInputContainer,
             )
         backingDomInput?.register()
 

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -701,6 +701,15 @@ fun ComposeViewport(
  *
  * Creates the composition in HTML canvas created in parent container identified by [viewportContainer] Element.
  * This size of canvas is adjusted with the size of the container
+ *
+ * The current hierarchy:
+ * <viewportContainer.shadowDom>
+ *     <app root>
+ *         <canvas/>
+ *         <interop elements container/>
+ *         <a11y elements root/>
+ *     </app root>
+ * </viewportContainer.shadowDom>
  */
 @ExperimentalComposeUiApi
 fun ComposeViewport(

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -97,6 +97,9 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.HTMLStyleElement
 import org.w3c.dom.HTMLTitleElement
 import org.w3c.dom.MediaQueryListEvent
+import org.w3c.dom.OPEN
+import org.w3c.dom.ShadowRootInit
+import org.w3c.dom.ShadowRootMode
 import org.w3c.dom.TouchEvent
 import org.w3c.dom.asList
 import org.w3c.dom.events.Event
@@ -257,18 +260,13 @@ internal class ComposeWindow(
 
         override val textInputService = object : WebTextInputService() {
 
-            override fun getOffset(rect: Rect): Offset {
-                val viewportRect = canvas.getBoundingClientRect()
-                val offsetX = viewportRect.left.toFloat().coerceAtLeast(0f) + (rect.left / density.density)
-                val offsetY = viewportRect.top.toFloat().coerceAtLeast(0f) + (rect.top / density.density)
-                return Offset(offsetX, offsetY)
-            }
+            override val backingDomInputContainer: HTMLElement
+                get() = interopContainerElement
 
             override fun getNewGeometryForBackingInput(rect: Rect): DpRect {
-                val viewportRect = canvas.getBoundingClientRect()
                 val dpRect = rect.toDpRect(density)
-                val left = viewportRect.left.toFloat() + dpRect.left.value
-                val top = viewportRect.top.toFloat() + dpRect.top.value
+                val left = dpRect.left.value
+                val top = dpRect.top.value
 
                 return DpRect(DpOffset(left.dp, top.dp), dpRect.size)
             }
@@ -722,7 +720,8 @@ fun ComposeViewport(
         position = "relative"
     }
 
-    viewportContainer.appendChild(layerRoot)
+    val shadowRoot = viewportContainer.attachShadow(ShadowRootInit(ShadowRootMode.OPEN))
+    shadowRoot.appendChild(layerRoot)
     layerRoot.appendChild(canvas)
 
     val interopContainerElement = document.createElement("div") as HTMLDivElement

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -39,8 +39,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
+import org.w3c.dom.Element
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.ShadowRoot
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventTarget
 import org.w3c.dom.get
@@ -85,8 +87,11 @@ internal interface OnCanvasTests {
         }
     }
 
+    fun getShadowRoot(): ExtendedShadowRoot =
+        (getCanvasContainer().shadowRoot as? ExtendedShadowRoot) ?: error("failed to get shadowRoot")
+
     fun getCanvas(): HTMLCanvasElement {
-        val canvas = (getAppRoot().querySelector("canvas") as? HTMLCanvasElement) ?: error("failed to get canvas")
+        val canvas = (getShadowRoot().querySelector("canvas") as? HTMLCanvasElement) ?: error("failed to get canvas")
         return canvas
     }
 
@@ -195,4 +200,10 @@ private suspend fun awaitWithYield() {
     repeat(100) {
         yield()
     }
+}
+
+@JsName("ShadowRoot")
+internal external class ExtendedShadowRoot : ShadowRoot {
+
+    fun elementFromPoint(x: Double, y: Double): Element
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -76,7 +76,7 @@ internal interface OnCanvasTests {
 
     private fun getContainer() = document.getElementById(containerId) ?: error("failed to get canvas with id ${containerId}")
 
-    private fun getAppRoot() = getContainer().children[0] as HTMLElement
+    private fun getAppRoot() = getShadowRoot().children[0] as HTMLElement
 
     fun getA11YContainer(): HTMLElement? {
         return if (getAppRoot().children.length < 3) {
@@ -88,7 +88,7 @@ internal interface OnCanvasTests {
     }
 
     fun getShadowRoot(): ExtendedShadowRoot =
-        (getCanvasContainer().shadowRoot as? ExtendedShadowRoot) ?: error("failed to get shadowRoot")
+        (getContainer().shadowRoot as? ExtendedShadowRoot) ?: error("failed to get shadowRoot")
 
     fun getCanvas(): HTMLCanvasElement {
         val canvas = (getShadowRoot().querySelector("canvas") as? HTMLCanvasElement) ?: error("failed to get canvas")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/MouseTextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/MouseTextInputTests.kt
@@ -70,19 +70,19 @@ class MouseTextInputTests: OnCanvasTests {
         awaitIdle()
         assertEquals(TextRange(0, 0), textRange.value)
 
-        val textArea = document.querySelector("textarea")
+        val textArea = getShadowRoot().querySelector("textarea")
         assertIs<HTMLTextAreaElement>(textArea)
 
         val textAreaRect = textArea.getBoundingClientRect()
         // Do a manual hit-test
-        val elementsAtPos = document.elementsFromPoint(
+        val elementsAtPos = getShadowRoot().elementFromPoint(
             textAreaRect.left + textAreaRect.width / 2 ,
             textAreaRect.top + textAreaRect.height / 2
         )
 
         // We expect the canvas to be on the top despite the coordinates match the textarea.
         // So it will be the first to process all the point inputs
-        assertEquals(canvas, elementsAtPos[0], "First element under mouse supposed to be canvas")
+        assertEquals(canvas, elementsAtPos, "First element under mouse supposed to be canvas")
         withContext(Dispatchers.Default) {
             delay(250) // to separate the mouse events
         }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/TextInputTests.kt
@@ -57,7 +57,7 @@ abstract class TextInputTests : OnCanvasTests {
 
     internal abstract suspend fun createTestInputState(): TestInputState
 
-    internal fun currentHtmlInput() = document.querySelector("textarea") as HTMLTextAreaElement
+    internal fun currentHtmlInput() = getShadowRoot().querySelector("textarea") as HTMLTextAreaElement
 
     internal suspend fun WebApplicationScope.createApplicationWithHolder(): TestInputState {
         val focusRequester = FocusRequester()
@@ -85,7 +85,7 @@ abstract class TextInputTests : OnCanvasTests {
 
     internal suspend fun WebApplicationScope.waitForHtmlInput(): HTMLTextAreaElement {
         while (true) {
-            val element = document.querySelector("textarea")
+            val element = getShadowRoot().querySelector("textarea")
             if (element is HTMLTextAreaElement) {
                 return element
             }
@@ -184,7 +184,7 @@ abstract class TextInputTests : OnCanvasTests {
     fun compositeInput() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
 
-        val backingTextField = document.querySelector("textarea")
+        val backingTextField = getShadowRoot().querySelector("textarea")
         assertIs<HTMLTextAreaElement>(backingTextField)
 
         sendToHtmlInput(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -334,7 +334,7 @@ class CfWA11YTest : OnCanvasTests {
         awaitIdle()
         awaitA11YChanges()
 
-        val textEl = document.getElementById("testText") as HTMLElement
+        val textEl = getShadowRoot().getElementById("testText") as HTMLElement
         assertEquals("Test", textEl.innerText)
 
 
@@ -462,7 +462,7 @@ class CfWA11YTest : OnCanvasTests {
         awaitIdle()
         awaitA11YChanges()
 
-        val button = document.getElementById("buttonTag") as? HTMLElement
+        val button = getShadowRoot().getElementById("buttonTag") as? HTMLElement
         assertNotNull(button)
         button.click()
         assertEquals(1, clickCounter)
@@ -471,7 +471,7 @@ class CfWA11YTest : OnCanvasTests {
         awaitIdle()
         awaitA11YChanges()
 
-        assertNull(document.getElementById("buttonTag"))
+        assertNull(getShadowRoot().getElementById("buttonTag"))
     }
 
     @Test
@@ -489,7 +489,7 @@ class CfWA11YTest : OnCanvasTests {
         awaitIdle()
         awaitA11YChanges()
 
-        val textField = document.getElementById("textFieldTag") as? HTMLElement
+        val textField = getShadowRoot().getElementById("textFieldTag") as? HTMLElement
         assertNotNull(textField)
 
         assertEquals("textbox", textField.getAttribute("role"))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/viewinterop/WebInteropTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/viewinterop/WebInteropTest.kt
@@ -64,13 +64,13 @@ class WebInteropTest : OnCanvasTests {
         }
 
 
-        var div = document.getElementById(divId) as HTMLDivElement?
+        var div = getShadowRoot().getElementById(divId) as HTMLDivElement?
         assertNull(div)
 
         showDiv.value = true
         awaitIdle()
 
-        div = document.getElementById(divId) as HTMLDivElement?
+        div = getShadowRoot().getElementById(divId) as HTMLDivElement?
         assertNotNull(div)
         assertTrue(div.isConnected)
         assertEquals("Text1", div.innerText)
@@ -173,9 +173,9 @@ class WebInteropTest : OnCanvasTests {
         }
         awaitIdle()
 
-        assertEquals("CANVAS", document.elementFromPoint(10.0, 10.0)!!.tagName)
-        assertEquals("DIV", document.elementFromPoint(50.0, 50.0)!!.tagName)
-        assertEquals("CANVAS", document.elementFromPoint(90.0, 90.0)!!.tagName)
+        assertEquals("CANVAS", getShadowRoot().elementFromPoint(10.0, 10.0).tagName)
+        assertEquals("DIV", getShadowRoot().elementFromPoint(50.0, 50.0).tagName)
+        assertEquals("CANVAS", getShadowRoot().elementFromPoint(90.0, 90.0).tagName)
     }
 }
 


### PR DESCRIPTION
Updated web tests and web text input service to use shadow DOM APIs instead of directly accessing the global `document`. This improves encapsulation by interacting with elements within the component's shadow root.

It also fixes https://youtrack.jetbrains.com/issue/CMP-8462 (when a browser has an active extension, e.g. Grazie)
___



## Testing
This should be tested by QA

## Release Notes
N/A
