### PR TITLE
Fix plural typo in Application.desktop.kt doc comment

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -93,7 +93,7 @@ import org.jetbrains.skiko.MainUIDispatcher
  * because underlying [MonotonicFrameClock] hasn't synchronized with any display, and produces
  * frames as fast as possible.
  *
- * All animation's should be created inside Composable content of the
+ * All animations should be created inside Composable content of the
  * [Window] / [DialogWindow] / [ComposePanel].
  *
  * @param exitProcessOnExit should `exitProcess(0)` be called after the application is closed.


### PR DESCRIPTION
Describe proposed changes and the issue being fixed

Fixes a small grammar issue in a KDoc comment: "animation's" (possessive) has been corrected to "animations" (plural), which is the intended meaning in context.

No related issue filed.

## Testing
N/A – this is a documentation comment and has no effect on runtime behavior.

## Release Notes
N/A

## Google CLA
I have signed the CLA at https://cla.developers.google.com
