### PR TITLE
Register mouse wheel listeners on the container rather than the compose content

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -32,7 +32,6 @@ import java.awt.FocusTraversalPolicy
 import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
-import java.awt.event.MouseWheelListener
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
 /**
@@ -190,13 +189,5 @@ internal class ComposeWindowPanel(
 
     override fun removeMouseMotionListener(listener: MouseMotionListener) {
         contentComponent.removeMouseMotionListener(listener)
-    }
-
-    override fun addMouseWheelListener(listener: MouseWheelListener) {
-        contentComponent.addMouseWheelListener(listener)
-    }
-
-    override fun removeMouseWheelListener(listener: MouseWheelListener) {
-        contentComponent.removeMouseWheelListener(listener)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -201,7 +201,7 @@ internal class ComposeSceneMediator(
                 // logic, it doesn't send mouse events to parents or another layers.
                 // In case if [component] is placed above [contentComponent] (see addToLayer),
                 // subscribe to mouse events from interop views to handle such input.
-                component.subscribeToMouseEvents(mouseListener, wheelEvents = false)
+                component.subscribeToMouseEvents(mouseListener)
             } else {
                 // Without interop blending, just add clip region to make proper
                 // "interop always on top" behaviour.
@@ -214,7 +214,7 @@ internal class ComposeSceneMediator(
             if (component !is SwingInteropViewGroup) return
 
             removeClipComponent(component)
-            component.unsubscribeFromMouseEvents(mouseListener, wheelEvents = false)
+            component.unsubscribeFromMouseEvents(mouseListener)
         }
 
         private fun addClipComponent(component: SwingInteropViewGroup) {
@@ -413,7 +413,7 @@ internal class ComposeSceneMediator(
             addInputMethodListener(inputMethodListener)
             addFocusListener(focusListener)
             addKeyListener(keyListener)
-            subscribeToMouseEvents(mouseListener, wheelEvents = false)
+            subscribeToMouseEvents(mouseListener)
         }
         // For mouse wheel events we subscribe on the container because otherwise we would not
         // receive mouse wheel events performed over an interop view (`SwingPanel`).
@@ -425,7 +425,7 @@ internal class ComposeSceneMediator(
             removeInputMethodListener(inputMethodListener)
             removeFocusListener(focusListener)
             removeKeyListener(keyListener)
-            unsubscribeFromMouseEvents(mouseListener, wheelEvents = false)
+            unsubscribeFromMouseEvents(mouseListener)
         }
         container.removeMouseWheelListener(mouseListener)
     }
@@ -956,26 +956,14 @@ private val MouseEvent.keyboardModifiers get() = PointerKeyboardModifiers(
     isNumLockOn = getLockingKeyStateSafe(KeyEvent.VK_NUM_LOCK),
 )
 
-private fun Component.subscribeToMouseEvents(
-    mouseAdapter: MouseAdapter,
-    wheelEvents: Boolean = true
-) {
+private fun Component.subscribeToMouseEvents(mouseAdapter: MouseAdapter) {
     addMouseListener(mouseAdapter)
     addMouseMotionListener(mouseAdapter)
-    if (wheelEvents) {
-        addMouseWheelListener(mouseAdapter)
-    }
 }
 
-private fun Component.unsubscribeFromMouseEvents(
-    mouseAdapter: MouseAdapter,
-    wheelEvents: Boolean = true
-) {
+private fun Component.unsubscribeFromMouseEvents(mouseAdapter: MouseAdapter) {
     removeMouseListener(mouseAdapter)
     removeMouseMotionListener(mouseAdapter)
-    if (wheelEvents) {
-        removeMouseWheelListener(mouseAdapter)
-    }
 }
 
 private fun getLockingKeyStateSafe(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -201,7 +201,7 @@ internal class ComposeSceneMediator(
                 // logic, it doesn't send mouse events to parents or another layers.
                 // In case if [component] is placed above [contentComponent] (see addToLayer),
                 // subscribe to mouse events from interop views to handle such input.
-                component.subscribeToMouseEvents(mouseListener)
+                component.subscribeToMouseEvents(mouseListener, wheelEvents = false)
             } else {
                 // Without interop blending, just add clip region to make proper
                 // "interop always on top" behaviour.
@@ -214,7 +214,7 @@ internal class ComposeSceneMediator(
             if (component !is SwingInteropViewGroup) return
 
             removeClipComponent(component)
-            component.unsubscribeFromMouseEvents(mouseListener)
+            component.unsubscribeFromMouseEvents(mouseListener, wheelEvents = false)
         }
 
         private fun addClipComponent(component: SwingInteropViewGroup) {
@@ -413,8 +413,11 @@ internal class ComposeSceneMediator(
             addInputMethodListener(inputMethodListener)
             addFocusListener(focusListener)
             addKeyListener(keyListener)
-            subscribeToMouseEvents(mouseListener)
+            subscribeToMouseEvents(mouseListener, wheelEvents = false)
         }
+        // For mouse wheel events we subscribe on the container because otherwise we would not
+        // receive mouse wheel events performed over an interop view (`SwingPanel`).
+        container.addMouseWheelListener(mouseListener)
     }
 
     private fun unsubscribeFromInputEvents() {
@@ -422,8 +425,9 @@ internal class ComposeSceneMediator(
             removeInputMethodListener(inputMethodListener)
             removeFocusListener(focusListener)
             removeKeyListener(keyListener)
-            unsubscribeFromMouseEvents(mouseListener)
+            unsubscribeFromMouseEvents(mouseListener, wheelEvents = false)
         }
+        container.removeMouseWheelListener(mouseListener)
     }
 
     private var isMouseEventProcessing = false
@@ -952,16 +956,26 @@ private val MouseEvent.keyboardModifiers get() = PointerKeyboardModifiers(
     isNumLockOn = getLockingKeyStateSafe(KeyEvent.VK_NUM_LOCK),
 )
 
-private fun Component.subscribeToMouseEvents(mouseAdapter: MouseAdapter) {
+private fun Component.subscribeToMouseEvents(
+    mouseAdapter: MouseAdapter,
+    wheelEvents: Boolean = true
+) {
     addMouseListener(mouseAdapter)
     addMouseMotionListener(mouseAdapter)
-    addMouseWheelListener(mouseAdapter)
+    if (wheelEvents) {
+        addMouseWheelListener(mouseAdapter)
+    }
 }
 
-private fun Component.unsubscribeFromMouseEvents(mouseAdapter: MouseAdapter) {
+private fun Component.unsubscribeFromMouseEvents(
+    mouseAdapter: MouseAdapter,
+    wheelEvents: Boolean = true
+) {
     removeMouseListener(mouseAdapter)
     removeMouseMotionListener(mouseAdapter)
-    removeMouseWheelListener(mouseAdapter)
+    if (wheelEvents) {
+        removeMouseWheelListener(mouseAdapter)
+    }
 }
 
 private fun getLockingKeyStateSafe(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
@@ -16,9 +16,16 @@
 
 package androidx.compose.ui.awt
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.LayoutBoundsHolder
 import androidx.compose.ui.layout.layoutBounds
 import androidx.compose.ui.platform.LocalDensity
@@ -27,20 +34,25 @@ import androidx.compose.ui.sendMousePress
 import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.sendMouseWheelEvent
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.runApplicationTest
+import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.Point
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
+import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class SwingPanelTest {
     /**
@@ -162,5 +174,40 @@ class SwingPanelTest {
         panel.invalidate()
         awaitIdle()
         assertPanelSizeIsItsPreferredSize()
+    }
+
+    @Test
+    fun swingPanelPropagatesMouseWheelEvents() = runApplicationTest {
+        val scrollState = ScrollState(0)
+        launchTestWindowApplication(
+            state = WindowState(size = DpSize(500.dp, 500.dp))
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+            ) {
+                Box(Modifier.fillMaxWidth().height(2000.dp)) {
+                    SwingPanel(
+                        background = Color.Red,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(400.dp),
+                        factory = {
+                            JPanel(BorderLayout()).also {
+                                it.add(JLabel("Swing content"))
+                            }
+                        },
+                    )
+                }
+            }
+        }
+        awaitIdle()
+
+        assertEquals(scrollState.value, 0)
+        window.sendMouseWheelEvent(x = 200, y = 200, wheelRotation = 50.0)
+        awaitIdle()
+        println(scrollState.value)
+        assertTrue(scrollState.value > 0, "Compose did not scroll; SwingPanel blocked the event")
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/SwingPanelTest.kt
@@ -207,7 +207,6 @@ class SwingPanelTest {
         assertEquals(scrollState.value, 0)
         window.sendMouseWheelEvent(x = 200, y = 200, wheelRotation = 50.0)
         awaitIdle()
-        println(scrollState.value)
         assertTrue(scrollState.value > 0, "Compose did not scroll; SwingPanel blocked the event")
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowInputEventTest.kt
@@ -31,11 +31,14 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
@@ -45,7 +48,6 @@ import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
-import java.awt.Toolkit
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
 import java.awt.event.MouseEvent.BUTTON1
@@ -54,9 +56,9 @@ import java.awt.event.MouseEvent.BUTTON3_DOWN_MASK
 import java.awt.event.MouseEvent.CTRL_DOWN_MASK
 import java.awt.event.MouseEvent.MOUSE_DRAGGED
 import java.awt.event.MouseEvent.MOUSE_PRESSED
-import java.awt.event.MouseEvent.MOUSE_RELEASED
 import java.awt.event.MouseEvent.SHIFT_DOWN_MASK
 import java.awt.event.MouseWheelEvent.WHEEL_UNIT_SCROLL
+import kotlin.test.assertTrue
 import org.jetbrains.skiko.hostOs
 import org.junit.Test
 
@@ -532,23 +534,16 @@ class WindowInputEventTest {
 
         awaitIdle()
         assertThat(receivedButtons.size).isEqualTo(1)
-        assertThat(receivedButtons.last()).isEqualTo(
-            PointerButtons(
-                // on macOS ctrl + primary click is treated as secondary click
-                isPrimaryPressed = !hostOs.isMacOS,
-                isSecondaryPressed = true,
-            )
-        )
+        receivedButtons.last().let { buttons ->
+            // on macOS ctrl + primary click is treated as secondary
+            assertThat(buttons.isPrimaryPressed).isEqualTo(!hostOs.isMacOS)
+            assertTrue(buttons.isSecondaryPressed)
+        }
         assertThat(receivedKeyboardModifiers.size).isEqualTo(1)
-        assertThat(receivedKeyboardModifiers.last()).isEqualTo(
-            PointerKeyboardModifiers(
-                isCtrlPressed = true,
-                isShiftPressed = true,
-                isCapsLockOn = getLockingKeyStateSafe(KeyEvent.VK_CAPS_LOCK),
-                isScrollLockOn = getLockingKeyStateSafe(KeyEvent.VK_SCROLL_LOCK),
-                isNumLockOn = getLockingKeyStateSafe(KeyEvent.VK_NUM_LOCK),
-            )
-        )
+        receivedKeyboardModifiers.last().let { modifiers ->
+            assertTrue(modifiers.isCtrlPressed)
+            assertTrue(modifiers.isShiftPressed)
+        }
 
         window.sendMouseWheelEvent(
             100, 50, WHEEL_UNIT_SCROLL,
@@ -559,23 +554,16 @@ class WindowInputEventTest {
 
         awaitIdle()
         assertThat(receivedButtons.size).isEqualTo(2)
-        assertThat(receivedButtons.last()).isEqualTo(
-            PointerButtons(
-                // on macOS ctrl + primary click is treated as secondary click
-                isPrimaryPressed = !hostOs.isMacOS,
-                isSecondaryPressed = true,
-            )
-        )
+        receivedButtons.last().let { buttons ->
+            // on macOS ctrl + primary click is treated as secondary
+            assertThat(buttons.isPrimaryPressed).isEqualTo(!hostOs.isMacOS)
+            assertTrue(buttons.isSecondaryPressed)
+        }
         assertThat(receivedKeyboardModifiers.size).isEqualTo(2)
-        assertThat(receivedKeyboardModifiers.last()).isEqualTo(
-            PointerKeyboardModifiers(
-                isCtrlPressed = true,
-                isShiftPressed = true,
-                isCapsLockOn = getLockingKeyStateSafe(KeyEvent.VK_CAPS_LOCK),
-                isScrollLockOn = getLockingKeyStateSafe(KeyEvent.VK_SCROLL_LOCK),
-                isNumLockOn = getLockingKeyStateSafe(KeyEvent.VK_NUM_LOCK),
-            )
-        )
+        receivedKeyboardModifiers.last().let { modifiers ->
+            assertTrue(modifiers.isCtrlPressed)
+            assertTrue(modifiers.isShiftPressed)
+        }
     }
 
     @Test
@@ -654,42 +642,6 @@ class WindowInputEventTest {
         assertThat(box2ReleaseCount).isEqualTo(0)
 
         window.dispose()
-    }
-
-    private fun getLockingKeyStateSafe(
-        mask: Int
-    ): Boolean = try {
-        Toolkit.getDefaultToolkit().getLockingKeyState(mask)
-    } catch (_: Exception) {
-        false
-    }
-
-    /**
-     * Handle only the first received event and drop all the others that are received
-     * in a single frame
-     */
-    private fun Modifier.onFirstPointerEvent(
-        eventType: PointerEventType,
-        onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
-    ) = pointerInput(eventType, onEvent) {
-        while (true) {
-            awaitPointerEventScope {
-                val event = awaitEvent(eventType)
-                onEvent(event)
-            }
-        }
-    }
-
-    private suspend fun AwaitPointerEventScope.awaitEvent(
-        eventType: PointerEventType
-    ): PointerEvent {
-        var event: PointerEvent
-        do {
-            event = awaitPointerEvent()
-        } while (
-            event.type != eventType
-        )
-        return event
     }
 
     private val PointerEvent.pressed get() = changes.first().pressed


