### PR TITLE
Use `onPlaced` instead of `onGloballyPositioned` in PopupLayout

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -211,10 +211,8 @@ internal fun rememberComposeSceneLayer(
 internal fun ComposeSceneLayer.Content(content: @Composable () -> Unit) {
     val currentContent by rememberUpdatedState(content)
     DisposableEffect(this) {
-        setContent {
-            currentContent()
-        }
-        onDispose {  }
+        setContent(currentContent)
+        onDispose { }
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -18,11 +18,11 @@ package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -35,7 +35,7 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.EmptyLayout
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalPlatformWindowInsets
@@ -419,9 +419,19 @@ private fun PopupLayout(
     onOutsidePointerEvent: ((eventType: PointerEventType, button: PointerButton?) -> Unit)? = null,
     content: @Composable () -> Unit
 ) {
+    // Use a MutableState directly to avoid recomposing when the value changes
+    val parentBoundsInWindow: MutableState<IntRect> = remember { mutableStateOf(IntRect.Zero) }
+    EmptyLayout(Modifier.onPlaced { childCoordinates ->
+        // This will be called before the popup measure policy is actually asked to calculate
+        // the popup's position, so it will never see the initial value of IntRect.Zero
+        childCoordinates.parentCoordinates?.let {
+            val layoutPosition = it.positionInWindow().round()
+            val layoutSize = it.size
+            parentBoundsInWindow.value = IntRect(layoutPosition, layoutSize)
+        }
+    })
+
     val currentContent by rememberUpdatedState(content)
-    var layoutParentBoundsInWindow: IntRect? by remember { mutableStateOf(null) }
-    EmptyLayout(Modifier.parentBoundsInWindow { layoutParentBoundsInWindow = it })
     val layer = rememberComposeSceneLayer(
         focusable = properties.focusable
     )
@@ -429,7 +439,6 @@ private fun PopupLayout(
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)
     layer.Content {
         val platformInsets = properties.platformInsets
-        val parentBoundsInWindow = layoutParentBoundsInWindow ?: return@Content
         val containerSize = LocalWindowInfo.current.containerSize
         val layoutDirection = LocalLayoutDirection.current
         val measurePolicy = rememberPopupMeasurePolicy(
@@ -463,16 +472,6 @@ private val PopupProperties.platformInsets: PlatformInsets
         }
     }
 
-private fun Modifier.parentBoundsInWindow(
-    onBoundsChanged: (IntRect) -> Unit
-) = this.onGloballyPositioned { childCoordinates ->
-    childCoordinates.parentCoordinates?.let {
-        val layoutPosition = it.positionInWindow().round()
-        val layoutSize = it.size
-        onBoundsChanged(IntRect(layoutPosition, layoutSize))
-    }
-}
-
 @Composable
 private fun rememberPopupMeasurePolicy(
     layer: ComposeSceneLayer,
@@ -481,15 +480,16 @@ private fun rememberPopupMeasurePolicy(
     containerSize: IntSize,
     platformInsets: PlatformInsets,
     layoutDirection: LayoutDirection,
-    parentBoundsInWindow: IntRect,
+    parentBoundsInWindow: MutableState<IntRect>
 ) = remember(layer, popupPositionProvider, properties, containerSize, platformInsets, layoutDirection, parentBoundsInWindow) {
     RootMeasurePolicy(
         platformInsets = platformInsets,
         usePlatformDefaultWidth = properties.usePlatformDefaultWidth
     ) { contentSize ->
+        val parentRectInWindow = parentBoundsInWindow.value
         val positionWithInsets = positionWithInsets(platformInsets, containerSize) { sizeWithoutInsets ->
             // Position provider works in coordinates without insets.
-            val boundsWithoutInsets = parentBoundsInWindow.translate(
+            val boundsWithoutInsets = parentRectInWindow.translate(
                 -platformInsets.left,
                 -platformInsets.top
             )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -425,6 +425,8 @@ private fun PopupLayout(
         // This will be called before the popup measure policy is actually asked to calculate
         // the popup's position, so it will never see the initial value of IntRect.Zero
         childCoordinates.parentCoordinates?.let {
+            // Nodes which read layout coordinates (including, e.g., positionInWindow) in
+            // layout/placement get invalidated when these coordinates change
             val layoutPosition = it.positionInWindow().round()
             val layoutSize = it.size
             parentBoundsInWindow.value = IntRect(layoutPosition, layoutSize)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/RootMeasurePolicy.skiko.kt
@@ -40,12 +40,12 @@ internal fun RootMeasurePolicy(
         constraints, platformInsets, usePlatformDefaultWidth
     )
     val placeables = measurables.fastMap { it.measure(platformConstraints) }
-    val contentSize = IntSize(
-        width = placeables.fastMaxBy { it.width }?.width ?: constraints.minWidth,
-        height = placeables.fastMaxBy { it.height }?.height ?: constraints.minHeight
-    )
-    val position = calculatePosition(contentSize)
     layout(constraints.maxWidth, constraints.maxHeight) {
+        val contentSize = IntSize(
+            width = placeables.fastMaxBy { it.width }?.width ?: constraints.minWidth,
+            height = placeables.fastMaxBy { it.height }?.height ?: constraints.minHeight
+        )
+        val position = calculatePosition(contentSize)
         placeables.fastForEach {
             it.place(position.x, position.y)
         }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.assertReceived
 import androidx.compose.ui.assertReceivedLast
 import androidx.compose.ui.assertReceivedNoEvents
 import androidx.compose.ui.assertThat
+import androidx.compose.ui.containsExactly
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.asComposeCanvas
@@ -41,6 +42,8 @@ import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.isEqualTo
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalPlatformWindowInsets
@@ -741,6 +744,44 @@ class PopupTest {
         } finally {
             scene.close()
         }
+    }
+
+    @Test
+    fun popupShownAtCorrectCoordinatesImmediately() = runSkikoComposeUiTest {
+        val positionProvider = object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize
+            ): IntOffset {
+                return anchorBounds.topLeft
+            }
+        }
+
+        var showPopup by mutableStateOf(false)
+        val popupPositions = mutableListOf<Offset>()
+        setContent {
+            Box(Modifier.size(300.dp)) {
+                Box(Modifier.size(100.dp).offset(100.dp, 100.dp)) {
+                    if (showPopup) {
+                        Popup(popupPositionProvider = positionProvider) {
+                            Box(
+                                Modifier
+                                    .size(50.dp)
+                                    .onPlaced {
+                                        popupPositions.add(it.positionInRoot())
+                                    }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        showPopup = true
+        waitForIdle()
+        assertThat(popupPositions).containsExactly(Offset(100f, 100f))
     }
 }
 


### PR DESCRIPTION
Use `Modifier.onPlaced` instead of `Modifier.onGloballyPositioned` to avoid calls when the window is moved.
Also use a `MutableState` instead of a delegate to it, in order to avoid an extra recomposition.

This also allows showing the popup without an extra recomposition because `onPlaced` is called in the layout phase following the initial composition when the popup is shown. It's also called before the popup measure policy is called, so there is not even a need to re-layout.

## Testing
Tested manually and added a unit test.
```
import androidx.compose.foundation.background
import androidx.compose.foundation.border
import androidx.compose.foundation.layout.*
import androidx.compose.material.*
import androidx.compose.runtime.*
import androidx.compose.ui.*
import androidx.compose.ui.Modifier
import androidx.compose.ui.geometry.Offset
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.unit.*
import androidx.compose.ui.window.*

@OptIn(ExperimentalMaterialApi::class)
fun main() {
    singleWindowApplication {
        Box(Modifier.fillMaxSize()) {
            var offsetX by remember { mutableStateOf(0) }
            LaunchedEffect(Unit) {
                var direction = 1
                while (true) {
                    withFrameNanos {
                        offsetX += direction
                        if (offsetX > 100) {
                            direction = -1
                        } else if (offsetX <= 0) {
                            direction = 1
                        }
                    }
                }
            }
            val dropdownState = remember { DropdownMenuState() }
            Box(
                modifier = Modifier
                    .offset(x = offsetX.dp, y = 0.dp)
                    .size(400.dp)
                    .border(1.dp, Color.Black)
                    .contextMenuOpenDetector(dropdownState),
                contentAlignment = Alignment.Center
            ) {
                Text("Right click to open dropdown")

                val status = dropdownState.status
                if (status is DropdownMenuState.Status.Open) {
                    Popup(
                        onDismissRequest = { dropdownState.status = DropdownMenuState.Status.Closed },
                        popupPositionProvider = popupPositionProvider(status.position),
                        properties = PopupProperties(
                            clippingEnabled = false
                        )
                    ) {
                        Box(
                            modifier = Modifier
                                .size(300.dp, 400.dp)
                                .background(Color.Yellow)
                                .border(10.dp, Color.Black),
                            contentAlignment = Alignment.Center
                        ) {
                            Text("I'm a dropdown")
                        }
                    }
                }
            }
        }
    }
}

@Composable
private fun popupPositionProvider(offset: Offset): PopupPositionProvider {
    return remember(offset) {
        object : PopupPositionProvider {
            override fun calculatePosition(
                anchorBounds: IntRect,
                windowSize: IntSize,
                layoutDirection: LayoutDirection,
                popupContentSize: IntSize
            ): IntOffset {
                return anchorBounds.topLeft
            }
        }
    }
}
```

## Release Notes
N/A