### PR TITLE
Show the "paste" item regardless of the the clipboard content state if the Clipboard  API is supported

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
@@ -20,7 +20,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.ComposeFoundationFlags
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.internal.checkPreconditionNotNull
-import androidx.compose.foundation.internal.hasText
 import androidx.compose.foundation.internal.readAnnotatedString
 import androidx.compose.foundation.internal.toClipEntry
 import androidx.compose.foundation.text.DefaultCursorThickness
@@ -54,7 +53,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.TextToolbar
 import androidx.compose.ui.platform.TextToolbarStatus
@@ -201,10 +199,7 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
      */
     internal var latestSelection: TextRange? = null
 
-    // TODO(grantapher) android ClipboardManager has a way to notify primary clip changes.
-    //  That could possibly be used so that this doesn't have to be updated manually.
-    /** The current clip entry. Updated via [updateClipboardEntry]. */
-    private var clipEntry: ClipEntry? by mutableStateOf(null)
+    private var hasAvailableTextToPaste by mutableStateOf(false)
 
     @VisibleForTesting internal var toolbarRequester: ToolbarRequester = ToolbarRequesterImpl()
 
@@ -776,7 +771,7 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
     internal fun canCopy(): Boolean = hasSelection && !isPassword
 
     internal suspend fun updateClipboardEntry() {
-        clipEntry = clipboard?.getClipEntry()
+        hasAvailableTextToPaste = hasAvailableTextToPaste()
     }
 
     private suspend fun notifyPlatformSelectionBehaviorsOnShowContextMenu() {
@@ -794,7 +789,7 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
     }
 
     /** Only fully accurate if [updateClipboardEntry] has been called. */
-    internal fun canPaste(): Boolean = editable && clipEntry?.hasText() == true
+    internal fun canPaste(): Boolean = editable && hasAvailableTextToPaste
 
     internal fun canCut(): Boolean = hasSelection && editable && !isPassword
 
@@ -1021,6 +1016,8 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
      */
     private fun showSelectionToolbarViaTextToolbar() =
         coroutineScope?.launch(start = CoroutineStart.UNDISPATCHED) {
+            updateClipboardEntry()
+
             // Because this is undispatched and the above is called once in CoreTextField
             // composition, disable read observation to avoid reading many states and landing
             // in a composition loop.
@@ -1041,7 +1038,6 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
                         }
                     } else null
 
-                updateClipboardEntry()
                 val paste: (() -> Unit)? =
                     if (canPaste()) {
                         {
@@ -1400,3 +1396,6 @@ internal expect fun Modifier.addBasicTextFieldTextContextMenuComponents(
     manager: TextFieldSelectionManager,
     coroutineScope: CoroutineScope,
 ): Modifier
+
+//TODO upstream https://youtrack.jetbrains.com/issue/CMP-7517
+internal expect suspend fun TextFieldSelectionManager.hasAvailableTextToPaste(): Boolean

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.text.selection
 
+import androidx.compose.foundation.internal.hasText
 import androidx.compose.foundation.text.DesktopTextContextMenuItems
 import androidx.compose.foundation.text.DesktopTextContextMenuItems.Copy
 import androidx.compose.foundation.text.DesktopTextContextMenuItems.Cut
@@ -79,4 +80,8 @@ internal actual fun Modifier.addBasicTextFieldTextContextMenuComponents(
         textFieldItem(SelectAll, enabled = canSelectAll()) { selectAll() }
         separator()
     }
+}
+
+internal actual suspend fun TextFieldSelectionManager.hasAvailableTextToPaste(): Boolean {
+    return clipboard?.getClipEntry()?.hasText() == true
 }

--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
@@ -46,10 +46,7 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
-    // Empty clipboardItems here mean that the read from web clipboard was ended with an error.
-    // The most common reason is that the permission was denied.
-    // In this case we want to show the "paste" menu item anyway.
-    if (this.clipboardItems.isEmpty()) return true
+    if (this.clipboardItems.isEmpty()) return false
     return doesJsArrayContainValue(this.clipboardItems[0].types, MIME_TYPE_PLAIN_TEXT)
 }
 

--- a/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.native.kt
+++ b/compose/foundation/foundation/src/nativeMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.native.kt
@@ -14,15 +14,10 @@
  * limitations under the License.
  */
 
-package androidx.compose.foundation.text.input.internal.selection
+package androidx.compose.foundation.text.selection
 
-import androidx.compose.ui.platform.Clipboard
+import androidx.compose.foundation.internal.hasText
 
-// the paste state is needed to show or hide the "paste" context menu item.
-// in browsers we don't want to bother users by a permission request,
-// so we return unconditionally true
-internal actual class ClipboardPasteState actual constructor(private val clipboard: Clipboard) {
-    actual val hasText = true
-    actual val hasClip = true
-    actual suspend fun update() {}
+internal actual suspend fun TextFieldSelectionManager.hasAvailableTextToPaste(): Boolean {
+    return clipboard?.getClipEntry()?.hasText() == true
 }

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.wasm.kt
@@ -47,10 +47,7 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
-    // Empty clipboardItems here mean that the read from web clipboard was ended with an error.
-    // The most common reason is that the permission was denied.
-    // In this case we want to show the "paste" menu item anyway.
-    if (this.clipboardItems.length == 0) return true
+    if (this.clipboardItems.length == 0) return false
     return doesJsArrayContainValue(this.clipboardItems.get(0)!!.types, MIME_TYPE_PLAIN_TEXT_JS)
 }
 

--- a/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.wasm.kt
+++ b/compose/foundation/foundation/src/wasmJsMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.wasm.kt
@@ -16,23 +16,13 @@
 
 package androidx.compose.foundation.text.input.internal.selection
 
-import androidx.compose.foundation.internal.hasText
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.Clipboard
 
+// the paste state is needed to show or hide the "paste" context menu item.
+// in browsers we don't want to bother users by a permission request,
+// so we return unconditionally true
 internal actual class ClipboardPasteState actual constructor(private val clipboard: Clipboard) {
-    private var _hasClip = false
-    private var _hasText = false
-
-    actual val hasText: Boolean get() = _hasText
-    actual val hasClip: Boolean get() = _hasClip
-
-    // TODO: replace the experimental API usage when a common ClipEntry API is ready - https://youtrack.jetbrains.com/issue/CMP-7624
-    @OptIn(ExperimentalComposeUiApi::class)
-    actual suspend fun update() {
-        val entry = clipboard.getClipEntry()
-        val itemsSize = entry?.clipboardItems?.length ?: 0
-        _hasClip = itemsSize > 0
-        _hasText = entry?.hasText() ?: false
-    }
+    actual val hasText = true
+    actual val hasClip = true
+    actual suspend fun update() {}
 }

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.web.kt
@@ -78,3 +78,8 @@ internal actual fun Modifier.addBasicTextFieldTextContextMenuComponents(
         separator()
     }
 }
+
+// the paste state is needed to show or hide the "paste" context menu item.
+// in browsers we don't want to bother users by a permission request,
+// so we return unconditionally true
+internal actual suspend fun TextFieldSelectionManager.hasAvailableTextToPaste(): Boolean = true


### PR DESCRIPTION
It helps to avoid a unnecessary clipboard permission request

Additionally:
Extract a suspend call out of `Snapshot.withoutReadObservation` block to fix failing with snapshot mutations.

Fixes https://youtrack.jetbrains.com/issue/CMP-8601

## Release Notes
### Fixes - Web
- _(prerelease fix)_ Show the "paste" item regardless of the the clipboard content state if the Clipboard  API is supported
