### PR TITLE
Missing experimental annotation for `ClipEntry`

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+@file:OptIn(ExperimentalComposeUiApi::class)
+
 package androidx.compose.foundation.internal
 
 import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.NativeClipboard
+import androidx.compose.ui.platform.asAwtTransferable
 import androidx.compose.ui.text.AnnotatedString
 import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.ClipboardOwner
@@ -38,7 +42,7 @@ private val annotatedStringFlavor: DataFlavor =
 internal actual suspend fun ClipEntry.readText(): String? {
     if (!hasText()) return null
 
-    val transferable = nativeClipEntry as? Transferable
+    val transferable = asAwtTransferable
     return withContext(Dispatchers.IO) {
         try {
             transferable?.getTransferData(DataFlavor.stringFlavor) as? String
@@ -55,7 +59,7 @@ internal actual suspend fun ClipEntry.readAnnotatedString(): AnnotatedString? {
         return readText()?.let { AnnotatedString(it) }
     }
 
-    val transferable = nativeClipEntry as? Transferable
+    val transferable = asAwtTransferable
     return withContext(Dispatchers.IO) {
         try {
             transferable?.getTransferData(annotatedStringFlavor) as? AnnotatedString
@@ -74,13 +78,13 @@ internal actual fun AnnotatedString?.toClipEntry(): ClipEntry? {
 
 internal fun ClipEntry?.hasAnnotatedString(): Boolean {
     if (this == null) return false
-    val transferable = nativeClipEntry as? Transferable ?: return false
+    val transferable = asAwtTransferable ?: return false
     return transferable.isDataFlavorSupported(annotatedStringFlavor)
 }
 
 internal actual fun ClipEntry?.hasText(): Boolean {
     if (this == null) return false
-    val transferable = nativeClipEntry as? Transferable ?: return false
+    val transferable = asAwtTransferable ?: return false
     return transferable.isDataFlavorSupported(DataFlavor.stringFlavor)
 }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -52,7 +53,7 @@ import kotlin.test.assertEquals
 import org.junit.Test
 
 
-@OptIn(ExperimentalTestApi::class)
+@OptIn(ExperimentalTestApi::class, ExperimentalComposeUiApi::class)
 class ContextMenuTest {
 
     // https://github.com/JetBrains/compose-multiplatform/issues/2729

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/internal/ClipboardUtilsTest.desktop.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/internal/ClipboardUtilsTest.desktop.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation.internal
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.text.AnnotatedString
@@ -34,6 +35,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+@OptIn(ExperimentalComposeUiApi::class)
 @RunWith(JUnit4::class)
 class ClipboardUtilsTest {
 

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.web.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/components/DragAndDropExample.web.kt
@@ -209,6 +209,7 @@ actual fun DragAndDropExample() {
 }
 
 @Composable
+@OptIn(ExperimentalComposeUiApi::class)
 private fun DraggableColorSource(color: Color) {
     Box(
         Modifier

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -564,7 +564,6 @@ public final class androidx/compose/ui/awt/SwingWindow_desktopKt {
 
 public final class androidx/compose/ui/draganddrop/DragAndDropEvent {
 	public static final field $stable I
-	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferAction;Ljava/lang/Object;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class androidx/compose/ui/draganddrop/DragAndDropModifierNode : androidx/compose/ui/draganddrop/DragAndDropTarget, androidx/compose/ui/node/DelegatableNode {
@@ -610,7 +609,6 @@ public final class androidx/compose/ui/draganddrop/DragAndDropTransferAction$Com
 public final class androidx/compose/ui/draganddrop/DragAndDropTransferData {
 	public static final field $stable I
 	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Landroidx/compose/ui/draganddrop/DragAndDropTransferable;Ljava/lang/Iterable;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class androidx/compose/ui/draganddrop/DragData$FilesList : androidx/compose/ui/draganddrop/DragData {
@@ -3565,9 +3563,7 @@ public final class androidx/compose/ui/platform/AccessibilityManager$DefaultImpl
 
 public final class androidx/compose/ui/platform/ClipEntry {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/Object;)V
 	public final fun getClipMetadata ()Landroidx/compose/ui/platform/ClipMetadata;
-	public final fun getNativeClipEntry ()Ljava/lang/Object;
 }
 
 public final class androidx/compose/ui/platform/ClipMetadata {

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -1540,6 +1540,10 @@ final class androidx.compose.ui.autofill/AutofillTree { // androidx.compose.ui.a
     final fun plusAssign(androidx.compose.ui.autofill/AutofillNode) // androidx.compose.ui.autofill/AutofillTree.plusAssign|plusAssign(androidx.compose.ui.autofill.AutofillNode){}[0]
 }
 
+final class androidx.compose.ui.draganddrop/DragAndDropEvent // androidx.compose.ui.draganddrop/DragAndDropEvent|null[0]
+
+final class androidx.compose.ui.draganddrop/DragAndDropTransferData // androidx.compose.ui.draganddrop/DragAndDropTransferData|null[0]
+
 final class androidx.compose.ui.draw/CacheDrawScope : androidx.compose.ui.unit/Density { // androidx.compose.ui.draw/CacheDrawScope|null[0]
     final val density // androidx.compose.ui.draw/CacheDrawScope.density|{}density[0]
         final fun <get-density>(): kotlin/Float // androidx.compose.ui.draw/CacheDrawScope.density.<get-density>|<get-density>(){}[0]
@@ -4414,18 +4418,6 @@ final inline fun androidx.compose.ui.platform/debugInspectorInfo(crossinline kot
 final suspend fun (androidx.compose.ui.node/DelegatableNode).androidx.compose.ui.relocation/bringIntoView(kotlin/Function0<androidx.compose.ui.geometry/Rect?>? = ...) // androidx.compose.ui.relocation/bringIntoView|bringIntoView@androidx.compose.ui.node.DelegatableNode(kotlin.Function0<androidx.compose.ui.geometry.Rect?>?){}[0]
 final suspend fun (androidx.compose.ui.platform/PlatformTextInputModifierNode).androidx.compose.ui.platform/establishTextInputSession(kotlin.coroutines/SuspendFunction1<androidx.compose.ui.platform/PlatformTextInputSessionScope, kotlin/Nothing>): kotlin/Nothing // androidx.compose.ui.platform/establishTextInputSession|establishTextInputSession@androidx.compose.ui.platform.PlatformTextInputModifierNode(kotlin.coroutines.SuspendFunction1<androidx.compose.ui.platform.PlatformTextInputSessionScope,kotlin.Nothing>){}[0]
 
-// Targets: [ios, js, wasmJs]
-final class androidx.compose.ui.draganddrop/DragAndDropEvent // androidx.compose.ui.draganddrop/DragAndDropEvent|null[0]
-
-// Targets: [js, macos, wasmJs]
-final class androidx.compose.ui.draganddrop/DragAndDropTransferData { // androidx.compose.ui.draganddrop/DragAndDropTransferData|null[0]
-    // Targets: [js, wasmJs]
-    constructor <init>(org.w3c.dom/DataTransfer? = ...) // androidx.compose.ui.draganddrop/DragAndDropTransferData.<init>|<init>(org.w3c.dom.DataTransfer?){}[0]
-
-    // Targets: [macos]
-    constructor <init>() // androidx.compose.ui.draganddrop/DragAndDropTransferData.<init>|<init>(){}[0]
-}
-
 // Targets: [ios]
 abstract interface androidx.compose.ui.uikit/ComposeUIViewControllerDelegate { // androidx.compose.ui.uikit/ComposeUIViewControllerDelegate|null[0]
     open val preferredStatusBarStyle // androidx.compose.ui.uikit/ComposeUIViewControllerDelegate.preferredStatusBarStyle|{}preferredStatusBarStyle[0]
@@ -4480,9 +4472,6 @@ sealed interface androidx.compose.ui.viewinterop/UIKitInteropInteractionMode { /
         final fun toString(): kotlin/String // androidx.compose.ui.viewinterop/UIKitInteropInteractionMode.NonCooperative.toString|toString(){}[0]
     }
 }
-
-// Targets: [ios]
-final class androidx.compose.ui.draganddrop/DragAndDropTransferData // androidx.compose.ui.draganddrop/DragAndDropTransferData|null[0]
 
 // Targets: [ios]
 final class androidx.compose.ui.main/DefaultIOSAppDelegate : platform.UIKit/UIApplicationDelegateProtocol, platform.UIKit/UIResponder { // androidx.compose.ui.main/DefaultIOSAppDelegate|null[0]
@@ -4916,11 +4905,6 @@ final fun androidx.compose.ui.window/androidx_compose_ui_window_KeyboardModeStat
 abstract interface androidx.compose.ui.window/WindowScope { // androidx.compose.ui.window/WindowScope|null[0]
     abstract val window // androidx.compose.ui.window/WindowScope.window|{}window[0]
         abstract fun <get-window>(): platform.AppKit/NSWindow // androidx.compose.ui.window/WindowScope.window.<get-window>|<get-window>(){}[0]
-}
-
-// Targets: [macos]
-final class androidx.compose.ui.draganddrop/DragAndDropEvent { // androidx.compose.ui.draganddrop/DragAndDropEvent|null[0]
-    constructor <init>() // androidx.compose.ui.draganddrop/DragAndDropEvent.<init>|<init>(){}[0]
 }
 
 // Targets: [macos]

--- a/compose/ui/ui/api/ui.klib.api
+++ b/compose/ui/ui/api/ui.klib.api
@@ -2042,14 +2042,6 @@ final class androidx.compose.ui.platform/ClipEntry { // androidx.compose.ui.plat
     final object Companion // androidx.compose.ui.platform/ClipEntry.Companion|null[0]
 
     // Targets: [js, wasmJs]
-    final val clipboardItems // androidx.compose.ui.platform/ClipEntry.clipboardItems|{}clipboardItems[0]
-        // Targets: [js]
-        final fun <get-clipboardItems>(): kotlin/Array<androidx.compose.ui.platform/ClipboardItem> // androidx.compose.ui.platform/ClipEntry.clipboardItems.<get-clipboardItems>|<get-clipboardItems>(){}[0]
-
-        // Targets: [wasmJs]
-        final fun <get-clipboardItems>(): kotlin.js/JsArray<androidx.compose.ui.platform/ClipboardItem> // androidx.compose.ui.platform/ClipEntry.clipboardItems.<get-clipboardItems>|<get-clipboardItems>(){}[0]
-
-    // Targets: [js, wasmJs]
     final object Companion { // androidx.compose.ui.platform/ClipEntry.Companion|null[0]
         final fun withPlainText(kotlin/String): androidx.compose.ui.platform/ClipEntry // androidx.compose.ui.platform/ClipEntry.Companion.withPlainText|withPlainText(kotlin.String){}[0]
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.desktop.kt
@@ -26,8 +26,7 @@ import java.awt.dnd.DropTargetDropEvent
 /**
  * Encapsulates the information needed to start a drag-and-drop session from Compose on the desktop.
  */
-@OptIn(ExperimentalComposeUiApi::class)
-actual class DragAndDropTransferData(
+actual class DragAndDropTransferData @ExperimentalComposeUiApi constructor(
     /**
      * The object being transferred during a drag-and-drop gesture.
      */
@@ -55,11 +54,9 @@ actual class DragAndDropTransferData(
     @property:ExperimentalComposeUiApi
     val onTransferCompleted: ((userAction: DragAndDropTransferAction?) -> Unit)? = null,
 ) {
-
     init {
         require(supportedActions.firstOrNull() != null) { "supportedActions may not be empty" }
     }
-
 }
 
 /**
@@ -98,7 +95,7 @@ class DragAndDropTransferAction private constructor(private val name: String) {
 /**
  * The event dispatched to [DragAndDropTarget] implementations during a drag-and-drop session.
  */
-actual class DragAndDropEvent(
+actual class DragAndDropEvent @ExperimentalComposeUiApi constructor(
     /**
      * The action currently selected by the user.
      */
@@ -117,7 +114,6 @@ actual class DragAndDropEvent(
     internal val positionInRootImpl: Offset
 )
 
-
 /**
  * The base class for [DragAndDropTransferable] for AWT that simply wraps an AWT [Transferable]
  * instance.
@@ -125,7 +121,6 @@ actual class DragAndDropEvent(
 internal interface AwtDragAndDropTransferable : DragAndDropTransferable {
     fun toAwtTransferable(): Transferable
 }
-
 
 /**
  * Returns a [DragAndDropTransferable] that simply wraps an AWT [Transferable] instance.
@@ -136,7 +131,6 @@ fun DragAndDropTransferable(transferable: Transferable): DragAndDropTransferable
         override fun toAwtTransferable() = transferable
     }
 }
-
 
 /**
  * Returns the AWT [Transferable] associated with the [DragAndDropEvent].
@@ -198,4 +192,3 @@ interface DragData {
 
 internal actual val DragAndDropEvent.positionInRoot: Offset
     get() = positionInRootImpl
-

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
@@ -44,7 +44,7 @@ internal class AwtPlatformClipboard internal constructor() : Clipboard {
     }
 
     override suspend fun setClipEntry(clipEntry: ClipEntry?) {
-        val transferable = clipEntry?.nativeClipEntry as? Transferable
+        val transferable = clipEntry?.asAwtTransferable
         systemClipboard?.setContents(
             /* contents = */ transferable ?: EmptyTransferable,
             /* owner = */ transferable as? ClipboardOwner,
@@ -76,7 +76,12 @@ val Clipboard.awtClipboard: java.awt.datatransfer.Clipboard?
  *
  * See [asAwtTransferable] to access [Transferable].
  */
-actual class ClipEntry(val nativeClipEntry: Any) {
+actual class ClipEntry
+@ExperimentalComposeUiApi
+constructor(
+    @property:ExperimentalComposeUiApi
+    val nativeClipEntry: Any
+) {
     // TODO https://youtrack.jetbrains.com/issue/CMP-1260/ClipboardManager.-Implement-getClip-getClipMetadata-setClip
     actual val clipMetadata: ClipMetadata
         get() = TODO("ClipMetadata is not implemented. Consider using nativeClipboard")

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
@@ -96,7 +96,10 @@ internal actual fun createPlatformClipboard(): Clipboard = jsPlatformClipboard
 
 actual class ClipEntry
 @ExperimentalComposeUiApi
-constructor(val clipboardItems: Array<ClipboardItem>) {
+constructor(
+    @property:ExperimentalComposeUiApi
+    val clipboardItems: Array<ClipboardItem>
+) {
 
     // TODO https://youtrack.jetbrains.com/issue/CMP-1260/ClipboardManager.-Implement-getClip-getClipMetadata-setClip
     actual val clipMetadata: ClipMetadata

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/draganddrop/DragAndDrop.macos.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.geometry.Offset
 /**
  * A representation of an event sent by the platform during a drag and drop operation.
  */
-actual class DragAndDropEvent
+actual class DragAndDropEvent private constructor()
 
 /**
  * Returns the position of this [DragAndDropEvent] relative to the root Compose View in the
@@ -34,4 +34,4 @@ internal actual val DragAndDropEvent.positionInRoot: Offset
  * Definition for a type representing transferable data. It could be a remote URI,
  * rich text data on the clip board, a local file, or more.
  */
-actual class DragAndDropTransferData
+actual class DragAndDropTransferData private constructor()

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
@@ -98,7 +98,10 @@ internal actual fun createPlatformClipboard(): Clipboard = wasmPlatformClipboard
 
 actual class ClipEntry
 @ExperimentalComposeUiApi
-constructor(val clipboardItems: JsArray<ClipboardItem>) {
+constructor(
+    @property:ExperimentalComposeUiApi
+    val clipboardItems: JsArray<ClipboardItem>
+) {
 
     // TODO https://youtrack.jetbrains.com/issue/CMP-1260/ClipboardManager.-Implement-getClip-getClipMetadata-setClip
     actual val clipMetadata: ClipMetadata

--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/DragAndDropTransferData.web.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/draganddrop/DragAndDropTransferData.web.kt
@@ -7,7 +7,9 @@ import org.w3c.dom.DataTransfer
  * Definition for a type representing transferable data. It could be a remote URI,
  * rich text data on the clip board, a local file, or more.
  */
-actual class DragAndDropTransferData(internal val nativeTransferData: DataTransfer? = null)
+actual class DragAndDropTransferData @ExperimentalComposeUiApi constructor(
+    internal val nativeTransferData: DataTransfer? = null
+)
 
 /**
  * While we'll definitely benefit from (even partial) commonization of transfer data,


### PR DESCRIPTION
## Release Notes
### Fixes - Multiple Platforms
- Added previously missing `ExperimentalComposeUiApi` annotation to platform-specific `DragAndDropTransferData`, `DragAndDropEvent` and `ClipEntry` constructors on Desktop and Web. Working with these APIs already requires this annotation due to types of parameters, so it wasn't supposed to be marked as "stable" yet. You can follow [CMP-7624](https://youtrack.jetbrains.com/issue/CMP-7624) to track the updates about finalizing the shape of these APIs.
