### PR TITLE
CfW: Listen to the Clip events on the narrower scope rather than on the document

### DIFF
--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.js.kt
@@ -19,10 +19,12 @@ package androidx.compose.foundation.text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.NonRestartableComposable
-import kotlinx.browser.document
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.window.LocalActiveClipEventsTarget
 import org.w3c.dom.clipboard.ClipboardEvent
 import org.w3c.dom.events.EventListener
 
+@OptIn(InternalComposeUiApi::class)
 @Composable
 @NonRestartableComposable
 internal actual inline fun rememberClipboardEventsHandler(
@@ -32,8 +34,8 @@ internal actual inline fun rememberClipboardEventsHandler(
     isEnabled: Boolean
 ) {
     if (isEnabled) {
+        val clipEventsTargetProvider = LocalActiveClipEventsTarget.current
         DisposableEffect(Unit) {
-
             val copyListener = EventListener { event ->
                 val textToCopy = onCopy()
                 if (textToCopy != null && event is ClipboardEvent) {
@@ -58,14 +60,15 @@ internal actual inline fun rememberClipboardEventsHandler(
                 }
             }
 
-            document.addEventListener("copy", copyListener)
-            document.addEventListener("paste", pasteListener)
-            document.addEventListener("cut", cutListener)
+            val eventsTarget = clipEventsTargetProvider()
+            eventsTarget?.addEventListener("copy", copyListener)
+            eventsTarget?.addEventListener("paste", pasteListener)
+            eventsTarget?.addEventListener("cut", cutListener)
 
             onDispose {
-                document.removeEventListener("copy", copyListener)
-                document.removeEventListener("paste", pasteListener)
-                document.removeEventListener("cut", cutListener)
+                eventsTarget?.removeEventListener("copy", copyListener)
+                eventsTarget?.removeEventListener("paste", pasteListener)
+                eventsTarget?.removeEventListener("cut", cutListener)
             }
         }
     }

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/ClipboardEventsHandler.wasm.kt
@@ -19,11 +19,13 @@ package androidx.compose.foundation.text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.NonRestartableComposable
-import kotlinx.browser.document
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.window.LocalActiveClipEventsTarget
 import org.w3c.dom.clipboard.ClipboardEvent
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventListener as EventListenerInterface
 
+@OptIn(InternalComposeUiApi::class)
 @Composable
 @NonRestartableComposable
 internal actual inline fun rememberClipboardEventsHandler(
@@ -33,6 +35,7 @@ internal actual inline fun rememberClipboardEventsHandler(
     isEnabled: Boolean
 ) {
     if (isEnabled) {
+        val clipEventsTargetProvider = LocalActiveClipEventsTarget.current
         DisposableEffect(Unit) {
             val copyListener = EventListener { event ->
                 val textToCopy = onCopy()
@@ -58,14 +61,15 @@ internal actual inline fun rememberClipboardEventsHandler(
                 }
             }
 
-            document.addEventListener("copy", copyListener)
-            document.addEventListener("paste", pasteListener)
-            document.addEventListener("cut", cutListener)
+            val eventsTarget = clipEventsTargetProvider()
+            eventsTarget?.addEventListener("copy", copyListener)
+            eventsTarget?.addEventListener("paste", pasteListener)
+            eventsTarget?.addEventListener("cut", cutListener)
 
             onDispose {
-                document.removeEventListener("copy", copyListener)
-                document.removeEventListener("paste", pasteListener)
-                document.removeEventListener("cut", cutListener)
+                eventsTarget?.removeEventListener("copy", copyListener)
+                eventsTarget?.removeEventListener("paste", pasteListener)
+                eventsTarget?.removeEventListener("cut", cutListener)
             }
         }
     }

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/interops/HtmlInteropDemos.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/interops/HtmlInteropDemos.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.WebElementView
 import kotlinx.browser.document
 import org.w3c.dom.HTMLDivElement
+import org.w3c.dom.HTMLTextAreaElement
 
 val HtmlInteropDemos = Screen.Selection(
     "HtmlInteropDemos",
@@ -60,12 +61,16 @@ fun SyncTextState() {
 
         WebElementView(
             factory = {
-                (document.createElement("div") as HTMLDivElement).apply {
-                    innerText = textState.text.toString()
+                (document.createElement("textarea") as HTMLTextAreaElement).apply {
+                    style.apply {
+                        boxSizing = "border-box"
+                    }
                 }
             },
-            modifier = Modifier.size(300.dp).padding(50.dp),
-            update = { div -> div.innerText = textState.text.toString() }
+            update = { input ->
+                input.value = textState.text.toString()
+            },
+            modifier = Modifier.size(300.dp).padding(50.dp)
         )
     }
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -53,7 +53,7 @@ internal class BackingDomInput(
         composeCommunicator
     )
 
-    private val backingElement = inputStrategy.htmlInput
+    internal val backingElement = inputStrategy.htmlInput
 
     fun register() {
         setBackingInputBox(container = inputContainer, 0f, 0f, 0f, 0f)

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -77,6 +77,10 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         showSoftwareKeyboard()
     }
 
+    fun getBackingInput(): HTMLElement? {
+        return backingDomInput?.backingElement?.takeIf { it.isConnected }
+    }
+
     override fun stopInput() {
         backingDomInput?.dispose()
     }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.composeButton
 import androidx.compose.ui.input.pointer.composeButtons
 import androidx.compose.ui.platform.DefaultInputModeManager
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInternalViewModelStoreOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
@@ -425,6 +426,9 @@ internal class ComposeWindow(
                 LocalLifecycleOwner provides this,
                 LocalInternalViewModelStoreOwner provides this,
                 LocalInteropContainer provides interopContainer,
+                LocalActiveClipEventsTarget provides {
+                    (platformContext.textInputService as WebTextInputService).getBackingInput() ?: canvas
+                },
                 content = {
                     interopContainer.TrackInteropPlacementContainer {
                         content()

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebCompositionLocals.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebCompositionLocals.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.InternalComposeUiApi
+import org.w3c.dom.HTMLElement
+
+/**
+ * Internal usages only!
+ * Usually, it would be either an active backing HTML input/textarea or the canvas
+ */
+@InternalComposeUiApi
+val LocalActiveClipEventsTarget = staticCompositionLocalOf<() -> HTMLElement?> {
+    error("LocalActiveClipEventsTarget not provided")
+}

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebCompositionLocals.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebCompositionLocals.kt
@@ -26,5 +26,5 @@ import org.w3c.dom.HTMLElement
  */
 @InternalComposeUiApi
 val LocalActiveClipEventsTarget = staticCompositionLocalOf<() -> HTMLElement?> {
-    error("LocalActiveClipEventsTarget not provided")
+    { null }
 }


### PR DESCRIPTION
When listening to Clip events on the document, we used to preventDefault it, which is incorrect when there are other elements expecting Clip events.

The Clip events target is not static:
If there is a backing textarea/input present and the Textfield is focused, then it will be the events target. Otherwise, the `<canvas>` itself will be the events target.

Partially fixes https://youtrack.jetbrains.com/issue/CMP-8492

## Testing
This should be tested by QA

## Release Notes
N/A
