### PR TITLE
Add support for `WindowInsets.cutoutPath`

### DIFF
--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsets.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsets.skiko.kt
@@ -67,10 +67,9 @@ actual val WindowInsets.Companion.tappableElement: WindowInsets
     @Composable
     get() = LocalPlatformWindowInsets.current.tappableElement.toWindowInsets()
 
-// TODO: https://youtrack.jetbrains.com/issue/CMP-8684
 actual val WindowInsets.Companion.cutoutPath: Path?
     @Composable
-    get() = null
+    get() = LocalPlatformWindowInsets.current.cutoutPath
 
 actual val WindowInsets.Companion.waterfall: WindowInsets
     @Composable

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformWindowInsets.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformWindowInsets.skiko.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -42,6 +43,11 @@ interface PlatformWindowInsets {
      * An empty list is returned when there are no display cutouts.
      */
     val displayCutouts: List<Rect> get() = emptyList()
+    /**
+     * A [Path] representing the union of all display cutouts.
+     * Returns null if there are no cutouts or if the platform does not provide cutout geometry.
+     */
+    val cutoutPath: Path? get() = null
     val captionBar: PlatformInsets get() = PlatformInsets.Zero
     /**
      * Represents the safe inset areas that content should observe to avoid all display cutouts.


### PR DESCRIPTION
Add default support for `WindowInsets.cutoutPath`

Fixes https://youtrack.jetbrains.com/issue/CMP-8684

## Release Notes
N/A
