### PR TITLE
Fix instrumented tests for iOS 15-26 and iPad

### DIFF
--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
@@ -285,7 +285,7 @@ class BasicInteractionTest {
         if (available(OS.Ios to OSVersion(16))) {
             findNodeWithLabel(label).tap()
         } else {
-            // Because on iOS <= 16 the context menu is shown in a separate window,
+            // Because on iOS < 16 the context menu is shown in a separate window,
             // it's not fully interactive with the default Tap action.
             findNodeWithLabel(label)
                 .touchDown(forceNodeWindow = true)

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
@@ -288,7 +288,7 @@ class BasicInteractionTest {
             // Because on iOS < 16 the context menu is shown in a separate window,
             // it's not fully interactive with the default Tap action.
             findNodeWithLabel(label)
-                .touchDown(forceNodeWindow = true)
+                .touchDown(useNodeWindow = true)
                 .hold()
                 .also { delay(100) }
                 .up()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/BasicInteractionTest.kt
@@ -22,10 +22,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -38,6 +35,8 @@ import androidx.compose.ui.test.findNodeWithLabel
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.firstNodeOrNull
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.hold
+import androidx.compose.ui.test.utils.up
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpRect
@@ -50,6 +49,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.cinterop.ExperimentalForeignApi
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
 import platform.UIKit.UIPasteboard
 
 class BasicInteractionTest {
@@ -204,10 +206,11 @@ class BasicInteractionTest {
         waitForContextMenu()
         assertFalse(textFieldValue.isFullySelected())
 
-        findNodeWithLabel("Select All").tap()
+        tapContextMenuButton("Select All")
 
-        waitForIdle()
-        assertTrue(textFieldValue.isFullySelected())
+        waitUntil("Text field should be fully selected") {
+            textFieldValue.isFullySelected()
+        }
     }
 
     @Test
@@ -227,10 +230,11 @@ class BasicInteractionTest {
         waitForContextMenu()
         assertFalse(textFieldState.isFullySelected())
 
-        findNodeWithLabel("Select All").tap()
+        tapContextMenuButton("Select All")
 
-        waitForIdle()
-        assertTrue(textFieldState.isFullySelected())
+        waitUntil("Text field should be fully selected") {
+            textFieldState.isFullySelected()
+        }
     }
 
     private fun UIKitInstrumentedTest.openToolbar(textFieldTag: String) {
@@ -277,11 +281,30 @@ class BasicInteractionTest {
         }
     }
 
+    private fun UIKitInstrumentedTest.tapContextMenuButton(label: String) {
+        if (available(OS.Ios to OSVersion(16))) {
+            findNodeWithLabel(label).tap()
+        } else {
+            // Because on iOS <= 16 the context menu is shown in a separate window,
+            // it's not fully interactive with the default Tap action.
+            findNodeWithLabel(label)
+                .touchDown(forceNodeWindow = true)
+                .hold()
+                .also { delay(100) }
+                .up()
+        }
+    }
+
     private fun UIKitInstrumentedTest.waitForContextMenu() {
+        val menuClassName = if (available(OS.Ios to OSVersion(16))) {
+            "_UIEditMenuContainerView"
+        } else {
+            "UICalloutBar"
+        }
         waitForIdle()
         waitUntil {
             firstNodeOrNull { node ->
-                node.element?.let { it::class.simpleName } == "_UIEditMenuContainerView"
+                node.element?.let { it::class.simpleName } == menuClassName
             } != null
         }
         // Additional delay to wait until toolbar animation ends

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/InteropUIKitViewSizingWithUILabelTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/InteropUIKitViewSizingWithUILabelTest.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
 import androidx.compose.ui.unit.size
 import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.unit.toDpSize
 import androidx.compose.ui.unit.width
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
@@ -360,8 +361,8 @@ class InteropUIKitViewSizingWithUILabelTest {
 
     @Test
     fun testUILabelMultiLineLongTextFixedHeight() = runUIKitInstrumentedTestWithInterop { overlay ->
-        var unboundedTextRect = DpRectZero()
-        var boundedHeightTextRect = DpRectZero()
+        var unboundedTextRect = DpSize.Zero
+        var boundedHeightTextRect = DpSize.Zero
 
         setContent {
             Column {
@@ -372,7 +373,9 @@ class InteropUIKitViewSizingWithUILabelTest {
                             text = LONG_TEXT
                         }
                     },
-                    modifier = Modifier.onGloballyPositioned { unboundedTextRect = it.boundsInRoot().toDpRect(density) },
+                    modifier = Modifier.onGloballyPositioned {
+                        unboundedTextRect = it.boundsInRoot().size.toDpSize(density)
+                    },
                     properties = UIKitInteropProperties(placedAsOverlay = overlay)
                 )
                 UIKitView(
@@ -384,14 +387,16 @@ class InteropUIKitViewSizingWithUILabelTest {
                     },
                     modifier = Modifier
                         .height(100.dp)
-                        .onGloballyPositioned { boundedHeightTextRect = it.boundsInRoot().toDpRect(density) },
+                        .onGloballyPositioned {
+                            boundedHeightTextRect = it.boundsInRoot().size.toDpSize(density)
+                        },
                     properties = UIKitInteropProperties(placedAsOverlay = overlay)
                 )
             }
         }
 
         assertEquals(100.dp, boundedHeightTextRect.height)
-        assertEquals(unboundedTextRect.width, boundedHeightTextRect.width, )
+        assertEquals(unboundedTextRect.width, boundedHeightTextRect.width)
         assertTrue(boundedHeightTextRect.height < unboundedTextRect.height)
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/InteropUIKitViewSizingWithUILabelTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/InteropUIKitViewSizingWithUILabelTest.kt
@@ -361,8 +361,8 @@ class InteropUIKitViewSizingWithUILabelTest {
 
     @Test
     fun testUILabelMultiLineLongTextFixedHeight() = runUIKitInstrumentedTestWithInterop { overlay ->
-        var unboundedTextRect = DpSize.Zero
-        var boundedHeightTextRect = DpSize.Zero
+        var unboundedTextSize = DpSize.Zero
+        var boundedHeightTextSize = DpSize.Zero
 
         setContent {
             Column {
@@ -374,7 +374,7 @@ class InteropUIKitViewSizingWithUILabelTest {
                         }
                     },
                     modifier = Modifier.onGloballyPositioned {
-                        unboundedTextRect = it.boundsInRoot().size.toDpSize(density)
+                        unboundedTextSize = it.boundsInRoot().size.toDpSize(density)
                     },
                     properties = UIKitInteropProperties(placedAsOverlay = overlay)
                 )
@@ -388,16 +388,16 @@ class InteropUIKitViewSizingWithUILabelTest {
                     modifier = Modifier
                         .height(100.dp)
                         .onGloballyPositioned {
-                            boundedHeightTextRect = it.boundsInRoot().size.toDpSize(density)
+                            boundedHeightTextSize = it.boundsInRoot().size.toDpSize(density)
                         },
                     properties = UIKitInteropProperties(placedAsOverlay = overlay)
                 )
             }
         }
 
-        assertEquals(100.dp, boundedHeightTextRect.height)
-        assertEquals(unboundedTextRect.width, boundedHeightTextRect.width)
-        assertTrue(boundedHeightTextRect.height < unboundedTextRect.height)
+        assertEquals(100.dp, boundedHeightTextSize.height)
+        assertEquals(unboundedTextSize.width, boundedHeightTextSize.width)
+        assertTrue(boundedHeightTextSize.height < unboundedTextSize.height)
     }
 
     @Test

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/InteropUIMenuTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/InteropUIMenuTest.kt
@@ -36,6 +36,9 @@ import kotlin.test.assertTrue
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.readValue
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGPoint
 import platform.CoreGraphics.CGRectZero
 import platform.UIKit.UIAction
@@ -50,7 +53,10 @@ import platform.UIKit.UIMenu
 internal class InteropUIMenuTest {
 
     @Test
-    fun testUIMenuDismissByTapOnComposeView() = runUIKitInstrumentedTestWithInterop { overlay ->
+    fun testUIMenuDismissByTapOnComposeView() = runUIKitInstrumentedTestWithInterop(
+        ignoreIf = !available(OS.Ios to OSVersion(16)),
+        ignoreNotes = "The test does not receive touches on iOS < 15 when the context menu opened"
+    ) { overlay ->
         var isMenuOpen: () -> Boolean = { false }
 
         setContent {
@@ -93,7 +99,10 @@ internal class InteropUIMenuTest {
     }
 
     @Test
-    fun testUIMenuEmbeddedInComposeViewDismissByTapOnOtherComposeView() = runUIKitInstrumentedTestWithInterop { overlay ->
+    fun testUIMenuEmbeddedInComposeViewDismissByTapOnOtherComposeView() = runUIKitInstrumentedTestWithInterop(
+        ignoreIf = !available(OS.Ios to OSVersion(16)),
+        ignoreNotes = "The test does not receive touches on iOS < 15 when the context menu opened"
+    ) { overlay ->
         var isMenuOpen: () -> Boolean = { false }
 
         setContent {
@@ -143,7 +152,10 @@ internal class InteropUIMenuTest {
     }
 
     @Test
-    fun testUIMenuDismissByTapOnUIButton() = runUIKitInstrumentedTestWithInterop { overlay ->
+    fun testUIMenuDismissByTapOnUIButton() = runUIKitInstrumentedTestWithInterop(
+        ignoreIf = !available(OS.Ios to OSVersion(16)),
+        ignoreNotes = "The test does not receive touches on iOS < 15 when the context menu opened"
+    ) { overlay ->
         var isMenuOpen: () -> Boolean = { false }
 
         setContent {
@@ -191,7 +203,10 @@ internal class InteropUIMenuTest {
     }
 
     @Test
-    fun testUIMenuDismissByTapOnUIAction() = runUIKitInstrumentedTestWithInterop { overlay ->
+    fun testUIMenuDismissByTapOnUIAction() = runUIKitInstrumentedTestWithInterop(
+        ignoreIf = !available(OS.Ios to OSVersion(16)),
+        ignoreNotes = "The test does not receive touches on iOS < 15 when the context menu opened"
+    ) { overlay ->
         var isMenuOpen: () -> Boolean = { false }
 
         setContent {
@@ -235,7 +250,7 @@ private class ContextMenuButton(
     override fun contextMenuInteraction(
         interaction: UIContextMenuInteraction,
         configurationForMenuAtLocation: CValue<CGPoint>
-    ): UIContextMenuConfiguration? {
+    ): UIContextMenuConfiguration {
         isMenuOpen = true
         return UIContextMenuConfiguration.configurationWithIdentifier(
             identifier = null,

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/UIKitInteropInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interop/UIKitInteropInstrumentedTest.kt
@@ -31,3 +31,18 @@ internal fun runUIKitInstrumentedTestWithInterop(
         testBlock(true)
     }
 }
+
+internal fun runUIKitInstrumentedTestWithInterop(
+    ignoreIf: Boolean,
+    ignoreNotes: String,
+    testBlock: UIKitInstrumentedTest.(Boolean) -> Unit
+) {
+    runUIKitInstrumentedTest(ignoreIf = ignoreIf, ignoreNotes = ignoreNotes) {
+        println("Debug: Interop view placed as overlay: false")
+        testBlock(false)
+    }
+    runUIKitInstrumentedTest(ignoreIf = ignoreIf, ignoreNotes = ignoreNotes) {
+        println("Debug: Interop view placed as overlay: true")
+        testBlock(true)
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/keyboard/ImeOptionsTest.kt
@@ -58,7 +58,7 @@ import platform.UIKit.UIKeyboardTypeURL
 import platform.UIKit.UIReturnKeyType
 import platform.UIKit.UITextAutocapitalizationType
 import platform.UIKit.UITextAutocorrectionType
-import platform.UIKit.UITextContentTypeBirthdate
+import platform.UIKit.UITextContentTypeDateTime
 import platform.UIKit.UITextContentTypeEmailAddress
 import platform.UIKit.UITextContentTypePassword
 import platform.UIKit.UITextContentTypeTelephoneNumber
@@ -130,9 +130,9 @@ internal class ImeOptionsTest {
     @Test
     fun testContentType() = runUIKitInstrumentedTest {
         val input = setContentAndFindInput(
-            imeOptions = PlatformImeOptions { textContentType(UITextContentTypeBirthdate) }
+            imeOptions = PlatformImeOptions { textContentType(UITextContentTypeDateTime) }
         )
-        assertEquals(UITextContentTypeBirthdate, input.textContentType)
+        assertEquals(UITextContentTypeDateTime, input.textContentType)
     }
 
     @Test
@@ -296,10 +296,10 @@ internal class ImeOptionsTest {
         val input = setContentAndFindInput(
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Password,
-                platformImeOptions = PlatformImeOptions { textContentType(UITextContentTypeBirthdate) }
+                platformImeOptions = PlatformImeOptions { textContentType(UITextContentTypeDateTime) }
             )
         )
-        assertEquals(UITextContentTypeBirthdate, input.textContentType)
+        assertEquals(UITextContentTypeDateTime, input.textContentType)
     }
 
     @Test

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsPaddingTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsPaddingTest.kt
@@ -81,7 +81,7 @@ class WindowInsetsPaddingTest {
     @Test
     fun testDisplayCutoutPadding_InterfaceOrientationLandscapeLeft() = runUIKitInstrumentedTest(
         ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
-        ignoreNotes = "Device rotation does not work for iOS <= 15 and iPad"
+        ignoreNotes = "Device rotation does not work for iOS < 16 and iPad"
     ) {
         var boxRect = DpRectZero()
 
@@ -112,7 +112,7 @@ class WindowInsetsPaddingTest {
     @Test
     fun testDisplayCutoutPadding_InterfaceOrientationLandscapeRight() = runUIKitInstrumentedTest(
         ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
-        ignoreNotes = "Device rotation does not work for iOS <= 15 and iPad"
+        ignoreNotes = "Device rotation does not work for iOS < 16 and iPad"
     ) {
         var boxRect = DpRectZero()
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsPaddingTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsPaddingTest.kt
@@ -45,8 +45,13 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
+import platform.UIKit.UIDevice
 import platform.UIKit.UIInterfaceOrientationMaskLandscapeLeft
 import platform.UIKit.UIInterfaceOrientationMaskLandscapeRight
+import platform.UIKit.UIUserInterfaceIdiomPad
 
 class WindowInsetsPaddingTest {
     @Test
@@ -74,7 +79,10 @@ class WindowInsetsPaddingTest {
 
     @OptIn(ExperimentalForeignApi::class)
     @Test
-    fun testDisplayCutoutPadding_InterfaceOrientationLandscapeLeft() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutPadding_InterfaceOrientationLandscapeLeft() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 15 and iPad"
+    ) {
         var boxRect = DpRectZero()
 
         setContent(interfaceOrientation = UIInterfaceOrientationMaskLandscapeLeft) {
@@ -102,7 +110,10 @@ class WindowInsetsPaddingTest {
 
     @OptIn(ExperimentalForeignApi::class)
     @Test
-    fun testDisplayCutoutPadding_InterfaceOrientationLandscapeRight() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutPadding_InterfaceOrientationLandscapeRight() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 15 and iPad"
+    ) {
         var boxRect = DpRectZero()
 
         setContent(interfaceOrientation = UIInterfaceOrientationMaskLandscapeRight) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsRulersTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsRulersTest.kt
@@ -37,10 +37,15 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlinx.cinterop.ExperimentalForeignApi
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
+import platform.UIKit.UIDevice
 import platform.UIKit.UIInterfaceOrientationMaskLandscapeLeft
 import platform.UIKit.UIInterfaceOrientationMaskLandscapeRight
 import platform.UIKit.UIInterfaceOrientationMaskPortrait
 import platform.UIKit.UIInterfaceOrientationMaskPortraitUpsideDown
+import platform.UIKit.UIUserInterfaceIdiomPad
 import platform.UIKit.UIView
 
 @OptIn(ExperimentalForeignApi::class)
@@ -51,7 +56,10 @@ class WindowInsetsRulersTest {
     private val displayCutoutRects = mutableObjectListOf<IntRect?>()
 
     @Test
-    fun testDisplayCutoutsForPortrait() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutsForPortrait() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskPortrait) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }
@@ -65,7 +73,10 @@ class WindowInsetsRulersTest {
     }
 
     @Test
-    fun testDisplayCutoutsForLandscapeLeft() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutsForLandscapeLeft() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskLandscapeLeft) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }
@@ -79,7 +90,10 @@ class WindowInsetsRulersTest {
     }
 
     @Test
-    fun testDisplayCutoutsForLandscapeRight() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutsForLandscapeRight() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskLandscapeRight) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }
@@ -93,7 +107,10 @@ class WindowInsetsRulersTest {
     }
 
     @Test
-    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsPortrait() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsPortrait() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskPortrait) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }
@@ -102,7 +119,10 @@ class WindowInsetsRulersTest {
     }
 
     @Test
-    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsLandscapeLeft() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsLandscapeLeft() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskLandscapeLeft) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }
@@ -111,7 +131,10 @@ class WindowInsetsRulersTest {
     }
 
     @Test
-    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsLandscapeRight() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsLandscapeRight() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskLandscapeRight) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }
@@ -120,7 +143,10 @@ class WindowInsetsRulersTest {
     }
 
     @Test
-    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsPortraitUpsideDown() = runUIKitInstrumentedTest {
+    fun testDisplayCutoutWindowInsetsRulersBoundedByDisplayCutoutsPortraitUpsideDown() = runUIKitInstrumentedTest(
+        ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
+        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+    ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskPortraitUpsideDown) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))
         }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsRulersTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsRulersTest.kt
@@ -58,7 +58,7 @@ class WindowInsetsRulersTest {
     @Test
     fun testDisplayCutoutsForPortrait() = runUIKitInstrumentedTest(
         ignoreIf = !available(OS.Ios to OSVersion(16)) || UIDevice.currentDevice.userInterfaceIdiom == UIUserInterfaceIdiomPad,
-        ignoreNotes = "Device rotation does not work for iOS <= 16 and iPad"
+        ignoreNotes = "Device rotation does not work for iOS < 16 and iPad"
     ) {
         setContent(interfaceOrientation = UIInterfaceOrientationMaskPortrait) {
             SimpleRulerContent(rulerState = mutableStateOf(DisplayCutout))

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scroll/ScrollTest.kt
@@ -72,6 +72,9 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.readValue
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
 import platform.CoreGraphics.CGRectZero
 import platform.CoreGraphics.CGSizeMake
 import platform.UIKit.UIColor
@@ -274,9 +277,9 @@ internal class ScrollTest {
         val touch = touchDown(screenSize.center)
         var previousBoxTop = boxRect.top
         var previousDiff = 0f
-
+        val dragDelta = screenSize.center.y / 10
         repeat(10) { i ->
-            touch.dragBy(dy = 20.dp, duration = 100.milliseconds)
+            touch.dragBy(dy = dragDelta, duration = 100.milliseconds)
             waitForIdle()
 
             val currentBoxTop = boxRect.top
@@ -287,7 +290,7 @@ internal class ScrollTest {
                 try {
                     assertEquals(currentDiff, previousDiff, 5e-5f)
                 } catch (_: AssertionError) {
-                    assertTrue(currentDiff < previousDiff)
+                    assertTrue(currentDiff < previousDiff, "$currentDiff < $previousDiff")
                 }
             }
 
@@ -329,9 +332,10 @@ internal class ScrollTest {
         val touch = touchDown(screenSize.center)
         var previousBoxTop = boxRect.top
         var previousDiff = 0f
+        val dragDelta = screenSize.center.y / 10
 
         repeat(10) { i ->
-            touch.dragBy(dy = -20.dp, duration = 0.1.seconds)
+            touch.dragBy(dy = -dragDelta, duration = 0.1.seconds)
             waitForIdle()
 
             val currentBoxTop = boxRect.top
@@ -357,14 +361,14 @@ internal class ScrollTest {
     }
 
     @Test
-    fun testOverscrollAndFlick() = runUIKitInstrumentedTest {
+    fun testOverscrollAndFling() = runUIKitInstrumentedTest {
         val state = ScrollState(0)
         val boxHeight = 100.0
         var boxRect = DpRectZero()
 
         setContent {
             Column(modifier = Modifier.fillMaxSize().verticalScroll(state)) {
-                repeat(10) { index ->
+                repeat(20) { index ->
                     Box(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -393,7 +397,7 @@ internal class ScrollTest {
         // overscroll does not alter scroll state
         assertEquals(0 * density.density, state.value.toFloat())
 
-        // flick up
+        // fling up
         touch
             .dragBy(dy = -(boxHeight + 50).dp, duration = 100.milliseconds)
             .up()
@@ -721,6 +725,12 @@ internal class ScrollTest {
 
         findNodeWithTag("UIKit.UIScrollView")
             .touchDown()
+            .also {
+                // There is an issue on iOS < 15 where the simulated drag is not applied immediately.
+                if (!available(OS.Ios to OSVersion(16))) {
+                    delay(100)
+                }
+            }
             .dragBy(dy = -(250 + CUPERTINO_TOUCH_SLOP).dp)
             .also { delay(500) }
             .up()
@@ -1024,7 +1034,7 @@ private fun VerticalScrollWithHorizontalUIKitScroll(
     screenSize: DpSize,
     topContentHeight: Dp,
     uiKitScrollViewHeight: Dp,
-    uiKitScrollViewContentWidth: Double = 1000.0,
+    uiKitScrollViewContentWidth: Double = 5000.0,
     uiKitScrollViewRectInWindow: (() -> DpRect) -> Unit = {},
     uiKitContentOffset: (() -> DpOffset) -> Unit = { },
 ) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/AccessibilityTestNode.kt
@@ -29,6 +29,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.cinterop.ExperimentalForeignApi
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
 import platform.UIKit.UIAccessibilityElement
 import platform.UIKit.UIAccessibilityTraitAdjustable
 import platform.UIKit.UIAccessibilityTraitAllowsDirectInteraction
@@ -81,25 +84,24 @@ import platform.darwin.NSObject
 internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode {
     fun buildNode(element: NSObject, isAccessibilityElementContent: Boolean): AccessibilityTestNode {
         val children = mutableListOf<AccessibilityTestNode>()
-        val elements = element.accessibilityElements()
         val accessibilityElementContent = isAccessibilityElementContent || element.isAccessibilityElement
 
-        if (accessibilityElementContent) {
+        if (element.accessibilityElements() != null) {
+            element.accessibilityElements()?.forEach {
+                children.add(buildNode(it as NSObject, accessibilityElementContent))
+            }
+        } else if (element is UIView) {
+            element.subviews.forEach {
+                children.add(buildNode(it as UIView, accessibilityElementContent))
+            }
+        } else if (available(OS.Ios to OSVersion(major = 17)) &&
+            (element.automationElements?.isNotEmpty() ?: false)
+        ) {
             // iOS Automation uses `automationElements` to build the semantics tree inside the
             // accessibility element.
             // Exceptions are UIKit elements that use private logic to build their semantics tree
             // for automation.
-            if ((element.automationElements?.isNotEmpty() ?: false)) {
-                element.automationElements?.forEach {
-                    children.add(buildNode(it as NSObject, accessibilityElementContent))
-                }
-            } else if (element is UIView) {
-                element.subviews.forEach {
-                    children.add(buildNode(it as UIView, accessibilityElementContent))
-                }
-            }
-        } else if (elements != null) {
-            elements.forEach {
+            element.automationElements?.forEach {
                 children.add(buildNode(it as NSObject, accessibilityElementContent))
             }
         } else {
@@ -153,7 +155,7 @@ internal fun UIKitInstrumentedTest.getAccessibilityTree(): AccessibilityTestNode
     return buildNode(appDelegate.window!!.windowScene!!, isAccessibilityElementContent = false)
 }
 
-private val allAccessibilityTraits = mapOf(
+private val allAccessibilityTraits = mutableMapOf(
     UIAccessibilityTraitNone to "UIAccessibilityTraitNone",
     UIAccessibilityTraitButton to "UIAccessibilityTraitButton",
     UIAccessibilityTraitLink to "UIAccessibilityTraitLink",
@@ -172,11 +174,15 @@ private val allAccessibilityTraits = mapOf(
     UIAccessibilityTraitAllowsDirectInteraction to "UIAccessibilityTraitAllowsDirectInteraction",
     UIAccessibilityTraitCausesPageTurn to "UIAccessibilityTraitCausesPageTurn",
     UIAccessibilityTraitTabBar to "UIAccessibilityTraitTabBar",
-    UIAccessibilityTraitToggleButton to "UIAccessibilityTraitToggleButton",
-    UIAccessibilityTraitSupportsZoom to "UIAccessibilityTraitSupportsZoom",
     CMPAccessibilityTraitTextView to "CMPAccessibilityTraitTextView",
     CMPAccessibilityTraitIsEditing to "CMPAccessibilityTraitIsEditing",
-)
+).let {
+    if (available(OS.Ios to OSVersion(major = 17))) {
+        it[UIAccessibilityTraitToggleButton] = "UIAccessibilityTraitToggleButton"
+        it[UIAccessibilityTraitSupportsZoom] = "UIAccessibilityTraitSupportsZoom"
+    }
+    it as Map<UIAccessibilityTraits, String>
+}
 
 /**
  * Represents a node in an accessibility tree, which is used for testing accessibility features

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -93,6 +93,26 @@ internal fun runUIKitInstrumentedTest(
 }
 
 /**
+ * Sets up the test environment for iOS instrumented tests, runs the given [test][testBlock]
+ * and then tears down the test environment. Use the methods on [UIKitInstrumentedTest]
+ * in the test to find compose content and make assertions on it.
+ * @param [ignoreIf] Condition to ignore the test.
+ * @param [ignoreNotes] A description of why the test is ignored if it doesn't run.
+ * @param [testBlock] The test function.
+ */
+internal fun runUIKitInstrumentedTest(
+    ignoreIf: Boolean,
+    ignoreNotes: String,
+    testBlock: UIKitInstrumentedTest.() -> Unit
+) {
+    if (ignoreIf) {
+        println("Ignored test: $ignoreNotes")
+        return
+    }
+    runUIKitInstrumentedTest(testBlock)
+}
+
+/**
  * A class designed for instrumented testing of UIKit-related functionality. It provides methods for setting
  * content, simulating user interactions, and managing application lifecycle during testing scenarios.
  *
@@ -203,15 +223,16 @@ internal class UIKitInstrumentedTest {
      * Simulates a touch-down event at the specified position on the screen.
      *
      * @param position The position on the root hosting controller.
+     * @param forceWindow If true, the window hosting the view will be used to send the touch event.
      * @return A UITouch object representing the touch interaction.
      */
-    fun touchDown(position: DpOffset): UITouch {
+    fun touchDown(position: DpOffset, forceWindow: UIWindow? = null): UITouch {
         val positionOnWindow = hostingViewController.view.convertPoint(
             point = position.toCGPoint(),
             toView = appDelegate.window()
         )
 
-        val window = appDelegate.window()!!
+        val window = forceWindow ?: appDelegate.window()!!
             .windowScene!!
             .windows
             .findLast {
@@ -249,9 +270,10 @@ internal class UIKitInstrumentedTest {
     /**
      * Simulates a touch-down event at the center of a given AccessibilityTestNode.
      */
-    fun AccessibilityTestNode.touchDown(): UITouch {
+    fun AccessibilityTestNode.touchDown(forceNodeWindow: Boolean = false): UITouch {
         val frame = frame ?: error("Internal error. Frame is missing.")
-        return touchDown(frame.center())
+        val window = (element as? UIView)?.window?.takeIf { forceNodeWindow }
+        return touchDown(frame.center(), window)
     }
 
     /**

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -223,16 +223,17 @@ internal class UIKitInstrumentedTest {
      * Simulates a touch-down event at the specified position on the screen.
      *
      * @param position The position on the root hosting controller.
-     * @param forceWindow If true, the window hosting the view will be used to send the touch event.
+     * @param window will be used to handle touches; otherwise,
+     * the window hosting the view will be used.
      * @return A UITouch object representing the touch interaction.
      */
-    fun touchDown(position: DpOffset, forceWindow: UIWindow? = null): UITouch {
+    fun touchDown(position: DpOffset, window: UIWindow? = null): UITouch {
         val positionOnWindow = hostingViewController.view.convertPoint(
             point = position.toCGPoint(),
             toView = appDelegate.window()
         )
 
-        val window = forceWindow ?: appDelegate.window()!!
+        val targetWindow = window ?: appDelegate.window()!!
             .windowScene!!
             .windows
             .findLast {
@@ -240,7 +241,7 @@ internal class UIKitInstrumentedTest {
                 it.hitTest(position.toCGPoint(), it.getTouchesEvent()) != null
             } as UIWindow
 
-        return window.touchDown(positionOnWindow.asDpOffset())
+        return targetWindow.touchDown(positionOnWindow.asDpOffset())
     }
 
     /**
@@ -270,9 +271,9 @@ internal class UIKitInstrumentedTest {
     /**
      * Simulates a touch-down event at the center of a given AccessibilityTestNode.
      */
-    fun AccessibilityTestNode.touchDown(forceNodeWindow: Boolean = false): UITouch {
+    fun AccessibilityTestNode.touchDown(useNodeWindow: Boolean = false): UITouch {
         val frame = frame ?: error("Internal error. Frame is missing.")
-        val window = (element as? UIView)?.window?.takeIf { forceNodeWindow }
+        val window = (element as? UIView)?.window?.takeIf { useNodeWindow }
         return touchDown(frame.center(), window)
     }
 


### PR DESCRIPTION
The first part of the preparation for running iOS instrumented tests on all sets of iOS simulators.
- Mute screen rotation-dependent tests for iOS < 16 and iPads:: https://youtrack.jetbrains.com/issue/CMP-9267/Fix-iOS-instrumented-tests-with-screen-rotation
- Mute UIMenu tests for iOS < 16:: https://youtrack.jetbrains.com/issue/CMP-9268/Fix-iOS-InteropUIMenuTest-tests
- Rework context menu tests to me able to work for all iOS versions
- Fix accessibility tree structure building for iOS < 17

## Release Notes
N/A