### PR TITLE
Refactor buildSrc (Move JB logic to a separate package)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@
 
 import androidx.build.AndroidXRootPlugin
 import androidx.build.SdkHelperKt
+import org.jetbrains.androidx.build.JetBrainsAndroidXRootPlugin
 
 buildscript {
     SdkHelperKt.setSupportRootFolder(project, project.projectDir)
@@ -34,16 +35,10 @@ buildscript {
 apply from: "buildSrc/dependencies.gradle"
 
 apply plugin: AndroidXRootPlugin
+apply plugin: JetBrainsAndroidXRootPlugin
 
 // workaround for https://github.com/gradle/gradle/issues/24822
 if (project.hasProperty("androidx.update.signatures")) {
     apply plugin: "java-library"
     apply from: "buildSrc/shared-dependencies.gradle"
-}
-
-allprojects {
-    this.tasks.configureEach {
-        if (it.name == "kotlinStoreYarnLock") it.enabled = false
-        if (it.name == "kotlinWasmStoreYarnLock") it.enabled = false
-    }
 }

--- a/buildSrc/apply/applyJetBrainsAndroidXRootImplPlugin.gradle
+++ b/buildSrc/apply/applyJetBrainsAndroidXRootImplPlugin.gradle
@@ -1,0 +1,9 @@
+import org.jetbrains.androidx.build.JetBrainsAndroidXRootImplPlugin
+
+buildscript {
+    dependencies {
+        classpath(project.files("${project.rootProject.ext["buildSrcOut"]}/private/build/libs/private.jar"))
+    }
+}
+
+apply plugin: JetBrainsAndroidXRootImplPlugin

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -56,7 +56,6 @@ allprojects {
 
 dependencies {
     api(project("plugins"))
-    implementation project(':public')
 }
 
 // use jvmTarget 17 for buildSrc .kts scripts. Keep during merge

--- a/buildSrc/plugins/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootPlugin.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.androidx.build
+
+import androidx.build.getSupportRootFolder
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * This plugin needs to be applied to the root of an AndroidX build
+ */
+abstract class JetBrainsAndroidXRootPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        val supportRoot = project.getSupportRootFolder()
+        project.apply(
+            mapOf<String, String>(
+                "from" to "$supportRoot/buildSrc/apply/applyJetBrainsAndroidXRootImplPlugin.gradle"
+            )
+        )
+    }
+}

--- a/buildSrc/plugins/src/main/resources/META-INF/gradle-plugins/JetBrainsAndroidXRootPlugin.properties
+++ b/buildSrc/plugins/src/main/resources/META-INF/gradle-plugins/JetBrainsAndroidXRootPlugin.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2025 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.jetbrains.androidx.build.JetBrainsAndroidXRootPlugin

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -140,7 +140,7 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
         }
 
         project.configureTaskTimeouts()
-        project.configureMavenArtifactUpload(extension, kmpExtension, componentFactory)
+//        project.configureMavenArtifactUpload(extension, kmpExtension, componentFactory)
         project.configureExternalDependencyLicenseCheck()
 //        project.configureProjectStructureValidation(extension)
         // TODO: [1.4 Update] check that it is not needed
@@ -152,7 +152,7 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
         project.registerAndroidxArtifact(extension)
 
         project.registerProjectOrArtifact()
-        project.addCreateLibraryBuildInfoFileTasks(extension)
+       // project.addCreateLibraryBuildInfoFileTasks(extension)
 
         project.configurations.create("samples")
 //        project.validateMultiplatformPluginHasNotBeenApplied()
@@ -178,7 +178,6 @@ class AndroidXImplPlugin @Inject constructor(val componentFactory: SoftwareCompo
                 }
             }
         }
