### PR TITLE
[web] WebDragAndDropManager.kt: Append domHolder to the shadowRoot if…

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/WebDragAndDropManager.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/WebDragAndDropManager.kt
@@ -21,8 +21,11 @@ import org.w3c.dom.DragEvent
 import org.w3c.dom.HTMLCanvasElement
 import org.w3c.dom.ImageData
 import org.w3c.dom.HTMLElement
+import org.w3c.dom.ShadowRoot
 
-internal abstract class WebDragAndDropManager(eventListener: EventTargetListener, globalEventsListener: EventTargetListener, private val density: Density) :
+internal abstract class WebDragAndDropManager(
+    private val canvas: HTMLElement, eventListener: EventTargetListener, globalEventsListener: EventTargetListener, private val density: Density
+) :
     PlatformDragAndDropManager {
     override val isRequestDragAndDropTransferRequired: Boolean
         get() = false
@@ -45,9 +48,13 @@ internal abstract class WebDragAndDropManager(eventListener: EventTargetListener
             setProperty("pointer-events", "none")
         }
 
-        // non-image elements passed to setDragImage should be present on document
+        // https://developer.mozilla.org/en-US/docs/Web/API/Node/getRootNode
+        val rootNode = canvas.getRootNode()
+        val dragHolder = if (rootNode is ShadowRoot) rootNode else document.body
+
+        // non-image elements passed to setDragImage should be present on a document
         // the only browser the only browser not burdened with this limitation is Firefox
-        document.body?.appendChild(ghostImage)
+        dragHolder?.appendChild(ghostImage)
 
         dataTransfer?.setDragImage(ghostImage, 0, 0)
 

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -216,7 +216,9 @@ internal class ComposeWindow(
         override val architectureComponentsOwner get() = archComponentsOwner
         override val inputModeManager: InputModeManager = DefaultInputModeManager()
 
-        override val dragAndDropManager: PlatformDragAndDropManager = object : WebDragAndDropManager(canvasEvents, state.globalEvents, density) {
+        override val dragAndDropManager: PlatformDragAndDropManager = object : WebDragAndDropManager(
+         canvas, canvasEvents, state.globalEvents, density
+        ) {
             override val rootDragAndDropNode: ComposeSceneDragAndDropNode
                 get() = scene.rootDragAndDropNode
         }


### PR DESCRIPTION
In order to obtain ghost image to the DOM world we have to create a DOM element and attach it to the document
Without that step in the majority of browsers we'll fail to path image to transferData - this is already the case. 
What's done in framework of this PR is that if we are in shadow root - we attach it to the shadow root rather then to the document body

## Testing
manual

## Release Notes
N/A