### PR TITLE
Fix the klib manifest issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -130,8 +130,7 @@ artifactRedirection.modulesForKNativeManifest=\
   :lifecycle:lifecycle-runtime=artifactRedirection.version.androidx.lifecycle,\
   :lifecycle:lifecycle-viewmodel=artifactRedirection.version.androidx.lifecycle,\
   :lifecycle:lifecycle-viewmodel-savedstate=artifactRedirection.version.androidx.lifecycle,\
-  :savedstate:savedstate=artifactRedirection.version.androidx.savedstate,\
-  :window:window-core=artifactRedirection.version.androidx.window
+  :savedstate:savedstate=artifactRedirection.version.androidx.savedstate
 
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true


### PR DESCRIPTION
window:window-core redirect is now completely disabled

Fixes https://youtrack.jetbrains.com/issue/CMP-8534

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fixed `Undefined symbols for architecture arm64: _kfun:androidx.compose.material3.adaptive.WindowAdaptiveInfo`
