### PR TITLE
Do not set autocorrect="off" for backing DOM input - otherwise autoco…

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/DomInputStrategy.kt
@@ -97,7 +97,10 @@ private fun ImeOptions.createDomElement(): HTMLElement {
         if (singleLine) "input" else "textarea"
     ) as HTMLElement
 
-    htmlElement.setAttribute("autocorrect", "off")
+    // without autocorrect set "on" iOS virtual keyboard won't suggest
+    // see https://youtrack.jetbrains.com/issue/CMP-8807
+    htmlElement.setAttribute("autocorrect", "on")
+    htmlElement.setAttribute("autocomplete", "off")
     htmlElement.setAttribute("autocapitalize", "off")
     htmlElement.setAttribute("spellcheck", "false")
 


### PR DESCRIPTION
Do not set autocorrect="off" for backing DOM input - otherwise autocomplete will be turned off in mobile Safari  

This is a fix for https://youtrack.jetbrains.com/issue/CMP-8807

## Testing
manual

## Release Notes
N/A