### PR TITLE
Fix crash in accessibility on iOS < 17

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -548,7 +548,9 @@ private class AccessibilityElement(
         isAlive = false
         setAccessibilityContainer(null)
         setAccessibilityElements(emptyList<Any>())
-        setAutomationElements(null)
+        if (available(OS.Ios to OSVersion(major = 17))) {
+            setAutomationElements(null)
+        }
         cachedProperties.clear()
     }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9141

## Release Notes
### Fixes - iOS
- Fix crash on iOS older than 17 when accessibility is enabled