### PR TITLE
Add API to configure `inputView` and `inputAccessoryView` with `PlatformImeOptions`

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
@@ -186,9 +186,15 @@ private val IosImeOptionsInputViewExample = Screen.Example("Input View") {
         val randomCharacterInput = rememberSaveable { mutableStateOf("") }
         Item(
             "Random Character Input View",
-            options = PlatformImeOptions { inputView(CustomActionInputView(action = { randomCharacterInput.value += ('a'..'z').random().toString() })) },
+            options = PlatformImeOptions { inputView(ActionInputView("Random Character", action = { randomCharacterInput.value += ('a'..'z').random().toString() })) },
             value = randomCharacterInput.value,
             onValueChange = { randomCharacterInput.value = it }
+        )
+
+        val keyboardController = LocalSoftwareKeyboardController.current
+        Item(
+            title = "Action Input Accessory View",
+            options = PlatformImeOptions { inputAccessoryView(ActionButton("Hide", action = { keyboardController?.hide() })) }
         )
     }
 }
@@ -246,15 +252,27 @@ private fun EditLine(
     )
 }
 
-private class CustomActionInputView(
+private class ActionButton(
+    title: String,
+    val action: () -> Unit
+): UIButton(frame = CGRectZero.readValue()) {
+    init {
+        setTitle(title, forState = UIControlStateNormal)
+        backgroundColor = UIColor.redColor
+        translatesAutoresizingMaskIntoConstraints = false
+        addTarget(this, NSSelectorFromString(::handleTap.name), UIControlEventTouchUpInside)
+    }
+
+    @ObjCAction
+    fun handleTap() = action()
+}
+
+private class ActionInputView(
+    title: String,
     val action: () -> Unit
 ) : UIInputView(frame = CGRectMake(0.0, 0.0, 0.0, 300.0), inputViewStyle = UIInputViewStyle.UIInputViewStyleKeyboard), UIInputViewAudioFeedbackProtocol {
     init {
-        val button = UIButton(frame = CGRectZero.readValue())
-        button.setTitle( "TAP", forState = UIControlStateNormal)
-        button.backgroundColor = UIColor.redColor
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.addTarget(this, NSSelectorFromString(::handleTap.name), UIControlEventTouchUpInside)
+        val button = ActionButton(title, action)
         addSubview(button)
 
         NSLayoutConstraint.activateConstraints(listOf(
@@ -264,9 +282,6 @@ private class CustomActionInputView(
             button.rightAnchor.constraintEqualToAnchor(rightAnchor, constant = -10.0),
         ))
     }
-
-    @ObjCAction
-    fun handleTap() = action()
 
     override fun enableInputClicksWhenVisible(): Boolean = true
 }

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.mpp.demo
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.BasicTextField
@@ -31,6 +32,19 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.PlatformImeOptions
+import kotlinx.cinterop.ObjCAction
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRectMake
+import platform.CoreGraphics.CGRectZero
+import platform.Foundation.NSSelectorFromString
+import platform.UIKit.NSLayoutConstraint
+import platform.UIKit.UIButton
+import platform.UIKit.UIColor
+import platform.UIKit.UIControlEventTouchUpInside
+import platform.UIKit.UIControlStateNormal
+import platform.UIKit.UIInputView
+import platform.UIKit.UIInputViewAudioFeedbackProtocol
+import platform.UIKit.UIInputViewStyle
 import platform.UIKit.UIKeyboardAppearanceDark
 import platform.UIKit.UIKeyboardAppearanceDefault
 import platform.UIKit.UIKeyboardAppearanceLight
@@ -46,6 +60,7 @@ import platform.UIKit.UIKeyboardTypeWebSearch
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.constraintEqualToSystemSpacingBelowAnchor
 
 private val keyboardTypes = listOf(
     "Default" to UIKeyboardTypeDefault,
@@ -163,6 +178,21 @@ private val IosImeOptionsAutocorrectionTypeExample = Screen.Example("Autocapital
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
+private val IosImeOptionsInputViewExample = Screen.Example("Input View") {
+    Column {
+        Item("Null Input View", PlatformImeOptions { inputView(null) })
+
+        val randomCharacterInput = rememberSaveable { mutableStateOf("") }
+        Item(
+            "Random Character Input View",
+            options = PlatformImeOptions { inputView(CustomActionInputView(action = { randomCharacterInput.value += ('a'..'z').random().toString() })) },
+            value = randomCharacterInput.value,
+            onValueChange = { randomCharacterInput.value = it }
+        )
+    }
+}
+
 val IosImeOptionsExample = Screen.Selection(
     "iOS Platform IME Options",
     IosImeOptionsKeyboardTypeExample,
@@ -171,7 +201,8 @@ val IosImeOptionsExample = Screen.Selection(
     IosImeOptionsIsSecureTextEntryExample,
     IosImeOptionsEnablesReturnKeyTypeAutomaticallyExample,
     IosImeOptionsAutocapitalizationTypeExample,
-    IosImeOptionsAutocorrectionTypeExample
+    IosImeOptionsAutocorrectionTypeExample,
+    IosImeOptionsInputViewExample,
 )
 
 @Composable
@@ -179,26 +210,63 @@ private fun Item(
     title: String,
     options: PlatformImeOptions
 ) {
+    val state = rememberSaveable { mutableStateOf("") }
     Text(title)
-    EditLine(options)
+    EditLine(options, value = state.value, onValueChange = { state.value = it })
+}
+
+@Composable
+private fun Item(
+    title: String,
+    options: PlatformImeOptions,
+    value: String,
+    onValueChange: (String) -> Unit
+) {
+    Text(title)
+    EditLine(options, value = value, onValueChange = onValueChange)
 }
 
 @Composable
 private fun EditLine(
     options: PlatformImeOptions,
-    text: String = ""
+    value: String,
+    onValueChange: (String) -> Unit
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    val state = rememberSaveable { mutableStateOf(text) }
     BasicTextField(
         modifier = demoTextFieldModifiers,
-        value = state.value,
+        value = value,
         singleLine = true,
         keyboardOptions = KeyboardOptions(
             platformImeOptions = options
         ),
         keyboardActions = KeyboardActions { keyboardController?.hide() },
-        onValueChange = { state.value = it },
+        onValueChange = onValueChange,
         textStyle = TextStyle(fontSize = fontSize8),
     )
+}
+
+private class CustomActionInputView(
+    val action: () -> Unit
+) : UIInputView(frame = CGRectMake(0.0, 0.0, 0.0, 300.0), inputViewStyle = UIInputViewStyle.UIInputViewStyleKeyboard), UIInputViewAudioFeedbackProtocol {
+    init {
+        val button = UIButton(frame = CGRectZero.readValue())
+        button.setTitle( "TAP", forState = UIControlStateNormal)
+        button.backgroundColor = UIColor.redColor
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(this, NSSelectorFromString(::handleTap.name), UIControlEventTouchUpInside)
+        addSubview(button)
+
+        NSLayoutConstraint.activateConstraints(listOf(
+            button.topAnchor.constraintEqualToSystemSpacingBelowAnchor(safeAreaLayoutGuide.topAnchor, multiplier = 1.0),
+            button.bottomAnchor.constraintEqualToAnchor(safeAreaLayoutGuide.bottomAnchor, constant = -10.0),
+            button.leftAnchor.constraintEqualToAnchor(leftAnchor, constant = 10.0),
+            button.rightAnchor.constraintEqualToAnchor(rightAnchor, constant = -10.0),
+        ))
+    }
+
+    @ObjCAction
+    fun handleTap() = action()
+
+    override fun enableInputClicksWhenVisible(): Boolean = true
 }

--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -37,7 +37,8 @@ private class PlatformImeOptionsImpl(
     val autocapitalizationType: UITextAutocapitalizationType?,
     val autocorrectionType: UITextAutocorrectionType?,
     val hasExplicitTextContentType: Boolean,
-    val inputView: UIView?
+    val inputView: UIView?,
+    val inputAccessoryView: UIView?,
 ): PlatformImeOptions()
 
 /**
@@ -55,7 +56,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
     private var autocorrectionType: UITextAutocorrectionType? = null
     private var hasExplicitTextContentType: Boolean = false
     private var inputView: UIView? = null
-
+    private var inputAccessoryView: UIView? = null
     /**
      * Sets the keyboard type to be used for the text input field.
      * If not set, the value will be derived from [ImeOptions].
@@ -154,6 +155,17 @@ class PlatformImeOptionsConfiguration internal constructor() {
     }
 
     /**
+     * Sets a custom accessory view to be attached to system keyboard or custom [inputView] when IME becomes first responder.
+     * Default value is `null`.
+     *
+     * See [UIKit documentation](https://developer.apple.com/documentation/uikit/uiresponder/inputaccessoryview)
+     */
+    @ExperimentalComposeUiApi
+    fun inputAccessoryView(value: UIView?): PlatformImeOptionsConfiguration = apply {
+        inputAccessoryView = value
+    }
+
+    /**
      * Builds the final PlatformImeOptions instance with the configured values.
      */
     internal fun build(): PlatformImeOptions {
@@ -168,6 +180,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
             autocorrectionType = autocorrectionType,
             hasExplicitTextContentType = hasExplicitTextContentType,
             inputView = inputView,
+            inputAccessoryView = inputAccessoryView,
         )
     }
 }
@@ -225,3 +238,7 @@ val PlatformImeOptions.hasExplicitTextContentType: Boolean
 @ExperimentalComposeUiApi
 val PlatformImeOptions.inputView: UIView?
     get() = (this as? PlatformImeOptionsImpl)?.inputView
+
+@ExperimentalComposeUiApi
+val PlatformImeOptions.inputAccessoryView: UIView?
+    get() = (this as? PlatformImeOptionsImpl)?.inputAccessoryView

--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -25,6 +25,7 @@ import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextContentType
+import platform.UIKit.UIView
 
 private class PlatformImeOptionsImpl(
     val keyboardType: UIKeyboardType?,
@@ -35,7 +36,8 @@ private class PlatformImeOptionsImpl(
     val enablesReturnKeyAutomatically: Boolean,
     val autocapitalizationType: UITextAutocapitalizationType?,
     val autocorrectionType: UITextAutocorrectionType?,
-    val hasExplicitTextContentType: Boolean
+    val hasExplicitTextContentType: Boolean,
+    val inputView: UIView?
 ): PlatformImeOptions()
 
 /**
@@ -52,6 +54,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
     private var autocapitalizationType: UITextAutocapitalizationType? = null
     private var autocorrectionType: UITextAutocorrectionType? = null
     private var hasExplicitTextContentType: Boolean = false
+    private var inputView: UIView? = null
 
     /**
      * Sets the keyboard type to be used for the text input field.
@@ -139,6 +142,12 @@ class PlatformImeOptionsConfiguration internal constructor() {
         autocorrectionType = value
     }
 
+    // TODO add doc
+    @ExperimentalComposeUiApi
+    fun inputView(value: UIView?): PlatformImeOptionsConfiguration = apply {
+        inputView = value
+    }
+
     /**
      * Builds the final PlatformImeOptions instance with the configured values.
      */
@@ -152,7 +161,8 @@ class PlatformImeOptionsConfiguration internal constructor() {
             enablesReturnKeyAutomatically = enablesReturnKeyAutomatically,
             autocapitalizationType = autocapitalizationType,
             autocorrectionType = autocorrectionType,
-            hasExplicitTextContentType = hasExplicitTextContentType
+            hasExplicitTextContentType = hasExplicitTextContentType,
+            inputView = inputView,
         )
     }
 }
@@ -206,3 +216,7 @@ val PlatformImeOptions.autocorrectionType: UITextAutocorrectionType?
 @ExperimentalComposeUiApi
 val PlatformImeOptions.hasExplicitTextContentType: Boolean
     get() = (this as? PlatformImeOptionsImpl)?.hasExplicitTextContentType ?: false
+
+@ExperimentalComposeUiApi
+val PlatformImeOptions.inputView: UIView?
+    get() = (this as? PlatformImeOptionsImpl)?.inputView

--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -142,7 +142,12 @@ class PlatformImeOptionsConfiguration internal constructor() {
         autocorrectionType = value
     }
 
-    // TODO add doc
+    /**
+     * Sets a custom input view to be presented instead of the system keyboard when IME becomes first responder.
+     * Default value is `null`.
+     *
+     * See [UIKit documentation](https://developer.apple.com/documentation/uikit/uiresponder/inputview)
+     */
     @ExperimentalComposeUiApi
     fun inputView(value: UIView?): PlatformImeOptionsConfiguration = apply {
         inputView = value

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -46,4 +46,6 @@
 
 - (NSTimeInterval)editMenuDelay;
 
+- (UIView*)inputView;
+
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -48,4 +48,6 @@
 
 - (UIView*)inputView;
 
+- (UIView*)inputAccessoryView;
+
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -46,8 +46,8 @@
 
 - (NSTimeInterval)editMenuDelay;
 
-- (UIView*)inputView;
+- (UIView *)inputView;
 
-- (UIView*)inputAccessoryView;
+- (UIView *)inputAccessoryView;
 
 @end

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
@@ -56,6 +56,7 @@ import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeTelephoneNumber
 import platform.UIKit.UITextInputProtocol
 import platform.UIKit.UIView
+import platform.UIKit.inputAccessoryView
 import platform.UIKit.inputView
 
 internal class ImeOptionsTest {
@@ -327,6 +328,7 @@ internal class ImeOptionsTest {
     fun testInputViewDefault() = runUIKitInstrumentedTest {
         val input = setContentAndFindInputView(keyboardOptions = KeyboardOptions.Default)
 
+        assertNull(input.inputAccessoryView)
         assertNull(input.inputView)
     }
 
@@ -339,7 +341,46 @@ internal class ImeOptionsTest {
             platformImeOptions = PlatformImeOptions { inputView(customInputView) }
         ))
 
+        assertNull(input.inputAccessoryView)
         assertSame(customInputView, input.inputView)
+    }
+
+    @Test
+    fun testInputAccessoryViewDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInputView(keyboardOptions = KeyboardOptions.Default)
+
+        assertNull(input.inputView)
+        assertNull(input.inputAccessoryView)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testInputAccessoryViewCustom() = runUIKitInstrumentedTest {
+        val customInputAccessoryView = object: UIView(frame = CGRectZero.readValue()) {}
+
+        val input = setContentAndFindInputView(keyboardOptions = KeyboardOptions(
+            platformImeOptions = PlatformImeOptions { inputAccessoryView(customInputAccessoryView) }
+        ))
+
+        assertNull(input.inputView)
+        assertSame(customInputAccessoryView, input.inputAccessoryView)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testInputAccessoryViewCustomAndInputViewCustom() = runUIKitInstrumentedTest {
+        val customInputView = object: UIInputView(frame = CGRectZero.readValue(), inputViewStyle = UIInputViewStyle.UIInputViewStyleKeyboard) {}
+        val customInputAccessoryView = object: UIView(frame = CGRectZero.readValue()) {}
+
+        val input = setContentAndFindInputView(keyboardOptions = KeyboardOptions(
+            platformImeOptions = PlatformImeOptions {
+                inputView(customInputView)
+                inputAccessoryView(customInputAccessoryView)
+            }
+        ))
+
+        assertSame(customInputView, input.inputView)
+        assertSame(customInputAccessoryView, input.inputAccessoryView)
     }
 
     private fun UIKitInstrumentedTest.setContentAndFindInputView(keyboardOptions: KeyboardOptions): UIView {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.keyboard
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.TextField
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PlatformImeOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.readValue
+import platform.CoreGraphics.CGRectZero
+import platform.UIKit.UIInputView
+import platform.UIKit.UIInputViewStyle
+import platform.UIKit.UIKeyboardAppearanceDark
+import platform.UIKit.UIKeyboardAppearanceDefault
+import platform.UIKit.UIKeyboardTypeDefault
+import platform.UIKit.UIKeyboardTypeEmailAddress
+import platform.UIKit.UIKeyboardTypeURL
+import platform.UIKit.UIResponder
+import platform.UIKit.UIReturnKeyType
+import platform.UIKit.UITextAutocapitalizationType
+import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.UITextContentTypeBirthdate
+import platform.UIKit.UITextContentTypeEmailAddress
+import platform.UIKit.UITextContentTypePassword
+import platform.UIKit.UITextContentTypeTelephoneNumber
+import platform.UIKit.UITextInputProtocol
+import platform.UIKit.UIView
+import platform.UIKit.inputView
+
+internal class ImeOptionsTest {
+    @Test
+    fun testKeyboardTypeDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(UIKeyboardTypeDefault, input.keyboardType)
+    }
+
+    @Test
+    fun testKeyboardType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { keyboardType(UIKeyboardTypeURL) }
+        )
+        assertEquals(UIKeyboardTypeURL, input.keyboardType)
+    }
+
+    @Test
+    fun testKeyboardAppearanceDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(UIKeyboardAppearanceDefault, input.keyboardAppearance)
+    }
+
+    @Test
+    fun testKeyboardAppearance() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { keyboardAppearance(UIKeyboardAppearanceDark) }
+        )
+        assertEquals(UIKeyboardAppearanceDark, input.keyboardAppearance)
+    }
+
+    @Test
+    fun testReturnKeyTypeDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(UIReturnKeyType.UIReturnKeyDefault, input.returnKeyType)
+    }
+
+    @Test
+    fun testReturnKeyType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { returnKeyType(UIReturnKeyType.UIReturnKeyGo) }
+        )
+        assertEquals(UIReturnKeyType.UIReturnKeyGo, input.returnKeyType)
+    }
+
+    @Test
+    fun testContentTypeDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertNull(input.textContentType)
+    }
+
+    @Test
+    fun testContentType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { textContentType(UITextContentTypeBirthdate) }
+        )
+        assertEquals(UITextContentTypeBirthdate, input.textContentType)
+    }
+
+    @Test
+    fun testContentTypeForCommonKeyboardTypePassword() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+        )
+        assertEquals(UITextContentTypePassword, input.textContentType)
+    }
+
+    @Test
+    fun testContentTypeForCommonKeyboardTypeEmail() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email)
+        )
+        assertEquals(UITextContentTypeEmailAddress, input.textContentType)
+    }
+
+    @Test
+    fun testContentTypeForCommonKeyboardTypePhone() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone)
+        )
+        assertEquals(UITextContentTypeTelephoneNumber, input.textContentType)
+    }
+
+    @Test
+    fun testIsSecureTextEntryDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertFalse(input.isSecureTextEntry())
+    }
+
+    @Test
+    fun testIsSecureTextEntryFalse() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { isSecureTextEntry(false) }
+        )
+        assertFalse(input.isSecureTextEntry())
+    }
+
+    @Test
+    fun testIsSecureTextEntryTrue() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { isSecureTextEntry(true) }
+        )
+        assertTrue(input.isSecureTextEntry())
+    }
+
+    @Test
+    fun testIsSecureTextEntryForCommonKeyboardTypePassword() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password)
+        )
+        assertTrue(input.isSecureTextEntry())
+    }
+
+    @Test
+    fun testIsSecureTextEntryForCommonKeyboardTypeNumberPassword() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
+        )
+        assertTrue(input.isSecureTextEntry())
+    }
+
+    @Test
+    fun testEnablesReturnKeyAutomaticallyDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput()
+        assertFalse(input.enablesReturnKeyAutomatically)
+    }
+
+    @Test
+    fun testEnablesReturnKeyAutomaticallyFalse() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { enablesReturnKeyAutomatically(false) }
+        )
+        assertFalse(input.enablesReturnKeyAutomatically)
+    }
+
+    @Test
+    fun testEnablesReturnKeyAutomaticallyTrue() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { enablesReturnKeyAutomatically(true) }
+        )
+        assertTrue(input.enablesReturnKeyAutomatically)
+    }
+
+    @Test
+    fun testAutocapitalizationTypeDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(
+            UITextAutocapitalizationType.UITextAutocapitalizationTypeNone,
+            input.autocapitalizationType
+        )
+    }
+
+    @Test
+    fun testAutocapitalizationType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions {
+                autocapitalizationType(UITextAutocapitalizationType.UITextAutocapitalizationTypeWords)
+            }
+        )
+        assertEquals(
+            UITextAutocapitalizationType.UITextAutocapitalizationTypeWords,
+            input.autocapitalizationType
+        )
+    }
+
+    @Test
+    fun testAutocorrectionTypeDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(
+            UITextAutocorrectionType.UITextAutocorrectionTypeYes,
+            input.autocorrectionType
+        )
+    }
+
+    @Test
+    fun testAutocorrectionType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions {
+                autocorrectionType(UITextAutocorrectionType.UITextAutocorrectionTypeNo)
+            }
+        )
+        assertEquals(
+            UITextAutocorrectionType.UITextAutocorrectionTypeNo,
+            input.autocorrectionType
+        )
+    }
+
+    @Test
+    fun testPlatformOverridesCommonKeyboardType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Decimal,
+                platformImeOptions = PlatformImeOptions { keyboardType(UIKeyboardTypeEmailAddress) }
+            )
+        )
+        assertEquals(UIKeyboardTypeEmailAddress, input.keyboardType)
+    }
+
+    @Test
+    fun testPlatformOverridesCommonReturnKeyType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Search,
+                platformImeOptions = PlatformImeOptions { returnKeyType(UIReturnKeyType.UIReturnKeyGo) }
+            )
+        )
+        assertEquals(UIReturnKeyType.UIReturnKeyGo, input.returnKeyType)
+    }
+
+    @Test
+    fun testPlatformOverridesCommonContentType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                platformImeOptions = PlatformImeOptions { textContentType(UITextContentTypeBirthdate) }
+            )
+        )
+        assertEquals(UITextContentTypeBirthdate, input.textContentType)
+    }
+
+    @Test
+    fun testPlatformOverridesCommonIsSecureTextEntry() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                platformImeOptions = PlatformImeOptions { isSecureTextEntry(false) }
+            )
+        )
+        assertFalse(input.isSecureTextEntry())
+    }
+
+    @Test
+    fun testPlatformOverridesCommonAutocapitalizationType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                capitalization = KeyboardCapitalization.Characters,
+                platformImeOptions = PlatformImeOptions { autocapitalizationType(UITextAutocapitalizationType.UITextAutocapitalizationTypeWords) }
+            )
+        )
+        assertEquals(UITextAutocapitalizationType.UITextAutocapitalizationTypeWords, input.autocapitalizationType)
+    }
+
+    @Test
+    fun testPlatformOverridesCommonAutocorrectionType() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            keyboardOptions = KeyboardOptions(
+                autoCorrectEnabled = false,
+                platformImeOptions = PlatformImeOptions { autocorrectionType(UITextAutocorrectionType.UITextAutocorrectionTypeYes) }
+            )
+        )
+        assertEquals(UITextAutocorrectionType.UITextAutocorrectionTypeYes, input.autocorrectionType)
+    }
+
+    @Test
+    fun testInputViewDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInputView(keyboardOptions = KeyboardOptions.Default)
+
+        assertNull(input.inputView)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testInputViewCustom() = runUIKitInstrumentedTest {
+        val customInputView = object: UIInputView(frame = CGRectZero.readValue(), inputViewStyle = UIInputViewStyle.UIInputViewStyleKeyboard) {}
+
+        val input = setContentAndFindInputView(keyboardOptions = KeyboardOptions(
+            platformImeOptions = PlatformImeOptions { inputView(customInputView) }
+        ))
+
+        assertSame(customInputView, input.inputView)
+    }
+
+    private fun UIKitInstrumentedTest.setContentAndFindInputView(keyboardOptions: KeyboardOptions): UIView {
+        val focusRequester = FocusRequester()
+
+        setContent {
+            TextField(
+                value = "",
+                onValueChange = {},
+                keyboardOptions = keyboardOptions,
+                modifier = Modifier.focusRequester(focusRequester)
+            )
+            LaunchedEffect(Unit) {
+                focusRequester.requestFocus()
+            }
+        }
+        
+        return assertNotNull(findFirstUITextInput())
+    }
+
+    private fun UIKitInstrumentedTest.setContentAndFindInput(
+        keyboardOptions: KeyboardOptions
+    ): UITextInputProtocol {
+        setContentAndFindInputView(keyboardOptions = keyboardOptions)
+        return assertNotNull(findFirstUITextInput() as? UITextInputProtocol)
+    }
+
+    private fun UIKitInstrumentedTest.setContentAndFindInput(
+        imeOptions: PlatformImeOptions? = null
+    ): UITextInputProtocol = setContentAndFindInput(keyboardOptions = KeyboardOptions(platformImeOptions = imeOptions))
+
+    private fun UIKitInstrumentedTest.findFirstUITextInput(): UIView? {
+        val windowScene = hostingViewController.view.window?.windowScene ?: return null
+
+        fun traverseSubviews(view: UIView): UIView? {
+            if (view as? UITextInputProtocol != null) {
+                return view
+            }
+
+            view.subviews.forEach {
+                traverseSubviews(it as UIView)?.let { return it }
+            }
+
+            return null
+        }
+
+        return windowScene.windows.reversed().firstNotNullOfOrNull {
+            traverseSubviews(view = it as UIView)
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.autocapitalizationType
 import androidx.compose.ui.text.input.autocorrectionType
 import androidx.compose.ui.text.input.enablesReturnKeyAutomatically
 import androidx.compose.ui.text.input.hasExplicitTextContentType
+import androidx.compose.ui.text.input.inputView
 import androidx.compose.ui.text.input.isSecureTextEntry
 import androidx.compose.ui.text.input.keyboardAppearance
 import androidx.compose.ui.text.input.keyboardType
@@ -46,6 +47,7 @@ import platform.UIKit.UITextContentType
 import platform.UIKit.UITextContentTypeEmailAddress
 import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeTelephoneNumber
+import platform.UIKit.UIView
 
 internal interface SkikoUITextInputTraits {
     fun keyboardType(): UIKeyboardType =
@@ -71,6 +73,8 @@ internal interface SkikoUITextInputTraits {
 
     fun autocorrectionType(): UITextAutocorrectionType =
         UITextAutocorrectionType.UITextAutocorrectionTypeYes
+
+    fun inputView(): UIView? = null
 }
 
 internal object EmptyInputTraits : SkikoUITextInputTraits
@@ -181,6 +185,10 @@ internal fun getUITextInputTraits(currentImeOptions: ImeOptions?) =
                 false -> UITextAutocorrectionType.UITextAutocorrectionTypeNo
                 else -> UITextAutocorrectionType.UITextAutocorrectionTypeDefault
             }
+        }
+
+        override fun inputView(): UIView? {
+            return currentImeOptions?.platformImeOptions?.inputView
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.input.autocapitalizationType
 import androidx.compose.ui.text.input.autocorrectionType
 import androidx.compose.ui.text.input.enablesReturnKeyAutomatically
 import androidx.compose.ui.text.input.hasExplicitTextContentType
+import androidx.compose.ui.text.input.inputAccessoryView
 import androidx.compose.ui.text.input.inputView
 import androidx.compose.ui.text.input.isSecureTextEntry
 import androidx.compose.ui.text.input.keyboardAppearance
@@ -75,6 +76,8 @@ internal interface SkikoUITextInputTraits {
         UITextAutocorrectionType.UITextAutocorrectionTypeYes
 
     fun inputView(): UIView? = null
+
+    fun inputAccessoryView(): UIView? = null
 }
 
 internal object EmptyInputTraits : SkikoUITextInputTraits
@@ -189,6 +192,10 @@ internal fun getUITextInputTraits(currentImeOptions: ImeOptions?) =
 
         override fun inputView(): UIView? {
             return currentImeOptions?.platformImeOptions?.inputView
+        }
+
+        override fun inputAccessoryView(): UIView? {
+            return currentImeOptions?.platformImeOptions?.inputAccessoryView
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -101,6 +101,7 @@ internal class IntermediateTextInputUIView(
     var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
 
     override fun inputView(): UIView? = inputTraits.inputView()
+    override fun inputAccessoryView(): UIView? = inputTraits.inputAccessoryView()
 
     override fun canBecomeFirstResponder() = true
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -100,6 +100,8 @@ internal class IntermediateTextInputUIView(
 
     var inputTraits: SkikoUITextInputTraits = EmptyInputTraits
 
+    override fun inputView(): UIView? = inputTraits.inputView()
+
     override fun canBecomeFirstResponder() = true
 
     override fun resignFirstResponder(): Boolean {


### PR DESCRIPTION
- Adds API to configure `UIResponder.inputView` with `PlatformImeOptions`
- Adds API to configure `UIResponder.inputAccessoryView` with `PlatformImeOptions`
- Creates `ImeOptionsTest` and add tests for input traits and `inputView`

Fixes 
- [CMP-7883](https://youtrack.jetbrains.com/issue/CMP-7883) Provide API to configure inputView
- [CMP-8810](https://youtrack.jetbrains.com/issue/CMP-8810) Provide API to configure inputAccessoryView
- [CMP-8244](https://youtrack.jetbrains.com/issue/CMP-8244) iOS tests for native IME options API

## Testing
- Adds tests for providing custom `inputView`
- Adds tests for providing custom `inputAccessoryView`
- Adds example screen with custom `inputView` and `inputAccessoryView` to the demo app at `iOS-specific-features/iOS Platform IME Options/Input View`

## Release Notes
### Features - iOS
- Add API to configure `UIResponder.inputView` with `PlatformImeOptions`
- Add API to configure `UIResponder.inputAccessoryView` with `PlatformImeOptions`
