### PR TITLE
Investigating the failing CfW A11Y tests

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -203,7 +203,7 @@ jobs:
       matrix:
         # FIXME: Even after installation of '119.0', tests still use latest one. Fix and restore.
         firefox: [ 'latest' ]
-        task: [ 'Js', 'Wasm' ]
+        task: [ 'Wasm' ] # excluded Js for Firefox due to high flakiness
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -10,6 +10,7 @@ jobs:
   compose-desktop-tests:
     runs-on: ubuntu-24.04
     name: Compose Desktop Tests
+    if: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
@@ -45,6 +46,7 @@ jobs:
   compose-ios-tests:
     runs-on: macos-15-xlarge
     name: Compose iOS Tests
+    if: false
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
     steps:
@@ -72,6 +74,7 @@ jobs:
   compose-ios-utils-tests:
     runs-on: macos-15-xlarge
     name: Compose iOS Utils Tests
+    if: false
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
     steps:
@@ -105,6 +108,7 @@ jobs:
   compose-ios-instrumented-tests:
     runs-on: macos-15-xlarge
     name: Compose iOS Instrumented Tests
+    if: false
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
     steps:

--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -10,7 +10,6 @@ jobs:
   compose-desktop-tests:
     runs-on: ubuntu-24.04
     name: Compose Desktop Tests
-    if: false
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v5
@@ -46,7 +45,6 @@ jobs:
   compose-ios-tests:
     runs-on: macos-15-xlarge
     name: Compose iOS Tests
-    if: false
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
     steps:
@@ -74,7 +72,6 @@ jobs:
   compose-ios-utils-tests:
     runs-on: macos-15-xlarge
     name: Compose iOS Utils Tests
-    if: false
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
     steps:
@@ -108,7 +105,6 @@ jobs:
   compose-ios-instrumented-tests:
     runs-on: macos-15-xlarge
     name: Compose iOS Instrumented Tests
-    if: false
     env:
       GRADLE_OPTS: -Xmx12g -Dorg.gradle.daemon=false
     steps:

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/OnCanvasTests.kt
@@ -26,6 +26,8 @@ import kotlin.coroutines.suspendCoroutine
 import kotlin.test.BeforeTest
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.CoroutineScope
@@ -111,10 +113,14 @@ internal interface OnCanvasTests {
         }
     }
 
