### PR TITLE
Fix Canvas blue outline when focused with Tab

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -740,6 +740,7 @@ fun ComposeViewport(
     val canvas = document.createElement("canvas") as HTMLCanvasElement
     canvas.setAttribute("tabindex", "0")
     canvas.setAttribute("role", "generic")
+    canvas.style.outline = "none" // Fixes https://youtrack.jetbrains.com/issue/CMP-9040
 
     // Create a common container (parent html element) for canvas and the interop container
     // to position at the same place - the interop container is position at 0,0 relative to <canvas>.


### PR DESCRIPTION
Add a css property to disable the outline.

Fixes https://youtrack.jetbrains.com/issue/CMP-9040

## Testing
N/A

## Release Notes
### Fixes - Web
- Removed an outline on a `Canvas` element when it's focused

