### PR TITLE
Optimize some paths to use the optimized functions (Part 2)

### DIFF
--- a/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.desktop.kt
+++ b/compose/material3/material3/src/desktopMain/kotlin/androidx/compose/material3/internal/PlatformDateFormat.desktop.kt
@@ -92,7 +92,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
     //
     // Legacy model returns short ('Mon') format while newer version returns narrow ('M') format
     actual val weekdayNames: List<Pair<String, String>> get() {
-        return DayOfWeek.values().map {
+        return DayOfWeek.entries.map {
             it.getDisplayName(
                 TextStyle.FULL,
                 locale

--- a/compose/material3/material3/src/webCommonW3C/kotlin/androidx/compose/material3/internal/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/webCommonW3C/kotlin/androidx/compose/material3/internal/PlatformDateFormat.jsWasm.kt
@@ -20,6 +20,7 @@ package androidx.compose.material3.internal
 
 import androidx.compose.material3.CalendarLocale
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.util.fastMap
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.datetime.LocalDate
@@ -45,7 +46,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         listOf(
             7 to listOf("TH", "ET", "SG", "JM", "BT", "IN", "US", "MO", "KE", "DO", "AU", "IL", "AS", "TW", "MZ", "MM", "CN", "PR", "PK", "BD", "NP", "HN", "BR", "HK", "TT", "ZA", "VE", "MT", "PH", "PE", "ID", "DM", "WS", "ZW", "UM", "LA", "BZ", "JP", "SV", "SA", "CO", "GT", "BW", "KR", "PA", "YE", "BS", "MX", "MH", "GU", "PY", "AG", "CA", "KH", "PT", "VI", "NI"),
             6 to listOf("EG", "AF", "SY", "IR", "OM", "IQ", "DZ", "DJ", "AE", "SD", "KW", "JO", "BH", "QA", "LY")
-        ).map { (day, tags) -> tags.map { it to day } }.flatten().toMap()
+        ).fastMap { (day, tags) -> tags.fastMap { it to day } }.flatten().toMap()
     }
 
     private val regionsWith12HourFormat by lazy {
@@ -66,7 +67,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
 
         val jsDate = Date(utcTimeMillis.toDouble())
 
-        val (monthShort, monthLong) = listOf(SHORT, LONG).map {
+        val (monthShort, monthLong) = listOf(SHORT, LONG).fastMap {
             jsDate.toLocaleDateString(
                 locales = locale.toLanguageTag(),
                 options = dateLocaleOptions {
@@ -75,7 +76,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
             )
         }
 
-        val (wdShort, wdLong) = listOf(SHORT, LONG).map {
+        val (wdShort, wdLong) = listOf(SHORT, LONG).fastMap {
             jsDate.toLocaleDateString(
                 locales = locale.toLanguageTag(),
                 options = dateLocaleOptions {
@@ -189,8 +190,8 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
 
         val mondayToSunday = week.drop(1) + week.first()
 
-        val longAndShortWeekDays = listOf(LONG, NARROW).map { format ->
-            mondayToSunday.map {
+        val longAndShortWeekDays = listOf(LONG, NARROW).fastMap { format ->
+            mondayToSunday.fastMap {
                 it.toLocaleDateString(
                     locales = locale.toLanguageTag(),
                     options = dateLocaleOptions {

--- a/compose/material3/material3/src/webCommonW3C/kotlin/androidx/compose/material3/internal/PlatformDateFormat.jsWasm.kt
+++ b/compose/material3/material3/src/webCommonW3C/kotlin/androidx/compose/material3/internal/PlatformDateFormat.jsWasm.kt
@@ -20,6 +20,7 @@ package androidx.compose.material3.internal
 
 import androidx.compose.material3.CalendarLocale
 import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.util.fastFlatMap
 import androidx.compose.ui.util.fastMap
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
@@ -46,7 +47,7 @@ internal actual class PlatformDateFormat actual constructor(private val locale: 
         listOf(
             7 to listOf("TH", "ET", "SG", "JM", "BT", "IN", "US", "MO", "KE", "DO", "AU", "IL", "AS", "TW", "MZ", "MM", "CN", "PR", "PK", "BD", "NP", "HN", "BR", "HK", "TT", "ZA", "VE", "MT", "PH", "PE", "ID", "DM", "WS", "ZW", "UM", "LA", "BZ", "JP", "SV", "SA", "CO", "GT", "BW", "KR", "PA", "YE", "BS", "MX", "MH", "GU", "PY", "AG", "CA", "KH", "PT", "VI", "NI"),
             6 to listOf("EG", "AF", "SY", "IR", "OM", "IQ", "DZ", "DJ", "AE", "SD", "KW", "JO", "BH", "QA", "LY")
-        ).fastMap { (day, tags) -> tags.fastMap { it to day } }.flatten().toMap()
+        ).fastFlatMap { (day, tags) -> tags.fastMap { it to day } }.toMap()
     }
 
     private val regionsWith12HourFormat by lazy {

--- a/compose/ui/ui-text/src/webCommonW3C/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
+++ b/compose/ui/ui-text/src/webCommonW3C/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
@@ -16,6 +16,8 @@
 
 package androidx.compose.ui.text.intl
 
+import androidx.compose.ui.util.fastMap
+
 internal actual val PlatformLocale.language: String
     get() = _language
 
@@ -31,7 +33,7 @@ internal actual fun createPlatformLocaleDelegate(): PlatformLocaleDelegate =
     object : PlatformLocaleDelegate {
         override val current: LocaleList
             get() = LocaleList(
-                userPreferredLanguages().map {
+                userPreferredLanguages().fastMap {
                     Locale(it.toIntlLocale())
                 }
             )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -191,8 +191,8 @@ internal class SyntheticEventSender(
         return result
     }
 
-    private fun PointerInputEvent.pressedIds(): Sequence<PointerId> =
-        pointers.fastMapNotNull { if (it.down) it.id else null }.asSequence()
+    private fun PointerInputEvent.pressedIds(): List<PointerId> =
+        pointers.fastMapNotNull { if (it.down) it.id else null }
 
 
     private fun sendInternal(event: PointerInputEvent): PointerEventResult {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.scene.merging
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMapNotNull
 
 /**
  * Compose or user code can't work well if we miss some events.
@@ -123,7 +124,7 @@ internal class SyntheticEventSender(
     ): PointerEventResult {
         // issuesEnterExit means that the pointer can issues hover events (enter/exit), and so we
         // should generate a synthetic Move (see why we need to do that in the class description)
-        return if (currentEvent.pointers.any { it.activeHover } &&
+        return if (currentEvent.pointers.fastAny { it.activeHover } &&
             isMoveEventMissing(previousEvent, currentEvent)) {
             sendSyntheticMove(currentEvent)
         } else {
@@ -191,7 +192,8 @@ internal class SyntheticEventSender(
     }
 
     private fun PointerInputEvent.pressedIds(): Sequence<PointerId> =
-        pointers.asSequence().filter { it.down }.map { it.id }
+        pointers.fastMapNotNull { if (it.down) it.id else null }.asSequence()
+
 
     private fun sendInternal(event: PointerInputEvent): PointerEventResult {
         val anyMovementConsumed = _send(event)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/OffsetToFocusedRect.skiko.kt
@@ -33,6 +33,9 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toSize
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastMap
+import androidx.compose.ui.util.fastMaxOfOrDefault
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -96,12 +99,12 @@ internal fun OffsetToFocusedRect(
             // window insets changes.
             currentOffset = startOffset + (endOffset - startOffset) * offsetProgress
 
-            val placeables = measurables.map { it.measure(constraints) }
+            val placeables = measurables.fastMap { it.measure(constraints) }
             layout(
-                placeables.maxOfOrNull { it.width } ?: constraints.minWidth,
-                placeables.maxOfOrNull { it.height } ?: constraints.minHeight
+                placeables.fastMaxOfOrDefault(constraints.minWidth) { it.width },
+                placeables.fastMaxOfOrDefault(constraints.minHeight) { it.height }
             ) {
-                placeables.forEach {
+                placeables.fastForEach {
                     it.place(currentOffset)
                 }
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/WindowInsetsRulers.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/WindowInsetsRulers.skiko.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.node.TraversableNode
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformWindowInsets
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.util.fastForEachIndexed
 
 internal actual fun findDisplayCutouts(placementScope: Placeable.PlacementScope): List<RectRulers> {
     var node = placementScope.coordinates?.findRootCoordinates() as? NodeCoordinator
@@ -114,7 +115,7 @@ internal class RulerProviderModifierNode(
             }
         }
 
-        displayCutouts.forEachIndexed { index, rect ->
+        displayCutouts.fastForEachIndexed { index, rect ->
             val rulers = displayCutoutRulers[index]
             rulers.left provides rect.left
             rulers.top provides rect.top

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -160,7 +160,7 @@ private class CanvasLayersComposeSceneImpl(
     }
     private val _ownersCopyCache = CopiedList {
         it.add(mainOwner)
-        for (layer in layers) {
+        layers.fastForEach { layer ->
             it.add(layer.owner)
         }
     }
@@ -291,7 +291,7 @@ private class CanvasLayersComposeSceneImpl(
         if (owner == mainOwner) {
             return false
         }
-        for (layer in layers) {
+        layers.fastForEach { layer ->
             if (layer == focusedLayer) {
                 return true
             }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.input.pointer.areAnyPressed
 import androidx.compose.ui.input.pointer.copy
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.util.fastFirstOrNull
+import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
 import org.jetbrains.skiko.currentNanoTime
 
@@ -151,7 +152,7 @@ internal class ComposeSceneInputHandler(
 
     private fun updatePointerPositions(event: PointerInputEvent) {
         // update positions for pointers that are down + mouse (if it is not Exit event)
-        for (pointer in event.pointers) {
+        event.pointers.fastForEach { pointer ->
             if ((pointer.type == PointerType.Mouse && event.eventType != PointerEventType.Exit) ||
                 pointer.down
             ) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
 import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastForEach
 import org.w3c.dom.events.CompositionEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.UIEvent
@@ -66,7 +68,7 @@ internal abstract class NativeInputEventsProcessor(
 
         collectedEvents.sortBy { it.timeStamp.toInt() }
 
-        val isInIMEComposition = collectedEvents.any {
+        val isInIMEComposition = collectedEvents.fastAny {
             it.type == "compositionstart"
                 || it.type == "compositionupdate"
                 || it.type == "compositionend"
@@ -74,15 +76,15 @@ internal abstract class NativeInputEventsProcessor(
                 || it.type == "beforeinput" && (it as InputEvent).isComposing
         }
 
-        collectedEvents.forEach { evt ->
+        collectedEvents.fastForEach { evt ->
             val timestamp = evt.timeStamp.toDouble()
 
             when (evt.type) {
                 "keydown" -> {
-                    if (isInIMEComposition) return@forEach
+                    if (isInIMEComposition) return@fastForEach
 
                     evt as KeyboardEvent
-                    if (isTypedEvent(evt)) return@forEach
+                    if (isTypedEvent(evt)) return@fastForEach
 
                     val isFromLastComposition = timestamp < lastCompositionEndTimestamp
 

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -228,7 +228,7 @@ internal class ComposeWebSemanticsListener(
 
         if (config.contains(SemanticsProperties.Text)) {
             val text = config[SemanticsProperties.Text]
-            htmlNode.innerText = text.fastJoinToString ("\n") { it.text }
+            htmlNode.innerText = text.fastJoinToString("\n") { it.text }
         }
 
         if (config.contains(SemanticsProperties.ContentDescription)) {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/accessibility/ComposeWebSemanticsListener.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.util.fastForEach
+import androidx.compose.ui.util.fastJoinToString
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.browser.document
 import kotlinx.coroutines.CoroutineScope
@@ -169,7 +171,7 @@ internal class ComposeWebSemanticsListener(
 
             val children = node.replacedChildren.asReversed()
             dfsDeque.addAll(children)
-            children.forEach { it -> nodeToParent[it.id] = currentId }
+            children.fastForEach { it -> nodeToParent[it.id] = currentId }
 
             val htmlNode = if (nodes[currentId] != null) {
                 nodes[currentId] = node
@@ -226,12 +228,12 @@ internal class ComposeWebSemanticsListener(
 
         if (config.contains(SemanticsProperties.Text)) {
             val text = config[SemanticsProperties.Text]
-            htmlNode.innerText = text.joinToString("\n") { it.text }
+            htmlNode.innerText = text.fastJoinToString ("\n") { it.text }
         }
 
         if (config.contains(SemanticsProperties.ContentDescription)) {
             val contentDescription = config[SemanticsProperties.ContentDescription]
-            htmlNode.setAttribute("aria-label", contentDescription.joinToString(", "))
+            htmlNode.setAttribute("aria-label", contentDescription.fastJoinToString(", "))
         }
 
         if (config.contains(SemanticsActions.OnClick) && justCreated) {
@@ -268,7 +270,7 @@ internal class ComposeWebSemanticsListener(
             val width = rect.width.div(density.density)
             val height = rect.height.div(density.density)
 
-            setSizeAndPosition(htmlNode, newPosition.x, newPosition.y, width , height)
+            setSizeAndPosition(htmlNode, newPosition.x, newPosition.y, width, height)
         }
     }
 }


### PR DESCRIPTION
This is Part 2 of [Optimize some (fairly used) paths to use fast extension function](https://github.com/JetBrains/compose-multiplatform-core/pull/2176). Less allocations of iterators and simplified some intermediate functions to avoid multiple intermediate collections in some hot paths
Also change DayOfWeek.values() to DayOfWeek.entries as the recommended way to get enum entries

## Testing
Run internal performance benchmarks

## Release Notes
N/A
