### PR TITLE
[web] input Respect backspace pressed that was pressed in previous frame

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -43,6 +43,7 @@ internal abstract class NativeInputEventsProcessor(
     private val collectedEvents = mutableListOf<UIEvent>()
     private var isCheckpointScheduled = false
     private var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
+    var lastProcessedEventIsBackspace: Boolean = false
 
     /**
      * Schedules a checkpoint for processing input events.
@@ -72,8 +73,6 @@ internal abstract class NativeInputEventsProcessor(
                 || it.type == "keydown" && (it as KeyboardEvent).isComposing
                 || it.type == "beforeinput" && (it as InputEvent).isComposing
         }
-
-        var lastProcessedEventIsBackspace: Boolean = false
 
         collectedEvents.forEach { evt ->
             val timestamp = evt.timeStamp.toDouble()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -575,7 +575,7 @@ class NativeInputEventsProcessorTest {
     }
 
     @Test
-    fun testDeleteContentBackward_with_Backspace_key_pressed() {
+    fun testDeleteContentBackward_with_Backspace_key_pressed_same_frame() {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
 
@@ -604,4 +604,38 @@ class NativeInputEventsProcessorTest {
         assertEquals(1, communicator.keyboardEvents.size)
         assertEquals(0, communicator.editCommands.size)
     }
+
+    @Test
+    fun testDeleteContentBackward_with_Backspace_key_pressed_different_frame() {
+        val communicator = MockComposeCommandCommunicator()
+        val processor = TestNativeInputEventsProcessor(communicator)
+
+        // With a non-collapsed selection
+        val textFieldValue = TextFieldValue(
+            text = "example text",
+            selection = TextRange(2, 7) // Selection from "a" to "e" in "example"
+        )
+
+        // First add a keydown event for Backspace
+        val backspaceEvent = keyEvent(
+            key = "Backspace",
+            code = "Backspace",
+            type = "keydown"
+        )
+        processor.registerEvent(backspaceEvent)
+
+        processor.manuallyRunCheckpoint(textFieldValue)
+
+        // Then add a deleteContentBackward event
+        processor.registerEvent(
+            (beforeInput("deleteContentBackward", "") as InputEvent).apply { deleteContentBackwardSize = 1 },
+        )
+
+        processor.manuallyRunCheckpoint(textFieldValue)
+
+        // The deleteContentBackward event should be ignored since Backspace key was pressed
+        assertEquals(1, communicator.keyboardEvents.size)
+        assertEquals(0, communicator.editCommands.size)
+    }
+
 }


### PR DESCRIPTION
This is cherry-pick of 
https://github.com/JetBrains/compose-multiplatform-core/pull/2372

## Testing
Manual

## Release Notes
https://github.com/JetBrains/compose-multiplatform-core/pull/2372
