### PR TITLE
Unpin Lifecycle/Navigation

### DIFF
--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -41,7 +41,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("org.jetbrains.androidx.navigation:navigation-compose:2.9.0-beta04")
+                implementation(project(":navigation:navigation-compose"))
                 implementation(project(":compose:material:material"))
                 implementation(libs.kotlinStdlib)
             }

--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -41,7 +41,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation("org.jetbrains.androidx.navigation:navigation-compose:2.9.0-beta02")
+                implementation("org.jetbrains.androidx.navigation:navigation-compose:2.9.0-beta04")
                 implementation(project(":compose:material:material"))
                 implementation(libs.kotlinStdlib)
             }

--- a/compose/runtime/runtime-saveable/build.gradle
+++ b/compose/runtime/runtime-saveable/build.gradle
@@ -96,7 +96,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             commonMain.dependencies {
                 implementation(libs.kotlinStdlib)
                 implementation(project(":collection:collection"))
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
                 api(project(":compose:runtime:runtime"))
                 api(project(":savedstate:savedstate-compose"))
             }

--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -46,7 +46,7 @@ kotlin {
                 implementation(project(":annotation:annotation"))
                 implementation(project(":compose:runtime:runtime"))
                 implementation(project(":compose:ui:ui-util"))
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
             }
         }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -170,11 +170,11 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 api project(":compose:ui:ui-text")
                 api project(":compose:ui:ui-unit")
                 api project(":compose:ui:ui-util")
-                api("org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.1")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.9.1")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.1")
-                implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.1")
+                api(project(":lifecycle:lifecycle-common"))
+                implementation(project(":lifecycle:lifecycle-runtime"))
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-savedstate"))
             }
 
             androidMain.dependencies {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -219,13 +219,6 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(notMobileMain)
                 dependencies {
                     implementation(libs.kotlinStdlibJdk8)
-
-                    // TODO revert after https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom is fixed and the dependency is upgraded
-                    // lifecycle-viewmodel-savedstate-desktop:2.9.1 is broken for Maven projects.
-                    // See https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03
-                    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:2.9.1") {
-                        exclude group: "androidx.lifecycle", module: "lifecycle-viewmodel"
-                    }
                 }
             }
 

--- a/navigation/navigation-common/build.gradle
+++ b/navigation/navigation-common/build.gradle
@@ -59,10 +59,10 @@ androidXMultiplatform {
             dependencies {
                 api "androidx.annotation:annotation:1.9.1"
                 api "androidx.collection:collection:1.5.0"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.1"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.9.1"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.1"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.1"
+                api project(":lifecycle:lifecycle-common")
+                api project(":lifecycle:lifecycle-runtime")
+                api project(":lifecycle:lifecycle-viewmodel")
+                api project(":lifecycle:lifecycle-viewmodel-savedstate")
                 api project(":savedstate:savedstate")
 
                 api(libs.kotlinStdlib)

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -117,15 +117,6 @@ kotlin {
         desktopMain {
             dependsOn(jvmMain)
             dependsOn(nonAndroidMain)
-
-            dependencies {
-                // TODO revert after https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom is fixed and the dependency is upgraded
-                // lifecycle-viewmodel-savedstate-desktop:2.9.1 is broken for Maven projects.
-                // See https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03
-                implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:2.9.1") {
-                    exclude group: "androidx.lifecycle", module: "lifecycle-viewmodel"
-                }
-            }
         }
         desktopTest {
             dependsOn(jvmTest)

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -57,11 +57,11 @@ kotlin {
 
                 implementation "org.jetbrains.compose.animation:animation-core:1.8.2"
                 implementation "org.jetbrains.compose.foundation:foundation-layout:1.8.2"
-                implementation "org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.1"
-                implementation "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.1"
-                implementation "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.1"
-                implementation "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose:2.9.1"
-                implementation "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.1"
+                implementation(project(":lifecycle:lifecycle-common"))
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-savedstate"))
                 implementation project(":savedstate:savedstate")
                 implementation project(":savedstate:savedstate-compose")
             }

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -52,10 +52,10 @@ androidXMultiplatform {
             dependencies {
                 api "androidx.annotation:annotation:1.9.1"
                 api "androidx.collection:collection:1.5.0"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-common:2.9.1"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-runtime:2.9.1"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.1"
-                api "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.1"
+                api project(":lifecycle:lifecycle-common")
+                api project(":lifecycle:lifecycle-runtime")
+                api project(":lifecycle:lifecycle-viewmodel")
+                api project(":lifecycle:lifecycle-viewmodel-savedstate")
                 api project(":savedstate:savedstate")
                 api project(":navigation:navigation-common")
 

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -119,15 +119,6 @@ androidXMultiplatform {
         desktopMain {
             dependsOn(jvmMain)
             dependsOn(nonAndroidMain)
-
-            dependencies {
-                // TODO revert after https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom is fixed and the dependency is upgraded
-                // lifecycle-viewmodel-savedstate-desktop:2.9.1 is broken for Maven projects.
-                // See https://youtrack.jetbrains.com/issue/CMP-8577/Maven-project-doesnt-work-with-1.9.0-alpha03
-                implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate-desktop:2.9.1") {
-                    exclude group: "androidx.lifecycle", module: "lifecycle-viewmodel"
-                }
-            }
         }
         desktopTest {
             dependsOn(jvmTest)


### PR DESCRIPTION
1. Lifecycle 2.9.2 was merged to jb-main and it fixes https://youtrack.jetbrains.com/issue/CMP-8582/androidx.lifecyclelifecycle-viewmodel-savedstate-desktop2.9.1-depend-on-an-Android-artifact-in-pom

To use it in the project, we need to unpin the dependencies

2. unpin navigation in material-navigation, because:
- Lifecycle 2.9.2 is [incompatible](https://youtrack.jetbrains.com/issue/CMP-8704/Investigate-incompatibility-between-Lifecycle-2.9.2-and-material-navigation2.9.0-beta02) with `material-navigation:2.9.0-beta02` for Native:
```
e: file:///opt/buildAgent/work/42d4a48e2f801fd0/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/SheetContentHost.kt:69:24 Cannot access 'ViewModelStoreOwner' which is a supertype of 'NavBackStackEntry'. Check your module classpath for missing or conflicting dependencies.
e: file:///opt/buildAgent/work/42d4a48e2f801fd0/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/SheetContentHost.kt:69:24 Cannot access 'HasDefaultViewModelProviderFactory' which is a supertype of 'NavBackStackEntry'. Check your module classpath for missing or conflicting dependencies.
e: file:///opt/buildAgent/work/42d4a48e2f801fd0/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/SheetContentHost.kt:70:43 Cannot access 'ViewModelStoreOwner' which is a supertype of 'NavBackStackEntry'. Check your module classpath for missing or conflicting dependencies.
e: file:///opt/buildAgent/work/42d4a48e2f801fd0/compose/material/material-navigation/src/commonMain/kotlin/androidx/compose/material/navigation/SheetContentHost.kt:70:43 Cannot access 'HasDefaultViewModelProviderFactory' which is a supertype of 'NavBackStackEntry'. Check your module classpath for missing or conflicting dependencies.
```
- we need stability levels matching if we decide to stabilize navigation

## Release Notes
N/A