### PR TITLE
Fix Accessibility announcing old state of component

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -96,7 +96,7 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
                         }
                     }
                     element is UIWindowScene -> {
-                        element.windows.forEach {
+                        element.windows.filter { !(it as UIWindow).isHidden() }.forEach {
                             children.add(buildNode(it as UIWindow))
                         }
                     }
@@ -111,7 +111,7 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
                     children.add(buildNode(it as UIView))
                 }
             } else if (element is UIWindowScene) {
-                element.windows.forEach {
+                element.windows.filter { !(it as UIWindow).isHidden() }.forEach {
                     children.add(buildNode(it as UIWindow))
                 }
             }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -335,7 +335,7 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
         val window = UIWindow(frame = UIScreen.mainScreen.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
-        window.windowScene = UIApplication.sharedApplication().connectedScenes.first() as? UIWindowScene
+        window.windowScene = scene
         dispatch_async(dispatch_get_main_queue()) {
             window.windowScene = null
             window.resignKeyWindow()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -329,6 +329,9 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
     }
 
     fun cleanUp() {
+        val scene = UIApplication.sharedApplication().connectedScenes.first() as? UIWindowScene
+        val allWindows = scene?.windows ?: emptyList<UIWindow>()
+
         val window = UIWindow(frame = UIScreen.mainScreen.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
@@ -342,6 +345,10 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
         _window?.windowScene = null
         _window?.rootViewController = UIViewController()
         _window = null
+
+        allWindows.forEach {
+            (it as UIWindow).setHidden(true)
+        }
     }
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1137,6 +1137,7 @@ internal class AccessibilityMediator(
             // Will exit on CancellationException from within await on `invalidationChannel.receive()`
             // when [job] is cancelled
             while (true) {
+                hasPendingInvalidations = false
                 invalidationChannel.receive()
                 hasPendingInvalidations = true
 
@@ -1170,7 +1171,6 @@ internal class AccessibilityMediator(
                     // iOS Accessibility Engine will ignore them.
                     delay(100)
                 }
-                hasPendingInvalidations = false
             }
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1142,18 +1142,6 @@ internal class AccessibilityMediator(
                 invalidationChannel.receive()
                 hasPendingInvalidations = true
 
-                if (keyboardFocusedElementKey != null) {
-                    // Do nothing.
-                    // When full keyboard access is enabled, the selection rectangle can be updated
-                    // on every frame. To improve the user experience, we should update the
-                    // accessibility tree as quickly as possible.
-                } else {
-                    // Estimated delay between the iOS Accessibility Engine sync intervals.
-                    // There is no reason to post change notifications more frequently because the iOS
-                    // Accessibility Engine will ignore them.
-                    delay(100)
-                }
-
                 while (invalidationChannel.tryReceive().isSuccess) {
                     // Do nothing, just consume the channel
                     // Workaround for the channel buffering two invalidations despite the capacity of 1
@@ -1171,6 +1159,18 @@ internal class AccessibilityMediator(
                     refocusKeyboardElementIfNeeded()
                     root.element = null
                     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, null)
+                }
+
+                if (keyboardFocusedElementKey != null) {
+                    // Do nothing.
+                    // When full keyboard access is enabled, the selection rectangle can be updated
+                    // on every frame. To improve the user experience, we should update the
+                    // accessibility tree as quickly as possible.
+                } else {
+                    // Estimated delay between the iOS Accessibility Engine sync intervals.
+                    // There is no reason to post change notifications more frequently because the
+                    // iOS Accessibility Engine will ignore them.
+                    delay(100)
                 }
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -133,7 +133,6 @@ import platform.UIKit.accessibilityElementCount
 import platform.UIKit.accessibilityElements
 import platform.UIKit.accessibilityFrame
 import platform.UIKit.isAccessibilityElement
-import platform.UIKit.setAccessibilityElements
 import platform.darwin.NSObject
 import platform.objc.objc_getProtocol
 import platform.objc.protocol_isEqual
@@ -513,7 +512,7 @@ private class AccessibilityElement(
         children.forEach { it.setAccessibilityContainer(this) }
     }
 
-    override fun focusEffect(): UIFocusEffect? = UIFocusHaloEffect.effectWithRect(
+    override fun focusEffect(): UIFocusEffect = UIFocusHaloEffect.effectWithRect(
         rect = convertRect(rect = bounds, toCoordinateSpace = mediator.view)
     )
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1137,7 +1137,6 @@ internal class AccessibilityMediator(
             // Will exit on CancellationException from within await on `invalidationChannel.receive()`
             // when [job] is cancelled
             while (true) {
-                hasPendingInvalidations = false
                 invalidationChannel.receive()
                 hasPendingInvalidations = true
 
@@ -1171,6 +1170,7 @@ internal class AccessibilityMediator(
                     // iOS Accessibility Engine will ignore them.
                     delay(100)
                 }
+                hasPendingInvalidations = false
             }
         }
     }


### PR DESCRIPTION
Update the accessibility tree sync logic so that changes made after a long period are applied without delay.
Move delay to the end of the accessibility tree synchonization loop.

Fixes https://youtrack.jetbrains.com/issue/CMP-8663/iOS-A11y.-Toggleable-state-VoiceOver-state-out-of-sync

## Release Notes
### Fixes - iOS
- Fix Accessibility announcing the old state of component
