### PR TITLE
Increase CanvasBasedWindow deprecation level to DeprecationLevel.ERROR

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -643,7 +643,10 @@ private const val defaultCanvasElementId = "ComposeTarget"
  * This can be turned off by setting [applyDefaultStyles] to false.
  */
 @ExperimentalComposeUiApi
-@Deprecated("CanvasBasedWindow doesn't support HTML interop via WebElementView API and it doesn't support A11Y feature. Use ComposeViewport API instead")
+@Deprecated(
+message = "CanvasBasedWindow doesn't support HTML interop via WebElementView API and it doesn't support A11Y feature. Use ComposeViewport API instead",
+replaceWith = ReplaceWith("ComposeViewport"),
+level = DeprecationLevel.ERROR)
 fun CanvasBasedWindow(
     title: String? = null,
     canvasElementId: String = defaultCanvasElementId,

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -645,7 +645,7 @@ private const val defaultCanvasElementId = "ComposeTarget"
 @ExperimentalComposeUiApi
 @Deprecated(
 message = "CanvasBasedWindow doesn't support HTML interop via WebElementView API and it doesn't support A11Y feature. Use ComposeViewport API instead",
-replaceWith = ReplaceWith("ComposeViewport"),
+replaceWith = ReplaceWith("ComposeViewport(content = content)"),
 level = DeprecationLevel.ERROR)
 fun CanvasBasedWindow(
     title: String? = null,


### PR DESCRIPTION
This PR deprecates CanvasBasedWindow on web platforms, making an attempt to use it a compilation error 


## Testing
`./gradlew testWeb` plus manual

## Release Notes
###  Migration Notes  - Web
- `CanvasBasedWindow` is deprecated, use `ComposeViewport` instead. Unlike `CanvasBasedWindow`, which expect as an input param the id to the `HTMLCanvasElement` that will be used for rendering, `ComposeViewport` one passes `parentContainer` (and corresponding HTML Canvas element will be created automatically). By default such container is `document.body`. 