### PR TITLE
Pass `SkiaLayer.needRedraw(throttledToVsync)` flag

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -24,7 +24,7 @@ import java.awt.Component
 import java.awt.EventQueue
 import java.awt.Graphics
 import java.awt.Rectangle
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.*
 import javax.swing.JComponent
 import javax.swing.JDialog
 import javax.swing.JFrame
@@ -165,30 +165,27 @@ internal open class JLayeredPaneWithTransparencyHack: JLayeredPane() {
  * than once.
  */
 internal class DebouncingEdtExecutor {
-
     /**
-     * Whether any code has been scheduled.
+     * The keys for which code has been scheduled.
      */
-    private val isScheduled = AtomicBoolean(false)
+    private val scheduledKeys = Collections.synchronizedSet(mutableSetOf<Any>())
 
     /**
-     * Calls [block] on the event dispatching thread.
+     * Calls [block] on the event dispatching thread, or schedules it to be called with the given
+     * [key].
      *
      * If the thread calling this function is the event dispatching thread, executes [block] and
-     * cancels any previously scheduled blocks. Otherwise, if no block is currently scheduled,
-     * schedules [block] to run event dispatching thread. If a block is already scheduled, does
-     * nothing.
-     *
-     * Note that this utility is not intended to run or schedule multiple different blocks of code
-     * at the same time, as only one block of code can be scheduled at a time.
+     * cancels any blocks previously scheduled with [key]. Otherwise, if no block is currently
+     * scheduled with [key], schedules [block] to run event dispatching thread. If a block is
+     * already scheduled with [key], does nothing.
      */
-    fun runOrScheduleDebounced(block: () -> Unit) {
+    fun runOrScheduleDebounced(key: Any, block: () -> Unit) {
         if (EventQueue.isDispatchThread()) {
-            isScheduled.set(false)
+            scheduledKeys.remove(key)
             block()
-        } else if (!isScheduled.getAndSet(true)) {
+        } else if (scheduledKeys.add(key)) {
             EventQueue.invokeLater {
-                if (isScheduled.getAndSet(false)) {
+                if (scheduledKeys.remove(key)) {
                     block()
                 }
             }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -176,7 +176,7 @@ internal class ComposeSceneMediator(
     private val interopContainer = SwingInteropContainer(
         root = container,
         placeInteropAbove = shouldPlaceInteropAbove,
-        requestRedraw = ::onComposeInvalidation
+        requestRedraw = { onComposeInvalidation(throttledToVsync = false) }
     )
 
     private val interopContainerListener = object : ContainerListener {
@@ -558,12 +558,13 @@ internal class ComposeSceneMediator(
         }
     }
 
-    fun onComposeInvalidation() = composeInvalidationExecutor.runOrScheduleDebounced {
-        catchExceptions {
-            if (isDisposed) return@catchExceptions
-            skiaLayerComponent.onComposeInvalidation()
+    fun onComposeInvalidation(throttledToVsync: Boolean) =
+        composeInvalidationExecutor.runOrScheduleDebounced(throttledToVsync) {
+            catchExceptions {
+                if (isDisposed) return@catchExceptions
+                skiaLayerComponent.onComposeInvalidation(throttledToVsync = throttledToVsync)
+            }
         }
-    }
 
     fun onComponentPositionChanged() = catchExceptions {
         if (!container.isDisplayable) return

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
@@ -46,7 +46,7 @@ internal interface SkiaLayerComponent {
     fun dispose()
     fun requestNativeFocusOnAccessible(accessible: Accessible)
 
-    fun onComposeInvalidation()
+    fun onComposeInvalidation(throttledToVsync: Boolean)
     fun onRenderApiChanged(action: () -> Unit)
 }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -127,7 +127,9 @@ internal class SwingSkiaLayerComponent(
         contentComponent.requestNativeFocusOnAccessible(accessible)
     }
 
-    override fun onComposeInvalidation() {
+    override fun onComposeInvalidation(throttledToVsync: Boolean) {
+        // TODO: https://youtrack.jetbrains.com/issue/CMP-8124
+        // if throttledToVsync is true, delay until next frame
         contentComponent.repaint()
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -163,8 +163,8 @@ internal class WindowSkiaLayerComponent(
     override fun requestNativeFocusOnAccessible(accessible: Accessible) =
         contentComponent.requestNativeFocusOnAccessible(accessible)
 
-    override fun onComposeInvalidation() {
-        contentComponent.needRedraw()
+    override fun onComposeInvalidation(throttledToVsync: Boolean) {
+        contentComponent.needRedraw(throttledToVsync = throttledToVsync)
     }
 
     override fun onRenderApiChanged(action: () -> Unit) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/viewinterop/SwingInteropContainer.desktop.kt
@@ -232,7 +232,6 @@ internal class SwingInteropContainer(
         if (hasAnyUpdates) {
             // Sometimes Swing displays the rest of interop views in incorrect order after an update
             // so we need to re-validate and repaint the root component.
-
             root.validate()
             root.repaint()
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
@@ -61,7 +61,7 @@ internal class RenderingTestScope(
     private val canvas = surface.canvas.asComposeCanvas()
     val scene = CanvasLayersComposeScene(
         coroutineContext = coroutineContext,
-        invalidate = frameDispatcher::scheduleFrame
+        invalidate = { frameDispatcher.scheduleFrame() }
     ).apply {
         size = IntSize(width = width, height = height)
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/SnapshotInvalidationTracker.skiko.kt
@@ -25,7 +25,7 @@ import kotlinx.atomicfu.atomic
 
 /**
  * SnapshotCommandList is a class that manages commands and invalidations for snapshot-based recomposition.
- * It allows postponing execution of commands and performing them in the future.
+ * It allows postponing the execution of commands and performing them in the future.
  *
  * @param invalidate a function that is called whenever an invalidation is requested
  */

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -59,7 +59,9 @@ internal abstract class BaseComposeScene(
     coroutineContext: CoroutineContext,
     private val invalidate: (canRenderImmediately: Boolean) -> Unit,
 ) : ComposeScene {
-    protected val snapshotInvalidationTracker = SnapshotInvalidationTracker(::updateInvalidations)
+    protected val snapshotInvalidationTracker = SnapshotInvalidationTracker {
+        updateInvalidations(throttledToVsync = false)
+    }
     protected val inputHandler: ComposeSceneInputHandler =
         ComposeSceneInputHandler(
             prepareForPointerInputEvent = ::doMeasureAndLayout,
@@ -91,7 +93,7 @@ internal abstract class BaseComposeScene(
         check(!isClosed) { "postponeInvalidation called after ComposeScene is closed" }
         isInvalidationDisabled = true
         return try {
-            // Try to get see the up-to-date state before running block
+            // Try to get the up-to-date state before running block
             // Note that this doesn't guarantee it, if sendApplyNotifications is called concurrently
             // in a different thread than this code.
             snapshotInvalidationTracker.sendAndPerformSnapshotChanges()
@@ -100,17 +102,27 @@ internal abstract class BaseComposeScene(
             snapshotInvalidationTracker.sendAndPerformSnapshotChanges()
             isInvalidationDisabled = false
         }.also {
-            updateInvalidations()
+            // Perform invalidations that were requested while invalidation was disabled
+            updateInvalidations(throttledToVsync = !nonThrottledInvalidationRequested)
+            nonThrottledInvalidationRequested = false
         }
     }
 
     @Volatile
     private var hasPendingDraws = true
-    protected fun updateInvalidations(throttledToVsync: Boolean = false) {
+
+    private var nonThrottledInvalidationRequested = false
+
+    protected fun updateInvalidations(throttledToVsync: Boolean) {
         hasPendingDraws = frameClock.hasAwaiters ||
             snapshotInvalidationTracker.hasInvalidations
-        if (hasPendingDraws && !isInvalidationDisabled && !isClosed && composition != null) {
-            invalidate(throttledToVsync)
+
+        if (hasPendingDraws && !isClosed && composition != null) {
+            if (!isInvalidationDisabled) {
+                invalidate(throttledToVsync)
+            } else if (!throttledToVsync) {
+                nonThrottledInvalidationRequested = true
+            }
         }
     }
 
@@ -144,7 +156,7 @@ internal abstract class BaseComposeScene(
 
             /*
          * It's required before setting content to apply changed parameters
-         * before first recomposition. Otherwise, it can lead to double recomposition.
+         * before the first recomposition. Otherwise, it can lead to double recomposition.
          */
             recomposer.performScheduledRecomposerTasks()
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.withContext
 @OptIn(InternalComposeUiApi::class)
 internal abstract class BaseComposeScene(
     coroutineContext: CoroutineContext,
-    private val invalidate: () -> Unit,
+    private val invalidate: (canRenderImmediately: Boolean) -> Unit,
 ) : ComposeScene {
     protected val snapshotInvalidationTracker = SnapshotInvalidationTracker(::updateInvalidations)
     protected val inputHandler: ComposeSceneInputHandler =
@@ -71,7 +71,9 @@ internal abstract class BaseComposeScene(
     // Store this to avoid creating a lambda every frame
     private val updatePointerPosition = inputHandler::updatePointerPosition
 
-    private val frameClock = BroadcastFrameClock(onNewAwaiters = ::updateInvalidations)
+    private val frameClock = BroadcastFrameClock(
+        onNewAwaiters = { updateInvalidations(throttledToVsync = true) }
+    )
     private val recomposer: ComposeSceneRecomposer =
         ComposeSceneRecomposer(coroutineContext, frameClock)
     private var composition: Composition? = null
@@ -104,11 +106,11 @@ internal abstract class BaseComposeScene(
 
     @Volatile
     private var hasPendingDraws = true
-    protected fun updateInvalidations() {
+    protected fun updateInvalidations(throttledToVsync: Boolean = false) {
         hasPendingDraws = frameClock.hasAwaiters ||
             snapshotInvalidationTracker.hasInvalidations
         if (hasPendingDraws && !isInvalidationDisabled && !isClosed && composition != null) {
-            invalidate()
+            invalidate(throttledToVsync)
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -57,7 +57,7 @@ import kotlinx.coroutines.withContext
 @OptIn(InternalComposeUiApi::class)
 internal abstract class BaseComposeScene(
     coroutineContext: CoroutineContext,
-    private val invalidate: (canRenderImmediately: Boolean) -> Unit,
+    private val invalidate: (throttledToVsync: Boolean) -> Unit,
 ) : ComposeScene {
     protected val snapshotInvalidationTracker = SnapshotInvalidationTracker {
         updateInvalidations(throttledToVsync = false)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -453,7 +453,7 @@ private class CanvasLayersComposeSceneImpl(
         onOwnerAppended(layer.owner)
 
         inputHandler.onPointerUpdate()
-        updateInvalidations()
+        updateInvalidations(throttledToVsync = false)
     }
 
     private fun detachLayer(layer: AttachedComposeSceneLayer) {
@@ -464,7 +464,7 @@ private class CanvasLayersComposeSceneImpl(
         onOwnerRemoved(layer.owner)
 
         inputHandler.onPointerUpdate()
-        updateInvalidations()
+        updateInvalidations(throttledToVsync = false)
     }
 
     private fun requestFocus(layer: AttachedComposeSceneLayer) {
@@ -541,7 +541,7 @@ private class CanvasLayersComposeSceneImpl(
                     releaseFocus(this)
                 }
                 inputHandler.onPointerUpdate()
-                updateInvalidations()
+                updateInvalidations(throttledToVsync = false)
             }
 
         private val background: Modifier

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -88,7 +88,7 @@ fun CanvasLayersComposeScene(
     // TODO: Remove `Dispatchers.Unconfined` as a default
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     platformContext: PlatformContext = PlatformContext.Empty,
-    invalidate: () -> Unit = {},
+    invalidate: (throttledToVsync: Boolean) -> Unit = {},
 ): ComposeScene = CanvasLayersComposeSceneImpl(
     density = density,
     layoutDirection = layoutDirection,
@@ -104,7 +104,7 @@ private class CanvasLayersComposeSceneImpl(
     size: IntSize?,
     coroutineContext: CoroutineContext,
     override val platformContext: PlatformContext,
-    invalidate: () -> Unit = {},
+    invalidate: (throttledToVsync: Boolean) -> Unit = {},
 ) : BaseComposeScene(
     coroutineContext = coroutineContext,
     invalidate = invalidate

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -68,7 +68,7 @@ fun PlatformLayersComposeScene(
     // TODO: Remove `Dispatchers.Unconfined` as a default
     coroutineContext: CoroutineContext = Dispatchers.Unconfined,
     composeSceneContext: ComposeSceneContext = ComposeSceneContext.Empty,
-    invalidate: () -> Unit = {},
+    invalidate: (throttledToVsync: Boolean) -> Unit = {},
 ): ComposeScene = PlatformLayersComposeSceneImpl(
     density = density,
     layoutDirection = layoutDirection,
@@ -84,7 +84,7 @@ private class PlatformLayersComposeSceneImpl(
     size: IntSize?,
     coroutineContext: CoroutineContext,
     override val composeSceneContext: ComposeSceneContext,
-    invalidate: () -> Unit,
+    invalidate: (throttledToVsync: Boolean) -> Unit,
 ) : BaseComposeScene(
     coroutineContext = coroutineContext,
     invalidate = invalidate

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/input/pointer/PointerIconTest.kt
@@ -351,5 +351,5 @@ private fun SingleLayerComposeScene(
     composeSceneContext = object : ComposeSceneContext {
         override val platformContext get() = platformContext
     },
-    invalidate = invalidate
+    invalidate = { invalidate() }
 )

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -731,7 +731,7 @@ class PopupTest {
                 windowInfo.containerSize = IntSize(50, 50)
             },
             coroutineContext = coroutineContext,
-            invalidate = ::invalidate
+            invalidate = { invalidate() }
         )
         try {
             scene.size = size

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -486,7 +486,7 @@ internal class ComposeHostingViewController(
             platformContext = platformContext,
             layersHolder = layersHolder
         ),
-        invalidate = invalidate,
+        invalidate = { invalidate() },
     )
 
     /**

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -112,7 +112,7 @@ internal class UIKitComposeSceneLayer(
             layoutDirection = initLayoutDirection,
             coroutineContext = coroutineContext,
             composeSceneContext = createComposeSceneContext(platformContext),
-            invalidate = invalidate,
+            invalidate = { invalidate() },
         )
 
     val hasInvalidations by mediator::hasInvalidations


### PR DESCRIPTION
Following https://github.com/JetBrains/skiko/pull/1057 Compose now needs to call `SkiaLayer.needRedraw` with a `throttledToVsync` flag.

## Testing
No new testing required.

## Release Notes
### Features - Desktop
- [macOS, Metal] When using the Metal renderer, calls from Swing asking Compose to paint itself will no longer block the Event Dispatching Thread.
- [macOS, Metal] When using the Metal renderer, Compose will now allow multiple frames to be drawn between vsync events, with only the latest one actually flushed to the screen once vsync occurs.
