### PR TITLE
Adjust accessibility semantics for text fields

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -722,4 +722,57 @@ class ComponentsAccessibilitySemanticTest {
             }
         }
     }
+
+    @Test
+    fun testTextFieldLabelSemantics() = runUIKitInstrumentedTest {
+        setContent {
+            TextField(
+                value = "",
+                onValueChange = {},
+                label = { Text("Label") },
+                placeholder = { Text("Placeholder") }
+            )
+        }
+
+        assertAccessibilityTree {
+            value = "Label"
+            isAccessibilityElement = true
+            traits(CMPAccessibilityTraitTextView)
+        }
+    }
+
+    @Test
+    fun testTextPlaceholderSemantics() = runUIKitInstrumentedTest {
+        setContent {
+            TextField(
+                value = "",
+                onValueChange = {},
+                placeholder = { Text("Placeholder") }
+            )
+        }
+
+        assertAccessibilityTree {
+            value = "Placeholder"
+            isAccessibilityElement = true
+            traits(CMPAccessibilityTraitTextView)
+        }
+    }
+
+    @Test
+    fun testTextFieldWithValueSemantics() = runUIKitInstrumentedTest {
+        setContent {
+            TextField(
+                value = "Text",
+                onValueChange = {},
+                label = { Text("Label") },
+                placeholder = { Text("Placeholder") }
+            )
+        }
+
+        assertAccessibilityTree {
+            value = "Text"
+            isAccessibilityElement = true
+            traits(CMPAccessibilityTraitTextView)
+        }
+    }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticConfigurationUtils.kt
@@ -129,20 +129,31 @@ internal fun SemanticsConfiguration.accessibilityTraits(): UIAccessibilityTraits
 }
 
 internal fun SemanticsConfiguration.accessibilityLabel(): String? {
-    val contentDescription = getOrNull(SemanticsProperties.ContentDescription)?.joinToString("\n")
+    val contentDescription = getOrNull(SemanticsProperties.ContentDescription)
+        ?.joinToString("\n")
+        ?.takeIf { it.isNotBlank() }
 
-    return if (contentDescription != null) {
-        contentDescription
+    return contentDescription ?: if (contains(SemanticsProperties.EditableText)) {
+        null
     } else {
-        val editableText = getOrNull(SemanticsProperties.EditableText)?.text
-
-        editableText ?: getOrNull(SemanticsProperties.Text)?.joinToString("\n") { it.text }
+        getOrNull(SemanticsProperties.Text)?.joinToString("\n") { it.text }
     }
 }
 
 internal fun SemanticsConfiguration.accessibilityValue(): String? {
-    getOrNull(SemanticsProperties.StateDescription)?.let {
+    getOrNull(SemanticsProperties.StateDescription)?.takeIf { it.isNotBlank() }?.let {
         return it
+    }
+
+    if (contains(SemanticsProperties.EditableText)) {
+        getOrNull(SemanticsProperties.EditableText)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it.text }
+
+        getOrNull(SemanticsProperties.Text)
+            ?.joinToString("\n")
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return it }
     }
 
     return getOrNull(SemanticsProperties.ProgressBarRangeInfo)?.let {


### PR DESCRIPTION
Use accessibility value instead of accessibility label for TextField semantics.
Ignore blank semantics properties for accessibility label and accessibility value.

Fixes https://youtrack.jetbrains.com/issue/CMP-8636/iOS-A11y.-TextField-label-and-other-extra-parameters-omitted

## Release Notes
### Fixes - iOS
- Align the semantics of TextFields with iOS text inputs.