### PR TITLE
Fix the sizing of unfocusable layers in `SwingComposeSceneLayer`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -281,7 +281,7 @@ internal class ComposeContainer(
         if (!container.isDisplayable) return
 
         windowContext.setContainerSize(windowContainer.sizeInPx)
-        mediator.onComponentSizeChanged()
+        mediator.onContainerSizeChanged()
         layers.fastForEach(DesktopComposeSceneLayer::onWindowContainerSizeChanged)
 
         // Sometimes Swing displays interop views in incorrect order after resizing,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -290,10 +290,11 @@ internal class ComposeSceneMediator(
         private set
 
     /**
-     * The bounds of scene relative to [container]. Might be null if it's equal to [container] size.
+     * The bounds of [scene] relative to [container]. Might be null if it's equal to [container]
+     * size.
      *
      * It makes sense in cases when real [container] size doesn't match desired value.
-     * For example if we want to show dialog in a separate window with size of this
+     * For example, if we want to show a dialog in a separate window with the size of this
      * dialog, but constrains (and scene size) should remain the size of the main window.
      */
     var sceneBoundsInPx: Rect? = null
@@ -561,7 +562,7 @@ internal class ComposeSceneMediator(
         offsetInWindow = windowContext.offsetInWindow(container)
     }
 
-    fun onComponentSizeChanged() = catchExceptions {
+    fun onContainerSizeChanged() = catchExceptions {
         if (!container.isDisplayable) return
 
         val size = sceneBoundsInPx?.size ?: container.sizeInPx
@@ -579,7 +580,7 @@ internal class ComposeSceneMediator(
     fun onChangeDensity(density: Density = container.density) = catchExceptions {
         if (scene.density != density) {
             scene.density = density
-            onComponentSizeChanged()
+            onContainerSizeChanged()
         }
     }
 
@@ -641,7 +642,7 @@ internal class ComposeSceneMediator(
                             ?: policy.getDefaultComponent(root)
                     }
                     val hasFocus = toFocus?.hasFocus() == true
-                    !hasFocus && toFocus?.requestFocusInWindow(FocusEvent.Cause.TRAVERSAL_FORWARD) == true
+                    !hasFocus && toFocus?.requestFocusInWindow(TRAVERSAL_FORWARD) == true
                 }
 
                 FocusDirection.Previous -> {
@@ -651,7 +652,7 @@ internal class ComposeSceneMediator(
                             ?: policy.getDefaultComponent(root)
                     }
                     val hasFocus = toFocus?.hasFocus() == true
-                    !hasFocus && toFocus?.requestFocusInWindow(FocusEvent.Cause.TRAVERSAL_BACKWARD) == true
+                    !hasFocus && toFocus?.requestFocusInWindow(TRAVERSAL_BACKWARD) == true
                 }
 
                 else -> false

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -96,8 +96,12 @@ internal abstract class DesktopComposeSceneLayer(
     override var boundsInWindow: IntRect = IntRect.Zero
         set(value) {
             field = value
+            isBoundsInWindowSet = true
             boundsEventFilter.bounds = value.toAwtRectangle(density)
         }
+
+    protected var isBoundsInWindowSet: Boolean = false
+        private set
 
     final override var compositionLocalContext: CompositionLocalContext?
         get() = mediator?.compositionLocalContext
@@ -142,7 +146,7 @@ internal abstract class DesktopComposeSceneLayer(
                 right = boundsInWindow.right + maxDrawInflate.right,
                 bottom = boundsInWindow.bottom + maxDrawInflate.bottom
             )
-            onUpdateBounds()
+            onDrawBoundsChanged()
         }
 
     /**
@@ -170,9 +174,9 @@ internal abstract class DesktopComposeSceneLayer(
     }
 
     /**
-     * Called when bounds of the layer has been updated.
+     * Called when [drawBounds] has changed.
      */
-    open fun onUpdateBounds() {
+    open fun onDrawBoundsChanged() {
     }
 
     /**
@@ -239,7 +243,7 @@ internal abstract class DesktopComposeSceneLayer(
     }
 
     private inner class BoundsEventFilter(
-        var bounds: Rectangle,
+        var bounds: Rectangle?,
     ) : AwtEventFilter() {
         private val MouseEvent.isInBounds: Boolean
             get() {
@@ -248,7 +252,7 @@ internal abstract class DesktopComposeSceneLayer(
                 } else {
                     point
                 }
-                return bounds.contains(localPoint)
+                return bounds?.contains(localPoint) ?: false
             }
 
         override fun shouldSendMouseEvent(event: MouseEvent): Boolean {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -19,14 +19,15 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.ui.awt.toAwtColor
 import androidx.compose.ui.awt.toAwtRectangle
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.scene.skia.SwingSkiaLayerComponent
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.roundToIntRect
+import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.sizeInPx
 import java.awt.Dimension
@@ -34,7 +35,6 @@ import java.awt.Graphics
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import javax.swing.JLayeredPane
-import javax.swing.SwingUtilities
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
 internal class SwingComposeSceneLayer(
@@ -54,7 +54,7 @@ internal class SwingComposeSceneLayer(
         override fun addNotify() {
             super.addNotify()
             mediator?.onComponentAttached()
-            onUpdateBounds()
+            updateBounds()
 
             if (focusable) {
                 mediator?.contentComponent?.requestFocusInWindow()
@@ -62,44 +62,34 @@ internal class SwingComposeSceneLayer(
         }
 
         override fun paint(g: Graphics) {
-            g.color = background
-            g.fillRect(0,0, width, height)
+            scrimColor?.let { scrimColor ->
+                g.color = scrimColor.toAwtColor()
+                g.fillRect(0, 0, width, height)
+            }
 
-            // Draw content after background
+            // Draw content after the background
             super.paint(g)
         }
+
+        override fun toString() = "SwingComposeSceneLayer container"
     }.also {
         it.layout = null
         it.isOpaque = false
-        it.background = Color.Transparent.toAwtColor()
         it.size = Dimension(windowContainer.width, windowContainer.height)
         it.addMouseListener(backgroundMouseListener)
     }
-
-    private var containerSize = IntSize.Zero
-        set(value) {
-            if (field.width != value.width || field.height != value.height) {
-                field = value
-                container.setBounds(0, 0, value.width, value.height)
-                mediator?.contentComponent?.size = container.size
-                mediator?.onComponentSizeChanged()
-            }
-        }
 
     override var mediator: ComposeSceneMediator? = null
 
     override var focusable: Boolean = focusable
         set(value) {
+            if (field == value) return
             field = value
             mediator?.contentComponent?.isFocusable = value
+            updateBounds()
         }
 
     override var scrimColor: Color? = null
-        set(value) {
-            field = value
-            val background = value ?: Color.Transparent
-            container.background = background.toAwtColor()
-        }
 
     init {
         val boundsInPx = windowContainer.sizeInPx.toRect()
@@ -117,7 +107,6 @@ internal class SwingComposeSceneLayer(
             composeSceneFactory = ::createComposeScene,
         ).also {
             it.onWindowTransparencyChanged(true)
-            it.contentComponent.size = container.size
             it.contentComponent.isFocusable = focusable
         }
 
@@ -140,16 +129,35 @@ internal class SwingComposeSceneLayer(
     }
 
     override fun onWindowContainerSizeChanged() {
-        containerSize = IntSize(windowContainer.width, windowContainer.height)
+        updateBounds()
     }
 
-    override fun onUpdateBounds() {
-        val scaledRectangle = drawBounds.toAwtRectangle(density)
-        val localBounds = SwingUtilities.convertRectangle(
-            /* source = */ windowContainer,
-            /* aRectangle = */ scaledRectangle,
-            /* destination = */ container)
-        mediator?.contentComponent?.bounds = localBounds
+    override fun onDrawBoundsChanged() {
+        updateBounds()
+    }
+
+    // Updates the bounds of the container and the content component.
+    private fun updateBounds() {
+        if (!isBoundsInWindowSet) {
+            container.setBounds(0, 0, windowContainer.width, windowContainer.height)
+            mediator?.contentComponent?.setBounds(0, 0, container.width, container.height)
+        } else {
+            val contentComponent = mediator?.contentComponent ?: return
+            val localDrawBounds = drawBounds.toAwtRectangle(density)
+
+            if (focusable) {
+                container.setBounds(0, 0, windowContainer.width, windowContainer.height)
+                contentComponent.bounds = localDrawBounds
+                mediator?.sceneBoundsInPx = null
+            } else {
+                container.bounds = localDrawBounds
+                contentComponent.setBounds(0, 0, localDrawBounds.width, localDrawBounds.height)
+                mediator?.sceneBoundsInPx = Rect(
+                    offset = -drawBounds.topLeft.toOffset(),
+                    size = windowContainer.sizeInPx
+                )
+            }
+        }
     }
 
     private fun createSkiaLayerComponent(mediator: ComposeSceneMediator): SkiaLayerComponent {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -127,7 +127,7 @@ internal class WindowComposeSceneLayer(
             it.contentComponent.size = windowContainer.size
             it.contentComponent.isFocusable = focusable
         }
-        onUpdateBounds()
+        onDrawBoundsChanged()
 
         layerWindow.isVisible = true
 
@@ -151,7 +151,7 @@ internal class WindowComposeSceneLayer(
 
     override fun onWindowContainerPositionChanged() {
         val scaledRectangle = drawBounds.toAwtRectangle(density)
-        setDialogLocation(scaledRectangle.x, scaledRectangle.y)
+        setWindowContainerLocation(scaledRectangle.x, scaledRectangle.y)
     }
 
     override fun onWindowContainerSizeChanged() {
@@ -170,9 +170,9 @@ internal class WindowComposeSceneLayer(
         layerWindow.repaint()
     }
 
-    override fun onUpdateBounds() {
+    override fun onDrawBoundsChanged() {
         val scaledRectangle = drawBounds.toAwtRectangle(density)
-        setDialogLocation(scaledRectangle.x, scaledRectangle.y)
+        setWindowContainerLocation(scaledRectangle.x, scaledRectangle.y)
         layerWindow.setSize(scaledRectangle.width, scaledRectangle.height)
         mediator?.contentComponent?.setSize(scaledRectangle.width, scaledRectangle.height)
         mediator?.sceneBoundsInPx = Rect(
@@ -221,7 +221,7 @@ internal class WindowComposeSceneLayer(
         )
     }
 
-    private fun setDialogLocation(x: Int, y: Int) {
+    private fun setWindowContainerLocation(x: Int, y: Int) {
         if (!windowContainer.isShowing) {
             return
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -75,7 +75,7 @@ internal class SwingSkiaLayerComponent(
 
             override fun doLayout() {
                 super.doLayout()
-                mediator.onComponentSizeChanged()
+                mediator.onContainerSizeChanged()
             }
 
             override fun getPreferredSize(): Dimension = if (isPreferredSizeSet) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -97,7 +97,7 @@ internal class WindowSkiaLayerComponent(
 
         override fun doLayout() {
             super.doLayout()
-            mediator.onComponentSizeChanged()
+            mediator.onContainerSizeChanged()
         }
 
         override fun getPreferredSize(): Dimension = if (isPreferredSizeSet) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -15,7 +15,6 @@
  */
 package androidx.compose.ui.awt
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -35,6 +34,7 @@ import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Size
@@ -247,7 +247,7 @@ class ComposePanelTest {
                 savedState = composePanel.saveState()
             }
 
-            testPanel(savedState) { composePanel ->
+            testPanel(savedState) { _ ->
                 assertThat(lastState).isEqualTo(6)
             }
         } finally {
@@ -639,4 +639,51 @@ class ComposePanelTest {
         }
     }
 
+    @Test
+    fun unfocusablePopupLayer_withComponentLayerType_inComposePanel_isSizedCorrectly() {
+        ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
+            ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {
+                val window = JFrame()
+                try {
+                    var showPopup by mutableStateOf(false)
+                    runApplicationTest {
+                        val composePanel = ComposePanel()
+                        composePanel.setContent {
+                            Box(Modifier
+                                .size(200.dp)
+                                .background(Color.Yellow)
+                            )
+                            if (showPopup) {
+                                Popup(
+                                    properties = PopupProperties(focusable = false),
+                                ) {
+                                    Box(Modifier
+                                        .size(50.dp)
+                                        .background(Color.Blue)
+                                    )
+                                }
+                            }
+                        }
+
+                        composePanel.windowContainer = window.layeredPane
+
+                        window.contentPane.add(composePanel, BorderLayout.NORTH)
+                        window.pack()
+                        window.isVisible = true
+
+                        awaitIdle()
+
+                        val initialChildren = window.layeredPane.components
+                        showPopup = true
+                        awaitIdle()
+                        val newLayer = (window.layeredPane.components.toSet() - initialChildren).single()
+                        assertEquals(50, newLayer.size.width)
+                        assertEquals(50, newLayer.size.height)
+                    }
+                } finally {
+                    window.dispose()
+                }
+            }
+        }
+    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -48,7 +48,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.round
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
@@ -221,7 +220,7 @@ private class CanvasLayersComposeSceneImpl(
 
     override fun hitTestInteropView(position: Offset): InteropView? {
         forEachLayerReversed { layer ->
-            if (layer.isInBounds(position)) {
+            if (layer.contains(position)) {
                 return layer.owner.hitTestInteropView(position)
             } else if (layer == focusedLayer) {
                 return null
@@ -276,7 +275,7 @@ private class CanvasLayersComposeSceneImpl(
      */
     private fun hoveredOwner(event: PointerInputEvent): RootNodeOwner {
         val position = event.pointers.first().position
-        return layers.fastLastOrNull { it.isInBounds(position) }?.owner ?: mainOwner
+        return layers.fastLastOrNull { it.contains(position) }?.owner ?: mainOwner
     }
 
     /**
@@ -308,8 +307,8 @@ private class CanvasLayersComposeSceneImpl(
         val position = event.pointers.first().position
         forEachLayerReversed { layer ->
 
-            // If the position of in bounds of the owner - send event to it and stop processing
-            if (layer.isInBounds(position)) {
+            // If the position is in bounds of the owner - send event to it and stop processing
+            if (layer.contains(position)) {
                 // The layer doesn't have any offset from [mainOwner], so we don't need to
                 // convert event coordinates here.
                 val result = layer.owner.onPointerInput(event)
@@ -615,8 +614,6 @@ private class CanvasLayersComposeSceneImpl(
 
         override fun calculateLocalPosition(positionInWindow: IntOffset): IntOffset =
             positionInWindow // [ComposeScene] is equal to window in this implementation.
-
-        fun isInBounds(position: Offset) = boundsInWindow.contains(position.round())
 
         fun onOutsidePointerEvent(event: PointerInputEvent) {
             if (!event.isMouseOrSingleTouch()) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
@@ -33,12 +34,12 @@ import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.WindowInfo
-import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.round
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.Popup
@@ -46,8 +47,10 @@ import androidx.compose.ui.window.PopupProperties
 
 /**
  * An extra layer for the [ComposeScene].
- * This is utilized to display content as a new [LayoutNode] tree.
- * It is designed to be implemented by platform as adapter for separate platform view/canvas.
+ *
+ * This is used to display content as a new [LayoutNode] tree.
+ * It is designed to be implemented by the platform as the adapter for a separate platform
+ * view/canvas.
  *
  * @see Popup
  * @see Dialog
@@ -65,9 +68,10 @@ interface ComposeSceneLayer {
     var layoutDirection: LayoutDirection
 
     /**
-     * The real bounds of content in pixels relative to [WindowInfo.containerSize].
+     * The real bounds of content, in pixels, relative to [WindowInfo.containerSize].
+     *
      * This property is used to set the position and size of [Popup]/[Dialog].
-     * The implementation should be ready to react on the changes in size/position that can
+     * The implementation should be ready to react to the changes in size/position that can
      * happen during recompositions.
      */
     var boundsInWindow: IntRect
@@ -212,4 +216,13 @@ internal fun ComposeSceneLayer.Content(content: @Composable () -> Unit) {
         }
         onDispose {  }
     }
+}
+
+/**
+ * Returns whether the layer contains [point].
+ *
+ * @param point An offset relative to the layer's container.
+ */
+internal fun ComposeSceneLayer.contains(point: Offset): Boolean {
+    return boundsInWindow.contains(point.round())
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
@@ -32,7 +32,7 @@ internal class RecordDrawRectRenderDecorator(
     private val pictureRecorder = PictureRecorder()
     private val bbhFactory = RTreeFactory()
     private var drawRect = Rect.Zero
-        private set(value) {
+        set(value) {
             if (value != field) {
                 field = value
                 onDrawRectChange(value)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -50,7 +50,7 @@ class ComposeSceneMediatorTest {
         mediator.density = Density(2f)
         mediator.layoutDirection = LayoutDirection.Rtl
         mediator.compositionLocalContext = null
-        mediator.interactionBounds = IntRect.Companion.Zero
+        mediator.interactionBounds = IntRect.Zero
         mediator.isAccessibilityEnabled = true
         mediator.prepareAndGetSizeTransitionAnimation().invoke(10.milliseconds)
     }
@@ -101,10 +101,10 @@ class ComposeSceneMediatorTest {
             backGestureDispatcher = UIKitBackGestureDispatcher(
                 enableBackGesture = false,
                 density = Density(1f),
-                getTopLeftOffsetInWindow = { IntOffset.Companion.Zero }
+                getTopLeftOffsetInWindow = { IntOffset.Zero }
             ),
             interfaceOrientationState = mutableStateOf(InterfaceOrientation.Portrait),
-            composeSceneFactory = { invalidate, platformContext ->
+            composeSceneFactory = { _, _ ->
                 PlatformLayersComposeScene(
                     density = Density(1f)
                 )


### PR DESCRIPTION
Currently, `SwingComposeSceneLayer` always sizes the container to fill the `windowContainer`.
But this is wrong for unfocusable layers, where the container should be sized to the content.

This PR fixes it.

Fixes https://youtrack.jetbrains.com/issue/CMP-8925

## Testing
Manually, and added a unit test.

## Release Notes
### Fixes - Desktop
- Fixed the sizing of unfocusable layers when `compose.layers.type=COMPONENT` is used.
