### PR TITLE
Remove experimental flag from LocalUIView

### DIFF
--- a/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/ContextMenuNode.uikit.kt
+++ b/compose/foundation/foundation/src/uikitMain/kotlin/androidx/compose/foundation/text/ContextMenuNode.uikit.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.foundation.text
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
@@ -102,7 +101,6 @@ internal class ContextMenuLayoutNode(
         density = null
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun onObservedReadsChanged() {
         observeReads {
             val previousContainerView = containerView

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -5123,6 +5123,10 @@ final val androidx.compose.ui.scene/androidx_compose_ui_scene_UIKitComposeSceneL
 final val androidx.compose.ui.scene/androidx_compose_ui_scene_UIKitTransparentContainerView$stableprop // androidx.compose.ui.scene/androidx_compose_ui_scene_UIKitTransparentContainerView$stableprop|#static{}androidx_compose_ui_scene_UIKitTransparentContainerView$stableprop[0]
 
 // Targets: [ios]
+final val androidx.compose.ui.uikit/LocalUIView // androidx.compose.ui.uikit/LocalUIView|{}LocalUIView[0]
+    final fun <get-LocalUIView>(): androidx.compose.runtime/ProvidableCompositionLocal<platform.UIKit/UIView> // androidx.compose.ui.uikit/LocalUIView.<get-LocalUIView>|<get-LocalUIView>(){}[0]
+
+// Targets: [ios]
 final val androidx.compose.ui.uikit/LocalUIViewController // androidx.compose.ui.uikit/LocalUIViewController|{}LocalUIViewController[0]
     final fun <get-LocalUIViewController>(): androidx.compose.runtime/ProvidableCompositionLocal<platform.UIKit/UIViewController> // androidx.compose.ui.uikit/LocalUIViewController.<get-LocalUIViewController>|<get-LocalUIViewController>(){}[0]
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/UIKitCompositionLocals.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/UIKitCompositionLocals.uikit.kt
@@ -37,7 +37,6 @@ val LocalUIViewController = staticCompositionLocalOf<UIViewController> {
  * Please use it carefully and don't add or remove other views - check
  * [androidx.compose.ui.interop.UIKitView] for those purposes.
  */
-@ExperimentalComposeUiApi
 val LocalUIView = staticCompositionLocalOf<UIView> {
     error("CompositionLocal UIView not provided")
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/UIKitCompositionLocals.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/UIKitCompositionLocals.uikit.kt
@@ -17,7 +17,6 @@
 package androidx.compose.ui.uikit
 
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8546/Remove-Experimental-flag-from-LocalUIView

## Release Notes
### Migration Notes - iOS
- Remove experimental annotation from `LocalUIView`
