### PR TITLE
Add `modalityType` parameter to `DialogWindow`

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -4262,6 +4262,19 @@ public final class androidx/compose/ui/window/DesktopPopup_desktopKt {
 	public static final fun rememberCursorPositionProvider-B5uucgQ (JLandroidx/compose/ui/Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 
+public final class androidx/compose/ui/window/DialogModalityType {
+	public static final field $stable I
+	public static final field Companion Landroidx/compose/ui/window/DialogModalityType$Companion;
+	public final fun getName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class androidx/compose/ui/window/DialogModalityType$Companion {
+	public final fun getApplicationModal ()Landroidx/compose/ui/window/DialogModalityType;
+	public final fun getDocumentModal ()Landroidx/compose/ui/window/DialogModalityType;
+	public final fun getModeless ()Landroidx/compose/ui/window/DialogModalityType;
+}
+
 public final class androidx/compose/ui/window/DialogProperties {
 	public static final field $stable I
 	public fun <init> (ZZZ)V

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -4262,13 +4262,6 @@ public final class androidx/compose/ui/window/DesktopPopup_desktopKt {
 	public static final fun rememberCursorPositionProvider-B5uucgQ (JLandroidx/compose/ui/Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 
-public final class androidx/compose/ui/window/DialogModalityType {
-	public static final field $stable I
-	public static final field Companion Landroidx/compose/ui/window/DialogModalityType$Companion;
-	public final fun getName ()Ljava/lang/String;
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class androidx/compose/ui/window/DialogModalityType$Companion {
 	public final fun getApplicationModal ()Landroidx/compose/ui/window/DialogModalityType;
 	public final fun getDocumentModal ()Landroidx/compose/ui/window/DialogModalityType;

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.util.setPositionSafely
 import androidx.compose.ui.util.setSizeSafely
 import androidx.compose.ui.util.setUndecoratedSafely
 import androidx.compose.ui.util.windowListenerRef
+import androidx.compose.ui.window.DialogModalityType
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.DialogWindowScope
@@ -192,6 +193,7 @@ fun SwingDialog(
     alwaysOnTop: Boolean = false,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
+    modalityType: ModalityType = ModalityType.DOCUMENT_MODAL,
     init: (ComposeDialog) -> Unit,
     content: @Composable DialogWindowScope.() -> Unit
 ) {
@@ -206,6 +208,7 @@ fun SwingDialog(
     val currentEnabled by rememberUpdatedState(enabled)
     val currentFocusable by rememberUpdatedState(focusable)
     val currentAlwaysOnTop by rememberUpdatedState(alwaysOnTop)
+    val currentModalityType by rememberUpdatedState(modalityType)
     val currentOnCloseRequest by rememberUpdatedState(onCloseRequest)
 
     val updater = remember(::ComponentUpdater)
@@ -238,8 +241,8 @@ fun SwingDialog(
             val graphicsConfiguration = WindowLocationTracker.lastActiveGraphicsConfiguration
             val dialog = if (owner != null) {
                 ComposeDialog(
-                    owner,
-                    ModalityType.DOCUMENT_MODAL,
+                    owner = owner,
+                    modalityType = currentModalityType,
                     graphicsConfiguration = graphicsConfiguration
                 )
             } else {
@@ -291,6 +294,7 @@ fun SwingDialog(
                 set(currentEnabled, dialog::setEnabled)
                 set(currentFocusable, dialog::setFocusableWindowState)
                 set(currentAlwaysOnTop, dialog::setAlwaysOnTop)
+                set(currentModalityType, dialog::setModalityType)
                 set(currentDecoration.resizerThickness, dialog::undecoratedResizerThickness::set)
             }
             if (state.size != appliedState.size) {
@@ -308,4 +312,15 @@ fun SwingDialog(
         },
         content = content
     )
+}
+
+/**
+ * Returns the AWT [java.awt.Dialog.ModalityType] corresponding to the given Compose
+ * [DialogModalityType].
+ */
+internal fun DialogModalityType.toAwtModalityType(): ModalityType = when (this) {
+    DialogModalityType.Modeless -> ModalityType.MODELESS
+    DialogModalityType.DocumentModal -> ModalityType.DOCUMENT_MODAL
+    DialogModalityType.ApplicationModal -> ModalityType.APPLICATION_MODAL
+    else -> error("Unknown dialog modality type: $this")
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.awt.SwingDialog
+import androidx.compose.ui.awt.toAwtModalityType
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
 import java.awt.Window
@@ -58,6 +59,7 @@ fun Dialog(
     enabled = enabled,
     focusable = focusable,
     alwaysOnTop = false,
+    modalityType = DialogModalityType.DocumentModal,
     onPreviewKeyEvent = onPreviewKeyEvent,
     onKeyEvent = onKeyEvent,
     content = content
@@ -95,6 +97,7 @@ fun DialogWindow(
         enabled = enabled,
         focusable = focusable,
         alwaysOnTop = false,
+        modalityType = DialogModalityType.DocumentModal,
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         content = content
@@ -189,6 +192,7 @@ fun DialogWindow(
         enabled = enabled,
         focusable = focusable,
         alwaysOnTop = alwaysOnTop,
+        modalityType = DialogModalityType.DocumentModal,
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         content = content,
@@ -244,6 +248,7 @@ fun DialogWindow(
  * @param focusable Whether the dialog can receive focus.
  * @param alwaysOnTop whether the dialog will always be on top of other windows and dialogs in the
  * application.
+ * @param modalityType Modality type for the dialog.
  * @param onPreviewKeyEvent This callback is invoked when the user interacts with the hardware
  * keyboard. It gives ancestors of a focused component the chance to intercept a [KeyEvent].
  * Return true to stop propagation of this event. If you return false, the key event will be
@@ -262,12 +267,13 @@ fun DialogWindow(
     visible: Boolean = true,
     title: String = "Untitled",
     icon: Painter? = null,
-    decoration: WindowDecoration,
+    decoration: WindowDecoration = WindowDecoration.SystemDefault,
     transparent: Boolean = false,
     resizable: Boolean = true,
     enabled: Boolean = true,
     focusable: Boolean = true,
     alwaysOnTop: Boolean = false,
+    modalityType: DialogModalityType,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
     onKeyEvent: ((KeyEvent) -> Boolean) = { false },
     content: @Composable DialogWindowScope.() -> Unit
@@ -284,6 +290,7 @@ fun DialogWindow(
         enabled = enabled,
         focusable = focusable,
         alwaysOnTop = alwaysOnTop,
+        modalityType = modalityType.toAwtModalityType(),
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         init = { },
@@ -394,4 +401,39 @@ interface DialogWindowScope : WindowScope {
      * [ComposeDialog] that was created inside [androidx.compose.ui.window.DialogWindow].
      */
     override val window: ComposeDialog
+}
+
+/**
+ * Modal dialogs block all input to some windows.
+ *
+ * [DialogModalityType] defines the which set of windows input is blocked to.
+ */
+class DialogModalityType private constructor(val name: String) {
+    override fun toString() = name
+
+    companion object {
+        /**
+         * Indicates the dialog should be non-modal, i.e., should not block any windows.
+         *
+         * In AWT, this corresponds to [java.awt.Dialog.ModalityType.MODELESS].
+         */
+        val Modeless = DialogModalityType("Modeless")
+
+        /**
+         * Indicates the dialog should block windows from the same document, except its own
+         * descendants.
+         *
+         * A document is a top-level window without an owner.
+         *
+         * In AWT, this corresponds to [java.awt.Dialog.ModalityType.DOCUMENT_MODAL].
+         */
+        val DocumentModal = DialogModalityType("Document")
+
+        /**
+         * Indicates the dialog should block windows from the same application.
+         *
+         * In AWT, this corresponds to [java.awt.Dialog.ModalityType.APPLICATION_MODAL].
+         */
+        val ApplicationModal = DialogModalityType("Application")
+    }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -408,6 +408,7 @@ interface DialogWindowScope : WindowScope {
  *
  * [DialogModalityType] defines the which set of windows input is blocked to.
  */
+@ExperimentalComposeUiApi
 class DialogModalityType private constructor(val name: String) {
     override fun toString() = name
 


### PR DESCRIPTION
Add `modalityType` parameter to `DialogWindow`

## Testing
Tested manually with
```
import androidx.compose.foundation.background
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.Modifier
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.window.DialogModalityType
import androidx.compose.ui.window.DialogWindow
import androidx.compose.ui.window.Window
import androidx.compose.ui.window.application
import androidx.compose.ui.window.rememberWindowState
import java.awt.Dialog.ModalityType

@OptIn(ExperimentalComposeUiApi::class)
fun main() {
    application {
        val windowState = rememberWindowState()
        Window(
            onCloseRequest = ::exitApplication,
            state = windowState,
        ) {
            Box(
                modifier = Modifier
                    .fillMaxSize()
                    .background(Color.Black)
            )

            DialogWindow(
                onCloseRequest = {},
                modalityType = DialogModalityType.Modeless
            ) {
                Box(
                    modifier = Modifier
                        .fillMaxSize()
                        .background(Color.Black)
                )
            }
        }
    }
}
```

This could be tested by QA

## Release Notes
### Features - Desktop
- Added `modalityType` parameter to `DialogWindow()`.
