### PR TITLE
Refactor buildSrc - Move `androidXComposeMultiplatform` extension to `org.jetbrains.androidx.build`

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXComposeImplPlugin.kt
@@ -95,12 +95,6 @@ class AndroidXComposeImplPlugin : Plugin<Project> {
         ) {
             if (isMultiplatformEnabled) {
                 project.apply(plugin = "kotlin-multiplatform")
-
-                project.extensions.create(
-                    AndroidXComposeMultiplatformExtension::class.java,
-                    "androidXComposeMultiplatform",
-                    AndroidXComposeMultiplatformExtensionImpl::class.java
-                )
             } else {
                 project.apply(plugin = "org.jetbrains.kotlin.android")
             }

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/AndroidXComposeMultiplatformExtensionImpl.kt
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package androidx.build
+package org.jetbrains.androidx.build
 
+import androidx.build.AndroidXComposeMultiplatformExtension
 import javax.inject.Inject
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByName
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
+import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.konan.target.KonanTarget
 import org.tomlj.Toml
-import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 
 open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
     val project: Project
@@ -141,7 +143,7 @@ open class AndroidXComposeMultiplatformExtensionImpl @Inject constructor(
             return System.getProperty("idea.active")?.toBoolean() == true
         }
 
-    @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)
+    @OptIn(ExperimentalWasmDsl::class)
     override fun wasm(): Unit = multiplatformExtension.run {
         wasmJs {
             browser {

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXImplPlugin.kt
@@ -18,6 +18,7 @@
 
 package org.jetbrains.androidx.build
 
+import androidx.build.AndroidXComposeMultiplatformExtension
 import androidx.build.AndroidXExtension
 import androidx.build.AndroidXMultiplatformExtension
 import androidx.build.multiplatformExtension
@@ -168,6 +169,12 @@ class JetBrainsAndroidXImplPlugin @Inject constructor(
     }
 
     private fun onKotlinMultiplatformPluginApplied(project: Project) {
+        project.extensions.create(
+            AndroidXComposeMultiplatformExtension::class.java,
+            "androidXComposeMultiplatform",
+            AndroidXComposeMultiplatformExtensionImpl::class.java
+        )
+
         enableArtifactRedirectionPublishing(project)
         enableBinaryCompatibilityValidator(project)
         val multiplatformExtension =


### PR DESCRIPTION
Part of https://youtrack.jetbrains.com/issue/CMP-7927/Restore-publication-logic-in-the-new-buildSrc

Next steps after moving to the AOSP state:
- still keep `androidXComposeMultiplatform` instead of `androidXMultiplatform`. I tried to get rid of it, but it requires a lot of changes, even when we migrate to the AOSP buildSrc. More practical path is to keep it until we have everything working
- extend from [AndroidXMultiplatformExtension](https://github.com/androidx/androidx/blob/98817bea43540e93ecf9c9b7ce269c7c307ae1c2/buildSrc/private/src/main/kotlin/androidx/build/AndroidXMultiplatformExtension.kt#L75)
- remove some sourceSet configurations, reuse from the extension

## Testing
- [TeamCity build](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_AllPersonalBuild/5538940)
- `./gradlew publishComposeJbToMavenLocal -Pcompose.platforms=desktop,web` is successful
- wasm Demo works

## Release Notes
N/A