### PR TITLE
When the user moves the caret during a composition, commit the composition

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
 import androidx.compose.ui.text.input.EditCommand
+import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.OffsetMapping
@@ -148,6 +149,12 @@ internal actual fun legacyTextInputServiceAdapterAndService():
                         ) {
                             runOnEditCommand(
                                 SetComposingTextCommand(text.toString(), newCursorPosition)
+                            )
+                        }
+
+                        override fun finishComposingText() {
+                            runOnEditCommand(
+                                FinishComposingTextCommand()
                             )
                         }
                     }.block()

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -216,6 +216,10 @@ private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScop
 
         buffer.cursor = newCursorInBuffer
     }
+
+    override fun finishComposingText() {
+        buffer.commitComposition()
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/input/PlatformTextInputService2.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/input/PlatformTextInputService2.kt
@@ -65,4 +65,11 @@ interface TextEditingScope {
      * This intends to replicate [SetComposingTextCommand].
      */
     fun setComposingText(text: CharSequence, newCursorPosition: Int)
+
+    /**
+     * Finishes composing, leaving the text as-is.
+     *
+     * This intends to replicate [FinishComposingTextCommand].
+     */
+    fun finishComposingText()
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.awt.toAwtRectangleRounded
 import androidx.compose.ui.scene.ComposeSceneMediator
 import androidx.compose.ui.text.TextRange
@@ -29,31 +30,80 @@ import java.awt.im.InputMethodRequests
 import java.text.AttributedCharacterIterator
 import java.text.AttributedString
 import java.text.CharacterIterator
+import javax.swing.SwingUtilities
 import kotlin.math.max
 import kotlin.math.min
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 
 internal class DesktopTextInputService2(
-    private val component: PlatformComponent
+    private val component: PlatformComponent,
 ) {
 
     private var inputMethodSession: InputMethodSession? = null
 
-    private var receivedInputMethodEventsSinceStartInput = false
+    private val extraCommitEventWorkaround = ExtraCommitEventWorkaround()
 
-    private var composingText: String = ""
+    suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
+        val coroutineScope = CoroutineScope(currentCoroutineContext())
+        suspendCancellableCoroutine<Nothing> { continuation ->
+            coroutineScope.startInput(request)
+            continuation.invokeOnCancellation {
+                stopInput()
+                coroutineScope.cancel()
+            }
+        }
+    }
 
-    fun startInput(request: PlatformTextInputMethodRequest) {
-        receivedInputMethodEventsSinceStartInput = false
+    private fun CoroutineScope.startInput(request: PlatformTextInputMethodRequest) {
+        extraCommitEventWorkaround.onStartInput()
+
         component.enableInput(
             InputMethodSession(component, request).also {
                 inputMethodSession = it
             }
         )
+
+        // During composition, the selection should be collapsed and at the end of the composition.
+        // If it changes unexpectedly, finish composing.
+        // BTF1 commits the composition itself when the user clicks somewhere, but BTF2
+        // does not. This commits the composition for BTF2
+        launch {
+            snapshotFlow { request.state.selection }.collect { selection ->
+                val composition = request.state.composition ?: return@collect
+                if (!selection.collapsed || (selection.end != composition.end)) {
+                    request.editText {
+                        finishComposingText()
+                    }
+                }
+            }
+        }
+
+        // When something commits (or otherwise ends) the composition, end it for the platform too
+        launch {
+            snapshotFlow { request.state.composition }.collect { composition ->
+                val composingText = inputMethodSession?.imeComposingText ?: return@collect
+                if (composingText.isNotEmpty() && (composition == null)) {
+                    SwingUtilities.invokeLater {
+                        // The event sent due to ending the composition must be ignored because the
+                        // composition has already been committed.
+                        // Set this in `invokeLater` to make sure we ignore the event scheduled by
+                        // `component.endComposition()`, and not some event that has already been
+                        // scheduled beforehand.
+                        inputMethodSession?.ignoreNextInputMethodEvent = true
+                    }
+                    component.endComposition()
+                }
+            }
+        }
     }
 
-    fun stopInput() {
+    private fun stopInput() {
         component.disableInput()
 
         this.inputMethodSession = null
@@ -72,34 +122,10 @@ internal class DesktopTextInputService2(
         if (event.isConsumed) return
         val inputMethodSession = inputMethodSession ?: return
 
-        if (commitEventWorkaroundShouldIgnoreEvent(event)) return
+        if (extraCommitEventWorkaround.shouldIgnoreEvent(event)) return
 
-        inputMethodSession.replaceInputMethodText(event)
+        inputMethodSession.inputMethodTextChanged(event)
         event.consume()
-    }
-
-    /**
-     * Implements a workaround for https://youtrack.jetbrains.com/issue/CMP-7976; returns whether
-     * the given event should be ignored.
-     *
-     * JBR sends an extra [InputMethodEvent] when focus moves away from a text field. This event
-     * means to commit the current composition. Unfortunately, because we use a single actual Swing
-     * component (see [ComposeSceneMediator]) as a source of [InputMethodEvent]s, this event gets
-     * delivered to a new text session if the focus switches away to another text field.
-     *
-     * Regardless, Compose text fields commit their composition on focus loss (but not window focus
-     * loss) themselves, so we don't need this event.
-     */
-    private fun commitEventWorkaroundShouldIgnoreEvent(event: InputMethodEvent): Boolean {
-        val isFirstEventAfterStartInput = !receivedInputMethodEventsSinceStartInput
-        receivedInputMethodEventsSinceStartInput = true
-
-        val currentComposingText = composingText
-        composingText = event.composingText
-
-        return isFirstEventAfterStartInput &&
-            event.committedText == currentComposingText &&
-            event.composingText.isEmpty()
     }
 }
 
@@ -116,6 +142,12 @@ private class InputMethodSession(
 
     private val composition: TextRange?
         get() = state.composition
+
+    // The composing text from the last InputMethodEvent
+    var imeComposingText: String = ""
+        private set
+
+    var ignoreNextInputMethodEvent = false
 
     // This is required to support input of accented characters using press-and-hold method (http://support.apple.com/kb/PH11264).
     // JDK currently properly supports this functionality only for TextComponent/JTextComponent descendants.
@@ -203,9 +235,16 @@ private class InputMethodSession(
         return AttributedString(committed).iterator
     }
 
-    fun replaceInputMethodText(event: InputMethodEvent) {
+    fun inputMethodTextChanged(event: InputMethodEvent) {
         val committed = event.committedText
         val composing = event.composingText
+
+        imeComposingText = composing
+
+        if (ignoreNextInputMethodEvent) {
+            ignoreNextInputMethodEvent = false
+            return
+        }
 
         request.editText {
             if (needToDeletePreviousChar && selection.min > 0 && composing.isEmpty()) {
@@ -251,5 +290,42 @@ private fun AttributedCharacterIterator?.substringOrEmpty(
             append(c)
             c = next()
         }
+    }
+}
+
+/**
+ * Implements a workaround for https://youtrack.jetbrains.com/issue/CMP-7976
+ *
+ * JBR sends an extra [InputMethodEvent] when focus moves away from a text field. This event
+ * means to commit the current composition. Unfortunately, because we use a single actual Swing
+ * component (see [ComposeSceneMediator]) as a source of [InputMethodEvent]s, this event gets
+ * delivered to a new text session if the focus switches away to another text field.
+ *
+ * Regardless, Compose text fields commit their composition on focus loss (but not window focus
+ * loss) themselves, so we don't need this event.
+ */
+private class ExtraCommitEventWorkaround {
+
+    private var composingText: String = ""
+
+    private var receivedInputMethodEventsSinceStartInput = false
+
+    fun onStartInput() {
+        receivedInputMethodEventsSinceStartInput = false
+    }
+
+    /**
+     * Returns whether the given event should be ignored.
+     */
+    fun shouldIgnoreEvent(event: InputMethodEvent): Boolean {
+        val isFirstEventAfterStartInput = !receivedInputMethodEventsSinceStartInput
+        receivedInputMethodEventsSinceStartInput = true
+
+        val currentComposingText = composingText
+        composingText = event.composingText
+
+        return isFirstEventAfterStartInput &&
+            event.committedText == currentComposingText &&
+            event.composingText.isEmpty()
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformComponent.desktop.kt
@@ -29,12 +29,15 @@ internal interface PlatformComponent {
 
     fun disableInput()
 
+    fun endComposition()
+
     companion object {
         val Empty = object : PlatformComponent {
             override val locationOnScreen = Point(0, 0)
             override val density = Density(1f)
             override fun enableInput(inputMethodRequests: InputMethodRequests) = Unit
             override fun disableInput() = Unit
+            override fun endComposition() = Unit
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.scene
 
-import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ComposeFeatureFlags
@@ -31,6 +30,7 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.asComposeCanvas
+import androidx.compose.ui.input.key.KeyEvent as ComposeKeyEvent
 import androidx.compose.ui.input.key.internal
 import androidx.compose.ui.input.key.toComposeEvent
 import androidx.compose.ui.input.pointer.AwtCursor
@@ -90,7 +90,6 @@ import javax.swing.JComponent
 import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skiko.ClipRectangle
 import org.jetbrains.skiko.ExperimentalSkikoApi
@@ -712,12 +711,7 @@ internal class ComposeSceneMediator(
         override val textInputService = this@ComposeSceneMediator.textInputService
 
         override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
-            suspendCancellableCoroutine<Nothing> { continuation ->
-                textInputService2.startInput(request)
-                continuation.invokeOnCancellation {
-                    textInputService2.stopInput()
-                }
-            }
+            textInputService2.startInputMethod(request)
         }
 
         override fun setPointerIcon(pointerIcon: PointerIcon) {
@@ -754,6 +748,7 @@ internal class ComposeSceneMediator(
         override fun enableInput(inputMethodRequests: InputMethodRequests) {
             currentInputMethodRequests = inputMethodRequests
             contentComponent.enableInputMethods(true)
+            contentComponent.inputContext.endComposition()
             // Without resetting the focus, Swing won't update the status (doesn't show/hide popup)
             // enableInputMethods is design to used per-Swing component level at init stage,
             // not dynamically
@@ -767,6 +762,10 @@ internal class ComposeSceneMediator(
             // enableInputMethods is design to used per-Swing component level at init stage,
             // not dynamically
             resetFocus()
+        }
+
+        override fun endComposition() {
+            contentComponent.inputContext.endComposition()
         }
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -37,14 +37,23 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowTestScope
+import androidx.compose.ui.window.density
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
+import kotlin.math.roundToInt
 import org.junit.experimental.theories.DataPoint
 
 open class BaseWindowTextFieldTest {
@@ -88,6 +97,12 @@ open class BaseWindowTextFieldTest {
         abstract val selection: TextRange
         abstract val composition: TextRange?
 
+        var textLayoutResult: TextLayoutResult? = null
+            protected set
+
+        var textBoundingBox: Rect = Rect.Zero
+            protected set
+
         @Composable
         abstract fun TextField()
 
@@ -96,7 +111,7 @@ open class BaseWindowTextFieldTest {
         }
 
         suspend fun assertStateEquals(
-            actual: String,
+            text: String,
             selection: TextRange,
             composition: TextRange?,
             awaitIdle: Boolean = true
@@ -104,9 +119,34 @@ open class BaseWindowTextFieldTest {
             if (awaitIdle) {
                 windowTestScope.awaitIdle()
             }
-            assertThat(text).isEqualTo(actual)
-            assertThat(selection).isEqualTo(selection)
-            assertThat(composition).isEqualTo(composition)
+            assertThat(this.text).isEqualTo(text)
+            assertThat(this.selection).isEqualTo(selection)
+            assertThat(this.composition).isEqualTo(composition)
+        }
+
+        fun clickBeforeIndex(index: Int) {
+            val localLocation = textLayoutResult!!.let {
+                if (index == text.length)
+                    it.getBoundingBox(index-1).centerRight
+                else
+                    it.getBoundingBox(index).centerLeft
+            }
+            val location = localLocation + textBoundingBox.topLeft
+            val platformLocation = location.let {
+                val scale = window.density.density
+                IntOffset(
+                    x = (it.x / scale).roundToInt(),
+                    y = (it.y / scale).roundToInt()
+                )
+            }
+            window.sendMousePress(
+                x = platformLocation.x,
+                y = platformLocation.y
+            )
+            window.sendMouseRelease(
+                x = platformLocation.x,
+                y = platformLocation.y
+            )
         }
     }
 
@@ -173,7 +213,12 @@ open class BaseWindowTextFieldTest {
                         onValueChange = {
                             textFieldValue = it
                         },
-                        modifier = Modifier.focusRequester(focusRequester)
+                        onTextLayout = { textLayoutResult = it },
+                        modifier = Modifier
+                            .focusRequester(focusRequester)
+                            .onPlaced {
+                                textBoundingBox = it.boundsInWindow()
+                            }
                     )
 
                     LaunchedEffect(focusRequester) {
@@ -195,7 +240,12 @@ open class BaseWindowTextFieldTest {
                     BasicTextField(
                         state = textFieldState,
                         inputTransformation = inputTransformation,
-                        modifier = Modifier.focusRequester(focusRequester)
+                        onTextLayout = { textLayoutResult = it() },
+                        modifier = Modifier
+                            .focusRequester(focusRequester)
+                            .onPlaced {
+                                textBoundingBox = it.boundsInWindow()
+                            }
                     )
 
                     LaunchedEffect(focusRequester) {
@@ -217,8 +267,13 @@ open class BaseWindowTextFieldTest {
 
                     BasicSecureTextField(
                         state = textFieldState,
-                        modifier = Modifier.focusRequester(focusRequester),
-                        textObfuscationMode = textObfuscationMode
+                        textObfuscationMode = textObfuscationMode,
+                        onTextLayout = { textLayoutResult = it() },
+                        modifier = Modifier
+                            .focusRequester(focusRequester)
+                            .onPlaced {
+                                textBoundingBox = it.boundsInWindow()
+                            }
                     )
 
                     LaunchedEffect(focusRequester) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -739,6 +739,38 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         assertStateEquals("請問", selection = TextRange(2), composition = null)
     }
 
+    // Verifies the fix to https://youtrack.jetbrains.com/issue/CMP-8200
+    @Theory
+    internal fun `v, x, click before v, x, click at end(Korean, macOS)`(
+        textFieldKind: TextFieldKind<*>
+    ) = runTextFieldTest(textFieldKind, "Chinese, macOS") {
+        // Press 'v' key
+        window.sendKeyTypedEvent('v')
+        assertStateEquals("v", selection = TextRange(1), composition = null)
+
+        // Press 'x' key (produces 'ㅌ')
+        window.sendInputMethodEvent("ㅌ", 0)
+        window.sendKeyEvent(88, 'ㅌ', KEY_RELEASED)
+        assertStateEquals("vㅌ", selection = TextRange(2), composition = TextRange(1, 2))
+
+        clickBeforeIndex(0)
+        awaitIdle()
+        // Here PlatformComponent.endComposition() should be called, and in response the
+        // system should send a composition-ending event
+        window.sendInputMethodEvent("ㅌ", 1)
+        assertStateEquals("vㅌ", selection = TextRange(0), composition = null)
+
+        // Press 'x' key (produces 'ㅌ')
+        window.sendInputMethodEvent("ㅌ", 0)
+        window.sendKeyEvent(88, 'ㅌ', KEY_RELEASED)
+        assertStateEquals("ㅌvㅌ", selection = TextRange(1), composition = TextRange(0, 1))
+
+        clickBeforeIndex(3)
+        awaitIdle()
+        window.sendInputMethodEvent("ㅌ", 1)
+        assertStateEquals("ㅌvㅌ", selection = TextRange(3), composition = null)
+    }
+
     // Verifies that each typed character and character replaced by the input service is reported
     // (to `inputTransformation`) as a change in the last character only.
     // The behavior of `SecureTextField` with `TextObfuscationMode.RevealLastTyped` depends on this,


### PR DESCRIPTION
When the user moves the caret during a composition, e.g. by clicking somewhere, commit the composition immediately.

Fixes https://youtrack.jetbrains.com/issue/CMP-8200

## Testing
Tested manually.
Unfortunately it's not possible to create a unit test because the fix implies bidirectional interaction with the `InputContext`.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- [TextField] Fixed duplication of the composed characters when moving the caret by clicking during a composition.