### PR DESCRIPTION
The container is the common parent of the compose content (skia layer) and the interop views. This is needed to receive them even when they occur over an interop view.

Fixes https://youtrack.jetbrains.com/issue/CMP-1062/SwingPanel-breaks-vertical-scrolling

In `WindowInputEventTest.receive buttons and modifiers` I changed the check from exactly matching the keyboard modifiers to verifying that the expected modifiers are on. Because of a [problem in AWT](https://youtrack.jetbrains.com/issue/JBR-9532).

## Testing
Tested manually and added a unit tests.
```
fun main() = singleWindowApplication {
    val scrollState = rememberScrollState()
    Box(
        modifier = Modifier
            .fillMaxSize()
            .verticalScroll(scrollState)
    ) {
        Row(Modifier.fillMaxSize().height(2000.dp)) {
            SwingPanel(
                background = Color.Red,
                modifier = Modifier
                    .weight(1f)
                    .height(400.dp),
                factory = {
                    JPanel(BorderLayout()).also {
                        it.add(JLabel("Swing content"))
                    }
                },
            )
            Box(
                Modifier.weight(1f).height(400.dp).background(Color.Blue),
                contentAlignment = Alignment.Center
            ) {
                Text("Compose content")
            }
            VerticalScrollbar(
                modifier = Modifier.fillMaxHeight(),
                adapter = rememberScrollbarAdapter(scrollState)
            )
        }
    }
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix `SwingPanel` blocking mouse wheel scroll events from going to its parent.
