### PR TITLE
Provide access to `semanticsOwners` in desktop entry points

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.awt.RenderSettings.SkiaSurface
 import androidx.compose.ui.awt.RenderSettings.SwingGraphics
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.scene.ComposeContainer
+import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.savedstate.SavedState
 import java.awt.Color
@@ -213,13 +214,21 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             _composeContainer?.windowContainer = value
         }
 
-    override fun add(component: Component): Component {
-        return super.add(component)
-    }
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposePanel].
+     */
+    @ExperimentalComposeUiApi
+    val semanticsOwners: Collection<SemanticsOwner>
+        get() = _composeContainer?.semanticsOwners ?: emptyList()
 
-    override fun remove(component: Component) {
-        super.remove(component)
-    }
+    // Needed to preserve binary compatibility
+    @Suppress("RedundantOverride")
+    override fun add(component: Component): Component = super.add(component)
+
+    // Needed to preserve binary compatibility
+    @Suppress("RedundantOverride")
+    override fun remove(component: Component) = super.remove(component)
 
     override fun addNotify() {
         super.addNotify()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -217,6 +217,9 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ComposePanel].
+     *
+     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when set of semantics owners changes.
      */
     @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -217,9 +217,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ComposePanel].
-     *
-     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when set of semantics owners changes.
      */
     @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -85,9 +85,6 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ComposeWindow].
-     *
-     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when set of semantics owners changes.
      */
     @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.window.FrameWindowScope
 import androidx.compose.ui.window.UndecoratedWindowResizer
@@ -80,6 +81,14 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     // Don't override the accessible context of JFrame, since accessibility work through HardwareLayer
     internal val windowAccessible: Accessible
         get() = composePanel.windowAccessible
+
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ComposeWindow].
+     */
+    @ExperimentalComposeUiApi
+    val semanticsOwners: Collection<SemanticsOwner>
+        get() = composePanel.semanticsOwners
 
     init {
         contentPane.add(composePanel)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -85,6 +85,9 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ComposeWindow].
+     *
+     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when set of semantics owners changes.
      */
     @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -80,6 +80,7 @@ internal class ComposeWindowPanel(
     var exceptionHandler by composeContainer::exceptionHandler
     val windowHandle by composeContainer::windowHandle
     val renderApi by composeContainer::renderApi
+    val semanticsOwners by composeContainer::semanticsOwners
 
     var isWindowTransparent: Boolean = false
         set(value) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -190,6 +190,7 @@ internal class ComposeContainer(
     val windowHandle by mediator::windowHandle
     val renderApi by mediator::renderApi
     val preferredSize by mediator::preferredSize
+    val semanticsOwners by mediator::semanticsOwners
 
     override val lifecycle = LifecycleRegistry(this)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -669,7 +669,7 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners = mutableSetOf<SemanticsOwner>()
+        val semanticsOwners: Collection<SemanticsOwner> get() = _accessibilityControllers.keys
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)
@@ -682,12 +682,10 @@ internal class ComposeSceneMediator(
             ).also {
                 it.launchSyncLoop(coroutineContext)
             }
-            semanticsOwners.add(semanticsOwner)
         }
 
         override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
             _accessibilityControllers.remove(semanticsOwner)?.dispose()
-            semanticsOwners.remove(semanticsOwner)
         }
 
         override fun onSemanticsChange(semanticsOwner: SemanticsOwner) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -18,7 +18,6 @@ package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
-import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
@@ -669,7 +668,8 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners: Collection<SemanticsOwner> get() = _accessibilityControllers.keys
+        val semanticsOwners: Collection<SemanticsOwner>
+            get() = _accessibilityControllers.keys
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -669,7 +669,7 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners = mutableStateSetOf<SemanticsOwner>()
+        val semanticsOwners = mutableSetOf<SemanticsOwner>()
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -669,7 +669,7 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners = mutableSetOf<SemanticsOwner>()
+        val semanticsOwners = mutableStateSetOf<SemanticsOwner>()
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -669,7 +669,7 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners: Collection<SemanticsOwner> get() = _accessibilityControllers.keys
+        val semanticsOwners = mutableSetOf<SemanticsOwner>()
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)
@@ -682,10 +682,12 @@ internal class ComposeSceneMediator(
             ).also {
                 it.launchSyncLoop(coroutineContext)
             }
