### PR TITLE
Fix crash on `UIFocusHaloEffect` not found

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.h
@@ -19,7 +19,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CMPAccessibilityElement : UIAccessibilityElement
+@interface CMPAccessibilityElement : UIAccessibilityElement <UIFocusItem>
 
 - (NSArray<UIAccessibilityCustomAction *> *)accessibilityCustomActions;
 
@@ -58,6 +58,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setAccessibilityElements:(nullable NSArray *)accessibilityElements;
 
 - (BOOL)drawsFocusRingWhenChildrenFocused;
+
+- (CGRect)focusEffectRect;
+
+- (UIFocusEffect *)focusEffect API_AVAILABLE(ios(15.0));
 
 @end
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPAccessibilityElement.m
@@ -105,6 +105,14 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
+- (CGRect)focusEffectRect {
+    return CGRectZero;
+}
+
+- (UIFocusEffect *)focusEffect {
+    return [UIFocusHaloEffect effectWithRect:[self focusEffectRect]];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -118,9 +118,7 @@ import platform.UIKit.UIAccessibilityTraits
 import platform.UIKit.UICoordinateSpaceProtocol
 import platform.UIKit.UIEdgeInsetsInsetRect
 import platform.UIKit.UIFocusAnimationCoordinator
-import platform.UIKit.UIFocusEffect
 import platform.UIKit.UIFocusEnvironmentProtocol
-import platform.UIKit.UIFocusHaloEffect
 import platform.UIKit.UIFocusItemContainerProtocol
 import platform.UIKit.UIFocusItemProtocol
 import platform.UIKit.UIFocusItemScrollableContainerProtocol

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -516,15 +516,6 @@ private class AccessibilityElement(
         }
     }
 
-    override fun focusEffect(): UIFocusEffect? =
-        if (available(OS.Ios to OSVersion(major = 15))) {
-            UIFocusHaloEffect.effectWithRect(
-                rect = convertRect(rect = bounds, toCoordinateSpace = mediator.view)
-            )
-        } else {
-            null
-        }
-
     private fun nodeSemanticsElements(): List<Any> =
         getOrElse(CachedAccessibilityPropertyKeys.accessibilityElements) {
             listOfNotNull(node.accessibilityInteropView?.also {
@@ -715,6 +706,8 @@ private class AccessibilityElement(
     } else {
         convertRect(rect = bounds(), toCoordinateSpace = mediator.view)
     }
+
+    override fun focusEffectRect(): CValue<CGRect> = convertRect(rect = bounds, toCoordinateSpace = mediator.view)
 
     override fun bounds(): CValue<CGRect> {
         val offset = contentOffset()

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -516,9 +516,14 @@ private class AccessibilityElement(
         }
     }
 
-    override fun focusEffect(): UIFocusEffect = UIFocusHaloEffect.effectWithRect(
-        rect = convertRect(rect = bounds, toCoordinateSpace = mediator.view)
-    )
+    override fun focusEffect(): UIFocusEffect? =
+        if (available(OS.Ios to OSVersion(major = 15))) {
+            UIFocusHaloEffect.effectWithRect(
+                rect = convertRect(rect = bounds, toCoordinateSpace = mediator.view)
+            )
+        } else {
+            null
+        }
 
     private fun nodeSemanticsElements(): List<Any> =
         getOrElse(CachedAccessibilityPropertyKeys.accessibilityElements) {


### PR DESCRIPTION
Fix crash on `UIFocusHaloEffect` not found

Add iOS 15+ version check before using `UIFocusHaloEffect`

Fixes https://youtrack.jetbrains.com/issue/CMP-9026

## Testing

This should be tested by QA

## Release Notes
N/A
