### PR TITLE
Guard canvas drawing with a critical section

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -42,7 +42,7 @@ private class DisplayLinkConditions(
     val setPausedCallback: (Boolean) -> Unit
 ) {
     /**
-     * see [MetalRedrawer.needsProactiveDisplayLink]
+     * see [MetalRedrawer.ongoingInteractionEventsCount]
      */
     var needsToBeProactive: Boolean = false
         set(value) {
@@ -141,7 +141,7 @@ internal class MetalRedrawer(
     // Workaround for KN compiler bug
     // Type mismatch: inferred type is objcnames.protocols.MTLDeviceProtocol but platform.Metal.MTLDeviceProtocol was expected
     @Suppress("USELESS_CAST")
-    private val device = metalLayer.device as platform.Metal.MTLDeviceProtocol?
+    private val device = metalLayer.device as MTLDeviceProtocol?
         ?: throw IllegalStateException("CAMetalLayer.device can not be null")
     private val queue = getCachedCommandQueue(device)
     private val context = DirectContext.makeMetal(device.objcPtr(), queue.objcPtr())
@@ -151,6 +151,7 @@ internal class MetalRedrawer(
     // Semaphore for preventing command buffers count more than swapchain size to be scheduled/executed at the same time
     private val inflightSemaphore =
         dispatch_semaphore_create(metalLayer.maximumDrawableCount.toLong())
+    private val drawCanvasSemaphore = dispatch_semaphore_create(1)
     private val inflightCommandBuffers =
         InflightCommandBuffers(metalLayer.maximumDrawableCount.toInt())
 
@@ -422,16 +423,21 @@ internal class MetalRedrawer(
                 isInteropActive = true
             }
 
-            // TODO: encoding on separate thread requires investigation for reported crashes
-            //  https://github.com/JetBrains/compose-multiplatform/issues/3862
-            //  https://youtrack.jetbrains.com/issue/COMPOSE-608/iOS-reproduce-and-investigate-parallel-rendering-encoding-crash
             val mustEncodeAndPresentOnMainThread = presentsWithTransaction || waitUntilCompletion || !useSeparateRenderThreadWhenPossible
 
             val encodeAndPresentBlock = {
                 trace("MetalRedrawer:draw:encodeAndPresent") {
+                    if (useSeparateRenderThreadWhenPossible) {
+                        dispatch_semaphore_wait(drawCanvasSemaphore, DISPATCH_TIME_FOREVER)
+                    }
+
                     surface.canvas.drawPicture(picture)
                     picture.close()
                     surface.flushAndSubmit()
+
+                    if (useSeparateRenderThreadWhenPossible) {
+                        dispatch_semaphore_signal(drawCanvasSemaphore)
+                    }
 
                     val commandBuffer = queue.commandBuffer()!!
                     commandBuffer.label = "Present"
@@ -486,9 +492,7 @@ internal class MetalRedrawer(
                 encodeAndPresentBlock()
             } else {
                 dispatch_async(renderingDispatchQueue) {
-                    autoreleasepool {
-                        encodeAndPresentBlock()
-                    }
+                    encodeAndPresentBlock()
                 }
             }
         }


### PR DESCRIPTION
Add a critical section around the canvas drawing to prevent race conditions in this area.
Race conditions occur when asynchronous and synchronous frame draw calls follow one another.

Fixes https://youtrack.jetbrains.com/issue/CMP-8144/Crash-when-enabling-parallel-rendering-in-MetalRedrawer-for-iOS

## Release Notes
### Fixes - iOS
- Fix crash when `parallelRendering` is enabled.