### PR TITLE
Add measure-and-layout phase in `BaseComposeScene.setContent`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -118,7 +118,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private val _focusListeners = mutableSetOf<FocusListener?>()
 
     private var _composeContainer: ComposeContainer? = null
-    private var _composeContent: (@Composable () -> Unit)? = null
 
     /**
      * Determines whether the Compose state in [ComposePanel] should be disposed
@@ -181,12 +180,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * @param content Composable content of the ComposePanel.
      */
     fun setContent(content: @Composable () -> Unit) {
-        // The window (or root container) may not be ready to render composable content, so we need
-        // to keep the lambda describing composable content and set the content only when
-        // everything is ready to avoid accidental crashes and memory leaks on all supported OS
-        // types.
-        _composeContent = content
-        _composeContainer?.setContent(content)
+        val composeContainer = _composeContainer ?: createComposeContainer()
+        composeContainer.setContent(content)
     }
 
     /**
@@ -236,17 +231,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     override fun addNotify() {
         super.addNotify()
 
-        // After [super.addNotify] is called we can safely initialize the bridge and composable
-        // content.
-        val composeContainer = _composeContainer ?: createComposeContainer().also {
-            _composeContainer = it
-            val composeContent = _composeContent
-            if (composeContent != null) {
-                it.setContent(composeContent)
-            }
-            savedState = null
-        }
-        composeContainer.addNotify()
+        _composeContainer?.addNotify()
     }
 
     private fun createComposeContainer(): ComposeContainer {
@@ -256,20 +241,21 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             savedState = savedState,
             windowContainer = windowContainer,
             renderSettings = renderSettings,
-        ).apply {
-            setBounds(0, 0, width, height)
-            contentComponent.isFocusable = isFocusable
-            contentComponent.isRequestFocusEnabled = isRequestFocusEnabled
-            exceptionHandler = this@ComposePanel.exceptionHandler
+        ).also { cc ->
+            _composeContainer = cc
+            cc.setBounds(0, 0, width, height)
+            cc.contentComponent.isFocusable = isFocusable
+            cc.contentComponent.isRequestFocusEnabled = isRequestFocusEnabled
+            cc.exceptionHandler = this@ComposePanel.exceptionHandler
 
-            _focusListeners.forEach(contentComponent::addFocusListener)
-            contentComponent.addFocusListener(object : FocusListener {
+            _focusListeners.forEach { cc.contentComponent.addFocusListener(it) }
+            cc.contentComponent.addFocusListener(object : FocusListener {
                 override fun focusGained(e: FocusEvent) {
                     if (!e.isTemporary && !e.isFocusGainedHandledBySwingPanel(this@ComposePanel)) {
                         when (e.cause) {
                             FocusEvent.Cause.UNKNOWN, FocusEvent.Cause.ACTIVATION -> {
-                                if (!focusManager.hasFocus) {
-                                    focusManager.takeFocus(FocusDirection.Next)
+                                if (!cc.focusManager.hasFocus) {
+                                    cc.focusManager.takeFocus(FocusDirection.Next)
                                 }
                             }
                             else -> Unit
@@ -279,6 +265,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
 
                 override fun focusLost(e: FocusEvent) = Unit
             })
+
+            if (isDisplayable) {
+                cc.addNotify()
+            }
+
+            savedState = null
         }
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -206,6 +206,10 @@ internal class ComposeContainer(
     private var isMinimized = false
     private var isFocused = false
 
+    // The content lambda stored temporarily between `setContent` and when the container is ready
+    // to actually create a composition. See `applyContentIfReady`.
+    private var contentToApply: (@Composable () -> Unit)? = null
+
     init {
         savedStateController.performAttach()
         savedStateController.performRestore(savedState)
@@ -329,6 +333,8 @@ internal class ComposeContainer(
         onWindowContainerSizeChanged()
         onWindowContainerPositionChanged()
 
+        applyContentIfReady()
+
         isDetached = false
         updateLifecycleState()
     }
@@ -346,6 +352,8 @@ internal class ComposeContainer(
         // so re-checking the actual size on container resize too.
         onWindowContainerSizeChanged()
         onWindowContainerPositionChanged()
+
+        applyContentIfReady()
     }
 
     private fun setWindow(window: Window?) {
@@ -381,6 +389,17 @@ internal class ComposeContainer(
     }
 
     fun setContent(content: @Composable () -> Unit) {
+        this.contentToApply = content
+        applyContentIfReady()
+    }
+
+    private fun applyContentIfReady() {
+        val content = this.contentToApply ?: return
+        if (!contentComponent.isDisplayable) return
+        if (contentComponent.let { it.width <= 0 || it.height <= 0 }) return
+
+        contentToApply = null
+
         mediator.setContent {
             ProvideContainerCompositionLocals(this, backGestureDispatcher) {
                 content()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendMouseEvent
@@ -67,6 +68,7 @@ import javax.swing.JPanel
 import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -685,5 +687,30 @@ class ComposePanelTest {
                 }
             }
         }
+    }
+
+    @Test
+    fun `ComposePanel content is composed and placed when added to hierarchy`() = runApplicationTest {
+        var isComposed = false
+        var isPlaced = false
+
+        val composePanel = ComposePanel()
+        composePanel.setContent {
+            isComposed = true
+            Box(Modifier.size(100.dp).onPlaced { isPlaced = true })
+        }
+
+        val window = JFrame()
+        try {
+            window.size = Dimension(200, 200)
+            window.isVisible = true
+            window.contentPane.add(composePanel, BorderLayout.CENTER)
+
+            assertTrue(isComposed, "Content was not immediately composed")
+            assertTrue(isPlaced, "Content was not immediately placed")
+        } finally {
+            window.dispose()
+        }
+
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -46,10 +46,14 @@ import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.util.ThrowUncaughtExceptionRule
@@ -66,10 +70,11 @@ import java.awt.event.MouseEvent
 import javax.swing.JFrame
 import javax.swing.JPanel
 import junit.framework.TestCase.assertTrue
+import kotlin.math.roundToInt
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.ExperimentalSkikoApi
@@ -708,6 +713,38 @@ class ComposePanelTest {
 
             assertTrue(isComposed, "Content was not immediately composed")
             assertTrue(isPlaced, "Content was not immediately placed")
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun `first composition happens with correct LocalWindowInfo containerSize`() = runApplicationTest {
+        val sizes = mutableListOf<IntSize>()
+        lateinit var density: Density
+
+        val composePanel = ComposePanel().apply {
+            setContent {
+                sizes.add(LocalWindowInfo.current.containerSize)
+                density = LocalDensity.current
+            }
+            size = Dimension(100, 200)
+        }
+
+        val window = JFrame()
+        try {
+            window.size = Dimension(500, 500)
+            window.isVisible = true
+            window.contentPane.layout = null
+            window.contentPane.add(composePanel)
+
+            awaitIdle()
+            assertThat(sizes).containsExactly(
+                IntSize(
+                    width = (density.density * 100).roundToInt(),
+                    height = (density.density * 200).roundToInt()
+                )
+            )
         } finally {
             window.dispose()
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -42,13 +42,16 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.toInt
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.IntSize
@@ -60,6 +63,7 @@ import java.awt.Dimension
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import kotlin.math.roundToInt
 import kotlin.test.assertEquals
 import org.junit.Test
 
@@ -710,6 +714,32 @@ class DialogWindowTest {
 
         awaitIdle()
         assertThat(isDisplayableInInit).isFalse()
+    }
+
+    @Test
+    fun `first composition happens with correct LocalWindowInfo containerSize`() = runApplicationTest {
+        val sizes = mutableListOf<IntSize>()
+        lateinit var density: Density
+        lateinit var dialog: ComposeDialog
+        launchTestApplication {
+            DialogWindow(
+                state = DialogState(size = DpSize(100.dp, 200.dp)),
+                onCloseRequest = ::exitApplication
+            ) {
+                sizes.add(LocalWindowInfo.current.containerSize)
+                density = LocalDensity.current
+                dialog = this.window
+            }
+        }
+
+        awaitIdle()
+        val dialogInsets = dialog.insets
+        assertThat(sizes).containsExactly(
+            IntSize(
+                width = (density.density * (100 - dialogInsets.left - dialogInsets.right)).roundToInt(),
+                height = (density.density * (200 - dialogInsets.top - dialogInsets.bottom)).roundToInt()
+            )
+        )
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -132,9 +132,13 @@ internal class WindowTestScope(
     }
 
     fun launchTestWindowApplication(
+        state: WindowState? = null,
         content: @Composable FrameWindowScope.() -> Unit
     ) = launchTestApplication {
-       Window(onCloseRequest = ::exitApplication) {
+       Window(
+           state = state ?: rememberWindowState(),
+           onCloseRequest = ::exitApplication
+       ) {
            this@WindowTestScope.window = window
            content()
        }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.isLinux
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.toInt
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.window.*
@@ -765,5 +766,26 @@ class WindowTest {
 
         awaitIdle()
         assertThat(isDisplayableInInit).isFalse()
+    }
+
+    @Test
+    fun `first composition happens with correct LocalWindowInfo containerSize`() = runApplicationTest {
+        val sizes = mutableListOf<IntSize>()
+        lateinit var density: Density
+        launchTestWindowApplication(
+            state = WindowState(size = DpSize(100.dp, 200.dp))
+        ) {
+            sizes.add(LocalWindowInfo.current.containerSize)
+            density = LocalDensity.current
+        }
+
+        awaitIdle()
+        val windowInsets = window.insets
+        assertThat(sizes).containsExactly(
+            IntSize(
+                width = (density.density * (100 - windowInsets.left - windowInsets.right)).roundToInt(),
+                height = (density.density * (200 - windowInsets.top - windowInsets.bottom)).roundToInt()
+            )
+        )
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -140,10 +140,8 @@ internal abstract class BaseComposeScene(
             check(!isClosed) { "setContent called after ComposeScene is closed" }
             inputHandler.onChangeContent()
 
-            /*
-         * It's required before setting content to apply changed parameters
-         * before first recomposition. Otherwise, it can lead to double recomposition.
-         */
+            // It's required before setting content to apply changed parameters
+            // before the first recomposition. Otherwise, it can lead to double recomposition.
             recomposer.performScheduledRecomposerTasks()
 
             composition?.dispose()
