### PR TITLE
Ignore unstable web tests

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -201,7 +201,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        firefox: [ '119.0', 'latest' ]
+        # FIXME: Even after installation of '119.0', tests still use latest one. Fix and restore.
+        firefox: [ 'latest' ]
         task: [ 'Js', 'Wasm' ]
     steps:
       - name: Checkout Repository

--- a/compose/ui/ui/src/commonTest/kotlin/kotlinx/test/IgnoreTargets.kt
+++ b/compose/ui/ui/src/commonTest/kotlin/kotlinx/test/IgnoreTargets.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalMultiplatform::class)
+
+package kotlinx.test
+
+@OptionalExpectation
+expect annotation class IgnoreWasmTarget()
+
+@OptionalExpectation
+expect annotation class IgnoreJsTarget()

--- a/compose/ui/ui/src/jsTest/kotlin/kotlinx/test/IgnoreTargets.js.kt
+++ b/compose/ui/ui/src/jsTest/kotlin/kotlinx/test/IgnoreTargets.js.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.test
+
+actual typealias IgnoreJsTarget = kotlin.test.Ignore

--- a/compose/ui/ui/src/wasmJsTest/kotlin/kotlinx/test/IgnoreTargetsActuals.wasmJs.kt
+++ b/compose/ui/ui/src/wasmJsTest/kotlin/kotlinx/test/IgnoreTargetsActuals.wasmJs.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kotlinx.test
+
+actual typealias IgnoreWasmTarget = kotlin.test.Ignore

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+// "Declaration annotated with '@OptionalExpectation' can only be used in common module sources."
+// because of IgnoreJsTarget. https://youtrack.jetbrains.com/issue/KTIJ-22326
+@file:Suppress("OPTIONAL_DECLARATION_USAGE_IN_NON_COMMON_SOURCE")
+
 package androidx.compose.ui.platform.a11y
 
 import androidx.compose.material.Button

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.OnCanvasTests
 import androidx.compose.ui.currentTimeMillis
 import androidx.compose.ui.platform.testTag
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -35,18 +34,20 @@ import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.browser.document
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.test.IgnoreJsTarget
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
 
+// It's flaky on Firefox JS. After ignoring one test it fails on another.
+// FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
+@IgnoreJsTarget
 class CfWA11YTest : OnCanvasTests {
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
     @Test
     fun a11yButtonClick() = runApplicationTest {
         var clickCounter = 0
@@ -78,7 +79,6 @@ class CfWA11YTest : OnCanvasTests {
         }
     }
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
     @Test
     fun changesAreApplied() = runApplicationTest {
         var clickCounter1 = 0
@@ -208,7 +208,6 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("Button3", buttonsContainer.children[2]!!.innerHTML)
     }
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-8955
     @Test
     fun changesMustBeBatched() = runApplicationTest {
         var show1 by mutableStateOf(true)
@@ -259,7 +258,6 @@ class CfWA11YTest : OnCanvasTests {
         assertTrue(waitedForChangesMs in 50..150, "Changes must be batched, waited for $waitedForChangesMs ms. Allowed tolerance 50ms was exceeded")
     }
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-8955
     @Test
     fun changesMustBeAppliedDespiteConstantDebounceAfter1Second() = runApplicationTest {
         var show1 by mutableStateOf(true)
@@ -326,7 +324,6 @@ class CfWA11YTest : OnCanvasTests {
         )
     }
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-8955
     @Test
     fun noChangesFor1SecondTheDebounceShouldWork() = runApplicationTest {
         var show by mutableStateOf(true)
@@ -447,7 +444,6 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("DIV", appContainer.children[1]!!.tagName) // interop container
     }
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
     @Test
     fun modifierTestTagIsSetToId() = runApplicationTest {
         var showButton by mutableStateOf(true)
@@ -481,7 +477,6 @@ class CfWA11YTest : OnCanvasTests {
         assertNull(getShadowRoot().getElementById("buttonTag"))
     }
 
-    @Ignore // Sometimes fails on latest firefox FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
     @Test
     fun textFieldHasTextBoxRole() = runApplicationTest {
         var text by mutableStateOf("Hello, World!")


### PR DESCRIPTION
There are a few issues with it:
- In `CfWA11YTest`, after ignoring one, another test will fail so ignoring entire class is required
- `CfWA11YTest` fails (unstable) only on JS, so it's better to still run it on WASM
- Tests of Firefox 119 configuration sill uses latest (144) somehow. Excluded this configuration from matrix until the fix

## Release Notes
N/A
