### PR TITLE
CfW preventDefault the touch events only when Compose consumed an event

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -339,8 +339,6 @@ internal class ComposeWindow(
         var offset = Offset.Zero
 
         addTypedEvent<TouchEvent>("touchstart") { event ->
-            event.preventDefault()
-
             canvas.getBoundingClientRect().apply {
                 offset = Offset(x = left.toFloat(), y = top.toFloat())
             }
@@ -349,17 +347,14 @@ internal class ComposeWindow(
         }
 
         addTypedEvent<TouchEvent>("touchmove") { event ->
-            event.preventDefault()
             onTouchEvent(event, offset)
         }
 
         addTypedEvent<TouchEvent>("touchend") { event ->
-            event.preventDefault()
             onTouchEvent(event, offset)
         }
 
         addTypedEvent<TouchEvent>("touchcancel") { event ->
-            event.preventDefault()
             onTouchEvent(event, offset)
         }
 
@@ -547,7 +542,7 @@ internal class ComposeWindow(
         }
 
         activeTouchOffset = pointers.firstOrNull()?.position
-        scene.sendPointerEvent(
+        val result = scene.sendPointerEvent(
             eventType = eventType,
             pointers = pointers,
             buttons = PointerButtons(),
@@ -557,6 +552,10 @@ internal class ComposeWindow(
             button = null
         )
         activeTouchOffset = null
+
+        if (result.anyChangeConsumed) {
+            event.preventDefault()
+        }
     }
 
     private fun onMouseEvent(


### PR DESCRIPTION
Previously we called `event.preventDefault()` unconditionally. We need to preventDefault() only when Compose consumed/handled the event. This PR fixes that.

Fixes https://youtrack.jetbrains.com/issue/CMP-8100 (Mobile Chrome shows the keyboard again and again when touch events are always preventDefault())


## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- Fixed the issue with software keyboard when it was shown repeatedly in Chrome mobile
