### PR TITLE
Fix disabled menu items and ContextMenuTest that interacts with them

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -16,8 +16,6 @@
 
 package androidx.compose.foundation
 
-import androidx.compose.foundation.copyPasteAndroidTests.lazy.list.assertIsNotPlaced
-import androidx.compose.foundation.copyPasteAndroidTests.lazy.list.assertIsPlaced
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
@@ -36,7 +34,11 @@ import androidx.compose.ui.platform.PlatformLocalization
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -149,35 +151,44 @@ class ContextMenuTest {
             }
         }
 
-        onNodeWithText(localization.copy).assertIsNotPlaced()
-        onNodeWithText(localization.cut).assertIsNotPlaced()
-        onNodeWithText(localization.paste).assertIsNotPlaced()
-        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+        onNodeWithText(localization.copy).assertDoesNotExist()
+        onNodeWithText(localization.cut).assertDoesNotExist()
+        onNodeWithText(localization.paste).assertDoesNotExist()
+        onNodeWithText(localization.selectAll).assertDoesNotExist()
 
         onNodeWithTag("textfield").performMouseInput { rightClick() }
-        onNodeWithText(localization.copy).assertIsNotPlaced()
-        onNodeWithText(localization.cut).assertIsNotPlaced()
-        onNodeWithText(localization.paste).isDisplayed()
-        onNodeWithText(localization.selectAll).isDisplayed()
+        onNodeWithText(localization.copy).assertMenuItemDoesNotExistOrIsDisabled()
+        onNodeWithText(localization.cut).assertMenuItemDoesNotExistOrIsDisabled()
+        onNodeWithText(localization.paste).assertExists()
+        onNodeWithText(localization.selectAll).assertExists()
 
         onNodeWithTag("textfield").performKeyInput { pressKey(Key.Escape) }
-        onNodeWithText(localization.copy).assertIsNotPlaced()
-        onNodeWithText(localization.cut).assertIsNotPlaced()
-        onNodeWithText(localization.paste).assertIsNotPlaced()
-        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+        onNodeWithText(localization.copy).assertDoesNotExist()
+        onNodeWithText(localization.cut).assertDoesNotExist()
+        onNodeWithText(localization.paste).assertDoesNotExist()
+        onNodeWithText(localization.selectAll).assertDoesNotExist()
 
         onNodeWithTag("textfield").performTextInputSelection(TextRange(0, "Text".length))
         onNodeWithTag("textfield").performMouseInput { rightClick() }
-        onNodeWithText(localization.copy).isDisplayed()
-        onNodeWithText(localization.cut).isDisplayed()
-        onNodeWithText(localization.paste).isDisplayed()
-        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+        onNodeWithText(localization.copy).assertExists()
+        onNodeWithText(localization.cut).assertExists()
+        onNodeWithText(localization.paste).assertExists()
+        onNodeWithText(localization.selectAll).assertMenuItemDoesNotExistOrIsDisabled()
 
         onNodeWithTag("textfield").performKeyInput { pressKey(Key.Escape) }
-        onNodeWithText(localization.copy).assertIsNotPlaced()
-        onNodeWithText(localization.cut).assertIsNotPlaced()
-        onNodeWithText(localization.paste).assertIsNotPlaced()
-        onNodeWithText(localization.selectAll).assertIsNotPlaced()
+        onNodeWithText(localization.copy).assertDoesNotExist()
+        onNodeWithText(localization.cut).assertDoesNotExist()
+        onNodeWithText(localization.paste).assertDoesNotExist()
+        onNodeWithText(localization.selectAll).assertDoesNotExist()
+    }
+
+    private fun SemanticsNodeInteraction.assertMenuItemDoesNotExistOrIsDisabled() {
+        // New context menus disabled items; old context menus don't show disabled items.
+        if (ComposeFoundationFlags.isNewContextMenuEnabled) {
+            assertIsNotEnabled()
+        } else {
+            assertDoesNotExist()
+        }
     }
 
     @Test
