### PR TITLE
Fix focus tests

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -107,7 +107,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8348
     @Test
     fun `compose panel in the end`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -138,7 +137,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8348
     @Test
     fun `compose panel in the beginning`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -230,7 +228,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8348
     @Test
     fun `swing panel in the end of compose panel`() = runFocusTest {
         val window = JFrame().disposeOnEnd()
@@ -270,7 +267,6 @@ class ComposeFocusTest {
         )
     }
 
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8348
     @Test
     fun `swing panel in the beginning of compose panel`() = runFocusTest {
         val window = JFrame().disposeOnEnd()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -361,7 +361,6 @@ internal class RootNodeOwner(
         override val coroutineContext: CoroutineContext,
     ) : Owner {
         private val platformFocusOwner = object : PlatformFocusOwner {
-            var g = false
             override fun requestOwnerFocus(
                 focusDirection: FocusDirection?,
                 previouslyFocusedRect: Rect?

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -361,6 +361,7 @@ internal class RootNodeOwner(
         override val coroutineContext: CoroutineContext,
     ) : Owner {
         private val platformFocusOwner = object : PlatformFocusOwner {
+            var g = false
             override fun requestOwnerFocus(
                 focusDirection: FocusDirection?,
                 previouslyFocusedRect: Rect?
@@ -387,9 +388,7 @@ internal class RootNodeOwner(
                     // if focusDirection is forward/backward,
                     // it will move the focus after/before ComposePanel
                     if (platformContext.parentFocusManager.moveFocus(requestedFocusDirection)) {
-                        FocusRequester.Cancel
-                    } else {
-                        FocusRequester.Default
+                        cancelFocusChange()
                     }
                 }
             }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8348/Fix-focus-tests-after-focus-owner-refactor

A mistake was made during migration from `exit` to `onExit` in https://github.com/JetBrains/compose-multiplatform-core/commit/7797c13544cfb6e010b89a7b2ec11e70a17d0573

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ Fix focus switching for ComposePanel embedded in Swing UI