### PR TITLE
Verify that a stable doesn't depend on an rc/beta/alpha

### DIFF
--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXImplPlugin.kt
@@ -165,6 +165,7 @@ class JetBrainsAndroidXImplPlugin @Inject constructor(
         project.changeMavenCoordinatesToJetBrains(androidxExtension)
         project.configureMavenArtifactUpload(
             androidxExtension, androidxMultiplatformExtension, componentFactory)
+        project.configureDependencyVerification()
 
         project.plugins.all { plugin ->
             if (plugin is KotlinMultiplatformPluginWrapper) {

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
@@ -17,7 +17,6 @@
 package org.jetbrains.androidx.build
 
 import androidx.build.AndroidXDependency
-import androidx.build.AndroidXExtension
 import androidx.build.Version
 import androidx.build.multiplatformExtension
 import androidx.build.uptodatedness.cacheEvenIfNoOutputs
@@ -62,21 +61,8 @@ abstract class JetBrainsVerifyDependencyVersionsTask : DefaultTask() {
     }
 
     private fun verifyDependencyVersion(dependency: AndroidXDependency) {
-        // If the version is unspecified then treat as an alpha version. If the depending project's
-        // version is unspecified then it won't matter, and if the dependency's version is
-        // unspecified then any non alpha project won't be able to depend on it to ensure safety.
-        val projectVersionExtra =
-            if (version.get() == AndroidXExtension.DEFAULT_UNSPECIFIED_VERSION) {
-                "-alpha01"
-            } else {
-                Version(version.get()).extra ?: ""
-            }
-        val dependencyVersionExtra =
-            if (dependency.version == AndroidXExtension.DEFAULT_UNSPECIFIED_VERSION) {
-                "-alpha01"
-            } else {
-                Version(dependency.version).extra ?: ""
-            }
+        val projectVersionExtra = Version(version.get()).extra ?: ""
+        val dependencyVersionExtra = Version(dependency.version).extra ?: ""
         val projectReleasePhase = releasePhase(projectVersionExtra)
         if (projectReleasePhase < 0) {
             throw GradleException("Project has unexpected release phase $projectVersionExtra")

--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2018 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jetbrains.androidx.build
+
+import androidx.build.AndroidXDependency
+import androidx.build.AndroidXExtension
+import androidx.build.Version
+import androidx.build.multiplatformExtension
+import androidx.build.uptodatedness.cacheEvenIfNoOutputs
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.setProperty
+
+/**
+ * Task for verifying the library dependency-stability-suffix rule (A library is only as stable as
+ * its least stable dependency)
+ */
+@CacheableTask
+abstract class JetBrainsVerifyDependencyVersionsTask : DefaultTask() {
+
+    init {
+        group = "Compose Multiplatform"
+        description = "Task for verifying the library dependency-stability-suffix rule"
+    }
+
+    @get:Input
+    abstract val version: Property<String>
+
+    @get:Input
+    val androidXDependencySet: SetProperty<AndroidXDependency> = project.objects.setProperty()
+
+    /**
+     * Iterate through the dependencies of the project and ensure none of them are of an inferior
+     * release. This means that a beta project should not have any alpha dependencies, an rc project
+     * should not have any alpha or beta dependencies and a stable version should only depend on
+     * other stable versions. Dependencies defined with testCompile and friends along with
+     * androidTestImplementation and similar are excluded from this verification.
+     */
+    @TaskAction
+    fun verifyDependencyVersions() {
+        androidXDependencySet.get().forEach { dependency -> verifyDependencyVersion(dependency) }
+    }
+
+    private fun verifyDependencyVersion(dependency: AndroidXDependency) {
+        // If the version is unspecified then treat as an alpha version. If the depending project's
+        // version is unspecified then it won't matter, and if the dependency's version is
+        // unspecified then any non alpha project won't be able to depend on it to ensure safety.
+        val projectVersionExtra =
+            if (version.get() == AndroidXExtension.DEFAULT_UNSPECIFIED_VERSION) {
+                "-alpha01"
+            } else {
+                Version(version.get()).extra ?: ""
+            }
+        val dependencyVersionExtra =
+            if (dependency.version == AndroidXExtension.DEFAULT_UNSPECIFIED_VERSION) {
+                "-alpha01"
+            } else {
+                Version(dependency.version).extra ?: ""
+            }
+        val projectReleasePhase = releasePhase(projectVersionExtra)
+        if (projectReleasePhase < 0) {
+            throw GradleException("Project has unexpected release phase $projectVersionExtra")
+        }
+        val dependencyReleasePhase = releasePhase(dependencyVersionExtra)
+        if (dependencyReleasePhase < 0) {
+            throw GradleException(
+                "Dependency ${dependency.group}:${dependency.name}" +
+                    ":${dependency.version} has unexpected release phase $dependencyVersionExtra"
+            )
+        }
+        if (dependencyReleasePhase < projectReleasePhase) {
+            throw GradleException(
+                "Project with version ${version.get()} may " +
+                    "not take a dependency on less-stable artifact ${dependency.group}:" +
+                    "${dependency.name}:${dependency.version} for configuration " +
+                    "${dependency.configurationName}. Dependency versions must be at least as " +
+                    "stable as the project version."
+            )
+        }
+    }
+
+    private fun releasePhase(versionExtra: String): Int {
+        return when {
+            versionExtra == "" -> 4
+            versionExtra.startsWith("-rc") -> 3
+            versionExtra.startsWith("-beta") -> 2
+            versionExtra.startsWith("-alpha") -> 1
+            versionExtra.startsWith("-SNAPSHOT") -> 0
+            else -> -1
+        }
+    }
+}
+
+internal fun Project.configureDependencyVerification() {
+    // Verify only what is publishing
+    val component = JetBrainsPublication.projectPathToComponent[path] ?: return
+
+    tasks.register(
+        "jbVerifyDependencyVersions",
+        JetBrainsVerifyDependencyVersionsTask::class.java
+    ) { task ->
+        task.version.set(project.provider { project.version.toString() })
+        task.androidXDependencySet.set(
+            project.provider {
+                multiplatformExtension!!
+                    .targets
+                    .filter { target ->
+                        component.supportedPlatforms.any {
+                            it.matches(target.name) && !hasRedirection(it)
+                        }
+                    }
+                    .flatMap { target ->
+                        target.compilations
+                            .filter { !it.name.contains("test", ignoreCase = true) }
+                            .flatMap { compilation ->
+                                listOf(
+                                    compilation.implementationConfigurationName,
+                                    compilation.apiConfigurationName,
+                                    compilation.runtimeOnlyConfigurationName
+                                )
+                            }
+                    }
+                    .asSequence()
+                    .map { project.configurations.getByName(it) }
+                    .flatMap { configuration ->
+                        configuration.allDependencies
+                            .filter { it.group != null && it.version != null }
+                            .map { dependency ->
+                                AndroidXDependency(
+                                    dependency.group!!,
+                                    dependency.name,
+                                    dependency.version!!,
+                                    configuration.name,
+                                )
+                            }
+                    }
+                    .toList()
+            }
+        )
+        task.cacheEvenIfNoOutputs()
+    }
+}

--- a/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/AbstractComposePublishingTask.kt
+++ b/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/AbstractComposePublishingTask.kt
@@ -39,6 +39,7 @@ abstract class AbstractComposePublishingTask : DefaultTask() {
         for (publication in publications) {
             dependsOnComposeTask("$project:publish${publication}PublicationTo$repository")
         }
+        dependsOnComposeTask("$project:jbVerifyDependencyVersions")
     }
 
     private fun publish(project: String, publications: Collection<String>, onlyWithPlatforms: Set<ComposePlatforms>) {
@@ -82,5 +83,6 @@ abstract class AbstractComposePublishingTask : DefaultTask() {
 
             dependsOnComposeTask("${component.path}:publish${platform.name}PublicationTo$repository")
         }
+        dependsOnComposeTask("${component.path}:jbVerifyDependencyVersions")
     }
 }

--- a/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/ComposePlatforms.kt
+++ b/buildSrc/public/src/main/kotlin/org/jetbrains/androidx/build/ComposePlatforms.kt
@@ -12,7 +12,7 @@ import org.gradle.api.Project
  * That means we need to be careful if/when renaming or deleting any enum value or its name.
  */
 enum class ComposePlatforms(vararg val alternativeNames: String) {
-    KotlinMultiplatform("Common"),
+    KotlinMultiplatform("Common", "Metadata"),
     Desktop("Jvm"),
     AndroidDebug("Android"),
     AndroidRelease("Android"),

--- a/mpp/build.gradle.kts
+++ b/mpp/build.gradle.kts
@@ -22,6 +22,7 @@ val pathToComposeComponent = libraryToComponents.values.flatten().associateBy { 
 val Project.composeComponent get() = pathToComposeComponent[path]
 
 tasks.register("publishComposeJb", ComposePublishingTask::class) {
+    group = "Compose Multiplatform"
     repository = "MavenRepository"
 
     libraries.forEach {
@@ -30,6 +31,7 @@ tasks.register("publishComposeJb", ComposePublishingTask::class) {
 }
 
 tasks.register("publishComposeJbToMavenLocal", ComposePublishingTask::class) {
+    group = "Compose Multiplatform"
     repository = "MavenLocal"
 
     libraries.forEach {
@@ -43,11 +45,13 @@ val libraries = project.findProperty("jetbrains.publication.libraries")
 
 
 tasks.register("testDesktop") {
+    group = "Compose Multiplatform"
     dependsOn(allTasksWith(name = "desktopTest"))
     dependsOn(":collection:collection:jvmTest")
 }
 
 tasks.register("testWeb") {
+    group = "Compose Multiplatform"
     dependsOn(testWebJs)
     dependsOn(testWebWasm)
 }
@@ -76,6 +80,7 @@ val testWebWasm = tasks.register("testWebWasm") {
 }
 
 tasks.register("testUIKit") {
+    group = "Compose Multiplatform"
     val suffix = if (System.getProperty("os.arch") == "aarch64") "SimArm64Test" else "X64Test"
     val uikitTestSubtaskName = "uikit$suffix"
 
@@ -88,10 +93,12 @@ tasks.register("testUIKit") {
 }
 
 tasks.register("testRuntimeNative") {
+    group = "Compose Multiplatform"
     dependsOn(":compose:runtime:runtime:macosX64Test")
 }
 
 tasks.register("testComposeModules") { // used in https://github.com/JetBrains/androidx/tree/jb-main/.github/workflows
+    group = "Compose Multiplatform"
     // TODO: download robolectrict to run ui:ui:test
     // dependsOn(":compose:ui:ui:test")
 
@@ -115,10 +122,12 @@ tasks.register("testComposeModules") { // used in https://github.com/JetBrains/a
 }
 
 tasks.register("jbApiDump") {
+    group = "Compose Multiplatform"
     dependsOn(apiValidationTasks(suffix = "ApiDump"))
 }
 
 tasks.register("jbApiCheck") {
+    group = "Compose Multiplatform"
     dependsOn(apiValidationTasks(suffix = "ApiCheck"))
 }
 


### PR DESCRIPTION
Fixes [CMP-7130](https://youtrack.jetbrains.com/issue/CMP-7130) Throw an error if the stability levels of dependencies aren't compatible

Fixes [CMP-7971](https://youtrack.jetbrains.com/issue/CMP-7971) Add a check that verifies that `jetbrains.publication.libraries` contains all needed dependencies (as a side effect because the default version is ...-SNAPSHOT)

Adaptation of [VerifyDependencyVersionsTask](https://github.com/androidx/androidx/blob/31357f9a6c37cc4642e526e32659494ac0e10d0b/buildSrc/private/src/main/kotlin/androidx/build/VerifyDependencyVersionsTask.kt#L38)

## Testing
1. Rebase on e3ca01a1.

2. Test the task separately:
```
./gradlew jbVerifyDependencyVersions // success, all are 9999.0.0-SNAPSHOT
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.10.0-beta02 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=1.10.0-alpha05  -Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE=1.3.0-alpha02 -Pjetbrains.publication.version.WINDOW=1.5.0-rc02 -Pjetbrains.publication.version.NAVIGATION_3=1.0.0-alpha05 -Pjetbrains.publication.version.NAVIGATION_EVENT=1.0.0-beta02 -Pjetbrains.publication.version.LIFECYCLE=2.10.0-alpha05 -Pjetbrains.publication.version.SAVEDSTATE=1.4.0-beta02 // success on the latest versions
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0 // fails because ui depends on androidx.compose.runtime:runtime-retain:1.10.0-beta01
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0-rc01 // fails by the same reason
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0-beta02 // success
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0-alpha01 // success
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0-beta02 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=1.0.0-rc01 // success because MATERIAL3 is pinned to Compose 1.9
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0-beta02 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=1.0.0-beta01  -Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE=1.0.0-beta01 -Pjetbrains.publication.version.WINDOW=1.0.0-beta01 -Pjetbrains.publication.version.NAVIGATION_3=1.0.0-beta01 -Pjetbrains.publication.version.NAVIGATION_EVENT=1.0.0-beta01 -Pjetbrains.publication.version.LIFECYCLE=1.0.0-beta01 // success
./gradlew jbVerifyDependencyVersions -Pjetbrains.publication.version.COMPOSE=1.0.0-beta02 -Pjetbrains.publication.version.COMPOSE_MATERIAL3=1.0.0-beta01  -Pjetbrains.publication.version.COMPOSE_MATERIAL3_ADAPTIVE=1.0.0-beta01 -Pjetbrains.publication.version.WINDOW=1.0.0-alpha01 -Pjetbrains.publication.version.NAVIGATION_3=1.0.0-beta01 -Pjetbrains.publication.version.NAVIGATION_EVENT=1.0.0-beta01 -Pjetbrains.publication.version.LIFECYCLE=1.0.0-beta01 // fails because window is downgraded to alpha
```

3. Test the same commands, but replace "jbVerifyDependencyVersions" by "publishComposeJbToMavenLocal"

## Release Notes
N/A