+            semanticsOwners.add(semanticsOwner)
         }
 
         override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
             _accessibilityControllers.remove(semanticsOwner)?.dispose()
+            semanticsOwners.remove(semanticsOwner)
         }
 
         override fun onSemanticsChange(semanticsOwner: SemanticsOwner) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
@@ -668,8 +669,7 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners: Collection<SemanticsOwner>
-            get() = _accessibilityControllers.keys
+        val semanticsOwners: Collection<SemanticsOwner> get() = _accessibilityControllers.keys
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -143,6 +143,7 @@ internal class ComposeSceneMediator(
     var fullscreen by skiaLayerComponent::fullscreen
     val windowHandle by skiaLayerComponent::windowHandle
     val renderApi by skiaLayerComponent::renderApi
+    val semanticsOwners: Collection<SemanticsOwner> by semanticsOwnerListener::semanticsOwners
 
     /**
      * @see ComposeFeatureFlags.useInteropBlending
@@ -666,6 +667,9 @@ internal class ComposeSceneMediator(
          */
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
+
+        val semanticsOwners: Collection<SemanticsOwner>
+            get() = _accessibilityControllers.keys
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.scene
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
@@ -668,8 +669,7 @@ internal class ComposeSceneMediator(
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
         val accessibilityControllers get() = _accessibilityControllers.values.reversed()
 
-        val semanticsOwners: Collection<SemanticsOwner>
-            get() = _accessibilityControllers.keys
+        val semanticsOwners = mutableStateSetOf<SemanticsOwner>()
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)
@@ -682,10 +682,12 @@ internal class ComposeSceneMediator(
             ).also {
                 it.launchSyncLoop(coroutineContext)
             }
+            semanticsOwners.add(semanticsOwner)
         }
 
         override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
             _accessibilityControllers.remove(semanticsOwner)?.dispose()
+            semanticsOwners.remove(semanticsOwner)
         }
 
         override fun onSemanticsChange(semanticsOwner: SemanticsOwner) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.runApplicationTest
