### PR TITLE
Unpin compose dependencies

### DIFF
--- a/lifecycle/lifecycle-runtime-compose-compatibility-stub/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose-compatibility-stub/build.gradle
@@ -61,6 +61,10 @@ kotlin {
             dependencies {
                 def version = project.findProperty('artifactRedirection.version.androidx.lifecycle')
                 api("androidx.lifecycle:lifecycle-runtime-compose:$version")
+
+                // Keep direct reference to Compose multiplatform 1.9.x to correctly resolve
+                // New redirections to Google's artifacts
+                implementation(project(":compose:runtime:runtime"))
             }
         }
     }

--- a/lifecycle/lifecycle-runtime-compose/build.gradle
+++ b/lifecycle/lifecycle-runtime-compose/build.gradle
@@ -62,7 +62,7 @@ kotlin {
                 api(project(":annotation:annotation"))
                 implementation(project(":lifecycle:lifecycle-common"))
                 api project(":lifecycle:lifecycle-runtime")
-                api(project(":compose:runtime:runtime"))
+                api project(":compose:runtime:runtime")
 
                 implementation(libs.kotlinStdlib)
             }

--- a/savedstate/savedstate-compose-compatibility-stub/build.gradle
+++ b/savedstate/savedstate-compose-compatibility-stub/build.gradle
@@ -61,6 +61,10 @@ kotlin {
             dependencies {
                 def version = project.findProperty('artifactRedirection.version.androidx.savedstate')
                 api("androidx.savedstate:savedstate-compose:$version")
+
+                // Keep direct reference to Compose multiplatform 1.9.x to correctly resolve
+                // New redirections to Google's artifacts
+                implementation(project(":compose:runtime:runtime"))
             }
         }
     }


### PR DESCRIPTION
Fix from #2367 to `jb-main`

We'll need to keep it unpinned at least before 1.9.0 release. Redirects in 1.10.0-alpha02 are also valid

## Release Notes
N/A
