### PR TITLE
adjust experimental material3 expressive api

### DIFF
--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/WideNavigationRail.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/WideNavigationRail.skiko.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 
 @Immutable
-@ExperimentalMaterial3ExpressiveApi
 actual class ModalWideNavigationRailProperties
 actual constructor(
     actual val shouldDismissOnBackPress: Boolean,
@@ -42,12 +41,10 @@ actual constructor(
     }
 }
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 internal actual fun createDefaultModalWideNavigationRailProperties() =
     ModalWideNavigationRailProperties()
 
 @OptIn(ExperimentalComposeUiApi::class)
-@ExperimentalMaterial3ExpressiveApi
 @Composable
 internal actual fun ModalWideNavigationRailDialog(
     onDismissRequest: () -> Unit,


### PR DESCRIPTION
## Proposed Changes

  - remove `ExperimentalMaterial3ExpressiveApi` annotation from no-longer-experimental API
## Release Notes
### Fixes - Multiple Platforms
  - `ExperimentalMaterial3ExpressiveApi` annotation removed from no-longer-experimental API

## Testing

Test: manual tests