### PR TITLE
Run measure-and-layout before focus requests 

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -334,6 +334,7 @@ internal class ComposeContainer(
     }
 
     fun removeNotify() {
+        mediator.onComponentDetached()
         isDetached = true
         updateLifecycleState()
         setWindow(null)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -125,6 +125,7 @@ internal class ComposeSceneMediator(
     composeSceneFactory: (ComposeSceneMediator) -> ComposeScene,
 ) : SkikoRenderDelegate {
     private var isDisposed = false
+    private var isComponentAttached = false
     private val invisibleComponent = InvisibleComponent()
 
     private val semanticsOwnerListener = DesktopSemanticsOwnerListener()
@@ -238,9 +239,9 @@ internal class ComposeSceneMediator(
     }
     private val focusListener = object : FocusListener {
         override fun focusGained(e: FocusEvent) {
-            // We don't reset focus for Compose when the component loses focus temporary.
+            // We don't reset focus for Compose when the component loses focus temporarily.
             // Partially because we don't support restoring focus after clearing it.
-            // Focus can be lost temporary when another window or popup takes focus.
+            // Focus can be lost temporarily when another window or popup takes focus.
             if (!e.isTemporary && !e.isFocusGainedHandledBySwingPanel(container)) {
                 when (e.cause) {
                     TRAVERSAL_BACKWARD -> {
@@ -259,10 +260,10 @@ internal class ComposeSceneMediator(
         }
 
         override fun focusLost(e: FocusEvent) {
-            // We don't reset focus for Compose when the component loses focus temporary.
+            // We don't reset focus for Compose when the component loses focus temporarily.
             // Partially because we don't support restoring focus after clearing it.
-            // Focus can be lost temporary when another window or popup takes focus.
-            if (!e.isTemporary) {
+            // Focus can be lost temporarily when another window or popup takes focus.
+            if (!e.isTemporary && isComponentAttached) {
                 scene.focusManager.releaseFocus()
             }
         }
@@ -510,10 +511,16 @@ internal class ComposeSceneMediator(
     }
 
     fun onComponentAttached() {
+        isComponentAttached = true
         onChangeDensity()
 
         _onComponentAttached?.invoke()
         _onComponentAttached = null
+    }
+
+    fun onComponentDetached() {
+        isComponentAttached = false
+        scene.focusManager.releaseFocus()
     }
 
     private var onPreviewKeyEvent: (ComposeKeyEvent) -> Boolean = { false }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -61,6 +61,11 @@ internal class SwingComposeSceneLayer(
             }
         }
 
+        override fun removeNotify() {
+            mediator?.onComponentDetached()
+            super.removeNotify()
+        }
+
         override fun paint(g: Graphics) {
             scrimColor?.let { scrimColor ->
                 g.color = scrimColor.toAwtColor()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -83,6 +83,11 @@ internal class WindowComposeSceneLayer(
                 mediator?.contentComponent?.requestFocusInWindow()
             }
         }
+
+        override fun removeNotify() {
+            mediator?.onComponentDetached()
+            super.removeNotify()
+        }
     }.also {
         it.layout = null
         it.isOpaque = !transparent

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -22,7 +22,9 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -37,6 +39,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEvent
@@ -257,7 +260,7 @@ class ComposePanelTest {
 
     @OptIn(ExperimentalComposeUiApi::class)
     @Test
-    fun `compose state shouldn't reset on panel remove and add with isDisposeOnRemove = false`() {
+    fun `compose state should not reset on panel remove and add with isDisposeOnRemove = false`() {
         assumeFalse(GraphicsEnvironment.getLocalGraphicsEnvironment().isHeadlessInstance)
 
         runBlocking(MainUIDispatcher) {
@@ -686,4 +689,28 @@ class ComposePanelTest {
             }
         }
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-8131/ComposePanel-doesnt-receive-initial-focus-in-JBR
+    @Test
+    fun `ComposePanel content receives initial focus`() = runApplicationTest {
+        val composePanel = ComposePanel()
+        var isTextFieldFocused = false
+        composePanel.setContent {
+            TextField(rememberTextFieldState(), Modifier.onFocusChanged { isTextFieldFocused = it.isFocused })
+        }
+
+        val window = JFrame()
+        try {
+            window.size = Dimension(200, 200)
+            window.contentPane.add(composePanel, BorderLayout.CENTER)
+            window.isVisible = true
+
+            awaitIdle()
+
+            assertTrue(isTextFieldFocused)
+        } finally {
+            window.dispose()
+        }
+    }
+
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -290,7 +290,7 @@ internal abstract class BaseComposeScene(
         }
     }
 
-    private fun doMeasureAndLayout() {
+    protected fun doMeasureAndLayout() {
         snapshotInvalidationTracker.onMeasureAndLayout()
         measureAndLayout()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -147,7 +147,10 @@ private class CanvasLayersComposeSceneImpl(
             forEachLayer { it.owner.size = value }
         }
 
-    override val focusManager = ComposeSceneFocusManager { focusedOwner.focusOwner }
+    override val focusManager = ComposeSceneFocusManager(
+        focusOwner = { focusedOwner.focusOwner },
+        measureAndLayout = ::doMeasureAndLayout
+    )
 
     override val rootDragAndDropNode = ComposeSceneDragAndDropNode { focusedOwner.dragAndDropOwner }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
@@ -27,34 +27,38 @@ import androidx.compose.ui.geometry.Rect
  */
 @InternalComposeUiApi
 class ComposeSceneFocusManager internal constructor(
-    private val focusOwner: () -> FocusOwner
+    private val focusOwner: () -> FocusOwner,
+    private val measureAndLayout: () -> Unit,
 ) {
     /**
-     * `true` if any child has focus
+     * Returns whether any child has focus.
      */
     val hasFocus: Boolean get() = focusOwner().rootState.hasFocus
 
-    /**
-     * Searches for the currently focused item, and returns its coordinates as a rect.
-     */
-    fun getFocusRect(): Rect? = focusOwner().getFocusRect()
+    private inline fun <T: Any?> measureAndLayoutThen(request: () -> T): T {
+        measureAndLayout()
+        return request()
+    }
 
     /**
-     * Take focus to ComposeScene in specified [focusDirection].
-     *
-     * Returns false if there are no focusable elements in this direction:
-     * - the scene is empty
-     * - we are in the end of the scene and move forward
-     * - we are in the beginning of the scene and move backward
+     * Searches for the currently focused node and returns its coordinates as a rect.
      */
-    fun takeFocus(focusDirection: FocusDirection): Boolean {
+    fun getFocusRect(): Rect? = measureAndLayoutThen { focusOwner().getFocusRect() }
+
+    /**
+     * Take focus to [ComposeScene] in specified [focusDirection].
+     *
+     * Returns `false` if there are no focusable elements in this direction:
+     * - The scene is empty
+     * - We are at the end of the scene and are asked to move forward
+     * - We are at the beginning of the scene and are asked to move backward
+     */
+    fun takeFocus(focusDirection: FocusDirection): Boolean = measureAndLayoutThen {
         return focusOwner().takeFocus(focusDirection, previouslyFocusedRect = null)
     }
 
     /**
-     * Release focus from ComposeScene
+     * Release focus from [ComposeScene].
      */
-    fun releaseFocus() {
-        focusOwner().releaseFocus()
-    }
+    fun releaseFocus() = measureAndLayoutThen { focusOwner().releaseFocus() }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -125,7 +125,10 @@ private class PlatformLayersComposeSceneImpl(
             mainOwner.size = value
         }
 
-    override val focusManager = ComposeSceneFocusManager { mainOwner.focusOwner }
+    override val focusManager = ComposeSceneFocusManager(
+        focusOwner = { mainOwner.focusOwner },
+        measureAndLayout = ::doMeasureAndLayout
+    )
 
     // TODO: Extract to interface and return `mainOwner.dragAndDropOwner.rootDragAndDropNode`
     override val rootDragAndDropNode = ComposeSceneDragAndDropNode { mainOwner.dragAndDropOwner }


### PR DESCRIPTION
Changing focus requires layout to be up-to-date, so run `ComposeScene.doMeasureAndLayout` before executing any focus commands in `ComposeSceneFocusManager`.

This fixes initial focus issues in `ComposePanel` on JBR because their cause is that the taking of focus happens there before the first measure-and-layout occurred in `ComposeScene`. This causes the focus manager to fail to find focusable nodes, as it only looks at placed nodes.

Fixes https://youtrack.jetbrains.com/issue/CMP-8131/ComposePanel-doesnt-receive-initial-focus-in-JBR
Fixes https://youtrack.jetbrains.com/issue/CMP-7707/Toolwindow-focus-in-the-IDE-doesnt-get-the-focus

## Testing
Added a unit test and also tested manually with
```
    SwingUtilities.invokeAndWait {
        JFrame().apply {
            size = Dimension(800, 1000)
            val composePanel = ComposePanel().also {
                it.setContent {
                    TextField(rememberTextFieldState())
                }
            }
            contentPane.add(composePanel)
            defaultCloseOperation = JFrame.EXIT_ON_CLOSE
            isVisible = true
        }
    }
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed `ComposePanel` not initially focusing the first focusable node, when running in JetBrains Runtime JVM.
