### PR TITLE
Fix recursion due to vararg overload

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/ContextMenuStrings.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/ContextMenuStrings.skiko.kt
@@ -35,20 +35,24 @@ internal actual value class ContextMenuStrings actual constructor(actual val val
     }
 }
 
-@Composable
-@ReadOnlyComposable
-internal actual fun getString(string: ContextMenuStrings): String {
-    return getLocalizedString(string)
-}
-
-internal fun getLocalizedString(string: ContextMenuStrings): String {
-    val locale = Locale.current
-
+private fun getTranslation(string: ContextMenuStrings, locale: Locale): String {
     val tag = localeTag(language = locale.language, region = locale.region)
     val translation = translationByLocaleTag.getOrPut(tag) {
         findTranslation(locale)
     }
     return translation[string] ?: error("Missing translation for $string")
+}
+
+@Composable
+@ReadOnlyComposable
+internal actual fun getString(string: ContextMenuStrings): String {
+    val locale = Locale.current
+    return getTranslation(string, locale)
+}
+
+internal fun getLocalizedString(string: ContextMenuStrings): String {
+    val locale = Locale.current
+    return getTranslation(string, locale)
 }
 
 /**

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Strings.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Strings.kt
@@ -22,15 +22,19 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.text.intl.Locale
 
-@Composable
-@ReadOnlyComposable
-internal actual fun getString(string: Strings): String {
-    val locale = Locale.current
+private fun getTranslation(string: Strings, locale: Locale): String {
     val tag = localeTag(language = locale.language, region = locale.region)
     val translation = translationByLocaleTag.getOrPut(tag) {
         findTranslation(locale)
     }
     return translation[string] ?: error("Missing translation for $string")
+}
+
+@Composable
+@ReadOnlyComposable
+internal actual fun getString(string: Strings): String {
+    val locale = Locale.current
+    return getTranslation(string, locale)
 }
 
 /**

--- a/compose/material3/adaptive/adaptive-layout/src/skikoMain/kotlin/androidx/compose/material3/adaptive/layout/internal/Strings.skiko.kt
+++ b/compose/material3/adaptive/adaptive-layout/src/skikoMain/kotlin/androidx/compose/material3/adaptive/layout/internal/Strings.skiko.kt
@@ -61,7 +61,7 @@ internal fun String.format(vararg formatArgs: Any?): String {
     return result
 }
 
-private fun getString(string: Strings, locale: Locale): String {
+private fun getTranslation(string: Strings, locale: Locale): String {
     val tag = localeTag(language = locale.language, region = locale.region)
     val translation = translationByLocaleTag.getOrPut(tag) {
         findTranslation(locale)
@@ -73,19 +73,19 @@ private fun getString(string: Strings, locale: Locale): String {
 @ReadOnlyComposable
 internal actual fun getString(string: Strings): String {
     val locale = Locale.current
-    return getString(string, locale)
+    return getTranslation(string, locale)
 }
 
 @Composable
 @ReadOnlyComposable
 internal actual fun getString(string: Strings, vararg formatArgs: Any): String {
     val locale = Locale.current
-    return getString(string, locale).format(*formatArgs)
+    return getTranslation(string, locale).format(*formatArgs)
 }
 
 internal actual fun CompositionLocalConsumerModifierNode.getString(string: Strings): String {
     val locale = Locale.current
-    return getString(string, locale)
+    return getTranslation(string, locale)
 }
 
 internal actual fun CompositionLocalConsumerModifierNode.getString(
@@ -93,7 +93,7 @@ internal actual fun CompositionLocalConsumerModifierNode.getString(
     vararg formatArgs: Any
 ): String {
     val locale = Locale.current
-    return getString(string, locale).format(*formatArgs)
+    return getTranslation(string, locale).format(*formatArgs)
 }
 
 /**

--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/Strings.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/internal/Strings.skiko.kt
@@ -122,10 +122,7 @@ internal actual fun formatString(string: String, vararg formatArgs: Any?): Strin
     return result
 }
 
-@Composable
-@ReadOnlyComposable
-internal actual fun getString(string: Strings): String {
-    val locale = Locale.current
+private fun getTranslation(string: Strings, locale: Locale): String {
     val tag = localeTag(language = locale.language, region = locale.region)
     val translation = translationByLocaleTag.getOrPut(tag) {
         findTranslation(locale)
@@ -135,8 +132,17 @@ internal actual fun getString(string: Strings): String {
 
 @Composable
 @ReadOnlyComposable
-internal actual fun getString(string: Strings, vararg formatArgs: Any): String =
-    formatString(getString(string), *formatArgs)
+internal actual fun getString(string: Strings): String {
+    val locale = Locale.current
+    return getTranslation(string, locale)
+}
+
+@Composable
+@ReadOnlyComposable
+internal actual fun getString(string: Strings, vararg formatArgs: Any): String {
+    val locale = Locale.current
+    return formatString(getTranslation(string, locale), *formatArgs)
+}
 
 /**
  * A single translation; should contain all the [Strings].


### PR DESCRIPTION
Fixes: [CMP-9115](https://youtrack.jetbrains.com/issue/CMP-9115) [Multiplatform] material3.adaptive. Crash when using ListDetailPaneScaffold

No release notes - regression is only in dev builds

## Release Notes
N/A
