### PR TITLE
Fix Context menu items configuration in JS target

### DIFF
--- a/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
+++ b/compose/foundation/foundation/src/jsMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.js.kt
@@ -58,10 +58,10 @@ internal actual fun ClipEntry?.hasText(): Boolean {
 }
 
 internal actual fun Clipboard.isReadSupported(): Boolean =
-    js("window.navigator.clipboard && window.navigator.clipboard.read")
+    js("Boolean(window.navigator.clipboard && window.navigator.clipboard.read)")
 
 internal actual fun Clipboard.isWriteSupported(): Boolean =
-    js("window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText)")
+    js("Boolean(window.navigator.clipboard && (window.navigator.clipboard.write || window.navigator.clipboard.writeText))")
 
 @Suppress("UNUSED_PARAMETER")
 private fun doesJsArrayContainValue(jsArray: Array<*>, value: Any): Boolean =


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8725

This code returns a "read" function(), not the boolean :
```
js("window.navigator.clipboard && window.navigator.clipboard.read")
```

but in the kotlin usage the returned value was compared with "true". And the comparison was false. For example `document.addEventListener == true` // false.

## Testing
This should be tested by QA

## Release Notes
###  Fixes - Web
- _(prerelease fix)_ The context menu had only "Select All" item when targeting k/js

