### PR TITLE
[fleet] Don't return functions providing height in noria.foundation.lazy

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/ApproximatingLazyColumn.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/ApproximatingLazyColumn.kt
@@ -43,7 +43,7 @@ fun approximatingLazyColumn(
     maxViewportHeight: Int = 0,
     startLayoutFromBottom: Boolean = false,
     nth: (Int) -> Row
-): (Int) -> ItemVerticalPosition {
+) {
     var maxSeenWidth by remember(state) { mutableStateOf(0.dp) }
     // TODO custom VerticalArrangement to respect overscrollPolicy or translate it into an OverscrollEffect
     val verticalArrangement = if (spacing != 0) {
@@ -78,14 +78,6 @@ fun approximatingLazyColumn(
             ) {
                 nth(index).render()
             }
-        }
-    }
-
-    return { index ->
-        state.layoutInfo.run {
-            visibleItemsInfo.find { it.index == index }?.let {
-                ItemVerticalPosition(it.offset, it.size)
-            } ?: ItemVerticalPosition(0, 0) // TODO
         }
     }
 }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/EagerCompleteExpensive.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/EagerCompleteExpensive.kt
@@ -30,7 +30,7 @@ fun eagerCompleteExpensiveColumn(
     overscrollPolicy: LazyColumnOverscrollPolicy = { 0 },
     spacing: Int,
     nth: (Int) -> Row,
-): (Int) -> ItemVerticalPosition {
+) {
     // TODO
     return approximatingLazyColumn(
         size,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/LazyColumn.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/LazyColumn.kt
@@ -48,7 +48,7 @@ fun heightKeyBasedLazyColumn(
     measureItemsWithWidthConstraints: Boolean = false,
     spacing: Int = 0,
     nth: (Int) -> Row,
-): (Int) -> ItemVerticalPosition {
+) {
     // TODO
     return approximatingLazyColumn(
         size,

--- a/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/SlidingPictureLazyColumn.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/noria/foundation/lazy/SlidingPictureLazyColumn.kt
@@ -24,7 +24,7 @@ import noria.Cell
 
 data class SlideAnimation(val toggledIndices: IntRange, val slideProgress: State<Float>, val isExpansion: Boolean)
 
-fun slidingPictureLazyColumn(slideAnimationCell: Cell<SlideAnimation?>, state: LazyListState, contentPadding: PaddingValues, spacing: Int): @Composable (size: Int, nth: (Int) -> Row) -> (Int) -> ItemVerticalPosition = { size, nth ->
+fun slidingPictureLazyColumn(slideAnimationCell: Cell<SlideAnimation?>, state: LazyListState, contentPadding: PaddingValues, spacing: Int): @Composable (size: Int, nth: (Int) -> Row) -> Unit = { size, nth ->
   // TODO
   approximatingLazyColumn(size, state, contentPadding, spacing = spacing, nth = nth)
 }


### PR DESCRIPTION
These changes target `fleet` branch.

- Removed returning a function that provides LazyColumn items' height as we don't want to rely on it anymore