### PR TITLE
Use touch event position for the initial positioning of backing HTML input

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -234,7 +234,6 @@ private fun ImeOptions.createDomElement(): HTMLElement {
         setProperty("width", "calc(var(--compose-internal-web-backing-input-width) * 1px")
         setProperty("height", "calc(var(--compose-internal-web-backing-input-height) * 1px")
         setProperty("padding", "0")
-        setProperty("opacity", "0")
         setProperty("color", "transparent")
         setProperty("background", "transparent")
         setProperty("caret-color", "transparent")
@@ -245,6 +244,13 @@ private fun ImeOptions.createDomElement(): HTMLElement {
         setProperty("z-index", "-1")
         // TODO: do we need pointer-events: none
         //setProperty("pointer-events", "none")
+
+        // I keep "opacity" commented to make it explicit that we can't use this property.
+        // Reason: Safari iOS keyboard overlaps the text input. See CMP-8611
+        // setProperty("opacity", "0")
+
+        // To prevent auto-zoom in some mobile browsers, we set a larger font-size
+        setProperty("font-size", "20px")
     }
 
     return htmlElement

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -16,7 +16,9 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
@@ -48,6 +50,15 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         }
 
     /**
+     * It's used for the initial positioning of the backing HTML input.
+     * It's rather a workaround for the problem that startInput doesn't know the correct position yet.
+     * To solve it properly, we need to change the common code.
+     * We need the correct position, so the software keyboard wouldn't overlap the text input.
+     * See https://youtrack.jetbrains.com/issue/CMP-8611 for details.
+     */
+    internal open val currentTouchOffset: Offset? = null
+
+    /**
      * This container will host the actual hidden HTML input element.
      */
     abstract val backingDomInputContainer: HTMLElement
@@ -58,22 +69,28 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
         onEditCommand: (List<EditCommand>) -> Unit,
         onImeActionPerformed: (ImeAction) -> Unit
     ) {
-        backingDomInput =
-            BackingDomInput(
-                imeOptions = imeOptions,
-                composeCommunicator = object : ComposeCommandCommunicator {
-                    override fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean {
-                        return this@WebTextInputService.processKeyboardEvent(keyboardEvent)
-                    }
+        backingDomInput = BackingDomInput(
+            imeOptions = imeOptions,
+            composeCommunicator = object : ComposeCommandCommunicator {
+                override fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean {
+                    return this@WebTextInputService.processKeyboardEvent(keyboardEvent)
+                }
 
-                    override fun sendEditCommand(commands: List<EditCommand>) {
-                        onEditCommand(commands)
-                    }
-                },
-                inputContainer = backingDomInputContainer,
-            )
+                override fun sendEditCommand(commands: List<EditCommand>) {
+                    onEditCommand(commands)
+                }
+            },
+            inputContainer = backingDomInputContainer,
+        )
         backingDomInput?.register()
 
+        if (currentTouchOffset != null) {
+            // We don't know the real position yet, but it's reasonable to assume that
+            // if startInput is caused by a touch event,
+            // then the TextField is positioned around the touch coordinates.
+            // See the currentTouchOffset KDoc for the details.
+            notifyFocusedRect(Rect(currentTouchOffset!!, Size(1f, 1f)))
+        }
         showSoftwareKeyboard()
     }
 
@@ -83,6 +100,7 @@ internal abstract class WebTextInputService : PlatformTextInputService, InputAwa
 
     override fun stopInput() {
         backingDomInput?.dispose()
+        backingDomInput = null
     }
 
     override fun showSoftwareKeyboard() {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -205,6 +205,9 @@ internal class ComposeWindow(
 
     private var keyboardModeState: KeyboardModeState = KeyboardModeState.Hardware
 
+    // Used in WebTextInputService. Also see https://youtrack.jetbrains.com/issue/CMP-8611
+    private var activeTouchOffset: Offset? = null
+
     private val platformContext: PlatformContext = object : PlatformContext by PlatformContext.Empty {
         override val windowInfo get() = _windowInfo
 
@@ -259,7 +262,10 @@ internal class ComposeWindow(
                 null
             }
 
-        override val textInputService = object : WebTextInputService() {
+        override val textInputService: WebTextInputService = object : WebTextInputService() {
+
+            override val currentTouchOffset: Offset?
+                get() = activeTouchOffset
 
             override val backingDomInputContainer: HTMLElement
                 get() = interopContainerElement
@@ -540,6 +546,7 @@ internal class ComposeWindow(
             )
         }
 
+        activeTouchOffset = pointers.firstOrNull()?.position
         scene.sendPointerEvent(
             eventType = eventType,
             pointers = pointers,
@@ -549,7 +556,7 @@ internal class ComposeWindow(
             nativeEvent = event,
             button = null
         )
-
+        activeTouchOffset = null
     }
 
     private fun onMouseEvent(

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebTextInputSession.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/WebTextInputSession.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.PlatformTextInputMethodRequest
 import androidx.compose.ui.platform.PlatformTextInputSessionScope
 import androidx.compose.ui.platform.WebTextInputService
@@ -42,7 +43,10 @@ internal class WebTextInputSession(
         }
         launch {
             snapshotFlow { request.focusedRectInRoot() }.filterNotNull().collect {
-                webTextInputService.notifyFocusedRect(it)
+                // Skip Rect.Zero, because it's an initial value. The real value is never Zero
+                if (it != Rect.Zero) {
+                    webTextInputService.notifyFocusedRect(it)
+                }
             }
         }
         suspendCancellableCoroutine<Nothing> { continuation ->


### PR DESCRIPTION
By the time `WebTextInputService.startInput` is called, the real/correct position for backing HTML input might be not known yet. Therefore requesting the focus (and thus showing the keyboard) would make the keyboard overlap the TextField. 

We know the real position later, but `input.focus()` request is ignored unless it's requested in a handler of some user interaction (e.g. touch event). So we check if startInput is within a touch event handler and use its x,y as an initial position for the backing HTML input.

Fixes https://youtrack.jetbrains.com/issue/CMP-8611

https://github.com/user-attachments/assets/717d22bc-b8e8-4a20-a8b9-16a7bbd1ad31




## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- Fix software keyboard behaviour for Compose Text Fields in iOS Safari