### PR TITLE
Implement scroll to focused interop views

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -53,12 +53,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)accessibilityPerformEscape;
 
-- (__nullable id)accessibilityElementAtIndex:(NSInteger)index;
-
-- (NSInteger)accessibilityElementCount;
-
-- (NSInteger)indexOfAccessibilityElement:(id)element;
-
 - (NSArray *)accessibilityElements;
 
 - (void)setAccessibilityElements:(nullable NSArray *)accessibilityElements;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -45,12 +45,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)accessibilityDecrement;
 
-// Private SDK method. Calls when the item is swipe-to-focused in VoiceOver.
-- (BOOL)accessibilityScrollToVisible;
-
-// Private SDK method. Calls when the item is swipe-to-focused in VoiceOver.
-- (BOOL)accessibilityScrollToVisibleWithChild:(id)child;
-
 - (void)accessibilityElementDidBecomeFocused;
 
 - (void)accessibilityElementDidLoseFocus;

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -81,14 +81,6 @@ NS_ASSUME_NONNULL_BEGIN
     return [super accessibilityPerformEscape];
 }
 
-- (BOOL)accessibilityScrollToVisible {
-    return NO;
-}
-
-- (BOOL)accessibilityScrollToVisibleWithChild:(id)child {
-    return NO;
-}
-
 - (void)accessibilityElementDidBecomeFocused {
     [super accessibilityElementDidBecomeFocused];
 }

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -89,18 +89,6 @@ NS_ASSUME_NONNULL_BEGIN
     [super accessibilityElementDidLoseFocus];
 }
 
-- (NSInteger)accessibilityElementCount {
-    return [super accessibilityElementCount];
-}
-
-- (NSInteger)indexOfAccessibilityElement:(nonnull id)element {
-    return [super indexOfAccessibilityElement:element];
-}
-
-- (id _Nullable)accessibilityElementAtIndex:(NSInteger)index {
-    return [super accessibilityElementAtIndex:index];
-}
-
 - (NSArray *)accessibilityElements {
     return [super accessibilityElements];
 }

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.h
@@ -23,6 +23,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (__nullable id)accessibilityContainer CMP_ABSTRACT_FUNCTION;
 
+- (NSArray *)accessibilityElements;
+
+- (void)setAccessibilityElements:(nullable NSArray *)accessibilityElements;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPInteropWrappingView.m
@@ -22,4 +22,12 @@
     CMP_ABSTRACT_FUNCTION_CALLED
 }
 
