### PR TITLE
Expose nodes inside Accessibility Elements for automation

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -62,6 +62,7 @@ import platform.UIKit.accessibilityFrame
 import platform.UIKit.accessibilityLabel
 import platform.UIKit.accessibilityTraits
 import platform.UIKit.accessibilityValue
+import platform.UIKit.automationElements
 import platform.UIKit.isAccessibilityElement
 import platform.darwin.NSIntegerMax
 import platform.darwin.NSObject
@@ -78,41 +79,57 @@ import platform.darwin.NSObject
  */
 @OptIn(ExperimentalForeignApi::class)
 internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode {
-    fun buildNode(element: NSObject): AccessibilityTestNode {
+    fun buildNode(element: NSObject, isAccessibilityElementContent: Boolean): AccessibilityTestNode {
         val children = mutableListOf<AccessibilityTestNode>()
         val elements = element.accessibilityElements()
+        val accessibilityElementContent = isAccessibilityElementContent || element.isAccessibilityElement
 
-        if (elements != null) {
+        if (accessibilityElementContent) {
+            // iOS Automation uses `automationElements` to build the semantics tree inside the
+            // accessibility element.
+            // Exceptions are UIKit elements that use private logic to build their semantics tree
+            // for automation.
+            if ((element.automationElements?.isNotEmpty() ?: false)) {
+                element.automationElements?.forEach {
+                    children.add(buildNode(it as NSObject, accessibilityElementContent))
+                }
+            } else if (element is UIView) {
+                element.subviews.forEach {
+                    children.add(buildNode(it as UIView, accessibilityElementContent))
+                }
+            }
+        } else if (elements != null) {
             elements.forEach {
-                children.add(buildNode(it as NSObject))
+                children.add(buildNode(it as NSObject, accessibilityElementContent))
             }
         } else {
             val count = element.accessibilityElementCount()
             if (count == NSIntegerMax) {
-                when {
-                    element is UIView -> {
+                when (element) {
+                    is UIView -> {
                         element.subviews.forEach {
-                            children.add(buildNode(it as UIView))
+                            children.add(buildNode(it as UIView, accessibilityElementContent))
                         }
                     }
-                    element is UIWindowScene -> {
+
+                    is UIWindowScene -> {
                         element.windows.filter { !(it as UIWindow).isHidden() }.forEach {
-                            children.add(buildNode(it as UIWindow))
+                            children.add(buildNode(it as UIWindow, accessibilityElementContent))
                         }
                     }
                 }
             } else if (count > 0) {
                 (0 until count).forEach {
                     val child = element.accessibilityElementAtIndex(it) as NSObject
-                    children.add(buildNode(child))
+                    children.add(buildNode(child, accessibilityElementContent))
                 }
             } else if (element is UIView) {
                 element.subviews.forEach {
-                    children.add(buildNode(it as UIView))
+                    children.add(buildNode(it as UIView, accessibilityElementContent))
                 }
             } else if (element is UIWindowScene) {
                 element.windows.filter { !(it as UIWindow).isHidden() }.forEach {
-                    children.add(buildNode(it as UIWindow))
+                    children.add(buildNode(it as UIWindow, accessibilityElementContent))
                 }
             }
         }
@@ -133,7 +150,7 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
         }
     }
 
-    return buildNode(appDelegate.window!!.windowScene!!)
+    return buildNode(appDelegate.window!!.windowScene!!, isAccessibilityElementContent = false)
 }
 
 private val allAccessibilityTraits = mapOf(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -133,6 +133,7 @@ import platform.UIKit.accessibilityElementCount
 import platform.UIKit.accessibilityElements
 import platform.UIKit.accessibilityFrame
 import platform.UIKit.isAccessibilityElement
+import platform.UIKit.setAutomationElements
 import platform.darwin.NSObject
 import platform.objc.objc_getProtocol
 import platform.objc.protocol_isEqual
@@ -510,6 +511,9 @@ private class AccessibilityElement(
     init {
         setAccessibilityElements(children + nodeSemanticsElements())
         children.forEach { it.setAccessibilityContainer(this) }
+        if (available(OS.Ios to OSVersion(major = 17))) {
+            setAutomationElements(children + nodeSemanticsElements())
+        }
     }
 
     override fun focusEffect(): UIFocusEffect = UIFocusHaloEffect.effectWithRect(
@@ -533,6 +537,9 @@ private class AccessibilityElement(
             (it as? CMPAccessibilityElement)?.setAccessibilityContainer(null)
         }
         setAccessibilityElements(children + nodeSemanticsElements())
+        if (available(OS.Ios to OSVersion(major = 17))) {
+            setAutomationElements(children + nodeSemanticsElements())
+        }
         children.forEach { it.setAccessibilityContainer(this) }
         this.cachedProperties.clear()
     }
@@ -545,6 +552,7 @@ private class AccessibilityElement(
         isAlive = false
         setAccessibilityContainer(null)
         setAccessibilityElements(emptyList<Any>())
+        setAutomationElements(null)
         cachedProperties.clear()
     }
 
@@ -1604,7 +1612,11 @@ internal class AccessibilityMediator(
                 }
             }
 
-            repeat(element.accessibilityElementCount().toInt()) { index ->
+            element.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach { element ->
+                findElement(element as NSObject, point)?.let {
+                    return it
+                }
+            } ?: repeat(element.accessibilityElementCount().toInt()) { index ->
                 element.accessibilityElementAtIndex(index.toLong())?.let { element ->
                     findElement(element as NSObject, point)?.let {
                         return it
@@ -1650,7 +1662,9 @@ internal class AccessibilityMediator(
         if (nsNode.isAccessibilityElement) {
             return nsNode
         }
-        repeat(node.accessibilityElementCount().toInt()) { index ->
+        nsNode.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach {
+            findFocusableElement(it as Any)
+        } ?: repeat(node.accessibilityElementCount().toInt()) { index ->
             node.accessibilityElementAtIndex(index.toLong())?.let {
                 findFocusableElement(it)
             }
@@ -1700,10 +1714,10 @@ private fun debugTraverse(debugLogger: AccessibilityDebugLogger, accessibilityOb
         is AccessibilityElement -> {
             accessibilityObject.debugLog(debugLogger, depth)
 
-            val count = accessibilityObject.accessibilityElementCount()
-            for (index in 0 until count) {
-                val element = accessibilityObject.accessibilityElementAtIndex(index)
-                element?.let {
+            accessibilityObject.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach {
+                debugTraverse(debugLogger, it as Any, depth + 1)
+            } ?: repeat(accessibilityObject.accessibilityElementCount().toInt()) { index ->
+                accessibilityObject.accessibilityElementAtIndex(index.toLong())?.let { element ->
                     debugTraverse(debugLogger, element, depth + 1)
                 }
             }


### PR DESCRIPTION
Unlike Accessibility Engine, UI Automation uses different approach to get content inside accessibility elements (`isAccessibilityElement = true`).
Add ability for UI Automation to reach child  elements inside accessibility elements.
Update semantics tree construction logic to mimic the UI Automation traversal behavior.

Fixes https://youtrack.jetbrains.com/issue/CMP-7024/Accessibility-for-compound-layouts-is-not-working-on-iOS-correctly

## Release Notes
### Fixes - iOS
- Add ability to reach internal accessibility elements inside accessibility nodes.