### PR TITLE
Include content in `ProvideDefaultPlatformTextContextMenuProviders` even if a menu dropdown provider already exists

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/contextmenu/internal/PlatformDefaultTextContextMenuProviders.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/contextmenu/internal/PlatformDefaultTextContextMenuProviders.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text.contextmenu.internal
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.contextmenu.provider.LocalTextContextMenuDropdownProvider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,6 +29,8 @@ internal actual fun ProvideDefaultPlatformTextContextMenuProviders(
     val dropdownDefined = LocalTextContextMenuDropdownProvider.current != null
     if (!dropdownDefined) {
         ProvideDefaultTextContextMenuDropdown(modifier, content)
+    } else {
+        Box(modifier, propagateMinConstraints = true) { content() }
     }
 }
 


### PR DESCRIPTION
Include content in `ProvideDefaultPlatformTextContextMenuProviders` even if a menu dropdown provider already exists

## Release Notes
N/A