### PR TITLE
[iOS] Removed minimal gesture speed for scrolling

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -431,7 +431,6 @@ internal class ScrollTest {
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
             .dragBy(dx = (150 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
 
         waitForIdle()
 
@@ -454,7 +453,6 @@ internal class ScrollTest {
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
             .dragBy(dx = -(150 + CUPERTINO_TOUCH_SLOP).dp)
-            .up()
 
         waitForIdle()
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -577,6 +577,7 @@ internal class ScrollTest {
         findNodeWithTag("UIKit.UILabel")
             .touchDown()
             .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -587,6 +588,7 @@ internal class ScrollTest {
         findNodeWithTag("Red Box")
             .touchDown()
             .dragBy(dy = (100 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -618,6 +620,7 @@ internal class ScrollTest {
         findNodeWithTag("UIKit.UIScrollView")
             .touchDown()
             .dragBy(dy = -(250 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -648,6 +651,7 @@ internal class ScrollTest {
         findNodeWithTag("Top Box")
             .touchDown()
             .dragBy(dy = -(100 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -721,6 +725,7 @@ internal class ScrollTest {
         findNodeWithTag("UIKit.UIScrollView")
             .touchDown()
             .dragBy(dx = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -755,6 +760,7 @@ internal class ScrollTest {
         findNodeWithTag("UIKit.UIScrollView")
             .touchDown()
             .dragBy(dy = -(50 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -794,6 +800,7 @@ internal class ScrollTest {
             .dragBy(dx = 20.dp, dy = -50.dp)
             .dragBy(dx = -70.dp, dy = 50.dp)
             .dragBy(dy = -150.dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()
@@ -831,6 +838,7 @@ internal class ScrollTest {
             .touchDown()
             .dragBy(dx = -(5 + CUPERTINO_TOUCH_SLOP).dp, dy = -(50 + CUPERTINO_TOUCH_SLOP).dp)
             .dragBy(dx = -50.dp, dy = -50.dp)
+            .also { delay(500) }
             .up()
 
         waitForIdle()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -410,7 +410,6 @@ internal class ScrollTest {
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
             .dragBy(dy = 50.dp)
-            .up()
 
         waitForIdle()
         assertEquals(initialBoxRect, boxRect)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -410,6 +410,7 @@ internal class ScrollTest {
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
             .dragBy(dy = 50.dp)
+            .up()
 
         waitForIdle()
         assertEquals(initialBoxRect, boxRect)
@@ -431,6 +432,8 @@ internal class ScrollTest {
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
             .dragBy(dx = (150 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
+            .up()
 
         waitForIdle()
 
@@ -453,6 +456,8 @@ internal class ScrollTest {
 
         touchDown(DpOffset(screenSize.center.x, 50.dp))
             .dragBy(dx = -(150 + CUPERTINO_TOUCH_SLOP).dp)
+            .also { delay(500) }
+            .up()
 
         waitForIdle()
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/pointer/util/VelocityTracker.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/input/pointer/util/VelocityTracker.uikit.kt
@@ -21,7 +21,6 @@ import kotlin.math.abs
 internal actual const val HistorySize: Int = 40 // Increased to store history on 120 Hz devices
 
 private const val MinimumGestureDurationMilliseconds: Int = 50
-private const val MinimumGestureSpeed: Float = 1.0f // Minimum tracking speed, dp/ms
 
 /**
  * Some platforms (e.g. iOS) filter certain gestures during velocity calculation.
@@ -38,11 +37,6 @@ internal actual fun VelocityTracker1D.shouldUseDataPoints(
 
     val timeDelta = abs(times[0] - times[count - 1])
     if (timeDelta < MinimumGestureDurationMilliseconds && afterPointerStop) {
-        return false
-    }
-
-    val distance = abs(points[0] - points[count - 1])
-    if (distance / timeDelta < MinimumGestureSpeed) {
         return false
     }
 


### PR DESCRIPTION
Removed minimal gesture speed in iOS VelocityTracker due to its redundancy

Fixes: https://youtrack.jetbrains.com/issue/CMP-6908/Decrease-or-remove-MinimumGestureSpeed

## Testing
This should be tested by QA

## Release Notes
N/A
