### PR TITLE
Fix quasi-composite input on iOS

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -125,7 +125,7 @@ internal abstract class NativeInputEventsProcessor(
                 // this means "deleteContentBackward" happened because of an earlier "keydown" event, so skipping it here
                 if (lastProcessedEventIsBackspace) return@buildList
 
-                if (!currentTextFieldValue.selection.collapsed) {
+                if (currentTextFieldValue.selection.collapsed) {
                     // Likely it's on mobile, where the Backspace has Unidentified key value.
                     // When Compose TextField shows text selection,
                     // a good UX for deleteContentBackward would be to emulate Backspace

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/СompositeInputTestSpec.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/СompositeInputTestSpec.kt
@@ -147,7 +147,7 @@ internal interface WinCompositeInput : СompositeInputTestSpec {
     }
 
     @Test
-    fun `input korean-hol`() = runApplicationTest {
+    fun `input hangul-hol`() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
         compositionStart("g", "ㅎ")
             .compositionUpdate("h", "호")
@@ -218,7 +218,7 @@ internal interface IosCompositeInput : СompositeInputTestSpec {
     }
 
     @Test
-    fun `input korean-hol`() = runApplicationTest {
+    fun `input hangul-hol`() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
         eventsSequence(
             keyEvent(key= "ㅎ", code = "Unidentified", keyCode = 0),
@@ -272,7 +272,7 @@ internal interface AndroidCompositeInput : СompositeInputTestSpec {
     }
 
     @Test
-    fun `input korean-hol`() = runApplicationTest {
+    fun `input hangul-hol`() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
         compositionStart("g", "ㅎ")
             .compositionUpdate("h", "호")

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/СompositeInputTestSpec.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/СompositeInputTestSpec.kt
@@ -216,6 +216,26 @@ internal interface IosCompositeInput : СompositeInputTestSpec {
             compositionEnd(typedKey),
         )
     }
+
+    @Test
+    fun `input korean-hol`() = runApplicationTest {
+        val textFieldValue = createApplicationWithHolder()
+        eventsSequence(
+            keyEvent(key= "ㅎ", code = "Unidentified", keyCode = 0),
+            beforeInput("insertText", data = "ㅎ", isComposing = false),
+            keyEvent(key= "ㅎ", code = "Unidentified", keyCode = 0, type = "keyup"),
+            keyEvent(key= "ㅗ", code = "Unidentified", keyCode = 0),
+            beforeInput("deleteContentBackward", data = null, isComposing = false),
+            beforeInput("insertText", data = "호", isComposing = false),
+            keyEvent(key= "ㅗ", code = "Unidentified", keyCode = 0, type = "keyup"),
+            keyEvent(key= "ㄹ", code = "Unidentified", keyCode = 0),
+            beforeInput("deleteContentBackward", data = null, isComposing = false),
+            beforeInput("insertText", data = "홀", isComposing = false),
+            keyEvent(key= "ㄹ", code = "Unidentified", keyCode = 0, type = "keyup")
+        ).sendToHtmlInput()
+
+        textFieldValue.awaitAndAssertTextEquals("홀")
+    }
 }
 
 internal interface AndroidCompositeInput : СompositeInputTestSpec {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -192,29 +192,6 @@ class NativeInputEventsProcessorTest {
     }
 
     @Test
-    fun testDeleteContentBackward() {
-        val communicator = MockComposeCommandCommunicator(
-            TextFieldValue("test", selection = TextRange( 4))
-        )
-        val processor = TestNativeInputEventsProcessor(communicator)
-
-        processor.registerEvent(
-            (beforeInput("deleteContentBackward", "") as InputEvent).apply {
-                deleteContentBackwardSize = 1
-            }
-        )
-        processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
-
-        assertEquals(1, communicator.editCommands.size)
-        val command = communicator.editCommands[0]
-        assertTrue(command is DeleteSurroundingTextCommand)
-        assertEquals(1, command.lengthBeforeCursor)
-        assertEquals(0, command.lengthAfterCursor)
-
-        assertEquals("tes", communicator.currentTextFieldValue().text)
-    }
-
-    @Test
     fun testInsertCompositionText() {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
@@ -519,31 +496,6 @@ class NativeInputEventsProcessorTest {
         assertEquals("é", (communicator.editCommands[11] as CommitTextCommand).text)
 
         assertEquals("é", communicator.currentTextFieldValue().text)
-    }
-
-    @Test
-    fun testDeleteContentBackward_with_non_collapsed_selection() {
-        // Create a TextFieldValue with a non-collapsed selection
-        val textFieldValue = TextFieldValue(
-            text = "example text",
-            selection = TextRange(2, 7) // Selection from "a" to "e" in "example"
-        )
-        val communicator = MockComposeCommandCommunicator(textFieldValue)
-        val processor = TestNativeInputEventsProcessor(communicator)
-
-        // Add deleteContentBackward event
-        processor.registerEvent(
-            beforeInput("deleteContentBackward", "") as InputEvent
-        )
-
-        // Process the event with a non-collapsed selection
-        processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
-
-        assertEquals(1, communicator.editCommands.size)
-        val command = communicator.editCommands[0]
-        assertTrue(command is BackspaceCommand)
-
-        assertEquals("ex text", communicator.currentTextFieldValue().text)
     }
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -567,11 +567,9 @@ class NativeInputEventsProcessorTest {
 
         assertEquals(1, communicator.editCommands.size)
         val command = communicator.editCommands[0]
-        assertTrue(command is DeleteSurroundingTextCommand)
-        assertEquals(2, (command as DeleteSurroundingTextCommand).lengthBeforeCursor)
-        assertEquals(0, command.lengthAfterCursor)
+        assertTrue(command is BackspaceCommand)
 
-        assertEquals("exale text", communicator.currentTextFieldValue().text)
+        assertEquals("examle text", communicator.currentTextFieldValue().text)
     }
 
     @Test


### PR DESCRIPTION
Fixes ([CMP-8773](https://youtrack.jetbrains.com/issue/CMP-8773) [Web] Mobile. Composite input. When a syllable block is created, a new block is added instead of replacing the old one)[https://youtrack.jetbrains.com/issue/CMP-8773]

## Testing
`./gradlew testWeb`

## Release Notes
### Fixes - Web
- Fix Hangul and Hindi input on iOS