### PR TITLE
[web] Fix Backspace behaviour on mobile iOS

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -50,29 +50,31 @@ internal class DomInputStrategy(
         })
 
         htmlInput.addEventListener("keydown", { evt ->
-            nativeInputEventsProcessor.addKeyEvent(evt as KeyboardEvent)
+            nativeInputEventsProcessor.registerEvent(evt as KeyboardEvent)
         })
 
         htmlInput.addEventListener("keyup", { evt ->
-            nativeInputEventsProcessor.addKeyEvent(evt as KeyboardEvent)
+            nativeInputEventsProcessor.registerEvent(evt as KeyboardEvent)
         })
 
         htmlInput.addEventListener("beforeinput", { evt ->
             if (evt is InputEvent) {
                 htmlInput as HTMLElementWithValue
                 val deleteContentBackwardSize = htmlInput.selectionEnd - htmlInput.selectionStart
-                nativeInputEventsProcessor.addInputEvent(
-                    event = evt, deleteContentBackwardSize = deleteContentBackwardSize
-                )
+
+                if (deleteContentBackwardSize > 0) {
+                    evt.deleteContentBackwardSize = deleteContentBackwardSize
+                }
+                nativeInputEventsProcessor.registerEvent(evt)
             }
         })
 
         htmlInput.addEventListener("compositionstart", { evt ->
-            nativeInputEventsProcessor.addCompositionEvent(evt as CompositionEvent)
+            nativeInputEventsProcessor.registerEvent(evt as CompositionEvent)
         })
 
         htmlInput.addEventListener("compositionend", { evt ->
-            nativeInputEventsProcessor.addCompositionEvent(evt as CompositionEvent)
+            nativeInputEventsProcessor.registerEvent(evt as CompositionEvent)
         })
     }
 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -21,12 +21,11 @@ import androidx.compose.ui.input.key.toComposeEvent
 import androidx.compose.ui.text.input.BackspaceCommand
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
-import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.TextFieldValue
 import org.w3c.dom.events.CompositionEvent
-import org.w3c.dom.events.Event
 import org.w3c.dom.events.KeyboardEvent
