### PR TITLE
Stabilize Popup/DialogProperties

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -4361,6 +4361,7 @@ public final class androidx/compose/ui/window/DialogProperties {
 	public fun <init> (ZZZ)V
 	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (ZZZZZJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ZZZZZJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDismissOnBackPress ()Z
 	public final fun getDismissOnClickOutside ()Z
@@ -4464,8 +4465,11 @@ public abstract interface class androidx/compose/ui/window/PopupPositionProvider
 
 public final class androidx/compose/ui/window/PopupProperties {
 	public static final field $stable I
+	public fun <init> ()V
 	public fun <init> (ZZZZ)V
 	public synthetic fun <init> (ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZZZ)V
+	public synthetic fun <init> (ZZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getClippingEnabled ()Z
 	public final fun getDismissOnBackPress ()Z

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -2277,6 +2277,7 @@ final class androidx.compose.ui.spatial/RelativeLayoutBounds { // androidx.compo
 
 final class androidx.compose.ui.window/DialogProperties { // androidx.compose.ui.window/DialogProperties|null[0]
     constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // androidx.compose.ui.window/DialogProperties.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., androidx.compose.ui.graphics/Color = ...) // androidx.compose.ui.window/DialogProperties.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;androidx.compose.ui.graphics.Color){}[0]
 
     final val dismissOnBackPress // androidx.compose.ui.window/DialogProperties.dismissOnBackPress|{}dismissOnBackPress[0]
         final fun <get-dismissOnBackPress>(): kotlin/Boolean // androidx.compose.ui.window/DialogProperties.dismissOnBackPress.<get-dismissOnBackPress>|<get-dismissOnBackPress>(){}[0]
@@ -2297,6 +2298,7 @@ final class androidx.compose.ui.window/DialogProperties { // androidx.compose.ui
 
 final class androidx.compose.ui.window/PopupProperties { // androidx.compose.ui.window/PopupProperties|null[0]
     constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // androidx.compose.ui.window/PopupProperties.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ...) // androidx.compose.ui.window/PopupProperties.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean){}[0]
 
     final val clippingEnabled // androidx.compose.ui.window/PopupProperties.clippingEnabled|{}clippingEnabled[0]
         final fun <get-clippingEnabled>(): kotlin/Boolean // androidx.compose.ui.window/PopupProperties.clippingEnabled.<get-clippingEnabled>|<get-clippingEnabled>(){}[0]

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposeFocusTest.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.performClick
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import com.google.common.truth.Truth.assertThat
 import java.awt.BorderLayout
 import java.awt.Dimension
@@ -47,7 +48,6 @@ import javax.swing.JButton
 import javax.swing.JFrame
 import javax.swing.JPanel
 import kotlin.random.Random
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
@@ -434,7 +434,9 @@ class ComposeFocusTest {
                 Column(Modifier.fillMaxSize()) {
                     composeButton1.Button()
                     composeButton2.Button()
-                    Popup(focusable = true) {
+                    Popup(
+                        properties = PopupProperties(focusable = true),
+                    ) {
                         composeButton3.Button()
                         composeButton4.Button()
                     }
@@ -466,7 +468,9 @@ class ComposeFocusTest {
                         Column(Modifier.fillMaxSize()) {
                             composeButton1.Button()
                             composeButton2.Button()
-                            Popup(focusable = true) {
+                            Popup(
+                                properties = PopupProperties(focusable = true),
+                            ) {
                                 composeButton3.Button()
                                 composeButton4.Button()
                             }
@@ -498,7 +502,9 @@ class ComposeFocusTest {
                 Column(Modifier.fillMaxSize()) {
                     composeButton1.Button()
                     composeButton2.Button()
-                    Popup(focusable = true) {
+                    Popup(
+                        properties = PopupProperties(focusable = true),
+                    ) {
                         Column(Modifier.fillMaxSize()) {
                             composeButton3.Button()
                             SwingPanel(
@@ -543,7 +549,9 @@ class ComposeFocusTest {
                             }
                         }
                     )
-                    Popup(focusable = true) {
+                    Popup(
+                        properties = PopupProperties(focusable = true),
+                    ) {
                         Column(Modifier.fillMaxSize()) {
                             composeButton3.Button()
                             composeButton4.Button()
@@ -572,7 +580,9 @@ class ComposeFocusTest {
                 Column(Modifier.fillMaxSize()) {
                     composeButton1.Button()
                     composeButton2.Button()
-                    Popup(focusable = true) {
+                    Popup(
+                        properties = PopupProperties(focusable = true),
+                    ) {
                         Column(Modifier.fillMaxSize()) {
                             composeButton3.Button()
                             composeButton4.Button()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/ApplicationAccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/ApplicationAccessibilityTest.kt
@@ -77,7 +77,10 @@ class ApplicationAccessibilityTest {
                         popupContentSize: IntSize
                     ): IntOffset = IntOffset(0, 25)
                 }
-                Popup(position, focusable = false) {
+                Popup(
+                    popupPositionProvider = position,
+                    properties = PopupProperties(focusable = false)
+                ) {
                     Button(
                         onClick = {},
                         modifier = Modifier.size(100.dp)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -223,8 +223,8 @@ class DesktopPopupTest {
                 owner?.navigationEventDispatcher?.addInput(navEventInput)
             }
             Popup(
-                focusable = true,
                 onDismissRequest = { onDismissRequestCallCount++ },
+                properties = PopupProperties(focusable = true),
                 onKeyEvent = { false }
             ) {
                 Box(Modifier)
@@ -241,8 +241,8 @@ class DesktopPopupTest {
         var onKeyEventCallCount = 0
         rule.setContent {
             Popup(
-                focusable = true,
                 onDismissRequest = { onDismissRequestCallCount++ },
+                properties = PopupProperties(focusable = true),
                 onKeyEvent = {
                     onKeyEventCallCount++
                     true

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -24,14 +24,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.platform.LocalInternalNavigationEventDispatcherOwner
 import androidx.compose.ui.platform.LocalPlatformWindowInsets
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
@@ -70,7 +68,7 @@ private val DefaultScrimColor = Color.Black.copy(alpha = DefaultScrimOpacity)
  * @property scrimColor Color of background fill.
  */
 @Immutable
-actual class DialogProperties @ExperimentalComposeUiApi constructor(
+actual class DialogProperties constructor(
     actual val dismissOnBackPress: Boolean = true,
     actual val dismissOnClickOutside: Boolean = true,
     actual val usePlatformDefaultWidth: Boolean = true,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
@@ -75,7 +74,7 @@ import androidx.compose.ui.unit.round
  * platform insets.
  */
 @Immutable
-actual class PopupProperties @ExperimentalComposeUiApi constructor(
+actual class PopupProperties constructor(
     actual val focusable: Boolean = false,
     actual val dismissOnBackPress: Boolean = true,
     actual val dismissOnClickOutside: Boolean = true,
@@ -147,12 +146,13 @@ actual class PopupProperties @ExperimentalComposeUiApi constructor(
  * @param content The content to be displayed inside the popup.
  */
 @Deprecated(
-    "Replaced by Popup with properties parameter",
-    ReplaceWith(
+    message = "Replaced by Popup with properties parameter",
+    replaceWith = ReplaceWith(
         "Popup(alignment, offset, onDismissRequest, " +
             "androidx.compose.ui.window.PopupProperties(focusable = focusable), " +
             "onPreviewKeyEvent, onKeyEvent, content)"
-    )
+    ),
+    level = DeprecationLevel.ERROR,
 )
 @Composable
 fun Popup(
@@ -199,12 +199,13 @@ fun Popup(
  * @param content The content to be displayed inside the popup.
  */
 @Deprecated(
-    "Replaced by Popup with properties parameter",
-    ReplaceWith(
+    message = "Replaced by Popup with properties parameter",
+    replaceWith = ReplaceWith(
         "Popup(popupPositionProvider, onDismissRequest, " +
             "androidx.compose.ui.window.PopupProperties(focusable = focusable), " +
             "onPreviewKeyEvent, onKeyEvent, content)"
-    )
+    ),
+    level = DeprecationLevel.ERROR,
 )
 @Composable
 fun Popup(


### PR DESCRIPTION
[CMP-9116](https://youtrack.jetbrains.com/issue/CMP-9116) Remove experimental annotation from Popup/DialogProperties

## Release Notes
### Migration Notes - Multiple Platforms
- Remove experimental annotation from `usePlatformInsets`, `useSoftwareKeyboardInset` and `scrimColor` in `DialogProperties`
- Remove experimental annotation from `usePlatformDefaultWidth`, `usePlatformInsets` in `PopupProperties`
- Deprecation level of `Popup` overloads without `PopupProperties` parameter changed from `WARNING` to `ERROR`
