### PR TITLE
Pin compose to 1.8.2 in lifecycle-viewmodel-compose

### DIFF
--- a/lifecycle/lifecycle-viewmodel-compose/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-compose/build.gradle
@@ -52,11 +52,11 @@ kotlin {
                 api(project(":lifecycle:lifecycle-common"))
                 api(project(":lifecycle:lifecycle-viewmodel"))
                 api("androidx.annotation:annotation:1.9.1")
-                api(project(":compose:runtime:runtime"))
+                api("org.jetbrains.compose.runtime:runtime:1.8.2")
 
                 // Moved from platform dependencies
                 api(project(":lifecycle:lifecycle-viewmodel-savedstate"))
-                api(project(":compose:ui:ui"))
+                api("org.jetbrains.compose.ui:ui:1.8.2")
 
                 api(libs.kotlinSerializationCore)
                 implementation(libs.kotlinStdlib)


### PR DESCRIPTION
[CMP-8765](https://youtrack.jetbrains.com/issue/CMP-8765) [CMP] [WASM] "WebAssembly.instantiate(): Import #4426 "./skiko.mjs" after lifecycle-* 2.9.2

## Release Notes
### Fixes - Lifecycle
- Fix dependency on Compose in `lifecycle-viewmodel-compose` module: `2.9.2` incorrectly refer Compose Multiplatform `1.9.0-beta03`. Now it reverted back to `1.8.2`