### PR TITLE
Refactor text fields focus order

### DIFF
--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -5063,7 +5063,7 @@ final val androidx.compose.ui.window/androidx_compose_ui_window_ComposeView$stab
 final val androidx.compose.ui.window/androidx_compose_ui_window_DisplayLinkListener$stableprop // androidx.compose.ui.window/androidx_compose_ui_window_DisplayLinkListener$stableprop|#static{}androidx_compose_ui_window_DisplayLinkListener$stableprop[0]
 
 // Targets: [ios]
-final val androidx.compose.ui.window/androidx_compose_ui_window_FocusStack$stableprop // androidx.compose.ui.window/androidx_compose_ui_window_FocusStack$stableprop|#static{}androidx_compose_ui_window_FocusStack$stableprop[0]
+final val androidx.compose.ui.window/androidx_compose_ui_window_FocusedViewsList$stableprop // androidx.compose.ui.window/androidx_compose_ui_window_FocusedViewsList$stableprop|#static{}androidx_compose_ui_window_FocusedViewsList$stableprop[0]
 
 // Targets: [ios]
 final val androidx.compose.ui.window/androidx_compose_ui_window_InflightCommandBuffers$stableprop // androidx.compose.ui.window/androidx_compose_ui_window_InflightCommandBuffers$stableprop|#static{}androidx_compose_ui_window_InflightCommandBuffers$stableprop[0]
@@ -5258,7 +5258,7 @@ final fun androidx.compose.ui.window/androidx_compose_ui_window_ComposeView$stab
 final fun androidx.compose.ui.window/androidx_compose_ui_window_DisplayLinkListener$stableprop_getter(): kotlin/Int // androidx.compose.ui.window/androidx_compose_ui_window_DisplayLinkListener$stableprop_getter|androidx_compose_ui_window_DisplayLinkListener$stableprop_getter(){}[0]
 
 // Targets: [ios]
-final fun androidx.compose.ui.window/androidx_compose_ui_window_FocusStack$stableprop_getter(): kotlin/Int // androidx.compose.ui.window/androidx_compose_ui_window_FocusStack$stableprop_getter|androidx_compose_ui_window_FocusStack$stableprop_getter(){}[0]
+final fun androidx.compose.ui.window/androidx_compose_ui_window_FocusedViewsList$stableprop_getter(): kotlin/Int // androidx.compose.ui.window/androidx_compose_ui_window_FocusedViewsList$stableprop_getter|androidx_compose_ui_window_FocusedViewsList$stableprop_getter(){}[0]
 
 // Targets: [ios]
 final fun androidx.compose.ui.window/androidx_compose_ui_window_InflightCommandBuffers$stableprop_getter(): kotlin/Int // androidx.compose.ui.window/androidx_compose_ui_window_InflightCommandBuffers$stableprop_getter|androidx_compose_ui_window_InflightCommandBuffers$stableprop_getter(){}[0]

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/Configuration.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui
 
