### PR TITLE
[Cherry-pick] Add direct references to fork modules to runtime-saveable

### DIFF
--- a/compose/runtime/runtime-saveable-compatibility-stub/build.gradle
+++ b/compose/runtime/runtime-saveable-compatibility-stub/build.gradle
@@ -57,6 +57,12 @@ kotlin {
             dependencies {
                 def version = project.findProperty('artifactRedirection.version.androidx.compose')
                 api("androidx.compose.runtime:runtime-saveable:$version")
+
+                // Keep direct references to fork versions to correctly resolve
+                // New redirections to Google's artifacts
+                implementation(project(":compose:runtime:runtime"))
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation(project(":savedstate:savedstate-compose"))
             }
         }
     }


### PR DESCRIPTION
Missing cherry-pick from #2370

Should fix:
- [CMP-9119](https://youtrack.jetbrains.com/issue/CMP-9119) Compose 1.9.1 compileKotlinWasmJs task fails with INTERNAL_ERROR (IR lowering failed)
- https://issuetracker.google.com/453194425

## Release Notes
### Fixes - Multiple Platforms
- Prevent possible symbol duplicates in `savedstate-compose` due to redirects to Google's `runtime-saveable` that supports all KMP platforms