### PR TITLE
Pin compose to 1.8.2 in savedstate-compose

### DIFF
--- a/savedstate/savedstate-compose/build.gradle
+++ b/savedstate/savedstate-compose/build.gradle
@@ -61,7 +61,7 @@ kotlin {
         commonMain {
             dependencies {
                 api(project(":savedstate:savedstate"))
-                api(project(":compose:runtime:runtime"))
+                api("org.jetbrains.compose.runtime:runtime:1.8.2")
             }
         }
 


### PR DESCRIPTION
## Release Notes
### Fixes - SavedState
- Fix dependency on Compose in `savedstate-compose` module: `1.3.2` incorrectly refer Compose Multiplatform `1.9.0-beta03`. Now it reverted back to `1.8.2`