### PR TITLE
[Cherry-pick] Make PlatformImeOptionsImpl a @Immutable data class (#2413)

### DIFF
--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -16,17 +16,18 @@
 
 package androidx.compose.ui.text.input
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import platform.UIKit.UIKeyboardAppearance
 import platform.UIKit.UIKeyboardAppearanceDefault
 import platform.UIKit.UIKeyboardType
-import platform.UIKit.UIKeyboardTypeDefault
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextContentType
 
-private class PlatformImeOptionsImpl(
+@Immutable
+private data class PlatformImeOptionsImpl(
     val keyboardType: UIKeyboardType?,
     val keyboardAppearance: UIKeyboardAppearance,
     val returnKeyType: UIReturnKeyType?,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.keyboard
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.TextField
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.InterceptPlatformTextInput
+import androidx.compose.ui.platform.PlatformTextInputMethodRequest
+import androidx.compose.ui.platform.PlatformTextInputSession
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.text.input.PlatformImeOptions
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import platform.UIKit.UIKeyboardTypeEmailAddress
+import platform.UIKit.UITextContentTypeUsername
+
+internal class ImeOptionsTest {
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testTextInputSessionDoesNotRestartWithChangedInput() = runUIKitInstrumentedTest {
+        val inputState = mutableStateOf("")
+        var startInputCount = 0
+
+        val testTextInputSession = object : PlatformTextInputSession {
+                override suspend fun startInputMethod(
+                    request: PlatformTextInputMethodRequest
+                ): Nothing {
+                    startInputCount++
+                    suspendCancellableCoroutine<Nothing> { }
+                }
+            }
+
+        setContent {
+            var input by rememberSaveable { inputState }
+
+            InterceptPlatformTextInput(
+                interceptor = { request, _ ->
+                    testTextInputSession.startInputMethod(request)
+                },
+                content = {
+                    TextField(
+                        modifier = Modifier.testTag("TextField"),
+                        value = input,
+                        onValueChange = { input = it },
+                        keyboardOptions = KeyboardOptions(platformImeOptions = PlatformImeOptions {
+                            keyboardType(UIKeyboardTypeEmailAddress)
+                            textContentType(UITextContentTypeUsername)
+                        })
+                    )
+                }
+            )
+        }
+
+        findNodeWithTag("TextField").tap()
+
+        waitForIdle()
+
+        assertEquals(1, startInputCount)
+
+        var input = ""
+        for (i in 1..4) {
+            input += "$i"
+            inputState.value = input
+            waitForIdle()
+            assertEquals(1, startInputCount)
+        }
+    }
+}


### PR DESCRIPTION
Adds `@Immutable` annotation to `PlatformImeOptionsImpl` so Compose can treat instances as immutable and skip unnecessary input session restarts.

Fixes [CMP-8917](https://youtrack.jetbrains.com/issue/CMP-8917) [iOS] PlatformImeOptions - flickering keyboard

## Testing

Adds test to `ImeOptionsTest`

This should be tested by QA

## Release Notes
https://github.com/jetbrains/compose-multiplatform-core/pull/2413
