### PR TITLE
Disable Clipboard-related context menu items when the necessary web API is not supported

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation.internal
 
 import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 
 // TODO: upstreaming the KDoc https://youtrack.jetbrains.com/issue/CMP-7544
@@ -43,3 +44,12 @@ internal expect fun AnnotatedString?.toClipEntry(): ClipEntry?
  * Otherwise, it returns false.
  */
 internal expect fun ClipEntry?.hasText(): Boolean
+
+/**
+ * All platforms except web always support both read and write operations.
+ * On the web, older browser versions have different APIs supported.
+ * We use this information for the context menu items.
+ */
+// TODO (o.karpovich): must be upstreamed https://youtrack.jetbrains.com/issue/CMP-7544 and its usages
+internal expect fun Clipboard?.isReadSupported(): Boolean
+internal expect fun Clipboard?.isWriteSupported(): Boolean

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.kt
@@ -51,5 +51,5 @@ internal expect fun ClipEntry?.hasText(): Boolean
  * We use this information for the context menu items.
  */
 // TODO (o.karpovich): must be upstreamed https://youtrack.jetbrains.com/issue/CMP-7544 and its usages
-internal expect fun Clipboard?.isReadSupported(): Boolean
-internal expect fun Clipboard?.isWriteSupported(): Boolean
+internal expect fun Clipboard.isReadSupported(): Boolean
+internal expect fun Clipboard.isWriteSupported(): Boolean

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -27,6 +27,8 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.internal.checkPreconditionNotNull
+import androidx.compose.foundation.internal.isReadSupported
+import androidx.compose.foundation.internal.isWriteSupported
 import androidx.compose.foundation.internal.readText
 import androidx.compose.foundation.internal.toClipEntry
 import androidx.compose.foundation.text.DefaultCursorThickness
