### PR TITLE
Disable the new context menus

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ComposeFoundationFlags.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/ComposeFoundationFlags.kt
@@ -68,7 +68,7 @@ object ComposeFoundationFlags {
      * [BasicTextField][androidx.compose.foundation.text.BasicTextField]s. If false, the previous
      * context menu that has no public APIs will be used instead.
      */
-    @Suppress("MutableBareField") @JvmField var isNewContextMenuEnabled = true
+    @Suppress("MutableBareField") @JvmField var isNewContextMenuEnabled = false
 
     /**
      * Whether to use the new smart selection feature in


### PR DESCRIPTION
Set `ComposeFoundationFlags.isNewContextMenuEnabled = false`

Fixes https://youtrack.jetbrains.com/issue/CMP-9058

## Testing
N/A

## Release Notes
### Migration Notes - Multiple Platforms
- _(prerelease fix)_ Disabled (by default) the new text context menus until they are fully supported. You can enable them by setting `ComposeFoundationFlags.isNewContextMenuEnabled = true`.
