### PR TITLE
WebDragAndDropManager: set transferData immediately on dragstart

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/DragAndDropTransferData.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/DragAndDropTransferData.web.kt
@@ -10,8 +10,8 @@ import org.w3c.dom.DataTransfer
 actual class DragAndDropTransferData(internal val nativeTransferData: DataTransfer? = null)
 
 /**
- * While we'll definitely benefit from  (even partial) commonization of transfer data
- * it's actually should be properly designed and coordinated throughout all teams, so now
+ * While we'll definitely benefit from (even partial) commonization of transfer data,
+ * it actually should be properly designed and coordinated throughout all teams, so now
  * the recommended way is to just pass/access native DataTransfer if needed
  */
 @ExperimentalComposeUiApi

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/WebDragAndDropManager.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/WebDragAndDropManager.kt
@@ -52,7 +52,7 @@ internal abstract class WebDragAndDropManager(eventListener: EventTargetListener
         dataTransfer?.setDragImage(ghostImage, 0, 0)
 
         // After browser made a snapshot we can safely remove ghostImage from document
-        // But it should be done in different frame
+        // But it should be done in a different frame
         window.requestAnimationFrame {
             ghostImage.remove()
         }
@@ -96,13 +96,17 @@ internal abstract class WebDragAndDropManager(eventListener: EventTargetListener
         eventListener.addDisposableEvent("dragstart") { event ->
             // Both internal (starting from within the application)
             // and external (triggered by dragging something for the outer world)
-            // trigger the "dragenter" event but we can not set drag image anywhere apart dragstart
+            // trigger the "dragenter" event, but we cannot set drag image anywhere apart dragstart
             previousDragEventIsStart = true
             event as DragEvent
 
             val scope = InternalStartTransferScope(density)
 
             if (scope.startTransfer(event)) {
+                // without setting any kind of data in data transfer Safari on iOS won't proceed with drag action
+                // luckily, the data is mutable and we can reset it in dragAndDropSource
+                // see https://youtrack.jetbrains.com/issue/CMP-7292/Drag-and-Drop-is-not-working-in-mobile-browsers
+                event.dataTransfer?.setData("text/plain", "")
                 scope.ghostImage?.let { ghostImage ->
                     event.setAsDragImage(ghostImage)
                 }

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -221,12 +221,6 @@ internal class ComposeWindow(
                 get() = scene.rootDragAndDropNode
         }
 
-        private fun getCanvasCoordinates(): Pair<Double, Double> {
-            return canvas.getBoundingClientRect().let {
-                it.left to it.top
-            }
-        }
-
         @Suppress("RedundantOverride")
         override fun convertLocalToWindowPosition(localPosition: Offset): Offset {
             // TODO (o.karpovich): Currently, CfW uses AttachedComposeSceneLayer, so


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-7292/Drag-and-Drop-is-not-working-in-mobile-browsers

## Testing
`./gradlew testWeb`

## Release Notes
### Fixes - Web
- Correct drag-and-drop behaviour on mobile devices
