### PR TITLE
Dispose `SwingInteropContainer` after closing the scene

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -490,10 +490,6 @@ internal class ComposeSceneMediator(
 
         unsubscribe(contentComponent)
 
-        interopContainer.root.removeContainerListener(interopContainerListener)
-        // Since rendering will not happen after, we need to execute all scheduled updates
-        interopContainer.dispose()
-
         container.remove(contentComponent)
         container.remove(invisibleComponent)
         container.transferHandler = null
@@ -501,6 +497,11 @@ internal class ComposeSceneMediator(
 
         scene.close()
         skiaLayerComponent.dispose()
+
+        interopContainer.root.removeContainerListener(interopContainerListener)
+        // Since rendering will not happen after, we need to execute all scheduled updates
+        interopContainer.dispose()
+
         _onComponentAttached = null
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -53,6 +53,7 @@ import javax.swing.JFrame
 import javax.swing.JPanel
 import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.ExperimentalSkikoApi
@@ -504,6 +505,42 @@ class ComposePanelTest {
 
             assertEquals(1, enterEvents)
             assertEquals(1, exitEvents)
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun `ComposePanel clears SwingPanels when removed`() = runApplicationTest {
+        val jPanels = mutableListOf<JPanel>()
+        val composePanel = ComposePanel()
+        composePanel.setContent {
+            SwingPanel(
+                factory = {
+                    JPanel().also {
+                        it.size = Dimension(100, 100)
+                        jPanels.add(it)
+                    }
+                },
+                modifier = Modifier.size(100.dp)
+            )
+        }
+
+        val window = JFrame()
+        window.size = Dimension(200, 200)
+        try {
+            window.contentPane.add(composePanel, BorderLayout.CENTER)
+            window.isVisible = true
+            awaitIdle()
+            window.contentPane.remove(composePanel)
+            awaitIdle()
+            window.contentPane.add(composePanel)
+            awaitIdle()
+
+            assertEquals(2, jPanels.size)
+            assertFalse(composePanel.isAncestorOf(jPanels[0]))
+            assertTrue(composePanel.isAncestorOf(jPanels[1]))
+            assertTrue(jPanels[1].isShowing)
         } finally {
             window.dispose()
         }


### PR DESCRIPTION
In `ComposeSceneMediator.dispose()`, we currently call (swing)`interopContainer.dispose()` before disposing the scene, but disposing the scene schedules calls for the interop container, which are then never executed because the mediator is already disposed.

Fixes https://youtrack.jetbrains.com/issue/CMP-8679/ComposePanel-doesnt-remove-interop-components-on-own-removal

## Testing
Added a unit test

## Release Notes
### Fixes - Desktop
- Correctly remove `SwingPanel` children of `ComposePanel`, when the compose panel is itself removed from the hierarchy.