@@ -216,9 +227,9 @@ class ContextMenuTest {
 
         onNodeWithTag("textfield").performMouseInput { rightClick(Offset(1f, height/2f)) }
         onNodeWithText(localization.copy).apply {
-            assertIsPlaced()
+            assertExists()
             performClick()
-            assertIsNotPlaced()
+            assertDoesNotExist()
         }
     }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.foundation
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -50,10 +52,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -98,8 +97,6 @@ internal fun DefaultOpenContextMenu(
             }
         },
     ) {
-        focusManager = LocalFocusManager.current
-        inputModeManager = LocalInputModeManager.current
         Column(
             modifier = Modifier
                 .shadow(8.dp)
@@ -110,21 +107,10 @@ internal fun DefaultOpenContextMenu(
         ) {
             components.forEach { component ->
                 when (component) {
-                    is TextContextMenuSeparator -> MenuSeparator(colors.textColor)
-                    is TextContextMenuItemWithComposableLeadingIcon -> {
-                        MenuItemContent(
-                            itemHoverColor = colors.hoverColor,
-                            onClick = { component.onClick(session) },
-                        ) {
-                            component.leadingIcon?.let { icon ->
-                                icon(colors.resolveIconColor(component.enabled))
-                            }
-                            BasicText(
-                                text = component.label,
-                                style = TextStyle(colors.resolveTextColor(component.enabled))
-                            )
-                        }
-                    }
+                    is TextContextMenuSeparator ->
+                        MenuSeparator(colors.textColor)
+                    is TextContextMenuItemWithComposableLeadingIcon ->
+                        MenuItem(session, colors, component)
                 }
             }
         }
@@ -143,19 +129,51 @@ private fun MenuSeparator(color: Color) {
 }
 
 @Composable
-private fun MenuItemContent(
-    itemHoverColor: Color,
-    onClick: () -> Unit,
-    content: @Composable RowScope.() -> Unit
+private fun MenuItem(
+    session: TextContextMenuSession,
+    colors: ContextMenuColors,
+    component: TextContextMenuItemWithComposableLeadingIcon
 ) {
-    var hovered by remember { mutableStateOf(false) }
+    MenuItemContent(
+        colors = colors,
+        onClick = { component.onClick(session) },
+        enabled = component.enabled
+    ) {
+        component.leadingIcon?.let { icon ->
+            icon(colors.resolveIconColor(component.enabled))
+        }
+        BasicText(
+            text = component.label,
+            style = TextStyle(colors.resolveTextColor(component.enabled))
+        )
+    }
+}
+
+@Composable
+private fun MenuItemContent(
+    colors: ContextMenuColors,
+    onClick: () -> Unit,
+    enabled: Boolean,
+    content: @Composable RowScope.() -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
     Row(
         modifier = Modifier
             .clickable(
                 onClick = onClick,
+                interactionSource = interactionSource,
+                enabled = enabled,
             )
-            .onHover { hovered = it }
-            .background(if (hovered) itemHoverColor else Color.Transparent)
+            .semantics(mergeDescendants = true) {}
+            .then(
+                if (enabled) {
+                    val hovered = interactionSource.collectIsHoveredAsState().value
+                    Modifier
+                        .background(if (hovered) colors.hoverColor else Color.Transparent)
+                } else {
+                    Modifier
+                }
+            )
             .fillMaxWidth()
             // Preferred min and max width used during the intrinsic measurement.
             .sizeIn(
@@ -169,22 +187,9 @@ private fun MenuItemContent(
                     vertical = 0.dp
                 )
             ),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        content()
-    }
-}
-
-private fun Modifier.onHover(onHover: (Boolean) -> Unit) = pointerInput(Unit) {
-    awaitPointerEventScope {
-        while (true) {
-            val event = awaitPointerEvent()
-            when (event.type) {
-                PointerEventType.Enter -> onHover(true)
-                PointerEventType.Exit -> onHover(false)
-            }
-        }
-    }
+        verticalAlignment = Alignment.CenterVertically,
+        content = content
+    )
 }
 
 private const val DisabledAlpha = 0.38f


### PR DESCRIPTION
Make disabled context menu items actually disabled, and also set their semantics correctly.
Also fix `ContextMenuTest` to allow menu items to be disabled rather than non-existing.

Fixes https://youtrack.jetbrains.com/issue/CMP-8804

## Testing
Tested manually and ran `ContextMenuTest`

## Release Notes
### Fixes - Desktop
- Made disabled new context menu items actually disabled, including the right semantics.
