### PR TITLE
[web] Support running Chromium tests

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -41,8 +41,9 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
     fun KotlinJsTest.passTestFlagsToEnvironment() {
         listOf(
             "jetbrains.androidx.web.tests.enableChrome",
+            "jetbrains.androidx.web.tests.enableChromium",
             "jetbrains.androidx.web.tests.enableFirefox",
-            "jetbrains.androidx.web.tests.enableSafari"
+            "jetbrains.androidx.web.tests.enableSafari",
         ).forEach { propertyName ->
             if (project.findProperty(propertyName)?.toString()?.toBoolean() == true) {
                 environment(propertyName, "1")

--- a/gradle.properties
+++ b/gradle.properties
@@ -130,6 +130,7 @@ kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
 jetbrains.androidx.web.tests.enableChrome=true
+jetbrains.androidx.web.tests.enableChromium=true
 jetbrains.androidx.web.tests.enableFirefox=false
 jetbrains.androidx.web.tests.enableSafari=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -130,7 +130,7 @@ kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
 jetbrains.androidx.web.tests.enableChrome=true
-jetbrains.androidx.web.tests.enableChromium=true
+jetbrains.androidx.web.tests.enableChromium=false
 jetbrains.androidx.web.tests.enableFirefox=false
 jetbrains.androidx.web.tests.enableSafari=false
 

--- a/mpp/karma.config.d/web/commonKarmaConfig.js
+++ b/mpp/karma.config.d/web/commonKarmaConfig.js
@@ -5,6 +5,9 @@ function configLaunchers(config) {
             base: "Chrome",
             flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
         },
+        ChromiumForComposeTests: {
+            base: "Chromium"
+        },
         FirefoxForComposeTests: {
             base: "Firefox",
             prefs: {
@@ -23,6 +26,9 @@ function configLaunchers(config) {
     config.browsers = [];
     if (process.env["jetbrains.androidx.web.tests.enableChrome"]) {
         config.browsers.push("ChromeForComposeTests");
+    }
+    if (process.env["jetbrains.androidx.web.tests.enableChromium"]) {
+        config.browsers.push("ChromiumForComposeTests");
     }
     if (process.env["jetbrains.androidx.web.tests.enableFirefox"]) {
         config.browsers.push("FirefoxForComposeTests");


### PR DESCRIPTION
For enthusiasts that prefer to develop web target on machines with Chromium but without Chrome

## Testing
`./gradlew :compose:ui:ui:wasmJsBrowserTest -Pjetbrains.androidx.web.tests.enableChrome=false -Pjetbrains.androidx.web.tests.enableChromium=true`

## Release Notes
N/A