### PR TITLE
Fix some flaky desktop tests

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -65,12 +65,17 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.runApplicationTest
+import androidx.compose.ui.window.waitForFocusGain
 import androidx.savedstate.SavedState
 import com.google.common.truth.Truth.assertThat
 import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.event.MouseEvent
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+import java.awt.event.WindowFocusListener
+import java.awt.event.WindowListener
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -82,6 +87,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.MainUIDispatcher
@@ -668,7 +674,12 @@ class ComposePanelTest {
         val composePanel = ComposePanel()
         var isTextFieldFocused = false
         composePanel.setContent {
-            TextField(rememberTextFieldState(), Modifier.onFocusChanged { isTextFieldFocused = it.isFocused })
+            TextField(
+                state = rememberTextFieldState(),
+                Modifier.onFocusChanged {
+                    isTextFieldFocused = it.isFocused
+                }
+            )
         }
 
         val window = JFrame()
@@ -676,6 +687,8 @@ class ComposePanelTest {
             window.size = Dimension(200, 200)
             window.contentPane.add(composePanel, BorderLayout.CENTER)
             window.isVisible = true
+            window.toFront()
+            window.waitForFocusGain()
 
             awaitIdle()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -51,13 +51,11 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
-import androidx.compose.ui.layout.layout
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendMouseEvent
 import androidx.compose.ui.sendMouseWheelEvent
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
 import androidx.compose.ui.util.ThrowUncaughtExceptionRule
@@ -72,10 +70,6 @@ import java.awt.BorderLayout
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 import java.awt.event.MouseEvent
-import java.awt.event.WindowAdapter
-import java.awt.event.WindowEvent
-import java.awt.event.WindowFocusListener
-import java.awt.event.WindowListener
 import javax.swing.BoxLayout
 import javax.swing.JFrame
 import javax.swing.JPanel
@@ -87,7 +81,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.suspendCancellableCoroutine
 import org.jetbrains.skiko.ExperimentalSkikoApi
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.MainUIDispatcher

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
@@ -82,6 +82,8 @@ class ComposeContainerLifecycleOwnerTest {
                     window.extendedState = Frame.NORMAL
                     allEvents.waitFor(Lifecycle.Event.ON_START)
                     allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+                } else {
+                    println("Setting ICONIFIED window state failed")
                 }
             } else {
                 println("ICONIFIED window state not supported")

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
@@ -18,243 +18,219 @@ package androidx.compose.ui.window
 
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.isEqualTo
+import androidx.compose.ui.layout.NoWindowInsetsAnimation.isVisible
 import androidx.compose.ui.scene.ComposeContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
-import java.time.Duration
+import java.awt.Frame
+import java.awt.Window
 import javax.swing.JFrame
 import javax.swing.JLayeredPane
-import javax.swing.SwingUtilities
-import kotlin.test.Ignore
-import kotlin.test.assertFailsWith
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.ClosedReceiveChannelException
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.time.withTimeout
+import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class ComposeContainerLifecycleOwnerTest {
-    @Ignore // TODO https://youtrack.jetbrains.com/issue/CMP-8957
     @Test
-    fun allEvents() = runTest {
-        val window = JFrame().apply {
-            isVisible = false
-        }
-        val allEvents = ChannelEventObserver()
-        val pane = TestComposePanel(window, allEvents)
+    fun allEvents() = runApplicationTest {
+        val window = JFrame()
+        try {
+            val allEvents = ChannelEventObserver()
+            val pane = TestComposePanel(window, allEvents)
+            window.contentPane.add(pane)
 
-        // initial state for a not-yet-shown window
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_CREATE)
+            // initial state for a not-yet-shown window
+            allEvents.waitFor(Lifecycle.Event.ON_CREATE)
 
-        // show window
-        SwingUtilities.invokeAndWait {
-            window.isVisible = true
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_START)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_RESUME)
+            // show window
+            window.showAndMoveToFront()
+            allEvents.waitFor(Lifecycle.Event.ON_START)
+            allEvents.waitFor(Lifecycle.Event.ON_RESUME)
 
-        // show another window, the window under test looses focus
-        val anotherWindow = JFrame().apply {
-            isVisible = true
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_PAUSE)
+            // show another window, the window under test loses focus
+            val anotherWindow = JFrame()
+            try {
+                anotherWindow.showAndMoveToFront()
 
-        // another window is closed, the window under test regains focus
-        anotherWindow.dispose()
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_RESUME)
+                allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
 
-        // cannot check window minimization/restoration on CI as we are running in Xvfb without a window manager
-        // so disabling this check for now
-        /*
-        // minimize window
-        SwingUtilities.invokeAndWait {
-            val toolkit = Toolkit.getDefaultToolkit()
-            println("Toolkit ${toolkit::class.qualifiedName} is ICONIFIED supported ${toolkit.isFrameStateSupported(Frame.ICONIFIED)}")
-            window.extendedState = Frame.ICONIFIED
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_PAUSE)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_STOP)
+                // another window is closed, the window under test regains focus
+                anotherWindow.isVisible = false
+                window.toFront()
+                allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+            } finally {
+                anotherWindow.dispose()
+            }
 
-        // restore window
-        SwingUtilities.invokeAndWait {
-            window.extendedState = Frame.NORMAL
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_START)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_RESUME)
-        */
+            if (window.toolkit.isFrameStateSupported(Frame.ICONIFIED)) {
+                // minimize window
+                window.extendedState = Frame.ICONIFIED
+                allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
+                allEvents.waitFor(Lifecycle.Event.ON_STOP)
 
-        // close window
-        SwingUtilities.invokeAndWait {
+                // restore window
+                window.extendedState = Frame.NORMAL
+                allEvents.waitFor(Lifecycle.Event.ON_START)
+                allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+            } else {
+                println("ICONIFIED window state not supported")
+            }
+
+            // close window
             pane.container.dispose()
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_PAUSE)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_STOP)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_DESTROY)
-        assertFailsWith<ClosedReceiveChannelException> {
-            allEvents.receiveOrTimeout()
+            allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
+            allEvents.waitFor(Lifecycle.Event.ON_STOP)
+            allEvents.waitFor(Lifecycle.Event.ON_DESTROY)
+
+            // no more events
+            assertTrue(allEvents.tryReceive().isFailure)
+        } finally {
+            window.dispose()
         }
     }
 
     @Test
-    fun detachAndReattach() = runTest {
+    fun detachAndReattach() = runApplicationTest {
         val window = JFrame()
-        val allEvents = ChannelEventObserver()
-        val pane = TestComposePanel(window, allEvents)
+        try {
+            val allEvents = ChannelEventObserver()
+            val pane = TestComposePanel(window, allEvents)
+            window.contentPane.add(pane)
 
-        // initial state
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_CREATE)
+            // initial state
+            allEvents.waitFor(Lifecycle.Event.ON_CREATE)
 
-        SwingUtilities.invokeAndWait {
-            window.isVisible = true
+            window.showAndMoveToFront()
+            allEvents.waitFor(Lifecycle.Event.ON_START)
+            allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+
+            window.contentPane.remove(pane)
+            allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
+            allEvents.waitFor(Lifecycle.Event.ON_STOP)
+
+            window.contentPane.add(pane)
+            allEvents.waitFor(Lifecycle.Event.ON_START)
+            allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+
+            // no more events
+            assertTrue(allEvents.tryReceive().isFailure)
+        } finally {
+            window.dispose()
         }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_START)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_RESUME)
-
-        SwingUtilities.invokeAndWait {
-            window.remove(pane)
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_PAUSE)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_STOP)
-
-        SwingUtilities.invokeAndWait {
-            window.add(pane)
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_START)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_RESUME)
-
-        // no more events
-        assertTrue(allEvents.tryReceive().isFailure)
     }
 
     @Test
