### PR TITLE
Fix crash when removing characters after string replacement

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -358,11 +358,8 @@ internal class IntermediateTextInputUIView(
     }
 
     override fun offsetFromPosition(from: UITextPosition, toPosition: UITextPosition): NSInteger {
-        if (from !is IntermediateTextPosition) {
-            error("from !is IntermediateTextPosition: $from")
-        }
-        if (toPosition !is IntermediateTextPosition) {
-            error("toPosition !is IntermediateTextPosition: $toPosition")
+        if (from !is IntermediateTextPosition || toPosition !is IntermediateTextPosition) {
+            return 0
         }
         return (toPosition.position - from.position).toLong()
     }


### PR DESCRIPTION
Ignore null value for `from` and `toPosition`

Fixes https://youtrack.jetbrains.com/issue/CMP-8798/UITextInputStringTokenizer-crashes-on-iOS-EXCBADACCESS-KERNINVALIDADDRESS

## Testing
Require manual testing on dev build

## Release Notes
### Fixes - iOS
- Fix crash when removing characters after string replacement