### PR TITLE
Fix `LocalDensity` propagation into `ComposeScene` layers

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeSceneMediatorTest.kt
@@ -49,7 +49,7 @@ class ComposeSceneMediatorTest {
         mediator.setContent {}
         mediator.dispose()
 
-        mediator.density = Density(2f)
+        mediator.composeSceneDensity = Density(2f)
         mediator.layoutDirection = LayoutDirection.Rtl
         mediator.compositionLocalContext = null
         mediator.interactionBounds = IntRect.Zero

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -32,6 +32,7 @@ import androidx.compose.material.TextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -43,6 +44,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.findNodeWithTag
@@ -50,6 +52,7 @@ import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.dpRectInWindow
 import androidx.compose.ui.test.utils.forEachWithPrevious
 import androidx.compose.ui.uikit.OnFocusBehavior
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
@@ -690,6 +693,44 @@ internal class KeyboardInsetsTest {
                     }
                 }
             )
+        }
+
+        findNodeWithTag("TextField").tap()
+        waitForIdle()
+
+        assertEquals(expected = frame?.bottom, actual = screenSize.height - keyboardHeight)
+    }
+
+    @Test
+    fun testImePaddingInDialogWithCustomDensity() = runUIKitInstrumentedTest {
+        val customDensity = Density(density = 5f)
+        var frame: DpRect? = null
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides customDensity) {
+                Dialog(
+                    onDismissRequest = {},
+                    properties = DialogProperties(
+                        usePlatformInsets = false,
+                        useSoftwareKeyboardInset = true,
+                        usePlatformDefaultWidth = false
+                    ),
+                    content = {
+                        Box(Modifier.fillMaxSize().statusBarsPadding().imePadding()) {
+                            BasicTextField(
+                                value = "",
+                                onValueChange = {},
+                                modifier = Modifier.fillMaxWidth()
+                                    .align(Alignment.BottomCenter)
+                                    .onGloballyPositioned {
+                                        frame = it.boundsInWindow().toDpRect(density)
+                                    }
+                                    .testTag("TextField")
+                            )
+                        }
+                    }
+                )
+            }
         }
 
         findNodeWithTag("TextField").tap()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/KeyboardInsetsTest.kt
@@ -631,7 +631,7 @@ internal class KeyboardInsetsTest {
     }
 
     @Test
