### PR TITLE
Remove `LocalInterfaceOrientation` usage and definition

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -40,7 +40,6 @@ import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
 import androidx.compose.ui.uikit.InterfaceOrientation
-import androidx.compose.ui.uikit.LocalInterfaceOrientation
 import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.uikit.PlistSanityCheck
 import androidx.compose.ui.uikit.density
@@ -81,7 +80,6 @@ import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGSize
 import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
 import platform.UIKit.UIApplication
-import platform.UIKit.UIEdgeInsets
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
 import platform.UIKit.UITraitCollection

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -544,7 +544,6 @@ internal class ComposeHostingViewController(
         CompositionLocalProvider(
             LocalHapticFeedback provides hapticFeedback,
             LocalUIViewController provides this,
-            LocalInterfaceOrientation provides interfaceOrientationState.value,
             LocalSystemTheme provides systemThemeState.value,
             LocalLifecycleOwner provides lifecycleOwner,
             LocalInternalViewModelStoreOwner provides lifecycleOwner,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/InterfaceOrientation.uikit.kt
@@ -40,9 +40,3 @@ enum class InterfaceOrientation(private val rawValue: UIInterfaceOrientation) {
         }
     }
 }
-
-/**
- * Composition local for [InterfaceOrientation]
- */
-@InternalComposeUiApi
-val LocalInterfaceOrientation = staticCompositionLocalOf { InterfaceOrientation.Portrait }


### PR DESCRIPTION
Remove `LocalInterfaceOrientation` usage and definition

## Fixes
- [CMP-6780](https://youtrack.jetbrains.com/issue/CMP-6780) Hide `LocalInterfaceOrientation`

## Release Notes
N/A