+- (NSArray *)accessibilityElements {
+    return [super accessibilityElements];
+}
+
+- (void)setAccessibilityElements:(nullable NSArray *)accessibilityElements {
+    [super setAccessibilityElements:accessibilityElements];
+}
+
 @end

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -284,6 +284,7 @@ private sealed interface AccessibilityNode {
             get() = semanticsNode.unmergedConfig.contains(SemanticsProperties.Focused)
 
         override fun didBecomeFocused() {
+            mediator.scrollToAccessibilityElement(key)
             mediator.keyboardFocusedElementKey = key
         }
 
@@ -777,19 +778,29 @@ internal class AccessibilityMediator(
     private var scrollJob: Job? = null
 
     private val focusObserver = AccessibilityFocusedElementObserver { focusedElement ->
-        val listener = displayLinkListener ?: return@AccessibilityFocusedElementObserver
+        scrollToAccessibilityElement(focusedElement)
+        scheduleFocusedScrollableParentsIdsUpdate(focusedElement)
+    }
 
-        val scrollableContainer = findFirstAccessibilityElementInHierarchy(focusedElement) {
+    fun scrollToAccessibilityElement(key: AccessibilityElementKey) {
+        val element = accessibilityElementsMap[key] ?: return
+        scrollToAccessibilityElement(element)
+    }
+
+    private fun scrollToAccessibilityElement(element: NSObject) {
+        val listener = displayLinkListener ?: return
+
+        val scrollableContainer = findFirstAccessibilityElementInHierarchy(element) {
             it.node.semanticsNode.canScroll
         }
         if (scrollableContainer != null) {
             scrollJob?.cancel()
             val rect = when {
-                focusedElement is AccessibilityElement ->
-                    focusedElement.node.semanticsNode.unclippedBoundsInWindow
+                element is AccessibilityElement ->
+                    element.node.semanticsNode.unclippedBoundsInWindow
 
                 else ->
-                    focusedElement.accessibilityFrame.asDpRect()
+                    element.accessibilityFrame.asDpRect()
                         .toRect(scrollableContainer.node.semanticsNode.layoutNode.density)
             }
             scrollJob = CoroutineScope(coroutineContext + listener.frameClock).launch {
@@ -800,7 +811,6 @@ internal class AccessibilityMediator(
             }
         }
 
-        scheduleFocusedScrollableParentsIdsUpdate(focusedElement)
     }
 
     private fun iterateAccessibilityElementHierarchy(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.accessibility.accessibilityLabel
 import androidx.compose.ui.platform.accessibility.accessibilityTraits
 import androidx.compose.ui.platform.accessibility.accessibilityValue
 import androidx.compose.ui.platform.accessibility.allScrollableParentNodeIds
+import androidx.compose.ui.platform.accessibility.canScroll
 import androidx.compose.ui.platform.accessibility.isRTL
 import androidx.compose.ui.platform.accessibility.isScreenReaderFocusable
 import androidx.compose.ui.platform.accessibility.scrollIfPossible
@@ -55,6 +56,7 @@ import kotlin.time.measureTime
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExportObjCClass
+import kotlinx.cinterop.ObjCAction
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.CoroutineScope
@@ -77,12 +79,18 @@ import platform.CoreGraphics.CGRectGetMinY
 import platform.CoreGraphics.CGRectIntersectsRect
 import platform.CoreGraphics.CGRectIsEmpty
 import platform.CoreGraphics.CGRectZero
+import platform.Foundation.NSNotification
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSSelectorFromString
 import platform.UIKit.NSStringFromCGRect
 import platform.UIKit.UIAccessibilityContainerType
 import platform.UIKit.UIAccessibilityContainerTypeNone
 import platform.UIKit.UIAccessibilityContainerTypeSemanticGroup
 import platform.UIKit.UIAccessibilityCustomAction
+import platform.UIKit.UIAccessibilityElement
+import platform.UIKit.UIAccessibilityElementFocusedNotification
 import platform.UIKit.UIAccessibilityFocusedElement
+import platform.UIKit.UIAccessibilityFocusedElementKey
 import platform.UIKit.UIAccessibilityLayoutChangedNotification
 import platform.UIKit.UIAccessibilityPageScrolledNotification
 import platform.UIKit.UIAccessibilityPostNotification
@@ -140,7 +148,6 @@ private sealed interface AccessibilityNode {
     fun accessibilityDecrement() {}
     fun accessibilityElementDidBecomeFocused() {}
     fun accessibilityElementDidLoseFocus() {}
-    fun accessibilityScrollToVisible(): Boolean = false
     fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean = false
     fun accessibilityPerformEscape(): Boolean = false
 
@@ -246,26 +253,6 @@ private sealed interface AccessibilityNode {
             mediator.clearFocusTargetIfNeeded(key)
         }
 
-        private var listener: DisplayLinkListener? = null
-        override fun accessibilityScrollToVisible(): Boolean {
-            if (listener != null) {
-                return false
-            }
-            val listener = DisplayLinkListener()
-            listener.start()
-            this.listener = listener
-            CoroutineScope(mediator.coroutineContext + listener.frameClock).launch {
-                semanticsNode.parent?.scrollToCenterRectIfNeeded(
-                    targetRect = semanticsNode.unclippedBoundsInWindow,
-                    safeAreaRectInWindow = mediator.safeAreaRectInWindow
-                )
-                listener.invalidate()
-                this@Semantics.listener = null
-            }
-
-            return true
-        }
-
         override fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean {
             if (cachedConfig.contains(SemanticsProperties.Disabled)) {
                 return false
@@ -302,7 +289,6 @@ private sealed interface AccessibilityNode {
             get() = semanticsNode.unmergedConfig.contains(SemanticsProperties.Focused)
 
         override fun didBecomeFocused() {
-            accessibilityScrollToVisible()
             mediator.keyboardFocusedElementKey = key
         }
 
@@ -518,26 +504,6 @@ private class AccessibilityElement(
         }
 
         node.accessibilityDecrement()
-    }
-
-    override fun accessibilityScrollToVisible(): Boolean {
-        if (!isAlive) {
-            return false
-        }
-
-        return node.accessibilityScrollToVisible()
-    }
-
-    override fun accessibilityScrollToVisibleWithChild(child: Any): Boolean {
-        if (!isAlive) {
-            return false
-        }
-
-        if (child is AccessibilityElement) {
-            return child.accessibilityScrollToVisible()
-        }
-
-        return false
     }
 
     override fun accessibilityScroll(direction: UIAccessibilityScrollDirection): Boolean {
@@ -795,6 +761,63 @@ internal class AccessibilityMediator(
         return rectInWindow.asDpRect().toRect(view.density)
     }
 
+    private var displayLinkListener: DisplayLinkListener? = null
+
+    private var scrollJob: Job? = null
+
+    private val focusObserver = AccessibilityFocusedElementObserver { focusedElement ->
+        val listener = displayLinkListener ?: return@AccessibilityFocusedElementObserver
+
+        val scrollableContainer = findFirstAccessibilityElementInHierarchy(focusedElement) {
+            it.node.semanticsNode.canScroll
+        }
+        if (scrollableContainer != null) {
+            scrollJob?.cancel()
+            val rect = when {
+                focusedElement is AccessibilityElement ->
+                    focusedElement.node.semanticsNode.unclippedBoundsInWindow
+
+                else ->
+                    focusedElement.accessibilityFrame.asDpRect()
+                        .toRect(scrollableContainer.node.semanticsNode.layoutNode.density)
+            }
+            scrollJob = CoroutineScope(coroutineContext + listener.frameClock).launch {
+                scrollableContainer.node.semanticsNode.scrollToCenterRectIfNeeded(
+                    targetRect = rect,
+                    safeAreaRectInWindow = safeAreaRectInWindow
+                )
+            }
+        }
+    }
+
+    private fun findFirstAccessibilityElementInHierarchy(
+        element: Any,
+        validate: (AccessibilityElement) -> Boolean,
+    ): AccessibilityElement? {
+        var iterator: Any? = element
+        var result: AccessibilityElement? = null
+        while (iterator != null) {
+            when (iterator) {
+                is AccessibilityElement -> {
+                    if (result == null && validate(iterator)) {
+                        result = iterator
+                    }
+                    iterator = iterator.accessibilityContainer
+                }
+
+                is InteropWrappingView -> iterator = iterator.actualAccessibilityContainer
+                is AccessibilityRoot -> {
+                    // Return true only of the result element has the same root
+                    return result.takeIf { iterator == root }
+                }
+                is UIView -> iterator = iterator.superview
+                is UIAccessibilityElement -> iterator = iterator.accessibilityContainer
+                else -> return null
+            }
+        }
+        return null
+    }
+
     init {
         accessibilityDebugLogger?.log("AccessibilityMediator for $view created")
 
@@ -846,7 +869,8 @@ internal class AccessibilityMediator(
     private fun scheduleAccessibilityDisablingAndCleanup() {
         if (disableAccessibilityJob != null ||
             keyboardFocusedElementKey != null ||
-            focusMode is AccessibilityElementFocusMode.KeepFocus) {
+            focusMode is AccessibilityElementFocusMode.KeepFocus ||
+            hasFocusedElement()) {
             return
         }
         disableAccessibilityJob = coroutineScope.launch {
@@ -857,6 +881,13 @@ internal class AccessibilityMediator(
 
             cleanUp()
         }
+    }
+
+    private fun hasFocusedElement(): Boolean {
+        val element = UIAccessibilityFocusedElement(null) ?: return false
+        return findFirstAccessibilityElementInHierarchy(element) {
+            true
+        } != null
     }
 
     private fun cancelAccessibilityDisabling() {
@@ -928,6 +959,7 @@ internal class AccessibilityMediator(
     }
 
     fun dispose() {
+        focusObserver.dispose()
         job.cancel()
         disableAccessibilityJob?.cancel()
 
@@ -943,6 +975,9 @@ internal class AccessibilityMediator(
     }
 
     private fun cleanUp() {
+        displayLinkListener?.invalidate()
+        displayLinkListener = null
+
         disableAccessibilityJob = null
         isAccessibilityActive = false
 
@@ -1132,6 +1167,11 @@ internal class AccessibilityMediator(
 
         val (element, focusedElementKey) = traverseSemanticsTree(rootSemanticsNode)
         root.element = element
+
+        if (displayLinkListener == null) {
+            displayLinkListener = DisplayLinkListener()
+            displayLinkListener?.start()
+        }
 
         accessibilityDebugLogger?.let {
             debugTraverse(it, view)
@@ -1411,5 +1451,29 @@ private class BeyondBoundsComparator(private val isRTL: Boolean) : Comparator<Se
         }
 
         return result
+    }
+}
+
+private class AccessibilityFocusedElementObserver(
+    private val onElementFocused: (NSObject) -> Unit
+): NSObject() {
+    init {
+        NSNotificationCenter.defaultCenter.addObserver(
+            observer = this,
+            selector = NSSelectorFromString(::onFocus.name + ":"),
+            name = UIAccessibilityElementFocusedNotification,
+            `object` = null
+        )
+    }
+
+    @OptIn(BetaInteropApi::class)
+    @ObjCAction
+    private fun onFocus(arg: NSNotification) {
+        val accessibilityElement = arg.userInfo?.get(UIAccessibilityFocusedElementKey) as? NSObject
+        accessibilityElement?.let { onElementFocused(it) }
+    }
+
+    fun dispose() {
+        NSNotificationCenter.defaultCenter.removeObserver(this)
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -713,7 +713,7 @@ internal class AccessibilityMediator(
 ) {
     private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
 
-    var focusedNodesScrollableParentsIds = setOf<Int>()
+    var focusedNodesScrollableParentsIds: Set<Int> = setOf()
         private set(value) {
             if (field != value) {
                 field = value

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -168,27 +168,22 @@ private sealed interface AccessibilityNode {
         private val isBeyondBounds: Boolean
     ) : AccessibilityNode {
         private val cachedConfig = semanticsNode.copyWithMergingEnabled().config
+        private val scrollableParentNodeIds by lazy { semanticsNode.allScrollableParentNodeIds }
 
         override val key: AccessibilityElementKey get() = semanticsNode.semanticsKey
 
         override val isAccessibilityElement: Boolean get() {
-            if (!semanticsNode.isScreenReaderFocusable()) {
-                return false
+            return if (semanticsNode.isScreenReaderFocusable()) {
+                isBeyondBoundsOrFocusable
+            } else {
+                false
             }
-
-            if (isBeyondBounds) {
-                // Semantics node is outside visible bounds.
-                // Check if it can be focused by scrolling.
-                return semanticsNode.allScrollableParentNodeIds.any {
-                    mediator.focusedNodesScrollableParentsIds.contains(it)
-                }
-            }
-
-            return true
         }
 
         override val accessibilityInteropView: InteropWrappingView?
-            get() = cachedConfig.getOrNull(NativeAccessibilityViewSemanticsKey)
+            get() = cachedConfig.getOrNull(NativeAccessibilityViewSemanticsKey)?.also {
+                it.isAccessibilityFocusable = ::isBeyondBoundsOrFocusable
+            }
 
         override val accessibilityLabel: String?
             get() = cachedConfig.accessibilityLabel()
@@ -296,6 +291,17 @@ private sealed interface AccessibilityNode {
             if (mediator.keyboardFocusedElementKey == key) {
                 mediator.keyboardFocusedElementKey = null
             }
+        }
+
+        private val isBeyondBoundsOrFocusable: Boolean get() = if (isBeyondBounds) {
+            // The accessibility element beyond the bounds should only be focusable
+            // when it is located within the same scrollable container as the element
+            // that is already focused, in order to prevent an unwanted selection order.
+            scrollableParentNodeIds.any {
+                mediator.focusedNodesScrollableParentsIds.contains(it)
+            }
+        } else {
+            true
         }
     }
 
@@ -706,15 +712,20 @@ internal class AccessibilityMediator(
     val onScreenReaderActive: (Boolean) -> Unit,
 ) {
     private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
-        set(value) {
-            field = value
-            accessibilityDebugLogger?.log("Focus mode: $focusMode")
-
-            scheduleFocusedScrollableParentsIdsUpdate()
-        }
 
     var focusedNodesScrollableParentsIds = setOf<Int>()
-        private set
+        private set(value) {
+            if (field != value) {
+                field = value
+                invalidateSemanticsTree()
+
+                if (value.isNotEmpty()) {
+                    // Hack to fix an issue where iOS accessibility only reads the items visible
+                    // at the moment of the beginning of the "Speak Screen" command.
+                    UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, null)
+                }
+            }
+        }
 
     var keyboardFocusedElementKey: AccessibilityElementKey? = null
     private var forceFocusedElementKey: AccessibilityElementKey? = null
@@ -788,34 +799,46 @@ internal class AccessibilityMediator(
                 )
             }
         }
+
+        scheduleFocusedScrollableParentsIdsUpdate(focusedElement)
     }
 
-    private fun findFirstAccessibilityElementInHierarchy(
+    private fun iterateAccessibilityElementHierarchy(
         element: Any,
-        validate: (AccessibilityElement) -> Boolean,
-    ): AccessibilityElement? {
+        onElement: (AccessibilityElement) -> Unit,
+    ): Boolean {
         var iterator: Any? = element
-        var result: AccessibilityElement? = null
         while (iterator != null) {
             when (iterator) {
                 is AccessibilityElement -> {
-                    if (result == null && validate(iterator)) {
-                        result = iterator
-                    }
+                    onElement(iterator)
                     iterator = iterator.accessibilityContainer
                 }
 
                 is InteropWrappingView -> iterator = iterator.actualAccessibilityContainer
                 is AccessibilityRoot -> {
                     // Return true only of the result element has the same root
-                    return result.takeIf { iterator == root }
+                    return iterator == root
                 }
                 is UIView -> iterator = iterator.superview
                 is UIAccessibilityElement -> iterator = iterator.accessibilityContainer
-                else -> return null
+                else -> return false
             }
         }
-        return null
+        return false
+    }
+
+    private fun findFirstAccessibilityElementInHierarchy(
+        element: Any,
+        validate: (AccessibilityElement) -> Boolean,
+    ): AccessibilityElement? {
+        var result: AccessibilityElement? = null
+        val isInHierarchy = iterateAccessibilityElementHierarchy(element) {
+            if (result == null && validate(it)) {
+                result = it
+            }
+        }
+        return result?.takeIf { isInHierarchy }
     }
 
     init {
@@ -986,26 +1009,22 @@ internal class AccessibilityMediator(
     }
 
     private var focusedScrollableParentsIdsUpdateJob: Job? = null
-    private fun scheduleFocusedScrollableParentsIdsUpdate() {
+    private fun scheduleFocusedScrollableParentsIdsUpdate(focusedElement: NSObject) {
         focusedScrollableParentsIdsUpdateJob?.cancel()
         focusedScrollableParentsIdsUpdateJob = coroutineScope.launch {
             // Throttle the recalculation of scrollable parent node IDs to avoid unnecessary
             // reloading of the accessibility tree when the focusMode changes quickly.
             delay(10)
-            val ids = (focusMode as? AccessibilityElementFocusMode.KeepFocus)?.key?.let {
-                accessibilityElementsMap[it]?.node?.semanticsNode?.allScrollableParentNodeIds
-            } ?: emptySet()
-
-            if (focusedNodesScrollableParentsIds != ids) {
-                focusedNodesScrollableParentsIds = ids
-                invalidateSemanticsTree()
-
-                if (ids.isNotEmpty()) {
-                    // Hack to fix an issue where iOS accessibility only reads the items visible
-                    // at the moment of the beginning of the "Speak Screen" command.
-                    UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, null)
+            val scrollableElementsIds = mutableSetOf<Int>()
+            val isInHierarchy = iterateAccessibilityElementHierarchy(focusedElement) {
+                if (it.node.semanticsNode.canScroll) {
+                    scrollableElementsIds.add(it.node.semanticsNode.id)
                 }
             }
+            if (!isInHierarchy) {
+                scrollableElementsIds.clear()
+            }
+            focusedNodesScrollableParentsIds = scrollableElementsIds
         }
     }
 
@@ -1066,7 +1085,9 @@ internal class AccessibilityMediator(
                 if (child.isValid) {
                     if (nodes.contains(child.id)) {
                         semanticsChildren.add(child)
-                    } else if (child.size != IntSize.Zero && child.isScreenReaderFocusable()) {
+                    } else if (child.size != IntSize.Zero && (child.isScreenReaderFocusable() ||
+                            child.unmergedConfig.contains(NativeAccessibilityViewSemanticsKey))
+                    ) {
                         if (child.isBeforeBeyondBoundsItem(container = this)) {
                             beforeBeyondBoundsChildren.add(child)
                         } else {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -813,6 +813,15 @@ internal class AccessibilityMediator(
 
     }
 
+    /**
+     * Iterates through the accessibility element hierarchy starting from the top element down to the root.
+     * For each element of type `AccessibilityElement` invokes [onElement] callback.
+     *
+     * @param element The starting point for the iteration in the hierarchy.
+     * @param onElement A callback function that is invoked for each `AccessibilityElement` encountered during the iteration.
+     * @return Returns `true` if the provided [element] located in the hierarchy of the tree of current [AccessibilityMediator],
+     * otherwise returns `false`.
+     */
     private fun iterateAccessibilityElementHierarchy(
         element: Any,
         onElement: (AccessibilityElement) -> Unit,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.kt
@@ -256,7 +256,7 @@ private val SemanticsNode.isHiddenFromAccessibility: Boolean
     get() = unmergedConfig.contains(HideFromAccessibility) ||
         unmergedConfig.contains(InvisibleToUser)
 
-private val SemanticsNode.canScroll: Boolean
+internal val SemanticsNode.canScroll: Boolean
     get() = unmergedConfig.contains(SemanticsActions.ScrollBy) ||
         unmergedConfig.contains(SemanticsActions.ScrollByOffset)
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/InteropWrappingView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/InteropWrappingView.uikit.kt
@@ -55,6 +55,7 @@ internal class InteropWrappingView(
     interactionMode: UIKitInteropInteractionMode?
 ) : CMPInteropWrappingView(frame = CGRectZero.readValue()) {
     var actualAccessibilityContainer: Any? = null
+    var isAccessibilityFocusable: () -> Boolean = { true }
 
     var interactionMode: UIKitInteropInteractionMode? = interactionMode
         set(value) {
@@ -63,18 +64,23 @@ internal class InteropWrappingView(
         }
 
     init {
-        updateAccessibilityElements()
         // required to properly clip the content of the wrapping view in case interop unclipped
         // bounds are larger than clipped bounds
         clipsToBounds = true
     }
 
     private fun updateAccessibilityElements() {
-        if (interactionMode == null) {
-            setAccessibilityElements(emptyList<Any>())
+        if (interactionMode != null && isAccessibilityFocusable()) {
+            setAccessibilityElements(subviews)
         } else {
-            setAccessibilityElements(null)
+            setAccessibilityElements(emptyList<Any>())
         }
+    }
+
+    override fun accessibilityElements(): List<*> {
+        updateAccessibilityElements()
+
+        return super.accessibilityElements()
     }
 
     override fun accessibilityContainer(): Any? {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.uikit.kt
@@ -34,6 +34,7 @@ import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectIntersection
 import platform.CoreGraphics.CGRectIsEmpty
 import platform.UIKit.UIView
+import platform.UIKit.accessibilityFrame
 
 internal abstract class UIKitInteropElementHolder<T : InteropView>(
     factory: () -> T,
@@ -118,10 +119,15 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
                 .toRect()
                 .toDpRect(density)
                 .asCGRect()
+            val groupAccessibilityFrame = unclippedRect
+                .toRect()
+                .toDpRect(density)
+                .asCGRect()
 
             container.scheduleUpdate {
                 UIView.performWithoutAnimation {
                     group.setFrame(groupFrame)
+                    group.accessibilityFrame = groupAccessibilityFrame
                 }
             }
         }


### PR DESCRIPTION
Use `UIAccessibilityElementFocusedNotification` instead of the private method `accessibilityScrollToVisible ` as a source of accessibility scroll.
Refactor `InteropWrappingView` to support accessibility focus beyond bounds.


Fixes https://youtrack.jetbrains.com/issue/CMP-7999/Autoscroll-does-not-work-when-accessibility-focuses-on-interop-views

## Release Notes
### Features - iOS
- Implement accessibility scroll to focused interop views