-import androidx.compose.test.interaction.BasicInteractionTest
 import androidx.compose.xctest.setupXCTestSuite
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.XCTest.XCTestSuite
@@ -31,5 +30,4 @@ fun testSuite(): XCTestSuite = setupXCTestSuite(
     // Run test cases from a test
     // BasicInteractionTest::testTextFieldCallout,
     // LayersAccessibilityTest::testLayersAppearanceOrder
-    BasicInteractionTest::class
 )

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -82,7 +82,7 @@ class ComposeSceneMediatorTest {
     private fun makeMediator(): ComposeSceneMediator {
         val mediator = ComposeSceneMediator(
             onFocusBehavior = OnFocusBehavior.DoNothing,
-            focusStack = null,
+            focusedViewsList = null,
             windowContext = PlatformWindowContext(),
             coroutineContext = Dispatchers.Main,
             redrawer = MetalRedrawer(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldFocusOrderTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldFocusOrderTest.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.material.TextField
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.window.Dialog
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import platform.UIKit.UITextInputProtocol
+import platform.UIKit.UIView
+
+class TextFieldFocusOrderTest {
+    @Test
+    fun testModalTextFieldsRefocus() = runUIKitInstrumentedTest {
+        val showDialog1 = mutableStateOf(false)
+        val showDialog2 = mutableStateOf(false)
+        val focusRequester0 = FocusRequester()
+        val focusRequester1 = FocusRequester()
+        val focusRequester2 = FocusRequester()
+
+        setContent {
+            TextField("Text 0", {}, modifier = Modifier.focusRequester(focusRequester0))
+            LaunchedEffect(Unit) {
+                focusRequester0.requestFocus()
+            }
+
+            if (showDialog1.value) {
+                Dialog({}) {
+                    TextField("Text 1", {}, modifier = Modifier.focusRequester(focusRequester1))
+                }
+                LaunchedEffect(Unit) {
+                    focusRequester1.requestFocus()
+                }
+            }
+
+            if (showDialog2.value) {
+                Dialog({}) {
+                    TextField("Text 2", {}, modifier = Modifier.focusRequester(focusRequester2))
+                }
+                LaunchedEffect(Unit) {
+                    focusRequester2.requestFocus()
+                }
+            }
+        }
+
+        assertEquals("Text 0", findFocusedUITextInput()?.text)
+
+        showDialog1.value = true
+        waitForIdle()
+        assertEquals("Text 1", findFocusedUITextInput()?.text)
+
+        showDialog2.value = true
+        waitForIdle()
+        assertEquals("Text 2", findFocusedUITextInput()?.text)
+
+        showDialog2.value = false
+        waitForIdle()
+        assertEquals("Text 1", findFocusedUITextInput()?.text)
+
+        showDialog1.value = false
+        waitForIdle()
+        assertEquals("Text 0", findFocusedUITextInput()?.text)
+    }
+
+    @Test
+    fun testModalTextFieldsRefocusWhenParentDismissed() = runUIKitInstrumentedTest {
+        val showTextField = mutableStateOf(true)
+        val showDialog1 = mutableStateOf(true)
+        val showDialog2 = mutableStateOf(true)
+        val focusRequester0 = FocusRequester()
+        val focusRequester1 = FocusRequester()
+        val focusRequester2 = FocusRequester()
+
+        setContent {
+            if (showTextField.value) {
+                TextField("Text 0", {}, modifier = Modifier.focusRequester(focusRequester0))
+                LaunchedEffect(Unit) {
+                    focusRequester0.requestFocus()
+                }
+            }
+
+            if (showDialog1.value) {
+                Dialog({}) {
+                    TextField("Text 1", {}, modifier = Modifier.focusRequester(focusRequester1))
+                }
+                LaunchedEffect(Unit) {
+                    focusRequester1.requestFocus()
+                }
+            }
+
+            if (showDialog2.value) {
+                Dialog({}) {
+                    TextField("Text 2", {}, modifier = Modifier.focusRequester(focusRequester2))
+                }
+                LaunchedEffect(Unit) {
+                    focusRequester2.requestFocus()
+                }
+            }
+        }
+
+        assertEquals("Text 2", findFocusedUITextInput()?.text)
+
+        showTextField.value = false
+        waitForIdle()
+        assertEquals("Text 2", findFocusedUITextInput()?.text)
+
+        showDialog1.value = false
+        waitForIdle()
+        assertEquals("Text 2", findFocusedUITextInput()?.text)
+
+        showDialog2.value = false
+        waitForIdle()
+        assertNull(findFocusedUITextInput())
+    }
+
+    private val UITextInputProtocol.text: String? get() {
+        val range = textRangeFromPosition(beginningOfDocument, endOfDocument) ?: return null
+        return textInRange(range)
+    }
+
+    private fun UIKitInstrumentedTest.findFocusedUITextInput(): UITextInputProtocol? {
+        val window = hostingViewController.view.window ?: return null
+
+        fun findFirstResponder(view: UIView): UIView? {
+            if (view.isFirstResponder) {
+                return view
+            }
+            view.subviews.forEach {
+                findFirstResponder(it as UIView)?.let { return it }
+            }
+            return null
+        }
+
+        return findFirstResponder(view = window) as? UITextInputProtocol
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.uikit.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.asCGRect
 import androidx.compose.ui.unit.asDpOffset
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
-import androidx.compose.ui.window.FocusStack
+import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.IntermediateTextInputUIView
 import kotlin.math.absoluteValue
 import kotlin.math.min
@@ -68,7 +68,7 @@ internal class UIKitTextInputService(
     private val updateView: () -> Unit,
     private val view: UIView,
     private val viewConfiguration: ViewConfiguration,
-    private val focusStack: FocusStack?,
+    private val focusedViewsList: FocusedViewsList?,
     private var onInputStarted: () -> Unit,
     /**
      * Callback to handle keyboard presses. The parameter is a [Set] of [UIPress] objects.
@@ -167,13 +167,13 @@ internal class UIKitTextInputService(
 
     override fun showSoftwareKeyboard() {
         textUIView?.let {
-            focusStack?.pushAndFocus(it)
+            focusedViewsList?.addAndFocus(it)
         }
     }
 
     override fun hideSoftwareKeyboard() {
         textUIView?.let {
-            focusStack?.popUntilNext(it, delayMillis = CLEAR_FOCUS_DELAY)
+            focusedViewsList?.remove(it, delayMillis = CLEAR_FOCUS_DELAY)
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -56,7 +56,7 @@ import androidx.compose.ui.viewinterop.UIKitInteropTransaction
 import androidx.compose.ui.window.ApplicationActiveStateListener
 import androidx.compose.ui.window.ComposeView
 import androidx.compose.ui.window.DisplayLinkListener
-import androidx.compose.ui.window.FocusStack
+import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.MetalRedrawer
 import androidx.compose.ui.window.MetalView
 import androidx.compose.ui.window.ViewControllerLifecycleDelegate
@@ -138,7 +138,7 @@ internal class ComposeHostingViewController(
     )
     private val systemThemeState: MutableState<SystemTheme> = mutableStateOf(SystemTheme.Unknown)
 
-    var focusStack: FocusStack? = FocusStack()
+    var focusedViewsList: FocusedViewsList? = FocusedViewsList()
 
     /*
      * On iOS >= 13.0 interfaceOrientation will be deduced from [UIWindowScene] of [UIWindow]
@@ -306,7 +306,7 @@ internal class ComposeHostingViewController(
 
         mediator = ComposeSceneMediator(
             onFocusBehavior = configuration.onFocusBehavior,
-            focusStack = focusStack,
+            focusedViewsList = focusedViewsList,
             windowContext = windowContext,
             coroutineContext = composeCoroutineContext,
             redrawer = metalView.redrawer,
@@ -466,7 +466,7 @@ internal class ComposeHostingViewController(
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
                     onAccessibilityChanged = ::onAccessibilityChanged,
-                    focusStack = if (focusable) focusStack else null,
+                    focusedViewsList = if (focusable) focusedViewsList else null,
                     windowContext = windowContext,
                     compositionContext = compositionContext,
                     coroutineContext = composeCoroutineContext,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -84,7 +84,7 @@ import androidx.compose.ui.viewinterop.UIKitInteropContainer
 import androidx.compose.ui.viewinterop.UIKitInteropTransaction
 import androidx.compose.ui.window.ApplicationForegroundStateListener
 import androidx.compose.ui.window.ComposeSceneKeyboardOffsetManager
-import androidx.compose.ui.window.FocusStack
+import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.KeyboardVisibilityListener
 import androidx.compose.ui.window.MetalRedrawer
 import androidx.compose.ui.window.TouchesEventKind
@@ -184,7 +184,7 @@ private class SemanticsOwnerListenerImpl(
 
 internal class ComposeSceneMediator(
     private val onFocusBehavior: OnFocusBehavior,
-    private val focusStack: FocusStack?,
+    private val focusedViewsList: FocusedViewsList?,
     private val windowContext: PlatformWindowContext,
     private val coroutineContext: CoroutineContext,
     private val redrawer: MetalRedrawer,
@@ -350,7 +350,7 @@ internal class ComposeSceneMediator(
             },
             view = _overlayView,
             viewConfiguration = viewConfiguration,
-            focusStack = focusStack,
+            focusedViewsList = focusedViewsList,
             onInputStarted = {
                 animateKeyboardOffsetChanges = true
             },
@@ -521,7 +521,7 @@ internal class ComposeSceneMediator(
 
     fun setContent(content: @Composable () -> Unit) {
         _overlayView.runOnceOnAppeared {
-            focusStack?.pushAndFocus(userInputView)
+            focusedViewsList?.addAndFocus(userInputView)
 
             scene.setContent {
                 ProvideComposeSceneMediatorCompositionLocals {
@@ -622,7 +622,7 @@ internal class ComposeSceneMediator(
         _overlayView.dispose()
         textInputService.stopInput()
         applicationForegroundStateListener.dispose()
-        focusStack?.popUntilNext(userInputView)
+        focusedViewsList?.remove(userInputView)
         keyboardManager.dispose()
         userInputView.dispose()
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -41,7 +41,7 @@ import androidx.compose.ui.unit.asDpRect
 import androidx.compose.ui.unit.round
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toRect
-import androidx.compose.ui.window.FocusStack
+import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.MetalView
 import kotlin.coroutines.CoroutineContext
 import kotlinx.cinterop.CValue
@@ -58,14 +58,14 @@ internal class UIKitComposeSceneLayer(
     private val initLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
     onFocusBehavior: OnFocusBehavior,
-    focusStack: FocusStack?,
+    focusedViewsList: FocusedViewsList?,
     windowContext: PlatformWindowContext,
     compositionContext: CompositionContext,
     private val coroutineContext: CoroutineContext,
     private val enableBackGesture: Boolean,
 ) : ComposeSceneLayer {
 
-    override var focusable: Boolean = focusStack != null
+    override var focusable: Boolean = focusedViewsList != null
         set(value) {
             if (field != value) {
                 field = value
@@ -89,7 +89,7 @@ internal class UIKitComposeSceneLayer(
 
     private val mediator = ComposeSceneMediator(
         onFocusBehavior = onFocusBehavior,
-        focusStack = focusStack,
+        focusedViewsList = focusedViewsList,
         windowContext = windowContext,
         coroutineContext = compositionContext.effectCoroutineContext,
         redrawer = metalView.redrawer,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitTransparentContainerView.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitTransparentContainerView.kt
@@ -31,6 +31,8 @@ internal class UIKitTransparentContainerView(
     private var onAppeared: (() -> Unit)? = null
 
     init {
+        showsHorizontalScrollIndicator = false
+        showsVerticalScrollIndicator = false
         panGestureRecognizer.setEnabled(false)
         bounces = false
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/FocusedViewsList.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/FocusedViewsList.uikit.kt
@@ -22,30 +22,29 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import platform.UIKit.UIView
 
-internal class FocusStack {
+internal class FocusedViewsList {
 
     private var activeViews = emptyList<UIView>()
     private var resignedViews = emptyList<UIView>()
     private val mainScope = MainScope()
 
     /**
-     * Add new view to stack and focus on it.
+     * Add new view to list and focus on it.
      */
-    fun pushAndFocus(view: UIView) {
+    fun addAndFocus(view: UIView) {
         activeViews += view
         resignedViews -= view
         view.becomeFirstResponder()
     }
 
     /**
-     * Pop all elements until some element. Also pop this element too.
-     * Last remaining element in Stack will be focused.
+     * Remove the view from the list and resigns first responder.
+     * The last element in the list will become a new first responder.
      */
-    fun popUntilNext(view: UIView, delayMillis: Long = 0) {
+    fun remove(view: UIView, delayMillis: Long = 0) {
         if (activeViews.contains(view)) {
-            val index = activeViews.indexOf(view)
-            resignedViews += activeViews.subList(index, activeViews.size)
-            activeViews = activeViews.subList(0, index)
+            resignedViews += view
+            activeViews = activeViews.filter { it != view }
 
             mainScope.launch {
                 delay(delayMillis)
@@ -53,13 +52,12 @@ internal class FocusStack {
                     it.resignFirstResponder()
                 }
                 resignedViews = emptyList()
-                activeViews.lastOrNull()?.becomeFirstResponder()
+                activeViews.lastOrNull()?.let {
+                    if (!it.isFirstResponder) {
+                        it.becomeFirstResponder()
+                    }
+                }
             }
         }
     }
-
-    /**
-     * Return first added view or null
-     */
-    fun first(): UIView? = activeViews.firstOrNull()
 }


### PR DESCRIPTION
Refactor the list of focused views to only remove dismissed views, rather than all of the following focused views.

Fixes https://youtrack.jetbrains.com/issue/CMP-8300/iOS-Not-showing-keyboard-in-Dialog-when-parent-UI-changes

## Release Notes
### Fixes - iOS
- Fixes the appearance of the keyboard when a pop-up or dialog on the background is dismissed.