### PR TITLE
Fix web SavedStateHandles initialization

### DIFF
--- a/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
+++ b/compose/ui/ui/src/webCommonW3C/kotlin/androidx/compose/ui/window/ComposeWindow.w3c.kt
@@ -417,6 +417,7 @@ internal class ComposeWindow(
         canvas.setAttribute("draggable", "true")
 
         scene.density = density
+        archComponentsOwner.enableSavedStateHandles()
 
         val interopContainer = WebInteropContainer(InteropViewGroup(interopContainerElement))
 
@@ -443,7 +444,6 @@ internal class ComposeWindow(
             )
         }
 
-        archComponentsOwner.enableSavedStateHandles()
         archComponentsOwner.lifecycle.handleLifecycleEvent(
             if (document.hasFocus()) Lifecycle.Event.ON_RESUME
             else Lifecycle.Event.ON_START


### PR DESCRIPTION
Fix web SavedStateHandles initialization: Move enableSavedStateHandles call before setContent call on web.

Fixes https://youtrack.jetbrains.com/issue/CMP-9293

## Testing
Manually

## Release Notes
### Fixes - SavedState
- _(prerelease fix)_ Fix `SavedStateHandles` initialization on web.