### PR TITLE
Refactor `ui-backhandler` to use compose-less NavigationEvent API

### DIFF
--- a/compose/ui/ui-backhandler/api/ui-backhandler.klib.api
+++ b/compose/ui/ui-backhandler/api/ui-backhandler.klib.api
@@ -7,5 +7,9 @@
 
 // Library unique name: <org.jetbrains.compose.ui:ui-backhandler>
 final val androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventCompat$stableprop // androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventCompat$stableprop|#static{}androidx_compose_ui_backhandler_BackEventCompat$stableprop[0]
+final val androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventHandler$stableprop // androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventHandler$stableprop|#static{}androidx_compose_ui_backhandler_BackEventHandler$stableprop[0]
+final val androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_ProgressBackEventHandler$stableprop // androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_ProgressBackEventHandler$stableprop|#static{}androidx_compose_ui_backhandler_ProgressBackEventHandler$stableprop[0]
 
 final fun androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventCompat$stableprop_getter(): kotlin/Int // androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventCompat$stableprop_getter|androidx_compose_ui_backhandler_BackEventCompat$stableprop_getter(){}[0]
+final fun androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventHandler$stableprop_getter(): kotlin/Int // androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_BackEventHandler$stableprop_getter|androidx_compose_ui_backhandler_BackEventHandler$stableprop_getter(){}[0]
+final fun androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_ProgressBackEventHandler$stableprop_getter(): kotlin/Int // androidx.compose.ui.backhandler/androidx_compose_ui_backhandler_ProgressBackEventHandler$stableprop_getter|androidx_compose_ui_backhandler_ProgressBackEventHandler$stableprop_getter(){}[0]

