### PR TITLE
Handle web lifecycle events for visibility and focus changes

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.web.kt
@@ -382,6 +382,13 @@ internal class ComposeWindow(
         state.globalEvents.addDisposableEvent("blur") {
             lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
         }
+
+        state.globalEvents.addDisposableEvent("visibilitychange") { event ->
+            lifecycle.handleLifecycleEvent(
+                if (documentIsVisible()) Lifecycle.Event.ON_START
+                else Lifecycle.Event.ON_STOP
+            )
+        }
     }
 
     init {
@@ -415,7 +422,10 @@ internal class ComposeWindow(
             )
         }
 
-        lifecycle.handleLifecycleEvent(if (document.hasFocus()) Lifecycle.Event.ON_RESUME else Lifecycle.Event.ON_START)
+        lifecycle.handleLifecycleEvent(
+            if (document.hasFocus()) Lifecycle.Event.ON_RESUME
+            else Lifecycle.Event.ON_START
+        )
     }
 
     fun resize(boxSize: IntSize) {
@@ -462,6 +472,13 @@ internal class ComposeWindow(
         event: TouchEvent,
         offset: Offset,
     ) {
+        // iOS Safari doesn't request focus when the page is shown,
+        // and the lifecycle doesn't trigger ON_RESUME.
+        // so, we decided to handle every touch
+        if (lifecycle.currentState != Lifecycle.State.RESUMED) {
+            lifecycle.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        }
+
         val inputModeManager = platformContext.inputModeManager
         if (inputModeManager.inputMode != InputMode.Touch) {
             inputModeManager.requestInputMode(InputMode.Touch)
@@ -580,6 +597,9 @@ internal class ComposeWindow(
         y = offsetY.toFloat()
     ) * density.density
 }
+
+//https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState
+private fun documentIsVisible(): Boolean = js("document.visibilityState === 'visible'")
 
 private const val defaultCanvasElementId = "ComposeTarget"
 


### PR DESCRIPTION
iOS Safari doesn't request a focus when the app is loaded or a user returns to the tab.
So, we decided to trigger ON_RESUME event on each touch event.

Fixes https://youtrack.jetbrains.com/issue/CMP-8014

## Testing
  This should be tested by QA

## Release Notes
### Fixes - Web
- Web Lifecycle triggers `START`/`STOP` events on the `visibilitychange` callback now.
- Lifecycle fix on iOS Safari: now touch events trigger `ON_RESUME` because Safari ignores interactions and doesn't request the focus