### PR TITLE
Focusable layers now request focus upon being attached

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
@@ -97,7 +97,7 @@ internal class FeatureFlag<T: Any>(defaultValueGetter: () -> T) {
     val value: T
         get() = override ?: defaultValue
 
-    fun withOverride(value: T, block: () -> Unit) {
+    inline fun withOverride(value: T, block: () -> Unit) {
         this.override = value
         try {
             block()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEventFilter.desktop.kt
@@ -39,23 +39,8 @@ internal interface AwtEventListener {
 internal class AwtEventListeners(
     private vararg val listeners: AwtEventListener
 ) : AwtEventListener {
-    override fun onMouseEvent(event: MouseEvent): Boolean {
-        for (listener in listeners) {
-            if (listener.onMouseEvent(event)) {
-                return true
-            }
-        }
-        return false
-    }
-
-    override fun onKeyEvent(event: KeyEvent): Boolean {
-        for (listener in listeners) {
-            if (listener.onKeyEvent(event)) {
-                return true
-            }
-        }
-        return false
-    }
+    override fun onMouseEvent(event: MouseEvent) = listeners.any { it.onMouseEvent(event) }
+    override fun onKeyEvent(event: KeyEvent) = listeners.any { it.onKeyEvent(event) }
 }
 
 internal open class AwtEventFilter : AwtEventListener {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -61,19 +61,22 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     )
 
     companion object {
+        private val SwingGraphics = SwingGraphics()
+
+        private val SkiaSurface = SkiaSurface()
+
         /**
          * [RenderSettings] based on the current environment variable configuration.
          *
          * @see ComposeFeatureFlags.useSwingGraphicsInComposePanel
          */
         @ExperimentalComposeUiApi
-        val DefaultRenderSettings: RenderSettings by lazy {
-            if (ComposeFeatureFlags.useSwingGraphicsInComposePanel.value) {
-                SwingGraphics()
+        val DefaultRenderSettings: RenderSettings
+            get() = if (ComposeFeatureFlags.useSwingGraphicsInComposePanel.value) {
+                SwingGraphics
             } else {
-                SkiaSurface()
+                SkiaSurface
             }
-        }
     }
 
     init {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/RenderingSettings.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/RenderingSettings.desktop.kt
@@ -34,16 +34,17 @@ sealed class RenderSettings {
      * Renders Compose content to a Swing provided offscreen buffer, with presentation controlled
      * by Swing.
      *
-     * This approach provides better integration with Swing components and prevents transitional 
-     * rendering issues when panels are being shown, hidden or resized. It also enables proper 
+     * This approach provides better integration with Swing components and prevents transitional
+     * rendering issues when panels are being shown, hidden or resized. It also enables proper
      * layering when combining Swing components and Compose panels.
      *
      * Note: This approach requires an additional copy from offscreen texture to Swing graphics
      * on each re-draw, which may result in some performance penalty (proportional to the size)
      * compared to [SkiaSurface].
      */
+    @Suppress("CanSealedSubClassBeObject")
     @ExperimentalComposeUiApi
-    class SwingGraphics: RenderSettings()
+    class SwingGraphics : RenderSettings()
 
     /**
      * Renders Compose content directly to a GPU surface for better performance.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -55,6 +55,10 @@ internal class SwingComposeSceneLayer(
             super.addNotify()
             mediator?.onComponentAttached()
             onUpdateBounds()
+
+            if (focusable) {
+                mediator?.contentComponent?.requestFocusInWindow()
+            }
         }
 
         override fun paint(g: Graphics) {
@@ -66,7 +70,6 @@ internal class SwingComposeSceneLayer(
         }
     }.also {
         it.layout = null
-        it.isFocusable = focusable
         it.isOpaque = false
         it.background = Color.Transparent.toAwtColor()
         it.size = Dimension(windowContainer.width, windowContainer.height)
@@ -88,7 +91,7 @@ internal class SwingComposeSceneLayer(
     override var focusable: Boolean = focusable
         set(value) {
             field = value
-            container.isFocusable = value
+            mediator?.contentComponent?.isFocusable = value
         }
 
     override var scrimColor: Color? = null
@@ -115,6 +118,7 @@ internal class SwingComposeSceneLayer(
         ).also {
             it.onWindowTransparencyChanged(true)
             it.contentComponent.size = container.size
+            it.contentComponent.isFocusable = focusable
         }
 
         // TODO: Currently it works only with offscreen rendering

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -79,6 +79,9 @@ internal class WindowComposeSceneLayer(
         override fun addNotify() {
             super.addNotify()
             mediator?.onComponentAttached()
+            if (focusable) {
+                mediator?.contentComponent?.requestFocusInWindow()
+            }
         }
     }.also {
         it.layout = null
@@ -99,6 +102,7 @@ internal class WindowComposeSceneLayer(
         set(value) {
             field = value
             layerWindow.focusableWindowState = value
+            mediator?.contentComponent?.isFocusable = value
         }
 
     override var scrimColor: Color? = null
@@ -121,6 +125,7 @@ internal class WindowComposeSceneLayer(
             it.onWindowTransparencyChanged(true)
             it.sceneBoundsInPx = boundsInPx
             it.contentComponent.size = windowContainer.size
+            it.contentComponent.isFocusable = focusable
         }
         onUpdateBounds()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -15,6 +15,8 @@
  */
 package androidx.compose.ui.awt
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.requiredSize
@@ -29,18 +31,29 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.sendCharTypedEvents
+import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.util.ThrowUncaughtExceptionRule
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.runApplicationTest
 import androidx.savedstate.SavedState
@@ -556,4 +569,74 @@ class ComposePanelTest {
 
         assertNotNull(composePanel.preferredSize)
     }
+
+    @Test
+    fun focusablePopup_withComponentLayerType_inComposePanel_grabsFocus() {
+        ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
+            ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {
+                val window = JFrame()
+                try {
+                    runApplicationTest {
+                        var showPopup by mutableStateOf(false)
+                        var dismissPopupRequested = false
+                        val keyEventsOnParent = mutableListOf<KeyEvent>()
+
+                        val composePanel = ComposePanel()
+                        composePanel.setContent {
+                            val focusRequester = remember { FocusRequester() }
+                            Box(Modifier
+                                .size(100.dp)
+                                .background(Color.Yellow)
+                                .focusRequester(focusRequester)
+                                .focusable()
+                                .onKeyEvent {
+                                    keyEventsOnParent.add(it)
+                                }
+                            )
+                            LaunchedEffect(Unit) {
+                                focusRequester.requestFocus()
+                            }
+
+                            if (showPopup) {
+                                Popup(
+                                    properties = PopupProperties(
+                                        focusable = true,
+                                        dismissOnBackPress = true,
+                                    ),
+                                    onDismissRequest = {
+                                        dismissPopupRequested = true
+                                    }
+                                ) {
+                                    Box(Modifier.size(50.dp))
+                                }
+                            }
+                        }
+
+                        composePanel.windowContainer = window.layeredPane
+
+                        window.contentPane.add(composePanel, BorderLayout.CENTER)
+                        window.pack()
+                        window.isVisible = true
+                        composePanel.requestFocusInWindow()
+
+                        awaitIdle()
+                        window.sendCharTypedEvents('a')
+                        awaitIdle()
+                        assertTrue(keyEventsOnParent.isNotEmpty())
+
+                        keyEventsOnParent.clear()
+                        showPopup = true
+                        awaitIdle()
+                        window.sendKeyEvent(java.awt.event.KeyEvent.VK_ESCAPE)
+                        awaitIdle()
+                        assertTrue(keyEventsOnParent.isEmpty())
+                        assertTrue(dismissPopupRequested)
+                    }
+                } finally {
+                    window.dispose()
+                }
+            }
+        }
+    }
+
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -60,8 +60,8 @@ import androidx.compose.ui.unit.round
  * @property dismissOnBackPress Whether the popup can be dismissed by pressing the back button
  * on Android or escape key on desktop.
  * If true, pressing the back button will call onDismissRequest. Note that [focusable] must be
- * set to true in order to receive key events such as the back button - if the popup is not
- * focusable then this property does nothing.
+ * set to true to receive key events such as the back button - if the popup is not focusable then
+ * this property does nothing.
  * @property dismissOnClickOutside Whether the popup can be dismissed by clicking outside the
  * popup's bounds. If true, clicking outside the popup will call onDismissRequest.
  * @property clippingEnabled Whether to allow the popup window to extend beyond the bounds of the
@@ -106,9 +106,9 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
          * Temporary hack to skip unsupported arguments from Android source set.
          * Should be removed after upstreaming changes from JetBrains' fork.
          *
-         * After skip this unsupported argument, you must name all subsequent arguments.
+         * After skipping this unsupported argument, you must name all later arguments.
          */
-        @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE")
+        @Suppress("FORBIDDEN_VARARG_PARAMETER_TYPE", "UNUSED_PARAMETER")
         vararg unsupported: Nothing,
 
         clippingEnabled: Boolean,
@@ -159,7 +159,7 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
  * Ltr/Rtl context, thus in Ltr it will be added to the original aligned position and in Rtl it
  * will be subtracted from it.
  * @param focusable Indicates if the popup can grab the focus.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param onDismissRequest Executes when the user clicks outside the popup.
  * @param onPreviewKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. It gives ancestors of a focused component the chance to intercept a [KeyEvent].
  * Return true to stop propagation of this event. If you return false, the key event will be
@@ -208,7 +208,7 @@ fun Popup(
  * @sample androidx.compose.ui.samples.PopupSample
  *
  * @param popupPositionProvider Provides the screen position of the popup.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param onDismissRequest Executes when the user clicks outside the popup.
  * @param focusable Indicates if the popup can grab the focus.
  * @param onPreviewKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. It gives ancestors of a focused component the chance to intercept a [KeyEvent].
@@ -264,7 +264,7 @@ fun Popup(
  * @param offset An offset from the original aligned position of the popup. Offset respects the
  * Ltr/Rtl context, thus in Ltr it will be added to the original aligned position and in Rtl it
  * will be subtracted from it.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param onDismissRequest Executes when the user clicks outside the popup.
  * @param properties [PopupProperties] for further customization of this popup's behavior.
  * @param content The content to be displayed inside the popup.
  */
@@ -293,7 +293,7 @@ actual fun Popup(
  * @sample androidx.compose.ui.samples.PopupSample
  *
  * @param popupPositionProvider Provides the screen position of the popup.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param onDismissRequest Executes when the user clicks outside the popup.
  * @param properties [PopupProperties] for further customization of this popup's behavior.
  * @param content The content to be displayed inside the popup.
  */
@@ -328,7 +328,7 @@ actual fun Popup(
  * @param offset An offset from the original aligned position of the popup. Offset respects the
  * Ltr/Rtl context, thus in Ltr it will be added to the original aligned position and in Rtl it
  * will be subtracted from it.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param onDismissRequest Executes when the user clicks outside the popup.
  * @param properties [PopupProperties] for further customization of this popup's behavior.
  * @param onPreviewKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. It gives ancestors of a focused component the chance to intercept a [KeyEvent].
@@ -371,7 +371,7 @@ fun Popup(
  * @sample androidx.compose.ui.samples.PopupSample
  *
  * @param popupPositionProvider Provides the screen position of the popup.
- * @param onDismissRequest Executes when the user clicks outside of the popup.
+ * @param onDismissRequest Executes when the user clicks outside the popup.
  * @param properties [PopupProperties] for further customization of this popup's behavior.
  * @param onPreviewKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. It gives ancestors of a focused component the chance to intercept a [KeyEvent].


### PR DESCRIPTION
Focusable layers do not currently request focus upon being attached, and in fact, the wrong component is being made focusable.

This PR makes the `ComposeMediator.contentComponent` focusable when the layer is, and requests focus on it when attached.

This fixes, for example, pressing ESC to close a focusable popup when it's used from a `ComposePanel` whose `windowContainer` has been set to the parent window's layered pane.

## Testing
Added a unit test, and also tested manually with:
```
import androidx.compose.foundation.ExperimentalFoundationApi
import androidx.compose.foundation.background
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.size
import androidx.compose.foundation.onClick
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.runtime.getValue
import androidx.compose.runtime.mutableStateOf
import androidx.compose.runtime.remember
import androidx.compose.runtime.setValue
import androidx.compose.ui.Alignment
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.Modifier
import androidx.compose.ui.awt.ComposePanel
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.Popup
import androidx.compose.ui.window.PopupProperties
import java.awt.BorderLayout
import javax.swing.BorderFactory
import javax.swing.JFrame
import javax.swing.JPanel
import javax.swing.SwingUtilities
import kotlinx.coroutines.delay

@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
fun main() = SwingUtilities.invokeLater {
    System.setProperty("compose.swing.render.on.graphics", "true")
    System.setProperty("compose.layers.type", "COMPONENT")

    val window = JFrame()
    val composePanel = ComposePanel()
    composePanel.setContent {
        var showPopup by remember { mutableStateOf(false) }
        Box(Modifier
            .size(100.dp)
            .background(Color.Yellow)
            .onClick { showPopup = true }
        )
        if (showPopup) {
            Popup(
                alignment = Alignment.Center,
                properties = PopupProperties(focusable = true),
                onDismissRequest = { showPopup = false }
            ) {
                Box(Modifier.size(200.dp).background(Color.Blue))
            }
        }

        LaunchedEffect(Unit) {
            while (true) {
                println(window.focusOwner)
                delay(1000)
            }
        }
    }
    composePanel.windowContainer = window.layeredPane

    val panel = JPanel().also {
        it.add(composePanel, BorderLayout.CENTER)
        it.border = BorderFactory.createEmptyBorder(100, 100, 100, 100)
    }

    window.contentPane.add(panel, BorderLayout.CENTER)
    window.pack()
    window.isVisible = true
}

```

## Release Notes
### Fixes - Desktop
- Request initial focus for focusable popups when used from `ComposePanel` in some cases.
