### PR TITLE
Size SwingPanel according to its content

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingPanel.desktop.kt
@@ -22,12 +22,22 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.IntrinsicMeasurable
+import androidx.compose.ui.layout.IntrinsicMeasureScope
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasurePolicy
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.InteropView
 import androidx.compose.ui.viewinterop.LocalInteropContainer
 import androidx.compose.ui.viewinterop.SwingInteropViewHolder
 import java.awt.Component
 import java.awt.Container
+import java.awt.Dimension
 import java.awt.event.FocusEvent
 import javax.swing.JPanel
 import javax.swing.LayoutFocusTraversalPolicy
@@ -51,7 +61,7 @@ val NoOpUpdate: Component.() -> Unit = {}
  * @param update The callback to be invoked after the layout is inflated.
  */
 @Composable
-public fun <T : Component> SwingPanel(
+fun <T : Component> SwingPanel(
     background: Color = Color.White,
     factory: () -> T,
     modifier: Modifier = Modifier,
@@ -82,15 +92,14 @@ public fun <T : Component> SwingPanel(
             container = interopContainer,
             group = group,
             focusSwitcher = focusSwitcher,
-            compositeKeyHashCode = compositeKeyHashCode
+            compositeKeyHashCode = compositeKeyHashCode,
+            measurePolicy = AwtContentMeasurePolicy(group)
         )
     }
 
     InteropView(
-        factory = {
-            interopViewHolder
-        },
-        modifier.then(focusSwitcher.modifier),
+        factory = { interopViewHolder },
+        modifier = modifier.then(focusSwitcher.modifier),
         update = {
             it.background = background.toAwtColor()
             update(it)
@@ -119,8 +128,11 @@ internal fun FocusEvent.isFocusGainedHandledBySwingPanel(container: Container) =
  */
 internal class SwingInteropViewGroup(
     key: CompositeKeyHashCode,
-    private val focusComponent: Component
+    private val focusComponent: Component,
 ) : JPanel() {
+
+    internal var onInvalidate: (() -> Unit)? = null
+
     init {
         name = "SwingPanel #${key.toString(MaxSupportedRadix)}"
         layout = null
@@ -149,9 +161,72 @@ internal class SwingInteropViewGroup(
         }
         isFocusCycleRoot = true
     }
+
+    override fun getPreferredSize(): Dimension {
+        return components[0].preferredSize
+    }
+
+    override fun getMinimumSize(): Dimension {
+        return components[0].minimumSize
+    }
+
+    override fun getMaximumSize(): Dimension {
+        return components[0].maximumSize
+    }
+
+    override fun invalidate() {
+        super.invalidate()
+        onInvalidate?.invoke()
+    }
 }
 
 /**
  * The maximum radix available for conversion to and from strings.
  */
-private val MaxSupportedRadix = 36
+private const val MaxSupportedRadix = 36
+
+private class AwtContentMeasurePolicy(
+    val component: Component,
+) : MeasurePolicy {
+
+    private fun Density.awtToPx(awtPx: Int): Int = awtPx.dp.roundToPx()
+
+    override fun MeasureScope.measure(
+        measurables: List<Measurable>,
+        constraints: Constraints
+    ): MeasureResult {
+        val prefSize = component.preferredSize
+        val width = awtToPx(prefSize.width).coerceIn(constraints.minWidth, constraints.maxWidth)
+        val height = awtToPx(prefSize.height).coerceIn(constraints.minHeight, constraints.maxHeight)
+        return layout(width, height) {}
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int
+    ): Int {
+        return awtToPx(component.minimumSize.width)
+    }
+
+    override fun IntrinsicMeasureScope.minIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int
+    ): Int {
+        return awtToPx(component.minimumSize.height)
+    }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicWidth(
+        measurables: List<IntrinsicMeasurable>,
+        height: Int
+    ): Int {
+        return awtToPx(component.maximumSize.width)
+    }
+
+    override fun IntrinsicMeasureScope.maxIntrinsicHeight(
+        measurables: List<IntrinsicMeasurable>,
+        width: Int
+    ): Int {
+        return awtToPx(component.maximumSize.height)
+    }
+}
+

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropViewHolder.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.viewinterop
 import androidx.compose.runtime.CompositeKeyHashCode
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.InteropFocusSwitcher
+import androidx.compose.ui.awt.SwingInteropViewGroup
 import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.awt.isFocusGainedHandledBySwingPanel
 import androidx.compose.ui.draw.drawBehind
@@ -44,17 +45,16 @@ import org.jetbrains.skiko.ClipRectangle
 internal class SwingInteropViewHolder<T : Component>(
     factory: () -> T,
     container: InteropContainer,
-    group: InteropViewGroup,
+    override val group: SwingInteropViewGroup,
     focusSwitcher: InteropFocusSwitcher,
     compositeKeyHashCode: CompositeKeyHashCode,
+    measurePolicy: MeasurePolicy
 ) : TypedInteropViewHolder<T>(
-    factory,
-    container,
-    group,
-    compositeKeyHashCode,
-    MeasurePolicy { _, constraints ->
-        layout(constraints.minWidth, constraints.minHeight) {}
-    }
+    factory = factory,
+    interopContainer = container,
+    group = group,
+    compositeKeyHashCode = compositeKeyHashCode,
+    measurePolicy = measurePolicy
 ), ClipRectangle {
     private var clipBounds: IntRect? = null
 
@@ -71,9 +71,6 @@ internal class SwingInteropViewHolder<T : Component>(
 
         override fun focusLost(e: FocusEvent) = Unit
     }
-
-    override fun getInteropView(): InteropView =
-        typedInteropView
 
     init {
         group.add(typedInteropView)
@@ -127,6 +124,9 @@ internal class SwingInteropViewHolder<T : Component>(
         root.add(group, index)
         super.insertInteropView(root, index)
         container.root.addFocusListener(focusListener)
+        group.onInvalidate = {
+            layoutNode.invalidateMeasurements()
+        }
     }
 
     override fun changeInteropViewIndex(root: InteropViewGroup, index: Int) {
@@ -137,6 +137,7 @@ internal class SwingInteropViewHolder<T : Component>(
         root.remove(group)
         super.removeInteropView(root)
         container.root.removeFocusListener(focusListener)
+        group.onInvalidate = null
     }
 
     override val x: Float

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
@@ -19,10 +19,14 @@ package androidx.compose.ui.awt
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.LayoutBoundsHolder
+import androidx.compose.ui.layout.layoutBounds
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.sendMousePress
 import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.sendMouseWheelEvent
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.runApplicationTest
@@ -33,6 +37,7 @@ import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
+import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -124,5 +129,38 @@ class SwingPanelTest {
         } finally {
             window.dispose()
         }
+    }
+
+    @Test
+    fun swingPanelIsSizedToContentPreferredSize() = runApplicationTest(useDelay = true) {
+        val panel = JPanel()
+
+        panel.preferredSize = Dimension(100, 100)
+
+        val layoutBounds = LayoutBoundsHolder()
+        lateinit var density: Density
+        launchTestApplication {
+            Window(onCloseRequest = {}) {
+                SwingPanel(
+                    modifier = Modifier.layoutBounds(layoutBounds),
+                    factory = { panel }
+                )
+                density = LocalDensity.current
+            }
+        }
+
+        fun assertPanelSizeIsItsPreferredSize() {
+            assertEquals((panel.preferredSize.width * density.density).roundToInt(), layoutBounds.bounds?.width)
+            assertEquals((panel.preferredSize.height * density.density).roundToInt(), layoutBounds.bounds?.height)
+        }
+
+        awaitIdle()
+        assertPanelSizeIsItsPreferredSize()
+
+        // Also check that when the preferred size is updated, the SwingPanel is resized
+        panel.preferredSize = Dimension(200, 200)
+        panel.invalidate()
+        awaitIdle()
+        assertPanelSizeIsItsPreferredSize()
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropViewHolder.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/viewinterop/InteropViewHolder.skiko.kt
@@ -39,7 +39,7 @@ private fun abstractInvocationError(name: String): Nothing {
  */
 internal open class InteropViewHolder(
     val container: InteropContainer,
-    val group: InteropViewGroup,
+    open val group: InteropViewGroup,
     private val compositeKeyHashCode: CompositeKeyHashCode,
     measurePolicy: MeasurePolicy
 ) : ComposeNodeLifecycleCallback {


### PR DESCRIPTION
Size `SwingPanel` according to its min/pref/max sizes.

Fixes https://youtrack.jetbrains.com/issue/CMP-3206

https://github.com/user-attachments/assets/90861f64-02ed-41e3-927b-7b863a3e78fd

## Testing
Added a unit test and tested manually with
```
fun main() {
    var text = "I'm a Swing JLabel"
    val label = JLabel(text)

    singleWindowApplication {
        Box(
            contentAlignment = Alignment.Center,
            modifier = Modifier
                .fillMaxSize()
                .background(Color.Red)
        ) {
            SwingPanel(
                factory = { label },
                modifier = Modifier
//                    .size(200.dp, 200.dp)
            )
        }

        LaunchedEffect(Unit) {
            delay(1000)
            while (true) {
                repeat(20) {
                    delay(200)
                    text = "#${text}#"
                    label.text = text
                }
                repeat(20) {
                    delay(200)
                    text = text.substring(1, text.length - 1)
                    label.text = text
                }
            }
        }
    }
}
```

## Release Notes
### Fixes - Desktop
- `SwingPanel` no longer requires to be manually sized to a fixed value; it will size according to its content's min/pref/max sizes.
