### PR TITLE
Track window info focused state

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/PlatformWindowContextTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/PlatformWindowContextTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.window.Dialog
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import platform.Foundation.NSNotificationCenter
+import platform.UIKit.UISceneDidActivateNotification
+import platform.UIKit.UISceneWillDeactivateNotification
+
+class PlatformWindowContextTest {
+    @Test
+    fun testSceneWindowFocusedWhenSceneActive() = runUIKitInstrumentedTest {
+        var isWindowFocused = false
+
+        setContent {
+            val windowInfo = LocalWindowInfo.current
+            isWindowFocused = windowInfo.isWindowFocused
+        }
+
+        assertTrue(isWindowFocused)
+
+        NSNotificationCenter.defaultCenter.postNotificationName(UISceneWillDeactivateNotification, appDelegate.window?.windowScene)
+        waitForIdle()
+
+        assertFalse(isWindowFocused)
+
+        NSNotificationCenter.defaultCenter.postNotificationName(UISceneDidActivateNotification, appDelegate.window?.windowScene)
+        waitForIdle()
+
+        assertTrue(isWindowFocused)
+    }
+
+    @Test
+    fun testDialogWindowFocusedWhenSceneActive() = runUIKitInstrumentedTest {
+        var isDialogWindowFocused = false
+
+        setContent {
+            Dialog({}) {
+                val windowInfo = LocalWindowInfo.current
+                isDialogWindowFocused = windowInfo.isWindowFocused
+            }
+        }
+
+        assertTrue(isDialogWindowFocused)
+
+        NSNotificationCenter.defaultCenter.postNotificationName(UISceneWillDeactivateNotification, appDelegate.window?.windowScene)
+        waitForIdle()
+
+        assertFalse(isDialogWindowFocused)
+
+        NSNotificationCenter.defaultCenter.postNotificationName(UISceneDidActivateNotification, appDelegate.window?.windowScene)
+        waitForIdle()
+
+        assertTrue(isDialogWindowFocused)
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.uikit.kt
@@ -18,45 +18,44 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.animation.withAnimationProgress
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.lerp
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.asCGPoint
-import androidx.compose.ui.unit.asCGRect
 import androidx.compose.ui.unit.asDpOffset
-import androidx.compose.ui.unit.asDpRect
 import androidx.compose.ui.unit.asDpSize
 import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.unit.toDpOffset
-import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.unit.toOffset
-import androidx.compose.ui.unit.toRect
 import androidx.compose.ui.unit.toSize
+import androidx.compose.ui.window.SceneActiveStateListener
 import kotlin.time.Duration
 import kotlinx.cinterop.useContents
 import platform.UIKit.UIView
+import platform.UIKit.UIWindow
 
 /**
  * Tracking a state of window.
  */
 internal class PlatformWindowContext {
-    private val _windowInfo = WindowInfoImpl().apply {
-        isWindowFocused = true
+    private val _windowInfo = WindowInfoImpl()
+
+    private val sceneFocusObserver = SceneActiveStateListener(getScene = { window?.windowScene }) {
+        _windowInfo.isWindowFocused = it
     }
 
     val windowInfo: WindowInfo get() = _windowInfo
 
     /**
-     * A container used for additional layers and as reference for window coordinate space.
+     * A window used to calculate the coordinate space and track the active state of the window
+     * scene.
      */
-    private var windowContainer: UIView? = null
-
-    fun setWindowContainer(windowContainer: UIView) {
-        this.windowContainer = windowContainer
-
-        updateWindowContainerSize()
-    }
+    var window: UIWindow? = null
+        set(value) {
+            field = value
+            _windowInfo.isWindowFocused = sceneFocusObserver.isSceneActive
+            updateWindowContainerSize()
+        }
 
     private var isAnimating = false
     fun prepareAndGetSizeTransitionAnimation(): suspend (Duration) -> Unit {
@@ -86,7 +85,7 @@ internal class PlatformWindowContext {
     }
 
     private val currentWindowContainerSize: Size? get() {
-        val windowContainer = windowContainer ?: return null
+        val windowContainer = window ?: return null
 
         return windowContainer.bounds.useContents {
             with(windowContainer.density) {
@@ -96,7 +95,7 @@ internal class PlatformWindowContext {
     }
 
     fun convertLocalToWindowPosition(container: UIView, localPosition: Offset): Offset {
-        val windowContainer = windowContainer ?: return localPosition
+        val windowContainer = window ?: return localPosition
         return convertPoint(
             point = localPosition,
             fromView = container,
@@ -105,7 +104,7 @@ internal class PlatformWindowContext {
     }
 
     fun convertWindowToLocalPosition(container: UIView, positionInWindow: Offset): Offset {
-        val windowContainer = windowContainer ?: return positionInWindow
+        val windowContainer = window ?: return positionInWindow
         return convertPoint(
             point = positionInWindow,
             fromView = windowContainer,
@@ -147,31 +146,6 @@ internal class PlatformWindowContext {
         }
     }
 
-    /**
-     * Converts the given [boundsInWindow] from the coordinate space of the container window to [toView] space.
-     */
-    fun convertWindowRect(boundsInWindow: Rect, toView: UIView): Rect {
-        val windowContainer = windowContainer ?: return boundsInWindow
-        return convertRect(
-            rect = boundsInWindow,
-            fromView = windowContainer,
-            toView = toView
-        )
-    }
-
-    private fun convertRect(rect: Rect, fromView: UIView, toView: UIView): Rect {
-        return if (fromView != toView) {
-            val density = fromView.density
-
-            fromView.convertRect(
-                rect = rect.toDpRect(density).asCGRect(),
-                toView = toView,
-            ).asDpRect().toRect(density)
-        } else {
-            rect
-        }
-    }
-
     private fun convertPoint(point: Offset, fromView: UIView, toView: UIView): Offset {
         return if (fromView != toView) {
             val density = fromView.density
@@ -184,5 +158,10 @@ internal class PlatformWindowContext {
         } else {
             point
         }
+    }
+
+    fun dispose() {
+        window = null
+        sceneFocusObserver.dispose()
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -206,12 +206,12 @@ internal class ComposeHostingViewController(
         navigationEventInput.onDidMoveToWindow(window, rootView)
         interfaceOrientationObserver.windowScene = window?.windowScene
 
-        val windowContainer = window ?: return
+        window ?: return
 
         updateInterfaceOrientationState()
 
         layersHolder?.layersViewController?.referenceWindow = view.window
-        windowContext.setWindowContainer(windowContainer)
+        windowContext.window = window
         updateMotionSpeed()
         lifecycleDelegate.windowScene = window.windowScene
     }
@@ -374,6 +374,8 @@ internal class ComposeHostingViewController(
         layersHolder = null
 
         interfaceOrientationObserver.isObservingEnabled = false
+
+        windowContext.dispose()
     }
 
     @OptIn(NativeRuntimeApi::class)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeLayersViewController.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeLayersViewController.kt
@@ -103,7 +103,7 @@ internal class ComposeLayersViewController(
         }
 
     private fun show() {
-        windowContext.setWindowContainer(window)
+        windowContext.window = window
         window.rootViewController = this
         window.windowLevel = UIWindowLevelAlert + 1
         window.setHidden(false)
@@ -130,6 +130,7 @@ internal class ComposeLayersViewController(
         hide()
         rootView.updateMetalView(metalView = null)
         referenceWindow = null
+        windowContext.dispose()
     }
 
     fun attach(layer: UIKitComposeSceneLayer) {

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SceneForegroundStateListener.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/SceneForegroundStateListener.uikit.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.window
 
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ObjCAction
 import platform.Foundation.NSNotification
 import platform.Foundation.NSNotificationCenter
@@ -57,6 +58,7 @@ internal class SceneForegroundStateListener(
         )
     }
 
+    @OptIn(BetaInteropApi::class)
     @ObjCAction
     fun sceneWillEnterForeground(notification: NSNotification) {
         if (notification.`object` == getScene()) {
@@ -64,6 +66,7 @@ internal class SceneForegroundStateListener(
         }
     }
 
+    @OptIn(BetaInteropApi::class)
     @ObjCAction
     fun sceneDidEnterBackground(notification: NSNotification) {
         if (notification.`object` == getScene()) {


### PR DESCRIPTION
Fixes: https://youtrack.jetbrains.com/issue/CMP-8382/LocalWindowInfo-doesnt-seem-to-detect-when-the-app-is-not-focused

## Release Notes
### Fixes - iOS
- Support updating of the `WindowInfo.isWindowFocused` property when the window's state changes
