### PR TITLE
Separate Material3 versioning

### DIFF
--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -204,7 +204,7 @@ COLLECTION = { group = "androidx.collection", atomicGroupVersion = "versions.COL
 COMPOSE_ANIMATION = { group = "org.jetbrains.compose.animation", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_FOUNDATION = { group = "org.jetbrains.compose.foundation", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_MATERIAL = { group = "org.jetbrains.compose.material", atomicGroupVersion = "versions.COMPOSE" }
-COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE" }
+COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3" }
 COMPOSE_MATERIAL3_ADAPTIVE = { group = "org.jetbrains.compose.material3.adaptive", atomicGroupVersion = "versions.COMPOSE_MATERIAL3_ADAPTIVE" }
 COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE", overrideInclude = [ ":compose:material3:material3-adaptive-navigation-suite" ] }
 COMPOSE_RUNTIME = { group = "org.jetbrains.compose.runtime", atomicGroupVersion = "versions.COMPOSE" }

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -36,11 +36,8 @@ val libraryToComponents = mapOf(
         ComposeComponent(":compose:foundation:foundation"),
         ComposeComponent(":compose:foundation:foundation-layout"),
         ComposeComponent(":compose:material:material"),
-        ComposeComponent(":compose:material3:material3"),
         //ComposeComponent(":compose:material:material-icons-core"),
         ComposeComponent(":compose:material:material-ripple"),
-        ComposeComponent(":compose:material3:material3-window-size-class"),
-        ComposeComponent(":compose:material3:material3-adaptive-navigation-suite"),
         ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":compose:runtime:runtime-saveable", supportedPlatforms = ComposePlatforms.ALL),
         ComposeComponent(":compose:ui:ui"),
@@ -74,6 +71,11 @@ val libraryToComponents = mapOf(
     ),
     "COMPOSE_MATERIAL_NAVIGATION" to listOf(
         ComposeComponent(":compose:material:material-navigation"),
+    ),
+    "COMPOSE_MATERIAL3" to listOf(
+        ComposeComponent(":compose:material3:material3"),
+        ComposeComponent(":compose:material3:material3-window-size-class"),
+        ComposeComponent(":compose:material3:material3-adaptive-navigation-suite"),
     ),
     "COMPOSE_MATERIAL3_COMMON" to listOf(
         ComposeComponent(":compose:material3:material3-common"),


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8268/Decouple-material3-versioning-from-Compose

[CI change](https://jetbrains.team/p/ui/reviews/33/timeline)

## Testing
```
./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=COMPOSE_MATERIAL3
./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=COMPOSE
./gradlew publishComposeJbToMavenLocal -Pjetbrains.publication.libraries=COMPOSE,COMPOSE_MATERIAL3 -Pjetbrains.publication.version.COMPOSE=0.1.0 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=0.2.0
```

## Release Notes
N/A