### PR TITLE
Pin Material-Navigation to Navigation 2.9.0-rc01

### DIFF
--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -44,6 +44,13 @@ kotlin {
                 implementation("org.jetbrains.androidx.navigation:navigation-compose:2.9.0-rc01")
                 implementation(project(":compose:material:material"))
                 implementation(libs.kotlinStdlib)
+
+                // Align navigation dependencies with Compose ones
+                // https://youtrack.jetbrains.com/issue/CMP-8704 workaround
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-savedstate"))
+                implementation(project(":savedstate:savedstate-compose"))
             }
         }
 

--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -41,7 +41,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(project(":navigation:navigation-compose"))
+                implementation("org.jetbrains.androidx.navigation:navigation-compose:2.9.0-rc01")
                 implementation(project(":compose:material:material"))
                 implementation(libs.kotlinStdlib)
             }


### PR DESCRIPTION
Because publication of Navigation is disabled.

Also apply the fix for iOS compilation from https://github.com/JetBrains/compose-multiplatform-core/pull/2371/files

## Release Notes
N/A