### PR TITLE
Remove experimental attribute from UIKitInteropInteractionMode

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/InteropExample.kt
@@ -40,7 +40,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -97,7 +96,6 @@ val InteropExample = Screen.Example("Interop") {
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun UIKitViewInteractionModeSection() {
     Text("UIKitView - interactionMode")
@@ -283,7 +281,6 @@ private fun TextSection() {
 }
 
 @Composable
-@OptIn(ExperimentalComposeUiApi::class)
 private fun UIKitViewControllerSection() {
     var updatedValue by remember { mutableStateOf(null as Offset?) }
 

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/UpdatableInteropPropertiesExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/UpdatableInteropPropertiesExample.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode
@@ -44,9 +43,8 @@ fun Int.interactionModeToString(): String = when (this) {
     else -> "Non-interactive"
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun ConfigutableMap(index: Int) {
+fun ConfigurableMap(index: Int) {
     var interactionMode by remember { mutableStateOf(0) }
 
     UIKitView(
@@ -94,10 +92,10 @@ fun ConfigurableMap(nestInsideBox: Boolean, index: Int) {
         Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            ConfigutableMap(index)
+            ConfigurableMap(index)
         }
     } else {
-        ConfigutableMap(index)
+        ConfigurableMap(index)
     }
 
 }

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -4654,6 +4654,30 @@ sealed interface androidx.compose.ui.uikit/OnFocusBehavior { // androidx.compose
 }
 
 // Targets: [ios]
+sealed interface androidx.compose.ui.viewinterop/UIKitInteropInteractionMode { // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode|null[0]
+    final class Cooperative : androidx.compose.ui.viewinterop/UIKitInteropInteractionMode { // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative|null[0]
+        constructor <init>(kotlin/Int = ...) // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.<init>|<init>(kotlin.Int){}[0]
+
+        final val delayMillis // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.delayMillis|{}delayMillis[0]
+            final fun <get-delayMillis>(): kotlin/Int // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.delayMillis.<get-delayMillis>|<get-delayMillis>(){}[0]
+
+        final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.hashCode|hashCode(){}[0]
+
+        final object Companion { // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.Companion|null[0]
+            final const val DefaultDelayMillis // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.Companion.DefaultDelayMillis|{}DefaultDelayMillis[0]
+                final fun <get-DefaultDelayMillis>(): kotlin/Int // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.Cooperative.Companion.DefaultDelayMillis.<get-DefaultDelayMillis>|<get-DefaultDelayMillis>(){}[0]
+        }
+    }
+
+    final object NonCooperative : androidx.compose.ui.viewinterop/UIKitInteropInteractionMode { // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.NonCooperative|null[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.NonCooperative.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.NonCooperative.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.NonCooperative.toString|toString(){}[0]
+    }
+}
+
+// Targets: [ios]
 final class androidx.compose.ui.draganddrop/DragAndDropTransferData // androidx.compose.ui.draganddrop/DragAndDropTransferData|null[0]
 
 // Targets: [ios]
@@ -4860,6 +4884,7 @@ final class androidx.compose.ui.uikit/ComposeUIViewControllerConfiguration { // 
 
 // Targets: [ios]
 final class androidx.compose.ui.viewinterop/UIKitInteropProperties { // androidx.compose.ui.viewinterop/UIKitInteropProperties|null[0]
+    constructor <init>(androidx.compose.ui.viewinterop/UIKitInteropInteractionMode? = ..., kotlin/Boolean = ...) // androidx.compose.ui.viewinterop/UIKitInteropProperties.<init>|<init>(androidx.compose.ui.viewinterop.UIKitInteropInteractionMode?;kotlin.Boolean){}[0]
     constructor <init>(kotlin/Boolean, kotlin/Boolean) // androidx.compose.ui.viewinterop/UIKitInteropProperties.<init>|<init>(kotlin.Boolean;kotlin.Boolean){}[0]
 
     final val interactionMode // androidx.compose.ui.viewinterop/UIKitInteropProperties.interactionMode|{}interactionMode[0]

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropInteractionMode.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropInteractionMode.uikit.kt
@@ -16,20 +16,18 @@
 
 package androidx.compose.ui.viewinterop
 
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.viewinterop.UIKitInteropInteractionMode.Cooperative.Companion.DefaultDelayMillis
 import platform.UIKit.UIScrollView
 
 /**
  * Represents a set of strategies on how the touches are processed when user interacts with the
  * interop view.
  */
-@ExperimentalComposeUiApi
 sealed interface UIKitInteropInteractionMode {
     /**
      * Represents a mode where the touches are not processed by the Compose UI if the interop view
      * is hit by the initial touch in the gesture.
      */
-    @ExperimentalComposeUiApi
     data object NonCooperative : UIKitInteropInteractionMode
 
     /**
@@ -48,7 +46,6 @@ sealed interface UIKitInteropInteractionMode {
      * @property delayMillis Indicates how much time in milliseconds is given for Compose to intercept
      * the touches before delivering them to the interop view. The default value is [DefaultDelayMillis].
      */
-    @ExperimentalComposeUiApi
     class Cooperative(
         val delayMillis: Int = DefaultDelayMillis
     ) : UIKitInteropInteractionMode {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropProperties.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropProperties.uikit.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.viewinterop
 
 import androidx.compose.runtime.Immutable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 
@@ -53,7 +52,7 @@ import androidx.compose.ui.semantics.semantics
  * @see Modifier.semantics
  */
 @Immutable
-class UIKitInteropProperties @ExperimentalComposeUiApi constructor(
+class UIKitInteropProperties(
     val interactionMode: UIKitInteropInteractionMode? = UIKitInteropInteractionMode.Cooperative(),
     val isNativeAccessibilityEnabled: Boolean = false
 ) {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-6769/Remove-experimental-flag-from-UIKitInteropInteractionMode

## Release Notes
### Migration Notes - iOS
- Remove experimental attribute from `UIKitInteropInteractionMode`