### PR TITLE
Dispose all a11yControllers after each a11y test

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -372,15 +372,20 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
         semanticsOwnerListener = semanticsOwnerListener,
         coroutineDispatcher = testDispatcher
     ) {
-        semanticsOwnerListener.accessibilityControllers.forEach {
-            it.launchSyncLoop(testDispatcher)
+        try {
+            semanticsOwnerListener.accessibilityControllers.forEach {
+                it.launchSyncLoop(testDispatcher)
+            }
+            val scope = ComposeA11yTestScope(
+                test = this,
+                sceneAccessible = composeSceneAccessible
+            )
+            block(scope)
+        } finally {
+//            semanticsOwnerListener.accessibilityControllers.forEach {
+//                it.dispose()
+//            }
         }
-
-        val scope = ComposeA11yTestScope(
-            test = this,
-            sceneAccessible = composeSceneAccessible
-        )
-        block(scope)
     }
 }
 


### PR DESCRIPTION
Fix a11y tests in 1.10

Fixes https://youtrack.jetbrains.com/issue/CMP-8784

## Testing
Tests fixed

## Release Notes
N/A
