### PR TITLE
Remove COMPOSE_MATERIAL_NAVIGATION version group

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -83,7 +83,6 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
    `-Pjetbrains.publication.version.CORE_BUNDLE`,
    `-Pjetbrains.publication.version.CORE_URI`,
    `-Pjetbrains.publication.version.COMPOSE`,
-   `-Pjetbrains.publication.version.COMPOSE_MATERIAL_NAVIGATION`,
    `-Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE`,
    `-Pjetbrains.publication.version.LIFECYCLE`,
    `-Pjetbrains.publication.version.NAVIGATION`,
@@ -95,7 +94,7 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
    The default value for the version is `0.0.0-SNAPSHOT`
 
    And library groups:
-   `-Pjetbrains.publication.libraries=COMPOSE,COMPOSE_MATERIAL_NAVIGATION,COMPOSE_MATERIAL3_ADAPTIVE,LIFECYCLE,NAVIGATION,NAVIGATION_3,NAVIGATION_EVENT,SAVEDSTATE,WINDOW`
+   `-Pjetbrains.publication.libraries=COMPOSE,COMPOSE_MATERIAL3_ADAPTIVE,LIFECYCLE,NAVIGATION,NAVIGATION_3,NAVIGATION_EVENT,SAVEDSTATE,WINDOW`
 
    The default value includes all libraries.
 

--- a/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
+++ b/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
@@ -37,6 +37,7 @@ object JetBrainsPublication {
             ComposeComponent(":compose:foundation:foundation"),
             ComposeComponent(":compose:foundation:foundation-layout"),
             ComposeComponent(":compose:material:material"),
+            ComposeComponent(":compose:material:material-navigation"),
             ComposeComponent(":compose:material:material-ripple"),
             ComposeComponent(":compose:runtime:runtime", supportedPlatforms = ComposePlatforms.ALL),
             ComposeComponent(":compose:runtime:runtime-saveable", supportedPlatforms = ComposePlatforms.ALL),
@@ -79,7 +80,6 @@ object JetBrainsPublication {
                     "Jvmwindows-arm64",
                 )
             ),
-            ComposeComponent(":compose:material:material-navigation"),
         ),
         "COMPOSE_MATERIAL3" to listOf(
             ComposeComponent(":compose:material3:material3"),

--- a/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
+++ b/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsPublication.kt
@@ -79,8 +79,6 @@ object JetBrainsPublication {
                     "Jvmwindows-arm64",
                 )
             ),
-        ),
-        "COMPOSE_MATERIAL_NAVIGATION" to listOf(
             ComposeComponent(":compose:material:material-navigation"),
         ),
         "COMPOSE_MATERIAL3" to listOf(


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8861/Revert-material-navigation-version-group-back-to-compose

[CI](https://jetbrains.team/p/ui/reviews/65/timeline)

## Testing
[CI passes](https://teamcity.jetbrains.com/buildConfiguration/JetBrainsPublicProjects_Compose_AllPersonalBuild/5557637)

## Release Notes
N/A