### PR TITLE
Revert special cursor processing logic for Text Fields with transformation

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -112,28 +112,17 @@ private fun getTapHandlerModifier(
                     )
                     if (currentState.handleState != HandleState.Selection) {
                         currentState.layoutResult?.let { layoutResult ->
-                            // TODO: Research native behavior with any text transformations (which adds symbols like with using NSNumberFormatter)
-                            if (currentManager.visualTransformation != VisualTransformation.None) {
-                                TextFieldDelegate.setCursorOffset(
-                                    touchPointOffset,
-                                    layoutResult,
-                                    currentState.processor,
-                                    currentOffsetMapping,
-                                    currentState.onValueChange
-                                )
-                            } else {
-                                TextFieldDelegate.cupertinoSetCursorOffsetFocused(
-                                    position = touchPointOffset,
-                                    textLayoutResult = layoutResult,
-                                    editProcessor = currentState.processor,
-                                    offsetMapping = currentOffsetMapping,
-                                    showContextMenu = { show ->
-                                        // it shouldn't be selection, but this is a way to call a context menu in BasicTextField
-                                        if (show) { currentManager.enterSelectionMode() } else { currentManager.exitSelectionMode() }
-                                    },
-                                    onValueChange = currentState.onValueChange
-                                )
-                            }
+                            TextFieldDelegate.cupertinoSetCursorOffsetFocused(
+                                position = touchPointOffset,
+                                textLayoutResult = layoutResult,
+                                editProcessor = currentState.processor,
+                                offsetMapping = currentOffsetMapping,
+                                showContextMenu = { show ->
+                                    // it shouldn't be selection, but this is a way to call a context menu in BasicTextField
+                                    if (show) { currentManager.enterSelectionMode() } else { currentManager.exitSelectionMode() }
+                                },
+                                onValueChange = currentState.onValueChange
+                            )
                         }
                     } else {
                         currentManager.deselect(touchPointOffset)


### PR DESCRIPTION
The issue partially reverts the fix https://github.com/JetBrains/compose-multiplatform-core/pull/1045

Fixes https://youtrack.jetbrains.com/issue/CMP-4502/Text-actions-menu-doesnt-show-up-when-a-visual-transformation-is-applied-on-iOS

## Testing
Verify that [the initial issue](https://github.com/JetBrains/compose-multiplatform/issues/4206) does not reproduce.

## Release Notes
### Fixes - iOS
- Fix context menu appearance for text fields with transformation