@@ -157,6 +155,9 @@ internal abstract class BaseComposeScene(
                     content = content
                 )
             }
+
+            // Need to measure and layout too, to keep the correct order of render phases
+            doMeasureAndLayout()
 
             recomposer.performScheduledRecomposerTasks()
         }


### PR DESCRIPTION
`BaseComposeScene.setContent` currently creates the composition, but doesn't call `measureAndLayout`.
This results in at least two problems:
1. The order of render phases becomes wrong because when `render` is called next time, the first thing it calls are effects (e.g. `LaunchedEffect`). So the apparent order is Composition -> Effects -> Layout, instead of the usual Composition -> Layout -> Effects.
2. Because `BaseComposeScene.render` is called in a separate EDT cycle, other events can be processed between the composition and layout. Specifically, in https://youtrack.jetbrains.com/issue/CMP-8131/ComposePanel-doesnt-receive-initial-focus-in-JBR what happens is that the focus is gained by `ComposePanel` after the composition is created but before layout, resulting in `FocusManager` being unable to find the focusable element (as it only looks at placed ones).

This PR does two things:
1. Have `ComposeContainer` wait until the content component is displayable and has a non-zero size before creating the composition.
2. Add `measureAndLayout` to `BaseComposeScene.setContent`.

Fixes https://youtrack.jetbrains.com/issue/CMP-8131/ComposePanel-doesnt-receive-initial-focus-in-JBR
Fixes https://youtrack.jetbrains.com/issue/CMP-7707/Toolwindow-focus-in-the-IDE-doesnt-get-the-focus
Fixes https://youtrack.jetbrains.com/issue/CMP-8821/LocalWindowInfo.current.containerSize-is-first-initialized-to-00

## Testing
Added several unit tests and tested manually with 
```
    SwingUtilities.invokeAndWait {
        JFrame().apply {
            size = Dimension(800, 1000)
            contentPane.add(ComposePanel().also {
                it.setContent {
                    TextField(rememberTextFieldState())
                }
            })
            defaultCloseOperation = JFrame.EXIT_ON_CLOSE
            isVisible = true
        }
    }
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix `ComposePanel` initially focusing the first focusable node in JBR.