-    fun textInsetsInDialogWhenUseSoftwareKeyboardInsetEnabled() = runUIKitInstrumentedTest {
+    fun testInsetsInDialogWhenUseSoftwareKeyboardInsetEnabled() = runUIKitInstrumentedTest {
         var frame: DpRect? = null
         setContent {
             Dialog(
@@ -665,7 +665,7 @@ internal class KeyboardInsetsTest {
     }
 
     @Test
-    fun textInsetsInDialogWhenUseSoftwareKeyboardInsetDisabled() = runUIKitInstrumentedTest {
+    fun testInsetsInDialogWhenUseSoftwareKeyboardInsetDisabled() = runUIKitInstrumentedTest {
         var frame: DpRect? = null
         setContent {
             Dialog(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
@@ -46,7 +46,7 @@ import kotlin.test.assertNotEquals
 
 class LocalDensityTest {
     @Test
-    fun testCustomDensityPropagatedToDialog() = runUIKitInstrumentedTest {
+    fun testCustomDensityNotPropagatedToDialog() = runUIKitInstrumentedTest {
         val customDensity = Density(density = 5f)
         var density = -1f
 
@@ -58,8 +58,8 @@ class LocalDensityTest {
             }
         }
 
-        assertEquals(customDensity.density, density)
-        assertNotEquals(hostingViewController.view.density.density, density)
+        assertNotEquals(customDensity.density, density)
+        assertEquals(hostingViewController.view.density.density, density)
     }
 
     @Test
@@ -75,8 +75,8 @@ class LocalDensityTest {
             }
         }
 
-        assertEquals(customDensity.density, density)
-        assertNotEquals(hostingViewController.view.density.density, density)
+        assertNotEquals(customDensity.density, density)
+        assertEquals(hostingViewController.view.density.density, density)
     }
 
     @Test
@@ -99,8 +99,8 @@ class LocalDensityTest {
             }
         }
 
-        assertEquals(outerDensity.density, actualOuterDensity)
-        assertNotEquals(hostingViewController.view.density.density, actualOuterDensity)
+        assertNotEquals(outerDensity.density, actualOuterDensity)
+        assertEquals(hostingViewController.view.density.density, actualOuterDensity)
         assertEquals(innerDensity.density, actualInnerDensity)
     }
 
@@ -124,8 +124,8 @@ class LocalDensityTest {
             }
         }
 
-        assertEquals(outerDensity.density, actualOuterDensity)
-        assertNotEquals(hostingViewController.view.density.density, actualOuterDensity)
+        assertNotEquals(outerDensity.density, actualOuterDensity)
+        assertEquals(hostingViewController.view.density.density, actualOuterDensity)
         assertEquals(innerDensity.density, actualInnerDensity)
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LocalDensityTest.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.layers
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.Button
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.uikit.density
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.compose.ui.window.Popup
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class LocalDensityTest {
+    @Test
+    fun testCustomDensityPropagatedToDialog() = runUIKitInstrumentedTest {
+        val customDensity = Density(density = 5f)
+        var density = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides customDensity) {
+                Dialog(onDismissRequest = {}) {
+                    density = LocalDensity.current.density
+                }
+            }
+        }
+
+        assertEquals(customDensity.density, density)
+        assertNotEquals(hostingViewController.view.density.density, density)
+    }
+
+    @Test
+    fun testCustomDensityPropagatedToPopup() = runUIKitInstrumentedTest {
+        val customDensity = Density(density = 5f)
+        var density = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides customDensity) {
+                Popup {
+                    density = LocalDensity.current.density
+                }
+            }
+        }
+
+        assertEquals(customDensity.density, density)
+        assertNotEquals(hostingViewController.view.density.density, density)
+    }
+
+    @Test
+    fun testCustomDensityPropagatedInDialogContent() = runUIKitInstrumentedTest {
+        val outerDensity = Density(density = 5f)
+        val innerDensity = Density(density = 10f)
+        var actualOuterDensity = -1f
+        var actualInnerDensity = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides outerDensity) {
+                Dialog(onDismissRequest = {}) {
+                    actualOuterDensity = LocalDensity.current.density
+                    CompositionLocalProvider(LocalDensity provides innerDensity) {
+                        Button(onClick = {}) {
+                            actualInnerDensity = LocalDensity.current.density
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(outerDensity.density, actualOuterDensity)
+        assertNotEquals(hostingViewController.view.density.density, actualOuterDensity)
+        assertEquals(innerDensity.density, actualInnerDensity)
+    }
+
+    @Test
+    fun testCustomDensityPropagatedInPopupContent() = runUIKitInstrumentedTest {
+        val outerDensity = Density(density = 5f)
+        val innerDensity = Density(density = 10f)
+        var actualOuterDensity = -1f
+        var actualInnerDensity = -1f
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides outerDensity) {
+                Popup {
+                    actualOuterDensity = LocalDensity.current.density
+                    CompositionLocalProvider(LocalDensity provides innerDensity) {
+                        Button(onClick = {}) {
+                            actualInnerDensity = LocalDensity.current.density
+                        }
+                    }
+                }
+            }
+        }
+
+        assertEquals(outerDensity.density, actualOuterDensity)
+        assertNotEquals(hostingViewController.view.density.density, actualOuterDensity)
+        assertEquals(innerDensity.density, actualInnerDensity)
+    }
+
+    @Test
+    fun testTapInteractionsInDialogWithOuterCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val interactionButtonNumber = 8
+        var interactionCount = 0
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides density) {
+                Dialog(onDismissRequest = {}) {
+                    Column {
+                        repeat(10) { number ->
+                            Button(
+                                onClick = { if (number == interactionButtonNumber) { interactionCount++ } },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $number")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $interactionButtonNumber").tap()
+
+        waitForIdle()
+
+        assertEquals(1, interactionCount)
+    }
+
+    @Test
+    fun testTapInteractionsInPopupWithOuterCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val targetButtonIndex = 8
+        var tappedButtonIndex = -1
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides density) {
+                Popup {
+                    Column {
+                        repeat(10) { index ->
+                            Button(
+                                onClick = { tappedButtonIndex = index },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $index")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $targetButtonIndex").tap()
+
+        waitForIdle()
+
+        assertEquals(targetButtonIndex, tappedButtonIndex)
+    }
+
+    @Test
+    fun testTapInteractionsInDialogWithInnerCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val targetButtonIndex = 8
+        var tappedButtonIndex = -1
+
+        setContent {
+            Dialog(onDismissRequest = {}) {
+                CompositionLocalProvider(LocalDensity provides density) {
+                    Column {
+                        repeat(10) { index ->
+                            Button(
+                                onClick = { tappedButtonIndex = index },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $index")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $targetButtonIndex").tap()
+
+        waitForIdle()
+
+        assertEquals(targetButtonIndex, tappedButtonIndex)
+    }
+
+    @Test
+    fun testTapInteractionsInPopupWithInnerCustomDensity() = runUIKitInstrumentedTest {
+        val density = Density(density = 5f)
+        val targetButtonIndex = 8
+        var tappedButtonIndex = -1
+
+        setContent {
+            Popup {
+                CompositionLocalProvider(LocalDensity provides density) {
+                    Column {
+                        repeat(10) { index ->
+                            Button(
+                                onClick = { tappedButtonIndex = index },
+                                modifier = Modifier.fillMaxWidth().weight(1f).testTag("Button $index")
+                            ) {}
+                        }
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("Button $targetButtonIndex").tap()
+
+        waitForIdle()
+
+        assertEquals(targetButtonIndex, tappedButtonIndex)
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.CUPERTINO_TOUCH_SLOP
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.findNodeWithTag
@@ -61,6 +62,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toDpRect
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -113,6 +116,53 @@ internal class ScrollTest {
         assertEquals(initialBoxRect, boxRect)
     }
 
+    @Test
+    fun testExactTouchSlopDragWithCustomDensityInDialog() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRectZero()
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(5f)) {
+                Dialog(
+                    onDismissRequest = { },
+                    properties = DialogProperties(
+                        usePlatformDefaultWidth = false,
+                        usePlatformInsets = false,
+                        useSoftwareKeyboardInset = false,
+                    )
+                ) {
+                    Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(100.dp)
+                                .background(Color.Red)
+                                .onGloballyPositioned {
+                                    boxRect = it.boundsInWindow().toDpRect(density)
+                                }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(screenSize.height)
+                                .background(Color.Blue)
+                        )
+                    }
+                }
+            }
+        }
+
+        val initialBoxRect = boxRect.copy()
+        val dyExact = CUPERTINO_TOUCH_SLOP.dp
+
+        touchDown(screenSize.center)
+            .dragBy(dy = dyExact)
+
+        waitForIdle()
+
+        assertEquals(initialBoxRect, boxRect)
+    }
+
     /**
      * Tests that a drag just over the touch slop threshold will trigger overscroll behavior
      * in a vertically scrollable Column.
@@ -135,6 +185,54 @@ internal class ScrollTest {
                     .height(screenSize.height)
                     .background(Color.White)
                 )
+            }
+        }
+
+        val dyJustOver = CUPERTINO_TOUCH_SLOP.dp + 1.dp
+
+        touchDown(screenSize.center)
+            .dragBy(dy = dyJustOver)
+
+        waitForIdle()
+
+        assertTrue(boxRect.top > 0.dp)
+        // Scroll state remains at 0 despite visual overscroll
+        assertEquals(0 * density.density, state.value.toFloat())
+    }
+
+    @Test
+    fun testJustOverTouchSlopDragWithCustomDensityInDialog() = runUIKitInstrumentedTest {
+        val state = ScrollState(0)
+        var boxRect = DpRectZero()
+
+        setContent {
+            CompositionLocalProvider(LocalDensity provides Density(5f)) {
+                Dialog(
+                    onDismissRequest = { },
+                    properties = DialogProperties(
+                        usePlatformDefaultWidth = false,
+                        usePlatformInsets = false,
+                        useSoftwareKeyboardInset = false,
+                    )
+                ) {
+                    Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(100.dp)
+                                .background(Color.Red)
+                                .onGloballyPositioned {
+                                    boxRect = it.boundsInWindow().toDpRect(density)
+                                }
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(screenSize.height)
+                                .background(Color.White)
+                        )
+                    }
+                }
             }
         }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -122,7 +122,7 @@ internal class ScrollTest {
         var boxRect = DpRectZero()
 
         setContent {
-            CompositionLocalProvider(LocalDensity provides Density(5f)) {
+            CompositionLocalProvider(LocalDensity provides Density(0.5f)) {
                 Dialog(
                     onDismissRequest = { },
                     properties = DialogProperties(
@@ -206,7 +206,7 @@ internal class ScrollTest {
         var boxRect = DpRectZero()
 
         setContent {
-            CompositionLocalProvider(LocalDensity provides Density(5f)) {
+            CompositionLocalProvider(LocalDensity provides Density(0.5f)) {
                 Dialog(
                     onDismissRequest = { },
                     properties = DialogProperties(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -487,7 +487,7 @@ internal class ComposeHostingViewController(
         platformContext: PlatformContext,
         layersHolder: ComposeLayersHolder
     ): ComposeScene = PlatformLayersComposeScene(
-        density = mediator?.screenDensity ?: view.density,
+        density = view.density,
         layoutDirection = layoutDirection,
         coroutineContext = composeCoroutineContext,
         composeSceneContext = createComposeSceneContext(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -462,7 +462,7 @@ internal class ComposeHostingViewController(
                     createComposeSceneContext = { createComposeSceneContext(it, layersHolder) },
                     hostCompositionLocals = { ProvideContainerCompositionLocals(it) },
                     layersViewController = layersHolder.getLayersViewController(),
-                    initDensity = density,
+                    initComposeSceneDensity = density,
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
                     endEdgeGestureBehavior = configuration.endEdgePanGestureBehavior,
@@ -526,7 +526,7 @@ internal class ComposeHostingViewController(
         )
 
     private fun ComposeSceneMediator.updateInteractionRect() {
-        interactionBounds = with(density) {
+        interactionBounds = with(view.density) {
             view.bounds.asDpRect().toRect().roundToIntRect()
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -462,7 +462,7 @@ internal class ComposeHostingViewController(
                     createComposeSceneContext = { createComposeSceneContext(it, layersHolder) },
                     hostCompositionLocals = { ProvideContainerCompositionLocals(it) },
                     layersViewController = layersHolder.getLayersViewController(),
-                    initLayoutDirection = layoutDirection,
+                    initialLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
                     endEdgeGestureBehavior = configuration.endEdgePanGestureBehavior,
                     onAccessibilityChanged = ::onAccessibilityChanged,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -462,7 +462,6 @@ internal class ComposeHostingViewController(
                     createComposeSceneContext = { createComposeSceneContext(it, layersHolder) },
                     hostCompositionLocals = { ProvideContainerCompositionLocals(it) },
                     layersViewController = layersHolder.getLayersViewController(),
-                    initComposeSceneDensity = density,
                     initLayoutDirection = layoutDirection,
                     onFocusBehavior = configuration.onFocusBehavior,
                     endEdgeGestureBehavior = configuration.endEdgePanGestureBehavior,
@@ -488,7 +487,7 @@ internal class ComposeHostingViewController(
         platformContext: PlatformContext,
         layersHolder: ComposeLayersHolder
     ): ComposeScene = PlatformLayersComposeScene(
-        density = view.density,
+        density = mediator?.screenDensity ?: view.density,
         layoutDirection = layoutDirection,
         coroutineContext = composeCoroutineContext,
         composeSceneContext = createComposeSceneContext(

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -238,7 +238,7 @@ internal class ComposeSceneMediator(
         get() = scene.density
         set(_) {
             if (!disposed) {
-                // compose scene density of the root cannot be customized
+                scene.density = screenDensity
             }
         }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -234,6 +234,13 @@ internal class ComposeSceneMediator(
             }
         }
 
+    /**
+     * Density used by the Compose scene for dp/px conversions within Compose.
+     *
+     * This value is intentionally separate from [screenDensity] so we can support setting custom
+     * composeSceneDensity without regressions (merging [screenDensity] and [composeSceneDensity]
+     * into one causes rendering and interaction issues because they are semantically different).
+     */
     var composeSceneDensity: Density
         get() = scene.density
         set(value) {
@@ -242,6 +249,12 @@ internal class ComposeSceneMediator(
             }
         }
 
+    /**
+     * Density of the hosting UIKit screen.
+     *
+     * This value is intentionally separate from [composeSceneDensity] so we can support setting
+     * composeSceneDensity without regressions.
+     */
     val screenDensity: Density get() = _overlayView.density
 
     var layoutDirection: LayoutDirection

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -210,7 +210,7 @@ internal class ComposeSceneMediator(
     private val viewConfiguration: ViewConfiguration =
         object : ViewConfiguration by EmptyViewConfiguration {
             override val touchSlop: Float
-                get() = with(density) {
+                get() = with(screenDensity) {
                     // this value is originating from iOS 16 drag behavior reverse engineering
                     CUPERTINO_TOUCH_SLOP.dp.toPx()
                 }
@@ -234,13 +234,15 @@ internal class ComposeSceneMediator(
             }
         }
 
-    var density: Density
+    var composeSceneDensity: Density
         get() = scene.density
         set(value) {
             if (!disposed) {
                 scene.density = value
             }
         }
+
+    private val screenDensity: Density get() = _overlayView.density
 
     var layoutDirection: LayoutDirection
         get() = scene.layoutDirection
@@ -340,7 +342,7 @@ internal class ComposeSceneMediator(
         ComposeSceneKeyboardOffsetManager(
             view = _overlayView,
             keyboardOverlapHeightChanged = { height ->
-                val heightPx = with(density) { height.roundToPx() }
+                val heightPx = with(screenDensity) { height.roundToPx() }
                 if (windowInsetsManager.keyboardOverlapHeight.value != heightPx) {
                     animateKeyboardOffsetChanges = false
                     windowInsetsManager.keyboardOverlapHeight.value = heightPx
@@ -377,7 +379,7 @@ internal class ComposeSceneMediator(
 
     private fun hitTestInteropView(point: CValue<CGPoint>): UIView? =
         point.useContents {
-            val position = asDpOffset().toOffset(density)
+            val position = asDpOffset().toOffset(composeSceneDensity)
             val interopView = scene.hitTestInteropView(position)
 
             // Find a group of a holder associated with a given interop view or view controller
@@ -403,12 +405,12 @@ internal class ComposeSceneMediator(
             pointers = listOf(
                 ComposeScenePointer(
                     id = PointerId(0),
-                    position = position.toOffset(density),
+                    position = position.toOffset(composeSceneDensity),
                     pressed = false,
                     type = PointerType.Mouse,
                 )
             ),
-            scrollDelta = delta.toOffset(density) * SCROLL_DELTA_MULTIPLIER,
+            scrollDelta = delta.toOffset(composeSceneDensity) * SCROLL_DELTA_MULTIPLIER,
             timeMillis = event.timeMillis,
             nativeEvent = event,
             keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero)
@@ -431,7 +433,7 @@ internal class ComposeSceneMediator(
             pointers = listOf(
                 ComposeScenePointer(
                     id = PointerId(0),
-                    position = position.toOffset(density),
+                    position = position.toOffset(composeSceneDensity),
                     pressed = false,
                     type = PointerType.Mouse,
                 )
@@ -471,7 +473,7 @@ internal class ComposeSceneMediator(
 
         val pointers = touches.mapIndexed { index, touch ->
             touch as UITouch
-            val position = touch.offsetInView(_backgroundView, density.density)
+            val position = touch.offsetInView(_backgroundView, screenDensity.density)
             val pointerType = when (touch.type) {
                 UITouchTypeDirect -> PointerType.Touch
                 UITouchTypeIndirect, UITouchTypeIndirectPointer -> PointerType.Mouse
@@ -490,7 +492,7 @@ internal class ComposeSceneMediator(
                 historical = event?.historicalChangesForTouch(
                     touch,
                     _overlayView,
-                    density.density
+                    screenDensity.density
                 ) ?: emptyList()
             )
         }
@@ -552,12 +554,12 @@ internal class ComposeSceneMediator(
                     withAnimationProgress(duration) { progress ->
                         windowInsetsManager.layoutMargins.value = lerp(
                             start = initialLayoutMargins,
-                            stop = _overlayView.layoutMargins.toPlatformInsets(density),
+                            stop = _overlayView.layoutMargins.toPlatformInsets(screenDensity),
                             fraction = progress
                         )
                         windowInsetsManager.safeAreaInsets.value = lerp(
                                 start = initialSafeAreaInsets,
-                                stop = _overlayView.safeAreaInsets.toPlatformInsets(density),
+                                stop = _overlayView.safeAreaInsets.toPlatformInsets(screenDensity),
                                 fraction = progress
                         )
                         size = lerp(
@@ -634,18 +636,16 @@ internal class ComposeSceneMediator(
      * Updates the [ComposeScene] with the properties derived from the [_overlayView].
      */
     private fun updateLayout() {
-        density = _overlayView.density
-
         if (isLayoutTransitionAnimating) {
             return
         }
-        windowInsetsManager.layoutMargins.value = _overlayView.layoutMargins.toPlatformInsets(density)
-        windowInsetsManager.safeAreaInsets.value = _overlayView.safeAreaInsets.toPlatformInsets(density)
+        windowInsetsManager.layoutMargins.value = _overlayView.layoutMargins.toPlatformInsets(_overlayView.density)
+        windowInsetsManager.safeAreaInsets.value = _overlayView.safeAreaInsets.toPlatformInsets(_overlayView.density)
         size = currentViewSize.roundToIntSize()
     }
 
     private val currentViewSize: Size get() {
-        return with(density) {
+        return with(_overlayView.density) {
             _overlayView.frame.useContents { size.asDpSize() }.toSize()
         }
     }

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -236,9 +236,9 @@ internal class ComposeSceneMediator(
 
     var composeSceneDensity: Density
         get() = scene.density
-        set(_) {
+        set(value) {
             if (!disposed) {
-                scene.density = screenDensity
+                scene.density = value
             }
         }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.uikit.kt
@@ -236,13 +236,13 @@ internal class ComposeSceneMediator(
 
     var composeSceneDensity: Density
         get() = scene.density
-        set(value) {
+        set(_) {
             if (!disposed) {
-                scene.density = value
+                // compose scene density of the root cannot be customized
             }
         }
 
-    private val screenDensity: Density get() = _overlayView.density
+    val screenDensity: Density get() = _overlayView.density
 
     var layoutDirection: LayoutDirection
         get() = scene.layoutDirection

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -60,7 +60,7 @@ internal class UIKitComposeSceneLayer(
     private val hostCompositionLocals: @Composable (@Composable () -> Unit) -> Unit,
 
     private val layersViewController: ComposeLayersViewController,
-    private val initLayoutDirection: LayoutDirection,
+    private val initialLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
     onFocusBehavior: OnFocusBehavior,
     endEdgeGestureBehavior: EndEdgePanGestureBehavior,
@@ -117,7 +117,7 @@ internal class UIKitComposeSceneLayer(
     ): ComposeScene =
         PlatformLayersComposeScene(
             density = mediator.screenDensity,
-            layoutDirection = initLayoutDirection,
+            layoutDirection = initialLayoutDirection,
             coroutineContext = coroutineContext,
             composeSceneContext = createComposeSceneContext(platformContext),
             invalidate = invalidate,

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -127,7 +127,11 @@ internal class UIKitComposeSceneLayer(
 
     var isAccessibilityEnabled by mediator::isAccessibilityEnabled
 
-    override var density by mediator::composeSceneDensity
+    override var density: Density
+        get() = mediator.composeSceneDensity
+        set(_) {
+            // density of the layer cannot be customized
+        }
 
     override var layoutDirection by mediator::layoutDirection
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -60,7 +60,7 @@ internal class UIKitComposeSceneLayer(
     private val hostCompositionLocals: @Composable (@Composable () -> Unit) -> Unit,
 
     private val layersViewController: ComposeLayersViewController,
-    private val initDensity: Density,
+    private val initComposeSceneDensity: Density,
     private val initLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
     onFocusBehavior: OnFocusBehavior,
@@ -117,7 +117,7 @@ internal class UIKitComposeSceneLayer(
         platformContext: PlatformContext
     ): ComposeScene =
         PlatformLayersComposeScene(
-            density = initDensity, // We should use the local density already set for the current layer.
+            density = initComposeSceneDensity,
             layoutDirection = initLayoutDirection,
             coroutineContext = coroutineContext,
             composeSceneContext = createComposeSceneContext(platformContext),
@@ -128,7 +128,7 @@ internal class UIKitComposeSceneLayer(
 
     var isAccessibilityEnabled by mediator::isAccessibilityEnabled
 
-    override var density by mediator::density
+    override var density by mediator::composeSceneDensity
 
     override var layoutDirection by mediator::layoutDirection
 
@@ -157,6 +157,7 @@ internal class UIKitComposeSceneLayer(
 
     fun render(canvas: Canvas, nanoTime: Long) {
         if (scrimColor != null) {
+            val density = layersViewController.metalView.density
             val rect = layersViewController.metalView.bounds.asDpRect().toRect(density)
 
             canvas.drawRect(rect, scrimPaint)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.uikit.kt
@@ -60,7 +60,6 @@ internal class UIKitComposeSceneLayer(
     private val hostCompositionLocals: @Composable (@Composable () -> Unit) -> Unit,
 
     private val layersViewController: ComposeLayersViewController,
-    private val initComposeSceneDensity: Density,
     private val initLayoutDirection: LayoutDirection,
     private val onAccessibilityChanged: () -> Unit,
     onFocusBehavior: OnFocusBehavior,
@@ -117,7 +116,7 @@ internal class UIKitComposeSceneLayer(
         platformContext: PlatformContext
     ): ComposeScene =
         PlatformLayersComposeScene(
-            density = initComposeSceneDensity,
+            density = mediator.screenDensity,
             layoutDirection = initLayoutDirection,
             coroutineContext = coroutineContext,
             composeSceneContext = createComposeSceneContext(platformContext),


### PR DESCRIPTION
`LocalDensity` from the parent composition did not flow correctly into newly created compose scenes (`Dialog`/`Popup`) on iOS causing interaction and rendering issues.  This PR fixes the bug by separating screen density (from the platform) and scene density (the current composition’s `LocalDensity`) in `ComposeSceneMediator`. This PR also aligns iOS with Android. On Android `Dialog` and `Popup` do not inherit `LocalDensity` from the parent but re-seed density from the platform. On Desktop layers do inherit `LocalDensity` from the parent.

Fixes [CMP-8662](https://youtrack.jetbrains.com/issue/CMP-8662) [iOS] Incorrect tap responses in a Dialog when LocalDensity is modified.

## Testing

- Adds `LocalDensityTest` test suite
- Adds tests to `KeyboardInsetsTest`
- Adds tests to `ScrollTest`

This should be tested by QA

## Release Notes
### Fixes - iOS
- Fix incorrect tap responses in `Dialog` when `LocalDensity` is modified
