### PR TITLE
[web] demo: fetch fonts that needs to be uploaded from a manifest

### DIFF
--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -207,6 +207,10 @@ kotlin {
             dependsOn(skikoMain)
             resources.setSrcDirs(resources.srcDirs)
             resources.srcDirs(unzipTask.map { it.destinationDir })
+
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+            }
         }
 
         val jsMain by getting {

--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -209,7 +209,7 @@ kotlin {
             resources.srcDirs(unzipTask.map { it.destinationDir })
 
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+                implementation(libs.kotlinSerializationJson)
             }
         }
 

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Main.web.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Main.web.kt
@@ -30,11 +30,12 @@ import androidx.compose.ui.window.ComposeViewport
 import androidx.navigation.ExperimentalBrowserHistoryApi
 import androidx.navigation.bindToBrowserNavigation
 import androidx.navigation.compose.rememberNavController
+import kotlin.js.ExperimentalJsReflectionCreateInstance
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
-
-private const val notoColorEmoji = "./NotoColorEmoji.ttf"
-private const val notoSansSC = "./NotoSansSC-Regular.ttf"
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.decodeFromString
 
 @OptIn(ExperimentalComposeUiApi::class)
 @ExperimentalBrowserHistoryApi
@@ -63,21 +64,15 @@ fun main() {
         }
 
         LaunchedEffect(Unit) {
-            val load1 = async {
-                loadResource(notoColorEmoji) ?: ByteArray(0)
-            }
-            val load2 = async {
-                loadResource(notoSansSC) ?: ByteArray(0)
-            }
-            val fontsDeferred = awaitAll(load1, load2).zip(listOf(
-                "NotoColorEmoji",
-                "NotoSansSC"
-            ))
+            val manifestString = async { loadResource("./fonts-manifest.json") !! }.await().decodeToString()
 
-            fontsDeferred.forEach { (font, name) ->
-                val fontFamily = FontFamily(listOf(Font(name, font)))
-                fontFamilyResolver.preload(fontFamily)
-            }
+            val manifest = Json.decodeFromString<FontsManifest>(manifestString)
+
+            awaitAll(*manifest.fonts.map { async { loadResource("./$it.ttf")!! } }.toTypedArray())
+                .forEachIndexed { index, font ->
+                    val fontFamily = FontFamily(listOf(Font(manifest.fonts[index], font)))
+                    fontFamilyResolver.preload(fontFamily)
+                }
 
             fontsLoaded.value = true
         }
@@ -87,3 +82,7 @@ fun main() {
         }
     }
 }
+
+
+@Serializable
+private data class FontsManifest(val fonts: List<String>)

--- a/compose/mpp/demo/src/webMain/resources/fonts-manifest.json
+++ b/compose/mpp/demo/src/webMain/resources/fonts-manifest.json
@@ -1,0 +1,3 @@
+{
+  "fonts": ["NotoColorEmoji", "NotoSansSC-Regular"]
+}


### PR DESCRIPTION
The goal of this PR to make demo application download actual fonts that needs to be uploaded from manifest
(rather then from a hardcoded list of fonts). That makes it possible for developer purposes to proxy such manifest request and return whatever list of fonts we are interested in currently without changing code at all

## Testing
Run any web demo configuration

## Release Notes
N/A