### PR TITLE
Revert "Refactor klib manifest workaround for k/native targets (#2237)"

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetBrainsAndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/jetbrains/JetBrainsAndroidXImplPlugin.kt
@@ -81,33 +81,14 @@ open class JetbrainsExtensions(
     fun KotlinNativeTarget.substituteForRedirectedPublishedDependencies() {
         val main = compilations.getByName("main")
         val test = compilations.getByName("test")
+        val kNativeManifestRedirectingModulesRaw =
+            project.property("artifactRedirection.modulesForKNativeManifest") as String
 
-        val targetName = name.lowercase()
-        // The target name in a dependency project might be different from this project,
-        // so we check for an alternative name too.
-        // Historically, we had such aliases only for the 'ios <-> uikit' pair.
-        val altName = if (targetName.startsWith("ios")) {
-            targetName.replace("ios", "uikit")
-        } else if (targetName.startsWith("uikit")) {
-            targetName.replace("uikit", "ios")
-        } else {
-            null
-        }
-
-        val rootProjectName = project.rootProject.name // compose-multiplatform-core
-
-        val redirectedProjects = project.rootProject.subprojects.mapNotNull { project ->
-            project.takeIf {
-                // we are not interested in intermediate (structural) projects which are not published.
-                // they have a group name with rootProjectName in it
-               !it.group.toString().contains(rootProjectName)
-            }?.artifactRedirection()?.takeIf {
-                it.targetNames.contains(targetName) || it.targetNames.contains(altName)
-            }?.let {
-                project.path to it.groupId + ":" + project.name + ":" + it.versionForTargetOrDefault(targetName)
+        val projectPathToRedirectingVersionMap = kNativeManifestRedirectingModulesRaw
+            .split(",").associate {
+                val pair = it.split("=")
+                pair[0] to project.property(pair[1]) as String
             }
-        }
-
         listOf(main, test).flatMap {
             val configurations = it.configurations
             listOf(
@@ -121,9 +102,11 @@ open class JetbrainsExtensions(
         }.forEach { c ->
             c?.resolutionStrategy {
                 it.dependencySubstitution {
-                    redirectedProjects.forEach { entry ->
-                        val path = entry.first
-                        val artifact = entry.second
+                    projectPathToRedirectingVersionMap.forEach { path, version ->
+                        val pathElements = path.split(":").filter { it.isNotEmpty() }
+                        val group = pathElements.dropLast(1).joinToString(".")
+                        val module = pathElements.last()
+                        val artifact = "androidx.$group:$module:$version"
                         it.substitute(it.project(path)).using(it.module(artifact))
                     }
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -121,6 +121,17 @@ artifactRedirection.version.androidx.performance=1.0.0-alpha01
 artifactRedirection.version.androidx.savedstate=1.3.0
 artifactRedirection.version.androidx.window=1.4.0
 
+# For the purpose of substituteForRedirectedPublishedDependencies (look for it in the code)
+artifactRedirection.modulesForKNativeManifest=\
+  :annotation:annotation=artifactRedirection.version.androidx.annotation,\
+  :collection:collection=artifactRedirection.version.androidx.collection,\
+  :graphics:graphics-shapes=artifactRedirection.version.androidx.graphics,\
+  :lifecycle:lifecycle-common=artifactRedirection.version.androidx.lifecycle,\
+  :lifecycle:lifecycle-runtime=artifactRedirection.version.androidx.lifecycle,\
+  :lifecycle:lifecycle-viewmodel=artifactRedirection.version.androidx.lifecycle,\
+  :lifecycle:lifecycle-viewmodel-savedstate=artifactRedirection.version.androidx.lifecycle,\
+  :savedstate:savedstate=artifactRedirection.version.androidx.savedstate
+
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true
 kotlinx.atomicfu.enableNativeIrTransformation=true


### PR DESCRIPTION
This reverts commit ea4c7a420ee5002c8dc1710df125880d5dfa5cbb. PR https://github.com/JetBrains/compose-multiplatform-core/pull/2237

The reason for revert is https://youtrack.jetbrains.com/issue/CMP-7847/Refactor-artifactRedirection.modulesForKNativeManifest#focus=Comments-27-12349989.0-0

## Testing
N/A


## Release Notes
N/A
