### PR TITLE
Add API to configure `writingToolsBehavior` with `PlatformImeOptions`

### DIFF
--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
@@ -115,8 +115,7 @@ private val writingToolsBehaviorTypes = listOf(
     "None" to UIWritingToolsBehaviorNone,
     "Default" to UIWritingToolsBehaviorDefault,
     "Limited" to UIWritingToolsBehaviorLimited,
-    "Complete" to UIWritingToolsBehaviorComplete,
-    "Null" to null
+    "Complete" to UIWritingToolsBehaviorComplete
 )
 
 @OptIn(ExperimentalComposeUiApi::class)

--- a/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
+++ b/compose/mpp/demo/src/uikitMain/kotlin/androidx/compose/mpp/demo/IosImeOptionsExample.kt
@@ -60,6 +60,10 @@ import platform.UIKit.UIKeyboardTypeWebSearch
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
+import platform.UIKit.UIWritingToolsBehaviorComplete
+import platform.UIKit.UIWritingToolsBehaviorDefault
+import platform.UIKit.UIWritingToolsBehaviorLimited
+import platform.UIKit.UIWritingToolsBehaviorNone
 import platform.UIKit.constraintEqualToSystemSpacingBelowAnchor
 
 private val keyboardTypes = listOf(
@@ -104,6 +108,14 @@ private val autocapitalizationTypes = listOf(
     "Sentences" to UITextAutocapitalizationType.UITextAutocapitalizationTypeSentences,
     "Words" to UITextAutocapitalizationType.UITextAutocapitalizationTypeWords,
     "All Characters" to UITextAutocapitalizationType.UITextAutocapitalizationTypeAllCharacters,
+    "Null" to null
+)
+
+private val writingToolsBehaviorTypes = listOf(
+    "None" to UIWritingToolsBehaviorNone,
+    "Default" to UIWritingToolsBehaviorDefault,
+    "Limited" to UIWritingToolsBehaviorLimited,
+    "Complete" to UIWritingToolsBehaviorComplete,
     "Null" to null
 )
 
@@ -199,6 +211,15 @@ private val IosImeOptionsInputViewExample = Screen.Example("Input View") {
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
+private val IosImeOptionsWritingToolsBehaviorExample = Screen.Example("Writing Tools Behavior") {
+    LazyColumn {
+        items(writingToolsBehaviorTypes) {
+            Item(it.first, PlatformImeOptions { writingToolsBehavior(it.second) })
+        }
+    }
+}
+
 val IosImeOptionsExample = Screen.Selection(
     "iOS Platform IME Options",
     IosImeOptionsKeyboardTypeExample,
@@ -209,6 +230,7 @@ val IosImeOptionsExample = Screen.Selection(
     IosImeOptionsAutocapitalizationTypeExample,
     IosImeOptionsAutocorrectionTypeExample,
     IosImeOptionsInputViewExample,
+    IosImeOptionsWritingToolsBehaviorExample
 )
 
 @Composable

--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -26,6 +26,7 @@ import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextContentType
 import platform.UIKit.UIView
+import platform.UIKit.UIWritingToolsBehavior
 
 @Immutable
 private data class PlatformImeOptionsImpl(
@@ -40,6 +41,7 @@ private data class PlatformImeOptionsImpl(
     val hasExplicitTextContentType: Boolean,
     val inputView: UIView?,
     val inputAccessoryView: UIView?,
+    val writingToolsBehavior: UIWritingToolsBehavior?,
 ): PlatformImeOptions()
 
 /**
@@ -58,6 +60,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
     private var hasExplicitTextContentType: Boolean = false
     private var inputView: UIView? = null
     private var inputAccessoryView: UIView? = null
+    private var writingToolsBehavior: UIWritingToolsBehavior? = null
     /**
      * Sets the keyboard type to be used for the text input field.
      * If not set, the value will be derived from [ImeOptions].
@@ -166,6 +169,12 @@ class PlatformImeOptionsConfiguration internal constructor() {
         inputAccessoryView = value
     }
 
+
+    @ExperimentalComposeUiApi
+    fun writingToolsBehavior(value: UIWritingToolsBehavior?): PlatformImeOptionsConfiguration = apply {
+        writingToolsBehavior = value
+    }
+
     /**
      * Builds the final PlatformImeOptions instance with the configured values.
      */
@@ -182,6 +191,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
             hasExplicitTextContentType = hasExplicitTextContentType,
             inputView = inputView,
             inputAccessoryView = inputAccessoryView,
+            writingToolsBehavior = writingToolsBehavior,
         )
     }
 }
@@ -243,3 +253,7 @@ val PlatformImeOptions.inputView: UIView?
 @ExperimentalComposeUiApi
 val PlatformImeOptions.inputAccessoryView: UIView?
     get() = (this as? PlatformImeOptionsImpl)?.inputAccessoryView
+
+@ExperimentalComposeUiApi
+val PlatformImeOptions.writingToolsBehavior: UIWritingToolsBehavior?
+    get() = (this as? PlatformImeOptionsImpl)?.writingToolsBehavior

--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -169,7 +169,11 @@ class PlatformImeOptionsConfiguration internal constructor() {
         inputAccessoryView = value
     }
 
-
+    /**
+     * Sets the writing tools behavior to apply to the IME.
+     *
+     * See [UIKit documentation](https://developer.apple.com/documentation/uikit/uitextinputtraits/writingtoolsbehavior)
+     */
     @ExperimentalComposeUiApi
     fun writingToolsBehavior(value: UIWritingToolsBehavior?): PlatformImeOptionsConfiguration = apply {
         writingToolsBehavior = value

--- a/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
+++ b/compose/ui/ui-text/src/uikitMain/kotlin/androidx/compose/ui/text/input/PlatformImeOptions.uikit.kt
@@ -27,6 +27,7 @@ import platform.UIKit.UITextAutocorrectionType
 import platform.UIKit.UITextContentType
 import platform.UIKit.UIView
 import platform.UIKit.UIWritingToolsBehavior
+import platform.UIKit.UIWritingToolsBehaviorDefault
 
 @Immutable
 private data class PlatformImeOptionsImpl(
@@ -41,7 +42,7 @@ private data class PlatformImeOptionsImpl(
     val hasExplicitTextContentType: Boolean,
     val inputView: UIView?,
     val inputAccessoryView: UIView?,
-    val writingToolsBehavior: UIWritingToolsBehavior?,
+    val writingToolsBehavior: UIWritingToolsBehavior,
 ): PlatformImeOptions()
 
 /**
@@ -60,7 +61,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
     private var hasExplicitTextContentType: Boolean = false
     private var inputView: UIView? = null
     private var inputAccessoryView: UIView? = null
-    private var writingToolsBehavior: UIWritingToolsBehavior? = null
+    private var writingToolsBehavior: UIWritingToolsBehavior = UIWritingToolsBehaviorDefault
     /**
      * Sets the keyboard type to be used for the text input field.
      * If not set, the value will be derived from [ImeOptions].
@@ -175,7 +176,7 @@ class PlatformImeOptionsConfiguration internal constructor() {
      * See [UIKit documentation](https://developer.apple.com/documentation/uikit/uitextinputtraits/writingtoolsbehavior)
      */
     @ExperimentalComposeUiApi
-    fun writingToolsBehavior(value: UIWritingToolsBehavior?): PlatformImeOptionsConfiguration = apply {
+    fun writingToolsBehavior(value: UIWritingToolsBehavior): PlatformImeOptionsConfiguration = apply {
         writingToolsBehavior = value
     }
 
@@ -259,5 +260,5 @@ val PlatformImeOptions.inputAccessoryView: UIView?
     get() = (this as? PlatformImeOptionsImpl)?.inputAccessoryView
 
 @ExperimentalComposeUiApi
-val PlatformImeOptions.writingToolsBehavior: UIWritingToolsBehavior?
-    get() = (this as? PlatformImeOptionsImpl)?.writingToolsBehavior
+val PlatformImeOptions.writingToolsBehavior: UIWritingToolsBehavior
+    get() = (this as? PlatformImeOptionsImpl)?.writingToolsBehavior ?: UIWritingToolsBehaviorDefault

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
@@ -65,6 +65,8 @@ import platform.UIKit.UITextContentTypeTelephoneNumber
 import platform.UIKit.UITextContentTypeUsername
 import platform.UIKit.UITextInputProtocol
 import platform.UIKit.UIView
+import platform.UIKit.UIWritingToolsBehaviorDefault
+import platform.UIKit.UIWritingToolsBehaviorLimited
 import platform.UIKit.inputAccessoryView
 import platform.UIKit.inputView
 
@@ -441,6 +443,22 @@ internal class ImeOptionsTest {
             waitForIdle()
             assertEquals(1, startInputCount)
         }
+    }
+
+    @Test
+    fun testWritingToolsBehaviorDefault() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions()
+        )
+        assertEquals(UIWritingToolsBehaviorDefault, input.writingToolsBehavior)
+    }
+
+    @Test
+    fun testWritingToolsBehavior() = runUIKitInstrumentedTest {
+        val input = setContentAndFindInput(
+            imeOptions = PlatformImeOptions { writingToolsBehavior(UIWritingToolsBehaviorLimited) }
+        )
+        assertEquals(UIWritingToolsBehaviorLimited, input.writingToolsBehavior)
     }
 
     private fun UIKitInstrumentedTest.setContentAndFindInputView(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/SkikoUITextInputTraits.uikit.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.input.keyboardAppearance
 import androidx.compose.ui.text.input.keyboardType
 import androidx.compose.ui.text.input.returnKeyType
 import androidx.compose.ui.text.input.textContentType
+import androidx.compose.ui.text.input.writingToolsBehavior
 import platform.UIKit.UIKeyboardAppearance
 import platform.UIKit.UIKeyboardAppearanceDefault
 import platform.UIKit.UIKeyboardType
@@ -49,6 +50,8 @@ import platform.UIKit.UITextContentTypeEmailAddress
 import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeTelephoneNumber
 import platform.UIKit.UIView
+import platform.UIKit.UIWritingToolsBehavior
+import platform.UIKit.UIWritingToolsBehaviorDefault
 
 internal interface SkikoUITextInputTraits {
     fun keyboardType(): UIKeyboardType =
@@ -78,6 +81,9 @@ internal interface SkikoUITextInputTraits {
     fun inputView(): UIView? = null
 
     fun inputAccessoryView(): UIView? = null
+
+    fun writingToolsBehavior(): UIWritingToolsBehavior =
+        UIWritingToolsBehaviorDefault
 }
 
 internal object EmptyInputTraits : SkikoUITextInputTraits
@@ -196,6 +202,10 @@ internal fun getUITextInputTraits(currentImeOptions: ImeOptions?) =
 
         override fun inputAccessoryView(): UIView? {
             return currentImeOptions?.platformImeOptions?.inputAccessoryView
+        }
+
+        override fun writingToolsBehavior(): UIWritingToolsBehavior {
+            return currentImeOptions?.platformImeOptions?.writingToolsBehavior ?: UIWritingToolsBehaviorDefault
         }
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.uikit.kt
@@ -70,6 +70,8 @@ import platform.UIKit.UITextRange
 import platform.UIKit.UITextSelectionRect
 import platform.UIKit.UITextStorageDirection
 import platform.UIKit.UIView
+import platform.UIKit.UIWritingToolsBehavior
+import platform.UIKit.UIWritingToolsResultOptions
 import platform.darwin.NSInteger
 
 private val NoOpOnKeyboardPresses: (Set<*>) -> Unit = {}
@@ -458,13 +460,10 @@ internal class IntermediateTextInputUIView(
     override fun returnKeyType(): UIReturnKeyType = inputTraits.returnKeyType()
     override fun textContentType(): UITextContentType = inputTraits.textContentType()
     override fun isSecureTextEntry(): Boolean = inputTraits.isSecureTextEntry()
-    override fun enablesReturnKeyAutomatically(): Boolean =
-        inputTraits.enablesReturnKeyAutomatically()
-
-    override fun autocapitalizationType(): UITextAutocapitalizationType =
-        inputTraits.autocapitalizationType()
-
+    override fun enablesReturnKeyAutomatically(): Boolean = inputTraits.enablesReturnKeyAutomatically()
+    override fun autocapitalizationType(): UITextAutocapitalizationType = inputTraits.autocapitalizationType()
     override fun autocorrectionType(): UITextAutocorrectionType = inputTraits.autocorrectionType()
+    override fun writingToolsBehavior(): UIWritingToolsBehavior = inputTraits.writingToolsBehavior()
 
     override fun dictationRecognitionFailed() {
         //todo may be useful


### PR DESCRIPTION
Adds API to configure `UITextInputTraits.writingToolsBehavior` with `PlatformImeOptions`

Fixes 
- (partially) [CMP-8970](https://youtrack.jetbrains.com/issue/CMP-8970) [iOS] Writing Tools cannot be opened in Dialog + Need API to control Apple Intelligence Writing Tools behavior in BasicTextField

## Testing
- Adds tests to `ImeOptionsTest`
- Adds example screen to the `iOS Platform IME Options` section in the demo app

This should be tested by QA

## Release Notes
### Features - iOS
- Add API to configure `UITextInputTraits.writingToolsBehavior` with `PlatformImeOptions`