-
     }
 
     /**

--- a/buildSrc/private/src/main/kotlin/androidx/build/buildInfo/CreateLibraryBuildInfoFileTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/buildInfo/CreateLibraryBuildInfoFileTask.kt
@@ -51,7 +51,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.named
 import org.gradle.work.DisableCachingByDefault
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
@@ -183,12 +182,6 @@ abstract class CreateLibraryBuildInfoFileTask : DefaultTask() {
             variant: VariantPublishPlan,
             shaProvider: Provider<String>
         ): TaskProvider<CreateLibraryBuildInfoFileTask> {
-            // We don't really use these tasks in our fork, and we may disable this completely.
-            // The reason for a duplicate is that we have a custom 'KotlinMultiplatformDecoration' publication,
-            // which leads to a task duplicate here.
-            val existingTask = project.tasks.findByName(TASK_NAME + variant.taskSuffix)
-            if (existingTask != null)
-                return project.tasks.named<CreateLibraryBuildInfoFileTask>(TASK_NAME + variant.taskSuffix)
             return project.tasks.register(
                 TASK_NAME + variant.taskSuffix,
                 CreateLibraryBuildInfoFileTask::class.java

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXImplPlugin.kt
@@ -19,11 +19,14 @@
 package org.jetbrains.androidx.build
 
 import androidx.build.AndroidXExtension
+import androidx.build.AndroidXMultiplatformExtension
 import androidx.build.multiplatformExtension
+import javax.inject.Inject
 import kotlinx.validation.ApiValidationExtension
 import kotlinx.validation.ExperimentalBCVApi
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.component.SoftwareComponentFactory
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.create
 import org.jetbrains.kotlin.gradle.InternalKotlinGradlePluginApi
@@ -143,10 +146,20 @@ open class JetBrainsExtensions(
     }
 
 }
-class JetBrainsAndroidXImplPlugin : Plugin<Project> {
+
+class JetBrainsAndroidXImplPlugin @Inject constructor(
+    val componentFactory: SoftwareComponentFactory
+) : Plugin<Project> {
 
     @Suppress("UNREACHABLE_CODE", "UNUSED_VARIABLE")
     override fun apply(project: Project) {
+        val androidxExtension =
+            project.extensions.getByType(AndroidXExtension::class.java)
+        val androidxMultiplatformExtension =
+            project.extensions.getByType(AndroidXMultiplatformExtension::class.java)
+        project.configureMavenArtifactUpload(
+            androidxExtension, androidxMultiplatformExtension, componentFactory)
+
         project.plugins.all { plugin ->
             if (plugin is KotlinMultiplatformPluginWrapper) {
                 onKotlinMultiplatformPluginApplied(project)

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootImplPlugin.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("unused")
+
+package org.jetbrains.androidx.build
+
+import javax.inject.Inject
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.component.SoftwareComponentFactory
+
+class JetBrainsAndroidXRootImplPlugin @Inject constructor(
+    val componentFactory: SoftwareComponentFactory
+) : Plugin<Project> {
+    override fun apply(project: Project) {
+        project.allprojects {
+            it.tasks.configureEach {
+                if (it.name == "kotlinStoreYarnLock") it.enabled = false
+                if (it.name == "kotlinWasmStoreYarnLock") it.enabled = false
+            }
+        }
+    }
+}

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/MavenUploadHelper.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/MavenUploadHelper.kt
@@ -14,8 +14,19 @@
  * limitations under the License.
  */
 
-package androidx.build
+package org.jetbrains.androidx.build
 
+import androidx.build.AndroidXExtension
+import androidx.build.AndroidXMultiplatformExtension
+import androidx.build.LibraryGroup
+import androidx.build.Release
+import androidx.build.getAlternativeProjectUrl
+import androidx.build.getBuildId
+import androidx.build.getProjectsMap
+import androidx.build.getRepositoryDirectory
+import androidx.build.isSnapshotBuild
+import androidx.build.multiplatformExtension
+import androidx.build.version
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
 import com.android.utils.childrenIterator
@@ -27,6 +38,10 @@ import java.io.File
 import java.io.StringReader
 import java.io.StringWriter
 import java.util.StringTokenizer
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.find
+import kotlin.collections.iterator
 import org.apache.xerces.jaxp.SAXParserImpl.JAXPSAXParser
 import org.dom4j.Document
 import org.dom4j.DocumentException

--- a/compose/mpp/build.gradle
+++ b/compose/mpp/build.gradle
@@ -20,6 +20,7 @@ plugins {
     id("AndroidXPlugin")
     id("AndroidXComposePlugin")
     id("kotlin-multiplatform")
+    id("JetBrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)

--- a/testutils/testutils-fonts/build.gradle
+++ b/testutils/testutils-fonts/build.gradle
@@ -29,6 +29,7 @@ plugins {
     id("com.android.library")
     //id("kotlin-android")
     id("AndroidXComposePlugin")
+    id("JetBrainsAndroidXPlugin")
 }
 
 AndroidXComposePlugin.applyAndConfigureKotlinPlugin(project)


### PR DESCRIPTION
Part of https://youtrack.jetbrains.com/issue/CMP-7927/Restore-publication-logic-in-the-new-buildSrc

- Create `JetBrainsAndroidXRootPlugin`
- Reset some build code to the previous AOSP state (that was before the buildSrc freeze)
- Temporarily comment some of AOSP code that interfere with the JB logic (we'll need to add a flag in AOSP to disable it later)

WIP for another PRs:
- Moving group/version logic
- Moving AndroidXComposeMultiplatformExtension
- Adapt the latest buildSrc from AOSP in a separate branch

## Testing
- [Full CI passes](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_AllPersonalBuild/5515298)

## Release Notes
N/A