### PR TITLE
Use higher-precision `currentCompositeKeyHashCode`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -16,7 +16,8 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.runtime.CompositeKeyHashCode
+import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.Modifier
@@ -57,7 +58,7 @@ public fun <T : Component> SwingPanel(
     update: (T) -> Unit = NoOpUpdate,
 ) {
     val interopContainer = LocalInteropContainer.current
-    val compositeKeyHash = currentCompositeKeyHash
+    val compositeKeyHashCode = currentCompositeKeyHashCode
     val focusManager = LocalFocusManager.current
 
     // TODO: entire interop context must be inside SwingInteropViewHolder in order to
@@ -66,7 +67,7 @@ public fun <T : Component> SwingPanel(
 
     val group = remember {
         SwingInteropViewGroup(
-            key = compositeKeyHash,
+            key = compositeKeyHashCode,
             focusComponent = interopContainer.root
         )
     }
@@ -81,7 +82,7 @@ public fun <T : Component> SwingPanel(
             container = interopContainer,
             group = group,
             focusSwitcher = focusSwitcher,
-            compositeKeyHash = compositeKeyHash
+            compositeKeyHashCode = compositeKeyHashCode
         )
     }
 
@@ -117,7 +118,7 @@ internal fun FocusEvent.isFocusGainedHandledBySwingPanel(container: Container) =
  * @param focusComponent The component that should receive focus.
  */
 internal class SwingInteropViewGroup(
-    key: Int,
+    key: CompositeKeyHashCode,
     private val focusComponent: Component
 ) : JPanel() {
     init {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.viewinterop
 
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.InteropFocusSwitcher
 import androidx.compose.ui.awt.awtEventOrNull
@@ -45,12 +46,12 @@ internal class SwingInteropViewHolder<T : Component>(
     container: InteropContainer,
     group: InteropViewGroup,
     focusSwitcher: InteropFocusSwitcher,
-    compositeKeyHash: Int,
+    compositeKeyHashCode: CompositeKeyHashCode,
 ) : TypedInteropViewHolder<T>(
     factory,
     container,
     group,
-    compositeKeyHash,
+    compositeKeyHashCode,
     MeasurePolicy { _, constraints ->
         layout(constraints.minWidth, constraints.minHeight) {}
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropView.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropView.skiko.kt
@@ -18,11 +18,12 @@ package androidx.compose.ui.viewinterop
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.runtime.CompositionLocalMap
 import androidx.compose.runtime.ReusableComposeNode
 import androidx.compose.runtime.Updater
 import androidx.compose.runtime.currentComposer
-import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.UiComposable
 import androidx.compose.ui.layout.MeasurePolicy
@@ -44,12 +45,12 @@ internal abstract class TypedInteropViewHolder<T : InteropView>(
     factory: () -> T,
     interopContainer: InteropContainer,
     group: InteropViewGroup,
-    compositeKeyHash: Int,
+    compositeKeyHashCode: CompositeKeyHashCode,
     measurePolicy: MeasurePolicy
 ) : InteropViewHolder(
     interopContainer,
     group,
-    compositeKeyHash,
+    compositeKeyHashCode,
     measurePolicy
 ) {
     val typedInteropView = factory()
@@ -95,15 +96,15 @@ internal abstract class TypedInteropViewHolder<T : InteropView>(
 
 /**
  * Create a [LayoutNode] factory that can be constructed from [TypedInteropViewHolder] built with
- * the [currentCompositeKeyHash]
+ * the [currentCompositeKeyHashCode]
  *
  * @see [AndroidView.android.kt:createAndroidViewNodeFactory]
  */
 @Composable
 private fun <T : InteropView> createInteropViewLayoutNodeFactory(
-    factory: (compositeKeyHash: Int) -> TypedInteropViewHolder<T>
+    factory: (compositeKeyHashCode: CompositeKeyHashCode) -> TypedInteropViewHolder<T>
 ): () -> LayoutNode {
-    val compositeKeyHash = currentCompositeKeyHash
+    val compositeKeyHash = currentCompositeKeyHashCode
 
     return {
         factory(compositeKeyHash).layoutNode
@@ -120,13 +121,13 @@ private fun <T : InteropView> createInteropViewLayoutNodeFactory(
 @Composable
 @UiComposable
 internal fun <T : InteropView> InteropView(
-    factory: (compositeKeyHash: Int) -> TypedInteropViewHolder<T>,
+    factory: (compositeKeyHashCode: CompositeKeyHashCode) -> TypedInteropViewHolder<T>,
     modifier: Modifier,
     onReset: ((T) -> Unit)? = null,
     onRelease: (T) -> Unit = NoOp,
     update: (T) -> Unit = NoOp,
 ) {
-    val compositeKeyHash = currentCompositeKeyHash
+    val compositeKeyHashCode = currentCompositeKeyHashCode
     val materializedModifier = currentComposer.materialize(modifier)
     val density = LocalDensity.current
     val compositionLocalMap = currentComposer.currentCompositionLocalMap
@@ -141,7 +142,7 @@ internal fun <T : InteropView> InteropView(
                     compositionLocalMap,
                     materializedModifier,
                     density,
-                    compositeKeyHash
+                    compositeKeyHashCode
                 )
 
                 set(update) { requireViewFactoryHolder<T>().updateBlock = it }
@@ -156,7 +157,7 @@ internal fun <T : InteropView> InteropView(
                     compositionLocalMap,
                     materializedModifier,
                     density,
-                    compositeKeyHash
+                    compositeKeyHashCode
                 )
 
                 set(onReset) { requireViewFactoryHolder<T>().resetBlock = it }
@@ -175,12 +176,12 @@ private fun <T : InteropView> Updater<LayoutNode>.updateParameters(
     compositionLocalMap: CompositionLocalMap,
     modifier: Modifier,
     density: Density,
-    compositeKeyHash: Int
+    compositeKeyHashCode: CompositeKeyHashCode
 ) {
     set(compositionLocalMap, SetResolvedCompositionLocals)
     set(modifier) { requireViewFactoryHolder<T>().modifier = it }
     set(density) { requireViewFactoryHolder<T>().density = it }
-    set(compositeKeyHash, SetCompositeKeyHash)
+    set(compositeKeyHashCode.hashCode(), SetCompositeKeyHash)
 }
 
 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropViewHolder.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropViewHolder.skiko.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.viewinterop
 
 import androidx.compose.runtime.ComposeNodeLifecycleCallback
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.runtime.snapshots.SnapshotStateObserver
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -39,7 +40,7 @@ private fun abstractInvocationError(name: String): Nothing {
 internal open class InteropViewHolder(
     val container: InteropContainer,
     val group: InteropViewGroup,
-    private val compositeKeyHash: Int,
+    private val compositeKeyHashCode: CompositeKeyHashCode,
     measurePolicy: MeasurePolicy
 ) : ComposeNodeLifecycleCallback {
     private var onModifierChanged: (() -> Unit)? = null
@@ -141,7 +142,7 @@ internal open class InteropViewHolder(
                 // container.onInteropViewLayoutChange(this)
             }
 
-        layoutNode.compositeKeyHash = compositeKeyHash
+        layoutNode.compositeKeyHash = compositeKeyHashCode.hashCode()
 
         layoutNode.modifier = modifier then platformModifier then coreModifier
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.viewinterop
 
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.BlendMode
@@ -41,12 +42,12 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
     interopContainer: InteropContainer,
     private val interopWrappingView: InteropWrappingView,
     properties: UIKitInteropProperties,
-    compositeKeyHash: Int
+    compositeKeyHashCode: CompositeKeyHashCode
 ) : TypedInteropViewHolder<T>(
     factory = factory,
     interopContainer = interopContainer,
     group = interopWrappingView,
-    compositeKeyHash = compositeKeyHash,
+    compositeKeyHashCode = compositeKeyHashCode,
     measurePolicy = MeasurePolicy { _, constraints ->
         layout(constraints.minWidth, constraints.minHeight) {
             // No-op, no children are expected
@@ -60,15 +61,15 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
         factory: () -> T,
         interopContainer: InteropContainer,
         properties: UIKitInteropProperties,
-        compositeKeyHash: Int,
+        compositeKeyHashCode: CompositeKeyHashCode,
     ) : this(
-        factory,
-        interopContainer,
+        factory = factory,
+        interopContainer = interopContainer,
         interopWrappingView = InteropWrappingView(
             interactionMode = null
         ),
-        properties,
-        compositeKeyHash
+        properties = properties,
+        compositeKeyHashCode = compositeKeyHashCode
     )
 
     private var currentUnclippedRect: IntRect? = null

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropViewControllerHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropViewControllerHolder.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.viewinterop
 
+import androidx.compose.runtime.CompositeKeyHashCode
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGRect
 import platform.UIKit.UIViewController
@@ -29,12 +30,12 @@ internal class UIKitInteropViewControllerHolder<T : UIViewController>(
     interopContainer: InteropContainer,
     private val parentViewController: UIViewController,
     properties: UIKitInteropProperties,
-    compositeKeyHash: Int,
+    compositeKeyHashCode: CompositeKeyHashCode,
 ) : UIKitInteropElementHolder<T>(
     factory,
     interopContainer,
     properties,
-    compositeKeyHash
+    compositeKeyHashCode
 ) {
     init {
         // Group will be placed to hierarchy in [InteropContainer.placeInteropView]

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropViewHolder.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropViewHolder.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.viewinterop
 
+import androidx.compose.runtime.CompositeKeyHashCode
 import kotlinx.cinterop.CValue
 import platform.CoreGraphics.CGRect
 import platform.UIKit.UIView
@@ -24,12 +25,12 @@ internal class UIKitInteropViewHolder<T : UIView>(
     factory: () -> T,
     interopContainer: InteropContainer,
     properties: UIKitInteropProperties,
-    compositeKeyHash: Int,
+    compositeKeyHashCode: CompositeKeyHashCode,
 ) : UIKitInteropElementHolder<T>(
     factory,
     interopContainer,
     properties,
-    compositeKeyHash
+    compositeKeyHashCode
 ) {
     init {
         // Group will be placed to hierarchy in [InteropContainer.placeInteropView]

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.wasmJs.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/viewinterop/WebInteropElementHolder.wasmJs.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.viewinterop
 
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.MeasurePolicy
@@ -33,12 +34,12 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
     factory: () -> T,
     interopContainer: InteropContainer,
     private val interopWrapper: HTMLElement,
-    compositeKeyHash: Int
+    compositeKeyHashCode: CompositeKeyHashCode
 ) : TypedInteropViewHolder<T>(
     factory = factory,
     interopContainer = interopContainer,
     group = InteropViewGroup(interopWrapper),
-    compositeKeyHash = compositeKeyHash,
+    compositeKeyHashCode = compositeKeyHashCode,
     measurePolicy = MeasurePolicy { _, constraints ->
         layout(constraints.minWidth, constraints.minHeight) {
             // No-op, no children are expected
@@ -48,7 +49,7 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
     constructor(
         factory: () -> T,
         interopContainer: InteropContainer,
-        compositeKeyHash: Int,
+        compositeKeyHashCode: CompositeKeyHashCode,
     ) : this(
         factory = factory,
         interopContainer = interopContainer,
@@ -60,7 +61,7 @@ internal abstract class WebInteropElementHolder<T : HTMLElement>(
                     // otherwise it can briefly flash at 0,0
                     toggleVisibility(this, isHidden = true)
                 },
-        compositeKeyHash = compositeKeyHash
+        compositeKeyHashCode = compositeKeyHashCode
     )
 
     private var isPositioned = false

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/viewinterop/WebInteropViewHolder.wasmJs.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/viewinterop/WebInteropViewHolder.wasmJs.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.viewinterop
 
+import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.BlendMode
@@ -27,11 +28,11 @@ import org.w3c.dom.HTMLElement
 internal class WebInteropViewHolder<T : HTMLElement>(
     factory: () -> T,
     interopContainer: InteropContainer,
-    compositeKeyHash: Int,
+    compositeKeyHashCode: CompositeKeyHashCode,
 ) : WebInteropElementHolder<T>(
     factory,
     interopContainer,
-    compositeKeyHash
+    compositeKeyHashCode
 ) {
     init {
         group.htmlElement.appendChild((typedInteropView as HTMLElement).apply { style.apply {


### PR DESCRIPTION
[CMP-8394](https://youtrack.jetbrains.com/issue/CMP-8394) Adapt higher-precision compositeKeyHash

`currentCompositeKeyHash` was deprecated in [3455760: Increase compositeKeyHash precision](https://android-review.googlesource.com/c/platform/frameworks/support/+/3455760)

## Release Notes
N/A