### PR TITLE
[web] Turn off telemetry for Firefox tests

### DIFF
--- a/mpp/karma.config.d/web/commonKarmaConfig.js
+++ b/mpp/karma.config.d/web/commonKarmaConfig.js
@@ -8,7 +8,11 @@ function configLaunchers(config) {
         FirefoxForComposeTests: {
             base: "Firefox",
             prefs: {
-                'dom.w3c_touch_events.enabled': 1
+                'dom.w3c_touch_events.enabled': 1,
+
+                // https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/internals/preferences.html
+                // Records the version of the policy notified to the user. This preference is also used on Android, used in tests, it allows to skip the notification check.
+                'datareporting.policy.dataSubmissionPolicyBypassNotification': true
             }
         },
         SafariForComposeTests: {


### PR DESCRIPTION
Turn off telemetry dialog in web tests

## Testing
`./gradlew testWeb -Pjetbrains.androidx.web.tests.enableFirefox=true` #this property is enabled by default in CI

## Release Notes
N/A