-    fun windowDeiconifiedWithoutAddNotify() = runTest {
+    fun windowDeiconifiedWithoutAddNotify() = runApplicationTest {
+        val window = JFrame()
+        try {
+            val pane = JLayeredPane()
+            val allEvents = ChannelEventObserver()
+            val container = ComposeContainer(
+                container = pane,
+                skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+                window = window,
+            )
+            container.lifecycle.addObserver(allEvents)
+            window.contentPane.add(pane)
+
+            // initial state
+            allEvents.waitFor(Lifecycle.Event.ON_CREATE)
+
+            window.state = JFrame.NORMAL
+
+            // no more events
+            assertTrue(allEvents.tryReceive().isFailure)
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun windowFocusedWithoutAddNotify() = runApplicationTest {
+        val window = JFrame()
+        try {
+            val pane = JLayeredPane()
+            val allEvents = ChannelEventObserver()
+            val container = ComposeContainer(
+                container = pane,
+                skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+                window = window,
+            )
+            container.lifecycle.addObserver(allEvents)
+            window.contentPane.add(pane)
+
+            // initial state
+            allEvents.waitFor(Lifecycle.Event.ON_CREATE)
+
+            window.showAndMoveToFront()
+
+            // no more events
+            assertTrue(allEvents.tryReceive().isFailure)
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun lateAddNotify() = runApplicationTest {
         val window = JFrame()
         val pane = JLayeredPane()
         val allEvents = ChannelEventObserver()
-        var container: ComposeContainer? = null
-        SwingUtilities.invokeAndWait {
-            container = ComposeContainer(
-                container = pane,
-                skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-                window = window,
-            ).also {
-                it.lifecycle.addObserver(allEvents)
-            }
-            window.add(pane)
-        }
+        val container = ComposeContainer(
+            container = pane,
+            skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+            window = window,
+        )
+        container.lifecycle.addObserver(allEvents)
+        window.contentPane.add(pane)
 
         // initial state
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_CREATE)
+        allEvents.waitFor(Lifecycle.Event.ON_CREATE)
 
-        SwingUtilities.invokeAndWait {
-            window.state = JFrame.NORMAL
-        }
-
-        // no more events
-        assertTrue(allEvents.tryReceive().isFailure)
-    }
-
-    @Test
-    fun windowFocusedWithoutAddNotify() = runTest {
-        val window = JFrame().apply {
-            isVisible = false
-        }
-        val pane = JLayeredPane()
-        val allEvents = ChannelEventObserver()
-        var container: ComposeContainer? = null
-        SwingUtilities.invokeAndWait {
-            container = ComposeContainer(
-                container = pane,
-                skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-                window = window,
-            ).also {
-                it.lifecycle.addObserver(allEvents)
-            }
-            window.add(pane)
-        }
-
-        // initial state
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_CREATE)
-
-        SwingUtilities.invokeAndWait {
-            window.isVisible = true
-        }
-
-        // no more events
-        assertTrue(allEvents.tryReceive().isFailure)
-    }
-
-    @Test
-    fun lateAddNotify() = runTest {
-        val window = JFrame().apply {
-            isVisible = false
-        }
-        val pane = JLayeredPane()
-        val allEvents = ChannelEventObserver()
-        var container: ComposeContainer? = null
-        SwingUtilities.invokeAndWait {
-            container = ComposeContainer(
-                container = pane,
-                skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-                window = window,
-            ).also {
-                it.lifecycle.addObserver(allEvents)
-            }
-            window.add(pane)
-        }
-
-        // initial state
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_CREATE)
-
-        SwingUtilities.invokeAndWait {
-            window.isVisible = true
-            window.state = JFrame.NORMAL
-        }
+        window.showAndMoveToFront()
+        window.state = JFrame.NORMAL
 
         // no events yet
         assertTrue(allEvents.tryReceive().isFailure)
 
         // addNotify arrives after various window events
-        SwingUtilities.invokeAndWait {
-            container!!.addNotify()
-        }
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_START)
-        assertThat(allEvents.receiveOrTimeout()).isEqualTo(Lifecycle.Event.ON_RESUME)
+        container.addNotify()
+        allEvents.waitFor(Lifecycle.Event.ON_START)
+        allEvents.waitFor(Lifecycle.Event.ON_RESUME)
 
         // no more events
         assertTrue(allEvents.tryReceive().isFailure)
+
+        window.dispose()
     }
 
     private class ChannelEventObserver: LifecycleEventObserver, Channel<Lifecycle.Event> by Channel(capacity = 8) {
         override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-            runBlocking {
-                send(event)
-                if (event == Lifecycle.Event.ON_DESTROY) {
-                    close()
-                }
+            trySendBlocking(event)
+            if (event == Lifecycle.Event.ON_DESTROY) {
+                close()
             }
         }
     }
 
     private class TestComposePanel(window: JFrame, observer: LifecycleEventObserver) : JLayeredPane() {
-        lateinit var container: ComposeContainer
+        val container: ComposeContainer = ComposeContainer(
+            container = this,
+            skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+            window = window,
+        )
 
         init {
-            SwingUtilities.invokeAndWait {
-                container = ComposeContainer(
-                    container = this,
-                    skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-                    window = window,
-                )
-                container.lifecycle.addObserver(observer)
-                window.add(this)
-            }
+            container.lifecycle.addObserver(observer)
+            isFocusable = true
         }
 
         override fun addNotify() {
@@ -268,11 +244,24 @@ class ComposeContainerLifecycleOwnerTest {
         }
     }
 
-    private suspend fun <E> Channel<E>.receiveOrTimeout(timeout: Duration = Duration.ofSeconds(1)): E {
-        return withContext(Dispatchers.Default) {
-            withTimeout(timeout) {
-                receive()
+    private fun Window.showAndMoveToFront() {
+        isVisible = true
+        toFront()
+    }
+
+    // Some window managers (on Linux) generate unexpected events, such as iconification when the
+    // window is first made visible. This means it's not possible to check for the expected stream
+    // of events exactly. Instead, we skip unexpected events, waiting for the next expected one.
+    private suspend fun <E> Channel<E>.waitFor(value: E, timeout: Duration = 1.seconds) {
+        withContext(Dispatchers.Default) {
+            var lastReceived: E? = null
+            withTimeoutOrNull(timeout) {
+                while (true) {
+                    lastReceived = receive()
+                    if (lastReceived == value) break
+                }
             }
+            assertThat(lastReceived).isEqualTo(value)
         }
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleOwnerTest.kt
@@ -18,13 +18,14 @@ package androidx.compose.ui.window
 
 import androidx.compose.ui.assertThat
 import androidx.compose.ui.isEqualTo
-import androidx.compose.ui.layout.NoWindowInsetsAnimation.isVisible
 import androidx.compose.ui.scene.ComposeContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import java.awt.Frame
 import java.awt.Window
+import java.awt.event.WindowEvent
+import java.awt.event.WindowStateListener
 import javax.swing.JFrame
 import javax.swing.JLayeredPane
 import kotlin.time.Duration
@@ -32,6 +33,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skiko.SkiaLayerAnalytics
@@ -72,14 +74,15 @@ class ComposeContainerLifecycleOwnerTest {
 
             if (window.toolkit.isFrameStateSupported(Frame.ICONIFIED)) {
                 // minimize window
-                window.extendedState = Frame.ICONIFIED
-                allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
-                allEvents.waitFor(Lifecycle.Event.ON_STOP)
+                if (window.setExtendedStateSucceeds(Frame.ICONIFIED)) {
+                    allEvents.waitFor(Lifecycle.Event.ON_PAUSE)
+                    allEvents.waitFor(Lifecycle.Event.ON_STOP)
 
-                // restore window
-                window.extendedState = Frame.NORMAL
-                allEvents.waitFor(Lifecycle.Event.ON_START)
-                allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+                    // restore window
+                    window.extendedState = Frame.NORMAL
+                    allEvents.waitFor(Lifecycle.Event.ON_START)
+                    allEvents.waitFor(Lifecycle.Event.ON_RESUME)
+                }
             } else {
                 println("ICONIFIED window state not supported")
             }
@@ -248,6 +251,23 @@ class ComposeContainerLifecycleOwnerTest {
         isVisible = true
         toFront()
     }
+
+    private suspend fun JFrame.setExtendedStateSucceeds(state: Int): Boolean =
+        withTimeoutOrNull(1.seconds) {
+            val actualNewState = suspendCancellableCoroutine { cont ->
+                extendedState = state
+                addWindowStateListener(object: WindowStateListener {
+                    override fun windowStateChanged(e: WindowEvent) {
+                        removeWindowStateListener(this)
+                        cont.resume(
+                            value = e.newState,
+                            onCancellation = { _, _, _ -> }
+                        )
+                    }
+                })
+            }
+            return@withTimeoutOrNull actualNewState == state
+        } ?: false
 
     // Some window managers (on Linux) generate unexpected events, such as iconification when the
     // window is first made visible. This means it's not possible to check for the expected stream

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -35,6 +35,10 @@ import kotlinx.coroutines.withTimeout
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
 import androidx.compose.ui.window.launchApplication as realLaunchApplication
+import java.awt.Window
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 
 internal fun runApplicationTest(
@@ -133,9 +137,14 @@ internal class WindowTestScope(
 
     fun launchTestWindowApplication(
         state: WindowState = WindowState(),
+        undecorated: Boolean = false,
         content: @Composable FrameWindowScope.() -> Unit
     ) = launchTestApplication {
-       Window(onCloseRequest = ::exitApplication, state = state) {
+       Window(
+           onCloseRequest = ::exitApplication,
+           state = state,
+           undecorated = undecorated
+       ) {
            this@WindowTestScope.window = window
            content()
        }
@@ -177,5 +186,17 @@ internal class WindowTestScope(
         }
 
         exceptionHandler.throwIfCaught()
+    }
+}
+
+suspend fun Window.waitForFocusGain() {
+    if (isFocused) return
+    suspendCancellableCoroutine { cont ->
+        addWindowFocusListener(object: WindowAdapter() {
+            override fun windowGainedFocus(e: WindowEvent) {
+                removeWindowFocusListener(this)
+                cont.resume(Unit) { _, _, _ -> }
+            }
+        })
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -97,9 +97,7 @@ open class BaseWindowTextFieldTest {
         abstract val text: String
         abstract val selection: TextRange
         abstract val composition: TextRange?
-
-        var textLayoutResult: TextLayoutResult? = null
-            protected set
+        abstract val textLayoutResult: TextLayoutResult?
 
         var textBoundingBox: Rect = Rect.Zero
             protected set
@@ -125,7 +123,8 @@ open class BaseWindowTextFieldTest {
             assertThat(this.composition).isEqualTo(composition)
         }
 
-        fun clickBeforeIndex(index: Int) {
+        suspend fun clickBeforeIndex(index: Int) {
+            awaitIdle() // To get the latest textLayoutResult
             val localLocation = textLayoutResult!!.let {
                 if (index == text.length)
                     it.getBoundingBox(index-1).centerRight
@@ -167,6 +166,9 @@ open class BaseWindowTextFieldTest {
         override val composition: TextRange?
             get() = textFieldValue.composition
 
+        override var textLayoutResult: TextLayoutResult? = null
+            protected set
+
         override fun toString() = "TextField1"
     }
 
@@ -185,6 +187,10 @@ open class BaseWindowTextFieldTest {
 
         override val composition: TextRange?
             get() = textFieldState.composition
+
+        protected var textLayoutResultGetter: (() -> TextLayoutResult?)? = null
+        override val textLayoutResult: TextLayoutResult?
+            get() = textLayoutResultGetter?.invoke()
     }
 
     internal abstract class SecureTextFieldScope(
@@ -241,7 +247,7 @@ open class BaseWindowTextFieldTest {
                     BasicTextField(
                         state = textFieldState,
                         inputTransformation = inputTransformation,
-                        onTextLayout = { textLayoutResult = it() },
+                        onTextLayout = { textLayoutResultGetter = it },
                         modifier = Modifier
                             .focusRequester(focusRequester)
                             .onPlaced {
@@ -269,7 +275,7 @@ open class BaseWindowTextFieldTest {
                     BasicSecureTextField(
                         state = textFieldState,
                         textObfuscationMode = textObfuscationMode,
-                        onTextLayout = { textLayoutResult = it() },
+                        onTextLayout = { textLayoutResultGetter = it },
                         modifier = Modifier
                             .focusRequester(focusRequester)
                             .onPlaced {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -48,10 +48,12 @@ import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.WindowTestScope
 import androidx.compose.ui.window.density
 import androidx.compose.ui.window.runApplicationTest
+import androidx.compose.ui.window.waitForFocusGain
 import com.google.common.truth.Truth.assertThat
 import kotlin.math.roundToInt
 import org.junit.experimental.theories.DataPoint
@@ -61,31 +63,30 @@ open class BaseWindowTextFieldTest {
         textFieldKind: TextFieldKind<S>,
         name: String,
         body: suspend S.() -> Unit
-    ) = runApplicationTest(
-        hasAnimations = true,
-        animationsDelayMillis = 100
-    ) {
+    ) = runApplicationTest {
         var scope: S? = null
-        launchTestApplication {
-            Window(onCloseRequest = ::exitApplication) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier.fillMaxSize()
-                ) {
-                    if (scope == null) {
-                        scope = textFieldKind.createScope(this@runApplicationTest, window)
-                    }
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Text("$name ($scope)")
-                        Box(Modifier.border(1.dp, Color.Black).padding(8.dp)) {
-                            scope!!.TextField()
-                        }
+        launchTestWindowApplication(
+            state = WindowState(position = WindowPosition(200.dp, 200.dp)),
+            undecorated = true
+        ) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.fillMaxSize()
+            ) {
+                if (scope == null) {
+                    scope = textFieldKind.createScope(this@runApplicationTest, window)
+                }
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text("$name ($scope)")
+                    Box(Modifier.border(1.dp, Color.Black).padding(8.dp)) {
+                        scope.TextField()
                     }
                 }
             }
         }
 
         awaitIdle()
+        window.waitForFocusGain()
         scope!!.body()
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -588,7 +588,6 @@ class WindowTest {
         assertThat(isWindowEffectEnded).isTrue()
     }
 
-    @Ignore("flaky") // TODO https://youtrack.jetbrains.com/issue/CMP-8957
     @Test
     fun `undecorated resizable window with unspecified size`() = runApplicationTest(
         useDelay = true

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -589,10 +589,8 @@ class WindowTest {
     }
 
     @Test
-    fun `undecorated resizable window with unspecified size`() = runApplicationTest(
-        useDelay = true
-    ) {
-        var window: ComposeWindow? = null
+    fun `undecorated resizable window with unspecified size`() = runApplicationTest {
+        lateinit var window: ComposeWindow
 
         launchTestApplication {
             Window(
@@ -607,8 +605,9 @@ class WindowTest {
         }
 
         awaitIdle()
-        assertEquals(32, window?.width)
-        assertEquals(32, window?.height)
+        window.renderImmediately()
+        assertEquals(32, window.width)
+        assertEquals(32, window.height)
     }
 
     @Test


### PR DESCRIPTION
- `ComposePanelTest.ComposePanel content receives initial focus`: needed to wait for the window to become focused.
- `ComposeContainerLifecycleOwnerTest`: improved overall (use `runApplicationTest`). The main problem was unexpected spurious window iconification/deiconification events sent by the window manager in Linux. These are now ignored.
- `WindowTypeTest`: needed to wait for the window to become focused (in `BaseWindowTextFieldTest`). Also BTF2 tests need to call the lambda passed to `onTextLayout` every time to get the latest text layout.
- `WindowTypingLocationTest`: needed the window to be positioned exactly and be undecorated because it checks input method text position on screen, and sometimes part of the check runs before the system takes into account the title bar height (so the text position appears to have moved downwards).

Fixes https://youtrack.jetbrains.com/issue/CMP-8957/Fix-Desktop-flaky-tests
except for `WindowTest.undecorated resizable window with unspecified size`.

## Testing
The tests themselves should no longer be flaky

## Release Notes
N/A

