### PR TITLE
[web] [tests] While triggering action from accessibility-dedicated DOM container, wait for recomposition

### DIFF
--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -71,9 +71,10 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("button", button1.getAttribute("role"))
         assertEquals("Button1", button1.innerText)
 
-        repeat(3) {
+        repeat(3) { repeatCounter ->
             button1.click()
-            assertEquals(it + 1, clickCounter)
+            awaitIdle()
+            assertEquals(repeatCounter, clickCounter)
         }
     }
 
@@ -127,11 +128,11 @@ class CfWA11YTest : OnCanvasTests {
         assertTrue(button2.isConnected)
 
 
-        repeat(3) {
+        repeat(3) { repeatCounter ->
             button1.click()
             button2.click()
-            assertEquals(it + 1, clickCounter1)
-            assertEquals(it + 1, clickCounter2)
+            assertEquals(repeatCounter + 1, clickCounter1)
+            assertEquals(repeatCounter + 1, clickCounter2)
         }
 
         showButton2 = false

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -58,6 +58,7 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
+
         awaitIdle()
 
         val a11yContainer = getA11YContainer()
@@ -74,7 +75,7 @@ class CfWA11YTest : OnCanvasTests {
         repeat(3) { repeatCounter ->
             button1.click()
             awaitIdle()
-            assertEquals(repeatCounter, clickCounter)
+            assertEquals(repeatCounter + 1, clickCounter)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -128,9 +128,9 @@ kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
-jetbrains.androidx.web.tests.enableChrome=false
+jetbrains.androidx.web.tests.enableChrome=true
 jetbrains.androidx.web.tests.enableChromium=false
-jetbrains.androidx.web.tests.enableFirefox=true
+jetbrains.androidx.web.tests.enableFirefox=false
 jetbrains.androidx.web.tests.enableSafari=false
 
 # WA for a build issue on Linux agents

--- a/gradle.properties
+++ b/gradle.properties
@@ -128,9 +128,9 @@ kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
-jetbrains.androidx.web.tests.enableChrome=true
+jetbrains.androidx.web.tests.enableChrome=false
 jetbrains.androidx.web.tests.enableChromium=false
-jetbrains.androidx.web.tests.enableFirefox=false
+jetbrains.androidx.web.tests.enableFirefox=true
 jetbrains.androidx.web.tests.enableSafari=false
 
 # WA for a build issue on Linux agents


### PR DESCRIPTION
This is supposed fix for flakiness of our web CfWA11YTest

## Testing
`./gradlewTest` (but easier to encounter in pipeline)

## Release Notes
N/A