+import org.w3c.dom.events.UIEvent
 
 /**
  * Processes native input events and handles their translation to commands
@@ -41,7 +40,7 @@ internal abstract class NativeInputEventsProcessor(
     private val composeSender: ComposeCommandCommunicator
 ) {
 
-    private val collectedEvents = mutableListOf<Event>()
+    private val collectedEvents = mutableListOf<UIEvent>()
     private var isCheckpointScheduled = false
     private var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
 
@@ -74,88 +73,44 @@ internal abstract class NativeInputEventsProcessor(
                 || it.type == "beforeinput" && (it as InputEvent).isComposing
         }
 
-        var keydownEvent: KeyboardEvent? = null
-        var compositionEndEvt: CompositionEvent? = null
+        var lastProcessedEventIsBackspace: Boolean = false
 
         collectedEvents.forEach { evt ->
-            val eventName = evt.type
+            val timestamp = evt.timeStamp.toDouble()
 
-            when (eventName) {
+            when (evt.type) {
                 "keydown" -> {
-                    keydownEvent = evt as KeyboardEvent
-                    val isTypedEvent = isTypedEvent(keydownEvent)
-                    val isFromLastComposition =
-                        keydownEvent.timeStamp.toDouble() < lastCompositionEndTimestamp
-                    if (!isInIMEComposition && !isTypedEvent && !isFromLastComposition) {
-                        composeSender.sendKeyboardEvent(keydownEvent.toComposeEvent())
+                    if (isInIMEComposition) return@forEach
+
+                    evt as KeyboardEvent
+                    if (isTypedEvent(evt)) return@forEach
+
+                    val isFromLastComposition = timestamp < lastCompositionEndTimestamp
+
+                    // see https://youtrack.jetbrains.com/issue/CMP-8745/Web-Mobile.-iOS.-Composite-input.-Characters-arent-deleted
+                    // on mobile iOS we cannot rely on the timestamp of the "keydown" event, it's always zero
+                    // it might seem strange that we are ignoring the isFromLastComposition safeguard
+                    // which was historically introduced exactly to resolve issues in Safari -
+                    // but isFromLastComposition is needed so that we won't type a number digit if it was pressed during composition mode
+                    // this is something that is not supposed to happen on mobile devices
+                    val shouldBeProcessed = timestamp == 0.0 || !isFromLastComposition
+
+                    if (shouldBeProcessed) {
+                        lastProcessedEventIsBackspace = evt.key == "Backspace"
+                        composeSender.sendKeyboardEvent(evt.toComposeEvent())
                     }
                 }
 
                 "compositionend" -> {
-                    compositionEndEvt = evt as CompositionEvent
-                    lastCompositionEndTimestamp = evt.timeStamp.toDouble()
-                    composeSender.sendEditCommand(CommitTextCommand(compositionEndEvt.data, 1))
+                    lastCompositionEndTimestamp = timestamp
+                    composeSender.sendEditCommand(CommitTextCommand((evt as CompositionEvent).data, 1))
                 }
 
                 "beforeinput" -> {
-                    evt as InputEvent
-                    val inputType = evt.inputType
-                    val data = evt.data
-
-                    val editCommands = mutableListOf<EditCommand>()
-                    when (inputType) {
-                        "insertFromComposition", "deleteCompositionText" -> {
-                            // We see these events in Safari just before 'compositionEnd' event.
-                            // We do nothing here, because Safari also sends 'insertCompositionText' which we handle,
-                            // and the behavior is as expected atm. We also handle 'compositionEnd'.
-                        }
-
-                        "deleteContentBackward" -> {
-                            // If it's "Backspace", then it's handled earlier in "keydown" above, so skipping it here
-                            if (keydownEvent?.key != "Backspace") {
-                                if (!currentTextFieldValue.selection.collapsed) {
-                                    // Likely it's on mobile, where the Backspace has Unidentified key value.
-                                    // When Compose TextField shows text selection,
-                                    // a good UX for deleteContentBackward would be to emulate Backspace
-                                    editCommands.add(BackspaceCommand())
-                                } else {
-                                    // This happens when an autocorrection is applied on mobile:
-                                    // The system first tells us to delete the old text,
-                                    // and then it would send the "insertText" event.
-                                    val deleteSize = evt.deleteContentBackwardSize
-                                    if (deleteSize > 0) {
-                                        editCommands.add(DeleteSurroundingTextCommand(deleteSize, 0))
-                                    }
-                                }
-                            }
-                        }
-
-                        "insertReplacementText" -> if (data != null) {
-                            val deleteSize = evt.deleteContentBackwardSize
-                            if (deleteSize > 0) {
-                                editCommands.add(DeleteSurroundingTextCommand(deleteSize, 0))
-                            }
-                            editCommands.add(CommitTextCommand(data, 1))
-                        }
-
-                        "insertText" -> if (data != null) {
-                            val deleteSize = evt.deleteContentBackwardSize
-                            if (deleteSize > 0 && currentTextFieldValue.selection.collapsed) {
-                                editCommands.add(DeleteSurroundingTextCommand(deleteSize, 0))
-                            }
-
-                            editCommands.add(CommitTextCommand(data, 1))
-                        }
-
-                        "insertCompositionText" -> if (data != null) {
-                            val deleteSize = evt.deleteContentBackwardSize
-                            if (deleteSize > 0) {
-                                editCommands.add(DeleteSurroundingTextCommand(deleteSize, 0))
-                            }
-                            editCommands.add(SetComposingTextCommand(data, 1))
-                        }
-                    }
-                    composeSender.sendEditCommand(editCommands)
+                    (evt as InputEvent).process(
+                        lastProcessedEventIsBackspace = lastProcessedEventIsBackspace,
+                        currentTextFieldValue = currentTextFieldValue
+                    )
                 }
             }
         }
@@ -163,24 +118,72 @@ internal abstract class NativeInputEventsProcessor(
         collectedEvents.clear()
     }
 
-    internal fun addInputEvent(event: InputEvent, deleteContentBackwardSize: Int = 0) {
-        if (deleteContentBackwardSize > 0) {
-            event.deleteContentBackwardSize = deleteContentBackwardSize
+    private fun InputEvent.process(lastProcessedEventIsBackspace: Boolean, currentTextFieldValue: TextFieldValue) {
+        val editCommands = when (inputType) {
+            "deleteContentBackward" -> buildList {
+                // this means "deleteContentBackward" happened because of an earlier "keydown" event, so skipping it here
+                if (lastProcessedEventIsBackspace) return@buildList
+
+                if (!currentTextFieldValue.selection.collapsed) {
+                    // Likely it's on mobile, where the Backspace has Unidentified key value.
+                    // When Compose TextField shows text selection,
+                    // a good UX for deleteContentBackward would be to emulate Backspace
+                    add(BackspaceCommand())
+                } else {
+                    // This happens when an autocorrection is applied on mobile:
+                    // The system first tells us to delete the old text,
+                    // and then it would send the "insertText" event.
+                    val deleteSize = deleteContentBackwardSize
+                    if (deleteSize > 0) {
+                        add(DeleteSurroundingTextCommand(deleteSize, 0))
+                    }
+                }
+            }
+
+            "insertReplacementText" -> buildList {
+                if (data == null) return@buildList
+                val deleteSize = deleteContentBackwardSize
+                if (deleteSize > 0) {
+                    add(DeleteSurroundingTextCommand(deleteSize, 0))
+                }
+
+                add(CommitTextCommand(data, 1))
+            }
+
+            "insertText" -> buildList {
+                if (data == null) return@buildList
+                val deleteSize = deleteContentBackwardSize
+                if (deleteSize > 0 && currentTextFieldValue.selection.collapsed) {
+                    add(DeleteSurroundingTextCommand(deleteSize, 0))
+                }
+
+                add(CommitTextCommand(data, 1))
+            }
+
+            "insertCompositionText" -> buildList {
+                if (data == null) return@buildList
+                val deleteSize = deleteContentBackwardSize
+                if (deleteSize > 0) {
+                    add(DeleteSurroundingTextCommand(deleteSize, 0))
+                }
+                add(SetComposingTextCommand(data, 1))
+            }
+
+            // "insertFromComposition", "deleteCompositionText" are triggered in Safari just before the 'compositionEnd' event.
+            // They're ignored because Safari also sends 'insertCompositionText' which we handle (alongside 'compositionEnd')
+            else -> emptyList()
         }
-        collectedEvents.add(event)
-        internalScheduleCheckpoint()
+
+        if (editCommands.isNotEmpty()) {
+            composeSender.sendEditCommand(editCommands)
+        }
     }
 
-    internal fun addKeyEvent(event: KeyboardEvent) {
-        collectedEvents.add(event)
-        internalScheduleCheckpoint()
-    }
-
-    internal fun addCompositionEvent(event: CompositionEvent) {
+    internal fun registerEvent(event: UIEvent) {
         collectedEvents.add(event)
         internalScheduleCheckpoint()
     }
 
     @TestOnly
-    internal fun getCollectedEvents(): List<Event> = collectedEvents
+    internal fun getCollectedEvents() = collectedEvents
 }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -101,16 +101,16 @@ class NativeInputEventsProcessorTest {
         val processor = TestNativeInputEventsProcessor(communicator)
         assertFalse(processor.checkpointScheduled)
 
-        processor.addKeyEvent(keyEvent("a"))
+        processor.registerEvent(keyEvent("a"))
         assertTrue(processor.checkpointScheduled)
 
         processor.checkpointScheduled = false
         val compositionEvent = compositionStart()
-        processor.addCompositionEvent(compositionEvent)
+        processor.registerEvent(compositionEvent)
         assertTrue(processor.checkpointScheduled)
 
         processor.checkpointScheduled = false
-        processor.addInputEvent(beforeInput("insertText", "") as InputEvent)
+        processor.registerEvent(beforeInput("insertText", "") as InputEvent)
         assertTrue(processor.checkpointScheduled)
 
         assertEquals(3, processor.getCollectedEvents().size)
@@ -123,8 +123,8 @@ class NativeInputEventsProcessorTest {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addKeyEvent(keyEvent("ArrowLeft"))
-        processor.addKeyEvent(keyEvent("ArrowLeft", type = "keyup"))
+        processor.registerEvent(keyEvent("ArrowLeft"))
+        processor.registerEvent(keyEvent("ArrowLeft", type = "keyup"))
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.keyboardEvents.size)
@@ -137,7 +137,7 @@ class NativeInputEventsProcessorTest {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addCompositionEvent(compositionEnd("test"))
+        processor.registerEvent(compositionEnd("test"))
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
@@ -153,7 +153,7 @@ class NativeInputEventsProcessorTest {
         )
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addInputEvent(beforeInput("insertText", "a") as InputEvent)
+        processor.registerEvent(beforeInput("insertText", "a") as InputEvent)
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
@@ -171,7 +171,7 @@ class NativeInputEventsProcessorTest {
         )
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addInputEvent(
+        processor.registerEvent(
             (beforeInput("insertText", "a") as InputEvent).apply {
                 deleteContentBackwardSize = 1
             }
@@ -198,7 +198,7 @@ class NativeInputEventsProcessorTest {
         )
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addInputEvent(
+        processor.registerEvent(
             (beforeInput("deleteContentBackward", "") as InputEvent).apply {
                 deleteContentBackwardSize = 1
             }
@@ -219,7 +219,7 @@ class NativeInputEventsProcessorTest {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addInputEvent(beforeInput("insertCompositionText", "test") as InputEvent)
+        processor.registerEvent(beforeInput("insertCompositionText", "test") as InputEvent)
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         // Verify that the input event was processed and sent to the communicator
@@ -241,12 +241,11 @@ class NativeInputEventsProcessorTest {
             code = "Backspace",
             type = "keydown"
         )
-        processor.addKeyEvent(backspaceEvent)
+        processor.registerEvent(backspaceEvent)
 
         // Add deleteContentBackward event
-        processor.addInputEvent(
-            beforeInput("deleteContentBackward", null) as InputEvent,
-            deleteContentBackwardSize = 1
+        processor.registerEvent(
+            (beforeInput("deleteContentBackward", null) as InputEvent).apply { deleteContentBackwardSize = 1 }
         )
         processor.manuallyRunCheckpoint(TextFieldValue("test"))
 
@@ -267,9 +266,8 @@ class NativeInputEventsProcessorTest {
         )
         val processor = TestNativeInputEventsProcessor(communicator)
 
-        processor.addInputEvent(
-            beforeInput("insertReplacementText", "replacement") as InputEvent,
-            deleteContentBackwardSize = 4
+        processor.registerEvent(
+            (beforeInput("insertReplacementText", "replacement") as InputEvent).apply { deleteContentBackwardSize = 4 },
         )
 
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -294,11 +292,11 @@ class NativeInputEventsProcessorTest {
 
         // 1. Simulate a key being long-pressed (e.g., 'e' key)
         // First keydown without repeat
-        processor.addKeyEvent(
+        processor.registerEvent(
             event = keyEvent(key = "e", type = "keydown", repeat = false)
         )
         // the first keydown is followed by the insertText
-        processor.addInputEvent(beforeInput("insertText", "e") as InputEvent)
+        processor.registerEvent(beforeInput("insertText", "e") as InputEvent)
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
@@ -306,7 +304,7 @@ class NativeInputEventsProcessorTest {
 
         // Several keydown events with repeat=true to simulate long press
         repeat(3) {
-            processor.addKeyEvent(
+            processor.registerEvent(
                 event = keyEvent(key = "e", type = "keydown", repeat = true)
             )
             processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -315,17 +313,17 @@ class NativeInputEventsProcessorTest {
         assertEquals(1, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
-        processor.addKeyEvent(keyEvent(key = "e", type = "keyup"))
+        processor.registerEvent(keyEvent(key = "e", type = "keyup"))
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
         // 2. Simulate selecting an accent by pressing a number key (e.g., '2' for é)
-        processor.addKeyEvent(event = keyEvent(key = "2", code = "Digit2"))
+        processor.registerEvent(event = keyEvent(key = "2", code = "Digit2"))
 
         // 3. Simulate the input event for the accented character
-        processor.addInputEvent(
+        processor.registerEvent(
             (beforeInput("insertText", "é") as InputEvent).apply {
                 deleteContentBackwardSize = 1 // to replace `e`
             }
@@ -362,11 +360,11 @@ class NativeInputEventsProcessorTest {
 
         // 1. Simulate a key being long-pressed (e.g., 'e' key)
         // First keydown without repeat
-        processor.addKeyEvent(
+        processor.registerEvent(
             event = keyEvent(key = "e", type = "keydown", repeat = false)
         )
         // the first keydown is followed by the insertText
-        processor.addInputEvent(beforeInput("insertText", "e") as InputEvent)
+        processor.registerEvent(beforeInput("insertText", "e") as InputEvent)
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
@@ -374,7 +372,7 @@ class NativeInputEventsProcessorTest {
 
         // Several keydown events with repeat=true to simulate long press
         repeat(3) {
-            processor.addKeyEvent(
+            processor.registerEvent(
                 event = keyEvent(key = "e", type = "keydown", repeat = true)
             )
             processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -384,16 +382,15 @@ class NativeInputEventsProcessorTest {
         assertEquals(0, communicator.keyboardEvents.size)
 
         // Key up event when the accent dialog appears
-        processor.addKeyEvent(keyEvent(key = "e", type = "keyup"))
+        processor.registerEvent(keyEvent(key = "e", type = "keyup"))
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
         // 2. Simulate choosing 'é' from the accent dialogues using a mouse, so no keydown events here
-        processor.addInputEvent(
-            beforeInput("insertText", "è") as InputEvent,
-            deleteContentBackwardSize = 1 // to replace `e`
+        processor.registerEvent(
+            (beforeInput("insertText", "è") as InputEvent).apply { deleteContentBackwardSize = 1 /* to replace `e` */ },
         )
 
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -424,11 +421,11 @@ class NativeInputEventsProcessorTest {
 
         // 1. Simulate a key being long-pressed (e.g., 'e' key)
         // First keydown without repeat
-        processor.addKeyEvent(
+        processor.registerEvent(
             event = keyEvent(key = "e", type = "keydown", repeat = false)
         )
         // the first keydown is followed by the insertText
-        processor.addInputEvent(beforeInput("insertText", "e") as InputEvent)
+        processor.registerEvent(beforeInput("insertText", "e") as InputEvent)
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
@@ -436,7 +433,7 @@ class NativeInputEventsProcessorTest {
 
         // Several keydown events with repeat=true to simulate long press
         repeat(3) {
-            processor.addKeyEvent(
+            processor.registerEvent(
                 event = keyEvent(key = "e", type = "keydown", repeat = true)
             )
             processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -446,16 +443,16 @@ class NativeInputEventsProcessorTest {
         assertEquals(0, communicator.keyboardEvents.size)
 
         // Key up event when the accent dialog appears
-        processor.addKeyEvent(keyEvent(key = "e", type = "keyup"))
+        processor.registerEvent(keyEvent(key = "e", type = "keyup"))
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(1, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
         // 2. Simulate arrow navigation through accent options
-        processor.addKeyEvent(keyEvent(key = "ArrowRight", code = "ArrowRight"))
-        processor.addCompositionEvent(compositionStart())
-        processor.addInputEvent(
+        processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight"))
+        processor.registerEvent(compositionStart())
+        processor.registerEvent(
             (beforeInput("insertText", "è") as InputEvent).apply {
                 deleteContentBackwardSize = 1
             }
@@ -464,8 +461,8 @@ class NativeInputEventsProcessorTest {
         assertEquals(3, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
-        processor.addKeyEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
-        processor.addInputEvent(
+        processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
+        processor.registerEvent(
             (beforeInput("insertCompositionText", "é") as InputEvent).apply {
                 deleteContentBackwardSize = 1
             }
@@ -475,8 +472,8 @@ class NativeInputEventsProcessorTest {
         assertEquals(5, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
-        processor.addKeyEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
-        processor.addInputEvent(
+        processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
+        processor.registerEvent(
             (beforeInput("insertCompositionText", "ê") as InputEvent).apply {
                 deleteContentBackwardSize = 1
             }
@@ -487,14 +484,14 @@ class NativeInputEventsProcessorTest {
         assertEquals(0, communicator.keyboardEvents.size)
 
         // Press ArrowLeft once to move back left
-        processor.addKeyEvent(keyEvent(key = "ArrowLeft", code = "ArrowLeft", isComposing = true))
+        processor.registerEvent(keyEvent(key = "ArrowLeft", code = "ArrowLeft", isComposing = true))
         processor.manuallyRunCheckpoint(TextFieldValue())
 
         processor.manuallyRunCheckpoint(TextFieldValue())
         assertEquals(7, communicator.editCommands.size)
         assertEquals(0, communicator.keyboardEvents.size)
 
-        processor.addInputEvent(
+        processor.registerEvent(
             (beforeInput("insertCompositionText", "é") as InputEvent).apply {
                 deleteContentBackwardSize = 1
             }
@@ -505,15 +502,14 @@ class NativeInputEventsProcessorTest {
         assertEquals(0, communicator.keyboardEvents.size)
 
         // 3. Press Enter to confirm selection
-        processor.addKeyEvent(keyEvent(key = "Enter", code = "Enter"))
+        processor.registerEvent(keyEvent(key = "Enter", code = "Enter"))
 
         // 4. Simulate the input event for the selected accented character
-        processor.addInputEvent(
-            beforeInput("insertCompositionText", "é") as InputEvent,
-            deleteContentBackwardSize = 1
+        processor.registerEvent(
+            (beforeInput("insertCompositionText", "é") as InputEvent).apply { deleteContentBackwardSize = 1 }
         )
 
-        processor.addCompositionEvent(compositionEnd("é"))
+        processor.registerEvent(compositionEnd("é"))
         processor.manuallyRunCheckpoint(TextFieldValue("e"))
 
         assertEquals(12, communicator.editCommands.size)
@@ -536,7 +532,7 @@ class NativeInputEventsProcessorTest {
         val processor = TestNativeInputEventsProcessor(communicator)
 
         // Add deleteContentBackward event
-        processor.addInputEvent(
+        processor.registerEvent(
             beforeInput("deleteContentBackward", "") as InputEvent
         )
 
@@ -562,9 +558,8 @@ class NativeInputEventsProcessorTest {
         val processor = TestNativeInputEventsProcessor(communicator)
 
         // Add deleteContentBackward event
-        processor.addInputEvent(
-            beforeInput("deleteContentBackward", "") as InputEvent,
-            deleteContentBackwardSize = 2 // Delete 2 characters
+        processor.registerEvent(
+            (beforeInput("deleteContentBackward", "") as InputEvent).apply { deleteContentBackwardSize = 2 },
         )
 
         // Process the event with a collapsed selection
@@ -590,12 +585,11 @@ class NativeInputEventsProcessorTest {
             code = "Backspace",
             type = "keydown"
         )
-        processor.addKeyEvent(backspaceEvent)
+        processor.registerEvent(backspaceEvent)
 
         // Then add a deleteContentBackward event
-        processor.addInputEvent(
-            beforeInput("deleteContentBackward", "") as InputEvent,
-            deleteContentBackwardSize = 1
+        processor.registerEvent(
+            (beforeInput("deleteContentBackward", "") as InputEvent).apply { deleteContentBackwardSize = 1 },
         )
 
         // With a non-collapsed selection


### PR DESCRIPTION
Fixes (https://youtrack.jetbrains.com/issue/CMP-8745/Web-Mobile.-iOS.-Composite-input.-Characters-arent-deleted)[link to the issue]

## Testing
`gradlew testWeb` and manual


## Release Notes
N/A