### PR TITLE
Order accessible children of nodes with `isTraversalGroup==true` according to their `traversalIndex`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -323,21 +323,21 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleIndexInParent(): Int {
-            val parentChildren = semanticsNode.parent?.replacedChildren
-            return parentChildren?.indexOfFirst { it.id == semanticsNode.id } ?: -1
+            val parentChildren = semanticsNode.parent?.traversalOrderedChildren()
+            return (parentChildren?.indexOfFirst { it.id == semanticsNode.id } ?: -1)
         }
 
         override fun getAccessibleChildrenCount(): Int {
             return semanticsNode.replacedChildren.size + auxiliaryChildren.size
         }
 
-        override fun getAccessibleChild(i: Int): Accessible? {
-            val replacedChildren = semanticsNode.replacedChildren
-            val replacedChildrenSize = replacedChildren.size
-            return if (i < replacedChildrenSize) {
-                controller.accessibleByNodeId(replacedChildren[i].id)
+        override fun getAccessibleChild(index: Int): Accessible? {
+            val regularChildren = semanticsNode.traversalOrderedChildren()
+            val childrenSize = regularChildren.size
+            return if (index < childrenSize) {
+                controller.accessibleByNodeId(regularChildren[index].id)
             } else {
-                auxiliaryChildren[i - replacedChildrenSize]
+                auxiliaryChildren[index - childrenSize]
             }
         }
 
@@ -934,5 +934,13 @@ private class ProgressBarAccessibleValue(
 
     override fun getMaximumAccessibleValue(): Number {
         return rangeInfo?.range?.endInclusive ?: 1f
+    }
+}
+
+private fun SemanticsNode.traversalOrderedChildren(): List<SemanticsNode> {
+    val children = replacedChildren
+    return if (config.getOrNull(SemanticsProperties.IsTraversalGroup) != true) children
+    else children.sortedBy {
+        it.config.getOrNull(SemanticsProperties.TraversalIndex) ?: 0f
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -373,12 +373,23 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleAt(p: Point): Accessible? {
-            for (i in 0 until accessibleChildrenCount) {
-                val child = (getAccessibleChild(i)?.accessibleContext as? AccessibleComponent)
-                child?.getAccessibleAt(p)?.let {
+            val accessibleChildren = semanticsNode.traversalOrderedChildren()
+            for (child in accessibleChildren) {
+                val accessible = controller.accessibleByNodeId(child.id) as? Accessible ?: continue
+                val accessibleComponent = (accessible.accessibleContext as? AccessibleComponent) ?: continue
+                accessibleComponent.getAccessibleAt(p)?.let {
                     return it
                 }
             }
+
+            for (accessibleChild in auxiliaryChildren) {
+                val accessibleComponent =
+                    accessibleChild.accessibleContext as? AccessibleComponent ?: continue
+                accessibleComponent.getAccessibleAt(p)?.let {
+                    return it
+                }
+            }
+
             if (contains(p)) {
                 return this@ComposeAccessible
             }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -448,7 +448,8 @@ class AccessibilityTest {
             assertNotNull(context)
 
             fun assertDescriptionAtIndexIs(index: Int, expectedDescription: String) {
-                context.getAccessibleChild(index).accessibleContext.accessibleDescription == expectedDescription
+                assertThat(context.getAccessibleChild(index).accessibleContext.accessibleDescription)
+                    .isEqualTo(expectedDescription)
             }
 
             assertThat(context.accessibleChildrenCount).isEqualTo(3)
@@ -458,7 +459,8 @@ class AccessibilityTest {
         }
 
         fun assertNodeWithTagIndexInParentIs(tag: String, expectedIndex: Int) {
-            assertThat(test.onNodeWithTag(tag).fetchAccessible().accessibleContext?.accessibleIndexInParent).isEqualTo(expectedIndex)
+            assertThat(test.onNodeWithTag(tag).fetchAccessible().accessibleContext?.accessibleIndexInParent)
+                .isEqualTo(expectedIndex)
         }
         assertNodeWithTagIndexInParentIs("item1", 0)
         assertNodeWithTagIndexInParentIs("item2", 2)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -40,11 +40,13 @@ import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.isContainer
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
@@ -404,6 +406,63 @@ class AccessibilityTest {
         }
 
         verifyTextFieldA11y(test.onNodeWithTag("textField"))
+    }
+
+    @Test
+    fun traversalIndexIsRespected() = runDesktopA11yTest {
+        test.setContent {
+            Column(Modifier
+                .testTag("container")
+                .semantics {
+                    isTraversalGroup = true
+                }
+            ) {
+                Text("Item 1",
+                    Modifier
+                        .semantics {
+                            traversalIndex = 0f
+                            contentDescription = "Item 1"
+                        }
+                        .testTag("item1")
+                )
+                Text("Item 2",
+                    Modifier
+                        .semantics {
+                            traversalIndex = 2f
+                            contentDescription = "Item 2"
+                        }
+                        .testTag("item2")
+                )
+                Text("Item 3",
+                    Modifier
+                        .semantics {
+                            traversalIndex = 1f
+                            contentDescription = "Item 3"
+                        }
+                        .testTag("item3")
+                )
+            }
+        }
+
+        test.onNodeWithTag("container").fetchAccessible().accessibleContext.let { context ->
+            assertNotNull(context)
+
+            fun assertDescriptionAtIndexIs(index: Int, expectedDescription: String) {
+                context.getAccessibleChild(index).accessibleContext.accessibleDescription == expectedDescription
+            }
+
+            assertThat(context.accessibleChildrenCount).isEqualTo(3)
+            assertDescriptionAtIndexIs(0, "Item 1")
+            assertDescriptionAtIndexIs(1, "Item 3")
+            assertDescriptionAtIndexIs(2, "Item 2")
+        }
+
+        fun assertNodeWithTagIndexInParentIs(tag: String, expectedIndex: Int) {
+            assertThat(test.onNodeWithTag(tag).fetchAccessible().accessibleContext?.accessibleIndexInParent).isEqualTo(expectedIndex)
+        }
+        assertNodeWithTagIndexInParentIs("item1", 0)
+        assertNodeWithTagIndexInParentIs("item2", 2)
+        assertNodeWithTagIndexInParentIs("item3", 1)
     }
 }
 


### PR DESCRIPTION
The children of nodes that have `isTraversalGroup` semantics are now ordered according to their `traversalIndex`.

Fixes https://youtrack.jetbrains.com/issue/CMP-8520/A11y-should-respect-traversalIndex

Unfortunately some screen readers, namely VoiceOver, ignore the order of children and only use the geometry to decide the order. I've created a [JBR ticket](https://youtrack.jetbrains.com/issue/JBR-9564/Accessible-children-order-ignored-by-or-not-passed-to-VoiceOver), but I'm not sure it can even be fixed on their end.
Add: according to the JBR folks, [this is expected behavior](https://youtrack.jetbrains.com/issue/JBR-9564/Accessible-children-order-ignored-by-or-not-passed-to-VoiceOver#focus=Comments-27-12934228.0-0), as the corresponding commands in VoiceOver are "move up/down/left/right" and there's no "move to next/previous" command. The item chooser (VO+I) does show the correct item order, so the information is being sent to VoiceOver correctly.

It does work correctly on Windows with NVDA.

## Testing
Tested manually and added a unit test

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Children of nodes with `isTraversalNode` semantics are now ordered according to their `traversalIndex`.
