### PR TITLE
Add `ComposePanel.renderImmediately`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -365,4 +365,17 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      */
     val renderApi: GraphicsApi
         get() = _composeContainer?.renderApi ?: GraphicsApi.UNKNOWN
+
+    /**
+     * Renders the panel's content synchronously.
+     *
+     * This doesn't need to be used in most cases, as the content will be rendered as needed
+     * automatically. It can, however, be used to force the rendering sooner than it normally would
+     * occur. Specifically, it allows rendering the content after the window has been made
+     * displayable, but before it has been shown, to avoid a brief flicker.
+     */
+    @ExperimentalComposeUiApi
+    fun renderImmediately() {
+        _composeContainer?.renderImmediately()
+    }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -525,6 +525,9 @@ class ComposePanelTest {
             window.contentPane.add(composePanel)
             awaitIdle()
 
+            // Needed to complete the addition of SwingInteropContainer
+            composePanel.renderImmediately()
+
             assertEquals(2, jPanels.size)
             assertFalse(composePanel.isAncestorOf(jPanels[0]))
             assertTrue(composePanel.isAncestorOf(jPanels[1]))


### PR DESCRIPTION
Add `ComposePanel.renderImmediately` to align it with similar API in `ComposeWindow` and `ComposeDialog`.
This is also needed to fix a flaky test.

## Testing
N/A

## Release Notes
N/A