### PR TITLE
Add support for configurable end edge gesture behaviors in UIKit navigation logic

### DIFF
--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -5138,6 +5138,15 @@ final val androidx.compose.ui.uikit/LocalUIViewController // androidx.compose.ui
 final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop|#static{}androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop[0]
 
 // Targets: [ios]
+final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop|#static{}androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop[0]
+
+// Targets: [ios]
+final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop|#static{}androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop[0]
+
+// Targets: [ios]
+final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop|#static{}androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop[0]
+
+// Targets: [ios]
 final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop|#static{}androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop[0]
 
 // Targets: [ios]
@@ -5342,6 +5351,15 @@ final fun androidx.compose.ui.scene/androidx_compose_ui_scene_UIKitTransparentCo
 
 // Targets: [ios]
 final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop_getter|androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop_getter(){}[0]
+
+// Targets: [ios]
+final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop_getter|androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop_getter(){}[0]
+
+// Targets: [ios]
+final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop_getter|androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop_getter(){}[0]
+
+// Targets: [ios]
+final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop_getter|androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop_getter(){}[0]
 
 // Targets: [ios]
 final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop_getter|androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop_getter(){}[0]

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -5138,13 +5138,13 @@ final val androidx.compose.ui.uikit/LocalUIViewController // androidx.compose.ui
 final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop|#static{}androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop[0]
 
 // Targets: [ios]
-final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop|#static{}androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop[0]
+final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Back$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Back$stableprop|#static{}androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Back$stableprop[0]
 
 // Targets: [ios]
-final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop|#static{}androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop[0]
+final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Disabled$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Disabled$stableprop|#static{}androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Disabled$stableprop[0]
 
 // Targets: [ios]
-final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop|#static{}androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop[0]
+final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Forward$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Forward$stableprop|#static{}androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Forward$stableprop[0]
 
 // Targets: [ios]
 final val androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop // androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop|#static{}androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop[0]
@@ -5353,13 +5353,13 @@ final fun androidx.compose.ui.scene/androidx_compose_ui_scene_UIKitTransparentCo
 final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop_getter|androidx_compose_ui_uikit_ComposeUIViewControllerConfiguration$stableprop_getter(){}[0]
 
 // Targets: [ios]
-final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop_getter|androidx_compose_ui_uikit_EndEdgeGestureBehavior_Back$stableprop_getter(){}[0]
+final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Back$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Back$stableprop_getter|androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Back$stableprop_getter(){}[0]
 
 // Targets: [ios]
-final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop_getter|androidx_compose_ui_uikit_EndEdgeGestureBehavior_Disabled$stableprop_getter(){}[0]
+final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Disabled$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Disabled$stableprop_getter|androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Disabled$stableprop_getter(){}[0]
 
 // Targets: [ios]
-final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop_getter|androidx_compose_ui_uikit_EndEdgeGestureBehavior_Forward$stableprop_getter(){}[0]
+final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Forward$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Forward$stableprop_getter|androidx_compose_ui_uikit_EndEdgePanGestureBehavior_Forward$stableprop_getter(){}[0]
 
 // Targets: [ios]
 final fun androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop_getter(): kotlin/Int // androidx.compose.ui.uikit/androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop_getter|androidx_compose_ui_uikit_OnFocusBehavior_DoNothing$stableprop_getter(){}[0]

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeSceneMediator
 import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.test.runUIKitInstrumentedTest
