### PR TITLE
Do not specify `Constraints.minWidth` for paragraph in text direction sample

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDirection.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDirection.kt
@@ -173,10 +173,11 @@ fun testContentDirectionLocaleFallback(text: String, locale: String) {
                         localeList = LocaleList(Locale(locale)),
                         textDirection = TextDirection.Content
                     ),
+                    annotations = emptyList(),
                     density = LocalDensity.current,
                     fontFamilyResolver = LocalFontFamilyResolver.current,
                 ),
-                constraints = Constraints.fixedWidth(size.width)
+                constraints = Constraints(maxWidth = size.width)
             )
             Canvas(
                 Modifier.size(


### PR DESCRIPTION
[CMP-8752](https://youtrack.jetbrains.com/issue/CMP-8752) [Multiplatform] Crash with IllegalArgumentException: Setting Constraints.minWidth and Constraints.minHeight is not supported, these should be the default zero values instead

## Release Notes
N/A