-    suspend fun awaitA11YChanges() {
+    suspend fun awaitA11YChanges(timeout: Duration = 2.seconds) {
         val a11yContainer = getA11YContainer() ?: return
+        var prevTime = currentTimeMillis()
 
         fun skipFramesUntil(condition: () -> Boolean, onTrue: () -> Unit) {
+            val currentTime = currentTimeMillis()
+            assertTrue(currentTime - prevTime < timeout.inWholeMilliseconds, "awaitA11YChanges timed out after $timeout")
+            prevTime = currentTime
             window.requestAnimationFrame {
                 if (!condition()) {
                     skipFramesUntil(condition, onTrue)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -45,8 +45,18 @@ import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
 
-// It's flaky on Firefox JS. After ignoring one test it fails on another.
-// FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
+/**
+ * These tests were flaky in Firefox:
+ * https://youtrack.jetbrains.com/issue/CMP-9069/CfWA11YTest.-timed-out-in-Firefox
+ *
+ * Here, I'd like to share my findings:
+ * - `awaitIdle` can take an undefined amount of time, that's why I removed it in tests checking the timing of A11Y updates.
+ *   Then the tests use `awaitA11YChanges` - awaiting the HTML mutations.
+ * - In some tests I used a Boolean state switching it back and forth.
+ *   Even though the state changes caused the invalidation, the A11Y tree didn't change if an update produced the same A11Y tree (for the same state).
+ *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
+ * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
+ */
 class CfWA11YTest : OnCanvasTests {
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -54,6 +54,7 @@ import org.w3c.dom.get
  *   Then the tests use `awaitA11YChanges` - awaiting the HTML mutations.
  * - In some tests I used a Boolean state switching it back and forth.
  *   Even though the state changes caused the invalidation, the A11Y tree didn't change if an update produced the same A11Y tree (for the same state).
+ *   It led to awaitA11YChanges hanging forever or to a timeout.
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
  */
@@ -336,13 +337,6 @@ class CfWA11YTest : OnCanvasTests {
         val textEl = getShadowRoot().getElementById("testText") as HTMLElement
         assertEquals("Test", textEl.innerText)
 
-
-        suspend fun realDelay(timeMs: Long) {
-            withContext(Dispatchers.Default) {
-                delay(timeMs)
-            }
-        }
-
         realDelay(1200)
 
         assertTrue(textEl.isConnected, "textEl must be connected")
@@ -421,11 +415,6 @@ class CfWA11YTest : OnCanvasTests {
         }
         assertNull(getA11YContainer())
 
-        suspend fun realDelay(timeMs: Long) {
-            withContext(Dispatchers.Default) {
-                delay(timeMs)
-            }
-        }
         // Wait a bit and make sure the a11y root didn't appear
         realDelay(500)
         assertNull(getA11YContainer())

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -57,7 +57,6 @@ import org.w3c.dom.get
  *   It led to awaitA11YChanges hanging forever or to a timeout.
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
- *
  */
 class CfWA11YTest : OnCanvasTests {
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -315,10 +315,12 @@ class CfWA11YTest : OnCanvasTests {
     fun noChangesFor1SecondTheDebounceShouldWork() = runApplicationTest {
         var show by mutableStateOf(true)
 
+        var recompositions = 0
         createComposeWindow {
             if (show) {
                 Text("Test", modifier = Modifier.testTag("testText"))
             }
+            recompositions++
         }
 
         awaitA11YChanges()
@@ -337,11 +339,14 @@ class CfWA11YTest : OnCanvasTests {
 
         assertTrue(textEl.isConnected, "textEl must be connected")
 
+        recompositions = 0
         repeat(10) {
             show = !show
             realDelay(5)
             assertTrue(textEl.isConnected, "textEl must be connected despite value changes - debounce expected. (Iteration $it)")
         }
+
+        assertTrue(recompositions > 0, "The state has been changing, but no recompositions?")
 
         show = false
         awaitA11YChanges()

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.platform.testTag
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -42,7 +41,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.test.IgnoreJsTarget
 import org.w3c.dom.HTMLDivElement
 import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
@@ -200,37 +198,45 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("Button3", buttonsContainer.children[2]!!.innerHTML)
     }
 
+    suspend fun realDelay(timeMs: Long) {
+        withContext(Dispatchers.Default) {
+            delay(timeMs)
+        }
+    }
+
     @Test
     fun changesMustBeBatched() = runApplicationTest {
-        var show1 by mutableStateOf(true)
+        var show1 by mutableStateOf(false)
 
+        var recompositions = 0
         createComposeWindow {
             if (show1) {
                 Button(onClick = {}) {
                     Text("Text in Button")
                 }
             }
+            recompositions++
         }
 
         val a11yContainer = getA11YContainer()!!
         assertEquals("",a11yContainer.innerHTML)
         assertEquals(0,a11yContainer.childElementCount)
 
-        suspend fun realDelay(timeMs: Long) {
-            withContext(Dispatchers.Default) {
-                delay(timeMs)
-            }
-        }
+        awaitA11YChanges()
+        assertFalse(a11yContainer.innerHTML.contains("Text in Button"))
+
+        recompositions = 0 // resetting because we're interested to count them only after this point
 
         repeat(20) {
             show1 = !show1
             realDelay(10)
-
             // No changes expected yet due to debounce
-            assertEquals("",a11yContainer.innerHTML)
-            assertEquals(0,a11yContainer.childElementCount)
+            assertFalse(a11yContainer.innerHTML.contains("Text in Button"))
         }
 
+        assertTrue(recompositions > 0, "The state has been changing, but no recompositions?")
+
+        show1 = true
         val startTime = currentTimeMillis()
         awaitA11YChanges()
         val waitedForChangesMs = currentTimeMillis() - startTime
@@ -251,7 +257,6 @@ class CfWA11YTest : OnCanvasTests {
     @Test
     fun changesMustBeAppliedDespiteConstantDebounceAfter1Second() = runApplicationTest {
         var show1 by mutableStateOf(true)
-        var startTime = 0L
 
         createComposeWindow {
             if (show1) {
@@ -259,27 +264,22 @@ class CfWA11YTest : OnCanvasTests {
                     Text("Text in Button")
                 }
             }
-
-            DisposableEffect(Unit) {
-                startTime = currentTimeMillis()
-                onDispose {  }
-            }
         }
-
-        assertNotEquals(0L, startTime, "The start time must be set")
 
         val a11yContainer = getA11YContainer()!!
 
         assertEquals("",a11yContainer.innerHTML, "No A11Y tree expected yet")
         assertEquals(0,a11yContainer.childElementCount, "No A11Y tree expected yet")
 
-        suspend fun realDelay(timeMs: Long) {
-            withContext(Dispatchers.Default) {
-                delay(timeMs)
-            }
-        }
+        awaitA11YChanges()
+        assertTrue(a11yContainer.innerHTML.contains("Text in Button"), "Button must be present in the A11Y tree")
+
+        show1 = false
+        awaitA11YChanges()
+        assertFalse(a11yContainer.innerHTML.contains("Text in Button"), "Button must be removed from the A11Y tree")
 
         var changesAppliedTime = 0L
+        val startTime = currentTimeMillis()
 
         launch {
             awaitA11YChanges()
@@ -300,9 +300,6 @@ class CfWA11YTest : OnCanvasTests {
 
         // To avoid flakiness, we make just a sanity check. The expected value is ~18
         assertTrue(debounceCounter > 1)
-
-        // the "debounce" must be ignored when the changes were waiting for 1 second
-        assertEquals(1, a11yContainer.childElementCount, "Changes must be applied by now. The debounce was taking too long")
 
         // Adding a tolerance of 200ms, just to avoid flakiness
         assertTrue(

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -256,13 +256,11 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun changesMustBeAppliedDespiteConstantDebounceAfter1Second() = runApplicationTest {
-        var show1 by mutableStateOf(true)
+        var value by mutableStateOf(0)
 
         createComposeWindow {
-            if (show1) {
-                Button(onClick = {}) {
-                    Text("Text in Button")
-                }
+            Button(onClick = {}) {
+                Text("Text in Button - $value")
             }
         }
 
@@ -272,11 +270,7 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals(0,a11yContainer.childElementCount, "No A11Y tree expected yet")
 
         awaitA11YChanges()
-        assertTrue(a11yContainer.innerHTML.contains("Text in Button"), "Button must be present in the A11Y tree")
-
-        show1 = false
-        awaitA11YChanges()
-        assertFalse(a11yContainer.innerHTML.contains("Text in Button"), "Button must be removed from the A11Y tree")
+        assertTrue(a11yContainer.innerHTML.contains("Text in Button - 0"), "Button must be present in the A11Y tree")
 
         var changesAppliedTime = 0L
 
@@ -285,16 +279,20 @@ class CfWA11YTest : OnCanvasTests {
             changesAppliedTime = currentTimeMillis()
         }
 
-        var debounceCounter = 0
+        // Make sure nothing else interferes with the A11Y tree
+        realDelay(250)
+        assertEquals(0, changesAppliedTime, "There were no state changes! Why did A11Y tree change?")
 
+        var debounceCounter = 0
         val startTime = currentTimeMillis()
+
         while(changesAppliedTime == 0L) {
             if (currentTimeMillis() - startTime > 2000) {
                 error("Changes must be applied after 1 second, waited for ${currentTimeMillis() - startTime} ms")
             }
-            // Change the state every 55ms. Such changes must be "debounced", (time delta is less than 100ms)
-            show1 = !show1
-            realDelay(55)
+            // Change the state every 10ms. Such changes must be "debounced", (time delta is less than 100ms)
+            value += 1
+            realDelay(10)
 
             if (changesAppliedTime == 0L) {
                 debounceCounter++

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -217,16 +217,14 @@ class CfWA11YTest : OnCanvasTests {
 
     @Test
     fun changesMustBeBatched() = runApplicationTest {
-        var show1 by mutableStateOf(false)
+        var value by mutableStateOf(0)
 
         var recompositions = 0
         createComposeWindow {
-            if (show1) {
-                Button(onClick = {}) {
-                    Text("Text in Button")
-                }
+            Button(onClick = {}) {
+                Text("Text in Button - $value")
+                recompositions++
             }
-            recompositions++
         }
 
         val a11yContainer = getA11YContainer()!!
@@ -234,20 +232,19 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals(0,a11yContainer.childElementCount)
 
         awaitA11YChanges()
-        assertFalse(a11yContainer.innerHTML.contains("Text in Button"))
+        assertTrue(a11yContainer.innerHTML.contains("Text in Button - 0"), "Expected the button to be added in HTML")
 
         recompositions = 0 // resetting because we're interested to count them only after this point
 
         repeat(20) {
-            show1 = !show1
+            value++
             awaitAnimationFrame()
             // No changes expected yet due to debounce
-            assertFalse(a11yContainer.innerHTML.contains("Text in Button"))
+            assertTrue(a11yContainer.innerHTML.contains("Text in Button - 0"), "The state is changing but we expect a debounce and no A11Y tree changes")
         }
 
         assertTrue(recompositions > 0, "The state has been changing, but no recompositions?")
 
-        show1 = true
         val startTime = currentTimeMillis()
         awaitA11YChanges()
         val waitedForChangesMs = currentTimeMillis() - startTime
@@ -257,7 +254,7 @@ class CfWA11YTest : OnCanvasTests {
 
         (buttonsContainer.children[0] as HTMLElement).let { button ->
             assertEquals("button", button.getAttribute("role"))
-            assertEquals("Text in Button", button.innerHTML)
+            assertEquals("Text in Button - 20", button.innerHTML)
         }
 
         // The tolerance is quite large, but it's so to reduce the flakiness.

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -57,6 +57,7 @@ import org.w3c.dom.get
  *   It led to awaitA11YChanges hanging forever or to a timeout.
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
+ *
  */
 class CfWA11YTest : OnCanvasTests {
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -262,7 +262,7 @@ class CfWA11YTest : OnCanvasTests {
 
         // The tolerance is quite large, but it's so to reduce the flakiness.
         // The idea is that the change is not expected to happen immediately, but with debounce.
-        assertTrue(waitedForChangesMs in 50..200, "Changes must be batched, waited for $waitedForChangesMs ms. Allowed tolerance was exceeded")
+        assertTrue(waitedForChangesMs in 50..250, "Changes must be batched, waited for $waitedForChangesMs ms. Allowed tolerance was exceeded")
     }
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -46,7 +46,7 @@ import org.w3c.dom.HTMLElement
 import org.w3c.dom.get
 
 /**
- * These tests were flaky in Firefox:
+ * These tests were flaky in Firefox when running the k/js target:
  * https://youtrack.jetbrains.com/issue/CMP-9069/CfWA11YTest.-timed-out-in-Firefox
  *
  * Here, I'd like to share my findings:
@@ -240,7 +240,7 @@ class CfWA11YTest : OnCanvasTests {
 
         repeat(20) {
             show1 = !show1
-            realDelay(10)
+            awaitAnimationFrame()
             // No changes expected yet due to debounce
             assertFalse(a11yContainer.innerHTML.contains("Text in Button"))
         }
@@ -291,7 +291,7 @@ class CfWA11YTest : OnCanvasTests {
         }
 
         // Make sure nothing else interferes with the A11Y tree
-        realDelay(250)
+        realDelay(1200)
         assertEquals(0, changesAppliedTime, "There were no state changes! Why did A11Y tree change?")
 
         var debounceCounter = 0
@@ -301,9 +301,9 @@ class CfWA11YTest : OnCanvasTests {
             if (currentTimeMillis() - startTime > 2000) {
                 error("Changes must be applied after 1 second, waited for ${currentTimeMillis() - startTime} ms")
             }
-            // Change the state every 10ms. Such changes must be "debounced", (time delta is less than 100ms)
+            // Change the state every frame. Such changes must be "debounced", (time delta is less than 100ms)
             value += 1
-            realDelay(10)
+            awaitAnimationFrame()
 
             if (changesAppliedTime == 0L) {
                 debounceCounter++
@@ -344,7 +344,7 @@ class CfWA11YTest : OnCanvasTests {
         recompositions = 0
         repeat(10) {
             show = !show
-            realDelay(5)
+            awaitAnimationFrame()
             assertTrue(textEl.isConnected, "textEl must be connected despite value changes - debounce expected. (Iteration $it)")
         }
 
@@ -416,7 +416,7 @@ class CfWA11YTest : OnCanvasTests {
         assertNull(getA11YContainer())
 
         // Wait a bit and make sure the a11y root didn't appear
-        realDelay(500)
+        realDelay(1200)
         assertNull(getA11YContainer())
 
         assertTrue(getCanvas().isConnected)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -270,8 +270,8 @@ class CfWA11YTest : OnCanvasTests {
 
         val a11yContainer = getA11YContainer()!!
 
-        assertEquals("",a11yContainer.innerHTML)
-        assertEquals(0,a11yContainer.childElementCount)
+        assertEquals("",a11yContainer.innerHTML, "No A11Y tree expected yet")
+        assertEquals(0,a11yContainer.childElementCount, "No A11Y tree expected yet")
 
         suspend fun realDelay(timeMs: Long) {
             withContext(Dispatchers.Default) {
@@ -294,8 +294,6 @@ class CfWA11YTest : OnCanvasTests {
             realDelay(55)
 
             if (changesAppliedTime == 0L) {
-                // No changes expected yet due to debounce
-                assertEquals(0, a11yContainer.childElementCount)
                 debounceCounter++
             }
         }
@@ -304,7 +302,7 @@ class CfWA11YTest : OnCanvasTests {
         assertTrue(debounceCounter > 1)
 
         // the "debounce" must be ignored when the changes were waiting for 1 second
-        assertEquals(1, a11yContainer.childElementCount)
+        assertEquals(1, a11yContainer.childElementCount, "Changes must be applied by now. The debounce was taking too long")
 
         // Adding a tolerance of 200ms, just to avoid flakiness
         assertTrue(
@@ -337,18 +335,18 @@ class CfWA11YTest : OnCanvasTests {
 
         realDelay(1200)
 
-        assertTrue(textEl.isConnected)
+        assertTrue(textEl.isConnected, "textEl must be connected")
 
         repeat(10) {
             show = !show
-            realDelay(10)
-            assertTrue(textEl.isConnected)
+            realDelay(5)
+            assertTrue(textEl.isConnected, "textEl must be connected despite value changes - debounce expected. (Iteration $it)")
         }
 
         show = false
         awaitA11YChanges()
 
-        assertFalse(textEl.isConnected)
+        assertFalse(textEl.isConnected, "textEl must be disconnected after debounce ended")
     }
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -57,7 +57,6 @@ import org.w3c.dom.get
  *   It led to awaitA11YChanges hanging forever or to a timeout.
  *   That's why it's better to use an Int state in such tests, so the change in HTML will be noticed 100%.
  * - Note: running the k/js tests in FF takes 15% longer than in Chrome. K/Wasm is fast in both cases.
- *
  */
 class CfWA11YTest : OnCanvasTests {
 
@@ -210,6 +209,10 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("Button3", buttonsContainer.children[2]!!.innerHTML)
     }
 
+    /**
+     * The tests use a TestCoroutineScope with delay skipping.
+     * In some cases we need a test to wait for some time, and that's the purpose of this function.
+     */
     suspend fun realDelay(timeMs: Long) {
         withContext(Dispatchers.Default) {
             delay(timeMs)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -251,7 +251,7 @@ class CfWA11YTest : OnCanvasTests {
 
         // The tolerance is quite large, but it's so to reduce the flakiness.
         // The idea is that the change is not expected to happen immediately, but with debounce.
-        assertTrue(waitedForChangesMs in 50..150, "Changes must be batched, waited for $waitedForChangesMs ms. Allowed tolerance 50ms was exceeded")
+        assertTrue(waitedForChangesMs in 50..200, "Changes must be batched, waited for $waitedForChangesMs ms. Allowed tolerance was exceeded")
     }
 
     @Test
@@ -279,7 +279,6 @@ class CfWA11YTest : OnCanvasTests {
         assertFalse(a11yContainer.innerHTML.contains("Text in Button"), "Button must be removed from the A11Y tree")
 
         var changesAppliedTime = 0L
-        val startTime = currentTimeMillis()
 
         launch {
             awaitA11YChanges()
@@ -288,7 +287,11 @@ class CfWA11YTest : OnCanvasTests {
 
         var debounceCounter = 0
 
-        repeat(20) {
+        val startTime = currentTimeMillis()
+        while(changesAppliedTime == 0L) {
+            if (currentTimeMillis() - startTime > 2000) {
+                error("Changes must be applied after 1 second, waited for ${currentTimeMillis() - startTime} ms")
+            }
             // Change the state every 55ms. Such changes must be "debounced", (time delta is less than 100ms)
             show1 = !show1
             realDelay(55)

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -49,7 +49,6 @@ import org.w3c.dom.get
 
 // It's flaky on Firefox JS. After ignoring one test it fails on another.
 // FIXME: https://youtrack.jetbrains.com/issue/CMP-9069
-@IgnoreJsTarget
 class CfWA11YTest : OnCanvasTests {
 
     @Test

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/a11y/CfWA11YTest.kt
@@ -63,10 +63,9 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
-
         val a11yContainer = getA11YContainer()
         assertNotNull(a11yContainer)
+        assertEquals("", a11yContainer.innerHTML, "No A11Y tree expected yet")
 
         awaitA11YChanges()
 
@@ -105,13 +104,11 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
-
         val a11yContainer = getA11YContainer()
         assertNotNull(a11yContainer)
+        assertEquals("", a11yContainer.innerHTML, "No A11Y tree expected yet")
 
         awaitA11YChanges()
-
         val buttonsContainer = a11yContainer.children[0] as HTMLDivElement
         assertEquals(1, buttonsContainer.children.length)
 
@@ -120,7 +117,6 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("Button1", button1.innerText)
 
         showButton2 = true
-        awaitIdle()
         awaitA11YChanges()
 
         assertEquals(2, buttonsContainer.children.length)
@@ -140,7 +136,6 @@ class CfWA11YTest : OnCanvasTests {
         }
 
         showButton2 = false
-        awaitIdle()
         awaitA11YChanges()
 
         assertEquals(1, buttonsContainer.children.length)
@@ -171,20 +166,16 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
-
         val a11yContainer = getA11YContainer()
         assertNotNull(a11yContainer)
+        assertEquals("", a11yContainer.innerHTML, "No A11Y tree expected yet")
 
         awaitA11YChanges()
-
         val buttonsContainer = a11yContainer.children[0] as HTMLDivElement
         assertEquals(1, buttonsContainer.children.length)
 
         show2 = true
         show3 = true
-
-        awaitIdle()
         awaitA11YChanges()
 
         assertEquals(3, buttonsContainer.children.length)
@@ -194,7 +185,6 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("Button3", buttonsContainer.children[2]!!.innerHTML)
 
         show1 = false
-        awaitIdle()
         awaitA11YChanges()
 
         assertEquals(2, buttonsContainer.children.length)
@@ -202,7 +192,6 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals("Button3", buttonsContainer.children[1]!!.innerHTML)
 
         show1 = true
-        awaitIdle()
         awaitA11YChanges()
 
         assertEquals(3, buttonsContainer.children.length)
@@ -223,9 +212,7 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
         val a11yContainer = getA11YContainer()!!
-
         assertEquals("",a11yContainer.innerHTML)
         assertEquals(0,a11yContainer.childElementCount)
 
@@ -279,7 +266,6 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
         assertNotEquals(0L, startTime, "The start time must be set")
 
         val a11yContainer = getA11YContainer()!!
@@ -337,7 +323,6 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
         awaitA11YChanges()
 
         val textEl = getShadowRoot().getElementById("testText") as HTMLElement
@@ -384,8 +369,6 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-
-        awaitIdle()
         awaitA11YChanges()
 
         val a11yContainer = getA11YContainer()!!
@@ -425,8 +408,6 @@ class CfWA11YTest : OnCanvasTests {
                 Text("Button1")
             }
         }
-
-        awaitIdle()
         assertNull(getA11YContainer())
 
         suspend fun realDelay(timeMs: Long) {
@@ -465,7 +446,6 @@ class CfWA11YTest : OnCanvasTests {
             }
         }
 
-        awaitIdle()
         awaitA11YChanges()
 
         val button = getShadowRoot().getElementById("buttonTag") as? HTMLElement
@@ -474,7 +454,6 @@ class CfWA11YTest : OnCanvasTests {
         assertEquals(1, clickCounter)
 
         showButton = false
-        awaitIdle()
         awaitA11YChanges()
 
         assertNull(getShadowRoot().getElementById("buttonTag"))
@@ -492,7 +471,6 @@ class CfWA11YTest : OnCanvasTests {
             )
         }
 
-        awaitIdle()
         awaitA11YChanges()
 
         val textField = getShadowRoot().getElementById("textFieldTag") as? HTMLElement

--- a/gradle.properties
+++ b/gradle.properties
@@ -127,9 +127,9 @@ kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
-jetbrains.androidx.web.tests.enableChrome=false
+jetbrains.androidx.web.tests.enableChrome=true
 jetbrains.androidx.web.tests.enableChromium=false
-jetbrains.androidx.web.tests.enableFirefox=true
+jetbrains.androidx.web.tests.enableFirefox=false
 jetbrains.androidx.web.tests.enableSafari=false
 
 # WA for a build issue on Linux agents

--- a/gradle.properties
+++ b/gradle.properties
@@ -127,9 +127,9 @@ kotlinx.atomicfu.enableNativeIrTransformation=true
 kotlinx.atomicfu.enableJsIrTransformation=true
 
 # In which browsers run web tests
-jetbrains.androidx.web.tests.enableChrome=true
+jetbrains.androidx.web.tests.enableChrome=false
 jetbrains.androidx.web.tests.enableChromium=false
-jetbrains.androidx.web.tests.enableFirefox=false
+jetbrains.androidx.web.tests.enableFirefox=true
 jetbrains.androidx.web.tests.enableSafari=false
 
 # WA for a build issue on Linux agents


### PR DESCRIPTION
Changes:
- Imroved the A11Y tests, see the comment in the test file
- Disabled FF K/JS job to avoid unstable pipeline. FF K/JS is flaky on compose-foundation tests too

https://youtrack.jetbrains.com/issue/CMP-9069/

## Testing
N/A

## Release Notes
N/A
