### PR TITLE
Set COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE to "versions.COMPOSE_MATERIAL3"

### DIFF
--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -205,7 +205,7 @@ COMPOSE_FOUNDATION = { group = "org.jetbrains.compose.foundation", atomicGroupVe
 COMPOSE_MATERIAL = { group = "org.jetbrains.compose.material", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_MATERIAL3 = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3" }
 COMPOSE_MATERIAL3_ADAPTIVE = { group = "org.jetbrains.compose.material3.adaptive", atomicGroupVersion = "versions.COMPOSE_MATERIAL3_ADAPTIVE" }
-COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE", overrideInclude = [ ":compose:material3:material3-adaptive-navigation-suite" ] }
+COMPOSE_MATERIAL3_ADAPTIVE_NAVIGATION_SUITE = { group = "org.jetbrains.compose.material3", atomicGroupVersion = "versions.COMPOSE_MATERIAL3", overrideInclude = [ ":compose:material3:material3-adaptive-navigation-suite" ] }
 COMPOSE_RUNTIME = { group = "org.jetbrains.compose.runtime", atomicGroupVersion = "versions.COMPOSE" }
 COMPOSE_RUNTIME_TRACING = { group = "androidx.compose.runtime", atomicGroupVersion = "versions.COMPOSE_RUNTIME_TRACING", overrideInclude = [ ":compose:runtime:runtime-tracing" ] }
 COMPOSE_UI = { group = "org.jetbrains.compose.ui", atomicGroupVersion = "versions.COMPOSE" }


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8757

It had to be done in https://github.com/JetBrains/compose-multiplatform-core/pull/2231, but missed

## Release Notes
N/A