### PR TITLE
Add `isNaN` check for align behavior with JVM

### DIFF
--- a/compose/ui/ui-util/src/commonTest/kotlin/androidx/compose/ui/util/InlineClassHelperTest.kt
+++ b/compose/ui/ui-util/src/commonTest/kotlin/androidx/compose/ui/util/InlineClassHelperTest.kt
@@ -102,4 +102,10 @@ class InlineClassHelperTest {
     }
 
     fun multZero(value: Float) = value * 0f
+
+    @Test
+    fun fastRoundNaNToInt() {
+        assertEquals(0, Float.NaN.fastRoundToInt())
+        assertEquals(0, Double.NaN.fastRoundToInt())
+    }
 }

--- a/compose/ui/ui-util/src/nonJvmMain/kotlin/androidx/compose/ui/util/InlineClassHelper.nonJvm.kt
+++ b/compose/ui/ui-util/src/nonJvmMain/kotlin/androidx/compose/ui/util/InlineClassHelper.nonJvm.kt
@@ -24,6 +24,6 @@ actual inline fun floatFromBits(bits: Int): Float = Float.fromBits(bits)
 
 actual inline fun doubleFromBits(bits: Long): Double = Double.fromBits(bits)
 
-actual inline fun Float.fastRoundToInt(): Int = roundToInt()
+actual inline fun Float.fastRoundToInt(): Int = if (isNaN()) 0 else roundToInt()
 
-actual inline fun Double.fastRoundToInt(): Int = roundToInt()
+actual inline fun Double.fastRoundToInt(): Int = if (isNaN()) 0 else roundToInt()


### PR DESCRIPTION
[CMP-8562](https://youtrack.jetbrains.com/issue/CMP-8562) iOS: "IllegalArgumentException: Cannot round NaN value" caused by `roundToInt()`

## Release Notes
### Fixes - Multiple Platforms
- Align `roundToPx()` behavior between platforms: `NaN` value produces `0` instead of `IllegalArgumentException` on non-JVM platforms now