### PR TITLE
Fix `ExplicitApiMode` setting and align it with AOSP

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -81,9 +81,11 @@ import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.register
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
 import org.jetbrains.kotlin.gradle.plugin.KotlinMultiplatformPluginWrapper
@@ -358,18 +360,13 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
                 task.compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
             }
 
-            val isAndroidProject = project.plugins.hasPlugin(LibraryPlugin::class.java) ||
-                project.plugins.hasPlugin(AppPlugin::class.java)
-            // Explicit API mode is broken for Android projects
-            // https://youtrack.jetbrains.com/issue/KT-37652
-            if (extension.shouldEnforceKotlinStrictApiMode() && !isAndroidProject) {
-                project.tasks.withType(KotlinCompile::class.java).configureEach { task ->
-                    // Workaround for https://youtrack.jetbrains.com/issue/KT-37652
-                    if (task.name.endsWith("TestKotlin")) return@configureEach
-                    if (task.name.endsWith("TestKotlinJvm")) return@configureEach
-                    task.compilerOptions.freeCompilerArgs.addAll(listOf("-Xexplicit-api=strict"))
+            val kotlinExtension = project.extensions.getByType<KotlinProjectExtension>()
+            kotlinExtension.explicitApi =
+                if (extension.shouldEnforceKotlinStrictApiMode()) {
+                    ExplicitApiMode.Strict
+                } else {
+                    ExplicitApiMode.Disabled
                 }
-            }
         }
         // setup a partial docs artifact that can be used to generate offline docs, if requested.
         AndroidXKmpDocsImplPlugin.setupPartialDocsArtifact(project)