+import java.awt.BorderLayout
+import javax.swing.JFrame
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+class SemanticsOwnersProviderTest {
+
+    @Test
+    fun semanticsOwnersProvidedInComposeWindow() = runApplicationTest {
+        launchTestWindowApplication {
+            TextApp()
+        }
+        awaitIdle()
+        assertSemanticsOwnersProvidedBy(window::semanticsOwners)
+    }
+
+    fun semanticsOwnersProvidedInComposePanel(visible: Boolean) = runApplicationTest {
+        val window = JFrame()
+        try {
+            val composePanel = ComposePanel()
+            composePanel.setContent {
+                TextApp()
+            }
+            composePanel.isVisible = visible
+
+            window.contentPane.add(composePanel, BorderLayout.CENTER)
+            window.pack()
+            window.isVisible = true
+
+            awaitIdle()
+            assertSemanticsOwnersProvidedBy(composePanel::semanticsOwners)
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun semanticsOwnersProvidedInVisibleComposePanel() =
+        semanticsOwnersProvidedInComposePanel(visible = true)
+
+    @Test
+    fun semanticsOwnersProvidedInInvisibleComposePanel() =
+        semanticsOwnersProvidedInComposePanel(visible = false)
+
+    @Test
+    fun semanticsOwnersProvidedInImageComposeScene() {
+        val imageComposeScene = ImageComposeScene(800, 600) {
+            TextApp()
+        }
+        imageComposeScene.render(0L)
+
+        assertSemanticsOwnersProvidedBy(imageComposeScene::semanticsOwners)
+    }
+
+    private fun assertSemanticsOwnersProvidedBy(
+        getSemanticsOwners: () -> Collection<SemanticsOwner>
+    ) {
+        val strings = getSemanticsOwners().collectText().map { it.text }
+        assertContentEquals(listOf("Hello", "World"), strings)
+    }
+
+    @Composable
+    private fun TextApp() {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            modifier = Modifier.padding(64.dp)
+        ) {
+            Text("Hello")
+            OutlinedTextField(rememberTextFieldState("World"))
+        }
+    }
+}
+
+private fun Collection<SemanticsOwner>.collectText(): List<AnnotatedString> {
+    val result = mutableListOf<AnnotatedString>()
+    forEach {
+        it.rootSemanticsNode.collectTextRecursive(result)
+    }
+    return result
+}
+
+private fun SemanticsNode.collectTextRecursive(result: MutableList<AnnotatedString>) {
+    result.addAll(config.getOrNull(SemanticsProperties.Text) ?: emptyList())
+    config.getOrNull(SemanticsProperties.EditableText)?.let {
+        result.add(it)
+    }
+    for (child in children) {
+        child.collectTextRecursive(result)
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -124,9 +124,9 @@ class SemanticsOwnersProviderTest {
 //    fun semanticsOwnersIsSnapshotStateInComposePanel() =
 //        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
 
-    @Test
-    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
-        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
+//    @Test
+//    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
+//        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
 }
 
 private interface SemanticsOwnersTestContext {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -105,28 +105,28 @@ class SemanticsOwnersProviderTest {
         ) {
             try {
                 dispatcher.scheduler.advanceUntilIdle()
-//                assertEquals(1, latestSemanticsOwners.size)
+                assertEquals(1, latestSemanticsOwners.size)
                 showPopup = true
                 awaitIdle()
                 dispatcher.scheduler.advanceUntilIdle()
-//                assertEquals(2, latestSemanticsOwners.size)
+                assertEquals(2, latestSemanticsOwners.size)
             } finally {
                 coroutineScope.cancel()
             }
         }
     }
 
-    @Test
-    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
-        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
-
-    @Test
-    fun semanticsOwnersIsSnapshotStateInComposePanel() =
-        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
-
-    @Test
-    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
-        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
+//    @Test
+//    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
+//        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
+//
+//    @Test
+//    fun semanticsOwnersIsSnapshotStateInComposePanel() =
+//        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
+//
+//    @Test
+//    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
+//        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
 }
 
 private interface SemanticsOwnersTestContext {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -120,9 +120,9 @@ class SemanticsOwnersProviderTest {
 //    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
 //        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
 
-    @Test
-    fun semanticsOwnersIsSnapshotStateInComposePanel() =
-        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
+//    @Test
+//    fun semanticsOwnersIsSnapshotStateInComposePanel() =
+//        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
 
     @Test
     fun semanticsOwnersIsSnapshotStateInImageComposeScene() =

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -105,11 +105,11 @@ class SemanticsOwnersProviderTest {
         ) {
             try {
                 dispatcher.scheduler.advanceUntilIdle()
-                assertEquals(1, latestSemanticsOwners.size)
+//                assertEquals(1, latestSemanticsOwners.size)
                 showPopup = true
                 awaitIdle()
                 dispatcher.scheduler.advanceUntilIdle()
-                assertEquals(2, latestSemanticsOwners.size)
+//                assertEquals(2, latestSemanticsOwners.size)
             } finally {
                 coroutineScope.cancel()
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -23,6 +23,11 @@ import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -30,29 +35,179 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.WindowTestScope
 import androidx.compose.ui.window.runApplicationTest
 import java.awt.BorderLayout
 import javax.swing.JFrame
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
 
 class SemanticsOwnersProviderTest {
 
-    @Test
-    fun semanticsOwnersProvidedInComposeWindow() = runApplicationTest {
-        launchTestWindowApplication {
-            TextApp()
+    private fun semanticsOwnersProvidedBy(provider: SemanticsOwnersTestContext) = provider.runTest(
+        content = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+                modifier = Modifier.padding(64.dp)
+            ) {
+                Text("Hello")
+                OutlinedTextField(rememberTextFieldState("World"))
+            }
         }
-        awaitIdle()
-        assertSemanticsOwnersProvidedBy(window::semanticsOwners)
+    ) {
+        val strings = semanticsOwners.collectText().map { it.text }
+        assertContentEquals(listOf("Hello", "World"), strings)
     }
 
-    fun semanticsOwnersProvidedInComposePanel(visible: Boolean) = runApplicationTest {
+    @Test
+    fun semanticsOwnersProvidedInComposeWindow() =
+        semanticsOwnersProvidedBy(ComposeWindowSemanticOwnersTestContext())
+
+    @Test
+    fun semanticsOwnersProvidedInVisibleComposePanel() =
+        semanticsOwnersProvidedBy(ComposePanelSemanticOwnersTestContext(visible = true))
+
+    @Test
+    fun semanticsOwnersProvidedInInvisibleComposePanel() =
+        semanticsOwnersProvidedBy(ComposePanelSemanticOwnersTestContext(visible = false))
+
+    @Test
+    fun semanticsOwnersProvidedInImageComposeScene() =
+        semanticsOwnersProvidedBy(ImageComposeSceneSemanticOwnersTestContext())
+
+    private fun semanticsOwnersIsSnapshotStateBy(provider: SemanticsOwnersTestContext) {
+        var latestSemanticsOwners: Collection<SemanticsOwner> = emptyList()
+        val dispatcher = StandardTestDispatcher()
+        val coroutineScope = CoroutineScope(dispatcher)
+        coroutineScope.launch {
+            snapshotFlow { provider.semanticsOwners }.collect {
+                latestSemanticsOwners = it
+            }
+        }
+        var showPopup by mutableStateOf(false)
+        provider.runTest(
+            content = {
+                Text("Hello")
+                if (showPopup) {
+                    println("Showing popup")
+                    Popup {
+                        Text("World")
+                    }
+                }
+            }
+        ) {
+            try {
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(1, latestSemanticsOwners.size)
+                showPopup = true
+                awaitIdle()
+                dispatcher.scheduler.advanceUntilIdle()
+                assertEquals(2, latestSemanticsOwners.size)
+            } finally {
+                coroutineScope.cancel()
+            }
+        }
+    }
+
+    @Test
+    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
+        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
+
+    @Test
+    fun semanticsOwnersIsSnapshotStateInComposePanel() =
+        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
+
+    @Test
+    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
+        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
+}
+
+private interface SemanticsOwnersTestContext {
+    val semanticsOwners: Collection<SemanticsOwner>
+
+    fun runTest(
+        content: @Composable () -> Unit,
+        test: suspend SemanticsOwnersTestContext.() -> Unit
+    )
+
+    suspend fun awaitIdle()
+}
+
+private class ImageComposeSceneSemanticOwnersTestContext : SemanticsOwnersTestContext {
+    private val scene: ImageComposeScene = ImageComposeScene(800, 600)
+    private var time = 0L
+
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = scene.semanticsOwners
+
+    override fun runTest(
+        content: @Composable () -> Unit,
+        test: suspend SemanticsOwnersTestContext.() -> Unit
+    ) {
+        scene.setContent(content)
+        scene.render(time)
+        runBlocking {
+            test()
+        }
+    }
+
+    override suspend fun awaitIdle() {
+        Snapshot.sendApplyNotifications()
+        while (scene.hasInvalidations()) {
+            time += 16L
+            scene.render(time)
+            Snapshot.sendApplyNotifications()
+        }
+    }
+}
+
+private class ComposeWindowSemanticOwnersTestContext : SemanticsOwnersTestContext {
+    private lateinit var testScope: WindowTestScope
+
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = testScope.window.semanticsOwners
+
+    override fun runTest(
+        content: @Composable (() -> Unit),
+        test: suspend SemanticsOwnersTestContext.() -> Unit
+    ) = runApplicationTest {
+        testScope = this
+        launchTestWindowApplication {
+            content()
+        }
+        awaitIdle()
+        test()
+    }
+
+    override suspend fun awaitIdle() = testScope.awaitIdle()
+}
+
+private class ComposePanelSemanticOwnersTestContext(
+    val visible: Boolean = true
+) : SemanticsOwnersTestContext {
+    private lateinit var testScope: WindowTestScope
+    private lateinit var composePanel: ComposePanel
+
+    override val semanticsOwners: Collection<SemanticsOwner>
+        get() = composePanel.semanticsOwners
+
+    override fun runTest(
+        content: @Composable (() -> Unit),
+        test: suspend SemanticsOwnersTestContext.() -> Unit
+    ) = runApplicationTest {
+        testScope = this
         val window = JFrame()
         try {
-            val composePanel = ComposePanel()
+            composePanel = ComposePanel()
             composePanel.setContent {
-                TextApp()
+                content()
             }
             composePanel.isVisible = visible
 
@@ -61,47 +216,13 @@ class SemanticsOwnersProviderTest {
             window.isVisible = true
 
             awaitIdle()
-            assertSemanticsOwnersProvidedBy(composePanel::semanticsOwners)
+            test()
         } finally {
             window.dispose()
         }
     }
 
-    @Test
-    fun semanticsOwnersProvidedInVisibleComposePanel() =
-        semanticsOwnersProvidedInComposePanel(visible = true)
-
-    @Test
-    fun semanticsOwnersProvidedInInvisibleComposePanel() =
-        semanticsOwnersProvidedInComposePanel(visible = false)
-
-    @Test
-    fun semanticsOwnersProvidedInImageComposeScene() {
-        val imageComposeScene = ImageComposeScene(800, 600) {
-            TextApp()
-        }
-        imageComposeScene.render(0L)
-
-        assertSemanticsOwnersProvidedBy(imageComposeScene::semanticsOwners)
-    }
-
-    private fun assertSemanticsOwnersProvidedBy(
-        getSemanticsOwners: () -> Collection<SemanticsOwner>
-    ) {
-        val strings = getSemanticsOwners().collectText().map { it.text }
-        assertContentEquals(listOf("Hello", "World"), strings)
-    }
-
-    @Composable
-    private fun TextApp() {
-        Column(
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-            modifier = Modifier.padding(64.dp)
-        ) {
-            Text("Hello")
-            OutlinedTextField(rememberTextFieldState("World"))
-        }
-    }
+    override suspend fun awaitIdle() = testScope.awaitIdle()
 }
 
 private fun Collection<SemanticsOwner>.collectText(): List<AnnotatedString> {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -105,11 +105,11 @@ class SemanticsOwnersProviderTest {
         ) {
             try {
                 dispatcher.scheduler.advanceUntilIdle()
-//                assertEquals(1, latestSemanticsOwners.size)
+                assertEquals(1, latestSemanticsOwners.size)
                 showPopup = true
                 awaitIdle()
                 dispatcher.scheduler.advanceUntilIdle()
-//                assertEquals(2, latestSemanticsOwners.size)
+                assertEquals(2, latestSemanticsOwners.size)
             } finally {
                 coroutineScope.cancel()
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -116,9 +116,9 @@ class SemanticsOwnersProviderTest {
         }
     }
 
-    @Test
-    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
-        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
+//    @Test
+//    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
+//        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
 
     @Test
     fun semanticsOwnersIsSnapshotStateInComposePanel() =

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SemanticsOwnersProviderTest.kt
@@ -105,28 +105,28 @@ class SemanticsOwnersProviderTest {
         ) {
             try {
                 dispatcher.scheduler.advanceUntilIdle()
-                assertEquals(1, latestSemanticsOwners.size)
+//                assertEquals(1, latestSemanticsOwners.size)
                 showPopup = true
                 awaitIdle()
                 dispatcher.scheduler.advanceUntilIdle()
-                assertEquals(2, latestSemanticsOwners.size)
+//                assertEquals(2, latestSemanticsOwners.size)
             } finally {
                 coroutineScope.cancel()
             }
         }
     }
 
-//    @Test
-//    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
-//        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
-//
-//    @Test
-//    fun semanticsOwnersIsSnapshotStateInComposePanel() =
-//        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
-//
-//    @Test
-//    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
-//        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
+    @Test
+    fun semanticsOwnersIsSnapshotStateInComposeWindow() =
+        semanticsOwnersIsSnapshotStateBy(ComposeWindowSemanticOwnersTestContext())
+
+    @Test
+    fun semanticsOwnersIsSnapshotStateInComposePanel() =
+        semanticsOwnersIsSnapshotStateBy(ComposePanelSemanticOwnersTestContext())
+
+    @Test
+    fun semanticsOwnersIsSnapshotStateInImageComposeScene() =
+        semanticsOwnersIsSnapshotStateBy(ImageComposeSceneSemanticOwnersTestContext())
 }
 
 private interface SemanticsOwnersTestContext {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComplexApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComplexApplicationTest.kt
@@ -693,8 +693,8 @@ class ComplexApplicationTest {
 
         Truth
             .assertWithMessage("Memory is increased more than 15% after opening multiple windows")
-            .that(newMemory < 1.15 * oldMemory)
-            .isTrue()
+            .that(newMemory.toDouble()/oldMemory)
+            .isLessThan(1.15)
     }
 
     @Test

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.awaitEDT
+import androidx.compose.ui.awt.ComposeWindow
 import java.awt.GraphicsEnvironment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -34,7 +35,6 @@ import kotlinx.coroutines.withTimeout
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
 import androidx.compose.ui.window.launchApplication as realLaunchApplication
-import javax.swing.JFrame
 
 
 internal fun runApplicationTest(
@@ -121,7 +121,7 @@ internal class WindowTestScope(
     var isOpen by mutableStateOf(true)
     private val initialRecomposers = Recomposer.runningRecomposers.value
 
-    lateinit var window: JFrame
+    lateinit var window: ComposeWindow
 
     fun launchTestApplication(
         content: @Composable ApplicationScope.() -> Unit
@@ -132,7 +132,7 @@ internal class WindowTestScope(
     }
 
     fun launchTestWindowApplication(
-        content: @Composable WindowScope.() -> Unit
+        content: @Composable FrameWindowScope.() -> Unit
     ) = launchTestApplication {
        Window(onCloseRequest = ::exitApplication) {
            this@WindowTestScope.window = window

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -153,7 +154,26 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
         containerSize = imageSize
     }
 
-    private val _platformContext = object : PlatformContext by PlatformContext.Empty {
+    private val _platformContext = object : PlatformContext by PlatformContext.Empty,
+        PlatformContext.SemanticsOwnerListener {
+
+        val semanticsOwners = linkedSetOf<SemanticsOwner>()
+
+        override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
+            semanticsOwners.add(semanticsOwner)
+        }
+
+        override fun onSemanticsOwnerRemoved(semanticsOwner: SemanticsOwner) {
+            semanticsOwners.remove(semanticsOwner)
+        }
+
+        override fun onSemanticsChange(semanticsOwner: SemanticsOwner) = Unit
+
+        override fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int) = Unit
+
+        override val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener
+            get() = this
+
         override val windowInfo: WindowInfo
             get() = _windowInfo
     }
@@ -173,6 +193,14 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      */
     @ExperimentalComposeUiApi
     var layoutDirection: LayoutDirection by scene::layoutDirection
+
+    /**
+     * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
+     * [ImageComposeScene].
+     */
+    @ExperimentalComposeUiApi
+    val semanticsOwners: Collection<SemanticsOwner>
+        get() = _platformContext.semanticsOwners
 
     /**
      * Close all resources and subscriptions. Not calling this method when [ImageComposeScene] is no

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -20,7 +20,6 @@ package androidx.compose.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.geometry.Offset
@@ -158,7 +157,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     private val _platformContext = object : PlatformContext by PlatformContext.Empty,
         PlatformContext.SemanticsOwnerListener {
 
-        val semanticsOwners = mutableStateSetOf<SemanticsOwner>()
+        val semanticsOwners = linkedSetOf<SemanticsOwner>()
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             semanticsOwners.add(semanticsOwner)
@@ -198,9 +197,6 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ImageComposeScene].
-     *
-     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
-     * composable function) will cause the function to restart when set of semantics owners changes.
      */
     @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -20,6 +20,7 @@ package androidx.compose.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.geometry.Offset
@@ -157,7 +158,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     private val _platformContext = object : PlatformContext by PlatformContext.Empty,
         PlatformContext.SemanticsOwnerListener {
 
-        val semanticsOwners = linkedSetOf<SemanticsOwner>()
+        val semanticsOwners = mutableStateSetOf<SemanticsOwner>()
 
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             semanticsOwners.add(semanticsOwner)
@@ -197,6 +198,9 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     /**
      * Returns the [SemanticsOwner]s corresponding to the roots of the semantics trees in this
      * [ImageComposeScene].
+     *
+     * This is backed by snapshot state, so reading this property in a restartable function (e.g., a
+     * composable function) will cause the function to restart when set of semantics owners changes.
      */
     @ExperimentalComposeUiApi
     val semanticsOwners: Collection<SemanticsOwner>


### PR DESCRIPTION
Provide access to `semanticsOwners` in `ComposeWindow`, `ComposePanel` and `ImageComposeScene`.

This is useful to allow external tools to examine the structure of the UI.

Fixes https://youtrack.jetbrains.com/issue/CMP-8824/Expose-semantics-tree-in-ComposePanel-and-ComposeWindow

<details>
      <summary>Example usage</summary>

```
import androidx.compose.foundation.ExperimentalFoundationApi
import androidx.compose.foundation.layout.Arrangement
import androidx.compose.foundation.layout.Column
import androidx.compose.foundation.layout.padding
import androidx.compose.foundation.text.input.rememberTextFieldState
import androidx.compose.material.OutlinedTextField
import androidx.compose.material.Text
import androidx.compose.runtime.Composable
import androidx.compose.runtime.LaunchedEffect
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.ImageComposeScene
import androidx.compose.ui.Modifier
import androidx.compose.ui.awt.ComposePanel
import androidx.compose.ui.semantics.SemanticsNode
import androidx.compose.ui.semantics.SemanticsOwner
import androidx.compose.ui.semantics.SemanticsProperties
import androidx.compose.ui.semantics.getOrNull
import androidx.compose.ui.text.AnnotatedString
import androidx.compose.ui.unit.dp
import androidx.compose.ui.window.singleWindowApplication
import java.awt.BorderLayout
import javax.swing.JFrame
import javax.swing.SwingUtilities

@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
fun main() = singleWindowApplication {
    SemanticsApp()

    LaunchedEffect(Unit) {
        val strings = mutableListOf<AnnotatedString>()
        window.semanticsOwners.forEach {
            it.rootSemanticsNode.collectTextRecursive(strings)
        }
        println(strings.joinToString("\n"))
    }
}

@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
fun main_panel() = SwingUtilities.invokeLater {
    val window = JFrame()
    val composePanel = ComposePanel()
    composePanel.setContent {
        SemanticsApp()
    }

    window.contentPane.add(composePanel, BorderLayout.CENTER)
    window.pack()
    window.isVisible = true

    println(composePanel.semanticsOwners.collectText().joinToString("\n"))
}

@OptIn(ExperimentalFoundationApi::class, ExperimentalComposeUiApi::class)
fun main_image_compose_scene() {
    val imageComposeScene = ImageComposeScene(800, 600) {
        SemanticsApp()
    }
    imageComposeScene.render(0L)

    println(imageComposeScene.semanticsOwners.collectText().joinToString("\n"))
}


@Composable
fun SemanticsApp() {
    Column(
        verticalArrangement = Arrangement.spacedBy(10.dp),
        modifier = Modifier.padding(64.dp)
    ) {
        Text("Hello")
        OutlinedTextField(rememberTextFieldState("World"))
    }
}

private fun Collection<SemanticsOwner>.collectText(): List<AnnotatedString> {
    val result = mutableListOf<AnnotatedString>()
    forEach {
        it.rootSemanticsNode.collectTextRecursive(result)
    }
    return result
}

private fun SemanticsNode.collectTextRecursive(result: MutableList<AnnotatedString>) {
    result.addAll(config.getOrNull(SemanticsProperties.Text) ?: emptyList())
    config.getOrNull(SemanticsProperties.EditableText)?.let {
        result.add(it)
    }
    for (child in children) {
        child.collectTextRecursive(result)
    }
}
```

<details>

## Testing
Tested manually and added unit tests.

## Release Notes
### Features - Desktop
- The Compose entry points on the desktop (`ComposeWindow`, `ComposePanel` and `ImageComposeScene`) now expose `val semanticsOwners: Collection<SemanticsOwner>`.
