### PR TITLE
[web] Fix quasi-composite input after pressing backspace in iOS

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -85,7 +85,12 @@ internal abstract class NativeInputEventsProcessor(
                     if (isInIMEComposition) return@fastForEach
 
                     evt as KeyboardEvent
-                    if (isTypedEvent(evt)) return@fastForEach
+                    if (isTypedEvent(evt)) {
+                        // we need to reset this each time we consider something to be typed
+                        // see  https://youtrack.jetbrains.com/issue/CMP-8773
+                        lastProcessedEventIsBackspace = evt.key == "Backspace"
+                        return@fastForEach
+                    }
 
                     val isFromLastComposition = timestamp < lastCompositionEndTimestamp
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/CompositeInputTestSpec.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/input/specs/CompositeInputTestSpec.kt
@@ -241,20 +241,55 @@ internal interface IosCompositeInput : СompositeInputTestSpec {
     fun `input hangul-hol`() = runApplicationTest {
         val textFieldValue = createApplicationWithHolder()
         eventsSequence(
-            keyEvent(key= "ㅎ", code = "Unidentified", keyCode = 0),
-            beforeInput("insertText", data = "ㅎ", isComposing = false),
-            keyEvent(key= "ㅎ", code = "Unidentified", keyCode = 0, type = "keyup"),
-            keyEvent(key= "ㅗ", code = "Unidentified", keyCode = 0),
-            beforeInput("deleteContentBackward", data = null, isComposing = false),
-            beforeInput("insertText", data = "호", isComposing = false),
-            keyEvent(key= "ㅗ", code = "Unidentified", keyCode = 0, type = "keyup"),
-            keyEvent(key= "ㄹ", code = "Unidentified", keyCode = 0),
-            beforeInput("deleteContentBackward", data = null, isComposing = false),
-            beforeInput("insertText", data = "홀", isComposing = false),
-            keyEvent(key= "ㄹ", code = "Unidentified", keyCode = 0, type = "keyup")
+            keyEvent(key = "ㅎ", code = "Unidentified", keyCode = 0),
+            beforeInput(inputType = "insertText", data = "ㅎ", isComposing = false),
+            keyEvent(key = "ㅎ", code = "Unidentified", keyCode = 0, type = "keyup"),
+            keyEvent(key = "ㅗ", code = "Unidentified", keyCode = 0),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            beforeInput(inputType = "insertText", data = "호", isComposing = false),
+            keyEvent(key = "ㅗ", code = "Unidentified", keyCode = 0, type = "keyup"),
+            keyEvent(key = "ㄹ", code = "Unidentified", keyCode = 0),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            beforeInput(inputType = "insertText", data = "홀", isComposing = false),
+            keyEvent(key = "ㄹ", code = "Unidentified", keyCode = 0, type = "keyup"),
         ).sendToHtmlInput()
 
-        textFieldValue.awaitAndAssertTextEquals("홀")
+        textFieldValue.awaitAndAssertTextEquals("홀", "hangul first time")
+
+        // deleting all and starting all over again
+        // https://youtrack.jetbrains.com/issue/CMP-8773
+
+        eventsSequence(
+            keyEvent(key = "Backspace", code = "Backspace", keyCode = 8),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            beforeInput(inputType = "insertText", data = "호", isComposing = false),
+            keyEvent(key = "Backspace", code = "Backspace", keyCode = 8, type = "keyup"),
+            keyEvent(key = "Backspace", code = "Backspace", keyCode = 8),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            beforeInput(inputType = "insertText", data = "ㅎ", isComposing = false),
+            keyEvent(key = "Backspace", code = "Backspace", keyCode = 8, type = "keyup"),
+            keyEvent(key = "Backspace", code = "Backspace", keyCode = 8),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            keyEvent(key = "Backspace", code = "Backspace", keyCode = 8, type = "keyup"),
+        ).sendToHtmlInput()
+
+        textFieldValue.awaitAndAssertTextEquals("")
+
+        eventsSequence(
+            keyEvent(key = "ㅎ", code = "Unidentified", keyCode = 0),
+            beforeInput(inputType = "insertText", data = "ㅎ", isComposing = false),
+            keyEvent(key = "ㅎ", code = "Unidentified", keyCode = 0, type = "keyup"),
+            keyEvent(key = "ㅗ", code = "Unidentified", keyCode = 0),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            beforeInput(inputType = "insertText", data = "호", isComposing = false),
+            keyEvent(key = "ㅗ", code = "Unidentified", keyCode = 0, type = "keyup"),
+            keyEvent(key = "ㄹ", code = "Unidentified", keyCode = 0),
+            beforeInput(inputType = "deleteContentBackward", data = "null", isComposing = false),
+            beforeInput(inputType = "insertText", data = "홀", isComposing = false),
+            keyEvent(key = "ㄹ", code = "Unidentified", keyCode = 0, type = "keyup"),
+        ).sendToHtmlInput()
+
+        textFieldValue.awaitAndAssertTextEquals("홀", "hangul second time")
     }
 }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-8773

## Testing
manual (mobile devices) and `gradlew testWeb`

## Release Notes
### Fixes - Web
- Fix the issue where Hangul input behaves inconsistently after deleting with Backspace