--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -93,6 +93,7 @@ androidx {
     type = LibraryType.PUBLISHED_LIBRARY
     inceptionYear = "2024"
     description = "Compose Material integration with Navigation"
+    legacyDisableKotlinStrictApiMode = true
 }
 
 android {

--- a/compose/material3/material3-adaptive-navigation-suite/build.gradle
+++ b/compose/material3/material3-adaptive-navigation-suite/build.gradle
@@ -131,5 +131,6 @@ androidx {
     type = LibraryType.PUBLISHED_LIBRARY
     inceptionYear = "2023"
     description = "Compose Material Design Adaptive Navigation Suite Library"
+    legacyDisableKotlinStrictApiMode = true
     //samples(project(":compose:material3:material3-adaptive-navigation-suite:material3-adaptive-navigation-suite-samples"))
 }

--- a/compose/material3/material3-window-size-class/build.gradle
+++ b/compose/material3/material3-window-size-class/build.gradle
@@ -142,6 +142,7 @@ androidx {
     type = LibraryType.PUBLISHED_LIBRARY
     inceptionYear = "2022"
     description = "Provides window size classes for building responsive UIs"
+    legacyDisableKotlinStrictApiMode = true
 }
 
 android {

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -331,6 +331,8 @@ androidx {
     type = LibraryType.PUBLISHED_LIBRARY
     inceptionYear = "2021"
     description = "Compose Material You Design Components library"
+    legacyDisableKotlinStrictApiMode = true
+    metalavaK2UastEnabled = false
 }
 
 // Screenshot tests related setup

--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -92,4 +92,5 @@ androidx {
     publish = Publish.SNAPSHOT_AND_RELEASE
     inceptionYear = "2025"
     description = "Provides BackHandler in Compose Multiplatform projects"
+    legacyDisableKotlinStrictApiMode = true
 }

--- a/navigation/navigation-common/build.gradle
+++ b/navigation/navigation-common/build.gradle
@@ -181,6 +181,4 @@ androidx {
     publish = Publish.SNAPSHOT_AND_RELEASE
     inceptionYear = "2017"
     description = "Android Navigation-Common"
-    metalavaK2UastEnabled = true
-    legacyDisableKotlinStrictApiMode = true
 }

--- a/navigation/navigation-compose/build.gradle
+++ b/navigation/navigation-compose/build.gradle
@@ -160,7 +160,6 @@ androidx {
     publish = Publish.SNAPSHOT_AND_RELEASE
     inceptionYear = "2020"
     description = "Compose integration with Navigation"
-    legacyDisableKotlinStrictApiMode = true
 }
 
 android {

--- a/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
+++ b/navigation/navigation-compose/src/androidMain/kotlin/androidx/navigation/compose/NavHost.android.kt
@@ -31,7 +31,7 @@ import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 
 @Composable
-actual fun NavHost(
+public actual fun NavHost(
     navController: NavHostController,
     graph: NavGraph,
     modifier: Modifier,

--- a/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
+++ b/navigation/navigation-compose/src/desktopMain/kotlin/androidx/navigation/compose/NavHost.desktop.kt
@@ -31,7 +31,7 @@ import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 
 @Composable
-actual fun NavHost(
+public actual fun NavHost(
     navController: NavHostController,
     graph: NavGraph,
     modifier: Modifier,

--- a/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/NavHost.macos.kt
+++ b/navigation/navigation-compose/src/macosMain/kotlin/androidx/navigation/compose/NavHost.macos.kt
@@ -28,7 +28,7 @@ import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 
 @Composable
-actual fun NavHost(
+public actual fun NavHost(
     navController: NavHostController,
     graph: NavGraph,
     modifier: Modifier,

--- a/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
+++ b/navigation/navigation-compose/src/uikitMain/kotlin/androidx/navigation/compose/NavHost.uikit.kt
@@ -38,7 +38,7 @@ import androidx.navigation.compose.internal.DefaultNavTransitions
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-actual fun NavHost(
+public actual fun NavHost(
     navController: NavHostController,
     graph: NavGraph,
     modifier: Modifier,

--- a/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/NavHost.web.kt
+++ b/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/NavHost.web.kt
@@ -28,7 +28,7 @@ import androidx.navigation.NavGraph
 import androidx.navigation.NavHostController
 
 @Composable
-actual fun NavHost(
+public actual fun NavHost(
     navController: NavHostController,
     graph: NavGraph,
     modifier: Modifier,

--- a/navigation/navigation-runtime/api/navigation-runtime.klib.api
+++ b/navigation/navigation-runtime/api/navigation-runtime.klib.api
@@ -110,12 +110,6 @@ open annotation class androidx.navigation/ExperimentalBrowserHistoryApi : kotlin
 }
 
 // Targets: [js, wasmJs]
-final fun androidx.navigation/decodeURIComponent(kotlin/String): kotlin/String // androidx.navigation/decodeURIComponent|decodeURIComponent(kotlin.String){}[0]
-
-// Targets: [js, wasmJs]
-final fun androidx.navigation/encodeURIComponent(kotlin/String): kotlin/String // androidx.navigation/encodeURIComponent|encodeURIComponent(kotlin.String){}[0]
-
-// Targets: [js, wasmJs]
 final suspend fun (androidx.navigation/NavController).androidx.navigation/bindToBrowserNavigation(kotlin/Function1<androidx.navigation/NavBackStackEntry, kotlin/String>? = ...) // androidx.navigation/bindToBrowserNavigation|bindToBrowserNavigation@androidx.navigation.NavController(kotlin.Function1<androidx.navigation.NavBackStackEntry,kotlin.String>?){}[0]
 
 // Targets: [js, wasmJs]

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -170,6 +170,4 @@ androidx {
     publish = Publish.SNAPSHOT_AND_RELEASE
     inceptionYear = "2017"
     description = "Android Navigation-Runtime"
-    metalavaK2UastEnabled = true
-    legacyDisableKotlinStrictApiMode = true
 }

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -44,7 +44,7 @@ import org.w3c.dom.Window
 @Suppress("UnusedReceiverParameter")
 @Deprecated(message = "Use bindToBrowserNavigation", replaceWith = ReplaceWith("navController.bindToBrowserNavigation(getBackStackEntryRoute)"))
 @ExperimentalBrowserHistoryApi
-suspend fun Window.bindToNavigation(
+public suspend fun Window.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -44,7 +44,7 @@ import org.w3c.dom.Window
 @ExperimentalBrowserHistoryApi
 @Suppress("UnusedReceiverParameter")
 @Deprecated(message = "Use bindToBrowserNavigation", replaceWith = ReplaceWith("navController.bindToBrowserNavigation(getBackStackEntryRoute)"))
-suspend fun Window.bindToNavigation(
+public suspend fun Window.bindToNavigation(
     navController: NavController,
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {

--- a/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
+++ b/navigation/navigation-runtime/src/webMain/kotlin/androidx/navigation/BrowserHistory.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.launch
 @RequiresOptIn(message = "This is an experimental browser API.")
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
-annotation class ExperimentalBrowserHistoryApi
+public annotation class ExperimentalBrowserHistoryApi
 
 /**
  * Binds the browser window state to the given navigation controller.
@@ -233,8 +233,8 @@ internal external interface BrowserConsole {
     fun warn(msg: String)
 }
 
-external fun decodeURIComponent(str: String): String
-external fun encodeURIComponent(str: String): String
+internal external fun decodeURIComponent(str: String): String
+internal external fun encodeURIComponent(str: String): String
 
 
 /**
@@ -261,7 +261,7 @@ external fun encodeURIComponent(str: String): String
  * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
  */
 @ExperimentalBrowserHistoryApi
-suspend fun NavController.bindToBrowserNavigation(
+public suspend fun NavController.bindToBrowserNavigation(
     getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
 ) {
     @Suppress("UNCHECKED_CAST_TO_EXTERNAL_INTERFACE")


### PR DESCRIPTION
A part of buildSrc aligning.
Removes incorrectly exposed `decodeURIComponent`/`encodeURIComponent` from public

## Release Notes
N/A
