### PR TITLE
Revert CMP-8704 workaround

### DIFF
--- a/compose/material/material-navigation/build.gradle
+++ b/compose/material/material-navigation/build.gradle
@@ -44,6 +44,13 @@ kotlin {
                 implementation("org.jetbrains.androidx.navigation:navigation-compose:2.9.1")
                 implementation(project(":compose:material:material"))
                 implementation(libs.kotlinStdlib)
+
+                // Align navigation dependencies with Compose ones
+                // https://youtrack.jetbrains.com/issue/CMP-8704 workaround
+                implementation(project(":lifecycle:lifecycle-runtime-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-compose"))
+                implementation(project(":lifecycle:lifecycle-viewmodel-savedstate"))
+                implementation(project(":savedstate:savedstate-compose"))
             }
         }
 


### PR DESCRIPTION
It was removed during previous pinning (#2504) and wasn't restored during recent unpinning (#2550)

## Release Notes
N/A
