### PR TITLE
Restrict selection gesture functions to private scope

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionGestures.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/selection/SelectionGestures.kt
@@ -239,7 +239,7 @@ internal suspend fun PointerInputScope.selectionGesturePointerInputBtf2(
  * press instead of immediately looking for drags. If no long press is found, this does not trigger
  * any observer.
  */
-internal suspend fun AwaitPointerEventScope.touchSelectionFirstPress(
+private suspend fun AwaitPointerEventScope.touchSelectionFirstPress(
     observer: TextDragObserver,
     downEvent: PointerEvent,
 ) {
@@ -352,7 +352,7 @@ private suspend fun AwaitPointerEventScope.touchSelectionSubsequentPress(
 }
 
 /** Gesture handler for mouse selection. */
-internal suspend fun AwaitPointerEventScope.mouseSelectionBtf2(
+private suspend fun AwaitPointerEventScope.mouseSelectionBtf2(
     observer: MouseSelectionObserver,
     clicksCounter: ClicksCounter,
     down: PointerEvent,


### PR DESCRIPTION
Restrict selection gesture functions to private scope

Addresses https://github.com/JetBrains/compose-multiplatform-core/pull/1923#discussion_r2276352222

## Release Notes
N/A
