### PR TITLE
Fix crash when version is 1.0.0+dev3241

### DIFF
--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsVerifyDependencyVersionsTask.kt
@@ -88,6 +88,7 @@ abstract class JetBrainsVerifyDependencyVersionsTask : DefaultTask() {
     private fun releasePhase(versionExtra: String): Int {
         return when {
             versionExtra == "" -> 4
+            !versionExtra.startsWith("-") -> 4
             versionExtra.startsWith("-rc") -> 3
             versionExtra.startsWith("-beta") -> 2
             versionExtra.startsWith("-alpha") -> 1


### PR DESCRIPTION
```
Execution failed for task ':window:window-core:jbVerifyDependencyVersions'. org.gradle.api.GradleException: Project has unexpected release phase +dev3241
```

## Release Notes
N/A