--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -62,7 +62,8 @@ kotlin {
         jbMain {
             dependsOn(commonMain)
             dependencies {
-                implementation(project(":navigationevent:navigationevent-compose"))
+                def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
+                implementation("androidx.navigationevent:navigationevent:$navigationEventVersion")
             }
         }
         desktopMain.dependsOn(jbMain)

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackEventHandler.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackEventHandler.kt
@@ -1,0 +1,16 @@
+package androidx.compose.ui.backhandler
+
+import androidx.navigationevent.NavigationEventHandler
+import androidx.navigationevent.NavigationEventInfo
+
+internal class BackEventHandler(
+    enabled: Boolean,
+    private val onBack: () -> Unit
+) : NavigationEventHandler<NavigationEventInfo.None>(
+    initialInfo = NavigationEventInfo.None,
+    isBackEnabled = enabled,
+) {
+    override fun onBackCompleted() {
+        onBack()
+    }
+}

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
@@ -20,25 +20,19 @@ package androidx.compose.ui.backhandler
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.navigationevent.NavigationEvent
-import androidx.navigationevent.NavigationEventInfo
-import androidx.navigationevent.NavigationEventTransitionState
-import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
-import androidx.navigationevent.compose.NavigationBackHandler
-import androidx.navigationevent.compose.rememberNavigationEventState
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.channels.Channel
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.navigationevent.NavigationEventDispatcherOwner
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.consumeAsFlow
-import kotlinx.coroutines.launch
 
+@InternalComposeUiApi
+val LocalCompatNavigationEventDispatcherOwner =
+    staticCompositionLocalOf<NavigationEventDispatcherOwner?> { null }
+
+@OptIn(InternalComposeUiApi::class)
 @Deprecated("Use NavigationEventHandler instead")
 @ExperimentalComposeUiApi
 @Composable
@@ -46,69 +40,36 @@ actual fun PredictiveBackHandler(
     enabled: Boolean,
     onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val navEventState = rememberNavigationEventState(NavigationEventInfo.None)
-
-    var progressChannel: Channel<BackEventCompat>? by remember(onBack) {
-        mutableStateOf(null)
-    }
-
-    fun getActiveProgressChannel(): Channel<BackEventCompat> {
-        val currentProgressChannel = progressChannel
-        if (currentProgressChannel == null) {
-            val progress = Channel<BackEventCompat>()
-            progressChannel = progress
-            coroutineScope.launch {
-                onBack(progress.consumeAsFlow())
-            }
-            return progress
-        } else {
-            return currentProgressChannel
-        }
-    }
-
-    val transitionState = navEventState.transitionState
-    if (transitionState is NavigationEventTransitionState.InProgress) {
-        LaunchedEffect(transitionState) {
-            val navEvent = transitionState.latestEvent
-            val swipeEdge = when (navEvent.swipeEdge) {
-                NavigationEvent.EDGE_RIGHT -> BackEventCompat.EDGE_RIGHT
-                else -> BackEventCompat.EDGE_LEFT
-            }
-            val event = BackEventCompat(
-                navEvent.touchX, navEvent.touchY, navEvent.progress, swipeEdge
-            )
-            getActiveProgressChannel().send(event)
-        }
-    }
-
-    NavigationBackHandler(
-        state = navEventState,
-        isBackEnabled = enabled,
-        onBackCancelled = {
-            getActiveProgressChannel().close(CancellationException("Cancelled"))
-            progressChannel = null
-        },
-        onBackCompleted = {
-            getActiveProgressChannel().close()
-            progressChannel = null
-        }
+    val owner = LocalCompatNavigationEventDispatcherOwner.current ?: error(
+        "No NavigationEventDispatcher was provided via LocalCompatNavigationEventDispatcherOwner"
     )
-    DisposableEffect(Unit) {
-        onDispose {
-            progressChannel?.close(CancellationException("Disposed"))
-            progressChannel = null
-        }
+    val dispatcher = owner.navigationEventDispatcher
+    val coroutineScope = rememberCoroutineScope()
+    val handler = remember(enabled, onBack) {
+        ProgressBackEventHandler(enabled, onBack, coroutineScope)
+    }
+
+    DisposableEffect(dispatcher, handler) {
+        dispatcher.addHandler(handler)
+        onDispose { handler.remove() }
     }
 }
 
+@OptIn(InternalComposeUiApi::class)
 @Deprecated("Use NavigationEventHandler instead")
 @ExperimentalComposeUiApi
 @Composable
 actual fun BackHandler(enabled: Boolean, onBack: () -> Unit) {
-    NavigationBackHandler(
-        state = rememberNavigationEventState(NavigationEventInfo.None),
-        isBackEnabled = enabled,
-        onBackCompleted = onBack
+    val owner = LocalCompatNavigationEventDispatcherOwner.current ?: error(
+        "No NavigationEventDispatcher was provided via LocalCompatNavigationEventDispatcherOwner"
     )
+    val dispatcher = owner.navigationEventDispatcher
+    val handler = remember(enabled, onBack) {
+        BackEventHandler(enabled, onBack)
+    }
+
+    DisposableEffect(dispatcher, handler) {
+        dispatcher.addHandler(handler)
+        onDispose { handler.remove() }
+    }
 }

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
@@ -45,9 +45,10 @@ actual fun PredictiveBackHandler(
     )
     val dispatcher = owner.navigationEventDispatcher
     val coroutineScope = rememberCoroutineScope()
-    val handler = remember(enabled, onBack) {
+    val handler = remember(onBack) {
         ProgressBackEventHandler(enabled, onBack, coroutineScope)
     }
+    handler.isBackEnabled = enabled
 
     DisposableEffect(dispatcher, handler) {
         dispatcher.addHandler(handler)
@@ -64,9 +65,10 @@ actual fun BackHandler(enabled: Boolean, onBack: () -> Unit) {
         "No NavigationEventDispatcher was provided via LocalCompatNavigationEventDispatcherOwner"
     )
     val dispatcher = owner.navigationEventDispatcher
-    val handler = remember(enabled, onBack) {
+    val handler = remember(onBack) {
         BackEventHandler(enabled, onBack)
     }
+    handler.isBackEnabled = enabled
 
     DisposableEffect(dispatcher, handler) {
         dispatcher.addHandler(handler)

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/ProgressBackEventHandler.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/ProgressBackEventHandler.kt
@@ -1,0 +1,58 @@
+package androidx.compose.ui.backhandler
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.navigationevent.NavigationEvent
+import androidx.navigationevent.NavigationEventHandler
+import androidx.navigationevent.NavigationEventInfo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalComposeUiApi::class)
+internal class ProgressBackEventHandler(
+    enabled: Boolean,
+    private val onBack: suspend (progress: Flow<BackEventCompat>) -> Unit,
+    private val coroutineScope: CoroutineScope
+) : NavigationEventHandler<NavigationEventInfo.None>(
+    initialInfo = NavigationEventInfo.None,
+    isBackEnabled = enabled,
+) {
+    private var progressChannel: Channel<BackEventCompat>? = null
+
+    override fun onBackStarted(event: NavigationEvent) {
+        progressChannel?.close(CancellationException("Disposed"))
+        progressChannel = Channel<BackEventCompat>().also { channel ->
+            coroutineScope.launch {
+                onBack(channel.consumeAsFlow())
+            }
+        }
+    }
+
+    override fun onBackProgressed(event: NavigationEvent) {
+        progressChannel?.let { channel ->
+            val swipeEdge = when (event.swipeEdge) {
+                NavigationEvent.EDGE_RIGHT -> BackEventCompat.EDGE_RIGHT
+                else -> BackEventCompat.EDGE_LEFT
+            }
+            val event = BackEventCompat(
+                event.touchX, event.touchY, event.progress, swipeEdge
+            )
+            coroutineScope.launch {
+                channel.send(event)
+            }
+        }
+    }
+
+    override fun onBackCancelled() {
+        progressChannel?.close(CancellationException("Cancelled"))
+        progressChannel = null
+    }
+
+    override fun onBackCompleted() {
+        progressChannel?.close()
+        progressChannel = null
+    }
+}

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -152,6 +152,7 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                     implementation(libs.atomicFu)
                     implementation(project(":lifecycle:lifecycle-runtime-compose"))
                     implementation(project(":navigationevent:navigationevent-compose"))
+                    implementation(project(":compose:ui:ui-backhandler"))
                 }
             }
 

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.backhandler.LocalCompatNavigationEventDispatcherOwner
 import androidx.compose.ui.draganddrop.DragAndDropTransferData
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -543,6 +544,7 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         CompositionLocalProvider(
             LocalLifecycleOwner provides testOwner,
             LocalNavigationEventDispatcherOwner provides testOwner,
+            LocalCompatNavigationEventDispatcherOwner provides testOwner,
             content = content,
         )
     }

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -211,6 +211,7 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                     api(project(":compose:ui:ui-text"))
                     api(libs.skikoCommon)
                     implementation(libs.atomicFu)
+                    implementation(project(":compose:ui:ui-backhandler")) //https://youtrack.jetbrains.com/issue/CMP-9008
                     def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
                     implementation("androidx.navigationevent:navigationevent:$navigationEventVersion")
                 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.awt.AwtEventFilter
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.awt.RenderSettings
+import androidx.compose.ui.backhandler.LocalCompatNavigationEventDispatcherOwner
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.navigationevent.DesktopNavigationEventInput
 import androidx.compose.ui.platform.DisposableSaveableStateRegistry
@@ -589,6 +590,7 @@ private fun ProvideContainerCompositionLocals(
         LocalSaveableStateRegistry provides saveableStateRegistry,
         LocalInternalViewModelStoreOwner provides composeContainer,
         LocalInternalNavigationEventDispatcherOwner provides composeContainer,
+        LocalCompatNavigationEventDispatcherOwner provides composeContainer,
         content = content,
     )
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.saveable.SaveableStateRegistry
 import androidx.compose.ui.LocalSystemTheme
 import androidx.compose.ui.SystemTheme
+import androidx.compose.ui.backhandler.LocalCompatNavigationEventDispatcherOwner
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.hapticfeedback.CupertinoHapticFeedback
 import androidx.compose.ui.navigationevent.UIKitNavigationEventInput
@@ -513,6 +514,7 @@ internal class ComposeHostingViewController(
             LocalLifecycleOwner provides archComponentsOwner,
             LocalInternalViewModelStoreOwner provides archComponentsOwner,
             LocalInternalNavigationEventDispatcherOwner provides archComponentsOwner,
+            LocalCompatNavigationEventDispatcherOwner provides archComponentsOwner,
             LocalSaveableStateRegistry provides savableStateRegistry,
             content = content
         )

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.backhandler.LocalCompatNavigationEventDispatcherOwner
 import androidx.compose.ui.draganddrop.WebDragAndDropManager
 import androidx.compose.ui.events.EventTargetListener
 import androidx.compose.ui.geometry.Offset
@@ -431,6 +432,7 @@ internal class ComposeWindow(
                 LocalLifecycleOwner provides this,
                 LocalInternalViewModelStoreOwner provides this,
                 LocalInternalNavigationEventDispatcherOwner provides this,
+                LocalCompatNavigationEventDispatcherOwner provides this,
                 LocalInteropContainer provides interopContainer,
                 LocalActiveClipEventsTarget provides {
                     (platformContext.textInputService as WebTextInputService).getBackingInput() ?: canvas

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/ComposeUiTestUtils.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/ComposeUiTestUtils.kt
@@ -16,34 +16,13 @@
 
 package androidx.navigation.compose
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
-import androidx.compose.runtime.saveable.SaveableStateRegistry
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.StateRestorationTester
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.testing.TestLifecycleOwner
 
 @OptIn(ExperimentalTestApi::class)
 internal fun runComposeUiTestOnUiThread(block: ComposeUiTest.() -> Unit) {
     runComposeUiTest {
         runOnUiThread { block() }
-    }
-}
-
-@OptIn(ExperimentalTestApi::class)
-internal fun ComposeUiTest.setContentWithLifecycleOwner(content: @Composable () -> Unit) {
-    setContent {
-        CompositionLocalProvider(LocalLifecycleOwner provides TestLifecycleOwner(Lifecycle.State.RESUMED)) {
-            content()
-        }
     }
 }

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/DialogNavigatorTest.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/DialogNavigatorTest.kt
@@ -39,7 +39,7 @@ class DialogNavigatorTest {
         val navigatorState = TestNavigatorState()
         navigator.onAttach(navigatorState)
 
-        setContentWithLifecycleOwner { DialogHost(navigator) }
+        setContent { DialogHost(navigator) }
 
         onNodeWithText(defaultText).assertDoesNotExist()
 
@@ -59,7 +59,7 @@ class DialogNavigatorTest {
         val entry = navigatorState.createBackStackEntry(dialog, null)
         navigator.navigate(listOf(entry), null, null)
 
-        setContentWithLifecycleOwner { DialogHost(navigator) }
+        setContent { DialogHost(navigator) }
 
         onNodeWithText(defaultText).assertIsDisplayed()
 
@@ -72,7 +72,7 @@ class DialogNavigatorTest {
     fun testNestedNavHostInDialogDismissed() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, "first") {
                 composable("first") {}
@@ -102,7 +102,7 @@ class DialogNavigatorTest {
     fun testDialogMarkedTransitionComplete() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, "first") {
                 composable("first") {}
@@ -139,7 +139,7 @@ class DialogNavigatorTest {
     fun testDialogMarkedTransitionCompleteInOrder() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, "first") {
                 composable("first") {}
@@ -182,7 +182,7 @@ class DialogNavigatorTest {
     fun testDialogNavigateConsecutively() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, "first") {
                 composable("first") {}
@@ -209,7 +209,7 @@ class DialogNavigatorTest {
     fun testDialogNavigatePopNavigate() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, route = "graph", startDestination = "first") {
                 composable("first") {}
@@ -240,7 +240,7 @@ class DialogNavigatorTest {
     fun testDialogNavigatePopNavigateSameDialog() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, route = "graph", startDestination = "first") {
                 composable("first") {}
@@ -270,7 +270,7 @@ class DialogNavigatorTest {
     fun testDialogNavigatePopPopNavigate() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, route = "graph", startDestination = "first") {
                 composable("first") {}
@@ -303,7 +303,7 @@ class DialogNavigatorTest {
     @Test
     fun testDialogObserveRemovedOnPopNavigate() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, route = "graph", startDestination = "first") {
                 composable("first") {}

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavGraphBuilderTest.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavGraphBuilderTest.kt
@@ -50,7 +50,7 @@ class NavGraphBuilderTest {
         lateinit var navController: TestNavHostController
         val uriString = "https://www.example.com"
         val deeplink = NavDeepLinkRequest.Builder.fromUri(NavUri(uriString)).build()
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -75,7 +75,7 @@ class NavGraphBuilderTest {
         lateinit var navController: TestNavHostController
         val uriString = "https://www.example.com"
         val deeplink = NavDeepLinkRequest.Builder.fromUri(NavUri(uriString)).build()
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -105,7 +105,7 @@ class NavGraphBuilderTest {
         lateinit var navController: TestNavHostController
         val key = "key"
         val arg = "myarg"
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -127,7 +127,7 @@ class NavGraphBuilderTest {
         lateinit var navController: TestNavHostController
         val key = "key"
         val defaultArg = "default"
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -150,7 +150,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationNestedStart() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -171,7 +171,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationNestedInGraph() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -196,7 +196,7 @@ class NavGraphBuilderTest {
         lateinit var navController: TestNavHostController
         val key = "key"
         val defaultArg = "default"
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -222,7 +222,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationKClassStart() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -242,7 +242,7 @@ class NavGraphBuilderTest {
     fun testNavigationNestedKClassStart() = runComposeUiTestOnUiThread {
         @Serializable class TestOuterClass
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -267,7 +267,7 @@ class NavGraphBuilderTest {
         @Serializable class NestedGraph
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -293,7 +293,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationObjectStart() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -312,7 +312,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationObjectStartArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -335,7 +335,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationNestedObjectStart() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -358,7 +358,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationNestedObjectStartArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -385,7 +385,7 @@ class NavGraphBuilderTest {
         @Serializable class NestedGraph
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -408,7 +408,7 @@ class NavGraphBuilderTest {
         @Serializable class NestedGraph(val graphArg: Boolean)
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -437,7 +437,7 @@ class NavGraphBuilderTest {
         @Serializable class NestedGraph
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -463,7 +463,7 @@ class NavGraphBuilderTest {
         @Serializable class NestedGraph
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -490,7 +490,7 @@ class NavGraphBuilderTest {
     @Test
     fun testComposableKClass() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -509,7 +509,7 @@ class NavGraphBuilderTest {
     @Test
     fun testComposableKClassArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -531,7 +531,7 @@ class NavGraphBuilderTest {
         @Serializable class TestClass(val arg: CustomType)
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -550,7 +550,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNestedComposableKClassArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -580,7 +580,7 @@ class NavGraphBuilderTest {
         lateinit var exception: String
         lateinit var navController: TestNavHostController
         try {
-            setContentWithLifecycleOwner {
+            setContent {
                 navController = TestNavHostController()
                 navController.navigatorProvider.addNavigator(ComposeNavigator())
 
@@ -603,7 +603,7 @@ class NavGraphBuilderTest {
     @Test
     fun testDialogKClass() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
             navController.navigatorProvider.addNavigator(DialogNavigator())
@@ -623,7 +623,7 @@ class NavGraphBuilderTest {
     @Test
     fun testDialogKClassArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(DialogNavigator())
             navController.navigatorProvider.addNavigator(ComposeNavigator())
@@ -646,7 +646,7 @@ class NavGraphBuilderTest {
         @Serializable class TestClass(val arg: CustomType)
 
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(DialogNavigator())
             navController.navigatorProvider.addNavigator(ComposeNavigator())
@@ -666,7 +666,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNestedDialogKClassArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(DialogNavigator())
             navController.navigatorProvider.addNavigator(ComposeNavigator())
@@ -697,7 +697,7 @@ class NavGraphBuilderTest {
         lateinit var exception: String
         lateinit var navController: TestNavHostController
         try {
-            setContentWithLifecycleOwner {
+            setContent {
                 navController = TestNavHostController()
                 navController.navigatorProvider.addNavigator(DialogNavigator())
                 navController.navigatorProvider.addNavigator(ComposeNavigator())
@@ -721,7 +721,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationDialogObjectStartArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(DialogNavigator())
             navController.navigatorProvider.addNavigator(ComposeNavigator())
@@ -743,7 +743,7 @@ class NavGraphBuilderTest {
     @Test
     fun testNavigationDialogNestedObjectStartArgs() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = TestNavHostController()
             navController.navigatorProvider.addNavigator(ComposeNavigator())
             navController.navigatorProvider.addNavigator(DialogNavigator())

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavHostControllerTest.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavHostControllerTest.kt
@@ -56,7 +56,7 @@ class NavHostControllerTest {
     fun testRememberNavController() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             // get state to trigger recompose on navigate
             navController.currentBackStackEntryAsState().value
@@ -82,7 +82,7 @@ class NavHostControllerTest {
     fun testRememberNavControllerAddsCustomNavigator() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             val customNavigator = remember { NoOpNavigator() }
             navController = rememberNavController(customNavigator)
             // get state to trigger recompose on navigate
@@ -107,7 +107,7 @@ class NavHostControllerTest {
     @Test
     fun testCurrentBackStackEntrySetGraph() = runComposeUiTestOnUiThread {
         var currentBackStackEntry: State<NavBackStackEntry?> = mutableStateOf(null)
-        setContentWithLifecycleOwner {
+        setContent {
             val navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -127,7 +127,7 @@ class NavHostControllerTest {
     fun testCurrentBackStackEntryNavigate() = runComposeUiTestOnUiThread {
         var currentBackStackEntry: State<NavBackStackEntry?> = mutableStateOf(null)
         lateinit var navController: NavController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -154,7 +154,7 @@ class NavHostControllerTest {
     fun testCurrentBackStackEntryPop() = runComposeUiTestOnUiThread {
         var currentBackStackEntry: State<NavBackStackEntry?> = mutableStateOf(null)
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -180,7 +180,7 @@ class NavHostControllerTest {
     fun testNavigateThenNavigateWithPop() = runComposeUiTestOnUiThread {
         var currentBackStackEntry: State<NavBackStackEntry?> = mutableStateOf(null)
         lateinit var navController: NavController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -215,7 +215,7 @@ class NavHostControllerTest {
     fun testNavigateOptionSingleTop() = runComposeUiTestOnUiThread {
         var currentBackStackEntry: State<NavBackStackEntry?> = mutableStateOf(null)
         lateinit var navController: NavController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -252,7 +252,7 @@ class NavHostControllerTest {
     fun testNavigateOptionSingleTopDifferentArguments() = runComposeUiTestOnUiThread {
         var value = ""
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first?arg={arg}") {
@@ -285,7 +285,7 @@ class NavHostControllerTest {
     fun testNavigateOptionSingleTopDifferentListArguments() = runComposeUiTestOnUiThread {
         var value: List<String> = listOf()
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first?arg=value1&arg=value2") {
@@ -318,7 +318,7 @@ class NavHostControllerTest {
     @Test
     fun testNavigateKClass() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -337,7 +337,7 @@ class NavHostControllerTest {
     fun testNavigateKClassArgsBundle() = runComposeUiTestOnUiThread {
         lateinit var args: TestClassArg
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -356,7 +356,7 @@ class NavHostControllerTest {
     fun testNavigateKClassArgsSavedStateHandle() = runComposeUiTestOnUiThread {
         lateinit var vm: TestVM
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -383,7 +383,7 @@ class NavHostControllerTest {
 
         lateinit var args: TestClass
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -408,7 +408,7 @@ class NavHostControllerTest {
 
         lateinit var vm: TestVM
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -440,7 +440,7 @@ class NavHostControllerTest {
 
         lateinit var args: TestClass
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -464,7 +464,7 @@ class NavHostControllerTest {
 
         lateinit var vm: TestVM
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -491,7 +491,7 @@ class NavHostControllerTest {
     @Test
     fun testNavigateDialogKClass() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -510,7 +510,7 @@ class NavHostControllerTest {
     fun testNavigateDialogKClassArgsBundle() = runComposeUiTestOnUiThread {
         lateinit var bundle: TestClassArg
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -529,7 +529,7 @@ class NavHostControllerTest {
     fun testNavigateDialogKClassArgsSavedStateHandle() = runComposeUiTestOnUiThread {
         lateinit var vm: TestVM
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -556,7 +556,7 @@ class NavHostControllerTest {
 
         lateinit var args: TestClass
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -581,7 +581,7 @@ class NavHostControllerTest {
 
         lateinit var vm: TestVM
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -613,7 +613,7 @@ class NavHostControllerTest {
 
         lateinit var args: TestClass
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -637,7 +637,7 @@ class NavHostControllerTest {
 
         lateinit var vm: TestVM
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -664,7 +664,7 @@ class NavHostControllerTest {
     @Test
     fun testGetBackStackEntry() = runComposeUiTestOnUiThread {
         lateinit var navController: NavController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -688,7 +688,7 @@ class NavHostControllerTest {
     @Test
     fun testGetBackStackEntryNoEntryFound() = runComposeUiTestOnUiThread {
         lateinit var navController: NavController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController(remember { TestNavigator() })
 
             navController.graph =
@@ -716,7 +716,7 @@ class NavHostControllerTest {
     @Test
     fun testGetBackStackEntryKClass() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "first") {

--- a/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavHostTest.kt
+++ b/navigation/navigation-compose/src/commonTest/kotlin/androidx/navigation/compose/NavHostTest.kt
@@ -72,7 +72,7 @@ class NavHostTest {
     @Test
     fun testSingleDestinationSet() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = createNavController()
 
             NavHost(navController, startDestination = "first") { test("first") }
@@ -86,7 +86,7 @@ class NavHostTest {
     @Test
     fun testNavigate() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = createNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -111,7 +111,7 @@ class NavHostTest {
         lateinit var navController: NavHostController
         val text = "myButton"
         var counter = 0
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             var state by remember { mutableStateOf(0) }
             Column(Modifier.fillMaxSize()) {
@@ -156,7 +156,7 @@ class NavHostTest {
     @Test
     fun testPop() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = createNavController()
 
             NavHost(navController, startDestination = "first") {
@@ -179,7 +179,7 @@ class NavHostTest {
     fun testChangeStartDestination() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
         lateinit var state: MutableState<String>
-        setContentWithLifecycleOwner {
+        setContent {
             state = remember { mutableStateOf("first") }
             navController = createNavController()
 
@@ -202,7 +202,7 @@ class NavHostTest {
     fun testSameControllerAfterDisposingNavHost() = runComposeUiTestOnUiThread {
         lateinit var navController: TestNavHostController
         lateinit var state: MutableState<Int>
-        setContentWithLifecycleOwner {
+        setContent {
             state = remember { mutableStateOf(0) }
             navController = createNavController()
             if (state.value == 0) {
@@ -229,7 +229,7 @@ class NavHostTest {
     fun testDialogSavedAfterConfigChange() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
         val defaultText = "dialogText"
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, startDestination = "dialog") {
                 dialog("dialog") { Text(defaultText) }
@@ -307,7 +307,7 @@ class NavHostTest {
         var lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
         lateinit var state: MutableState<Int>
         lateinit var viewModel: TestViewModel
-        setContentWithLifecycleOwner {
+        setContent {
             state = remember { mutableStateOf(0) }
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
                 navController = rememberNavController()
@@ -351,7 +351,7 @@ class NavHostTest {
         lateinit var viewModel_second: TestViewModel
         lateinit var viewModel_third: TestViewModel
 
-        setContentWithLifecycleOwner {
+        setContent {
             state = remember { mutableStateOf(0) }
             CompositionLocalProvider(LocalLifecycleOwner provides lifecycleOwner) {
                 navController = rememberNavController()
@@ -410,7 +410,7 @@ class NavHostTest {
         var increment = 0
         var numberOnScreen1 = -1
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "First") {
@@ -437,7 +437,7 @@ class NavHostTest {
         var increment = 0
         var numberOnScreen2 = -1
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
 
             NavHost(navController, startDestination = "First") {
@@ -467,7 +467,7 @@ class NavHostTest {
         lateinit var graph1: NavGraph
         lateinit var graph2: NavGraph
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             graph1 =
                 navController.createGraph(startDestination = "First") {
@@ -506,7 +506,7 @@ class NavHostTest {
         lateinit var graph2: NavGraph
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             graph1 =
                 navController.createGraph(startDestination = "First") {
@@ -555,7 +555,7 @@ class NavHostTest {
         lateinit var graph2: NavGraph
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             graph1 =
                 navController.createGraph(route = "route", startDestination = "First") {
@@ -604,7 +604,7 @@ class NavHostTest {
         lateinit var graph2: NavGraph
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             graph1 =
                 navController.createGraph(startDestination = "First") {
@@ -666,7 +666,7 @@ class NavHostTest {
         lateinit var graph2: NavGraph
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             graph1 =
                 navController.createGraph(route = "Root", startDestination = "First") {
@@ -727,7 +727,7 @@ class NavHostTest {
             lateinit var graph2: NavGraph
             lateinit var navController: NavHostController
 
-            setContentWithLifecycleOwner {
+            setContent {
                 navController = rememberNavController()
                 graph1 =
                     navController.createGraph(route = "Root", startDestination = "First") {
@@ -796,7 +796,7 @@ class NavHostTest {
         lateinit var graph1: NavGraph
         lateinit var graph2: NavGraph
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             graph1 =
                 navController.createGraph(route = "Root", startDestination = "First") {
@@ -845,7 +845,7 @@ class NavHostTest {
 
         mainClock.autoAdvance = false
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, startDestination = first) {
                 composable(first) { BasicText(first) }
@@ -924,7 +924,7 @@ class NavHostTest {
     fun testNavHostAnimationsBackInterrupt() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, startDestination = first) {
                 composable(first) {
@@ -967,7 +967,7 @@ class NavHostTest {
         lateinit var navController: NavHostController
         lateinit var text: MutableState<String>
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, "start") {
                 composable("start") {
@@ -1010,7 +1010,7 @@ class NavHostTest {
         lateinit var navController: NavHostController
         lateinit var model: TestViewModel
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, first) {
                 composable(first) {}
@@ -1043,7 +1043,7 @@ class NavHostTest {
         lateinit var navController: NavHostController
         lateinit var model: TestViewModel
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, first) {
                 composable(first) {}
@@ -1069,7 +1069,7 @@ class NavHostTest {
         lateinit var navController: NavHostController
         lateinit var model: TestViewModel
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             // this causes a recompose
             val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -1101,7 +1101,7 @@ class NavHostTest {
     fun testNestedNavHostNullLambda() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
 
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, startDestination = first) {
                 composable(first) { BasicText(first) }
@@ -1118,7 +1118,7 @@ class NavHostTest {
     fun navBackStackEntryLifecycleTest() = runComposeUiTestOnUiThread {
         var stopCount = 0
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, startDestination = "First") {
                 composable("First") {
@@ -1146,7 +1146,7 @@ class NavHostTest {
     fun navBackStackEntrySingleTopLifecycleTest() = runComposeUiTestOnUiThread {
         var lastEvent: Lifecycle.Event? = null
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             NavHost(navController, startDestination = "First") {
                 composable("First") {
@@ -1181,7 +1181,7 @@ class NavHostTest {
     @Test
     fun testPopWithBackHandler() = runComposeUiTestOnUiThread {
         lateinit var navController: NavHostController
-        setContentWithLifecycleOwner {
+        setContent {
             navController = rememberNavController()
             val innerNavController = rememberNavController()
             NavHost(navController, startDestination = first) {


### PR DESCRIPTION
It is required to handle a native klibs compilation problem: https://youtrack.jetbrains.com/issue/KT-60874

Fixes [CMP-9008](https://youtrack.jetbrains.com/issue/CMP-9008) Fix backward compatibility of `ui` module klibs due to removing `ui-backhandler` dependency

## Release Notes
N/A