### PR TITLE
Dispose scene after window/dialog dispose

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -260,8 +260,8 @@ class ComposeDialog : JDialog {
     }
 
     override fun dispose() {
-        composePanel.dispose()
         super.dispose()
+        composePanel.dispose()
     }
 
     override fun setUndecorated(value: Boolean) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -194,8 +194,8 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     }
 
     override fun dispose() {
-        composePanel.dispose()
         super.dispose()
+        composePanel.dispose()
     }
 
     override fun setUndecorated(value: Boolean) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -55,15 +55,15 @@ internal class WindowComposeSceneLayer(
     compositionContext: CompositionContext,
     private val renderSettings: RenderSettings
 ) : DesktopComposeSceneLayer(composeContainer, density, layoutDirection) {
-    private val parentWindow get() = requireNotNull(composeContainer.window)
+    // WindowComposeSceneLayer is tied to the window it was created with
+    private val parentWindow = requireNotNull(composeContainer.window)
+
     private val windowContext = PlatformWindowContext().also {
         it.isWindowTransparent = true
         it.setContainerSize(windowContainer.sizeInPx)
     }
 
-    private val layerWindow = JDialog(
-        parentWindow,
-    ).also {
+    private val layerWindow = JDialog(parentWindow).also {
         it.isAlwaysOnTop = true
         it.focusableWindowState = focusable
         it.isUndecorated = true

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.window
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -34,6 +33,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.awt.SwingDialog
+import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
@@ -56,11 +56,17 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.window.window.toSize
 import com.google.common.truth.Truth.assertThat
+import java.awt.Dialog
 import java.awt.Dimension
+import java.awt.Point
+import java.awt.Robot
+import java.awt.Window
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import kotlin.concurrent.thread
 import kotlin.test.assertEquals
+import kotlinx.coroutines.delay
 import org.junit.Test
 
 class DialogWindowTest {
@@ -710,6 +716,62 @@ class DialogWindowTest {
 
         awaitIdle()
         assertThat(isDisplayableInInit).isFalse()
+    }
+
+    @Test
+    fun `window does not flash background when closed`() = runApplicationTest {
+        lateinit var window: Window
+        lateinit var dialog: Dialog
+        var showDialog by mutableStateOf(false)
+        val windowSize = DpSize(800.dp, 800.dp)
+        launchTestWindowApplication(
+            state = WindowState(size = windowSize),
+        ) {
+            window = this.window
+            Box(Modifier.fillMaxSize().background(Color.Black))
+            if (showDialog) {
+                DialogWindow(
+                    onCloseRequest = {},
+                    state = rememberDialogState(size = windowSize)
+                ) {
+                    dialog = this.window
+                    Box(Modifier.fillMaxSize().background(Color.Black))
+                    LaunchedEffect(Unit) {
+                        dialog.location = window.location
+                    }
+                }
+            }
+        }
+        awaitIdle()
+
+        showDialog = true
+        awaitIdle()
+        delay(1000)
+
+        var nonBlackPixelDetected: java.awt.Color? = null
+        val testLocation = dialog.bounds.let {
+            Point(it.x + it.width / 2, it.y + it.height / 2)
+        }
+        val stopThread = java.util.concurrent.atomic.AtomicBoolean(false)
+        val t = thread {
+            val robot = Robot()
+            while (!stopThread.get()) {
+                val pixel = robot.getPixelColor(testLocation.x, testLocation.y)
+                if (pixel != java.awt.Color.BLACK) {
+                    nonBlackPixelDetected = pixel
+                    return@thread
+                }
+            }
+        }
+
+        dialog.dispose()
+        awaitIdle()
+        delay(1000)
+
+        stopThread.getAndSet(true)
+        t.join()
+
+        assertThat(nonBlackPixelDetected).isNull()
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -132,9 +132,10 @@ internal class WindowTestScope(
     }
 
     fun launchTestWindowApplication(
+        state: WindowState = WindowState(),
         content: @Composable FrameWindowScope.() -> Unit
     ) = launchTestApplication {
-       Window(onCloseRequest = ::exitApplication) {
+       Window(onCloseRequest = ::exitApplication, state = state) {
            this@WindowTestScope.window = window
            content()
        }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.window.window
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -36,6 +35,7 @@ import androidx.compose.ui.LeakDetector
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.awt.SwingWindow
+import androidx.compose.ui.background
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.isLinux
 import androidx.compose.ui.layout.Layout
@@ -48,9 +48,13 @@ import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
+import java.awt.Point
+import java.awt.Robot
 import java.awt.Toolkit
+import java.awt.Window
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import kotlin.concurrent.thread
 import kotlin.math.roundToInt
 import kotlin.test.assertEquals
 import kotlinx.coroutines.cancelAndJoin
@@ -765,5 +769,61 @@ class WindowTest {
 
         awaitIdle()
         assertThat(isDisplayableInInit).isFalse()
+    }
+
+    @Test
+    fun `window does not flash background when closed`() = runApplicationTest {
+        lateinit var outerWindow: Window
+        lateinit var innerWindow: Window
+        var showInnerWindow by mutableStateOf(false)
+        val windowSize = DpSize(800.dp, 800.dp)
+        launchTestWindowApplication(
+            state = WindowState(size = windowSize),
+        ) {
+            outerWindow = this.window
+            Box(Modifier.fillMaxSize().background(Color.Black))
+            if (showInnerWindow) {
+                Window(
+                    onCloseRequest = {},
+                    state = rememberWindowState(size = windowSize),
+                ) {
+                    innerWindow = this.window
+                    Box(Modifier.fillMaxSize().background(Color.Black))
+                    LaunchedEffect(Unit) {
+                        innerWindow.location = outerWindow.location
+                    }
+                }
+            }
+        }
+        awaitIdle()
+
+        showInnerWindow = true
+        awaitIdle()
+        delay(1000)
+
+        var nonBlackPixelDetected: java.awt.Color? = null
+        val testLocation = innerWindow.bounds.let {
+            Point(it.x + it.width / 2, it.y + it.height / 2)
+        }
+        val stopThread = java.util.concurrent.atomic.AtomicBoolean(false)
+        val t = thread {
+            val robot = Robot()
+            while (!stopThread.get()) {
+                val pixel = robot.getPixelColor(testLocation.x, testLocation.y)
+                if (pixel != java.awt.Color.BLACK) {
+                    nonBlackPixelDetected = pixel
+                    return@thread
+                }
+            }
+        }
+
+        innerWindow.dispose()
+        awaitIdle()
+        delay(1000)
+
+        stopThread.getAndSet(true)
+        t.join()
+
+        assertThat(nonBlackPixelDetected).isNull()
     }
 }


### PR DESCRIPTION
This prevents background flashing.

Fixes https://youtrack.jetbrains.com/issue/CMP-5651

## Testing
Tested manually and added unit tests.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed background flashing when a window or dialog are closed

