### PR TITLE
CMP-9264 Expose showLayoutBounds API on ComposePanel

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.awt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.layoutId
@@ -349,4 +350,16 @@ class ComposeDialog : JDialog {
 
     override fun removeMouseWheelListener(listener: MouseWheelListener) =
         composePanel.removeMouseWheelListener(listener)
+
+    /**
+     * Set the visual debug option that shows bounds for all nodes in the hierarchy.
+     */
+    @InternalComposeUiApi
+    var showLayoutBounds: Boolean
+        get() {
+            return composePanel.showLayoutBounds
+        }
+        set(value) {
+            composePanel.showLayoutBounds = value
+        }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -20,11 +20,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.awt.RenderSettings.SkiaSurface
 import androidx.compose.ui.awt.RenderSettings.SwingGraphics
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.isClearFocusOnMouseDownEnabled
+import androidx.compose.ui.node.InternalCoreApi
 import androidx.compose.ui.scene.ComposeContainer
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.window.WindowExceptionHandler
@@ -183,7 +185,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
 
     override fun getPreferredSize(): Dimension? = if (isPreferredSizeSet) {
         super.getPreferredSize()
-    } else  {
+    } else {
         _composeContainer?.preferredSize ?: Dimension(0, 0)
     }
 
@@ -252,6 +254,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         // content.
         val composeContainer = _composeContainer ?: createComposeContainer().also {
             _composeContainer = it
+            @OptIn(InternalCoreApi::class)
+            it.showLayoutBounds = showLayoutBounds
             val composeContent = _composeContent
             if (composeContent != null) {
                 it.setContent(composeContent)
@@ -284,6 +288,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
                                     focusManager.takeFocus(FocusDirection.Next)
                                 }
                             }
+
                             else -> Unit
                         }
                     }
@@ -392,4 +397,17 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     fun renderImmediately() {
         _composeContainer?.renderImmediately()
     }
+
+    /**
+     * Set the visual debug option that shows bounds for all nodes in the hierarchy.
+     */
+    @InternalComposeUiApi
+    var showLayoutBounds: Boolean = _composeContainer?.showLayoutBounds ?: false
+        set(value) {
+            // We're assuming we own the scene and thus this value, and nobody
+            // else will change it from under us, so we never get out of sync.
+            field = value
+            @OptIn(InternalCoreApi::class)
+            _composeContainer?.showLayoutBounds = value
+        }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.awt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalContext
 import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.layout.layoutId
@@ -333,4 +334,16 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
 
     override fun removeMouseWheelListener(listener: MouseWheelListener) =
         composePanel.removeMouseWheelListener(listener)
