### PR TITLE
Revert `ComposeFoundationFlags.isNewContextMenuEnabled` back to AOSP state

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ComposeFoundationFlags.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ComposeFoundationFlags.kt
@@ -68,8 +68,7 @@ object ComposeFoundationFlags {
      * [BasicTextField][androidx.compose.foundation.text.BasicTextField]s. If false, the previous
      * context menu that has no public APIs will be used instead.
      */
-    // TODO: https://youtrack.jetbrains.com/issue/CMP-7757/Adopt-new-context-menu-API
-    @Suppress("MutableBareField") @JvmField var isNewContextMenuEnabled = false
+    @Suppress("MutableBareField") @JvmField var isNewContextMenuEnabled = true
 
     /**
      * Whether to use the new smart selection feature in

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.unit.sp
 import kotlin.math.pow
 import kotlin.test.Test
+import kotlinx.test.IgnoreJsTarget
+import kotlinx.test.IgnoreWasmTarget
 
 @OptIn(ExperimentalTestApi::class)
 class BasicTextFieldSelectionHandleTest {
@@ -121,6 +123,9 @@ class BasicTextFieldSelectionHandleTest {
     }
 
     @Test
+    // FIXME https://youtrack.jetbrains.com/issue/CMP-8803
+    @IgnoreJsTarget
+    @IgnoreWasmTarget
     fun coreTextFieldSelectionHandles() = runSkikoComposeUiTest(size = Size(100f, 100f)) {
         val selection = TextRange(1, 3)
         var selectionStart: Rect = Rect.Zero


### PR DESCRIPTION
[CMP-7757](https://youtrack.jetbrains.com/issue/CMP-7757) Adopt new context menu API

## Release Notes
N/A
