### PR TITLE
Fix autosuggestion on Android when it was performed anywhere but the end ot the word

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -68,9 +68,10 @@ internal class DomInputStrategy(
         htmlInput.addEventListener("beforeinput", { evt ->
             if (evt is InputEvent) {
                 htmlInput as HTMLElementWithValue
-                val deleteContentBackwardSize = htmlInput.selectionEnd - htmlInput.selectionStart
 
-                evt.deleteContentBackwardSize = deleteContentBackwardSize
+                evt.textRangeStart = htmlInput.selectionStart
+                evt.textRangeEnd = htmlInput.selectionEnd
+
                 nativeInputEventsProcessor.registerEvent(evt)
             }
         })
@@ -89,8 +90,12 @@ internal external class InputEvent : UIEvent {
     val inputType: String
     val data: String?
     val isComposing: Boolean
-    var deleteContentBackwardSize: Int
+    var textRangeStart: Int
+    var textRangeEnd: Int
 }
+
+internal val InputEvent.textRangeSize: Int
+    get() = textRangeEnd - textRangeStart
 
 private fun ImeOptions.createDomElement(): HTMLElement {
     val htmlElement = document.createElement(

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -136,7 +136,11 @@ internal abstract class NativeInputEventsProcessor(
                     // The system first tells us to delete the old text,
                     // and then it would send the "insertText" event.
                     if (textRangeSize > 0) {
-                        add(DeleteSurroundingTextCommand(textRangeSize, 0))
+                        // deleteContentBackward can happen under very non-trivial circumstances,
+                        // for instance; when an input suggestion on Android Chrome is accepted,
+                        // the browser then deletes space after the word just to add space again
+                        add(SetSelectionCommand(textRangeStart, textRangeEnd))
+                        add(BackspaceCommand())
                     } else if (textRangeSize == 0) {
                         // under specific circumstance previous symbol can be deleted while inputing new one
                         // see https://youtrack.jetbrains.com/issue/CMP-8773

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.BackspaceCommand
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
 import androidx.compose.ui.text.input.SetComposingTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.util.fastAny
 import androidx.compose.ui.util.fastForEach
@@ -134,10 +135,9 @@ internal abstract class NativeInputEventsProcessor(
                     // This happens when an autocorrection is applied on mobile:
                     // The system first tells us to delete the old text,
                     // and then it would send the "insertText" event.
-                    val deleteSize = deleteContentBackwardSize
-                    if (deleteSize > 0) {
-                        add(DeleteSurroundingTextCommand(deleteSize, 0))
-                    } else if (deleteSize == 0) {
+                    if (textRangeSize > 0) {
+                        add(DeleteSurroundingTextCommand(textRangeSize, 0))
+                    } else if (textRangeSize == 0) {
                         // under specific circumstance previous symbol can be deleted while inputing new one
                         // see https://youtrack.jetbrains.com/issue/CMP-8773
                         add(BackspaceCommand())
@@ -147,9 +147,8 @@ internal abstract class NativeInputEventsProcessor(
 
             "insertReplacementText" -> buildList {
                 if (data == null) return@buildList
-                val deleteSize = deleteContentBackwardSize
-                if (deleteSize > 0) {
-                    add(DeleteSurroundingTextCommand(deleteSize, 0))
+                if (textRangeSize > 0) {
+                    add(SetSelectionCommand(textRangeStart, textRangeEnd))
                 }
 
                 add(CommitTextCommand(data, 1))
@@ -157,9 +156,8 @@ internal abstract class NativeInputEventsProcessor(
 
             "insertText" -> buildList {
                 if (data == null) return@buildList
-                val deleteSize = deleteContentBackwardSize
-                if (deleteSize > 0 && currentTextFieldValue.selection.collapsed) {
-                    add(DeleteSurroundingTextCommand(deleteSize, 0))
+                if (textRangeSize > 0 && currentTextFieldValue.selection.collapsed) {
+                    add(SetSelectionCommand(textRangeStart, textRangeEnd))
                 }
 
                 add(CommitTextCommand(data, 1))
@@ -167,9 +165,8 @@ internal abstract class NativeInputEventsProcessor(
 
             "insertCompositionText" -> buildList {
                 if (data == null) return@buildList
-                val deleteSize = deleteContentBackwardSize
-                if (deleteSize > 0) {
-                    add(DeleteSurroundingTextCommand(deleteSize, 0))
+                if (textRangeSize > 0) {
+                    add(SetSelectionCommand(textRangeStart, textRangeEnd))
                 }
                 add(SetComposingTextCommand(data, 1))
             }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/BasicTextFieldTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/BasicTextFieldTests.kt
@@ -23,6 +23,10 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.TestInputState
+import androidx.compose.ui.events.beforeInput
+import androidx.compose.ui.events.compositionEnd
+import androidx.compose.ui.events.compositionStart
+import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.specs.AccentDialogTestSpec
@@ -37,6 +41,7 @@ import androidx.compose.ui.input.specs.TextFieldTestSpec
 import androidx.compose.ui.input.specs.WinCompositeInput
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import kotlin.test.Test
 
 
 private class TextFieldValueHolder(private val textFieldValue: MutableState<TextFieldValue>) :
@@ -115,4 +120,44 @@ internal class WinCompositeInputWithValueTests : WinCompositeInput, BasicTextFie
 internal class WinCompositeInputWithStateTests : WinCompositeInput, BasicTextFieldWithState
 
 internal class AndroidCompositeInputWithValueTests : AndroidCompositeInput, BasicTextFieldWithValue
-internal class AndroidCompositeInputWithStateTests : AndroidCompositeInput, BasicTextFieldWithState
+internal class AndroidCompositeInputWithStateTests : AndroidCompositeInput, BasicTextFieldWithState {
+    @Test
+    fun `suggestion at the end` () = runApplicationTest {
+        // https://youtrack.jetbrains.com/issue/CMP-8809
+        val textFieldValue = createApplicationWithHolder()
+
+        sendToHtmlInput(
+            keyEvent("Unidentified", code=""),
+            compositionStart(""),
+            beforeInput("insertCompositionText", "h", isComposing = true),
+            keyEvent("Unidentified", code="", type = "keyup"),
+            keyEvent("Unidentified", code=""),
+            beforeInput("insertCompositionText", "he", isComposing = true),
+            keyEvent("Unidentified", code="", type = "keyup"),
+            keyEvent("Unidentified", code=""),
+            beforeInput("insertCompositionText", "her", isComposing = true),
+            keyEvent("Unidentified", code="", type = "keyup"),
+            keyEvent("Unidentified", code=""),
+            beforeInput("insertCompositionText", "here", isComposing = true),
+            keyEvent("Unidentified", code="", type = "keyup"),
+        )
+
+        textFieldValue.awaitAndAssertTextEquals(
+            "here"
+        )
+
+        sendToHtmlInput(
+            beforeInput("insertCompositionText", "where", isComposing = true),
+            compositionEnd("where"),
+            keyEvent("Unidentified", code="", type = "keyup"),
+            keyEvent("Unidentified", code=""),
+            beforeInput("insertCompositionText", " ", isComposing = true),
+            keyEvent("Unidentified", code="", type = "keyup"),
+        )
+
+        textFieldValue.awaitAndAssertTextEquals(
+            "where "
+        )
+    }
+
+}

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/CompositeInputTestSpec.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/CompositeInputTestSpec.kt
@@ -26,12 +26,11 @@ import androidx.compose.ui.events.keyEvent
 import kotlin.test.Test
 import kotlin.test.assertIs
 import org.w3c.dom.HTMLTextAreaElement
-import androidx.compose.ui.platform.InputEvent as InputEventDetailed
 
 internal interface СompositeInputTestSpec : TextFieldTestSpec {
 
     fun triggerComposingSequence(inputKey: String, compositionInput: String, typedKey: String): EventsSequence
-    fun compositionStart(inputKey: String, compositionKey: String = inputKey): EventsSequence
+    fun compositionStartFromInput(inputKey: String, compositionKey: String = inputKey): EventsSequence
 
     fun String.toProcessKeyDownEvent() = keyEvent("Process", code = eventKeyCode())
     fun String.toProcessKeyUpEvent() = keyEvent("Process", code = eventKeyCode(), type = "keyup")
@@ -54,7 +53,7 @@ internal interface СompositeInputTestSpec : TextFieldTestSpec {
 
 
 internal interface ChromeCompositeInput : СompositeInputTestSpec {
-    override fun compositionStart(
+    override fun compositionStartFromInput(
         inputKey: String,
         compositionKey: String
     ): EventsSequence {
@@ -71,7 +70,7 @@ internal interface ChromeCompositeInput : СompositeInputTestSpec {
         compositionInput: String,
         typedKey: String
     ): EventsSequence {
-        return compositionStart(inputKey, compositionInput).addAll(
+        return compositionStartFromInput(inputKey, compositionInput).addAll(
             keyEvent(compositionInput),
             beforeInput("insertCompositionText", compositionInput, isComposing = true),
             compositionEnd(typedKey),
@@ -101,7 +100,7 @@ internal interface ChromeCompositeInput : СompositeInputTestSpec {
 }
 
 internal interface FirefoxCompositeInput : СompositeInputTestSpec {
-    override fun compositionStart(
+    override fun compositionStartFromInput(
         inputKey: String,
         compositionKey: String
     ): EventsSequence {
@@ -119,7 +118,7 @@ internal interface FirefoxCompositeInput : СompositeInputTestSpec {
         compositionInput: String,
         typedKey: String
     ): EventsSequence {
-        return compositionStart(inputKey, compositionInput).addAll(
+        return compositionStartFromInput(inputKey, compositionInput).addAll(
             keyEvent( "Process", code  = compositionInput.eventKeyCode()),
             beforeInput("insertCompositionText", typedKey, isComposing = true),
             compositionEnd(typedKey),
@@ -148,7 +147,7 @@ internal interface WinCompositeInput : СompositeInputTestSpec {
         )
     }
 
-    override fun compositionStart(inputKey: String, compositionKey: String): EventsSequence {
+    override fun compositionStartFromInput(inputKey: String, compositionKey: String): EventsSequence {
         return eventsSequence(
             inputKey.toProcessKeyDownEvent(),
             compositionStart(),
@@ -170,7 +169,7 @@ internal interface WinCompositeInput : СompositeInputTestSpec {
     @Test
     fun `input hangul-hol`() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
-        compositionStart("g", "ㅎ")
+        compositionStartFromInput("g", "ㅎ")
             .compositionUpdate("h", "호")
             .compositionUpdate("f", "홀")
             .add(compositionEnd("홀"))
@@ -181,7 +180,7 @@ internal interface WinCompositeInput : СompositeInputTestSpec {
 }
 
 internal interface SafariCompositeInput : СompositeInputTestSpec {
-    override fun compositionStart(
+    override fun compositionStartFromInput(
         inputKey: String,
         compositionKey: String
     ): EventsSequence {
@@ -198,7 +197,7 @@ internal interface SafariCompositeInput : СompositeInputTestSpec {
         compositionInput: String,
         typedKey: String
     ): EventsSequence {
-        return compositionStart(inputKey, compositionInput).addAll(
+        return compositionStartFromInput(inputKey, compositionInput).addAll(
             compositionStart(),
             beforeInput("insertCompositionText", inputKey, isComposing = true),
             keyEvent(inputKey),
@@ -213,7 +212,7 @@ internal interface SafariCompositeInput : СompositeInputTestSpec {
 }
 
 internal interface IosCompositeInput : СompositeInputTestSpec {
-    override fun compositionStart(
+    override fun compositionStartFromInput(
         inputKey: String,
         compositionKey: String
     ): EventsSequence {
@@ -230,7 +229,7 @@ internal interface IosCompositeInput : СompositeInputTestSpec {
         compositionInput: String,
         typedKey: String
     ): EventsSequence {
-        return compositionStart(inputKey, compositionInput).addAll(
+        return compositionStartFromInput(inputKey, compositionInput).addAll(
             beforeInput("insertCompositionText", typedKey, isComposing = true),
             beforeInput("deleteCompositionText", null, isComposing = true),
             beforeInput("insertFromComposition", typedKey, isComposing = true),
@@ -275,7 +274,7 @@ internal interface AndroidCompositeInput : СompositeInputTestSpec {
         )
     }
 
-    override fun compositionStart(inputKey: String, compositionKey: String): EventsSequence {
+    override fun compositionStartFromInput(inputKey: String, compositionKey: String): EventsSequence {
         return eventsSequence(
             inputKey.toUnidentifiedKeyDownEvent(),
             compositionStart(),
@@ -295,7 +294,7 @@ internal interface AndroidCompositeInput : СompositeInputTestSpec {
     @Test
     fun `input hangul-hol`() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
-        compositionStart("g", "ㅎ")
+        compositionStartFromInput("g", "ㅎ")
             .compositionUpdate("h", "호")
             .compositionUpdate("f", "홀")
             .add(compositionEnd("홀"))

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.input.DeleteSurroundingTextCommand
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.EditingBuffer
 import androidx.compose.ui.text.input.SetComposingTextCommand
+import androidx.compose.ui.text.input.SetSelectionCommand
 import androidx.compose.ui.text.input.TextFieldValue
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -173,16 +174,17 @@ class NativeInputEventsProcessorTest {
 
         processor.registerEvent(
             (beforeInput("insertText", "a") as InputEvent).apply {
-                deleteContentBackwardSize = 1
+                textRangeStart = 3
+                textRangeEnd = 4
             }
         )
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
         assertEquals(2, communicator.editCommands.size)
         val command1 = communicator.editCommands[0]
-        assertTrue(command1 is DeleteSurroundingTextCommand)
-        assertEquals(1, command1.lengthBeforeCursor)
-        assertEquals(0, command1.lengthAfterCursor)
+        assertTrue(command1 is SetSelectionCommand)
+        assertEquals(3, command1.start)
+        assertEquals(4, command1.end)
 
         val command2 = communicator.editCommands[1]
         assertTrue(command2 is CommitTextCommand)
@@ -200,7 +202,8 @@ class NativeInputEventsProcessorTest {
 
         processor.registerEvent(
             (beforeInput("deleteContentBackward", "") as InputEvent).apply {
-                deleteContentBackwardSize = 1
+                textRangeStart = 2
+                textRangeEnd = 3
             }
         )
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -245,7 +248,10 @@ class NativeInputEventsProcessorTest {
 
         // Add deleteContentBackward event
         processor.registerEvent(
-            (beforeInput("deleteContentBackward", null) as InputEvent).apply { deleteContentBackwardSize = 1 }
+            (beforeInput("deleteContentBackward", null) as InputEvent).apply {
+                textRangeStart = 3
+                textRangeEnd = 4
+             }
         )
         processor.manuallyRunCheckpoint(TextFieldValue("test"))
 
@@ -267,16 +273,20 @@ class NativeInputEventsProcessorTest {
         val processor = TestNativeInputEventsProcessor(communicator)
 
         processor.registerEvent(
-            (beforeInput("insertReplacementText", "replacement") as InputEvent).apply { deleteContentBackwardSize = 4 },
+            (beforeInput("insertReplacementText", "replacement") as InputEvent).apply {
+
+                textRangeStart = 5
+                textRangeEnd = 9
+             },
         )
 
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
         assertEquals(2, communicator.editCommands.size)
 
         val deleteCommand = communicator.editCommands[0]
-        assertTrue(deleteCommand is DeleteSurroundingTextCommand)
-        assertEquals(4, deleteCommand.lengthBeforeCursor)
-        assertEquals(0, deleteCommand.lengthAfterCursor)
+        assertTrue(deleteCommand is SetSelectionCommand)
+        assertEquals(5, deleteCommand.start)
+        assertEquals(9, deleteCommand.end)
 
         val commitCommand = communicator.editCommands[1]
         assertTrue(commitCommand is CommitTextCommand)
@@ -325,7 +335,8 @@ class NativeInputEventsProcessorTest {
         // 3. Simulate the input event for the accented character
         processor.registerEvent(
             (beforeInput("insertText", "é") as InputEvent).apply {
-                deleteContentBackwardSize = 1 // to replace `e`
+                textRangeStart = 0
+                textRangeEnd = 1
             }
         )
 
@@ -342,9 +353,9 @@ class NativeInputEventsProcessorTest {
         assertEquals("e", commitCommand1.text)
 
         val deleteCommand = communicator.editCommands[1]
-        assertTrue(deleteCommand is DeleteSurroundingTextCommand)
-        assertEquals(1, deleteCommand.lengthBeforeCursor)
-        assertEquals(0, deleteCommand.lengthAfterCursor)
+        assertTrue(deleteCommand is SetSelectionCommand)
+        assertEquals(0, deleteCommand.start)
+        assertEquals(1, deleteCommand.end)
 
         val commitCommand2 = communicator.editCommands[2]
         assertTrue(commitCommand2 is CommitTextCommand)
@@ -390,7 +401,11 @@ class NativeInputEventsProcessorTest {
 
         // 2. Simulate choosing 'é' from the accent dialogues using a mouse, so no keydown events here
         processor.registerEvent(
-            (beforeInput("insertText", "è") as InputEvent).apply { deleteContentBackwardSize = 1 /* to replace `e` */ },
+            (beforeInput("insertText", "è") as InputEvent).apply {
+                // to replace `e`
+                textRangeStart = 0
+                textRangeEnd = 1
+             },
         )
 
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -403,9 +418,9 @@ class NativeInputEventsProcessorTest {
         assertEquals("e", commitCommand1.text)
 
         val deleteCommand = communicator.editCommands[1]
-        assertTrue(deleteCommand is DeleteSurroundingTextCommand)
-        assertEquals(1, deleteCommand.lengthBeforeCursor)
-        assertEquals(0, deleteCommand.lengthAfterCursor)
+        assertTrue(deleteCommand is SetSelectionCommand)
+        assertEquals(0, deleteCommand.start)
+        assertEquals(1, deleteCommand.end)
 
         val commitCommand2 = communicator.editCommands[2]
         assertTrue(commitCommand2 is CommitTextCommand)
@@ -454,7 +469,8 @@ class NativeInputEventsProcessorTest {
         processor.registerEvent(compositionStart())
         processor.registerEvent(
             (beforeInput("insertText", "è") as InputEvent).apply {
-                deleteContentBackwardSize = 1
+                textRangeStart = 0
+                textRangeEnd = 1
             }
         )
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
@@ -464,7 +480,8 @@ class NativeInputEventsProcessorTest {
         processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
         processor.registerEvent(
             (beforeInput("insertCompositionText", "é") as InputEvent).apply {
-                deleteContentBackwardSize = 1
+                textRangeStart = 0
+                textRangeEnd = 1
             }
         )
 
@@ -475,7 +492,8 @@ class NativeInputEventsProcessorTest {
         processor.registerEvent(keyEvent(key = "ArrowRight", code = "ArrowRight", isComposing = true))
         processor.registerEvent(
             (beforeInput("insertCompositionText", "ê") as InputEvent).apply {
-                deleteContentBackwardSize = 1
+                textRangeStart = 0
+                textRangeEnd = 1
             }
         )
 
@@ -493,7 +511,8 @@ class NativeInputEventsProcessorTest {
 
         processor.registerEvent(
             (beforeInput("insertCompositionText", "é") as InputEvent).apply {
-                deleteContentBackwardSize = 1
+                textRangeStart = 0
+                textRangeEnd = 1
             }
         )
 
@@ -506,7 +525,10 @@ class NativeInputEventsProcessorTest {
 
         // 4. Simulate the input event for the selected accented character
         processor.registerEvent(
-            (beforeInput("insertCompositionText", "é") as InputEvent).apply { deleteContentBackwardSize = 1 }
+            (beforeInput("insertCompositionText", "é") as InputEvent).apply {
+                textRangeStart = 0
+                textRangeEnd = 1
+             }
         )
 
         processor.registerEvent(compositionEnd("é"))
@@ -559,7 +581,10 @@ class NativeInputEventsProcessorTest {
 
         // Add deleteContentBackward event
         processor.registerEvent(
-            (beforeInput("deleteContentBackward", "") as InputEvent).apply { deleteContentBackwardSize = 2 },
+            (beforeInput("deleteContentBackward", "") as InputEvent).apply {
+                textRangeStart = 3
+                textRangeEnd = 5
+             },
         )
 
         // Process the event with a collapsed selection
@@ -568,7 +593,7 @@ class NativeInputEventsProcessorTest {
         assertEquals(1, communicator.editCommands.size)
         val command = communicator.editCommands[0]
         assertTrue(command is DeleteSurroundingTextCommand)
-        assertEquals(2, (command as DeleteSurroundingTextCommand).lengthBeforeCursor)
+        assertEquals(2, command.lengthBeforeCursor)
         assertEquals(0, command.lengthAfterCursor)
 
         assertEquals("exale text", communicator.currentTextFieldValue().text)
@@ -589,7 +614,10 @@ class NativeInputEventsProcessorTest {
 
         // Then add a deleteContentBackward event
         processor.registerEvent(
-            (beforeInput("deleteContentBackward", "") as InputEvent).apply { deleteContentBackwardSize = 1 },
+            (beforeInput("deleteContentBackward", "") as InputEvent).apply {
+                textRangeStart = 0
+                textRangeEnd = 1
+             },
         )
 
         // With a non-collapsed selection
@@ -628,7 +656,10 @@ class NativeInputEventsProcessorTest {
 
         // Then add a deleteContentBackward event
         processor.registerEvent(
-            (beforeInput("deleteContentBackward", "") as InputEvent).apply { deleteContentBackwardSize = 1 },
+            (beforeInput("deleteContentBackward", "") as InputEvent).apply {
+                textRangeStart = 0
+                textRangeEnd = 1
+            },
         )
 
         processor.manuallyRunCheckpoint(textFieldValue)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -202,17 +202,17 @@ class NativeInputEventsProcessorTest {
 
         processor.registerEvent(
             (beforeInput("deleteContentBackward", "") as InputEvent).apply {
-                textRangeStart = 2
-                textRangeEnd = 3
+                textRangeStart = 3
+                textRangeEnd = 4
             }
         )
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
-        assertEquals(1, communicator.editCommands.size)
+        assertEquals(2, communicator.editCommands.size)
         val command = communicator.editCommands[0]
-        assertTrue(command is DeleteSurroundingTextCommand)
-        assertEquals(1, command.lengthBeforeCursor)
-        assertEquals(0, command.lengthAfterCursor)
+        assertTrue(command is SetSelectionCommand)
+        assertEquals(3, command.start)
+        assertEquals(4, command.end)
 
         assertEquals("tes", communicator.currentTextFieldValue().text)
     }
@@ -590,11 +590,11 @@ class NativeInputEventsProcessorTest {
         // Process the event with a collapsed selection
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
 
-        assertEquals(1, communicator.editCommands.size)
+        assertEquals(2, communicator.editCommands.size)
         val command = communicator.editCommands[0]
-        assertTrue(command is DeleteSurroundingTextCommand)
-        assertEquals(2, command.lengthBeforeCursor)
-        assertEquals(0, command.lengthAfterCursor)
+        assertTrue(command is SetSelectionCommand)
+        assertEquals(3, command.start)
+        assertEquals(5, command.end)
 
         assertEquals("exale text", communicator.currentTextFieldValue().text)
     }


### PR DESCRIPTION
We can not rely on DeleteSurroundingTextCommand since text deleted is not necessarily at the end of the input

Fixes [CMP-8809](https://youtrack.jetbrains.com/issue/CMP-8809)

## Testing
manual and `gradlew testWeb`


## Release Notes
### Fixes - Web
- Correct behaviour when a virtual keyboard suggestion was accepted while the cursor was in the middle of the word
