### PR TITLE
Fix a wrong TimeSource API usage

### DIFF
--- a/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/UndoManager.native.kt
+++ b/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/UndoManager.native.kt
@@ -18,5 +18,7 @@ package androidx.compose.foundation.text
 
 import kotlin.time.TimeSource
 
+private val markNow = TimeSource.Monotonic.markNow()
+
 internal actual fun timeNowMillis(): Long =
-    TimeSource.Monotonic.markNow().elapsedNow().inWholeMilliseconds
+    markNow.elapsedNow().inWholeMilliseconds

--- a/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
+++ b/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
@@ -31,8 +31,10 @@ import kotlinx.coroutines.yield
 )
 public actual val DefaultMonotonicFrameClock: MonotonicFrameClock =
     object : MonotonicFrameClock {
+        private val markNow = TimeSource.Monotonic.markNow()
+
         override suspend fun <R> withFrameNanos(onFrame: (Long) -> R): R {
             yield()
-            return onFrame(TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds)
+            return onFrame(markNow.elapsedNow().inWholeNanoseconds)
         }
     }

--- a/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
+++ b/compose/runtime/runtime/src/nativeMain/kotlin/androidx/compose/runtime/MonotonicFrameClock.native.kt
@@ -31,10 +31,8 @@ import kotlinx.coroutines.yield
 )
 public actual val DefaultMonotonicFrameClock: MonotonicFrameClock =
     object : MonotonicFrameClock {
-        private val markNow = TimeSource.Monotonic.markNow()
-
         override suspend fun <R> withFrameNanos(onFrame: (Long) -> R): R {
             yield()
-            return onFrame(markNow.elapsedNow().inWholeNanoseconds)
+            return onFrame(TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds)
         }
     }

--- a/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.native.kt
+++ b/compose/ui/ui/src/nativeMain/kotlin/androidx/compose/ui/Actuals.native.kt
@@ -22,7 +22,9 @@ internal actual fun areObjectsOfSameType(a: Any, b: Any): Boolean {
     return a::class == b::class
 }
 
+private val markNow = TimeSource.Monotonic.markNow()
+
 internal actual fun currentTimeMillis(): Long {
-    return TimeSource.Monotonic.markNow().elapsedNow().inWholeMilliseconds
+    return markNow.elapsedNow().inWholeMilliseconds
 }
 

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/CurrentTimeTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/CurrentTimeTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+
+class CurrentTimeTest {
+
+    @Test
+    fun timeMonotonicallyIncreases() = runTest {
+        var time = currentTimeMillis()
+
+        suspend fun realDelay() {
+            withContext(Dispatchers.Default) {
+                delay(2)
+            }
+        }
+
+        repeat(100) {
+            realDelay()
+            val newTime = currentTimeMillis()
+            assertTrue(newTime > time, "Time did not increase: $newTime > $time")
+            time = newTime
+        }
+    }
+}


### PR DESCRIPTION
The wrong usage was added in https://github.com/JetBrains/compose-multiplatform-core/pull/1985

## Testing
Added a test

## Release Notes
N/A
