### PR TITLE
Ignore control characters for accented character input on macOS.

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -62,7 +62,7 @@ internal class DesktopTextInputService2(
     fun onKeyEvent(keyEvent: KeyEvent) {
         when (keyEvent.id) {
             KeyEvent.KEY_TYPED ->
-                inputMethodSession?.charKeyPressed = true
+                inputMethodSession?.charKeyPressed = !keyEvent.keyChar.isISOControl()
             KeyEvent.KEY_RELEASED ->
                 inputMethodSession?.charKeyPressed = false
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -685,6 +685,60 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         assertStateEquals("", selection = TextRange(0), composition = null)
     }
 
+    // Verifies the fix to https://youtrack.jetbrains.com/issue/CMP-8184
+    @Theory
+    internal fun `q, w, space, backspace 2x, q, w, space (Chinese, macOS)`(
+        textFieldKind: TextFieldKind<*>
+    ) = runTextFieldTest(textFieldKind, "Chinese, macOS") {
+        if (!isMacOs) return@runTextFieldTest  // Assume.assumeTrue doesn't work with @Theory
+
+        // q
+        window.sendInputMethodEvent("q", 0)
+        window.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assertStateEquals("q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window.sendInputMethodEvent("q'w", 0)
+        window.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assertStateEquals("q'w", selection = TextRange(3), composition = TextRange(0, 3))
+
+        // space
+        window.sendInputMethodEvent("請問", 2)
+        window.sendInputMethodEvent(null, 0)
+        window.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assertStateEquals("請問", selection = TextRange(2), composition = null)
+
+        // backspace
+        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window.sendKeyTypedEvent(Char(8))
+        triggerNeedsToDeletePreviousChar()
+        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assertStateEquals("請", selection = TextRange(1), composition = null)
+
+        // backspace
+        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window.sendKeyTypedEvent(Char(8))
+        triggerNeedsToDeletePreviousChar()
+        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assertStateEquals("", selection = TextRange(0), composition = null)
+
+        // q
+        window.sendInputMethodEvent("q", 0)
+        window.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assertStateEquals("q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        window.sendInputMethodEvent("q'w", 0)
+        window.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assertStateEquals("q'w", selection = TextRange(3), composition = TextRange(0, 3))
+
+        // space
+        window.sendInputMethodEvent("請問", 2)
+        window.sendInputMethodEvent(null, 0)
+        window.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assertStateEquals("請問", selection = TextRange(2), composition = null)
+    }
+
     // Verifies that each typed character and character replaced by the input service is reported
     // (to `inputTransformation`) as a change in the last character only.
     // The behavior of `SecureTextField` with `TextObfuscationMode.RevealLastTyped` depends on this,
@@ -758,11 +812,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
 
             window.sendKeyEvent('c'.code, 'c', KEY_PRESSED)
             window.sendKeyTypedEvent('c')
-            // This triggers the "needToDeletePreviousChar" hack in DesktopTextInputService(2).
-            // If the implementation of this ever changes, this test will need to change as well.
-            // Note that using java.awt.Robot to test this doesn't appear to work, as the accented
-            // characters toolbar isn't displayed.
-            window.focusOwner.inputMethodRequests.getSelectedText(null)
+            triggerNeedsToDeletePreviousChar()
             window.sendKeyEvent('c'.code, 'c', KEY_RELEASED)
             assertStateEquals("c", selection = TextRange(1), composition = null)
 
@@ -779,4 +829,12 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
             window.sendInputMethodEvent("·", committedCharacterCount = 1)
             assertStateEquals("·", selection = TextRange(1), composition = null)
         }
+
+    private fun TextFieldTestScope.triggerNeedsToDeletePreviousChar() {
+        // This triggers the "needToDeletePreviousChar" hack in DesktopTextInputService(2).
+        // If the implementation of this ever changes, this test will need to change as well.
+        // Note that using java.awt.Robot to test this doesn't appear to work, as the accented
+        // characters toolbar isn't displayed.
+        window.focusOwner.inputMethodRequests.getSelectedText(null)
+    }
 }


### PR DESCRIPTION
Fix the detection of accented character input on macOS to ignore control characters.
Before this change, it would react to e.g. `backspace`, which would then interfere with composition, deleting parts of it.

Fixes https://youtrack.jetbrains.com/issue/CMP-8184/InputMethod-input-breaks-after-pressing-backspace

## Testing
Tested manually and added a new `WindowTypeTest`.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- [macOS] Fix composite (e.g. Chinese) input after pressing backspace.
