### PR TITLE
Revert code changes, irrelevant for iOS magnifier

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/LongPressTextDragObserver.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/LongPressTextDragObserver.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.util.fastAny
-import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -77,13 +76,6 @@ internal suspend fun PointerInputScope.detectDownAndDragGesturesWithObserver(
     coroutineScope {
         launch(start = CoroutineStart.UNDISPATCHED) { detectPreDragGesturesWithObserver(observer) }
         launch(start = CoroutineStart.UNDISPATCHED) { detectDragGesturesWithObserver(observer) }
-            .invokeOnCompletion {
-                // Otherwise observer won't be notified if
-                // composable was disposed before the drag cancellation
-                if (it is CancellationException){
-                    observer.onCancel()
-                }
-            }
     }
 }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.kt
@@ -615,10 +615,7 @@ internal class TextFieldSelectionManager(val undoManager: UndoManager? = null) {
                 updateFloatingToolbar(show = true)
             }
 
-            override fun onCancel() {
-                draggingHandle = null
-                currentDragPosition = null
-            }
+            override fun onCancel() {}
         }
 
     /** [TextDragObserver] for dragging the cursor to change the selection in TextField. */


### PR DESCRIPTION
Revert code that makes no effect on iOS magnifier work.
Also, no need to upstream this code.

Previous PR and discussion: https://github.com/JetBrains/compose-multiplatform-core/pull/1713

Fixes https://youtrack.jetbrains.com/issue/CMP-5763/Upstreaming.-bug.-foundation.-iOS-magnifier.-fix-text-selection
Fixes https://youtrack.jetbrains.com/issue/CMP-5764/Upstreaming.-bug.-foundation.-iOS-magnifier.-fix-drag-cancellation

## Release Notes
N/A