-import androidx.compose.ui.uikit.EndEdgeGestureBehavior
+import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
 import androidx.compose.ui.uikit.InterfaceOrientation
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.unit.Density
@@ -104,7 +104,7 @@ class ComposeSceneMediatorTest {
             navigationEventInput = UIKitNavigationEventInput(
                 density = Density(1f),
                 getTopLeftOffsetInWindow = { IntOffset.Zero },
-                endEdgeGestureBehavior = EndEdgeGestureBehavior.Disabled,
+                endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Disabled,
             ),
             interfaceOrientationState = mutableStateOf(InterfaceOrientation.Portrait),
             composeSceneFactory = { _, _ ->

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeSceneMediator
 import androidx.compose.ui.scene.PlatformLayersComposeScene
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.uikit.EndEdgeGestureBehavior
 import androidx.compose.ui.uikit.InterfaceOrientation
 import androidx.compose.ui.uikit.OnFocusBehavior
 import androidx.compose.ui.unit.Density
@@ -102,7 +103,8 @@ class ComposeSceneMediatorTest {
             ),
             navigationEventInput = UIKitNavigationEventInput(
                 density = Density(1f),
-                getTopLeftOffsetInWindow = { IntOffset.Zero }
+                getTopLeftOffsetInWindow = { IntOffset.Zero },
+                endEdgeGestureBehavior = EndEdgeGestureBehavior.Disabled,
             ),
             interfaceOrientationState = mutableStateOf(InterfaceOrientation.Portrait),
             composeSceneFactory = { _, _ ->

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.kt
@@ -17,7 +17,7 @@
 package androidx.compose.ui.navigationevent
 
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.uikit.EndEdgeGestureBehavior
+import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
 import androidx.compose.ui.uikit.utils.CMPScreenEdgePanGestureRecognizer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -50,7 +50,7 @@ import platform.darwin.NSObject
 
 internal class UIKitNavigationEventInput(
     private val density: Density,
-    private val endEdgeGestureBehavior: EndEdgeGestureBehavior,
+    private val endEdgePanGestureBehavior: EndEdgePanGestureBehavior,
     private val getTopLeftOffsetInWindow: () -> IntOffset
 ) : BackNavigationEventInput() {
     companion object {
@@ -104,7 +104,7 @@ internal class UIKitNavigationEventInput(
         if (isRecognizersEnabled) {
             startEdgePanGestureRecognizer.enabled = true
             endEdgePanGestureRecognizer.enabled =
-                endEdgeGestureBehavior != EndEdgeGestureBehavior.Disabled
+                endEdgePanGestureBehavior != EndEdgePanGestureBehavior.Disabled
         } else {
             startEdgePanGestureRecognizer.enabled = false
             endEdgePanGestureRecognizer.enabled = false
@@ -144,7 +144,7 @@ internal class UIKitNavigationEventInput(
     inner class UiKitScreenEdgePanGestureHandler : NSObject() {
         private val UIScreenEdgePanGestureRecognizer.isBackEdge: Boolean
             get() = this === startEdgePanGestureRecognizer ||
-                (this === endEdgePanGestureRecognizer && endEdgeGestureBehavior == EndEdgeGestureBehavior.Back)
+                (this === endEdgePanGestureRecognizer && endEdgePanGestureBehavior == EndEdgePanGestureBehavior.Back)
 
         private fun dispatchOnEventStarted(
             recognizer: UIScreenEdgePanGestureRecognizer,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/navigationevent/UIKitNavigationEventInput.kt
@@ -17,11 +17,7 @@
 package androidx.compose.ui.navigationevent
 
 import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.type
+import androidx.compose.ui.uikit.EndEdgeGestureBehavior
 import androidx.compose.ui.uikit.utils.CMPScreenEdgePanGestureRecognizer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -30,7 +26,6 @@ import androidx.compose.ui.unit.asDpRect
 import androidx.compose.ui.unit.toOffset
 import androidx.compose.ui.unit.width
 import androidx.navigationevent.NavigationEvent
-import androidx.navigationevent.NavigationEventInput
 import kotlin.math.abs
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CPointed
@@ -48,12 +43,14 @@ import platform.UIKit.UIGestureRecognizerStateFailed
 import platform.UIKit.UIRectEdgeLeft
 import platform.UIKit.UIRectEdgeRight
 import platform.UIKit.UIScreenEdgePanGestureRecognizer
+import platform.UIKit.UIUserInterfaceLayoutDirection.*
 import platform.UIKit.UIView
 import platform.UIKit.UIWindow
 import platform.darwin.NSObject
 
 internal class UIKitNavigationEventInput(
     private val density: Density,
+    private val endEdgeGestureBehavior: EndEdgeGestureBehavior,
     private val getTopLeftOffsetInWindow: () -> IntOffset
 ) : BackNavigationEventInput() {
     companion object {
@@ -61,26 +58,30 @@ internal class UIKitNavigationEventInput(
         private const val BACK_GESTURE_VELOCITY = 100
     }
 
+    private var isRecognizersEnabled: Boolean = false
+        set(value) {
+            if (field == value) return
+            field = value
+            updateRecognizers()
+        }
+    private var isRtlEnabled: Boolean = false
+        set(value) {
+            if (field == value) return
+            field = value
+            updateRecognizers()
+        }
+
     private val iosGestureHandler = UiKitScreenEdgePanGestureHandler()
 
-    private val leftEdgePanGestureRecognizer = UIKitBackGestureRecognizer(
+    private val startEdgePanGestureRecognizer = UIKitBackGestureRecognizer(
         target = iosGestureHandler,
         action = NSSelectorFromString(UiKitScreenEdgePanGestureHandler::handleEdgePan.name + ":")
-    ).apply {
-        edges = UIRectEdgeLeft
-    }
+    )
 
-    private val rightEdgePanGestureRecognizer = UIKitBackGestureRecognizer(
+    private val endEdgePanGestureRecognizer = UIKitBackGestureRecognizer(
         target = iosGestureHandler,
         action = NSSelectorFromString(UiKitScreenEdgePanGestureHandler::handleEdgePan.name + ":")
-    ).apply {
-        edges = UIRectEdgeRight
-    }
-
-    override fun onHasEnabledHandlersChanged(hasEnabledHandlers: Boolean) {
-        leftEdgePanGestureRecognizer.enabled = hasEnabledHandlers
-        rightEdgePanGestureRecognizer.enabled = hasEnabledHandlers
-    }
+    )
 
     private val activeGestureStates = listOf(
         UIGestureRecognizerStateBegan,
@@ -89,12 +90,36 @@ internal class UIKitNavigationEventInput(
 
     val isBackGestureActive: Boolean
         get() =
-            leftEdgePanGestureRecognizer.state in activeGestureStates ||
-                rightEdgePanGestureRecognizer.state in activeGestureStates
+            startEdgePanGestureRecognizer.state in activeGestureStates ||
+                endEdgePanGestureRecognizer.state in activeGestureStates
+
+    init {
+        updateRecognizers()
+    }
+
+    private fun updateRecognizers() {
+        startEdgePanGestureRecognizer.edges = if (!isRtlEnabled) UIRectEdgeLeft else UIRectEdgeRight
+        endEdgePanGestureRecognizer.edges = if (isRtlEnabled) UIRectEdgeLeft else UIRectEdgeRight
+
+        if (isRecognizersEnabled) {
+            startEdgePanGestureRecognizer.enabled = true
+            endEdgePanGestureRecognizer.enabled =
+                endEdgeGestureBehavior != EndEdgeGestureBehavior.Disabled
+        } else {
+            startEdgePanGestureRecognizer.enabled = false
+            endEdgePanGestureRecognizer.enabled = false
+        }
+    }
+
+    override fun onHasEnabledHandlersChanged(hasEnabledHandlers: Boolean) {
+        isRecognizersEnabled = hasEnabledHandlers
+    }
 
     fun onDidMoveToWindow(window: UIWindow?, composeRootView: UIView) {
         removeGestureListeners()
         if (window != null) {
+            isRtlEnabled =
+                composeRootView.effectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft
             var view: UIView = composeRootView
             while (view.superview != window) {
                 view = requireNotNull(view.superview) {
@@ -106,17 +131,60 @@ internal class UIKitNavigationEventInput(
     }
 
     private fun addGestureListeners(view: UIView) {
-        view.addGestureRecognizer(leftEdgePanGestureRecognizer)
-        view.addGestureRecognizer(rightEdgePanGestureRecognizer)
+        view.addGestureRecognizer(startEdgePanGestureRecognizer)
+        view.addGestureRecognizer(endEdgePanGestureRecognizer)
     }
 
     private fun removeGestureListeners() {
-        leftEdgePanGestureRecognizer.view?.removeGestureRecognizer(leftEdgePanGestureRecognizer)
-        rightEdgePanGestureRecognizer.view?.removeGestureRecognizer(rightEdgePanGestureRecognizer)
+        startEdgePanGestureRecognizer.view?.removeGestureRecognizer(startEdgePanGestureRecognizer)
+        endEdgePanGestureRecognizer.view?.removeGestureRecognizer(endEdgePanGestureRecognizer)
     }
 
     @OptIn(BetaInteropApi::class, ExperimentalComposeUiApi::class)
     inner class UiKitScreenEdgePanGestureHandler : NSObject() {
+        private val UIScreenEdgePanGestureRecognizer.isBackEdge: Boolean
+            get() = this === startEdgePanGestureRecognizer ||
+                (this === endEdgePanGestureRecognizer && endEdgeGestureBehavior == EndEdgeGestureBehavior.Back)
+
+        private fun dispatchOnEventStarted(
+            recognizer: UIScreenEdgePanGestureRecognizer,
+            event: NavigationEvent
+        ) {
+            if (recognizer.isBackEdge) {
+                dispatchOnBackStarted(event)
+            } else {
+                dispatchOnForwardStarted(event)
+            }
+        }
+        private fun dispatchOnEventProgressed(
+            recognizer: UIScreenEdgePanGestureRecognizer,
+            event: NavigationEvent
+        ) {
+            if (recognizer.isBackEdge) {
+                dispatchOnBackProgressed(event)
+            } else {
+                dispatchOnForwardProgressed(event)
+            }
+        }
+        private fun dispatchOnEventCompleted(
+            recognizer: UIScreenEdgePanGestureRecognizer
+        ) {
+            if (recognizer.isBackEdge) {
+                dispatchOnBackCompleted()
+            } else {
+                dispatchOnForwardCompleted()
+            }
+        }
+        private fun dispatchOnEventCancelled(
+            recognizer: UIScreenEdgePanGestureRecognizer
+        ) {
+            if (recognizer.isBackEdge) {
+                dispatchOnBackCancelled()
+            } else {
+                dispatchOnForwardCancelled()
+            }
+        }
+
         @ObjCAction
         fun handleEdgePan(recognizer: UIScreenEdgePanGestureRecognizer) {
             val view = recognizer.view ?: return
@@ -125,7 +193,8 @@ internal class UIKitNavigationEventInput(
                     val touch = recognizer.locationOfTouch(0u, view).asDpOffset()
                     val eventOffset =
                         touch.toOffset(density) - getTopLeftOffsetInWindow().toOffset()
-                    dispatchOnBackStarted(
+                    dispatchOnEventStarted(
+                        recognizer,
                         NavigationEvent(
                             touchX = eventOffset.x,
                             touchY = eventOffset.y,
@@ -151,7 +220,8 @@ internal class UIKitNavigationEventInput(
                     } else {
                         (bounds.width - touch.x) / bounds.width
                     }
-                    dispatchOnBackProgressed(
+                    dispatchOnEventProgressed(
+                        recognizer,
                         NavigationEvent(
                             touchX = eventOffset.x,
                             touchY = eventOffset.y,
@@ -178,13 +248,13 @@ internal class UIKitNavigationEventInput(
                                     if (edge == UIRectEdgeLeft) this@velocity.x else -this@velocity.x
                                 when {
                                     //if movement is fast in the right direction
-                                    velX > BACK_GESTURE_VELOCITY -> dispatchOnBackCompleted()
+                                    velX > BACK_GESTURE_VELOCITY -> dispatchOnEventCompleted(recognizer)
                                     //if movement is backward
-                                    velX < -10 -> dispatchOnBackCancelled()
+                                    velX < -10 -> dispatchOnEventCancelled(recognizer)
                                     //if there is no movement, or the movement is slow,
                                     //but the touch is already more than BACK_GESTURE_SCREEN_SIZE
-                                    abs(x) >= size.width * BACK_GESTURE_SCREEN_SIZE -> dispatchOnBackCompleted()
-                                    else -> dispatchOnBackCancelled()
+                                    abs(x) >= size.width * BACK_GESTURE_SCREEN_SIZE -> dispatchOnEventCompleted(recognizer)
+                                    else -> dispatchOnEventCancelled(recognizer)
                                 }
                             }
                         }
@@ -192,11 +262,11 @@ internal class UIKitNavigationEventInput(
                 }
 
                 UIGestureRecognizerStateCancelled -> {
-                    dispatchOnBackCancelled()
+                    dispatchOnEventCancelled(recognizer)
                 }
 
                 UIGestureRecognizerStateFailed -> {
-                    dispatchOnBackCompleted()
+                    dispatchOnEventCompleted(recognizer)
                 }
             }
         }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -122,7 +122,8 @@ internal class ComposeHostingViewController(
     }
     private val navigationEventInput = UIKitNavigationEventInput(
         density = rootView.density,
-        getTopLeftOffsetInWindow = { IntOffset.Zero } //full screen
+        getTopLeftOffsetInWindow = { IntOffset.Zero }, //full screen
+        endEdgeGestureBehavior = configuration.endEdgeGestureBehavior
     )
 
     fun hasInvalidations(): Boolean {
@@ -464,6 +465,7 @@ internal class ComposeHostingViewController(
                     initDensity = density,
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
+                    endEdgeGestureBehavior = configuration.endEdgeGestureBehavior,
                     onAccessibilityChanged = ::onAccessibilityChanged,
                     focusedViewsList = if (focusable) focusedViewsList?.childFocusedViewsList() else null,
                     compositionContext = compositionContext,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -123,7 +123,7 @@ internal class ComposeHostingViewController(
     private val navigationEventInput = UIKitNavigationEventInput(
         density = rootView.density,
         getTopLeftOffsetInWindow = { IntOffset.Zero }, //full screen
-        endEdgeGestureBehavior = configuration.endEdgeGestureBehavior
+        endEdgePanGestureBehavior = configuration.endEdgePanGestureBehavior
     )
 
     fun hasInvalidations(): Boolean {
@@ -465,7 +465,7 @@ internal class ComposeHostingViewController(
                     initDensity = density,
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
-                    endEdgeGestureBehavior = configuration.endEdgeGestureBehavior,
+                    endEdgeGestureBehavior = configuration.endEdgePanGestureBehavior,
                     onAccessibilityChanged = ::onAccessibilityChanged,
                     focusedViewsList = if (focusable) focusedViewsList?.childFocusedViewsList() else null,
                     compositionContext = compositionContext,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.navigationevent.UIKitNavigationEventInput
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformArchitectureComponentsOwner
+import androidx.compose.ui.uikit.EndEdgeGestureBehavior
 import androidx.compose.ui.uikit.InterfaceOrientation
 import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.uikit.OnFocusBehavior
@@ -63,6 +64,7 @@ internal class UIKitComposeSceneLayer(
     private val initLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
     onFocusBehavior: OnFocusBehavior,
+    endEdgeGestureBehavior: EndEdgeGestureBehavior,
     private var focusedViewsList: FocusedViewsList?,
     compositionContext: CompositionContext,
     private val ownerProvider: PlatformArchitectureComponentsOwner,
@@ -89,7 +91,8 @@ internal class UIKitComposeSceneLayer(
 
     private val navigationEventInput = UIKitNavigationEventInput(
         density = interactionView.density,
-        getTopLeftOffsetInWindow = { boundsInWindow.topLeft }
+        getTopLeftOffsetInWindow = { boundsInWindow.topLeft },
+        endEdgeGestureBehavior = endEdgeGestureBehavior
     ).also { navigationEventDispatcher.addInput(it) }
 
     private val mediator = ComposeSceneMediator(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.navigationevent.UIKitNavigationEventInput
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformArchitectureComponentsOwner
-import androidx.compose.ui.uikit.EndEdgeGestureBehavior
+import androidx.compose.ui.uikit.EndEdgePanGestureBehavior
 import androidx.compose.ui.uikit.InterfaceOrientation
 import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.uikit.OnFocusBehavior
@@ -64,7 +64,7 @@ internal class UIKitComposeSceneLayer(
     private val initLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
     onFocusBehavior: OnFocusBehavior,
-    endEdgeGestureBehavior: EndEdgeGestureBehavior,
+    endEdgeGestureBehavior: EndEdgePanGestureBehavior,
     private var focusedViewsList: FocusedViewsList?,
     compositionContext: CompositionContext,
     private val ownerProvider: PlatformArchitectureComponentsOwner,
@@ -92,7 +92,7 @@ internal class UIKitComposeSceneLayer(
     private val navigationEventInput = UIKitNavigationEventInput(
         density = interactionView.density,
         getTopLeftOffsetInWindow = { boundsInWindow.topLeft },
-        endEdgeGestureBehavior = endEdgeGestureBehavior
+        endEdgePanGestureBehavior = endEdgeGestureBehavior
     ).also { navigationEventDispatcher.addInput(it) }
 
     private val mediator = ComposeSceneMediator(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -69,17 +69,17 @@ class ComposeUIViewControllerConfiguration {
     var parallelRendering: Boolean = false
 
     /**
-     * Determines how the end edge gestures will be handled.
+     * Determines how the end edge pan gestures will be handled.
      * In LTR layouts, the end edge is the right edge of the screen.
      * In RTL layouts, the end edge is the left edge of the screen.
      *
-     * Note: this setting only affects the behavior of the end edge gestures.
-     * The start edge gestures will always be handled as back navigation events.
+     * Note: this setting only affects the behavior of the end edge pan gestures.
+     * The start edge pan gestures will always be handled as back navigation events.
      *
-     * Default value is [EndEdgeGestureBehavior.Disabled].
+     * Default value is [EndEdgePanGestureBehavior.Disabled].
      */
     @ExperimentalComposeUiApi
-    var endEdgeGestureBehavior: EndEdgeGestureBehavior = EndEdgeGestureBehavior.Disabled
+    var endEdgePanGestureBehavior: EndEdgePanGestureBehavior = EndEdgePanGestureBehavior.Disabled
 }
 
 /**
@@ -137,19 +137,19 @@ sealed interface OnFocusBehavior {
 }
 
 @ExperimentalComposeUiApi
-sealed interface EndEdgeGestureBehavior {
+sealed interface EndEdgePanGestureBehavior {
     /**
      * No navigation events will be sent on the end edge.
      */
-    data object Disabled : EndEdgeGestureBehavior
+    data object Disabled : EndEdgePanGestureBehavior
 
     /**
      * Back navigation events will be sent on the end edge.
      */
-    data object Back : EndEdgeGestureBehavior
+    data object Back : EndEdgePanGestureBehavior
 
     /**
      * Forward navigation events will be sent on the end edge.
      */
-    data object Forward : EndEdgeGestureBehavior
+    data object Forward : EndEdgePanGestureBehavior
 }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/uikit/ComposeUIViewControllerConfiguration.uikit.kt
@@ -67,6 +67,19 @@ class ComposeUIViewControllerConfiguration {
      */
     @ExperimentalComposeUiApi
     var parallelRendering: Boolean = false
+
+    /**
+     * Determines how the end edge gestures will be handled.
+     * In LTR layouts, the end edge is the right edge of the screen.
+     * In RTL layouts, the end edge is the left edge of the screen.
+     *
+     * Note: this setting only affects the behavior of the end edge gestures.
+     * The start edge gestures will always be handled as back navigation events.
+     *
+     * Default value is [EndEdgeGestureBehavior.Disabled].
+     */
+    @ExperimentalComposeUiApi
+    var endEdgeGestureBehavior: EndEdgeGestureBehavior = EndEdgeGestureBehavior.Disabled
 }
 
 /**
@@ -121,4 +134,22 @@ sealed interface OnFocusBehavior {
      * A focusable element should be displayed above the keyboard.
      */
     data object FocusableAboveKeyboard : OnFocusBehavior
+}
+
+@ExperimentalComposeUiApi
+sealed interface EndEdgeGestureBehavior {
+    /**
+     * No navigation events will be sent on the end edge.
+     */
+    data object Disabled : EndEdgeGestureBehavior
+
+    /**
+     * Back navigation events will be sent on the end edge.
+     */
+    data object Back : EndEdgeGestureBehavior
+
+    /**
+     * Forward navigation events will be sent on the end edge.
+     */
+    data object Forward : EndEdgeGestureBehavior
 }


### PR DESCRIPTION
Added support for configurable end edge gesture behaviors in UIKit navigation logic.
```
fun MainViewController(): UIViewController = ComposeUIViewController(
    configure = {
        endEdgePanGestureBehavior = EndEdgePanGestureBehavior.Disabled //default
    }
) {
    App()
}
```

Fixes [CMP-9004](https://youtrack.jetbrains.com/issue/CMP-9004)

End edge gesture is disabled by default:

https://github.com/user-attachments/assets/0351c92c-dafe-4124-a288-acd160fc4416

There is `EndEdgeGestureBehavior.Back` option:

https://github.com/user-attachments/assets/9d62e572-dfbe-4a17-9867-aee62139d78e

And there is `EndEdgeGestureBehavior.Forward`.


## Release Notes
### Features - Navigation
- Add a new configuration option in `ComposeUIViewController` to set end-edge gestures behavior.

