### PR TITLE
Fix `ComposeDialog` constructors to call the correct super constructor

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -49,8 +49,8 @@ class ComposeDialog : JDialog {
     private val composePanel: ComposeWindowPanel
 
     private fun createComposePanel(
-        skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-        savedState: SavedState? = null,
+        skiaLayerAnalytics: SkiaLayerAnalytics,
+        savedState: SavedState?,
     ) = ComposeWindowPanel(
         window = this,
         isUndecorated = ::isUndecorated,
@@ -62,11 +62,13 @@ class ComposeDialog : JDialog {
      * ComposeDialog is a dialog for building UI using Compose for Desktop.
      * ComposeDialog inherits javax.swing.JDialog.
      *
-     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behaviour.
-     * SkiaLayer is underlying class used internally to draw Compose content.
-     * Implementation usually uses third-party solution to send info to some centralized analytics gatherer.
+     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behavior.
+     * SkiaLayer is the underlying class used internally to draw Compose content.
+     * Implementation usually uses a third-party solution to send info to an analytics gatherer.
      * @param savedState The saved state to restore the UI state from a previous instance.
      */
+    // All constructors that want to call JDialog(Window?) should call this constructor.
+    // On Windows, it will show a taskbar icon if the owner window is null
     @ExperimentalComposeUiApi
     constructor(
         owner: Window?,
@@ -83,19 +85,43 @@ class ComposeDialog : JDialog {
      * ComposeDialog is a dialog for building UI using Compose for Desktop.
      * ComposeDialog inherits javax.swing.JDialog.
      *
-     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behaviour.
-     * SkiaLayer is underlying class used internally to draw Compose content.
-     * Implementation usually uses third-party solution to send info to some centralized analytics gatherer.
+     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behavior.
+     * SkiaLayer is the underlying class used internally to draw Compose content.
+     * Implementation usually uses a third-party solution to send info to an analytics gatherer.
+     * @param savedState The saved state to restore the UI state from a previous instance.
+     */
+    // All constructors that want to call JDialog(Frame?) should call this constructor first.
+    // It will not show a taskbar icon if the owner frame is null
+    @ExperimentalComposeUiApi
+    constructor(
+        owner: Frame?,
+        modal: Boolean = false,
+        graphicsConfiguration: GraphicsConfiguration? = null,
+        skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+        savedState: SavedState? = null,
+    ) : super(owner, "", modal, graphicsConfiguration) {
+        composePanel = createComposePanel(skiaLayerAnalytics, savedState)
+        contentPane.add(composePanel)
+    }
+
+    /**
+     * ComposeDialog is a dialog for building UI using Compose for Desktop.
+     * ComposeDialog inherits javax.swing.JDialog.
+     *
+     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behavior.
+     * SkiaLayer is the underlying class used internally to draw Compose content.
+     * Implementation usually uses a third-party solution to send info to an analytics gatherer.
      * @param savedState The saved state to restore the UI state from a previous instance.
      */
     @ExperimentalComposeUiApi
     constructor(
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
         savedState: SavedState? = null,
-    ): super() {
-        composePanel = createComposePanel(skiaLayerAnalytics, savedState)
-        contentPane.add(composePanel)
-    }
+    ): this(
+        owner = null as Frame?,
+        skiaLayerAnalytics = skiaLayerAnalytics,
+        savedState = savedState
+    )
 
     constructor(
         owner: Window?,
@@ -112,20 +138,15 @@ class ComposeDialog : JDialog {
     constructor(
         graphicsConfiguration: GraphicsConfiguration? = null,
     ) : this(
-        owner = null,
-        modalityType = ModalityType.MODELESS,
+        owner = null as Frame?,
         graphicsConfiguration = graphicsConfiguration,
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
         savedState = null
     )
 
-    // don't replace super() by super(null, ModalityType.MODELESS), because
-    // this constructor creates an icon in the taskbar.
-    // Dialog's shouldn't be appeared in the taskbar.
-    constructor() : super() {
-        composePanel = createComposePanel()
-        contentPane.add(composePanel)
-    }
+    constructor() : this(
+        owner = null as Frame?,
+    )
 
     internal var rootForTestListener
         get() = composePanel.rootForTestListener


### PR DESCRIPTION
## Release Notes
https://github.com/jetbrains/compose-multiplatform-core/pull/2291
