### PR TITLE
Implement click-to-clear-focus

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ScrollbarTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,6 +51,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -866,38 +866,38 @@ class ScrollbarTest {
         rule.setContent {
             // Set up a text field that is exactly 10 lines tall, with text that has 20 lines,
             // Scrollbar thumb should be 50.dp -- half the scrollbar height
-            Row{
-                Box(
-                    modifier = Modifier.width(100.dp)
-                ){
-                    var text by remember {
-                        mutableStateOf(
-                            TextFieldValue(
-                                buildString {
-                                    repeat(19) { // 20 lines including the last empty one
-                                        append("A\n")
-                                    }
+            Box(
+                modifier = Modifier.width(100.dp)
+            ) {
+                var text by remember {
+                    mutableStateOf(
+                        TextFieldValue(
+                            buildString {
+                                repeat(19) { // 20 lines including the last empty one
+                                    append("A\n")
                                 }
-                            )
+                            }
                         )
-                    }
-                    BasicTextField(
-                        value = text,
-                        onValueChange = {
-                            text = it
-                        },
-                        scrollState = scrollState,
-                        maxLines = 10,  // Make sure not to give the text field any pixel height
-                        modifier = Modifier
-                            .testTag("textfield"),
                     )
                 }
+                BasicTextField(
+                    value = text,
+                    onValueChange = {
+                        text = it
+                    },
+                    scrollState = scrollState,
+                    maxLines = 10,  // Make sure not to give the text field any pixel height
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("textfield"),
+                )
 
                 VerticalScrollbar(
                     adapter = rememberScrollbarAdapter(scrollState),
                     modifier = Modifier
                         .width(10.dp)
                         .height(100.dp)
+                        .align(Alignment.CenterEnd)
                         .testTag("scrollbar")
                 )
             }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
@@ -46,11 +46,13 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.requestFocus
 import androidx.compose.ui.test.runComposeUiTest
@@ -270,7 +272,7 @@ class ClickableFocusTest {
     }
 
     @Test
-    fun clickOutsideClearsFocus() = runComposeUiTest {
+    fun mouseClickOutsideClearsFocus() = runComposeUiTest {
         val focusRequester = FocusRequester()
         setContent {
             Column(Modifier.size(300.dp, 400.dp)) {
@@ -288,7 +290,7 @@ class ClickableFocusTest {
         }
 
         onNodeWithTag("textField").assertIsFocused()
-        onNodeWithTag("box").performClick()
+        onNodeWithTag("box").performMouseInput { click() }
         onNodeWithTag("textField").assertIsNotFocused()
         onNode(isFocused()).assertDoesNotExist()
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ClickableFocusTest.kt
@@ -20,17 +20,23 @@ import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.input.key.Key
@@ -39,6 +45,8 @@ import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.isFocused
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
@@ -259,5 +267,29 @@ class ClickableFocusTest {
         // these overrides are required by [IndicationNodeFactory]
         override fun hashCode() = super.hashCode()
         override fun equals(other: Any?) = super.equals(other)
+    }
+
+    @Test
+    fun clickOutsideClearsFocus() = runComposeUiTest {
+        val focusRequester = FocusRequester()
+        setContent {
+            Column(Modifier.size(300.dp, 400.dp)) {
+                BasicTextField(
+                    state = rememberTextFieldState(),
+                    modifier = Modifier
+                        .testTag("textField")
+                        .focusRequester(focusRequester)
+                )
+                LaunchedEffect(Unit) {
+                    focusRequester.requestFocus()
+                }
+                Box(Modifier.testTag("box").fillMaxWidth().weight(1f))
+            }
+        }
+
+        onNodeWithTag("textField").assertIsFocused()
+        onNodeWithTag("box").performClick()
+        onNodeWithTag("textField").assertIsNotFocused()
+        onNode(isFocused()).assertDoesNotExist()
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -154,8 +154,6 @@ class ComposeDialog : JDialog {
 
     /**
      * Controls whether mouse-down on an unfocusable element clears focus.
-     *
-     * To have an effect, this needs to be set before the dialog is made visible.
      */
     @ExperimentalComposeUiApi
     var isClearFocusOnMouseDownEnabled: Boolean

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -152,6 +152,16 @@ class ComposeDialog : JDialog {
         get() = composePanel.rootForTestListener
         set(value) { composePanel.rootForTestListener = value }
 
+    /**
+     * Controls whether mouse-down on an unfocusable element clears focus.
+     *
+     * To have an effect, this needs to be set before the dialog is made visible.
+     */
+    @ExperimentalComposeUiApi
+    var isClearFocusOnMouseDownEnabled: Boolean
+        get() = composePanel.isClearFocusOnMouseDownEnabled
+        set(value) { composePanel.isClearFocusOnMouseDownEnabled = value }
+
     private val undecoratedWindowResizer = UndecoratedWindowResizer(this)
 
     override fun add(component: Component) = composePanel.add(component)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -122,11 +122,13 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
 
     /**
      * Controls whether mouse-down on an unfocusable element clears focus.
-     *
-     * To have an effect, this needs to be set before [ComposePanel] is added to the UI hierarchy.
      */
     @ExperimentalComposeUiApi
     var isClearFocusOnMouseDownEnabled: Boolean = true
+        set(value) {
+            field = value
+            _composeContainer?.isClearFocusOnMouseDownEnabled = value
+        }
 
     /**
      * Determines whether the Compose state in [ComposePanel] should be disposed

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -121,6 +121,14 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private var _composeContent: (@Composable () -> Unit)? = null
 
     /**
+     * Controls whether mouse-down on an unfocusable element clears focus.
+     *
+     * To have an effect, this needs to be set before [ComposePanel] is added to the UI hierarchy.
+     */
+    @ExperimentalComposeUiApi
+    var isClearFocusOnMouseDownEnabled: Boolean = true
+
+    /**
      * Determines whether the Compose state in [ComposePanel] should be disposed
      * when panel is detached from Swing hierarchy (when [removeNotify] is called).
      *
@@ -279,6 +287,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
 
                 override fun focusLost(e: FocusEvent) = Unit
             })
+
+            isClearFocusOnMouseDownEnabled = this@ComposePanel.isClearFocusOnMouseDownEnabled
         }
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -18,11 +18,13 @@ package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.awt.RenderSettings.SkiaSurface
 import androidx.compose.ui.awt.RenderSettings.SwingGraphics
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.isClearFocusOnMouseDownEnabled
 import androidx.compose.ui.scene.ComposeContainer
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.window.WindowExceptionHandler
@@ -124,7 +126,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      * Controls whether mouse-down on an unfocusable element clears focus.
      */
     @ExperimentalComposeUiApi
-    var isClearFocusOnMouseDownEnabled: Boolean = true
+    var isClearFocusOnMouseDownEnabled: Boolean = ComposeUiFlags.isClearFocusOnMouseDownEnabled
         set(value) {
             field = value
             _composeContainer?.isClearFocusOnMouseDownEnabled = value

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -93,6 +93,14 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
     val semanticsOwners: Collection<SemanticsOwner>
         get() = composePanel.semanticsOwners
 
+    /**
+     * Controls whether mouse-down on an unfocusable element clears focus.
+     *
+     * To have an effect, this needs to be set before the window is made visible.
+     */
+    @ExperimentalComposeUiApi
+    var isClearFocusOnMouseDownEnabled: Boolean by composePanel::isClearFocusOnMouseDownEnabled
+
     init {
         contentPane.add(composePanel)
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -95,8 +95,6 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
 
     /**
      * Controls whether mouse-down on an unfocusable element clears focus.
-     *
-     * To have an effect, this needs to be set before the window is made visible.
      */
     @ExperimentalComposeUiApi
     var isClearFocusOnMouseDownEnabled: Boolean by composePanel::isClearFocusOnMouseDownEnabled

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -81,6 +81,8 @@ internal class ComposeWindowPanel(
     val renderApi by composeContainer::renderApi
     val semanticsOwners by composeContainer::semanticsOwners
 
+    var isClearFocusOnMouseDownEnabled: Boolean by composeContainer::isClearFocusOnMouseDownEnabled
+
     var isWindowTransparent: Boolean = false
         set(value) {
             if (field != value) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -181,6 +181,8 @@ internal class ComposeContainer(
     private var isMinimized = false
     private var isFocused = false
 
+    var isClearFocusOnMouseDownEnabled by mediator::isClearFocusOnMouseDownEnabled
+
     init {
         architectureComponentsOwner.enableSavedStateHandles()
         setWindow(window)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.awt.AwtEventListener
 import androidx.compose.ui.awt.AwtEventListeners
 import androidx.compose.ui.awt.DebouncingEdtExecutor
@@ -42,6 +43,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.isClearFocusOnMouseDownEnabled
 import androidx.compose.ui.navigationevent.BackNavigationEventInput
 import androidx.compose.ui.platform.AwtDragAndDropManager
 import androidx.compose.ui.platform.DefaultInputModeManager
@@ -367,7 +369,7 @@ internal class ComposeSceneMediator(
 
     private val composeInvalidationExecutor = DebouncingEdtExecutor()
 
-    var isClearFocusOnMouseDownEnabled: Boolean = true
+    var isClearFocusOnMouseDownEnabled: Boolean = ComposeUiFlags.isClearFocusOnMouseDownEnabled
 
     init {
         // Transparency is used during redrawer creation that triggered by [addNotify], so

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -367,6 +367,8 @@ internal class ComposeSceneMediator(
 
     private val composeInvalidationExecutor = DebouncingEdtExecutor()
 
+    var isClearFocusOnMouseDownEnabled: Boolean = true
+
     init {
         // Transparency is used during redrawer creation that triggered by [addNotify], so
         // it must be set to correct value before adding to the hierarchy to handle cases
@@ -828,6 +830,8 @@ internal class ComposeSceneMediator(
             get() = this@ComposeSceneMediator.rootForTestListener
         override val semanticsOwnerListener
             get() = this@ComposeSceneMediator.semanticsOwnerListener
+        override val isClearFocusOnMouseDownEnabled: Boolean
+            get() = this@ComposeSceneMediator.isClearFocusOnMouseDownEnabled
     }
 
     private inner class DesktopPlatformComponent : PlatformComponent {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Text
@@ -52,9 +53,12 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendMouseEvent
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.sendMouseWheelEvent
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
@@ -809,4 +813,56 @@ class ComposePanelTest {
                 }
             }
         }
+
+    @Test
+    fun testComposePanelClearFocusOnMouseDownEnabled() =
+        testComposePanelClearFocusOnMouseDownEnabledFlag(true)
+
+    @Test
+    fun testComposePanelClearFocusOnMouseDownDisabled() =
+        testComposePanelClearFocusOnMouseDownEnabledFlag(false)
+
+    fun testComposePanelClearFocusOnMouseDownEnabledFlag(enabled: Boolean) = runApplicationTest {
+        val focusRequester = FocusRequester()
+        var textFieldIsFocused = false
+
+        val window = JFrame()
+        try {
+            window.contentPane.add(ComposePanel().apply {
+                isClearFocusOnMouseDownEnabled = enabled
+                setContent {
+                    Column(Modifier.size(300.dp, 400.dp)) {
+                        BasicTextField(
+                            state = rememberTextFieldState(),
+                            modifier = Modifier
+                                .testTag("textField")
+                                .fillMaxWidth()
+                                .height(100.dp)
+                                .focusRequester(focusRequester)
+                                .onFocusChanged {
+                                    textFieldIsFocused = it.isFocused
+                                }
+                        )
+                        LaunchedEffect(Unit) {
+                            focusRequester.requestFocus()
+                        }
+                        Box(Modifier.testTag("box").fillMaxWidth().weight(1f))
+                    }
+                }
+            })
+            window.size = Dimension(300, 400)
+            window.isVisible = true
+
+            awaitIdle()
+
+            assertThat(textFieldIsFocused).isTrue()
+            window.sendMousePress(x = 100, y = 300)
+            window.sendMouseRelease(x = 100, y = 300)
+            awaitIdle()
+
+            assertThat(textFieldIsFocused).isEqualTo(!enabled)
+        } finally {
+            window.dispose()
+        }
+    }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -18,8 +18,13 @@ package androidx.compose.ui.window
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -37,13 +42,17 @@ import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.sendKeyEvent
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.drawText
@@ -64,6 +73,7 @@ import java.awt.Window
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
+import javax.swing.JFrame
 import kotlin.concurrent.thread
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
@@ -773,6 +783,61 @@ class DialogWindowTest {
 
         assertThat(nonBlackPixelDetected).isNull()
     }
+
+    @Test
+    fun testComposeDialogClearFocusOnMouseDownEnabled() =
+        testComposeDialogClearFocusOnMouseDownEnabledFlag(true)
+
+    @Test
+    fun testComposeDialogClearFocusOnMouseDownDisabled() =
+        testComposeDialogClearFocusOnMouseDownEnabledFlag(false)
+
+    fun testComposeDialogClearFocusOnMouseDownEnabledFlag(enabled: Boolean) = runApplicationTest {
+        val focusRequester = FocusRequester()
+        var textFieldIsFocused = false
+
+        val window = JFrame()
+        val dialog = ComposeDialog(window)
+        try {
+            window.size = Dimension(800, 600)
+            dialog.isClearFocusOnMouseDownEnabled = enabled
+            dialog.setContent {
+                Column(Modifier.size(300.dp, 400.dp)) {
+                    BasicTextField(
+                        state = rememberTextFieldState(),
+                        modifier = Modifier
+                            .testTag("textField")
+                            .fillMaxWidth()
+                            .height(100.dp)
+                            .focusRequester(focusRequester)
+                            .onFocusChanged {
+                                textFieldIsFocused = it.isFocused
+                            }
+                    )
+                    LaunchedEffect(Unit) {
+                        focusRequester.requestFocus()
+                    }
+                    Box(Modifier.testTag("box").fillMaxWidth().weight(1f))
+                }
+            }
+
+            dialog.size = Dimension(300, 400)
+            dialog.isVisible = true
+
+            awaitIdle()
+
+            assertThat(textFieldIsFocused).isTrue()
+            dialog.sendMousePress(x = 100, y = 300)
+            dialog.sendMouseRelease(x = 100, y = 300)
+            awaitIdle()
+
+            assertThat(textFieldIsFocused).isEqualTo(!enabled)
+        } finally {
+            dialog.dispose()
+            window.dispose()
+        }
+    }
+
 }
 
 private fun assertDialogStateEquals(expected: DialogState, actual: DialogState) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -18,8 +18,13 @@ package androidx.compose.ui.window.window
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.Button
 import androidx.compose.material.Slider
 import androidx.compose.runtime.CompositionLocalProvider
@@ -36,14 +41,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.awt.SwingWindow
 import androidx.compose.ui.background
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.isLinux
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.toInt
-import androidx.compose.ui.unit.*
-import androidx.compose.ui.window.*
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntSize
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.density
+import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth.assertThat
 import java.awt.Dimension
@@ -56,6 +80,7 @@ import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import kotlin.concurrent.thread
 import kotlin.math.roundToInt
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
@@ -63,7 +88,6 @@ import kotlinx.coroutines.runBlocking
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
 import org.junit.Ignore
-import org.junit.Test
 
 class WindowTest {
 
@@ -824,5 +848,55 @@ class WindowTest {
         t.join()
 
         assertThat(nonBlackPixelDetected).isNull()
+    }
+
+    @Test
+    fun testComposeWindowClearFocusOnMouseDownEnabled() =
+        testComposeWindowClearFocusOnMouseDownEnabledFlag(true)
+
+    @Test
+    fun testComposeWindowClearFocusOnMouseDownDisabled() =
+        testComposeWindowClearFocusOnMouseDownEnabledFlag(false)
+
+    fun testComposeWindowClearFocusOnMouseDownEnabledFlag(enabled: Boolean) = runApplicationTest {
+        val focusRequester = FocusRequester()
+        var textFieldIsFocused = false
+
+        val window = ComposeWindow()
+        try {
+            window.isClearFocusOnMouseDownEnabled = enabled
+            window.setContent {
+                Column(Modifier.size(300.dp, 400.dp)) {
+                    BasicTextField(
+                        state = rememberTextFieldState(),
+                        modifier = Modifier
+                            .testTag("textField")
+                            .fillMaxWidth()
+                            .height(100.dp)
+                            .focusRequester(focusRequester)
+                            .onFocusChanged {
+                                textFieldIsFocused = it.isFocused
+                            }
+                    )
+                    LaunchedEffect(Unit) {
+                        focusRequester.requestFocus()
+                    }
+                    Box(Modifier.testTag("box").fillMaxWidth().weight(1f))
+                }
+            }
+            window.size = Dimension(300, 400)
+            window.isVisible = true
+
+            awaitIdle()
+
+            assertThat(textFieldIsFocused).isTrue()
+            window.sendMousePress(x = 100, y = 300)
+            window.sendMouseRelease(x = 100, y = 300)
+            awaitIdle()
+
+            assertThat(textFieldIsFocused).isEqualTo(!enabled)
+        } finally {
+            window.dispose()
+        }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
@@ -25,7 +25,7 @@ internal object SkikoComposeUiFlags {
 
     @Suppress("MutableBareField")
     @JvmField
-    var isClearFocusOnPointerDownEnabled: Boolean = false
+    var isClearFocusOnPointerDownEnabled: Boolean = true
 }
 
 /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
@@ -22,10 +22,6 @@ internal object SkikoComposeUiFlags {
     @Suppress("MutableBareField")
     @JvmField
     var useLegacyRenderNodeLayers: Boolean = false
-
-    @Suppress("MutableBareField")
-    @JvmField
-    var isClearFocusOnPointerDownEnabled: Boolean = true
 }
 
 /**
@@ -36,7 +32,3 @@ internal object SkikoComposeUiFlags {
  */
 @ExperimentalComposeUiApi
 var ComposeUiFlags.useLegacyRenderNodeLayers by SkikoComposeUiFlags::useLegacyRenderNodeLayers
-
-/** This flag enables clearing focus on pointer down by default. */
-@ExperimentalComposeUiApi
-var ComposeUiFlags.isClearFocusOnPointerDownEnabled by SkikoComposeUiFlags::isClearFocusOnPointerDownEnabled

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
@@ -17,12 +17,15 @@
 package androidx.compose.ui
 
 import kotlin.jvm.JvmField
-import kotlin.jvm.JvmName
 
 internal object SkikoComposeUiFlags {
     @Suppress("MutableBareField")
     @JvmField
     var useLegacyRenderNodeLayers: Boolean = false
+
+    @Suppress("MutableBareField")
+    @JvmField
+    var isClearFocusOnPointerDownEnabled: Boolean = false
 }
 
 /**
@@ -33,3 +36,7 @@ internal object SkikoComposeUiFlags {
  */
 @ExperimentalComposeUiApi
 var ComposeUiFlags.useLegacyRenderNodeLayers by SkikoComposeUiFlags::useLegacyRenderNodeLayers
+
+/** This flag enables clearing focus on pointer down by default. */
+@ExperimentalComposeUiApi
+var ComposeUiFlags.isClearFocusOnPointerDownEnabled by SkikoComposeUiFlags::isClearFocusOnPointerDownEnabled

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
@@ -22,6 +22,10 @@ internal object SkikoComposeUiFlags {
     @Suppress("MutableBareField")
     @JvmField
     var useLegacyRenderNodeLayers: Boolean = false
+
+    @Suppress("MutableBareField")
+    @JvmField
+    var isClearFocusOnMouseDownEnabled: Boolean = true
 }
 
 /**
@@ -32,3 +36,11 @@ internal object SkikoComposeUiFlags {
  */
 @ExperimentalComposeUiApi
 var ComposeUiFlags.useLegacyRenderNodeLayers by SkikoComposeUiFlags::useLegacyRenderNodeLayers
+
+/**
+ * This flag enables clearing focus on mouse down by default.
+ *
+ * More granular control is available in the various platform-specific entry points.
+ */
+@ExperimentalComposeUiApi
+var ComposeUiFlags.isClearFocusOnMouseDownEnabled by SkikoComposeUiFlags::isClearFocusOnMouseDownEnabled

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -180,6 +180,11 @@ interface PlatformContext {
      */
     val semanticsOwnerListener: SemanticsOwnerListener? get() = null
 
+    /**
+     * Controls whether mouse-down on an unfocusable element clears focus.
+     */
+    val isClearFocusOnMouseDownEnabled: Boolean get() = true
+
     interface RootForTestListener {
         fun onRootForTestCreated(root: PlatformRootForTest)
         fun onRootForTestDisposed(root: PlatformRootForTest)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.platform
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.FrameRateCategory
 import androidx.compose.ui.InternalComposeUiApi
@@ -28,6 +29,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.isClearFocusOnMouseDownEnabled
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.node.Owner
@@ -181,9 +183,10 @@ interface PlatformContext {
     val semanticsOwnerListener: SemanticsOwnerListener? get() = null
 
     /**
-     * Controls whether mouse-down on an unfocusable element clears focus.
+     * Returns whether mouse-down on an unfocusable element clears focus.
      */
-    val isClearFocusOnMouseDownEnabled: Boolean get() = true
+    val isClearFocusOnMouseDownEnabled: Boolean
+        get() = ComposeUiFlags.isClearFocusOnMouseDownEnabled
 
     interface RootForTestListener {
         fun onRootForTestCreated(root: PlatformRootForTest)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
-import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
@@ -38,7 +37,6 @@ import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
-import androidx.compose.ui.isClearFocusOnPointerDownEnabled
 import androidx.compose.ui.node.SnapshotInvalidationTracker
 import androidx.compose.ui.platform.GlobalSnapshotManager
 import androidx.compose.ui.platform.ProvidePlatformCompositionLocals
@@ -298,7 +296,7 @@ internal abstract class BaseComposeScene(
 
     private fun onPointerInputEvent(event: PointerInputEvent) = processPointerInputEvent(event)
         .also {
-            if (ComposeUiFlags.isClearFocusOnPointerDownEnabled) {
+            if (composeSceneContext.platformContext.isClearFocusOnMouseDownEnabled) {
                 val isDown = event.eventType == PointerEventType.Press
                 val pointer = event.pointers.singleOrNull()
                 val isFromMouse = pointer?.type == PointerType.Mouse

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -21,12 +21,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Composition
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.runtime.CompositionLocalContext
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.MonotonicFrameClock
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Canvas
@@ -38,10 +38,9 @@ import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.isClearFocusOnPointerDownEnabled
 import androidx.compose.ui.node.SnapshotInvalidationTracker
 import androidx.compose.ui.platform.GlobalSnapshotManager
-import androidx.compose.ui.platform.LocalPlatformScreenReader
-import androidx.compose.ui.platform.LocalPlatformWindowInsets
 import androidx.compose.ui.platform.ProvidePlatformCompositionLocals
 import androidx.compose.ui.util.trace
 import kotlin.concurrent.Volatile
@@ -64,9 +63,9 @@ internal abstract class BaseComposeScene(
     protected val inputHandler: ComposeSceneInputHandler =
         ComposeSceneInputHandler(
             prepareForPointerInputEvent = ::doMeasureAndLayout,
-            processPointerInputEvent = ::processPointerInputEvent,
+            processPointerInputEvent = ::onPointerInputEvent,
             cancelPointerInput = ::processCancelPointerInput,
-            processKeyEvent = ::processKeyEvent
+            processKeyEvent = ::processKeyEvent,
         )
 
     // Store this to avoid creating a lambda every frame
@@ -296,6 +295,18 @@ internal abstract class BaseComposeScene(
     }
 
     protected abstract fun createComposition(content: @Composable () -> Unit): Composition
+
+    private fun onPointerInputEvent(event: PointerInputEvent) = processPointerInputEvent(event)
+        .also {
+            if (ComposeUiFlags.isClearFocusOnPointerDownEnabled) {
+                val isDown = event.eventType == PointerEventType.Press
+                val pointer = event.pointers.singleOrNull()
+                val isFromMouse = pointer?.type == PointerType.Mouse
+                if (isDown && isFromMouse) {
+                    focusManager.clearFocusIfOutsideOfActiveFocusTargetNode(pointer.position)
+                }
+            }
+        }
 
     protected abstract fun processPointerInputEvent(event: PointerInputEvent): PointerEventResult
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
@@ -20,7 +20,10 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusOwner
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.node.requireLayoutCoordinates
 
 /**
  * The extension of [FocusManager] to manage focus within a [ComposeScene].
@@ -66,4 +69,27 @@ class ComposeSceneFocusManager internal constructor(
      * Release focus from [ComposeScene].
      */
     fun releaseFocus() = measureAndLayoutThen { focusOwner().releaseFocus() }
+
+    /**
+     * If [position] is outside the bounds of the currently focused node, clear focus.
+     */
+    fun clearFocusIfOutsideOfActiveFocusTargetNode(position: Offset) = measureAndLayoutThen {
+        val focusOwner = focusOwner()
+        val activeFocusTargetNode = focusOwner.activeFocusTargetNode
+        if (activeFocusTargetNode != null) {
+            val focusedNodeBounds =
+                activeFocusTargetNode.requireLayoutCoordinates().boundsInRoot()
+            // Only clear focus if the motion event doesn't fall inside the bounds
+            // of the node that is currently focused
+            // Note that we don't use the current focusRect which can be different
+            // from the bounds of the currently focused node.
+            // If a focusable node is choosing to have the focusRect be different from
+            // its own bounds, we shouldn't clear focus from it if the down event
+            // occurs over that node.
+            if (!focusedNodeBounds.contains(position)) {
+                focusOwner.clearFocus()
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
Originally implemented in AOSP [here](https://android-review.googlesource.com/c/platform/frameworks/support/+/3664179)

Fixes https://youtrack.jetbrains.com/issue/CMP-8891/Implement-Click-To-Clear-focus

## Testing
Added a unit test and also tested manually with a few text fields.

## Release Notes
### Features - Multiple Platforms
- Clicking outside of any focusable node using the mouse will now clear focus from the currently focused node, if any. This behavior can be disabled by setting `isClearFocusOnMouseDownEnabled = false` in `ComposePanel`, `ComposeWindow` or `ComposeDialog`.
