### PR TITLE
Fix ignored keyboard insets tests

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.animation.withAnimationProgress
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -51,12 +52,21 @@ internal fun OffsetToFocusedRect(
     var offsetProgress by remember { mutableStateOf(1f) }
     val density = LocalDensity.current
 
+    fun translatedFocusedRect(): Rect? {
+        // The current implementation of OffsetToFocusedRect assumes that the focus rectangle is
+        // either static or only changes during the animation.
+        // The [Snapshot.withoutReadObservation] function is used here to avoid side effects caused
+        // by the internal implementation of the [getFocusedRect] function.
+        val rect = Snapshot.withoutReadObservation { getFocusedRect() }
+        return rect?.translate(-currentOffset.toOffset())
+    }
+
     LaunchedEffect(insets, animationDuration) {
         startOffset = currentOffset
         if (animationDuration.isPositive()) {
             if (startOffset == density.adjustedToFocusedRectOffset(
                     insets = insets,
-                    focusedRect = getFocusedRect()?.translate(-currentOffset.toOffset()),
+                    focusedRect = translatedFocusedRect(),
                     size = size
                 )
             ) {
@@ -77,7 +87,7 @@ internal fun OffsetToFocusedRect(
         measurePolicy = { measurables, constraints ->
             val endOffset = density.adjustedToFocusedRectOffset(
                 insets = insets,
-                focusedRect = getFocusedRect()?.translate(-currentOffset.toOffset()),
+                focusedRect = translatedFocusedRect(),
                 size = size
             )
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -357,7 +357,6 @@ internal class KeyboardInsetsTest {
 
     @OptIn(ExperimentalForeignApi::class)
     @Test
-    @Ignore // FIXME Fails after 1.10.0-alpha01 merge
     fun testRefocusByTapKeyboardSizeNotChanges() = runUIKitInstrumentedTest {
         val keyboardFrames = mutableListOf<DpRect>()
         val contentFrames = mutableListOf<DpRect>()
@@ -390,7 +389,7 @@ internal class KeyboardInsetsTest {
             Column(modifier = Modifier.fillMaxSize().imePadding().onGloballyPositioned {
                 contentFrames.add(it.boundsInRoot().toDpRect(density))
             }) {
-                Spacer(Modifier.weight(100f))
+                Spacer(Modifier.weight(1f))
                 TextField(
                     value = "",
                     onValueChange = {},
@@ -427,7 +426,6 @@ internal class KeyboardInsetsTest {
 
     @OptIn(ExperimentalForeignApi::class)
     @Test
-    @Ignore // FIXME Fails after 1.10.0-alpha01 merge
     fun testRefocusProgrammaticallyKeyboardSizeNotChanges() = runUIKitInstrumentedTest {
         val focusRequester1 = FocusRequester()
         val focusRequester2 = FocusRequester()
@@ -462,7 +460,7 @@ internal class KeyboardInsetsTest {
             Column(modifier = Modifier.fillMaxSize().imePadding().onGloballyPositioned {
                 contentFrames.add(it.boundsInRoot().toDpRect(density))
             }) {
-                Spacer(Modifier.weight(100f))
+                Spacer(Modifier.weight(1f))
                 TextField(
                     value = "",
                     onValueChange = {},


### PR DESCRIPTION
The new implementation of FocusTargetNode.focusRect() together with access to the mutable state value causes endless content re-layout.
The OffsetToFocusedRect method assumes that getFocusedRect() should return a non-observable rectangle of the focused element. To resolve this issue, the code was modified to use the `Snapshot.withoutReadObservation` method.

Fixes https://youtrack.jetbrains.com/issue/CMP-8781/Fix-KeyboardInsetsTest-after-1.10.0-alpha01-merge

## Release Notes
N/A