### PR TITLE
Fix missing version pinning in navigation-compose

### DIFF
--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -109,7 +109,7 @@ kotlin {
         nonAndroidMain {
             dependsOn(commonMain)
             dependencies {
-                implementation project(":compose:ui:ui-backhandler")
+                implementation "org.jetbrains.compose.ui:ui-backhandler:1.8.2"
             }
         }
         nonAndroidTest.dependsOn(commonTest)


### PR DESCRIPTION
It had to be a part of #2220

## Release Notes
N/A