@@ -1311,8 +1313,8 @@ internal class TextFieldSelectionState(
      * requires the selection to not be collapsed, the text field to be editable, and for it to NOT
      * be a password.
      */
-    fun canCut(): Boolean =
-        !textFieldState.visualText.selection.collapsed && editable && !isPassword
+    fun canCut(): Boolean = clipboard.isWriteSupported()
+        && !textFieldState.visualText.selection.collapsed && editable && !isPassword
 
     /**
      * The method for cutting text.
@@ -1342,7 +1344,9 @@ internal class TextFieldSelectionState(
      * Whether a copy operation can execute now and modify the clipboard. The copy operation
      * requires the selection to not be collapsed, and the text field to NOT be a password.
      */
-    fun canCopy(): Boolean = !textFieldState.visualText.selection.collapsed && !isPassword
+    fun canCopy(): Boolean = clipboard.isWriteSupported()
+        && !textFieldState.visualText.selection.collapsed
+        && !isPassword
 
     /**
      * The method for copying text.
@@ -1386,7 +1390,7 @@ internal class TextFieldSelectionState(
      * calling [updateClipboardEntry].
      */
     fun canPaste(): Boolean {
-        if (!editable) return false
+        if (!editable || !clipboard.isReadSupported()) return false
         // if receive content is not configured, we expect at least a text item to be present
         if (clipboardPasteState.hasText) return true
         // if receive content is configured, hasClip should be enough to show the paste option

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionContainer.kt
@@ -18,6 +18,7 @@ package androidx.compose.foundation.text.selection
 
 import androidx.compose.foundation.ComposeFoundationFlags
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.internal.isWriteSupported
 import androidx.compose.foundation.internal.toClipEntry
 import androidx.compose.foundation.text.ContextMenuArea
 import androidx.compose.foundation.text.detectDownAndDragGesturesWithObserver
@@ -101,10 +102,14 @@ internal fun SelectionContainer(
     manager.hapticFeedBack = LocalHapticFeedback.current
     manager.onCopyHandler =
         remember(coroutineScope, clipboard) {
-            { textToCopy ->
-                coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-                    clipboard.setClipEntry(textToCopy.toClipEntry())
+            if (clipboard.isWriteSupported()) {
+                { textToCopy ->
+                    coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+                        clipboard.setClipEntry(textToCopy.toClipEntry())
+                    }
                 }
+            } else {
+                null
             }
         }
     manager.textToolbar = LocalTextToolbar.current

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.kt
@@ -804,13 +804,17 @@ internal class SelectionManager(private val selectionRegistrar: SelectionRegistr
         }
     }
 
+    // No need to show the "Copy" context menu item if onCopyHandler is not provided
+    internal fun canCopy(): Boolean =
+        onCopyHandler != null && isNonEmptySelection()
+
     private fun updateSelectionTextToolbar() {
         val textToolbar = textToolbar ?: return
         if (showToolbar && isInTouchMode) {
             val rect = getContentRect() ?: return
             textToolbar.showMenu(
                 rect = rect,
-                onCopyRequested = if (isNonEmptySelection()) ::toolbarCopy else null,
+                onCopyRequested = if (canCopy()) ::toolbarCopy else null,
                 onSelectAllRequested = if (isEntireContainerSelected()) null else ::selectAll,
                 onAutofillRequested = null,
             )

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
@@ -771,10 +771,10 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
         get() = !value.selection.collapsed
 
     internal fun canCopy(): Boolean =
-        clipboard.isWriteSupported() && hasSelection && !isPassword
+        hasSelection && !isPassword && (clipboard?.isWriteSupported() == true)
 
     internal suspend fun updateClipboardEntry() {
-        if (clipboard.isReadSupported()) {
+        if (clipboard?.isReadSupported() == true) {
             hasAvailableTextToPaste = hasAvailableTextToPaste()
         }
     }
@@ -795,10 +795,10 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
 
     /** Only fully accurate if [updateClipboardEntry] has been called. */
     internal fun canPaste(): Boolean =
-        editable && clipboard.isReadSupported() && hasAvailableTextToPaste
+        editable && (clipboard?.isReadSupported() == true) && hasAvailableTextToPaste
 
     internal fun canCut(): Boolean =
-        clipboard.isWriteSupported() && hasSelection && editable && !isPassword
+        hasSelection && editable && !isPassword && clipboard?.isWriteSupported() == true
 
     internal fun canSelectAll(): Boolean = value.selection.length != value.text.length
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
@@ -20,6 +20,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.ComposeFoundationFlags
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.internal.checkPreconditionNotNull
+import androidx.compose.foundation.internal.isReadSupported
+import androidx.compose.foundation.internal.isWriteSupported
 import androidx.compose.foundation.internal.readAnnotatedString
 import androidx.compose.foundation.internal.toClipEntry
 import androidx.compose.foundation.text.DefaultCursorThickness
@@ -768,10 +770,13 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
     private val hasSelection: Boolean
         get() = !value.selection.collapsed
 
-    internal fun canCopy(): Boolean = hasSelection && !isPassword
+    internal fun canCopy(): Boolean =
+        clipboard.isWriteSupported() && hasSelection && !isPassword
 
     internal suspend fun updateClipboardEntry() {
-        hasAvailableTextToPaste = hasAvailableTextToPaste()
+        if (clipboard.isReadSupported()) {
+            hasAvailableTextToPaste = hasAvailableTextToPaste()
+        }
     }
 
     private suspend fun notifyPlatformSelectionBehaviorsOnShowContextMenu() {
@@ -789,9 +794,11 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
     }
 
     /** Only fully accurate if [updateClipboardEntry] has been called. */
-    internal fun canPaste(): Boolean = editable && hasAvailableTextToPaste
+    internal fun canPaste(): Boolean =
+        editable && clipboard.isReadSupported() && hasAvailableTextToPaste
 
-    internal fun canCut(): Boolean = hasSelection && editable && !isPassword
+    internal fun canCut(): Boolean =
+        clipboard.isWriteSupported() && hasSelection && editable && !isPassword
 
     internal fun canSelectAll(): Boolean = value.selection.length != value.text.length
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
@@ -84,8 +84,8 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return transferable.isDataFlavorSupported(DataFlavor.stringFlavor)
 }
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean = this != null
-internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean = this != null
+internal actual fun androidx.compose.ui.platform.Clipboard.isReadSupported(): Boolean = true
+internal actual fun androidx.compose.ui.platform.Clipboard.isWriteSupported(): Boolean = true
 
 // Here we rely on the NativeClipboard directly instead of using ClipEntry,
 // because getClipEntry is a suspend function, but in ContextMenu.desktop.kt we have older code

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
@@ -84,8 +84,8 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return transferable.isDataFlavorSupported(DataFlavor.stringFlavor)
 }
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean = true
-internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean = true
+internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean = this != null
+internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean = this != null
 
 // Here we rely on the NativeClipboard directly instead of using ClipEntry,
 // because getClipEntry is a suspend function, but in ContextMenu.desktop.kt we have older code

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
@@ -84,6 +84,9 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return transferable.isDataFlavorSupported(DataFlavor.stringFlavor)
 }
 
+internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean = true
+internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean = true
+
 // Here we rely on the NativeClipboard directly instead of using ClipEntry,
 // because getClipEntry is a suspend function, but in ContextMenu.desktop.kt we have older code
 // expecting a synchronous execution.

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
@@ -19,6 +19,7 @@
 package androidx.compose.foundation.internal
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.text.AnnotatedString
 import kotlin.js.Promise
@@ -27,8 +28,11 @@ import org.w3c.files.Blob
 
 private const val MIME_TYPE_PLAIN_TEXT = "text/plain"
 
+@OptIn(InternalComposeUiApi::class)
 internal actual suspend fun ClipEntry.readText(): String? {
     if (!this.hasText()) return null
+    if (this.fallbackPlainText != null) return this.fallbackPlainText
+
     if (this.clipboardItems.isEmpty()) return null
     val blob = clipboardItems[0].getType(MIME_TYPE_PLAIN_TEXT).await<Blob>()
     return getTextFromBlob(blob).await<String>().toString()
@@ -44,11 +48,19 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
     return ClipEntry.withPlainText(this.text)
 }
 
+@OptIn(InternalComposeUiApi::class)
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
+    if (this.fallbackPlainText != null) return true
     if (this.clipboardItems.isEmpty()) return false
     return doesJsArrayContainValue(this.clipboardItems[0].types, MIME_TYPE_PLAIN_TEXT)
 }
+
+internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean =
+    js("window.navigator.clipboard && window.navigator.clipboard.read")
+
+internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean =
+    js("window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText)")
 
 @Suppress("UNUSED_PARAMETER")
 private fun doesJsArrayContainValue(jsArray: Array<*>, value: Any): Boolean =

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
@@ -21,6 +21,7 @@ package androidx.compose.foundation.internal
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -56,10 +57,10 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return doesJsArrayContainValue(this.clipboardItems[0].types, MIME_TYPE_PLAIN_TEXT)
 }
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean =
+internal actual fun Clipboard?.isReadSupported(): Boolean =
     js("window.navigator.clipboard && window.navigator.clipboard.read")
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean =
+internal actual fun Clipboard?.isWriteSupported(): Boolean =
     js("window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText)")
 
 @Suppress("UNUSED_PARAMETER")

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
@@ -57,10 +57,10 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return doesJsArrayContainValue(this.clipboardItems[0].types, MIME_TYPE_PLAIN_TEXT)
 }
 
