### PR TITLE
Enable virtual keyboard suggestions in iOS

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -98,7 +98,6 @@ private fun ImeOptions.createDomElement(): HTMLElement {
     ) as HTMLElement
 
     htmlElement.setAttribute("autocorrect", "off")
-    htmlElement.setAttribute("autocomplete", "off")
     htmlElement.setAttribute("autocapitalize", "off")
     htmlElement.setAttribute("spellcheck", "false")
 


### PR DESCRIPTION
Do not set autocomplete="off" for backing DOM input - otherwise autocomplete will be turned off in mobile Safari  

This is a fix for https://youtrack.jetbrains.com/issue/CMP-8807

## Testing
manual

## Release Notes
### Fixes - Web
- Unblock autocomplete and the other keyboard features on mobile iOS
