### PR TITLE
Return 0x0 from ComposePanel.getPreferredSize instead of null

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -168,7 +168,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     override fun getPreferredSize(): Dimension? = if (isPreferredSizeSet) {
         super.getPreferredSize()
     } else  {
-        _composeContainer?.preferredSize
+        _composeContainer?.preferredSize ?: Dimension(0, 0)
     }
 
     /**

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -54,6 +54,7 @@ import javax.swing.JPanel
 import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.ExperimentalSkikoApi
@@ -544,5 +545,15 @@ class ComposePanelTest {
         } finally {
             window.dispose()
         }
+    }
+
+    @Test
+    fun `ComposePanel returns non-null preferred size before added to hierarchy`() = runApplicationTest {
+        val composePanel = ComposePanel()
+        composePanel.setContent {
+            Text("Hello")
+        }
+
+        assertNotNull(composePanel.preferredSize)
     }
 }


### PR DESCRIPTION
Returning `null` in `getPreferredSize` breaks some layouts, so return 0x0 instead.
This is also what AWT components return before they have a peer.

Fixes https://youtrack.jetbrains.com/issue/CMP-8687/ComposePanel.getPreferredSize-returns-null-before-being-added-to-hierarchy

## Testing
Tested manually and added a unit test.

## Release Notes
### Fixes - Desktop
- Change `ComposePanel.getPreferredSize` to return 0x0 instead of `null`.