-internal actual fun Clipboard?.isReadSupported(): Boolean =
+internal actual fun Clipboard.isReadSupported(): Boolean =
     js("window.navigator.clipboard && window.navigator.clipboard.read")
 
-internal actual fun Clipboard?.isWriteSupported(): Boolean =
+internal actual fun Clipboard.isWriteSupported(): Boolean =
     js("window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText)")
 
 @Suppress("UNUSED_PARAMETER")

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.macos.kt
@@ -39,8 +39,8 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean = this?.getPlainText() != null
 
-internal actual fun Clipboard?.isReadSupported(): Boolean = this != null
-internal actual fun Clipboard?.isWriteSupported(): Boolean = this != null
+internal actual fun Clipboard.isReadSupported(): Boolean = true
+internal actual fun Clipboard.isWriteSupported(): Boolean = true
 
 internal fun NativeClipboard.hasText(): Boolean {
     return this.types?.contains(platform.AppKit.NSPasteboardTypeString) ?: false

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.macos.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.NativeClipboard
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.Clipboard
 
 
 internal actual suspend fun ClipEntry.readText(): String? = getPlainText()
@@ -38,8 +39,8 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean = this?.getPlainText() != null
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean = true
-internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean = true
+internal actual fun Clipboard?.isReadSupported(): Boolean = this != null
+internal actual fun Clipboard?.isWriteSupported(): Boolean = this != null
 
 internal fun NativeClipboard.hasText(): Boolean {
     return this.types?.contains(platform.AppKit.NSPasteboardTypeString) ?: false

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.macos.kt
@@ -38,6 +38,9 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean = this?.getPlainText() != null
 
+internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean = true
+internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean = true
+
 internal fun NativeClipboard.hasText(): Boolean {
     return this.types?.contains(platform.AppKit.NSPasteboardTypeString) ?: false
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.skiko.kt
@@ -35,7 +35,7 @@ internal fun SelectionManager.contextMenuBuilder(
     }
 
     listOf(
-        selectionItem(Copy, enabled = isNonEmptySelection()) { copy() },
+        selectionItem(Copy, enabled = canCopy()) { copy() },
         selectionItem(SelectAll, enabled = !isEntireContainerSelected()) { selectAll() },
     )
 }

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
@@ -38,5 +38,5 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean = this?.hasPlainText() ?: false
 
-internal actual fun Clipboard?.isReadSupported(): Boolean = true
-internal actual fun Clipboard?.isWriteSupported(): Boolean = true
+internal actual fun Clipboard?.isReadSupported(): Boolean = this != null
+internal actual fun Clipboard?.isWriteSupported(): Boolean = this != null

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
@@ -20,6 +20,7 @@ package androidx.compose.foundation.internal
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 
 
@@ -36,3 +37,6 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 }
 
 internal actual fun ClipEntry?.hasText(): Boolean = this?.hasPlainText() ?: false
+
+internal actual fun Clipboard?.isReadSupported(): Boolean = true
+internal actual fun Clipboard?.isWriteSupported(): Boolean = true

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.uikit.kt
@@ -38,5 +38,5 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean = this?.hasPlainText() ?: false
 
-internal actual fun Clipboard?.isReadSupported(): Boolean = this != null
-internal actual fun Clipboard?.isWriteSupported(): Boolean = this != null
+internal actual fun Clipboard.isReadSupported(): Boolean = true
+internal actual fun Clipboard.isWriteSupported(): Boolean = true

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
@@ -21,6 +21,7 @@ package androidx.compose.foundation.internal
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -57,13 +58,13 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return doesJsArrayContainValue(this.clipboardItems.get(0)!!.types, MIME_TYPE_PLAIN_TEXT_JS)
 }
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean =
+internal actual fun Clipboard?.isReadSupported(): Boolean =
     isClipboardReadSupported()
 
 private fun isClipboardReadSupported(): Boolean =
     js("Boolean(window.navigator.clipboard && window.navigator.clipboard.read)")
 
-internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean =
+internal actual fun Clipboard?.isWriteSupported(): Boolean =
     isClipboardWriteSupported()
 
 private fun isClipboardWriteSupported(): Boolean =

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
@@ -19,7 +19,9 @@
 package androidx.compose.foundation.internal
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -28,8 +30,11 @@ import org.w3c.files.Blob
 private const val MIME_TYPE_PLAIN_TEXT = "text/plain"
 private val MIME_TYPE_PLAIN_TEXT_JS = MIME_TYPE_PLAIN_TEXT.toJsString()
 
+@OptIn(InternalComposeUiApi::class)
 internal actual suspend fun ClipEntry.readText(): String? {
     if (!this.hasText()) return null
+    if (this.fallbackPlainText != null) return this.fallbackPlainText
+
     if (this.clipboardItems.length == 0) return null
     val blob = clipboardItems[0]!!.getType(MIME_TYPE_PLAIN_TEXT_JS).await<Blob>()
     return getTextFromBlob(blob).await<JsString>().toString()
@@ -45,11 +50,25 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
     return ClipEntry.withPlainText(this.text)
 }
 
+@OptIn(InternalComposeUiApi::class)
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
+    if (this.fallbackPlainText != null) return true
     if (this.clipboardItems.length == 0) return false
     return doesJsArrayContainValue(this.clipboardItems.get(0)!!.types, MIME_TYPE_PLAIN_TEXT_JS)
 }
+
+internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): Boolean =
+    isClipboardReadSupported()
+
+private fun isClipboardReadSupported(): Boolean =
+    js("window.navigator.clipboard && window.navigator.clipboard.read")
+
+internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean =
+    isClipboardWriteSupported()
+
+private fun isClipboardWriteSupported(): Boolean =
+    js("window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText)")
 
 @Suppress("UNUSED_PARAMETER")
 private fun doesJsArrayContainValue(jsArray: JsArray<*>, value: JsAny): Boolean =

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
@@ -58,13 +58,13 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return doesJsArrayContainValue(this.clipboardItems.get(0)!!.types, MIME_TYPE_PLAIN_TEXT_JS)
 }
 
-internal actual fun Clipboard?.isReadSupported(): Boolean =
+internal actual fun Clipboard.isReadSupported(): Boolean =
     isClipboardReadSupported()
 
 private fun isClipboardReadSupported(): Boolean =
     js("Boolean(window.navigator.clipboard && window.navigator.clipboard.read)")
 
-internal actual fun Clipboard?.isWriteSupported(): Boolean =
+internal actual fun Clipboard.isWriteSupported(): Boolean =
     isClipboardWriteSupported()
 
 private fun isClipboardWriteSupported(): Boolean =

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
@@ -21,7 +21,6 @@ package androidx.compose.foundation.internal
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.text.AnnotatedString
 import kotlin.js.Promise
 import kotlinx.coroutines.await
@@ -62,13 +61,13 @@ internal actual fun androidx.compose.ui.platform.Clipboard?.isReadSupported(): B
     isClipboardReadSupported()
 
 private fun isClipboardReadSupported(): Boolean =
-    js("window.navigator.clipboard && window.navigator.clipboard.read")
+    js("Boolean(window.navigator.clipboard && window.navigator.clipboard.read)")
 
 internal actual fun androidx.compose.ui.platform.Clipboard?.isWriteSupported(): Boolean =
     isClipboardWriteSupported()
 
 private fun isClipboardWriteSupported(): Boolean =