+
+    /**
+     * Set the visual debug option that shows bounds for all nodes in the hierarchy.
+     */
+    @InternalComposeUiApi
+    var showLayoutBounds: Boolean
+        get() {
+            return composePanel.showLayoutBounds
+        }
+        set(value) {
+            composePanel.showLayoutBounds = value
+        }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -192,4 +192,12 @@ internal class ComposeWindowPanel(
     override fun removeMouseMotionListener(listener: MouseMotionListener) {
         contentComponent.removeMouseMotionListener(listener)
     }
+
+    var showLayoutBounds: Boolean
+        get() {
+            return _composeContainer?.showLayoutBounds ?: false
+        }
+        set(value) {
+            _composeContainer?.showLayoutBounds = value
+        }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -176,6 +176,8 @@ internal class ComposeContainer(
     val preferredSize by mediator::preferredSize
     val semanticsOwners by mediator::semanticsOwners
 
+    var showLayoutBounds by mediator::showLayoutBounds
+
     private var isDisposed = false
     private var isDetached = true
     private var isMinimized = false

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -325,6 +325,12 @@ internal class ComposeSceneMediator(
     var compositionLocalContext: CompositionLocalContext?
         get() = scene.compositionLocalContext
         set(value) { scene.compositionLocalContext = value }
+    var showLayoutBounds: Boolean
+        get() = scene.showLayoutBounds
+        set(value) {
+            scene.showLayoutBounds = value
+        }
+
 
     /**
      * Provides the size of ComposeScene content inside infinity constraints

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -498,7 +498,7 @@ internal class RootNodeOwner(
         override val fontLoader = androidx.compose.ui.text.platform.FontLoader()
         override val fontFamilyResolver = createFontFamilyResolver()
         override val layoutDirection get() = _layoutDirection
-        override var showLayoutBounds = false
+        override var showLayoutBounds by mutableStateOf(false)
             @InternalCoreApi
             set
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.node.InternalCoreApi
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.setContent
@@ -272,6 +273,13 @@ private class CanvasLayersComposeSceneImpl(
     override fun draw(canvas: Canvas) {
         forEachOwner { it.draw(canvas) }
     }
+
+    override var showLayoutBounds: Boolean = false
+        @OptIn(InternalCoreApi::class)
+        set(value) {
+            field = value
+            forEachOwner { it.owner.showLayoutBounds = value }
+        }
 
     /**
      * Find hovered owner for position of first pointer.
@@ -560,6 +568,8 @@ private class CanvasLayersComposeSceneImpl(
         private var onKeyEvent: ((KeyEvent) -> Boolean)? = null
 
         init {
+            @OptIn(InternalCoreApi::class)
+            owner.owner.showLayoutBounds = showLayoutBounds
             attachLayer(this)
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -284,4 +284,9 @@ sealed interface ComposeScene : AutoCloseable {
      * provided by the [androidx.compose.runtime.Recomposer] of the current scene.
      */
     suspend fun withMonotonicFrameClock(block: suspend () -> Unit)
+
+    /**
+     * Set the visual debug option that shows bounds for all nodes in the hierarchy.
+     */
+    var showLayoutBounds: Boolean
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.node.InternalCoreApi
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.platform.setContent
@@ -191,6 +192,13 @@ private class PlatformLayersComposeSceneImpl(
     override fun draw(canvas: Canvas) {
         mainOwner.draw(canvas)
     }
+
+    override var showLayoutBounds: Boolean
+        get() = mainOwner.owner.showLayoutBounds
+        set(value) {
+            @OptIn(InternalCoreApi::class)
+            mainOwner.owner.showLayoutBounds = value
+        }
 
     private fun onOwnerAppended(owner: RootNodeOwner) {
         semanticsOwnerListener?.onSemanticsOwnerAppended(owner.semanticsOwner)


### PR DESCRIPTION
This exposes a `showLayoutBounds` property on `ComposePanel` (desktop only) that allows users to turn on or off the `showLayoutBounds` property on the root layout node owner(s).

The change mostly pipes the property up to the `ComposePanel`, but has no public API impact. The new property is also annotated as experimental. The Skiko `RootNodeOwner`'s `showLayoutBounds` is now also a state, to cause a full recomposition when the value changes and see it reflected in the UI.

https://github.com/user-attachments/assets/506361ed-cc3d-4921-ad9b-3cb49c0e666f

Fixes https://youtrack.jetbrains.com/issue/CMP-9264/Expose-API-on-ComposePanel-to-toggle-showLayoutBounds

## Testing
Manual testing as it's not automatable:

```kotlin
/*
 * Copyright 2025 The Android Open Source Project
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *      http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */

package androidx.compose.mpp.demo

import androidx.compose.foundation.background
import androidx.compose.foundation.border
import androidx.compose.foundation.clickable
import androidx.compose.foundation.hoverable
import androidx.compose.foundation.interaction.MutableInteractionSource
import androidx.compose.foundation.layout.Arrangement
import androidx.compose.foundation.layout.Box
import androidx.compose.foundation.layout.Column
import androidx.compose.foundation.layout.FlowRow
import androidx.compose.foundation.layout.Row
import androidx.compose.foundation.layout.Spacer
import androidx.compose.foundation.layout.fillMaxSize
import androidx.compose.foundation.layout.height
import androidx.compose.foundation.layout.padding
import androidx.compose.foundation.layout.size
import androidx.compose.foundation.layout.width
import androidx.compose.foundation.shape.RoundedCornerShape
import androidx.compose.foundation.text.BasicText
import androidx.compose.runtime.remember
import androidx.compose.ui.Alignment
import androidx.compose.ui.ExperimentalComposeUiApi
import androidx.compose.ui.Modifier
import androidx.compose.ui.awt.ComposePanel
import androidx.compose.ui.draw.clip
import androidx.compose.ui.graphics.Color
import androidx.compose.ui.input.pointer.PointerIcon
import androidx.compose.ui.input.pointer.pointerHoverIcon
import androidx.compose.ui.unit.dp
import java.awt.BorderLayout
import java.awt.Dimension
import javax.swing.JFrame
import javax.swing.JPanel
import javax.swing.SwingUtilities

fun main() {
    SwingUtilities.invokeLater { swingMain() }
}

@OptIn(ExperimentalComposeUiApi::class)
private fun swingMain() {
    val frame = JFrame("Show layout bounds")
    frame.defaultCloseOperation = JFrame.EXIT_ON_CLOSE
    frame.minimumSize = Dimension(500, 400)
    frame.isResizable = false

    val mainPanel = JPanel(BorderLayout()).apply {
        val composePanel = ComposePanel()

        composePanel.setContent {
            Column(
                Modifier.fillMaxSize().padding(12.dp)
            ) {
                BasicText("Text 123 text")

                Spacer(Modifier.height(10.dp))

                Box(
                    Modifier.border(1.dp, Color.LightGray, RoundedCornerShape(4.dp))
                        .background(Color.White, RoundedCornerShape(4.dp))
                        .clip(RoundedCornerShape(4.dp)).clickable {
                            composePanel.showLayoutBounds = !composePanel.showLayoutBounds
                        }.padding(horizontal = 16.dp, vertical = 8.dp)
                ) {
                    BasicText("Toggle layout bounds")
                }

                Spacer(Modifier.height(10.dp))

                FlowRow(
                    horizontalArrangement = Arrangement.spacedBy(10.dp),
                    verticalArrangement = Arrangement.spacedBy(10.dp)
                ) {
                    repeat(25) {
                        Row(
                            Modifier.padding(2.dp).clickable {}.pointerHoverIcon(
                                PointerIcon.Hand
                            ), verticalAlignment = Alignment.CenterVertically
                        ) {
                            Box(
                                Modifier.size(16.dp)
                                    .background(Color.LightGray, RoundedCornerShape(4.dp))
                            )
                            Spacer(Modifier.width(2.dp))
                            BasicText(
                                "Text", Modifier.background(Color.White).hoverable(
                                    remember { MutableInteractionSource() })
                            )
                            BasicText(" $it")
                        }
                    }
                }
            }
        }

        add(composePanel, BorderLayout.CENTER)
    }

    frame.contentPane.add(mainPanel, BorderLayout.CENTER)
    frame.isVisible = true
}
```

## Release Notes
N/A