### PR TITLE
Deprecate androidx.compose.desktop.ui.tooling.preview.Preview annotation

### DIFF
--- a/compose/ui/ui-tooling-preview/src/desktopMain/kotlin/androidx/compose/desktop/ui/tooling/preview/Preview.kt
+++ b/compose/ui/ui-tooling-preview/src/desktopMain/kotlin/androidx/compose/desktop/ui/tooling/preview/Preview.kt
@@ -20,4 +20,8 @@ package androidx.compose.desktop.ui.tooling.preview
 @Target(
     AnnotationTarget.FUNCTION
 )
+@Deprecated(
+    "Use androidx.compose.ui.tooling.preview.Preview instead",
+    ReplaceWith("Preview", "androidx.compose.ui.tooling.preview.Preview")
+)
 annotation class Preview


### PR DESCRIPTION
Deprecate `androidx.compose.desktop.ui.tooling.preview.Preview` annotation in favor of `androidx.compose.ui.tooling.preview.Preview`

Fixes [CMP-4869](https://youtrack.jetbrains.com/issue/CMP-4869/Reduce-variety-of-Preview-annotations)

## Release Notes
### Migration Notes - Desktop
- Deprecate `androidx.compose.desktop.ui.tooling.preview.Preview` annotation in favor of `androidx.compose.ui.tooling.preview.Preview` to reduce variety of Preview annotations