### PR TITLE
Show the web text toolbar on text touch selection.

### DIFF
--- a/compose/foundation/foundation/api/foundation.klib.api
+++ b/compose/foundation/foundation/api/foundation.klib.api
@@ -2427,13 +2427,7 @@ final fun androidx.compose.foundation/androidx_compose_foundation_PlatformMagnif
 final fun androidx.compose.foundation/androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter(): kotlin/Int // androidx.compose.foundation/androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter|androidx_compose_foundation_PlatformMagnifierFactoryIos17Impl_PlatformMagnifierImpl$stableprop_getter(){}[0]
 
 // Targets: [js, wasmJs]
-final val androidx.compose.foundation.text.contextmenu.internal/androidx_compose_foundation_text_contextmenu_internal_WebTextContextMenuToolbarProvider$stableprop // androidx.compose.foundation.text.contextmenu.internal/androidx_compose_foundation_text_contextmenu_internal_WebTextContextMenuToolbarProvider$stableprop|#static{}androidx_compose_foundation_text_contextmenu_internal_WebTextContextMenuToolbarProvider$stableprop[0]
-
-// Targets: [js, wasmJs]
 final val androidx.compose.foundation.text/androidx_compose_foundation_text_WebContextMenuToolbarSpec$stableprop // androidx.compose.foundation.text/androidx_compose_foundation_text_WebContextMenuToolbarSpec$stableprop|#static{}androidx_compose_foundation_text_WebContextMenuToolbarSpec$stableprop[0]
