### PR TITLE
Fix some text field accessibility issues

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -138,11 +138,11 @@ internal class AccessibilityController(
                         val text = newSemanticsNode.config.getOrNull(SemanticsProperties.EditableText)
                         val prevHasSelection = prevTextSelectionRange?.collapsed == false
                         val nowHasSelection = !newTextSelectionRange.collapsed
-                        if ((text != null) && (prevHasSelection != nowHasSelection)) {
+                        if (prevHasSelection != nowHasSelection) {
                             accessibleContext.firePropertyChange(
                                 ACCESSIBLE_SELECTION_PROPERTY,
                                 null,  // AccessibleJTextComponent also sends oldValue = null
-                                text.subSequence(newTextSelectionRange)
+                                text?.subSequence(newTextSelectionRange)
                             )
                         }
                     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.TextRange
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext.ACCESSIBLE_CARET_PROPERTY
+import javax.accessibility.AccessibleContext.ACCESSIBLE_SELECTION_PROPERTY
 import javax.accessibility.AccessibleContext.ACCESSIBLE_STATE_PROPERTY
 import javax.accessibility.AccessibleContext.ACCESSIBLE_TEXT_PROPERTY
 import javax.accessibility.AccessibleContext.ACCESSIBLE_VALUE_PROPERTY
@@ -87,7 +88,7 @@ internal class AccessibilityController(
      * Invoked when a [ComposeAccessible] is removed.
      */
     private fun onNodeRemoved(accessible: ComposeAccessible) {
-        accessible.removed = true
+        accessible.dispose()
     }
 
     /**
@@ -98,29 +99,52 @@ internal class AccessibilityController(
         previousSemanticsNode: SemanticsNode,
         newSemanticsNode: SemanticsNode
     ) {
+        val accessibleContext by lazy { component.composeAccessibleContext }
         for (entry in newSemanticsNode.config) {
             val prev = previousSemanticsNode.config.getOrNull(entry.key)
             if (entry.value != prev) {
                 when (entry.key) {
                     SemanticsProperties.Text -> {
-                        component.composeAccessibleContext.firePropertyChange(
+                        accessibleContext.firePropertyChange(
                             ACCESSIBLE_TEXT_PROPERTY,
                             prev, entry.value
                         )
                     }
 
                     SemanticsProperties.EditableText -> {
-                        component.composeAccessibleContext.firePropertyChange(
+                        // The docs on ACCESSIBLE_TEXT_PROPERTY say that the value should be
+                        // an AccessibleTextSequence, but in reality, AccessibleJTextComponent
+                        // sends the position of the start of the change
+                        accessibleContext.firePropertyChange(
                             ACCESSIBLE_TEXT_PROPERTY,
-                            prev, entry.value
+                            null,
+                            0  // Ideally, we should track the position of the change; 0 means everything changed
                         )
                     }
 
                     SemanticsProperties.TextSelectionRange -> {
-                        component.composeAccessibleContext.firePropertyChange(
-                            ACCESSIBLE_CARET_PROPERTY,
-                            (prev as? TextRange)?.start, (entry.value as TextRange).start
-                        )
+                        val prevTextSelectionRange = prev as? TextRange
+                        val newTextSelectionRange = entry.value as TextRange
+
+                        val prevCaretPosition = prevTextSelectionRange?.end
+                        val newCaretPosition = newTextSelectionRange.end
+                        if (prevCaretPosition != newCaretPosition) {
+                            accessibleContext.firePropertyChange(
+                                ACCESSIBLE_CARET_PROPERTY,
+                                prevCaretPosition, newCaretPosition
+                            )
+                        }
+
+                        val text = newSemanticsNode.config.getOrNull(SemanticsProperties.EditableText)
+                        val prevHasSelection = prevTextSelectionRange?.collapsed == false
+                        val nowHasSelection = !newTextSelectionRange.collapsed
+                        if ((text != null) && (prevHasSelection != nowHasSelection)) {
+                            accessibleContext.firePropertyChange(
+                                ACCESSIBLE_SELECTION_PROPERTY,
+                                null,  // AccessibleJTextComponent also sends oldValue = null
+                                text.subSequence(newTextSelectionRange)
+                            )
+                        }
                     }
 
                     SemanticsProperties.Focused ->

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -112,10 +112,14 @@ internal class ComposeAccessible(
 
     val composeAccessibleContext: ComposeAccessibleComponent by lazy { ComposeAccessibleComponent() }
 
-    var removed = false
+    private var disposed = false
+
+    fun dispose() {
+        disposed = true
+    }
 
     override fun getAccessibleContext(): AccessibleContext? {
-        if (removed) {
+        if (disposed) {
             // The accessibility system keeps calling functions on the context even after the node
             // has been removed. We return null so it doesn't do that.
             return null
@@ -179,10 +183,10 @@ internal class ComposeAccessible(
         val auxiliaryChildren
             get() = buildList {
                 horizontalScroll?.let {
-                    add(makeScrollbarChild(false))
+                    add(makeScrollbarChild(vertical = false))
                 }
                 verticalScroll?.let {
-                    add(makeScrollbarChild(true))
+                    add(makeScrollbarChild(vertical = true))
                 }
             }
 
@@ -419,8 +423,8 @@ internal class ComposeAccessible(
             return when {
                 fromSemanticRole != null -> fromSemanticRole
                 isPassword -> AccessibleRole.PASSWORD_TEXT
-                scrollBy != null -> AccessibleRole.SCROLL_PANE
                 setText != null -> AccessibleRole.TEXT
+                scrollBy != null -> AccessibleRole.SCROLL_PANE
                 text != null -> AccessibleRole.LABEL
                 progressBarRangeInfo != null -> {
                     if (semanticsConfig.getOrNull(SemanticsActions.SetProgress) != null)
@@ -442,6 +446,8 @@ internal class ComposeAccessible(
 
                 if (isEnabled)
                     add(AccessibleState.ENABLED)
+                if (semanticsConfig.getOrNull(SemanticsProperties.IsEditable) == true)
+                    add(AccessibleState.EDITABLE)
                 if (isShowing)
                     add(AccessibleState.SHOWING)
                 if (isVisible)
@@ -588,18 +594,19 @@ internal class ComposeAccessible(
             }
 
             override fun getSelectionStart(): Int {
-                return textSelectionRange?.start ?: 0
+                return textSelectionRange?.min ?: 0
             }
 
             override fun getSelectionEnd(): Int {
-                return textSelectionRange?.end ?: 0
+                return textSelectionRange?.max ?: 0
             }
 
-            override fun getSelectedText(): String {
-                return textSelectionRange?.let { selection ->
-                    // could be end less than start here?
-                    text!!.subSequence(selection.start, selection.end).toString()
-                } ?: ""
+            override fun getSelectedText(): String? {
+                val selection = textSelectionRange ?: return null
+                val start = selection.min
+                val end = selection.max
+                return if (start == end) null
+                else text!!.subSequence(start, end).toString()
             }
 
             override fun getTextRange(startIndex: Int, endIndex: Int): String {
@@ -688,16 +695,11 @@ internal class ComposeAccessible(
         }
 
         private val accessibleText by lazy {
+            // Technically it's wrong to cache this because `setText` or `text` may change
             when {
-                setText != null -> {
-                    ComposeAccessibleEditableText()
-                }
-                text != null -> {
-                    ComposeAccessibleText()
-                }
-                else -> {
-                    null
-                }
+                setText != null -> ComposeAccessibleEditableText()
+                text != null -> ComposeAccessibleText()
+                else -> null
             }
         }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -21,6 +21,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.Button
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Tab
@@ -48,7 +50,9 @@ import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTextInputSelection
 import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.toDpSize
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
@@ -324,6 +328,83 @@ class AccessibilityTest {
         }
     }
 
+    private fun ComposeA11yTestScope.verifyTextFieldA11y(node: SemanticsNodeInteraction) {
+        fun AccessibleText.asString() = buildString {
+            for (i in 0 until charCount) {
+                append(getAtIndex(AccessibleText.CHARACTER, i))
+            }
+        }
+
+        fun SemanticsNodeInteraction.accessibleText() =
+            fetchAccessible().accessibleContext?.accessibleText
+
+        with(node) {
+            // Check role and states
+            assertHasAccessibleRole(AccessibleRole.TEXT)
+            assertHasAccessibleState(AccessibleState.EDITABLE)
+
+            // Check text
+            accessibleText().let { accessibleText ->
+                assertNotNull(accessibleText, "AccessibleText is null")
+                assertThat(accessibleText.asString()).isEqualTo("Hello world")
+                assertThat(accessibleText.getAtIndex(AccessibleText.WORD, 0)).isEqualTo("Hello")
+                assertThat(accessibleText.getAtIndex(AccessibleText.WORD, 6)).isEqualTo("world")
+                assertThat(accessibleText.selectedText).isEqualTo(null)
+            }
+
+            // Check selection change events
+            var caretChanged = false
+            var selectionChanged = false
+            fetchAccessible().accessibleContext!!.addPropertyChangeListener { evt ->
+                when (evt.propertyName) {
+                    AccessibleContext.ACCESSIBLE_CARET_PROPERTY -> caretChanged = true
+                    AccessibleContext.ACCESSIBLE_SELECTION_PROPERTY -> selectionChanged = true
+                }
+            }
+            performTextInputSelection(TextRange(5, 0))
+            test.waitForIdle()
+            assertTrue(caretChanged)
+            assertTrue(selectionChanged)
+            // Check new selection
+            accessibleText().let { accessibleText ->
+                assertNotNull(accessibleText, "AccessibleText is null")
+                assertThat(accessibleText.selectedText).isEqualTo("Hello")
+            }
+
+            // Check empty selection
+            performTextInputSelection(TextRange(3, 3))
+            test.waitForIdle()
+            accessibleText().let { accessibleText ->
+                assertNotNull(accessibleText, "AccessibleText is null")
+                assertThat(accessibleText.selectedText).isEqualTo(null)
+            }
+        }
+    }
+
+    @Test
+    fun verifyTextField1A11y() = runDesktopA11yTest {
+        test.setContent {
+            BasicTextField(
+                value = "Hello world",
+                onValueChange = { },
+                modifier = Modifier.testTag("textField")
+            )
+        }
+
+        verifyTextFieldA11y(test.onNodeWithTag("textField"))
+    }
+
+    @Test
+    fun verifyTextField2A11y() = runDesktopA11yTest {
+        test.setContent {
+            BasicTextField(
+                state = rememberTextFieldState("Hello world"),
+                modifier = Modifier.testTag("textField")
+            )
+        }
+
+        verifyTextFieldA11y(test.onNodeWithTag("textField"))
+    }
 }
 
 


### PR DESCRIPTION
Fix several text field accessibility issues:
1. Report scrollable text nodes as having `TEXT` role, rather than `SCROLL_PANE`. This fixes accessibility for BTF2.
2. Add `AccessibleState.EDITABLE` to editable text fields.
3. Correctly return `getSelectionStart` and `getSelectionEnd` for inverted selection.
4. Correctly return `getSelectedText()` as `null` when there is no selection.
5. Fire `ACCESSIBLE_TEXT_PROPERTY` property change event with the position rather than the text, as `AccessibleJTextComponent` does.
6. Fire `ACCESSIBLE_SELECTION_PROPERTY` when the selection changes. 

Fixes https://youtrack.jetbrains.com/issue/CMP-7461
Fixes https://youtrack.jetbrains.com/issue/CMP-9229

## Testing
Tested manually and added unit tests.
```kotlin
fun main() = singleWindowApplication {
    TextFields()
}

@Composable
private fun TextFields() {
    Column(
        modifier = Modifier.fillMaxSize().padding(16.dp),
    ) {
        Text("TextField1 1")
        var text1 by remember { mutableStateOf("") }
        TextField(
            value = text1,
            onValueChange = { text1 = it },
        )

        Spacer(Modifier.height(64.dp))
        Text("TextField2")
        val textFieldState = rememberTextFieldState()
        TextField(state = textFieldState)

        Spacer(Modifier.height(64.dp))
        Text("JTextField 1")
        SwingPanel(
            factory = {
                JTextField()
            },
            modifier = Modifier
                .size(500.dp, 60.dp)
        )
    }
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix the accessibility issue where screen readers cannot review text in a text field
- Fix the accessibility issue where scrollable text fields are not accessible for screen readers
