### PR TITLE
Redispatch unconsumed mouse wheel events

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
@@ -88,6 +88,17 @@ internal object ComposeFeatureFlags {
     val useInteropBlending = FeatureFlag {
         System.getProperty("compose.interop.blending").toBoolean()
     }
+
+    /**
+     * Whether to redispatch unconsumed mouse wheel events to the parent heavyweight component.
+     * This allows any scrollable components beneath Compose to be scrolled.
+     *
+     * This flag will be removed in the future, and the default behavior will correspond to a value
+     * of `true`.
+     */
+    val redispatchUnconsumedMouseWheelEvents = FeatureFlag {
+        System.getProperty("compose.swing.redispatchMouseWheelEvents", "true").toBoolean()
+    }
 }
 
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -472,7 +472,9 @@ internal class ComposeSceneMediator(
         processMouseEvent {
             val processingResult = scene.onMouseWheelEvent(event.position, event)
             if (!processingResult.anyChangeConsumed) {
-                redispatchUnconsumedMouseEvent(event)
+                if (ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.value) {
+                    redispatchUnconsumedMouseEvent(event)
+                }
             }
         }
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -381,7 +381,7 @@ internal class ComposeSceneMediator(
 
         contentComponent.focusTraversalKeysEnabled = false
 
-        subscribe(contentComponent)
+        subscribeToInputEvents()
     }
 
     private inline fun catchExceptions(block: () -> Unit) {
@@ -399,18 +399,22 @@ internal class ComposeSceneMediator(
         }
     }
 
-    private fun subscribe(component: Component) {
-        component.addInputMethodListener(inputMethodListener)
-        component.addFocusListener(focusListener)
-        component.addKeyListener(keyListener)
-        component.subscribeToMouseEvents(mouseListener)
+    private fun subscribeToInputEvents() {
+        with(contentComponent) {
+            addInputMethodListener(inputMethodListener)
+            addFocusListener(focusListener)
+            addKeyListener(keyListener)
+            subscribeToMouseEvents(mouseListener)
+        }
     }
 
-    private fun unsubscribe(component: Component) {
-        component.removeInputMethodListener(inputMethodListener)
-        component.removeFocusListener(focusListener)
-        component.removeKeyListener(keyListener)
-        component.unsubscribeFromMouseEvents(mouseListener)
+    private fun unsubscribeFromInputEvents() {
+        with(contentComponent) {
+            removeInputMethodListener(inputMethodListener)
+            removeFocusListener(focusListener)
+            removeKeyListener(keyListener)
+            unsubscribeFromMouseEvents(mouseListener)
+        }
     }
 
     private var isMouseEventProcessing = false
@@ -464,8 +468,55 @@ internal class ComposeSceneMediator(
         if (eventListener.onMouseEvent(event)) {
             return
         }
+
         processMouseEvent {
-            scene.onMouseWheelEvent(event.position, event)
+            val processingResult = scene.onMouseWheelEvent(event.position, event)
+            if (!processingResult.anyChangeConsumed) {
+                redispatchUnconsumedMouseEvent(event)
+            }
+        }
+    }
+
+    /**
+     * Returns the first heavyweight ancestor of the given component.
+     */
+    private fun Component.heavyWeightAncestorOrNull() : Component? {
+        var parent = parent
+        while (parent != null) {
+            if (!parent.isLightweight) return parent
+            parent = parent.parent
+        }
+        return null
+    }
+
+    /**
+     * (Re)Dispatches the given mouse event to the component that would have received it had
+     * this [ComposeSceneMediator] not been listening to the corresponding type of mouse events.
+     *
+     * The problem this attempts to solve is that [ComposeSceneMediator] has to register listeners
+     * for all types of mouse events, even if there is nothing in the scene that listens to them.
+     * AWT/Swing, however, interprets listening to mouse events as "interest" in them and sends them
+     * only to the "interested" component "under" the mouse pointer.
+     */
+    private fun redispatchUnconsumedMouseEvent(event: MouseEvent) {
+        // Redispatch the event to the heavyweight ancestor, which in turn will try to find the
+        // correct target component and send the event to it. Unregistering from mouse events
+        // during this call allows the event to be sent to the component it would've been sent to
+        // if ComposeSceneMediator wasn't listening to the corresponding type of mouse events.
+        //
+        // This is possibly a dangerous hack. If it breaks something, the alternative is to dispatch
+        // only to the parent of the source. This isn't ideal because the "right" component may not
+        // be the parent/ancestor, but a sibling of the source component.
+        // With that approach, there would probably also be a need to add a flag (or multiple flags)
+        // to ComposePanel that would control which types of events should be listened to.
+        val source = event.component ?: return  // Should be contentComponent
+        val target = source.heavyWeightAncestorOrNull() ?: return
+        try {
+            unsubscribeFromInputEvents()
+            val retargetedEvent = SwingUtilities.convertMouseEvent(source, event, target)
+            target.dispatchEvent(retargetedEvent)
+        } finally {
+            subscribeToInputEvents()
         }
     }
 
@@ -493,7 +544,7 @@ internal class ComposeSceneMediator(
         check(!isDisposed) { "ComposeSceneMediator is already disposed" }
         isDisposed = true
 
-        unsubscribe(contentComponent)
+        unsubscribeFromInputEvents()
 
         container.remove(contentComponent)
         container.remove(invisibleComponent)
@@ -829,8 +880,8 @@ internal val MouseEvent.composePointerButton: PointerButton? get() {
 private fun ComposeScene.onMouseWheelEvent(
     position: Offset,
     event: MouseWheelEvent
-) {
-    sendPointerEvent(
+) : PointerEventResult {
+    return sendPointerEvent(
         eventType = PointerEventType.Scroll,
         position = position,
         scrollDelta = if (event.isShiftDown) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -186,8 +186,8 @@ fun Container.sendMouseEvent(
 }
 
 fun Container.sendMouseWheelEvent(
-    x: Int,
-    y: Int,
+    x: Int = width / 2,
+    y: Int = height / 2,
     scrollType: Int = MouseWheelEvent.WHEEL_UNIT_SCROLL,
     wheelRotation: Double = 0.0,
     modifiers: Int = 0,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -15,14 +15,19 @@
  */
 package androidx.compose.ui.awt
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -51,6 +56,7 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendMouseEvent
+import androidx.compose.ui.sendMouseWheelEvent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
@@ -65,8 +71,11 @@ import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.event.MouseEvent
+import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.ScrollPaneConstants
 import junit.framework.TestCase.assertTrue
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -713,4 +722,113 @@ class ComposePanelTest {
         }
     }
 
+    @Test
+    fun `ComposePanel propagates unconsumed mouse wheel scroll events to parent`() = runApplicationTest {
+        val composePanel = ComposePanel()
+        composePanel.preferredSize = Dimension(200, 200)
+        val scrollState = ScrollState(0)
+        composePanel.setContent {
+            Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Yellow)) {
+                Column(Modifier.fillMaxWidth().height(400.dp)) {
+                    Text("Hello World")
+                    Text("Hello World")
+                    Text("Hello World")
+                    Text("Hello World")
+                    Text("Hello World")
+                }
+            }
+        }
+
+        val window = JFrame()
+        try {
+            window.size = Dimension(200, 200)
+            val scrollPane = JScrollPane(
+                JPanel().apply {
+                    layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                    add(composePanel)
+                    add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
+                }
+            )
+            scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+            window.contentPane.add(scrollPane, BorderLayout.CENTER)
+            window.isVisible = true
+
+            awaitIdle()
+
+            // Scroll a little and check that compose content was scrolled
+            composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
+            awaitIdle()
+            assertThat(scrollState.value).isGreaterThan(0)
+
+            // Scroll a lot and check that the Swing JScrollPane was scrolled
+            // Note that we need two scroll events for now because Compose can't partially consume
+            // scroll events. So one event is needed to scroll Compose content to the end, and
+            // another one to scroll JScrollPane.
+            window.sendMouseWheelEvent(wheelRotation = 1000.0)
+            awaitIdle()
+            window.sendMouseWheelEvent(wheelRotation = 1000.0)
+            assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun `ComposePanel propagates unconsumed mouse wheel scroll events to sibling`() = runApplicationTest {
+        val composePanel = ComposePanel()
+        val scrollState = ScrollState(0)
+        composePanel.setContent {
+            Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Green)) {
+                Column(Modifier.fillMaxWidth().height(400.dp)) {
+                    Text("Hello World")
+                    Text("Hello World")
+                    Text("Hello World")
+                    Text("Hello World")
+                    Text("Hello World")
+                }
+            }
+        }
+
+        val container = JPanel(null)
+        container.size = Dimension(200, 200)
+
+        val scrollPane = JScrollPane(
+            JPanel().apply {
+                layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
+            }
+        )
+        scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+
+        composePanel.size = Dimension(200, 200)
+        scrollPane.size = Dimension(200, 400)
+
+        val window = JFrame()
+        try {
+            window.size = Dimension(200, 400)
+            container.add(composePanel)
+            container.add(scrollPane)
+
+            window.contentPane.add(container, BorderLayout.CENTER)
+            window.isVisible = true
+
+            awaitIdle()
+
+            // Scroll a little and check that compose content was scrolled
+            composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
+            awaitIdle()
+            assertThat(scrollState.value).isGreaterThan(0)
+
+            // Scroll a lot and check that the Swing JScrollPane was scrolled
+            // Note that we need two scroll events for now because Compose can't partially consume
+            // scroll events. So one event is needed to scroll Compose content to the end, and
+            // another one to scroll JScrollPane.
+            composePanel.sendMouseWheelEvent(wheelRotation = 1000.0)
+            awaitIdle()
+            window.sendMouseWheelEvent(wheelRotation = 1000.0)
+            assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
+        } finally {
+            window.dispose()
+        }
+    }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -723,112 +723,118 @@ class ComposePanelTest {
     }
 
     @Test
-    fun `ComposePanel propagates unconsumed mouse wheel scroll events to parent`() = runApplicationTest {
-        val composePanel = ComposePanel()
-        composePanel.preferredSize = Dimension(200, 200)
-        val scrollState = ScrollState(0)
-        composePanel.setContent {
-            Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Yellow)) {
-                Column(Modifier.fillMaxWidth().height(400.dp)) {
-                    Text("Hello World")
-                    Text("Hello World")
-                    Text("Hello World")
-                    Text("Hello World")
-                    Text("Hello World")
+    fun `ComposePanel propagates unconsumed mouse wheel scroll events to parent`() =
+        ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.withOverride(true) {
+            runApplicationTest {
+                val composePanel = ComposePanel()
+                composePanel.preferredSize = Dimension(200, 200)
+                val scrollState = ScrollState(0)
+                composePanel.setContent {
+                    Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Yellow)) {
+                        Column(Modifier.fillMaxWidth().height(400.dp)) {
+                            Text("Hello World")
+                            Text("Hello World")
+                            Text("Hello World")
+                            Text("Hello World")
+                            Text("Hello World")
+                        }
+                    }
+                }
+
+                val window = JFrame()
+                try {
+                    window.size = Dimension(200, 200)
+                    val scrollPane = JScrollPane(
+                        JPanel().apply {
+                            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                            add(composePanel)
+                            add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
+                        }
+                    )
+                    scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+                    window.contentPane.add(scrollPane, BorderLayout.CENTER)
+                    window.isVisible = true
+
+                    awaitIdle()
+
+                    // Scroll a little and check that compose content was scrolled
+                    composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
+                    awaitIdle()
+                    assertThat(scrollState.value).isGreaterThan(0)
+
+                    // Scroll a lot and check that the Swing JScrollPane was scrolled
+                    // Note that we need two scroll events for now because Compose can't partially consume
+                    // scroll events. So one event is needed to scroll Compose content to the end, and
+                    // another one to scroll JScrollPane.
+                    window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                    awaitIdle()
+                    window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                    assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
+                } finally {
+                    window.dispose()
                 }
             }
         }
-
-        val window = JFrame()
-        try {
-            window.size = Dimension(200, 200)
-            val scrollPane = JScrollPane(
-                JPanel().apply {
-                    layout = BoxLayout(this, BoxLayout.Y_AXIS)
-                    add(composePanel)
-                    add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
-                }
-            )
-            scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
-            window.contentPane.add(scrollPane, BorderLayout.CENTER)
-            window.isVisible = true
-
-            awaitIdle()
-
-            // Scroll a little and check that compose content was scrolled
-            composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
-            awaitIdle()
-            assertThat(scrollState.value).isGreaterThan(0)
-
-            // Scroll a lot and check that the Swing JScrollPane was scrolled
-            // Note that we need two scroll events for now because Compose can't partially consume
-            // scroll events. So one event is needed to scroll Compose content to the end, and
-            // another one to scroll JScrollPane.
-            window.sendMouseWheelEvent(wheelRotation = 1000.0)
-            awaitIdle()
-            window.sendMouseWheelEvent(wheelRotation = 1000.0)
-            assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
-        } finally {
-            window.dispose()
-        }
-    }
 
     @Test
-    fun `ComposePanel propagates unconsumed mouse wheel scroll events to sibling`() = runApplicationTest {
-        val composePanel = ComposePanel()
-        val scrollState = ScrollState(0)
-        composePanel.setContent {
-            Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Green)) {
-                Column(Modifier.fillMaxWidth().height(400.dp)) {
-                    Text("Hello World")
-                    Text("Hello World")
-                    Text("Hello World")
-                    Text("Hello World")
-                    Text("Hello World")
+    fun `ComposePanel propagates unconsumed mouse wheel scroll events to sibling`() =
+        ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.withOverride(true) {
+            runApplicationTest {
+                val composePanel = ComposePanel()
+                val scrollState = ScrollState(0)
+                composePanel.setContent {
+                    Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Green)) {
+                        Column(Modifier.fillMaxWidth().height(400.dp)) {
+                            Text("Hello World")
+                            Text("Hello World")
+                            Text("Hello World")
+                            Text("Hello World")
+                            Text("Hello World")
+                        }
+                    }
+                }
+
+                val container = JPanel(null)
+                container.size = Dimension(200, 200)
+
+                val scrollPane = JScrollPane(
+                    JPanel().apply {
+                        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                        add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
+                    }
+                )
+                scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+
+                composePanel.size = Dimension(200, 200)
+                scrollPane.size = Dimension(200, 400)
+
+                val window = JFrame()
+                try {
+                    window.size = Dimension(200, 400)
+                    container.add(composePanel)
+                    container.add(scrollPane)
+
+                    window.contentPane.add(container, BorderLayout.CENTER)
+                    window.isVisible = true
+
+                    awaitIdle()
+
+                    // Scroll a little and check that compose content was scrolled
+                    composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
+                    awaitIdle()
+                    assertThat(scrollState.value).isGreaterThan(0)
+
+                    // Scroll a lot and check that the Swing JScrollPane was scrolled
+                    // Note that we need two scroll events for now because Compose can't partially consume
+                    // scroll events. So one event is needed to scroll Compose content to the end, and
+                    // another one to scroll JScrollPane.
+                    composePanel.sendMouseWheelEvent(wheelRotation = 1000.0)
+                    awaitIdle()
+                    window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                    assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
+                } finally {
+                    window.dispose()
                 }
             }
         }
-
-        val container = JPanel(null)
-        container.size = Dimension(200, 200)
-
-        val scrollPane = JScrollPane(
-            JPanel().apply {
-                layout = BoxLayout(this, BoxLayout.Y_AXIS)
-                add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
-            }
-        )
-        scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
-
-        composePanel.size = Dimension(200, 200)
-        scrollPane.size = Dimension(200, 400)
-
-        val window = JFrame()
-        try {
-            window.size = Dimension(200, 400)
-            container.add(composePanel)
-            container.add(scrollPane)
-
-            window.contentPane.add(container, BorderLayout.CENTER)
-            window.isVisible = true
-
-            awaitIdle()
-
-            // Scroll a little and check that compose content was scrolled
-            composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
-            awaitIdle()
-            assertThat(scrollState.value).isGreaterThan(0)
-
-            // Scroll a lot and check that the Swing JScrollPane was scrolled
-            // Note that we need two scroll events for now because Compose can't partially consume
-            // scroll events. So one event is needed to scroll Compose content to the end, and
-            // another one to scroll JScrollPane.
-            composePanel.sendMouseWheelEvent(wheelRotation = 1000.0)
-            awaitIdle()
-            window.sendMouseWheelEvent(wheelRotation = 1000.0)
-            assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
-        } finally {
-            window.dispose()
-        }
-    }
 }


### PR DESCRIPTION
Redispatch mouse wheel events which the Compose scene did not consume.

### Difference with Swing behavior
This fix introduces a slight difference with how Swing handles nested mouse-wheel scrolling. In Swing, there is essentially no nested scrolling. In a scenario with a `JScrollPane` inside another `JScrollPane`, only the inner one can be scrolled when the mouse is over it. With this PR, a `ComposePanel` with a scrollable element within a `JScrollPane` will scroll until it reaches the start/end and then the outer `JScrollPane` will scroll.
This behavior seems to be an improvement, so we thought it was ok to have this difference.

### Danger, Will Robinson
Note that this includes a potentially dangerous hack of whose consequences I'm not yet sure. If it proves too problematic, we will need to take a different approach (documented in the source).
The hack is that in order to allow AWT to find the correct target for the redispatched event, we temporarily unregister `ComposeSceneMediator`'s mouse listeners.

### Feature flag
I've put the behavior behind `ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents`. The flag will be:
- `false` by default in 1.9.1
- `true` by default in 1.10
- Removed in 1.11, if no major problems are discovered.
In this PR, it's `true`, as it merges into `jb-main`. In the cherry-pick to 1.9.1, we should change it to `false`. When it's approved I will add a ticket to remove it for 1.11

### Other mouse events
Note that this PR only deals with mouse wheel events, but at least in the case of a lightweight skia layer (i.e. `SkiaSwingLayer`), we should probably do the same for other mouse events.

Fixes https://youtrack.jetbrains.com/issue/CMP-4601

## Testing
Added unit tests, and also tested manually with
```
import androidx.compose.foundation.*
import androidx.compose.foundation.layout.*
import androidx.compose.material.*
import androidx.compose.runtime.Composable
import androidx.compose.ui.*
import androidx.compose.ui.awt.*
import androidx.compose.ui.graphics.*
import androidx.compose.ui.unit.*
import java.awt.*
import javax.swing.*

fun main() = SwingUtilities.invokeLater {
    val frame = JFrame("CfD repro")
    frame.defaultCloseOperation = JFrame.EXIT_ON_CLOSE
    frame.minimumSize = Dimension(500, 400)
    System.setProperty("compose.swing.render.on.graphics", "true")

    val mainPanel =
        JPanel(null).apply {
            val container =
                JPanel(null).apply {
                    layout = BoxLayout(this, BoxLayout.Y_AXIS)
                    addChildren()
                }
            val scrollPane = JScrollPane(container)
            scrollPane.setBounds(0, 0, 500, 500)
            add(scrollPane)
        }

    frame.contentPane.add(mainPanel, BorderLayout.CENTER)
    frame.isVisible = true
}

private fun JPanel.addChildren() {
    repeat(10) {
        repeat(5) {
            add(JLabel("<html>" + "Very long text here ".repeat(10) + "</html>"))
            add(Box.createVerticalStrut(10))
        }

        add(
            ComposePanel().apply {
                setContent {
                    ComposeBox()
                }
            }
        )
        add(Box.createVerticalStrut(10))
    }
}

@Composable
fun ComposeBox() {
    Box(
        modifier = Modifier
            .height(100.dp)
            .background(color = Color(180, 180, 180))
            .padding(10.dp)
    ) {
        val stateVertical = rememberScrollState(0)

        Box(
            modifier = Modifier
                .verticalScroll(stateVertical)
                .padding(end = 12.dp, bottom = 12.dp)
        ) {
            Column {
                for (item in 0..10) {
                    TextBox("Item #$item")
                }
            }
        }
    }
}

@Composable
fun TextBox(text: String = "Item") {
    Box(
        modifier = Modifier.height(32.dp)
            .width(400.dp)
            .background(color = Color(0, 0, 0, 20))
            .padding(start = 10.dp),
        contentAlignment = Alignment.CenterStart
    ) {
        Text(text = text)
    }
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- ComposePanel now re-dispatches unconsumed mouse wheel events, allowing scrollable components beneath to be scrolled. To disable this, set the system property `"compose.swing.redispatchMouseWheelEvents"` to `"false"`.
