### PR TITLE
Provide DP-based window size in `WindowInfo`

### DIFF
--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -39,7 +39,9 @@ import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toSize
 import androidx.lifecycle.Lifecycle
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -475,9 +477,11 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         override val isWindowFocused: Boolean
             get() = true
 
-        @ExperimentalComposeUiApi
         override val containerSize: IntSize
             get() = size
+
+        override val containerDpSize: DpSize
+            get() = with(density) { size.toSize().toDpSize() }
     }
 
     private inner class TestDragAndDropManager : PlatformDragAndDropManager {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/AwtDragAndDropManager.desktop.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.scene.ComposeSceneDragAndDropNode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.window.asDpOffset
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.layoutDirectionFor
 import java.awt.Image
@@ -86,16 +88,7 @@ internal class AwtDragAndDropManager(
     private val density: Density
         get() = rootContainer.density
 
-    private val scale: Float
-        get() = density.density
-
-    private fun Point.toOffset(): Offset {
-        val scale = this@AwtDragAndDropManager.scale
-        return Offset(
-            x = x * scale,
-            y = y * scale
-        )
-    }
+    private fun Point.toOffset() = asDpOffset().toOffset(density)
 
     override val isRequestDragAndDropTransferRequired: Boolean
         get() = true

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -66,11 +66,9 @@ internal class PlatformWindowContext {
         _windowContainer = windowContainer
     }
 
-    fun setContainerSize(size: Size) {
-        _windowInfo.containerSize = IntSize(
-            width = size.width.roundToInt(),
-            height = size.height.roundToInt()
-        )
+    fun setContainerSizeFromComponent(component: Component) {
+        _windowInfo.containerSize = component.sizeInPx.roundToIntSize()
+        _windowInfo.containerDpSize = component.size.asDpSize()
     }
 
     fun convertLocalToWindowPosition(container: Component, localPosition: Offset) =

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.desktop.kt
@@ -24,8 +24,14 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.roundToIntSize
+import androidx.compose.ui.unit.toIntSize
+import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.asDpOffset
+import androidx.compose.ui.window.asDpSize
 import androidx.compose.ui.window.density
+import androidx.compose.ui.window.sizeInPx
 import java.awt.Component
 import java.awt.Container
 import java.awt.Frame
@@ -68,10 +74,10 @@ internal class PlatformWindowContext {
     }
 
     fun convertLocalToWindowPosition(container: Component, localPosition: Offset) =
-        localPosition + offsetInWindow(container).toOffset(container.density)
+        localPosition + offsetInWindow(container).asDpOffset().toOffset(container.density)
 
     fun convertWindowToLocalPosition(container: Component, positionInWindow: Offset) =
-        positionInWindow - offsetInWindow(container).toOffset(container.density)
+        positionInWindow - offsetInWindow(container).asDpOffset().toOffset(container.density)
 
     /**
      * If the [component]'s location on screen is undefined, returns [Offset.Unspecified]; otherwise
@@ -86,7 +92,7 @@ internal class PlatformWindowContext {
         val frame = SwingUtilities.getWindowAncestor(component) as? Frame
         if ((frame != null) && (frame.state == Frame.ICONIFIED)) return Offset.Unspecified
 
-        return block(component.locationOnScreen.toOffset(component.density))
+        return block(component.locationOnScreen.asDpOffset().toOffset(component.density))
     }
 
     fun convertLocalToScreenPosition(container: Component, localPosition: Offset): Offset {
@@ -115,12 +121,4 @@ internal class PlatformWindowContext {
             Point(0, 0)
         }
     }
-}
-
-internal fun Point.toOffset(density: Density): Offset {
-    val scale = density.density
-    return Offset(
-        x = x * scale,
-        y = y * scale
-    )
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -37,7 +37,8 @@ import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.window.asDpOffset
 import java.awt.Color
 import java.awt.Cursor
 import java.awt.Dimension
@@ -213,9 +214,8 @@ internal class ComposeAccessible(
             return bar
         }
 
-        private fun Point.toComposeOffset() = with(density) {
-            Offset(x.dp.toPx(), y.dp.toPx())
-        }
+        private fun Point.toComposeOffset() =
+            asDpOffset().toOffset(density)
 
         private fun Dp.toAwtPx() =
             if (value.isInfinite()) Constraints.Infinity else value.roundToInt()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -46,7 +46,6 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.WindowExceptionHandler
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.layoutDirectionFor
-import androidx.compose.ui.window.sizeInPx
 import androidx.lifecycle.Lifecycle.State
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -288,7 +287,7 @@ internal class ComposeContainer(
     private fun onWindowContainerSizeChanged() {
         if (!container.isDisplayable) return
 
-        windowContext.setContainerSize(windowContainer.sizeInPx)
+        windowContext.setContainerSizeFromComponent(windowContainer)
         mediator.onContainerSizeChanged()
         layers.fastForEach(DesktopComposeSceneLayer::onWindowContainerSizeChanged)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -65,8 +65,10 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.viewinterop.SwingInteropContainer
 import androidx.compose.ui.window.WindowExceptionHandler
+import androidx.compose.ui.window.asDpOffset
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.sizeInPx
 import java.awt.Component
@@ -446,8 +448,7 @@ internal class ComposeSceneMediator(
         get() {
             val pointInContainer = SwingUtilities.convertPoint(component, point, container)
             val offset = sceneBoundsInPx?.topLeft ?: Offset.Zero
-            val density = contentComponent.density
-            return Offset(pointInContainer.x.toFloat(), pointInContainer.y.toFloat()) * density.density - offset
+            return pointInContainer.asDpOffset().toOffset(contentComponent.density) - offset
         }
 
     private fun onMouseEvent(event: MouseEvent): Unit = catchExceptions {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -60,7 +60,7 @@ internal class WindowComposeSceneLayer(
 
     private val windowContext = PlatformWindowContext().also {
         it.isWindowTransparent = true
-        it.setContainerSize(windowContainer.sizeInPx)
+        it.setContainerSizeFromComponent(windowContainer)
     }
 
     private val layerWindow = JDialog(parentWindow).also {
@@ -161,7 +161,7 @@ internal class WindowComposeSceneLayer(
     }
 
     override fun onWindowContainerSizeChanged() {
-        windowContext.setContainerSize(windowContainer.sizeInPx)
+        windowContext.setContainerSizeFromComponent(windowContainer)
 
         // Update compose constrains based on main window size
         mediator?.sceneBoundsInPx = Rect(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Geometry.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Geometry.desktop.kt
@@ -16,6 +16,10 @@
 
 package androidx.compose.ui.window
 
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
 import java.awt.Dimension
 import java.awt.Point
 import java.awt.Rectangle
@@ -26,3 +30,12 @@ internal operator fun Point.minus(other: Point) = Point(x - other.x, y - other.y
 
 internal val Rectangle.leftTop get() = Point(x, y)
 internal val Rectangle.rightBottom get() = Point(x + width, y + height)
+
+internal fun Dimension.asDpSize() = DpSize(width.dp, height.dp)
+internal fun Point.asDpOffset() = DpOffset(x.dp, y.dp)
+internal fun Rectangle.asDpRect() = DpRect(
+    left = x.dp,
+    top = y.dp,
+    right = x.dp + width.dp,
+    bottom = y.dp + height.dp
+)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/LayoutConfiguration.desktop.kt
@@ -16,17 +16,15 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.toSize
 import java.awt.Component
 import java.awt.ComponentOrientation
 import java.awt.GraphicsConfiguration
 import java.awt.GraphicsEnvironment
-import java.util.Locale
+import java.util.*
 
 // TODO(demin): detect OS fontScale
 //  font size can be changed on Windows 10 in Settings - Ease of Access,
@@ -45,13 +43,7 @@ internal val GlobalDensity get() = GraphicsEnvironment.getLocalGraphicsEnvironme
 internal val Component.density: Density get() = graphicsConfiguration.density
 
 internal val Component.sizeInPx: Size
-    get() {
-        val scale = density.density
-        return Size(
-            width = width * scale,
-            height = height * scale
-        )
-    }
+    get() = size.asDpSize().toSize(density)
 
 private val GraphicsConfiguration.density: Density get() = Density(
     defaultTransform.scaleX.toFloat(),

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/DesktopWindowInfoTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/DesktopWindowInfoTest.kt
@@ -16,35 +16,96 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.scene.BaseComposeScene
-import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
+import com.google.common.truth.Truth.assertThat
+import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DesktopWindowInfoTest {
 
     @Test
-    fun windowContainerSize() = runApplicationTest {
+    fun windowInfoIsFocused() = runApplicationTest {
+        lateinit var window1: ComposeWindow
+        lateinit var window2: ComposeWindow
+        lateinit var window1Info: WindowInfo
+        lateinit var window2Info: WindowInfo
+
         launchTestApplication {
-            val state = rememberWindowState(
-                size = DpSize(123.dp, 321.dp)
-            )
-            Window(onCloseRequest = {}, state = state) {
-                val containerSize = window.windowContext.windowInfo.containerSize
-                assertEquals(123, containerSize.width)
-                assertEquals(321, containerSize.height)
+            Window(onCloseRequest = ::exitApplication) {
+                window1 = window
+                window1Info = LocalWindowInfo.current
+            }
+
+            Window(onCloseRequest = ::exitApplication) {
+                window2 = window
+                window2Info = LocalWindowInfo.current
             }
         }
+
+        awaitIdle()
+        assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
+        assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
+
+        window1.requestFocus()
+        awaitIdle()
+        assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
+        assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
+
+        window2.requestFocus()
+        awaitIdle()
+        assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
+        assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
+    }
+
+    @Test
+    fun windowInfoContainerSizeIsSet() = runApplicationTest {
+        lateinit var windowInfo: WindowInfo
+        launchTestWindowApplication {
+            windowInfo = LocalWindowInfo.current
+        }
+        awaitIdle()
+
+        val containerSize = windowInfo.containerSize
+        assertThat(containerSize.width).isGreaterThan(0)
+        assertThat(containerSize.height).isGreaterThan(0)
+
+        val containerDpSize = windowInfo.containerDpSize
+        assertThat(containerDpSize.width).isGreaterThan(0.dp)
+        assertThat(containerDpSize.height).isGreaterThan(0.dp)
+    }
+
+    @Test
+    fun windowInfoContainerSize() = runApplicationTest {
+        lateinit var windowInfo: WindowInfo
+        lateinit var density: Density
+        launchTestApplication {
+            val state = rememberWindowState(
+                size = DpSize(234.dp, 432.dp)
+            )
+            Window(
+                onCloseRequest = {},
+                undecorated = true, // To match the size without a title bar.
+                state = state
+            ) {
+                windowInfo = LocalWindowInfo.current
+                density = LocalDensity.current
+            }
+        }
+        awaitIdle()
+
+        val containerSize = windowInfo.containerSize
+        assertEquals(with(density) { 234.dp.toPx() }.roundToInt(), containerSize.width)
+        assertEquals(with(density) { 432.dp.toPx() }.roundToInt(), containerSize.height)
+
+        val containerDpSize = windowInfo.containerDpSize
+        assertEquals(234.dp, containerDpSize.width)
+        assertEquals(432.dp, containerDpSize.height)
     }
 }
-
-private val ComposeScene.windowInfo: WindowInfo
-    get() {
-        this as BaseComposeScene
-        return composeSceneContext.platformContext.windowInfo
-    }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -29,8 +29,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.isLinux
 import androidx.compose.ui.isMacOs
-import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.toDpSize
@@ -803,57 +801,6 @@ class WindowStateTest {
         sendChannel.send(2)
         awaitIdle()
         assertThat(receivedNumbers).isEqualTo(listOf(1, 2))
-    }
-
-    @Test
-    fun `WindowInfo isFocused`() = runApplicationTest {
-        lateinit var window1: ComposeWindow
-        lateinit var window2: ComposeWindow
-        lateinit var window1Info: WindowInfo
-        lateinit var window2Info: WindowInfo
-
-        launchTestApplication {
-            Window(onCloseRequest = ::exitApplication) {
-                window1 = window
-                window1Info = LocalWindowInfo.current
-            }
-
-            Window(onCloseRequest = ::exitApplication) {
-                window2 = window
-                window2Info = LocalWindowInfo.current
-            }
-        }
-
-        awaitIdle()
-        assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
-        assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
-
-        window1.requestFocus()
-        awaitIdle()
-        assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
-        assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
-
-        window2.requestFocus()
-        awaitIdle()
-        assertThat(window1.isFocused).isEqualTo(window1Info.isWindowFocused)
-        assertThat(window2.isFocused).isEqualTo(window2Info.isWindowFocused)
-    }
-
-    @Test
-    fun windowContainerSizeIsSet() = runApplicationTest {
-        lateinit var windowInfo: WindowInfo
-        launchTestWindowApplication {
-            windowInfo = LocalWindowInfo.current
-        }
-        awaitIdle()
-
-        val containerSize = windowInfo.containerSize
-        assertThat(containerSize.width).isGreaterThan(0)
-        assertThat(containerSize.height).isGreaterThan(0)
-
-        val containerDpSize = windowInfo.containerDpSize
-        assertThat(containerDpSize.width).isGreaterThan(0.dp)
-        assertThat(containerDpSize.height).isGreaterThan(0.dp)
     }
 
     @Test

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowStateTest.kt
@@ -840,6 +840,23 @@ class WindowStateTest {
     }
 
     @Test
+    fun windowContainerSizeIsSet() = runApplicationTest {
+        lateinit var windowInfo: WindowInfo
+        launchTestWindowApplication {
+            windowInfo = LocalWindowInfo.current
+        }
+        awaitIdle()
+
+        val containerSize = windowInfo.containerSize
+        assertThat(containerSize.width).isGreaterThan(0)
+        assertThat(containerSize.height).isGreaterThan(0)
+
+        val containerDpSize = windowInfo.containerDpSize
+        assertThat(containerDpSize.width).isGreaterThan(0.dp)
+        assertThat(containerDpSize.height).isGreaterThan(0.dp)
+    }
+
+    @Test
     fun `start invisible undecorated window`() = runApplicationTest {
         val receivedNumbers = mutableListOf<Int>()
 

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/window/ComposeWindow.macos.kt
@@ -37,7 +37,9 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpSize
 import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.unit.toSize
 import androidx.lifecycle.Lifecycle
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
@@ -113,6 +115,7 @@ private class ComposeWindow(
         override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
             val sizeInPx = IntSize(width, height)
             _windowInfo.containerSize = sizeInPx
+            _windowInfo.containerDpSize = sizeInPx.toSize().toDpSize(scene.density)
             scene.size = sizeInPx // TODO: Move it out from onRender to avoid extra invalidation
             scene.render(canvas.asComposeCanvas(), nanoTime)
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpSize
+import androidx.compose.ui.unit.toSize
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmName
 import kotlin.time.Duration
@@ -153,6 +155,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     private val _windowInfo = WindowInfoImpl().apply {
         isWindowFocused = true
         containerSize = imageSize
+        containerDpSize = imageSize.toSize().toDpSize(density)
     }
 
     private val _platformContext = object : PlatformContext by PlatformContext.Empty,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/unit/Density.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/unit/Density.skiko.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("NOTHING_TO_INLINE")
+
 package androidx.compose.ui.unit
 
 import androidx.compose.runtime.Stable
@@ -47,31 +49,33 @@ internal fun DpOffset.toOffset(density: Density): Offset = with(density) {
 }
 
 /**
- * Convert a [Rect] to a [DpRect].
+ * Converts a [Rect] to a [DpRect].
  */
 @Stable
-internal fun Rect.toDpRect(density: Density): DpRect = with(density) {
+internal inline fun Rect.toDpRect(density: Density): DpRect = with(density) {
     DpRect(
         origin = topLeft.toDpOffset(density),
         size = size.toDpSize()
     )
 }
 
-/**
- * Convert a [DpRect] to a [Rect].
- */
+/** Convert a [DpRect] to a [Rect]. */
+// Preventing more copies, keep for discoverability
 @Stable
-internal fun DpRect.toRect(density: Density): Rect = with(density) {
-    Rect(
-        offset = DpOffset(left, top).toOffset(density),
-        size = size.toSize()
-    )
+internal inline fun DpRect.toRect(density: Density): Rect = with(density) {
+    toRect()
 }
 
-/**
- * Convert a [Size] to a [DpSize]
- */
+/** Convert a [Size] to a [DpSize]. */
+// Preventing more copies, keep for discoverability
 @Stable
-internal fun Size.toDpSize(density: Density): DpSize = with(density) {
-    DpSize(width.toDp(), height.toDp())
+internal inline fun Size.toDpSize(density: Density): DpSize = with(density) {
+   toDpSize()
+}
+
+/** Convert a [DpSize] to a [Size]. */
+// Preventing more copies, keep for discoverability
+@Stable
+internal inline fun DpSize.toSize(density: Density): Size = with(density) {
+   toSize()
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,16 +35,21 @@ class WindowInfoTest {
 
     @Test
     fun windowContainerSize() = runSkikoComposeUiTest(
-        size = Size(123f, 321f)
+        size = Size(234f, 432f),
+        density = Density(2f),
     ) {
         setContent {
             Box(Modifier.fillMaxSize().testTag("box"))
 
             val containerSize = LocalWindowInfo.current.containerSize
-            assertEquals(123, containerSize.width)
-            assertEquals(321, containerSize.height)
+            assertEquals(234, containerSize.width)
+            assertEquals(432, containerSize.height)
+
+            val containerDpSize = LocalWindowInfo.current.containerDpSize
+            assertEquals(117.dp, containerDpSize.width)
+            assertEquals(216.dp, containerDpSize.height)
         }
-        onNodeWithTag("box").assertWidthIsEqualTo(123.dp)
-        onNodeWithTag("box").assertHeightIsEqualTo(321.dp)
+        onNodeWithTag("box").assertWidthIsEqualTo(117.dp)
+        onNodeWithTag("box").assertHeightIsEqualTo(216.dp)
     }
 }

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/WindowInfoTest.kt
@@ -34,21 +34,24 @@ import kotlin.test.assertEquals
 class WindowInfoTest {
 
     @Test
-    fun windowContainerSize() = runSkikoComposeUiTest(
+    fun windowInfoContainerSize() = runSkikoComposeUiTest(
         size = Size(234f, 432f),
         density = Density(2f),
     ) {
+        lateinit var windowInfo: WindowInfo
         setContent {
             Box(Modifier.fillMaxSize().testTag("box"))
-
-            val containerSize = LocalWindowInfo.current.containerSize
-            assertEquals(234, containerSize.width)
-            assertEquals(432, containerSize.height)
-
-            val containerDpSize = LocalWindowInfo.current.containerDpSize
-            assertEquals(117.dp, containerDpSize.width)
-            assertEquals(216.dp, containerDpSize.height)
+            windowInfo = LocalWindowInfo.current
         }
+
+        val containerSize = windowInfo.containerSize
+        assertEquals(234, containerSize.width)
+        assertEquals(432, containerSize.height)
+
+        val containerDpSize = windowInfo.containerDpSize
+        assertEquals(117.dp, containerDpSize.width)
+        assertEquals(216.dp, containerDpSize.height)
+
         onNodeWithTag("box").assertWidthIsEqualTo(117.dp)
         onNodeWithTag("box").assertHeightIsEqualTo(216.dp)
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/PlatformWindowContextTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/PlatformWindowContextTest.kt
@@ -17,8 +17,10 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import platform.Foundation.NSNotificationCenter
@@ -70,5 +72,21 @@ class PlatformWindowContextTest {
         waitForIdle()
 
         assertTrue(isDialogWindowFocused)
+    }
+
+    @Test
+    fun testWindowContainerSizeIsSet() = runUIKitInstrumentedTest {
+        lateinit var windowInfo: WindowInfo
+        setContent {
+            windowInfo = LocalWindowInfo.current
+        }
+
+        val containerSize = windowInfo.containerSize
+        assertTrue(containerSize.width > 0)
+        assertTrue(containerSize.height > 0)
+
+        val containerDpSize = windowInfo.containerDpSize
+        assertTrue(containerDpSize.width > 0.dp)
+        assertTrue(containerDpSize.height > 0.dp)
     }
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformWindowContext.uikit.kt
@@ -18,13 +18,14 @@ package androidx.compose.ui.platform
 
 import androidx.compose.ui.animation.withAnimationProgress
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.lerp
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.asCGPoint
 import androidx.compose.ui.unit.asDpOffset
-import androidx.compose.ui.unit.asDpSize
+import androidx.compose.ui.unit.asDpRect
+import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.unit.roundToIntSize
+import androidx.compose.ui.unit.size
 import androidx.compose.ui.unit.toDpOffset
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.toSize
@@ -60,15 +61,27 @@ internal class PlatformWindowContext {
     private var isAnimating = false
     fun prepareAndGetSizeTransitionAnimation(): suspend (Duration) -> Unit {
         isAnimating = true
-        val initialSize = _windowInfo.containerSize.toSize()
+        val initialSize = _windowInfo.containerSize
+        val initialDpSize = _windowInfo.containerDpSize
 
-        return { duration ->
+        return Animation@ { duration ->
             try {
-                if (initialSize != currentWindowContainerSize) {
-                    withAnimationProgress(duration) { progress ->
-                        val size = currentWindowContainerSize ?: initialSize
-                        _windowInfo.containerSize =
-                            lerp(initialSize, size, progress).roundToIntSize()
+                val windowContainer = window ?: return@Animation
+                val size = windowContainer.bounds.asDpRect().size
+                val sizeInPx = size.toSize(windowContainer.density).roundToIntSize()
+                if (initialSize == sizeInPx) {
+                    return@Animation
+                }
+                withAnimationProgress(duration) { progress ->
+                    val windowContainer = window
+                    if (windowContainer != null) {
+                        val currentSize = windowContainer.bounds.asDpRect().size
+                        val currentSizeInPx = size.toSize(windowContainer.density).roundToIntSize()
+                        _windowInfo.containerSize = lerp(initialSize.toSize(), currentSizeInPx.toSize(), progress).roundToIntSize()
+                        _windowInfo.containerDpSize = lerp(initialDpSize, currentSize, progress)
+                    } else {
+                        _windowInfo.containerSize = initialSize
+                        _windowInfo.containerDpSize = initialDpSize
                     }
                 }
             } finally {
@@ -81,17 +94,11 @@ internal class PlatformWindowContext {
     fun updateWindowContainerSize() {
         if (isAnimating) return
 
-        _windowInfo.containerSize = currentWindowContainerSize?.roundToIntSize() ?: return
-    }
-
-    private val currentWindowContainerSize: Size? get() {
-        val windowContainer = window ?: return null
-
-        return windowContainer.bounds.useContents {
-            with(windowContainer.density) {
-                size.asDpSize().toSize()
-            }
-        }
+        val windowContainer = window ?: return
+        val size = windowContainer.bounds.asDpRect().size
+        val sizeInPx = size.toSize(windowContainer.density).roundToIntSize()
+        _windowInfo.containerSize = sizeInPx
+        _windowInfo.containerDpSize = size
     }
 
     fun convertLocalToWindowPosition(container: UIView, localPosition: Offset): Offset {

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -58,10 +58,13 @@ import androidx.compose.ui.scene.ComposeScenePointer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.size
 import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toIntSize
+import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.viewinterop.InteropViewGroup
 import androidx.compose.ui.viewinterop.LocalInteropContainer
@@ -429,7 +432,9 @@ internal class ComposeWindow(
 
                     rememberCoroutineScope().launch {
                         state.sizeFlow().collect { size ->
-                            this@ComposeWindow.resize(size)
+                            // Convert to proper type: IntSize was exposed to public API with meaning of DPs.
+                            val boxSize = DpSize(size.width.dp, size.height.dp)
+                            this@ComposeWindow.resize(boxSize)
                         }
                     }
                 }
@@ -442,26 +447,23 @@ internal class ComposeWindow(
         )
     }
 
-    fun resize(boxSize: IntSize) {
-        val scale = density.density
+    private fun resize(boxSize: DpSize) {
+        val sizeInPx = boxSize.toSize(density).toIntSize()
 
-        val width = (boxSize.width * scale).toInt()
-        val height = (boxSize.height * scale).toInt()
-
-        canvas.width = width
-        canvas.height = height
+        canvas.width = sizeInPx.width
+        canvas.height = sizeInPx.height
 
         // Scale canvas to allow high DPI rendering as suggested in
         // https://www.khronos.org/webgl/wiki/HandlingHighDPI.
-        canvas.style.width = "${boxSize.width}px"
-        canvas.style.height = "${boxSize.height}px"
+        canvas.style.width = "${boxSize.width.value}px"
+        canvas.style.height = "${boxSize.height.value}px"
 
-        val containerSize = IntSize(width, height)
-        _windowInfo.containerSize = containerSize
+        _windowInfo.containerSize = sizeInPx
+        _windowInfo.containerDpSize = boxSize
 
         // TODO: Align with Container/Mediator architecture
         skiaLayer.attachTo(canvas)
-        scene.size = containerSize
+        scene.size = sizeInPx
         skiaLayer.needRedraw()
     }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebWindowInfoTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebWindowInfoTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.OnCanvasTests
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class WebWindowInfoTest : OnCanvasTests {
+
+    @Test
+    fun windowContainerSizeIsSet() = runTest {
+        lateinit var windowInfo: WindowInfo
+        createComposeWindow {
+            windowInfo = LocalWindowInfo.current
+        }
+
+        val containerSize = windowInfo.containerSize
+        assertTrue(containerSize.width > 0)
+        assertTrue(containerSize.height > 0)
+
+        val containerDpSize = windowInfo.containerDpSize
+        assertTrue(containerDpSize.width > 0.dp)
+        assertTrue(containerDpSize.height > 0.dp)
+    }
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebWindowInfoTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/WebWindowInfoTest.kt
@@ -25,7 +25,7 @@ import kotlinx.coroutines.test.runTest
 class WebWindowInfoTest : OnCanvasTests {
 
     @Test
-    fun windowContainerSizeIsSet() = runTest {
+    fun windowInfoContainerSizeIsSet() = runTest {
         lateinit var windowInfo: WindowInfo
         createComposeWindow {
             windowInfo = LocalWindowInfo.current


### PR DESCRIPTION
[CMP-9107](https://youtrack.jetbrains.com/issue/CMP-9107) Provide DP-based window size in WindowInfo

## Release Notes
### Fixes - Multiple Platforms
- _(prerelease fix)_ Provide `LocalWindowInfo.current.containerDpSize` value
