### PR TITLE
Handle instant back events

### DIFF
--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/ProgressBackEventHandler.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/ProgressBackEventHandler.kt
@@ -55,6 +55,11 @@ internal class ProgressBackEventHandler(
 
     override fun onBackCompleted() {
         coroutineScope.launch {
+            if (progressChannel == null) {
+                // it was an instant back event (Esc click)
+                // we need to start a new progress event stream
+                onBackStarted(NavigationEvent())
+            }
             progressChannel?.close()
             progressChannel = null
         }


### PR DESCRIPTION
Handle instant back events in a compatibility `ui-bachandler`.

Fixes [CMP-9111](https://youtrack.jetbrains.com/issue/CMP-9111) [Desktop, iOS] Back navigation doesn't work when pressing Esc

## Release Notes
N/A