-    js("window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText)")
+    js("Boolean(window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText))")
 
 @Suppress("UNUSED_PARAMETER")
 private fun doesJsArrayContainValue(jsArray: JsArray<*>, value: JsAny): Boolean =

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.web.kt
@@ -71,7 +71,7 @@ internal actual fun Modifier.addSelectionContainerTextContextMenuComponents(
 
     with(selectionManager) {
         separator()
-        selectionContainerItem(Copy, enabled = isNonEmptySelection()) { copy() }
+        selectionContainerItem(Copy, enabled = canCopy()) { copy() }
         selectionContainerItem(
             item = SelectAll,
             enabled = !isEntireContainerSelected(),

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
@@ -17,12 +17,23 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import kotlin.js.Promise
-import kotlinx.browser.window
 import kotlinx.coroutines.await
 import org.w3c.files.Blob
 
 actual typealias NativeClipboard = W3CTemporaryClipboard
+
+
+private val isSecureContext: Boolean by lazy {
+    isSecureContext()
+}
+
+// We don't expect the availability of browser APIs to change at runtime, so detect it and save
+// It's necessary for https://youtrack.jetbrains.com/issue/CMP-8631
+private val isFullClipboardApiSupported: Boolean by lazy {
+    isSecureContext && isFullClipboardApiSupported()
+}
 
 class JsPlatformClipboard : Clipboard {
 
@@ -33,6 +44,11 @@ class JsPlatformClipboard : Clipboard {
     private val emptyClipboardItems = emptyArray<ClipboardItem>()
 
     override suspend fun getClipEntry(): ClipEntry? {
+        if (!isFullClipboardApiSupported) {
+            console.warn("The browser doesn't support Clipboard.read()")
+            return null
+        }
+
         val items = nativeClipboard.read().catch {
             // The most common reason is that the permission was denied
             println("Failed to read from Clipboard: $it")
@@ -42,30 +58,26 @@ class JsPlatformClipboard : Clipboard {
     }
 
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        if (clipEntry == null) {
-            nativeClipboard.write(emptyClipboardItems()).await<Any?>()
-            return
+        when {
+            isFullClipboardApiSupported -> if (clipEntry == null) {
+                // clear the clipboard
+                nativeClipboard.write(emptyClipboardItems()).await<Any?>()
+            } else {
+                nativeClipboard.write(clipEntry.clipboardItems).await<Any?>()
+            }
+            isFallbackWriteTextApiAvailable() -> {
+                val text = clipEntry?.fallbackPlainText ?: ""
+                nativeClipboard.writeText(text).await<Any?>()
+            }
+            else -> console.warn("The browser doesn't support Clipboard.write() and Clipboard.writeText()")
         }
-        nativeClipboard.write(clipEntry.clipboardItems).await<Any?>()
     }
 
     override val nativeClipboard: NativeClipboard
         get() = browserClipboard
 }
 
-private fun getW3CClipboard(): W3CTemporaryClipboard =
-    js("window.navigator.clipboard")
-
-internal actual fun createPlatformClipboard(): Clipboard {
-    return if (isSecureContext()) {
-        JsPlatformClipboard()
-    } else {
-        DumbInsecureContextClipboard()
-    }
-}
-
-private fun isSecureContext(): Boolean =
-    window.asDynamic().isSecureContext == true
+internal actual fun createPlatformClipboard(): Clipboard = JsPlatformClipboard()
 
 actual class ClipEntry
 @ExperimentalComposeUiApi
@@ -75,13 +87,25 @@ constructor(val clipboardItems: Array<ClipboardItem>) {
     actual val clipMetadata: ClipMetadata
         get() = TODO("ClipMetadata is not implemented. Consider using nativeClipboard")
 
+    @InternalComposeUiApi
+    var fallbackPlainText: String? = null
+
     companion object {
         fun withPlainText(text: String): ClipEntry {
-            if (!isSecureContext()) {
+            if (!isSecureContext) {
                 println("ClipboardItem is not available in insecure contexts.")
-                return ClipEntry(emptyArray())
             }
-            return ClipEntry(createClipboardItemWithPlainText(text))
+            return when {
+                isFullClipboardApiSupported -> ClipEntry(
+                    if (isSecureContext) {
+                        createClipboardItemWithPlainText(text)
+                    } else {
+                        emptyClipboardItems()
+                    }
+                )
+                else -> ClipEntry(emptyArray())
+                    .apply { fallbackPlainText = text }
+            }
         }
     }
 }
@@ -97,7 +121,7 @@ private fun emptyClipboardItems(): Array<ClipboardItem> =
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
  *
- * We declare this external interface temporary, because
+ * We declare this external interface temporary because
  * the IDL in kotlinx-browser is incorrect:
  * https://github.com/Kotlin/kotlinx-browser/issues/14
  */
@@ -106,12 +130,13 @@ private fun emptyClipboardItems(): Array<ClipboardItem> =
 external class W3CTemporaryClipboard {
     fun read(): Promise<Array<ClipboardItem>>
     fun write(data: Array<ClipboardItem>): Promise<Nothing>
+    fun writeText(text: String): Promise<Nothing>
 }
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
  *
- * We declare this external interface temporary, because
+ * We declare this external interface temporary because
  * the IDL in kotlinx-browser is incorrect:
  * https://github.com/Kotlin/kotlinx-browser/issues/14
  */
@@ -120,29 +145,4 @@ external class W3CTemporaryClipboard {
 external interface ClipboardItem {
     val types: Array<String>
     fun getType(type: String): Promise<Blob>
-}
-
-/**
- * This Clipboard implementation is dumb.
- * It's created when window.isSecureContext != true.
- * See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
- */
-private class DumbInsecureContextClipboard : Clipboard {
-
-    override suspend fun getClipEntry(): ClipEntry? {
-        println("Clipboard is not available in insecure contexts.")
-        return null
-    }
-
-    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        println("Clipboard is not available in insecure contexts.")
-    }
-
-    private val browserClipboard by lazy {
-        println("Clipboard is not available in insecure contexts.")
-        getW3CClipboard()
-    }
-
-    override val nativeClipboard: NativeClipboard
-        get() = browserClipboard
 }

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
@@ -24,7 +24,6 @@ import org.w3c.files.Blob
 
 actual typealias NativeClipboard = W3CTemporaryClipboard
 
-
 private val isSecureContext: Boolean by lazy {
     isSecureContext()
 }
@@ -35,10 +34,24 @@ private val isFullClipboardApiSupported: Boolean by lazy {
     isSecureContext && isFullClipboardApiSupported()
 }
 
+private val isFallbackWriteTextApiAvailable: Boolean by lazy {
+    isSecureContext && isFallbackWriteTextApiAvailable()
+}
+
 class JsPlatformClipboard : Clipboard {
 
     private val browserClipboard by lazy {
         getW3CClipboard()
+    }
+
+    init {
+        if (!isSecureContext) {
+            console.warn("Clipboard API is not available in insecure contexts.")
+        } else if (!isFallbackWriteTextApiAvailable) {
+            console.warn("The browser doesn't support Clipboard.read(), Clipboard.write() and Clipboard.writeText()")
+        } else if (!isFullClipboardApiSupported) {
+            console.warn("The browser doesn't support Clipboard.read() and Clipboard.write()")
+        }
     }
 
     private val emptyClipboardItems = emptyArray<ClipboardItem>()
@@ -77,7 +90,9 @@ class JsPlatformClipboard : Clipboard {
         get() = browserClipboard
 }
 
-internal actual fun createPlatformClipboard(): Clipboard = JsPlatformClipboard()
+private val jsPlatformClipboard: JsPlatformClipboard by lazy { JsPlatformClipboard() }
+
+internal actual fun createPlatformClipboard(): Clipboard = jsPlatformClipboard
 
 actual class ClipEntry
 @ExperimentalComposeUiApi
@@ -92,9 +107,6 @@ constructor(val clipboardItems: Array<ClipboardItem>) {
 
     companion object {
         fun withPlainText(text: String): ClipEntry {
-            if (!isSecureContext) {
-                println("ClipboardItem is not available in insecure contexts.")
-            }
             return when {
                 isFullClipboardApiSupported -> ClipEntry(
                     if (isSecureContext) {

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
@@ -36,10 +36,24 @@ private val isFullClipboardApiSupported: Boolean by lazy {
     isSecureContext && isFullClipboardApiSupported()
 }
 
+private val isFallbackWriteTextApiAvailable: Boolean by lazy {
+    isSecureContext && isFallbackWriteTextApiAvailable()
+}
+
 class WasmPlatformClipboard : Clipboard {
 
     private val browserClipboard by lazy {
         getW3CClipboard()
+    }
+
+    init {
+        if (!isSecureContext) {
+            warn("Clipboard API is not available in insecure contexts.")
+        } else if (!isFallbackWriteTextApiAvailable) {
+            warn("The browser doesn't support Clipboard.read(), Clipboard.write() and Clipboard.writeText()")
+        } else if (!isFullClipboardApiSupported) {
+            warn("The browser doesn't support Clipboard.read() and Clipboard.write()")
+        }
     }
 
     private val emptyClipboardItems = emptyArray<ClipboardItem>().toJsArray()
@@ -59,9 +73,6 @@ class WasmPlatformClipboard : Clipboard {
     }
 
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        if (!isSecureContext) {
-            println("Clipboard API is not available in insecure contexts.")
-        }
         when {
             isFullClipboardApiSupported -> if (clipEntry == null) {
                 // clear the clipboard
@@ -69,7 +80,7 @@ class WasmPlatformClipboard : Clipboard {
             } else {
                 nativeClipboard.write(clipEntry.clipboardItems).await<Any?>()
             }
-            isFallbackWriteTextApiAvailable() -> {
+            isFallbackWriteTextApiAvailable -> {
                 val text = clipEntry?.fallbackPlainText ?: ""
                 nativeClipboard.writeText(text).await<Any?>()
             }
@@ -81,7 +92,9 @@ class WasmPlatformClipboard : Clipboard {
         get() = browserClipboard
 }
 
-internal actual fun createPlatformClipboard(): Clipboard = WasmPlatformClipboard()
+private val wasmPlatformClipboard: WasmPlatformClipboard by lazy { WasmPlatformClipboard() }
+
+internal actual fun createPlatformClipboard(): Clipboard = wasmPlatformClipboard
 
 actual class ClipEntry
 @ExperimentalComposeUiApi
@@ -96,9 +109,6 @@ constructor(val clipboardItems: JsArray<ClipboardItem>) {
 
     companion object {
         fun withPlainText(text: String): ClipEntry {
-            if (!isSecureContext) {
-                println("ClipboardItem is not available in insecure contexts.")
-            }
             return when {
                 isFullClipboardApiSupported -> ClipEntry(
                     if (isSecureContext) {

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
@@ -17,12 +17,24 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
+import kotlin.getValue
 import kotlin.js.Promise
 import kotlinx.browser.window
 import kotlinx.coroutines.await
 import org.w3c.files.Blob
 
 actual typealias NativeClipboard = W3CTemporaryClipboard
+
+private val isSecureContext: Boolean by lazy {
+    isSecureContext()
+}
+
+// We don't expect the availability of browser APIs to change at runtime, so detect it and save
+// It's necessary for https://youtrack.jetbrains.com/issue/CMP-8631
+private val isFullClipboardApiSupported: Boolean by lazy {
+    isSecureContext && isFullClipboardApiSupported()
+}
 
 class WasmPlatformClipboard : Clipboard {
 
@@ -33,6 +45,11 @@ class WasmPlatformClipboard : Clipboard {
     private val emptyClipboardItems = emptyArray<ClipboardItem>().toJsArray()
 
     override suspend fun getClipEntry(): ClipEntry? {
+        if (!isFullClipboardApiSupported) {
+            warn("The browser doesn't support Clipboard.read()")
+            return null
+        }
+
         val items = nativeClipboard.read().catch {
             // The most common reason is that the permission was denied
             println("Failed to read from Clipboard: $it")
@@ -42,27 +59,29 @@ class WasmPlatformClipboard : Clipboard {
     }
 
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        if (clipEntry == null) {
-            nativeClipboard.write(emptyClipboardItems()).await<JsAny>()
-            return
+        if (!isSecureContext) {
+            println("Clipboard API is not available in insecure contexts.")
         }
-        nativeClipboard.write(clipEntry.clipboardItems).await<JsAny>()
+        when {
+            isFullClipboardApiSupported -> if (clipEntry == null) {
+                // clear the clipboard
+                nativeClipboard.write(emptyClipboardItems()).await<Any?>()
+            } else {
+                nativeClipboard.write(clipEntry.clipboardItems).await<Any?>()
+            }
+            isFallbackWriteTextApiAvailable() -> {
+                val text = clipEntry?.fallbackPlainText ?: ""
+                nativeClipboard.writeText(text).await<Any?>()
+            }
+            else -> warn("The browser doesn't support Clipboard.write() and Clipboard.writeText()")
+        }
     }
 
     override val nativeClipboard: NativeClipboard
         get() = browserClipboard
 }
 
-private fun getW3CClipboard(): W3CTemporaryClipboard =
-    js("window.navigator.clipboard")
-
-internal actual fun createPlatformClipboard(): Clipboard {
-    return if (isSecureContext().toBoolean()) {
-        WasmPlatformClipboard()
-    } else {
-        DumbInsecureContextClipboard()
-    }
-}
+internal actual fun createPlatformClipboard(): Clipboard = WasmPlatformClipboard()
 
 actual class ClipEntry
 @ExperimentalComposeUiApi
@@ -72,13 +91,25 @@ constructor(val clipboardItems: JsArray<ClipboardItem>) {
     actual val clipMetadata: ClipMetadata
         get() = TODO("ClipMetadata is not implemented. Consider using nativeClipboard")
 
+    @InternalComposeUiApi
+    var fallbackPlainText: String? = null
+
     companion object {
         fun withPlainText(text: String): ClipEntry {
-            if (!isSecureContext().toBoolean()) {
+            if (!isSecureContext) {
                 println("ClipboardItem is not available in insecure contexts.")
-                return ClipEntry(invalidClipboardItems())
             }
-            return ClipEntry(createClipboardItemWithPlainText(text))
+            return when {
+                isFullClipboardApiSupported -> ClipEntry(
+                    if (isSecureContext) {
+                        createClipboardItemWithPlainText(text)
+                    } else {
+                        emptyClipboardItems()
+                    }
+                )
+                else -> ClipEntry(invalidClipboardItems())
+                    .apply { fallbackPlainText = text }
+            }
         }
     }
 }
@@ -91,17 +122,19 @@ private fun createClipboardItemWithPlainText(text: String): JsArray<ClipboardIte
 private fun emptyClipboardItems(): JsArray<ClipboardItem> =
     js("[new ClipboardItem({'text/plain': new Blob([''], { type: 'text/plain' })})]")
 
-private fun isSecureContext(): JsBoolean = js("window.isSecureContext")
-
 // We use it when we detect isSecureContext() != true,
 // because we can't call ClipboardItem constructor - it's undefined.
 private fun invalidClipboardItems(): JsArray<ClipboardItem> =
     js("[]")
 
+private fun warn(text: String) {
+    js("console.warn(text)")
+}
+
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
  *
- * We declare this external interface temporary, because
+ * We declare this external interface temporary because
  * the IDL in kotlinx-browser is incorrect:
  * https://github.com/Kotlin/kotlinx-browser/issues/14
  */
@@ -110,12 +143,13 @@ private fun invalidClipboardItems(): JsArray<ClipboardItem> =
 external class W3CTemporaryClipboard {
     fun read(): Promise<JsArray<ClipboardItem>>
     fun write(data: JsArray<ClipboardItem>): Promise<Nothing>
+    fun writeText(text: String): Promise<Nothing>
 }
 
 /**
  * https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API
  *
- * We declare this external interface temporary, because
+ * We declare this external interface temporary because
  * the IDL in kotlinx-browser is incorrect:
  * https://github.com/Kotlin/kotlinx-browser/issues/14
  */
@@ -124,29 +158,4 @@ external class W3CTemporaryClipboard {
 external interface ClipboardItem : JsAny {
     val types: JsArray<JsString>
     fun getType(type: JsString): Promise<Blob>
-}
-
-/**
- * This Clipboard implementation is dumb.
- * It's created when window.isSecureContext != true.
- * See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
- */
-private class DumbInsecureContextClipboard : Clipboard {
-
-    override suspend fun getClipEntry(): ClipEntry? {
-        println("Clipboard is not available in insecure contexts.")
-        return null
-    }
-
-    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        println("Clipboard is not available in insecure contexts.")
-    }
-
-    private val browserClipboard by lazy {
-        println("Clipboard is not available in insecure contexts.")
-        getW3CClipboard()
-    }
-
-    override val nativeClipboard: NativeClipboard
-        get() = browserClipboard
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/PlatformClipboard.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/PlatformClipboard.w3c.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+// clipboard.read(), clipboard.write(), ClipboardItem are not available in FF < 127 versions
+// https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/read#browser_compatibility
+// https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write#browser_compatibility
+// It's possible to fall back to clipboard.writeText() if the content type is a text.
+internal fun isFullClipboardApiSupported(): Boolean =
+    js("""
+        window.navigator.clipboard && 
+        window.navigator.clipboard.write && 
+        window.navigator.clipboard.read && 
+        typeof(ClipboardItem) !== 'undefined'
+    """)
+
+internal fun isSecureContext(): Boolean = js("window.isSecureContext === true")
+
+internal fun isFallbackWriteTextApiAvailable(): Boolean =
+    js("window.navigator.clipboard && window.navigator.clipboard.writeText")
+
+/**
+ * This Clipboard implementation is dumb.
+ * It's created when window.isSecureContext != true.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
+ */
+internal class DumbInsecureContextClipboard : Clipboard {
+
+    override suspend fun getClipEntry(): ClipEntry? {
+        println("Clipboard is not available in insecure contexts.")
+        return null
+    }
+
+    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+        println("Clipboard is not available in insecure contexts.")
+    }
+
+    private val browserClipboard by lazy {
+        println("Clipboard is not available in insecure contexts.")
+        getW3CClipboard()
+    }
+
+    override val nativeClipboard: NativeClipboard
+        get() = browserClipboard
+}
+
+internal fun getW3CClipboard(): NativeClipboard = js("window.navigator.clipboard")

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/PlatformClipboard.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/PlatformClipboard.w3c.kt
@@ -21,41 +21,19 @@ package androidx.compose.ui.platform
 // https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/write#browser_compatibility
 // It's possible to fall back to clipboard.writeText() if the content type is a text.
 internal fun isFullClipboardApiSupported(): Boolean =
-    js("""
+    js(
+        """Boolean(
         window.navigator.clipboard && 
         window.navigator.clipboard.write && 
         window.navigator.clipboard.read && 
         typeof(ClipboardItem) !== 'undefined'
-    """)
+        )
+    """
+    )
 
 internal fun isSecureContext(): Boolean = js("window.isSecureContext === true")
 
 internal fun isFallbackWriteTextApiAvailable(): Boolean =
-    js("window.navigator.clipboard && window.navigator.clipboard.writeText")
-
-/**
- * This Clipboard implementation is dumb.
- * It's created when window.isSecureContext != true.
- * See https://developer.mozilla.org/en-US/docs/Web/API/Clipboard
- */
-internal class DumbInsecureContextClipboard : Clipboard {
-
-    override suspend fun getClipEntry(): ClipEntry? {
-        println("Clipboard is not available in insecure contexts.")
-        return null
-    }
-
-    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        println("Clipboard is not available in insecure contexts.")
-    }
-
-    private val browserClipboard by lazy {
-        println("Clipboard is not available in insecure contexts.")
-        getW3CClipboard()
-    }
-
-    override val nativeClipboard: NativeClipboard
-        get() = browserClipboard
-}
+    js("Boolean(window.navigator.clipboard && window.navigator.clipboard.writeText)")
 
 internal fun getW3CClipboard(): NativeClipboard = js("window.navigator.clipboard")


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8631

<img width="262" height="123" alt="Screenshot 2025-07-24 at 15 33 41" src="https://github.com/user-attachments/assets/3c4a1360-15f6-404f-abde-fc143542bc93" />

<img width="364" height="256" alt="Screenshot 2025-07-24 at 15 33 34" src="https://github.com/user-attachments/assets/bd67c25c-ca29-45f8-adfc-16f81334da86" />


## Testing
This should be tested by QA

## Release Notes 
### Fixes - Web
- _(prerelease fix)_ The context menu will not show the Clipboard-related items when the Clipboard API are not supported by a browser

