### PR TITLE
[Cherry-pick] Expose nodes inside Accessibility Elements for automation (#2416)

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -52,6 +52,8 @@ import platform.UIKit.UIAccessibilityTraitToggleButton
 import platform.UIKit.UIAccessibilityTraitUpdatesFrequently
 import platform.UIKit.UIAccessibilityTraits
 import platform.UIKit.UIView
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
 import platform.UIKit.accessibilityCustomActions
 import platform.UIKit.accessibilityElementAtIndex
 import platform.UIKit.accessibilityElementCount
@@ -60,6 +62,7 @@ import platform.UIKit.accessibilityFrame
 import platform.UIKit.accessibilityLabel
 import platform.UIKit.accessibilityTraits
 import platform.UIKit.accessibilityValue
+import platform.UIKit.automationElements
 import platform.UIKit.isAccessibilityElement
 import platform.darwin.NSIntegerMax
 import platform.darwin.NSObject
@@ -76,32 +79,57 @@ import platform.darwin.NSObject
  */
 @OptIn(ExperimentalForeignApi::class)
 internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode {
-    fun buildNode(element: NSObject, level: Int): AccessibilityTestNode {
+    fun buildNode(element: NSObject, isAccessibilityElementContent: Boolean): AccessibilityTestNode {
         val children = mutableListOf<AccessibilityTestNode>()
         val elements = element.accessibilityElements()
+        val accessibilityElementContent = isAccessibilityElementContent || element.isAccessibilityElement
 
-        if (elements != null) {
+        if (accessibilityElementContent) {
+            // iOS Automation uses `automationElements` to build the semantics tree inside the
+            // accessibility element.
+            // Exceptions are UIKit elements that use private logic to build their semantics tree
+            // for automation.
+            if ((element.automationElements?.isNotEmpty() ?: false)) {
+                element.automationElements?.forEach {
+                    children.add(buildNode(it as NSObject, accessibilityElementContent))
+                }
+            } else if (element is UIView) {
+                element.subviews.forEach {
+                    children.add(buildNode(it as UIView, accessibilityElementContent))
+                }
+            }
+        } else if (elements != null) {
             elements.forEach {
-                children.add(buildNode(it as NSObject, level = level + 1))
+                children.add(buildNode(it as NSObject, accessibilityElementContent))
             }
         } else {
             val count = element.accessibilityElementCount()
             if (count == NSIntegerMax) {
-                when {
-                    element is UIView -> {
-                        element.subviews.mapNotNull {
-                            children.add(buildNode(it as UIView, level = level + 1))
+                when (element) {
+                    is UIView -> {
+                        element.subviews.forEach {
+                            children.add(buildNode(it as UIView, accessibilityElementContent))
+                        }
+                    }
+
+                    is UIWindowScene -> {
+                        element.windows.filter { !(it as UIWindow).isHidden() }.forEach {
+                            children.add(buildNode(it as UIWindow, accessibilityElementContent))
                         }
                     }
                 }
             } else if (count > 0) {
-                (0 until count).mapNotNull {
+                (0 until count).forEach {
                     val child = element.accessibilityElementAtIndex(it) as NSObject
-                    children.add(buildNode(child, level = level + 1))
+                    children.add(buildNode(child, accessibilityElementContent))
                 }
             } else if (element is UIView) {
-                element.subviews.mapNotNull {
-                    children.add(buildNode(it as UIView, level = level + 1))
+                element.subviews.forEach {
+                    children.add(buildNode(it as UIView, accessibilityElementContent))
+                }
+            } else if (element is UIWindowScene) {
+                element.windows.filter { !(it as UIWindow).isHidden() }.forEach {
+                    children.add(buildNode(it as UIWindow, accessibilityElementContent))
                 }
             }
         }
@@ -122,7 +150,7 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
         }
     }
 
-    return buildNode(appDelegate.window!!, 0)
+    return buildNode(appDelegate.window!!.windowScene!!, isAccessibilityElementContent = false)
 }
 
 private val allAccessibilityTraits = mapOf(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -67,6 +67,9 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGPointMake
 import platform.CoreGraphics.CGRect
@@ -115,6 +118,7 @@ import platform.UIKit.accessibilityElements
 import platform.UIKit.accessibilityFrame
 import platform.UIKit.isAccessibilityElement
 import platform.UIKit.setAccessibilityElements
+import platform.UIKit.setAutomationElements
 import platform.darwin.NSObject
 
 private val DUMMY_UI_ACCESSIBILITY_CONTAINER = NSObject()
@@ -421,6 +425,9 @@ private class AccessibilityElement(
     init {
         setAccessibilityElements(children + nodeSemanticsElements())
         children.forEach { it.setAccessibilityContainer(this) }
+        if (available(OS.Ios to OSVersion(major = 17))) {
+            setAutomationElements(children + nodeSemanticsElements())
+        }
     }
 
     private fun nodeSemanticsElements(): List<Any> =
@@ -440,6 +447,9 @@ private class AccessibilityElement(
             (it as? CMPAccessibilityElement)?.setAccessibilityContainer(null)
         }
         setAccessibilityElements(children + nodeSemanticsElements())
+        if (available(OS.Ios to OSVersion(major = 17))) {
+            setAutomationElements(children + nodeSemanticsElements())
+        }
         children.forEach { it.setAccessibilityContainer(this) }
         this.cachedProperties.clear()
     }
@@ -452,6 +462,7 @@ private class AccessibilityElement(
         isAlive = false
         setAccessibilityContainer(null)
         setAccessibilityElements(emptyList<Any>())
+        setAutomationElements(null)
         cachedProperties.clear()
     }
 
@@ -1314,7 +1325,11 @@ internal class AccessibilityMediator(
                 }
             }
 
-            repeat(element.accessibilityElementCount().toInt()) { index ->
+            element.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach { element ->
+                findElement(element as NSObject, point)?.let {
+                    return it
+                }
+            } ?: repeat(element.accessibilityElementCount().toInt()) { index ->
                 element.accessibilityElementAtIndex(index.toLong())?.let { element ->
                     findElement(element as NSObject, point)?.let {
                         return it
@@ -1360,7 +1375,9 @@ internal class AccessibilityMediator(
         if (nsNode.isAccessibilityElement) {
             return nsNode
         }
-        repeat(node.accessibilityElementCount().toInt()) { index ->
+        nsNode.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach {
+            findFocusableElement(it as Any)
+        } ?: repeat(node.accessibilityElementCount().toInt()) { index ->
             node.accessibilityElementAtIndex(index.toLong())?.let {
                 findFocusableElement(it)
             }
@@ -1410,10 +1427,10 @@ private fun debugTraverse(debugLogger: AccessibilityDebugLogger, accessibilityOb
         is AccessibilityElement -> {
             accessibilityObject.debugLog(debugLogger, depth)
 
-            val count = accessibilityObject.accessibilityElementCount()
-            for (index in 0 until count) {
-                val element = accessibilityObject.accessibilityElementAtIndex(index)
-                element?.let {
+            accessibilityObject.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach {
+                debugTraverse(debugLogger, it as Any, depth + 1)
+            } ?: repeat(accessibilityObject.accessibilityElementCount().toInt()) { index ->
+                accessibilityObject.accessibilityElementAtIndex(index.toLong())?.let { element ->
                     debugTraverse(debugLogger, element, depth + 1)
                 }
             }


### PR DESCRIPTION
Unlike Accessibility Engine, UI Automation uses different approach to get content inside accessibility elements (`isAccessibilityElement = true`).
Add ability for UI Automation to reach child elements inside accessibility elements.
Update semantics tree construction logic to mimic the UI Automation traversal behavior.

Fixes
https://youtrack.jetbrains.com/issue/CMP-7024/Accessibility-for-compound-layouts-is-not-working-on-iOS-correctly

## Release Notes
https://github.com/jetbrains/compose-multiplatform-core/pull/2416
