### PR TITLE
Remove `density` parameter from `ComposeSceneContext.createLayer`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -531,12 +531,11 @@ internal class ComposeContainer(
         override val platformContext: PlatformContext,
     ) : ComposeSceneContext {
         override fun createLayer(
-            density: Density,
             layoutDirection: LayoutDirection,
             focusable: Boolean,
             compositionContext: CompositionContext
         ): ComposeSceneLayer = createPlatformLayer(
-            density = density,
+            density = container.density,
             layoutDirection = layoutDirection,
             focusable = focusable,
             compositionContext = compositionContext

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -418,7 +418,6 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     override fun createLayer(
-        density: Density,
         layoutDirection: LayoutDirection,
         focusable: Boolean,
         compositionContext: CompositionContext,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneContext.skiko.kt
@@ -55,7 +55,6 @@ interface ComposeSceneContext {
     /**
      * Creates a scene layer to display content as a new [LayoutNode] tree.
      *
-     * @param density The density of the layer.
      * @param layoutDirection The layout direction of the layer.
      * @param focusable Indicates whether the layer is focusable.
      * @param compositionContext The composition context for the layer.
@@ -64,7 +63,6 @@ interface ComposeSceneContext {
      * @see ComposeSceneLayer
      */
     fun createLayer(
-        density: Density,
         layoutDirection: LayoutDirection,
         focusable: Boolean,
         compositionContext: CompositionContext,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.LayoutNode
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.unit.Density
@@ -179,13 +178,11 @@ internal fun rememberComposeSceneLayer(
     focusable: Boolean = false
 ): ComposeSceneLayer {
     val sceneContext = LocalComposeSceneContext.requireCurrent()
-    val density = LocalDensity.current
     val layoutDirection = LocalLayoutDirection.current
     val parentComposition = rememberCompositionContext()
     val compositionLocalContext = currentCompositionLocalContext
     val layer = remember {
         sceneContext.createLayer(
-            density = density,
             layoutDirection = layoutDirection,
             focusable = focusable,
             compositionContext = parentComposition,
@@ -193,7 +190,6 @@ internal fun rememberComposeSceneLayer(
     }
     layer.focusable = focusable
     layer.compositionLocalContext = compositionLocalContext
-    layer.density = density
     layer.layoutDirection = layoutDirection
 
     DisposableEffect(Unit) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
@@ -16,9 +16,14 @@
 
 package androidx.compose.ui.layers
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Button
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.uikit.density
 import androidx.compose.ui.unit.Density
@@ -84,6 +89,7 @@ class LocalDensityTest {
         }
 
         assertNotEquals(outerDensity.density, actualOuterDensity)
+        assertEquals(hostingViewController.view.density.density, actualOuterDensity)
         assertEquals(innerDensity.density, actualInnerDensity)
     }
 
@@ -108,6 +114,119 @@ class LocalDensityTest {
         }
 
         assertNotEquals(outerDensity.density, actualOuterDensity)
+        assertEquals(hostingViewController.view.density.density, actualOuterDensity)
         assertEquals(innerDensity.density, actualInnerDensity)
+    }
+
+    @Test
+    fun testTapInteractionsInDialogWithOuterCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val interactionButtonNumber = 8
+        var interactionCount = 0
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides density) {
+                Dialog(onDismissRequest = {}) {
+                    Column {
+                        repeat(10) { number ->
+                            Button(
+                                onClick = { if (number == interactionButtonNumber) { interactionCount++ } },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $number")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $interactionButtonNumber").tap()
+
+        waitForIdle()
+
+        assertEquals(1, interactionCount)
+    }
+
+    @Test
+    fun testTapInteractionsInPopupWithOuterCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val targetButtonIndex = 8
+        var tappedButtonIndex = -1
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides density) {
+                Popup {
+                    Column {
+                        repeat(10) { index ->
+                            Button(
+                                onClick = { tappedButtonIndex = index },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $index")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $targetButtonIndex").tap()
+
+        waitForIdle()
+
+        assertEquals(targetButtonIndex, tappedButtonIndex)
+    }
+
+    @Test
+    fun testTapInteractionsInDialogWithInnerCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val targetButtonIndex = 8
+        var tappedButtonIndex = -1
+
+        setContent {
+            Dialog(onDismissRequest = {}) {
+                CompositionLocalProvider(LocalDensity provides density) {
+                    Column {
+                        repeat(10) { index ->
+                            Button(
+                                onClick = { tappedButtonIndex = index },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $index")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $targetButtonIndex").tap()
+
+        waitForIdle()
+
+        assertEquals(targetButtonIndex, tappedButtonIndex)
+    }
+
+    @Test
+    fun testTapInteractionsInPopupWithInnerCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val targetButtonIndex = 8
+        var tappedButtonIndex = -1
+
+        setContent {
+            Popup {
+                CompositionLocalProvider(LocalDensity provides density) {
+                    Column {
+                        repeat(10) { index ->
+                            Button(
+                                onClick = { tappedButtonIndex = index },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $index")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $targetButtonIndex").tap()
+
+        waitForIdle()
+
+        assertEquals(targetButtonIndex, tappedButtonIndex)
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.layers
+
+import androidx.compose.material.Button
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.uikit.density
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.Popup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class LocalDensityTest {
+    @Test
+    fun testCustomDensityNotPropagatedToDialog() = runUIKitInstrumentedTest {
+        val customDensity = Density(density = 5f)
+        var density = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides customDensity) {
+                Dialog(onDismissRequest = {}) {
+                    density = LocalDensity.current.density
+                }
+            }
+        }
+
+        assertNotEquals(customDensity.density, density)
+        assertEquals(hostingViewController.view.density.density, density)
+    }
+
+    @Test
+    fun testCustomDensityNotPropagatedToPopup() = runUIKitInstrumentedTest {
+        val customDensity = Density(density = 5f)
+        var density = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides customDensity) {
+                Popup {
+                    density = LocalDensity.current.density
+                }
+            }
+        }
+
+        assertNotEquals(customDensity.density, density)
+        assertEquals(hostingViewController.view.density.density, density)
+    }
+
+    @Test
+    fun testCustomDensityPropagatedInDialogContent() = runUIKitInstrumentedTest {
+        val outerDensity = Density(density = 5f)
+        val innerDensity = Density(density = 10f)
+        var actualOuterDensity = -1f
+        var actualInnerDensity = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides outerDensity) {
+                Dialog(onDismissRequest = {}) {
+                    actualOuterDensity = LocalDensity.current.density
+                    CompositionLocalProvider(LocalDensity provides innerDensity) {
+                        Button(onClick = {}) {
+                            actualInnerDensity = LocalDensity.current.density
+                        }
+                    }
+                }
+            }
+        }
+
+        assertNotEquals(outerDensity.density, actualOuterDensity)
+        assertEquals(innerDensity.density, actualInnerDensity)
+    }
+
+    @Test
+    fun testCustomDensityPropagatedInPopupContent() = runUIKitInstrumentedTest {
+        val outerDensity = Density(density = 5f)
+        val innerDensity = Density(density = 10f)
+        var actualOuterDensity = -1f
+        var actualInnerDensity = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides outerDensity) {
+                Popup {
+                    actualOuterDensity = LocalDensity.current.density
+                    CompositionLocalProvider(LocalDensity provides innerDensity) {
+                        Button(onClick = {}) {
+                            actualInnerDensity = LocalDensity.current.density
+                        }
+                    }
+                }
+            }
+        }
+
+        assertNotEquals(outerDensity.density, actualOuterDensity)
+        assertEquals(innerDensity.density, actualInnerDensity)
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -448,11 +448,11 @@ internal class ComposeHostingViewController(
             override val platformContext: PlatformContext = platformContext
 
             override fun createLayer(
-                density: Density,
                 layoutDirection: LayoutDirection,
                 focusable: Boolean,
                 compositionContext: CompositionContext
             ): ComposeSceneLayer {
+
                 val layer = UIKitComposeSceneLayer(
                     onClosed = {
                         layersHolder.getLayersViewController().detach(it)
@@ -461,7 +461,7 @@ internal class ComposeHostingViewController(
                     createComposeSceneContext = { createComposeSceneContext(it, layersHolder) },
                     hostCompositionLocals = { ProvideContainerCompositionLocals(it) },
                     layersViewController = layersHolder.getLayersViewController(),
-                    initDensity = density,
+                    initDensity = layersHolder.getLayersViewController().view.density,
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
                     onAccessibilityChanged = ::onAccessibilityChanged,


### PR DESCRIPTION
Remove the density parameter from ComposeSceneContext.createLayer. Newly created compose scene layers now use the system / screen density (not the parent context density). This aligns behavior with Android where `Dialog` and `Popup` do not inherit `LocalDensity` from the parent but re-seed density from the platform.

Fixes [CMP-8662](https://youtrack.jetbrains.com/issue/CMP-8662) [iOS] Incorrect tap responses in a Dialog when LocalDensity is modified.

## Testing

Adds `LocalDensityTest` test suite.

This should be tested by QA

## Release Notes
### Fixes - iOS
- Fix incorrect tap responses in `Dialog` when `LocalDensity` is modified
### Breaking Changes - Desktop
- Apps that relied on Desktop behavior of root density changes propagating into dialogs/popups for zoom/scale must re-provide the parent density inside the dialog/popup content
