### PR TITLE
Pin compose to 1.9.3 in `lifecycle-viewmodel-compose`

### DIFF
--- a/lifecycle/lifecycle-viewmodel-compose/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-compose/build.gradle
@@ -52,11 +52,11 @@ kotlin {
                 api(project(":lifecycle:lifecycle-common"))
                 api(project(":lifecycle:lifecycle-viewmodel"))
                 api("androidx.annotation:annotation:1.9.1")
-                api(project(":compose:runtime:runtime"))
+                api("org.jetbrains.compose.runtime:runtime:1.9.3")
 
                 // Moved from platform dependencies
                 api(project(":lifecycle:lifecycle-viewmodel-savedstate"))
-                api(project(":compose:ui:ui"))
+                api("org.jetbrains.compose.ui:ui:1.9.3")
 
                 api(libs.kotlinSerializationCore)
                 implementation(libs.kotlinStdlib)


### PR DESCRIPTION
[CMP-9277](https://youtrack.jetbrains.com/issue/CMP-9277) Lifecycle 2.10 isn't compatible with Compose 1.9

## Release Notes
### Fixes - Lifecycle
- _(prerelease fix)_ Fixed `lifecycle-viewmodel-compose` 2.10 compatibility with Compose `1.9.*`
