### PR TITLE
Fix Maven Project test template

### DIFF
--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -219,6 +219,13 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(notMobileMain)
                 dependencies {
                     implementation(libs.kotlinStdlibJdk8)
+
+                    // TODO revert after https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom is fixed and the dependency is upgraded
+                    // lifecycle-viewmodel-savedstate-desktop:2.9.1 is broken for Maven projects.
+                    // See https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03
+                    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:2.9.1") {
+                        exclude group: "androidx.lifecycle", module: "lifecycle-viewmodel"
+                    }
                 }
             }
 

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -117,6 +117,15 @@ kotlin {
         desktopMain {
             dependsOn(jvmMain)
             dependsOn(nonAndroidMain)
+
+            dependencies {
+                // TODO revert after https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom is fixed and the dependency is upgraded
+                // lifecycle-viewmodel-savedstate-desktop:2.9.1 is broken for Maven projects.
+                // See https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03
+                implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:2.9.1") {
+                    exclude group: "androidx.lifecycle", module: "lifecycle-viewmodel"
+                }
+            }
         }
         desktopTest {
             dependsOn(jvmTest)

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -119,6 +119,15 @@ androidXMultiplatform {
         desktopMain {
             dependsOn(jvmMain)
             dependsOn(nonAndroidMain)
+
+            dependencies {
+                // TODO revert after https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom is fixed and the dependency is upgraded
+                // lifecycle-viewmodel-savedstate-desktop:2.9.1 is broken for Maven projects.
+                // See https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03
+                implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:2.9.1") {
+                    exclude group: "androidx.lifecycle", module: "lifecycle-viewmodel"
+                }
+            }
         }
         desktopTest {
             dependsOn(jvmTest)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03

Apply a workaround by manually excluding the dependency in all modules that depend on `org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate`.

It is written in the pom itself:
```
    <dependency>
      <groupId>androidx.lifecycle</groupId>
      <artifactId>lifecycle-viewmodel-savedstate-desktop</artifactId>
      <version>2.9.1</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <groupId>androidx.lifecycle</groupId>
          <artifactId>lifecycle-viewmodel</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
```
And when we test the maven project it shows these dependencies:
```
[DEBUG]       org.jetbrains.compose.ui:ui-desktop:jar:9999.0.0-SNAPSHOT:compile
...
[DEBUG]          androidx.lifecycle:lifecycle-viewmodel-desktop:jar:2.9.1:runtime
[DEBUG]          androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:jar:2.9.1:runtime
[DEBUG]             androidx.savedstate:savedstate-desktop:jar:1.3.0:compile
[DEBUG]             org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:jar:1.7.3:compile
```
instead of:
```
[DEBUG]       org.jetbrains.compose.ui:ui-desktop:jar:1.9.0-alpha03:compile
...
[DEBUG]          androidx.lifecycle:lifecycle-viewmodel-desktop:jar:2.9.1:runtime
[DEBUG]          androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:jar:2.9.1:runtime
[DEBUG]             androidx.lifecycle:lifecycle-viewmodel:jar:2.9.1:runtime
[DEBUG]                androidx.lifecycle:lifecycle-viewmodel-android:aar:2.9.1:runtime
[DEBUG]                   org.jetbrains.kotlinx:kotlinx-coroutines-android:jar:1.7.3:runtime
[DEBUG]                   androidx.core:core-viewtree:jar:1.0.0:runtime
[DEBUG]             androidx.savedstate:savedstate-desktop:jar:1.3.0:compile
[DEBUG]             org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:jar:1.7.3:compile
```

## Testing
```
cd .../compose-multiplatform-core
./gradlew publishComposeJbToMavenLocal

cd .../compose-multiplatform/ci/templates/maven-test-project
./check.sh -Dcompose.version=9999.0.0-SNAPSHOT -Dcompose.material3.version=9999.0.0-SNAPSHOT
```

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ Fix Maven project doesn't work with 1.9.0-alpha03