-
-// Targets: [js, wasmJs]
-final fun androidx.compose.foundation.text.contextmenu.internal/androidx_compose_foundation_text_contextmenu_internal_WebTextContextMenuToolbarProvider$stableprop_getter(): kotlin/Int // androidx.compose.foundation.text.contextmenu.internal/androidx_compose_foundation_text_contextmenu_internal_WebTextContextMenuToolbarProvider$stableprop_getter|androidx_compose_foundation_text_contextmenu_internal_WebTextContextMenuToolbarProvider$stableprop_getter(){}[0]
 
 // Targets: [js, wasmJs]
 final fun androidx.compose.foundation.text/androidx_compose_foundation_text_WebContextMenuToolbarSpec$stableprop_getter(): kotlin/Int // androidx.compose.foundation.text/androidx_compose_foundation_text_WebContextMenuToolbarSpec$stableprop_getter|androidx_compose_foundation_text_WebContextMenuToolbarSpec$stableprop_getter(){}[0]

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/WebContextMenuToolbarUi.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/WebContextMenuToolbarUi.web.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.contextmenu.ContextMenuState
 import androidx.compose.foundation.contextmenu.DefaultContextMenuColors
 import androidx.compose.foundation.contextmenu.close
 import androidx.compose.foundation.contextmenu.computeContextMenuColors
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -33,6 +34,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSizeIn
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -140,12 +142,13 @@ internal fun WebContextMenuRow(
     Row(
         modifier =
             modifier
+                .padding(horizontal = WebContextMenuToolbarSpec.ContainerPadding)
                 .shadow(
                     WebContextMenuToolbarSpec.MenuContainerElevation,
                     WebContextMenuToolbarSpec.CornerShape
                 )
                 .background(colors.backgroundColor)
-                .width(IntrinsicSize.Max)
+                .horizontalScroll(rememberScrollState())
                 .padding(horizontal = WebContextMenuToolbarSpec.ContainerPadding),
         content = content,
     )

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/contextmenu/internal/ProvideDefaultPlatformTextContextMenuProviders.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/contextmenu/internal/ProvideDefaultPlatformTextContextMenuProviders.web.kt
@@ -44,7 +44,7 @@ internal actual fun ProvideDefaultPlatformTextContextMenuProviders(
         Box(modifier, propagateMinConstraints = true) { content() }
     } else if (dropdownDefined) {
         // Dropdown is defined, so the toolbar isn't.
-        ProvidePlatformTextContextMenuToolbar(modifier, content)
+        ProvideDefaultTextContextMenuToolbar(modifier, content)
     } else if (toolbarDefined) {
         // Toolbar is defined, so the dropdown isn't.
         ProvideDefaultTextContextMenuDropdown(modifier, content)
@@ -68,7 +68,7 @@ private fun ProvideBothDefaultProviders(modifier: Modifier, content: @Composable
     }
 
     val dropdownProvider = defaultTextContextMenuDropdown()
-    val toolbarProvider = platformTextContextMenuToolbarProvider(layoutCoordinatesBlock)
+    val toolbarProvider = defaultTextContextMenuToolbar()
 
     CompositionLocalProvider(
         LocalTextContextMenuToolbarProvider provides toolbarProvider,
@@ -79,6 +79,7 @@ private fun ProvideBothDefaultProviders(modifier: Modifier, content: @Composable
             modifier = modifier.onGloballyPositioned { layoutCoordinates = it },
         ) {
             content()
+            toolbarProvider.ContextMenu(layoutCoordinatesBlock)
             dropdownProvider.ContextMenu(layoutCoordinatesBlock)
         }
     }

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/contextmenu/internal/WebTextContextMenuToolbarProvider.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/contextmenu/internal/WebTextContextMenuToolbarProvider.web.kt
@@ -16,56 +16,130 @@
 
 package androidx.compose.foundation.text.contextmenu.internal
 
+import androidx.compose.foundation.contextmenu.ContextMenuPopupPositionProvider
+import androidx.compose.foundation.contextmenu.computeContextMenuColors
 import androidx.compose.foundation.internal.checkPreconditionNotNull
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.text.WebContextMenuToolbarPopup
+import androidx.compose.foundation.text.WebContextMenuToolbarSpec
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItemWithComposableLeadingIcon
+import androidx.compose.foundation.text.contextmenu.data.TextContextMenuSession
+import androidx.compose.foundation.text.contextmenu.provider.BasicTextContextMenuProvider
 import androidx.compose.foundation.text.contextmenu.provider.LocalTextContextMenuToolbarProvider
 import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuDataProvider
 import androidx.compose.foundation.text.contextmenu.provider.TextContextMenuProvider
+import androidx.compose.foundation.text.contextmenu.provider.basicTextContextMenuProvider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.neverEqualPolicy
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.round
+import androidx.compose.ui.util.fastForEach
+
+@Composable
+internal fun ProvideDefaultTextContextMenuToolbar(
+    modifier: Modifier,
+    content: @Composable () -> Unit
+) {
+    ProvidePlatformTextContextMenuToolbar(
+        modifier = modifier,
+        providableCompositionLocal = LocalTextContextMenuToolbarProvider,
+        contextMenu = { session, dataProvider, anchorLayoutCoordinates ->
+            OpenContextMenuToolbar(session, dataProvider, anchorLayoutCoordinates)
+        },
+        content = content
+    )
+}
 
 @Composable
 internal fun ProvidePlatformTextContextMenuToolbar(
-    modifier: Modifier = Modifier,
+    modifier: Modifier,
+    providableCompositionLocal: ProvidableCompositionLocal<TextContextMenuProvider?>,
+    contextMenu:
+    @Composable
+        (
+        session: TextContextMenuSession,
+        dataProvider: TextContextMenuDataProvider,
+        anchorLayoutCoordinates: () -> LayoutCoordinates,
+    ) -> Unit,
     content: @Composable () -> Unit,
 ) {
-    var layoutCoordinates by remember {
-        mutableStateOf<LayoutCoordinates?>(null, policy = neverEqualPolicy())
+    var layoutCoordinates: LayoutCoordinates? by remember {
+        mutableStateOf(null, neverEqualPolicy())
     }
 
     val layoutCoordinatesBlock: () -> LayoutCoordinates = remember {
         { checkPreconditionNotNull(layoutCoordinates) }
     }
-    val provider = platformTextContextMenuToolbarProvider(layoutCoordinatesBlock)
 
-    CompositionLocalProvider(LocalTextContextMenuToolbarProvider provides provider) {
+    val provider = basicTextContextMenuProvider(contextMenu)
+    CompositionLocalProvider(providableCompositionLocal provides provider) {
         Box(
             propagateMinConstraints = true,
             modifier = modifier.onGloballyPositioned { layoutCoordinates = it },
         ) {
             content()
+            provider.ContextMenu(layoutCoordinatesBlock)
         }
     }
 }
 
 @Composable
-internal fun platformTextContextMenuToolbarProvider(
-    anchorLayoutCoordinates: () -> LayoutCoordinates
-): TextContextMenuProvider {
-    val provider: TextContextMenuProvider = remember { WebTextContextMenuToolbarProvider() }
-    return provider
-}
-
-internal class WebTextContextMenuToolbarProvider() : TextContextMenuProvider {
-    override suspend fun showTextContextMenu(dataProvider: TextContextMenuDataProvider) {
-        // TODO show web text toolbar here
+internal fun defaultTextContextMenuToolbar(): BasicTextContextMenuProvider =
+    basicTextContextMenuProvider { session, dataProvider, anchorLayoutCoordinates ->
+        OpenContextMenuToolbar(session, dataProvider, anchorLayoutCoordinates)
     }
+
+@Composable
+private fun OpenContextMenuToolbar(
+    session: TextContextMenuSession,
+    dataProvider: TextContextMenuDataProvider,
+    anchorLayoutCoordinates: () -> LayoutCoordinates,
+) {
+    val toolbarOffset = with(LocalDensity.current) {
+        (WebContextMenuToolbarSpec.ContainerHeight + 16.dp).roundToPx()
+    }.let { Offset(0f, it.toFloat()) }
+
+    val popupPositionProvider = remember(dataProvider) {
+        ContextMenuPopupPositionProvider(
+            anchorPositionBlock = {
+                val anchorLayoutCoordinates = anchorLayoutCoordinates()
+                val localBoundingBox = dataProvider.position(anchorLayoutCoordinates)
+                localBoundingBox.minus(toolbarOffset).round()
+            }
+        )
+    }
+
+    val data by remember(dataProvider) { derivedStateOf(dataProvider::data) }
+
+    WebContextMenuToolbarPopup(
+        popupPositionProvider = popupPositionProvider,
+        onDismiss = { /*don't hide the toolbar on click outside*/ },
+        colors = computeContextMenuColors(),
+        contextMenuBuilderBlock = {
+            data.components.fastForEach { component ->
+                when (component) {
+                    is TextContextMenuItemWithComposableLeadingIcon -> {
+                        item(
+                            label = { component.label },
+                            enabled = component.enabled,
+                            onClick = { component.onClick(session) },
+                            leadingIcon = component.leadingIcon
+                        )
+                    }
+                }
+            }
+        }
+    )
 }

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Selection.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Selection.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.mpp.demo.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,6 +24,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.contextmenu.builder.item
+import androidx.compose.foundation.text.contextmenu.modifier.appendTextContextMenuComponents
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
@@ -39,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SelectionExample() {
     var count by remember { mutableStateOf(0) }
@@ -58,6 +62,30 @@ fun SelectionExample() {
             }
             SelectionContainer(
                 Modifier.padding(24.dp).fillMaxWidth()
+                    .appendTextContextMenuComponents {
+                        separator()
+                        item(
+                            key = "custom item 1",
+                            label = "custom item 1",
+                            onClick = { close() }
+                        )
+                        item(
+                            key = "custom item 2",
+                            label = "custom item 2",
+                            onClick = { close() }
+                        )
+                        item(
+                            key = "custom item 3",
+                            label = "custom item 3",
+                            onClick = { close() }
+                        )
+                        item(
+                            key = "custom item 4",
+                            label = "custom item 4",
+                            onClick = { close() }
+                        )
+                        separator()
+                    }
             ) {
                 Column {
                     TextField(


### PR DESCRIPTION
With `ComposeFoundationFlags.isNewContextMenuEnabled=true`

https://github.com/user-attachments/assets/ba48bad9-0e3b-4426-92e4-314f62404fab

Fixes https://youtrack.jetbrains.com/issue/CMP-8433

## Release Notes
### Features - Web
- Support of the new context menu toolbar in web mobile targets
