### PR TITLE
Align TextFieldSelectionState to upstreamed changes

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.kt
@@ -505,24 +505,23 @@ internal class TextFieldSelectionState(
         coroutineScope {
             launch(start = CoroutineStart.UNDISPATCHED) { detectTouchMode() }
             launch(start = CoroutineStart.UNDISPATCHED) {
-                detectPressDownGesture(
-                    onDown = {
-                        markStartContentVisibleOffset()
-                        updateHandleDragging(
-                            handle =
-                                if (isStartHandle) {
-                                    Handle.SelectionStart
-                                } else {
-                                    Handle.SelectionEnd
-                                },
-                            position = getAdjustedCoordinates(getHandlePosition(isStartHandle)),
-                        )
-                    },
-                    onUp = { clearHandleDragging() },
-                )
-            }.invokeOnCompletion {
-                clearHandleDragging()
-            }
+                    detectPressDownGesture(
+                        onDown = {
+                            markStartContentVisibleOffset()
+                            updateHandleDragging(
+                                handle =
+                                    if (isStartHandle) {
+                                        Handle.SelectionStart
+                                    } else {
+                                        Handle.SelectionEnd
+                                    },
+                                position = getAdjustedCoordinates(getHandlePosition(isStartHandle)),
+                            )
+                        },
+                        onUp = { clearHandleDragging() },
+                    )
+                }
+                .invokeOnCompletion { clearHandleDragging() }
             launch(start = CoroutineStart.UNDISPATCHED) {
                 detectSelectionHandleDragGestures(isStartHandle)
             }
@@ -574,7 +573,13 @@ internal class TextFieldSelectionState(
         interactionSource: MutableInteractionSource?,
         requestFocus: () -> Unit,
         showKeyboard: () -> Unit,
-    ) = detectTextFieldTapGestures(this@TextFieldSelectionState, interactionSource, requestFocus, showKeyboard)
+    ) =
+        this@TextFieldSelectionState.detectTextFieldTapGestures(
+            this,
+            interactionSource,
+            requestFocus,
+            showKeyboard,
+        )
 
     /**
      * Calculates the valid cursor position nearest to [offset] and sets the cursor to it. Takes
@@ -715,10 +720,10 @@ internal class TextFieldSelectionState(
      *   exception is the first mouse down does immediately place the cursor at the position.
      */
     suspend fun PointerInputScope.textFieldSelectionGestures(requestFocus: () -> Unit) =
