### PR TITLE
Correct the usage of ComposeUiTest.setContent in AssertionsTest.kt

### DIFF
--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/AssertionsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/AssertionsTest.kt
@@ -316,22 +316,20 @@ class AssertionsTest {
     @Test
     fun testAssertIsNotFocused() = runComposeUiTest {
         setContent {
-            setContent {
-                val focusRequester = remember { FocusRequester() }
-                Box(
-                    Modifier
-                        .testTag("tag1")
-                        .focusRequester(focusRequester)
-                        .focusable()
-                )
-                Box(
-                    Modifier
-                        .testTag("tag2")
-                        .focusable()
-                )
-                LaunchedEffect(Unit) {
-                    focusRequester.requestFocus()
-                }
+            val focusRequester = remember { FocusRequester() }
+            Box(
+                Modifier
+                    .testTag("tag1")
+                    .focusRequester(focusRequester)
+                    .focusable()
+            )
+            Box(
+                Modifier
+                    .testTag("tag2")
+                    .focusable()
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
             }
         }
 


### PR DESCRIPTION
Just correcting the usage of the API: calling `setContent` nestedly can cause unexpected issue on web.

## Testing
N/A

## Release Notes
N/A
