### PR TITLE
[web] [demo] Explicitely disable selection for mobile Safari

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
@@ -18,7 +18,6 @@ package androidx.compose.mpp.demo
 
 import androidx.compose.ui.platform.ClipEntry
 import kotlinx.browser.document
-import org.w3c.dom.HTMLElement
 
 expect suspend fun ClipEntry?.getPlainText(): String?
 
@@ -26,43 +25,44 @@ expect fun createClipEntryWithPlainText(text: String): ClipEntry
 
 // Setting the colors to indicate the presence of the backing textarea or input, and its focus state
 internal fun setupBackingTextAreaDebugHints() {
-    val sr = document.getElementById("composeApplication")!!.shadowRoot!!
+    val shadowRootStyle = document.createElement("style")
+    shadowRootStyle.textContent = """
+        :host {
+            --input-mode-indicator: transparent;
+                
+            -webkit-touch-callout: none; 
+            -webkit-user-select: none; 
+            user-select: none;
+        }
+        
+        :host:has(input, textarea) {
+            --input-mode-indicator: aliceblue;
+        }
+        
+        :host:has(input:focus, textarea:focus) {
+            --input-mode-indicator: #eaffe3;
+        }
+        
+        #debugBackingInputIndicator {
+            background-color: var(--input-mode-indicator);
+            position: absolute;
+            top: 0;
+            left: 0;
+            margin: 0;
+            width: 100%;
+            height: 100%;
+            z-index: -10;
+        }
+""".trimIndent()
 
-    val srStyle = document.createElement("style").apply {
-        // language=css
-        textContent = """
-            :host {
-                --my-variable: transparent;
-            }
-            :host:has(textarea) {
-                --my-variable: aliceblue;
-            }
-            :host:has(input) {
-                --my-variable: aliceblue;
-            }
-            :host:has(textarea:focus) {
-                --my-variable: #eaffe3;
-            }
-            :host:has(input:focus) {
-                --my-variable: #eaffe3;
-            }
-            #debugBackingInputIndicator {
-                background-color: var(--my-variable);
-                position: absolute;
-                top: 0;
-                left: 0;
-                margin: 0;
-                width: 100%;
-                height: 100%;
-                z-index: -10;
-            }
-        """.trimIndent()
-    }
+    val shadowRoot = document.getElementById("composeApplication")?.shadowRoot!!
 
-    val firstChild = sr.children.item(0) as HTMLElement
-    sr.insertBefore(srStyle, firstChild)
+    shadowRoot.addEventListener("touchstart", { evt ->
+        evt.preventDefault()
+    })
 
-    sr.appendChild(document.createElement("div").apply {
+    shadowRoot.prepend(shadowRootStyle)
+    shadowRoot.appendChild(document.createElement("div").apply {
         id = "debugBackingInputIndicator"
     })
 }

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
@@ -57,10 +57,6 @@ internal fun setupBackingTextAreaDebugHints() {
 
     val shadowRoot = document.getElementById("composeApplication")?.shadowRoot!!
 
-    shadowRoot.addEventListener("touchstart", { evt ->
-        evt.preventDefault()
-    })
-
     shadowRoot.prepend(shadowRootStyle)
     shadowRoot.appendChild(document.createElement("div").apply {
         id = "debugBackingInputIndicator"

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/Utils.kt
@@ -26,6 +26,7 @@ expect fun createClipEntryWithPlainText(text: String): ClipEntry
 // Setting the colors to indicate the presence of the backing textarea or input, and its focus state
 internal fun setupBackingTextAreaDebugHints() {
     val shadowRootStyle = document.createElement("style")
+    // language=css
     shadowRootStyle.textContent = """
         :host {
             --input-mode-indicator: transparent;


### PR DESCRIPTION
The goal of this particular PR is very humble - to disable redundant touch behaviour on mobile iOS devices
Later on we inevitably need to come up with some policy of how we customize our shadow root generally. 

## Testing
Open demo and try to longtap wherever

## Release Notes
N/A