-        getTextFieldSelectionGestures(
-            this@TextFieldSelectionState,
+        this@TextFieldSelectionState.textFieldSelectionGestures(
+            this,
             TextFieldMouseSelectionObserver(requestFocus),
-            TextFieldTextDragObserver(requestFocus)
+            TextFieldTextDragObserver(requestFocus),
         )
 
     private inner class TextFieldMouseSelectionObserver(private val requestFocus: () -> Unit) :
@@ -1709,39 +1714,39 @@ internal class TextFieldSelectionState(
 }
 
 /** Runs platform-specific text tap gestures logic. */
-internal expect suspend fun PointerInputScope.detectTextFieldTapGestures(
-    selectionState: TextFieldSelectionState,
+internal expect suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
+    pointerInputScope: PointerInputScope,
     interactionSource: MutableInteractionSource?,
     requestFocus: () -> Unit,
-    showKeyboard: () -> Unit
+    showKeyboard: () -> Unit,
 )
 
-internal suspend fun PointerInputScope.defaultDetectTextFieldTapGestures(
-    selectionState: TextFieldSelectionState,
+internal suspend fun TextFieldSelectionState.defaultDetectTextFieldTapGestures(
+    pointerInputScope: PointerInputScope,
     interactionSource: MutableInteractionSource?,
     requestFocus: () -> Unit,
-    showKeyboard: () -> Unit
+    showKeyboard: () -> Unit,
 ) {
-    detectTapAndPress(
+    pointerInputScope.detectTapAndPress(
         onTap = { offset ->
             logDebug { "onTapTextField" }
             requestFocus()
 
-            if (selectionState.enabled && selectionState.isFocused) {
-                if (!selectionState.readOnly) {
+            if (enabled && isFocused) {
+                if (!readOnly) {
                     showKeyboard()
-                    if (selectionState.textFieldState.visualText.isNotEmpty()) {
-                        selectionState.showCursorHandle = true
+                    if (textFieldState.visualText.isNotEmpty()) {
+                        showCursorHandle = true
                     }
                 }
 
                 // do not show any TextToolbar.
-                selectionState.updateTextToolbarState(None)
+                updateTextToolbarState(None)
 
-                val coercedOffset = selectionState.textLayoutState.coercedInVisibleBoundsOfInputText(offset)
+                val coercedOffset = textLayoutState.coercedInVisibleBoundsOfInputText(offset)
 
-                selectionState.placeCursorAtNearestOffset(
-                    selectionState.textLayoutState.fromDecorationToTextLayout(coercedOffset)
+                placeCursorAtNearestOffset(
+                    textLayoutState.fromDecorationToTextLayout(coercedOffset)
                 )
             }
         },
@@ -1750,18 +1755,18 @@ internal suspend fun PointerInputScope.defaultDetectTextFieldTapGestures(
                 coroutineScope {
                     launch {
                         // Remove any old interactions if we didn't fire stop / cancel properly
-                        selectionState.pressInteraction?.let { oldValue ->
+                        pressInteraction?.let { oldValue ->
                             val interaction = PressInteraction.Cancel(oldValue)
                             interactionSource.emit(interaction)
-                            selectionState.pressInteraction = null
+                            pressInteraction = null
                         }
 
                         val press = PressInteraction.Press(offset)
                         interactionSource.emit(press)
-                        selectionState.pressInteraction = press
+                        pressInteraction = press
                     }
                     val success = tryAwaitRelease()
-                    selectionState.pressInteraction?.let { pressInteraction ->
+                    pressInteraction?.let { pressInteraction ->
                         val endInteraction =
                             if (success) {
                                 PressInteraction.Release(pressInteraction)
@@ -1770,23 +1775,23 @@ internal suspend fun PointerInputScope.defaultDetectTextFieldTapGestures(
                             }
                         interactionSource.emit(endInteraction)
                     }
-                    selectionState.pressInteraction = null
+                    pressInteraction = null
                 }
             }
-        }
+        },
     )
 }
 
 /** Runs platform-specific text selection gestures logic. */
-internal expect suspend fun PointerInputScope.getTextFieldSelectionGestures(
-    selectionState: TextFieldSelectionState,
+internal expect suspend fun TextFieldSelectionState.textFieldSelectionGestures(
+    pointerInputScope: PointerInputScope,
     mouseSelectionObserver: MouseSelectionObserver,
-    textDragObserver: TextDragObserver
+    textDragObserver: TextDragObserver,
 )
 
 internal suspend fun PointerInputScope.defaultTextFieldSelectionGestures(
     mouseSelectionObserver: MouseSelectionObserver,
-    textDragObserver: TextDragObserver
+    textDragObserver: TextDragObserver,
 ) {
     awaitSelectionGestures(
         mouseSelectionObserver = mouseSelectionObserver,

--- a/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.jvm.kt
+++ b/compose/foundation/foundation/src/jvmMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.jvm.kt
@@ -22,16 +22,16 @@ import androidx.compose.foundation.text.selection.MouseSelectionObserver
 import androidx.compose.ui.input.pointer.PointerInputScope
 
 /** Runs platform-specific text tap gestures logic. */
-internal actual suspend fun PointerInputScope.detectTextFieldTapGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
+    pointerInputScope: PointerInputScope,
     interactionSource: MutableInteractionSource?,
     requestFocus: () -> Unit,
     showKeyboard: () -> Unit
-) = defaultDetectTextFieldTapGestures(selectionState, interactionSource, requestFocus, showKeyboard)
+) = defaultDetectTextFieldTapGestures(pointerInputScope, interactionSource, requestFocus, showKeyboard)
 
 /** Runs platform-specific text selection gestures logic. */
-internal actual suspend fun PointerInputScope.getTextFieldSelectionGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.textFieldSelectionGestures(
+    pointerInputScope: PointerInputScope,
     mouseSelectionObserver: MouseSelectionObserver,
     textDragObserver: TextDragObserver
-) = defaultTextFieldSelectionGestures(mouseSelectionObserver, textDragObserver)
+) = pointerInputScope.defaultTextFieldSelectionGestures(mouseSelectionObserver, textDragObserver)

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.macos.kt
@@ -27,19 +27,19 @@ import androidx.compose.ui.platform.Clipboard
 import kotlinx.coroutines.CoroutineScope
 
 /** Runs platform-specific text tap gestures logic. */
-internal actual suspend fun PointerInputScope.detectTextFieldTapGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
+    pointerInputScope: PointerInputScope,
     interactionSource: MutableInteractionSource?,
     requestFocus: () -> Unit,
-    showKeyboard: () -> Unit
-) = defaultDetectTextFieldTapGestures(selectionState, interactionSource, requestFocus, showKeyboard)
+    showKeyboard: () -> Unit,
+) = defaultDetectTextFieldTapGestures(pointerInputScope, interactionSource, requestFocus, showKeyboard)
 
 /** Runs platform-specific text selection gestures logic. */
-internal actual suspend fun PointerInputScope.getTextFieldSelectionGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.textFieldSelectionGestures(
+    pointerInputScope: PointerInputScope,
     mouseSelectionObserver: MouseSelectionObserver,
     textDragObserver: TextDragObserver
-) = defaultTextFieldSelectionGestures(mouseSelectionObserver, textDragObserver)
+) = pointerInputScope.defaultTextFieldSelectionGestures(mouseSelectionObserver, textDragObserver)
 
 internal actual fun Modifier.addBasicTextFieldTextContextMenuComponents(
     state: TextFieldSelectionState,

--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.uikit.kt
@@ -64,35 +64,35 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
 /** Runs platform-specific text tap gestures logic. */
-internal actual suspend fun PointerInputScope.detectTextFieldTapGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
+    pointerInputScope: PointerInputScope,
     interactionSource: MutableInteractionSource?,
     requestFocus: () -> Unit,
     showKeyboard: () -> Unit
 ) {
-    detectTapAndPress(
+    pointerInputScope.detectTapAndPress(
         onTap = { offset ->
             requestFocus()
 
-            if (selectionState.enabled && selectionState.isFocused) {
-                if (!selectionState.readOnly) {
+            if (enabled && isFocused) {
+                if (!readOnly) {
                     showKeyboard()
-                    if (selectionState.textFieldState.visualText.isNotEmpty()) {
-                        selectionState.showCursorHandle = true
+                    if (textFieldState.visualText.isNotEmpty()) {
+                        showCursorHandle = true
                     }
                 }
 
-                selectionState.updateTextToolbarState(None)
+                updateTextToolbarState(None)
 
                 val coercedOffset =
-                    selectionState.textLayoutState.coercedInVisibleBoundsOfInputText(offset)
-                val cursorMoved = selectionState.placeCursorAtDesiredOffset(
-                    selectionState.textLayoutState.fromDecorationToTextLayout(coercedOffset)
+                    textLayoutState.coercedInVisibleBoundsOfInputText(offset)
+                val cursorMoved = placeCursorAtDesiredOffset(
+                    textLayoutState.fromDecorationToTextLayout(coercedOffset)
                 )
 
                 // TODO: It should be toggleable
                 if (!cursorMoved) {
-                    selectionState.updateTextToolbarState(Cursor)
+                    updateTextToolbarState(Cursor)
                 }
             }
         },
@@ -101,18 +101,18 @@ internal actual suspend fun PointerInputScope.detectTextFieldTapGestures(
                 coroutineScope {
                     launch {
                         // Remove any old interactions if we didn't fire stop / cancel properly
-                        selectionState.pressInteraction?.let { oldValue ->
+                        pressInteraction?.let { oldValue ->
                             val interaction = PressInteraction.Cancel(oldValue)
                             interactionSource.emit(interaction)
-                            selectionState.pressInteraction = null
+                            pressInteraction = null
                         }
 
                         val press = PressInteraction.Press(offset)
                         interactionSource.emit(press)
-                        selectionState.pressInteraction = press
+                        pressInteraction = press
                     }
                     val success = tryAwaitRelease()
-                    selectionState.pressInteraction?.let { pressInteraction ->
+                    pressInteraction?.let { pressInteraction ->
                         val endInteraction =
                             if (success) {
                                 PressInteraction.Release(pressInteraction)
@@ -121,7 +121,7 @@ internal actual suspend fun PointerInputScope.detectTextFieldTapGestures(
                             }
                         interactionSource.emit(endInteraction)
                     }
-                    selectionState.pressInteraction = null
+                    pressInteraction = null
                 }
             }
         }
@@ -205,14 +205,15 @@ private fun TextFieldSelectionState.placeCursorAtDesiredOffset(offset: Offset): 
 }
 
 /** Runs platform-specific text selection gestures logic. */
-internal actual suspend fun PointerInputScope.getTextFieldSelectionGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.textFieldSelectionGestures(
+    pointerInputScope: PointerInputScope,
     mouseSelectionObserver: MouseSelectionObserver,
     textDragObserver: TextDragObserver
 ) {
+    val selectionState = this
     val uiKitTextDragObserver = UIKitTextFieldTextDragObserver(selectionState)
-    val clicksCounter = ClicksCounter(viewConfiguration)
-    awaitEachGesture {
+    val clicksCounter = ClicksCounter(pointerInputScope.viewConfiguration)
+    pointerInputScope.awaitEachGesture {
         while (true) {
             val downEvent = awaitPress({true})
             clicksCounter.update(downEvent.changes[0])

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.web.kt
@@ -35,19 +35,19 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 
 /** Runs platform-specific text tap gestures logic. */
-internal actual suspend fun PointerInputScope.detectTextFieldTapGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.detectTextFieldTapGestures(
+    pointerInputScope: PointerInputScope,
     interactionSource: MutableInteractionSource?,
     requestFocus: () -> Unit,
     showKeyboard: () -> Unit
-) = defaultDetectTextFieldTapGestures(selectionState, interactionSource, requestFocus, showKeyboard)
+) = defaultDetectTextFieldTapGestures(pointerInputScope, interactionSource, requestFocus, showKeyboard)
 
 /** Runs platform-specific text selection gestures logic. */
-internal actual suspend fun PointerInputScope.getTextFieldSelectionGestures(
-    selectionState: TextFieldSelectionState,
+internal actual suspend fun TextFieldSelectionState.textFieldSelectionGestures(
+    pointerInputScope: PointerInputScope,
     mouseSelectionObserver: MouseSelectionObserver,
     textDragObserver: TextDragObserver
-) = defaultTextFieldSelectionGestures(mouseSelectionObserver, textDragObserver)
+) = pointerInputScope.defaultTextFieldSelectionGestures(mouseSelectionObserver, textDragObserver)
 
 internal actual fun Modifier.addBasicTextFieldTextContextMenuComponents(
     state: TextFieldSelectionState,


### PR DESCRIPTION
Align TextFieldSelectionState to upstreamed changes

Upstreamed `commonMain` changes are in CL: https://android-review.googlesource.com/c/platform/frameworks/support/+/3735846

Fixes [CMP-7866](https://youtrack.jetbrains.com/issue/CMP-7866) Upstreaming BTF2 iOS adjustments

## Release Notes
N/A