### PR TITLE
Fix non-focusable popup with `compose.layers.type=WINDOW` stealing focus

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
@@ -54,7 +54,7 @@ internal object ComposeFeatureFlags {
      * The default value is `OnSameCanvas`, implying that new layers
      * (such as for [Popup] and [Dialog]) are created within the initial canvas.
      */
-    val layerType: LayerType by lazy {
+    val layerType = FeatureFlag {
         LayerType.parse(System.getProperty("compose.layers.type"))
     }
 
@@ -71,7 +71,7 @@ internal object ComposeFeatureFlags {
      *
      * @see androidx.compose.ui.awt.RenderSettings.SwingGraphics
      */
-    val useSwingGraphicsInComposePanel: Boolean by lazy {
+    val useSwingGraphicsInComposePanel = FeatureFlag {
         System.getProperty("compose.swing.render.on.graphics").toBoolean()
     }
 
@@ -85,7 +85,24 @@ internal object ComposeFeatureFlags {
      * - On macOS, render and event dispatching order differs. It means that interop view might
      *   catch the mouse event even if visually it renders below Compose content
      */
-    val useInteropBlending: Boolean by lazy {
+    val useInteropBlending = FeatureFlag {
         System.getProperty("compose.interop.blending").toBoolean()
+    }
+}
+
+
+internal class FeatureFlag<T: Any>(defaultValueGetter: () -> T) {
+    private val defaultValue: T by lazy(defaultValueGetter)
+    private var override: T? = null
+    val value: T
+        get() = override ?: defaultValue
+
+    fun withOverride(value: T, block: () -> Unit) {
+        this.override = value
+        try {
+            block()
+        } finally {
+            this.override = null
+        }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -68,7 +68,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
          */
         @ExperimentalComposeUiApi
         val DefaultRenderSettings: RenderSettings by lazy {
-            if (ComposeFeatureFlags.useSwingGraphicsInComposePanel) {
+            if (ComposeFeatureFlags.useSwingGraphicsInComposePanel.value) {
                 SwingGraphics()
             } else {
                 SkiaSurface()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -56,7 +56,7 @@ internal class ComposeWindowPanel(
         window = window,
         windowContainer = this,
         savedState = savedState,
-        layerType = ComposeFeatureFlags.layerType.let {
+        layerType = ComposeFeatureFlags.layerType.value.let {
             // LayerType.OnComponent may can only be used with rendering via Swing graphics,
             // but it's always disabled here. Using fallback instead of [check] to support
             // opening separate windows from [ComposePanel] with such layer type.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -102,7 +102,7 @@ internal class ComposeContainer(
 
     savedState: SavedState? = null,
 
-    private val layerType: LayerType = ComposeFeatureFlags.layerType,
+    private val layerType: LayerType = ComposeFeatureFlags.layerType.value,
     private val renderSettings: RenderSettings = RenderSettings.SkiaSurface(),
 ) : WindowFocusListener,
     WindowListener,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -148,7 +148,8 @@ internal class ComposeSceneMediator(
      * @see ComposeFeatureFlags.useInteropBlending
      */
     private val useInteropBlending: Boolean
-        get() = ComposeFeatureFlags.useInteropBlending && skiaLayerComponent.interopBlendingSupported
+        get() = ComposeFeatureFlags.useInteropBlending.value &&
+            skiaLayerComponent.interopBlendingSupported
 
     /**
      * Adding any components below [contentComponent] makes our bridge non-transparent on macOS.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
-import androidx.compose.ui.scene.skia.WindowSkiaLayerComponent
 import androidx.compose.ui.skiko.OverlayRenderDecorator
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
@@ -56,17 +55,17 @@ internal class WindowComposeSceneLayer(
     compositionContext: CompositionContext,
     private val renderSettings: RenderSettings
 ) : DesktopComposeSceneLayer(composeContainer, density, layoutDirection) {
-    private val window get() = requireNotNull(composeContainer.window)
+    private val parentWindow get() = requireNotNull(composeContainer.window)
     private val windowContext = PlatformWindowContext().also {
         it.isWindowTransparent = true
         it.setContainerSize(windowContainer.sizeInPx)
     }
 
-    private val dialog = JDialog(
-        window,
+    private val layerWindow = JDialog(
+        parentWindow,
     ).also {
         it.isAlwaysOnTop = true
-        it.isFocusable = focusable
+        it.focusableWindowState = focusable
         it.isUndecorated = true
         it.background = getTransparentWindowBackground(
             isWindowTransparent = transparent,
@@ -85,7 +84,7 @@ internal class WindowComposeSceneLayer(
         it.layout = null
         it.isOpaque = !transparent
 
-        dialog.contentPane = it
+        layerWindow.contentPane = it
     }
 
     private val windowPositionListener = object : ComponentAdapter() {
@@ -99,7 +98,7 @@ internal class WindowComposeSceneLayer(
     override var focusable: Boolean = focusable
         set(value) {
             field = value
-            dialog.isFocusable = value
+            layerWindow.focusableWindowState = value
         }
 
     override var scrimColor: Color? = null
@@ -125,11 +124,11 @@ internal class WindowComposeSceneLayer(
         }
         onUpdateBounds()
 
-        dialog.isVisible = true
+        layerWindow.isVisible = true
 
         // Track window position in addition to [onChangeWindowPosition] because [windowContainer]
         // might be not the same as real [window].
-        window.addComponentListener(windowPositionListener)
+        parentWindow.addComponentListener(windowPositionListener)
 
         composeContainer.attachLayer(this)
     }
@@ -140,9 +139,9 @@ internal class WindowComposeSceneLayer(
         mediator?.dispose()
         mediator = null
 
-        window.removeComponentListener(windowPositionListener)
+        parentWindow.removeComponentListener(windowPositionListener)
 
-        dialog.dispose()
+        layerWindow.dispose()
     }
 
     override fun onWindowContainerPositionChanged() {
@@ -163,13 +162,13 @@ internal class WindowComposeSceneLayer(
     override fun onLayersChange() {
         // Force redraw because rendering depends on other layers
         // see [onRenderOverlay]
-        dialog.repaint()
+        layerWindow.repaint()
     }
 
     override fun onUpdateBounds() {
         val scaledRectangle = drawBounds.toAwtRectangle(density)
         setDialogLocation(scaledRectangle.x, scaledRectangle.y)
-        dialog.setSize(scaledRectangle.width, scaledRectangle.height)
+        layerWindow.setSize(scaledRectangle.width, scaledRectangle.height)
         mediator?.contentComponent?.setSize(scaledRectangle.width, scaledRectangle.height)
         mediator?.sceneBoundsInPx = Rect(
             offset = -drawBounds.topLeft.toOffset(),
@@ -222,7 +221,7 @@ internal class WindowComposeSceneLayer(
             return
         }
         val locationOnScreen = windowContainer.locationOnScreen
-        dialog.location = Point(
+        layerWindow.location = Point(
             locationOnScreen.x + x,
             locationOnScreen.y + y
         )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -38,6 +40,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performKeyPress
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
+import java.awt.Window
+import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -253,5 +257,33 @@ class DesktopPopupTest {
             .performKeyPress(KeyEvent(Key.Escape, KeyEventType.KeyUp))
         rule.waitForIdle()
         assertThat(onDismissRequestCallCount).isEqualTo(0)
+    }
+
+    @Test
+    fun nonFocusablePopup_withWindowLayerType_doesNotGrabFocus() {
+        ComposeFeatureFlags.layerType.withOverride(LayerType.OnWindow) {
+            runApplicationTest {
+                lateinit var window: Window
+                var showPopup by mutableStateOf(false)
+                launchTestWindowApplication {
+                    window = this.window
+                    Box(Modifier.size(100.dp))
+                    if (showPopup) {
+                        Popup(
+                            properties = PopupProperties(focusable = false)
+                        ) {
+                            Box(Modifier.size(50.dp))
+                        }
+                    }
+                }
+
+                awaitIdle()
+                assertTrue(window.isFocused)
+
+                showPopup = true
+                awaitIdle()
+                assertTrue(window.isFocused)
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, a popup created with
```
Popup(properties=PopupProperties(focusable=false))
```
nevertheless steals focus when using `compose.layers.type=WINDOW`.
This happens because to make a window (`JDialog` in this case) non-focusable, we need to set `focusableWindowState = false`, not `isFocusable = false`.

I also renamed `window` to `parentWindow` and `dialog` to `layerWindow`.

## Testing
Added a unit test, and also tested manually with:
```

@OptIn(ExperimentalFoundationApi::class)
fun main() {
    System.setProperty("compose.layers.type", "WINDOW")

    singleWindowApplication(WindowState(size = DpSize(400.dp, 400.dp))) {
        var showPopup by remember { mutableStateOf(false) }
        Box(
            Modifier.fillMaxSize(),
            contentAlignment = Alignment.Center
        ) {
            Box(Modifier
                .size(100.dp)
                .background(Color.Blue)
                .onClick { showPopup = true }
            )
        }

        if (showPopup) {
            Popup(
                alignment = Alignment.Center,
                properties = PopupProperties(focusable = false),
            ) {
                Text("I'm a popup", modifier = Modifier.background(Color.Yellow).size(50.dp))
            }
        }
    }
}
```

Before:

<img width="405" height="410" alt="SCR-20250805-oque" src="https://github.com/user-attachments/assets/c394961e-ad43-405e-9e5d-e3a74a3e4823" />

After:

<img width="402" height="406" alt="SCR-20250805-oqpx" src="https://github.com/user-attachments/assets/4c47ce6f-fa0b-457d-9e13-4a773ec8fe2f" />


## Release Notes
### Fixes - Desktop
- Fix non-focusable popup with `compose.layers.type=WINDOW` stealing focus