### PR TITLE
Support voice scroll commands

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		991A97F72E1FB99300B47130 /* CMPScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = 991A97F62E1FB99300B47130 /* CMPScrollView.m */; };
 		9968C35B2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C35A2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m */; };
 		9968C3612D7746BD005E8DE4 /* CMPHoverGestureHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C3602D7746BD005E8DE4 /* CMPHoverGestureHandler.m */; };
 		9968C38B2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 9968C38A2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m */; };
@@ -63,6 +64,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		991A97F52E1FB99300B47130 /* CMPScrollView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPScrollView.h; sourceTree = "<group>"; };
+		991A97F62E1FB99300B47130 /* CMPScrollView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPScrollView.m; sourceTree = "<group>"; };
 		9968C3592D76FE16005E8DE4 /* CMPPanGestureRecognizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPPanGestureRecognizer.h; sourceTree = "<group>"; };
 		9968C35A2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPPanGestureRecognizer.m; sourceTree = "<group>"; };
 		9968C35F2D7746BD005E8DE4 /* CMPHoverGestureHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPHoverGestureHandler.h; sourceTree = "<group>"; };
@@ -142,6 +145,8 @@
 				EADD02922C98484F003F66E8 /* CMPDropInteractionProxy.m */,
 				99D97A862BF73A9B0035552B /* CMPEditMenuView.h */,
 				99D97A872BF73A9B0035552B /* CMPEditMenuView.m */,
+				991A97F52E1FB99300B47130 /* CMPScrollView.h */,
+				991A97F62E1FB99300B47130 /* CMPScrollView.m */,
 				EA4B52942C2EDEF200FBB55C /* CMPGestureRecognizer.h */,
 				EA4B52952C2EDEF200FBB55C /* CMPGestureRecognizer.m */,
 				9968C35F2D7746BD005E8DE4 /* CMPHoverGestureHandler.h */,
@@ -342,6 +347,7 @@
 				9968C38B2D7892DF005E8DE4 /* CMPScreenEdgePanGestureRecognizer.m in Sources */,
 				EAB33E182C12E746002CFF44 /* CMPMetalDrawablesHandler.m in Sources */,
 				9968C35B2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m in Sources */,
+				991A97F72E1FB99300B47130 /* CMPScrollView.m in Sources */,
 				99D97A882BF73A9B0035552B /* CMPEditMenuView.m in Sources */,
 				EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */,
 				EADD02902C9846D9003F66E8 /* CMPDragInteractionProxy.m in Sources */,

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPScrollView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPScrollView.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface CMPScrollView : UIScrollView
+
+- (BOOL)accessibilityScrollUpPageSupported;
+- (BOOL)accessibilityScrollDownPageSupported;
+- (BOOL)accessibilityScrollLeftPageSupported;
+- (BOOL)accessibilityScrollRightPageSupported;
+
+@end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPScrollView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPScrollView.m
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "CMPScrollView.h"
+
+@implementation CMPScrollView
+
+// Private API methods that enable scroll commands.
+// The scroll command will be propagated as an accessibilityScroll
+// function call for the corresponding accessibility element.
+
+- (BOOL)accessibilityScrollUpPageSupported {
+    return YES;
+}
+
+- (BOOL)accessibilityScrollDownPageSupported {
+    return YES;
+}
+
+- (BOOL)accessibilityScrollLeftPageSupported {
+    return YES;
+}
+
+- (BOOL)accessibilityScrollRightPageSupported {
+    return YES;
+}
+
+@end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
@@ -33,3 +33,4 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 #import "CMPPanGestureRecognizer.h"
 #import "CMPHoverGestureHandler.h"
 #import "CMPScreenEdgePanGestureRecognizer.h"
+#import "CMPScrollView.h"

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitTransparentContainerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitTransparentContainerView.kt
@@ -23,11 +23,17 @@ import platform.CoreGraphics.CGRectIsEmpty
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIEvent
 import platform.UIKit.UIView
+import androidx.compose.ui.uikit.utils.CMPScrollView
 
 internal class UIKitTransparentContainerView(
     var onLayoutSubviews: () -> Unit = {}
-) : UIView(CGRectZero.readValue()) {
+) : CMPScrollView(CGRectZero.readValue()) {
     private var onAppeared: (() -> Unit)? = null
+
+    init {
+        panGestureRecognizer.setEnabled(false)
+        bounces = false
+    }
 
     fun runOnceOnAppeared(block: () -> Unit) {
         onAppeared = {


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7952/iOS-A11y.-Voice-Control.-Scroll-Up-Down-doesnt-work

## Release Notes
### Features - iOS
- Support scroll commands with Voice Control