### PR TITLE
Refactor compose container lifecycle delegate

### DIFF
--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils.xcodeproj/project.pbxproj
@@ -19,6 +19,10 @@
 		997DFCF32B18DE59000B56B5 /* MockAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCF22B18DE59000B56B5 /* MockAppDelegate.swift */; };
 		997DFCF52B18E276000B56B5 /* XCTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCF42B18E276000B56B5 /* XCTestCase.swift */; };
 		997DFCFD2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 997DFCFC2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift */; };
+		99CC4B2E2ECE0838007C5C44 /* CMPView.m in Sources */ = {isa = PBXBuildFile; fileRef = 99CC4B2D2ECE0838007C5C44 /* CMPView.m */; };
+		99CC4B2F2ECE0838007C5C44 /* CMPView.m in Sources */ = {isa = PBXBuildFile; fileRef = 99CC4B2D2ECE0838007C5C44 /* CMPView.m */; };
+		99CC4B302ECE0838007C5C44 /* CMPView.m in Sources */ = {isa = PBXBuildFile; fileRef = 99CC4B2D2ECE0838007C5C44 /* CMPView.m */; };
+		99CC4B322ECE16C8007C5C44 /* CMPViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CC4B312ECE16C8007C5C44 /* CMPViewTests.swift */; };
 		99D97A882BF73A9B0035552B /* CMPEditMenuView.m in Sources */ = {isa = PBXBuildFile; fileRef = 99D97A872BF73A9B0035552B /* CMPEditMenuView.m */; };
 		99DCAB0E2BD00F5C002E6AC7 /* CMPTextLoupeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 99DCAB0D2BD00F5C002E6AC7 /* CMPTextLoupeSession.m */; };
 		EA4B52962C2EDEF200FBB55C /* CMPGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = EA4B52952C2EDEF200FBB55C /* CMPGestureRecognizer.m */; };
@@ -87,6 +91,11 @@
 		997DFCFA2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CMPUIKitUtilsTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		997DFCFC2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPUIKitUtilsTestApp.swift; sourceTree = "<group>"; };
 		99BE84D22C3467B100E43826 /* CMPUIKitUtilsTestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = CMPUIKitUtilsTestApp.xctestplan; sourceTree = "<group>"; };
+		99CC4B282ECE04AC007C5C44 /* CMPComposeContainerLifecycleDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPComposeContainerLifecycleDelegate.h; sourceTree = "<group>"; };
+		99CC4B2B2ECE07EA007C5C44 /* CMPComposeContainerLifecycleState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPComposeContainerLifecycleState.h; sourceTree = "<group>"; };
+		99CC4B2C2ECE0838007C5C44 /* CMPView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPView.h; sourceTree = "<group>"; };
+		99CC4B2D2ECE0838007C5C44 /* CMPView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPView.m; sourceTree = "<group>"; };
+		99CC4B312ECE16C8007C5C44 /* CMPViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMPViewTests.swift; sourceTree = "<group>"; };
 		99D97A862BF73A9B0035552B /* CMPEditMenuView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPEditMenuView.h; sourceTree = "<group>"; };
 		99D97A872BF73A9B0035552B /* CMPEditMenuView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CMPEditMenuView.m; sourceTree = "<group>"; };
 		99DCAB0C2BD00F5C002E6AC7 /* CMPTextLoupeSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CMPTextLoupeSession.h; sourceTree = "<group>"; };
@@ -140,6 +149,8 @@
 		996EFEEB2B02CE5D0000FE0F /* CMPUIKitUtils */ = {
 			isa = PBXGroup;
 			children = (
+				99CC4B282ECE04AC007C5C44 /* CMPComposeContainerLifecycleDelegate.h */,
+				99CC4B2B2ECE07EA007C5C44 /* CMPComposeContainerLifecycleState.h */,
 				EA70A7E62B27106100300068 /* CMPAccessibilityElement.h */,
 				EA70A7E82B27106100300068 /* CMPAccessibilityElement.m */,
 				EADD028E2C9846D9003F66E8 /* CMPDragInteractionProxy.h */,
@@ -174,6 +185,8 @@
 				996EFEF52B02CE8A0000FE0F /* CMPUIKitUtils.h */,
 				997DFCDC2B18D135000B56B5 /* CMPViewController.h */,
 				997DFCDD2B18D135000B56B5 /* CMPViewController.m */,
+				99CC4B2C2ECE0838007C5C44 /* CMPView.h */,
+				99CC4B2D2ECE0838007C5C44 /* CMPView.m */,
 			);
 			path = CMPUIKitUtils;
 			sourceTree = "<group>";
@@ -204,6 +217,7 @@
 			children = (
 				997DFCF02B18DBF2000B56B5 /* CMPUIKitUtilsTests-Bridging-Header.h */,
 				997DFCE52B18D99E000B56B5 /* CMPViewControllerTests.swift */,
+				99CC4B312ECE16C8007C5C44 /* CMPViewTests.swift */,
 				997DFCF12B18DE47000B56B5 /* Utils */,
 			);
 			path = CMPUIKitUtilsTests;
@@ -354,6 +368,7 @@
 				9968C35B2D76FE16005E8DE4 /* CMPPanGestureRecognizer.m in Sources */,
 				991A97F72E1FB99300B47130 /* CMPScrollView.m in Sources */,
 				99D97A882BF73A9B0035552B /* CMPEditMenuView.m in Sources */,
+				99CC4B2E2ECE0838007C5C44 /* CMPView.m in Sources */,
 				EABD912B2BC02B5F00455279 /* CMPInteropWrappingView.m in Sources */,
 				EADD02902C9846D9003F66E8 /* CMPDragInteractionProxy.m in Sources */,
 				992EDDFB2E55EC8400FB44C5 /* CMPKeyValueObserver.m in Sources */,
@@ -371,6 +386,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				99CC4B2F2ECE0838007C5C44 /* CMPView.m in Sources */,
+				99CC4B322ECE16C8007C5C44 /* CMPViewTests.swift in Sources */,
 				997DFCF52B18E276000B56B5 /* XCTestCase.swift in Sources */,
 				997DFCE62B18D99E000B56B5 /* CMPViewControllerTests.swift in Sources */,
 				997DFCEE2B18DB7B000B56B5 /* CMPViewController.m in Sources */,
@@ -387,6 +404,7 @@
 				EAC703E52B8C826E001ECDA6 /* CMPOSLogger.m in Sources */,
 				997DFCFD2B18E5D3000B56B5 /* CMPUIKitUtilsTestApp.swift in Sources */,
 				EAC703E62B8C826E001ECDA6 /* CMPOSLoggerInterval.m in Sources */,
+				99CC4B302ECE0838007C5C44 /* CMPView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPComposeContainerLifecycleDelegate.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPComposeContainerLifecycleDelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,11 @@
  */
 
 #import <UIKit/UIKit.h>
-#import "CMPComposeContainerLifecycleDelegate.h"
 
-NS_ASSUME_NONNULL_BEGIN
+@protocol CMPComposeContainerLifecycleDelegate
 
-@interface CMPViewController : UIViewController
-
-- (id)initWithLifecycleDelegate:(id<CMPComposeContainerLifecycleDelegate> _Nullable)delegate;
-
-/// Indicates that view controller is considered alive in terms of structural containment
-- (void)viewControllerDidEnterWindowHierarchy;
-
-/// Indicates that view controller is considered closed in terms of structural containment
-- (void)viewControllerDidLeaveWindowHierarchy;
+- (void)composeContainerWillAppear;
+- (void)composeContainerDidDisappear;
+- (void)composeContainerWillDealloc;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPComposeContainerLifecycleState.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPComposeContainerLifecycleState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,9 @@
  */
 
 #import <UIKit/UIKit.h>
-#import "CMPComposeContainerLifecycleDelegate.h"
 
-NS_ASSUME_NONNULL_BEGIN
-
-@interface CMPViewController : UIViewController
-
-- (id)initWithLifecycleDelegate:(id<CMPComposeContainerLifecycleDelegate> _Nullable)delegate;
-
-/// Indicates that view controller is considered alive in terms of structural containment
-- (void)viewControllerDidEnterWindowHierarchy;
-
-/// Indicates that view controller is considered closed in terms of structural containment
-- (void)viewControllerDidLeaveWindowHierarchy;
-
-@end
-
-NS_ASSUME_NONNULL_END
+typedef NS_ENUM(NSInteger, CMPComposeContainerLifecycleState) {
+    CMPComposeContainerLifecycleStateInitialized,
+    CMPComposeContainerLifecycleStateStarted,
+    CMPComposeContainerLifecycleStateStopped
+};

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPUIKitUtils.h
@@ -23,6 +23,7 @@ FOUNDATION_EXPORT double CMPUIKitUtilsVersionNumber;
 FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 
 #import "CMPViewController.h"
+#import "CMPView.h"
 #import "CMPAccessibilityElement.h"
 #import "CMPOSLogger.h"
 #import "CMPTextLoupeSession.h"
@@ -34,3 +35,4 @@ FOUNDATION_EXPORT const unsigned char CMPUIKitUtilsVersionString[];
 #import "CMPHoverGestureHandler.h"
 #import "CMPScreenEdgePanGestureRecognizer.h"
 #import "CMPScrollView.h"
+#import "CMPComposeContainerLifecycleDelegate.h"

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.h
@@ -23,6 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)initWithLifecycleDelegate:(id<CMPComposeContainerLifecycleDelegate> _Nullable)delegate;
 
+/// Notifies the view is added to a view hierarchy
+- (void)viewDidAppear;
+
+/// Notifies the view was removed from a view hierarchy
+- (void)viewDidDisappear;
+
 /// Indicates that view is considered alive in terms of structural containment
 - (void)viewDidEnterWindowHierarchy;
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Indicates that view is considered as closed in terms of structural containment
 - (void)viewDidLeaveWindowHierarchy;
 
+/// Indicates that trait interface style trait changed
+- (void)userInterfaceStyleDidChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CMPViewController : UIViewController
+@interface CMPView : UIView
 
 - (id)initWithLifecycleDelegate:(id<CMPComposeContainerLifecycleDelegate> _Nullable)delegate;
 
-/// Indicates that view controller is considered alive in terms of structural containment
-- (void)viewControllerDidEnterWindowHierarchy;
+/// Indicates that view is considered alive in terms of structural containment
+- (void)viewDidEnterWindowHierarchy;
 
-/// Indicates that view controller is considered closed in terms of structural containment
-- (void)viewControllerDidLeaveWindowHierarchy;
+/// Indicates that view is considered as closed in terms of structural containment
+- (void)viewDidLeaveWindowHierarchy;
 
 @end
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
@@ -109,7 +109,7 @@
 
     if (@available(iOS 17, *)) {
         // Do nothing
-    } else {
+    } else if (self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
         [self userInterfaceStyleDidChange];
     }
 }

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "CMPView.h"
+#import "CMPComposeContainerLifecycleState.h"
+
+#pragma mark - CMPViewController
+
+@implementation CMPView {
+    CMPComposeContainerLifecycleState _lifecycleState;
+    id<CMPComposeContainerLifecycleDelegate> _lifecycleDelegate;
+    BOOL _isViewInWindowHierarchy;
+}
+
+- (id)initWithLifecycleDelegate:(id<CMPComposeContainerLifecycleDelegate>)delegate {
+    self = [super initWithFrame:CGRectZero];
+    
+    if (self) {
+        _lifecycleDelegate = delegate;
+        _lifecycleState = CMPComposeContainerLifecycleStateInitialized;
+        _isViewInWindowHierarchy = NO;
+    }
+    
+    return self;
+}
+
+- (void)didMoveToWindow {
+    [super didMoveToWindow];
+    
+    [self updateViewAppearanceState];
+}
+
+- (void)didMoveToSuperview {
+    [super didMoveToSuperview];
+    
+    [self updateViewAppearanceState];
+}
+
+- (void)updateViewAppearanceState {
+    BOOL isViewInWindowHierarchy = self.superview != nil && self.window != nil;
+    if (_isViewInWindowHierarchy != isViewInWindowHierarchy) {
+        _isViewInWindowHierarchy = isViewInWindowHierarchy;
+        if (isViewInWindowHierarchy) {
+            [_lifecycleDelegate composeContainerWillAppear];
+            [self transitViewLifecycleToStarted];
+        } else {
+            [self scheduleViewHierarchyContainmentCheck];
+            [_lifecycleDelegate composeContainerDidDisappear];
+        }
+    }
+}
+
+- (void)transitViewLifecycleToStarted {
+    switch (_lifecycleState) {
+        case CMPComposeContainerLifecycleStateInitialized:
+        case CMPComposeContainerLifecycleStateStopped:
+            _lifecycleState = CMPComposeContainerLifecycleStateStarted;
+            [self viewDidEnterWindowHierarchy];
+            break;
+        case CMPComposeContainerLifecycleStateStarted:
+            break;
+    }
+}
+
+- (void)scheduleViewHierarchyContainmentCheck {
+    double delayInSeconds = 0.5;
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        switch (self->_lifecycleState) {
+            case CMPComposeContainerLifecycleStateInitialized:
+            case CMPComposeContainerLifecycleStateStopped:
+                assert(false);
+                break;
+            case CMPComposeContainerLifecycleStateStarted:
+                // perform check
+                if (!self->_isViewInWindowHierarchy) {
+                    self->_lifecycleState = CMPComposeContainerLifecycleStateStopped;
+                    [self viewDidLeaveWindowHierarchy];
+                }
+                break;
+        }
+    });
+}
+
+- (void)viewDidEnterWindowHierarchy {
+}
+
+- (void)viewDidLeaveWindowHierarchy {
+}
+
+- (void)dealloc {
+    if (_lifecycleState == CMPComposeContainerLifecycleStateStarted) {
+        [self viewDidLeaveWindowHierarchy];
+    }
+    
+    [_lifecycleDelegate composeContainerWillDealloc];
+}
+
+@end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
@@ -65,7 +65,9 @@
         if (isViewInWindowHierarchy) {
             [_lifecycleDelegate composeContainerWillAppear];
             [self transitViewLifecycleToStarted];
+            [self viewDidAppear];
         } else {
+            [self viewDidDisappear];
             [self scheduleViewHierarchyContainmentCheck];
             [_lifecycleDelegate composeContainerDidDisappear];
         }
@@ -90,8 +92,9 @@
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         switch (self->_lifecycleState) {
             case CMPComposeContainerLifecycleStateInitialized:
+                NSAssert(false, @"Attempt to schedule hierarchy check without starting the container");
+                break;
             case CMPComposeContainerLifecycleStateStopped:
-                assert(false);
                 break;
             case CMPComposeContainerLifecycleStateStarted:
                 // perform check
@@ -112,6 +115,12 @@
     } else if (self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
         [self userInterfaceStyleDidChange];
     }
+}
+
+- (void)viewDidAppear {
+}
+
+- (void)viewDidDisappear {
 }
 
 - (void)viewDidEnterWindowHierarchy {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPView.m
@@ -32,6 +32,15 @@
         _lifecycleDelegate = delegate;
         _lifecycleState = CMPComposeContainerLifecycleStateInitialized;
         _isViewInWindowHierarchy = NO;
+        
+        __weak typeof(self) weakSelf = self;
+        if (@available(iOS 17, *)) {
+            [self registerForTraitChanges:@[[UITraitUserInterfaceStyle class]]
+                              withHandler:^(__kindof id<UITraitEnvironment>  _Nonnull traitEnvironment,
+                                            UITraitCollection * _Nonnull previousCollection) {
+                [weakSelf userInterfaceStyleDidChange];
+            }];
+        }
     }
     
     return self;
@@ -95,10 +104,23 @@
     });
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    if (@available(iOS 17, *)) {
+        // Do nothing
+    } else {
+        [self userInterfaceStyleDidChange];
+    }
+}
+
 - (void)viewDidEnterWindowHierarchy {
 }
 
 - (void)viewDidLeaveWindowHierarchy {
+}
+
+- (void)userInterfaceStyleDidChange {
 }
 
 - (void)dealloc {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.h
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.h
@@ -29,6 +29,9 @@ NS_ASSUME_NONNULL_BEGIN
 /// Indicates that view controller is considered closed in terms of structural containment
 - (void)viewControllerDidLeaveWindowHierarchy;
 
+/// Indicates that trait interface style trait changed
+- (void)userInterfaceStyleDidChange;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -164,7 +164,7 @@
 
     if (@available(iOS 17, *)) {
         // Do nothing
-    } else {
+    } else if (self.traitCollection.userInterfaceStyle != previousTraitCollection.userInterfaceStyle) {
         [self userInterfaceStyleDidChange];
     }
 }

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -16,6 +16,7 @@
 
 #import "CMPViewController.h"
 #import <objc/runtime.h>
+#import "CMPComposeContainerLifecycleState.h"
 
 #pragma mark - UIViewController + CMPUIKitUtilsPrivate
 
@@ -65,27 +66,19 @@
 
 @end
 
-#pragma mark - CMPViewControllerLifecycleState
-
-typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
-    CMPViewControllerLifecycleStateInitialized,
-    CMPViewControllerLifecycleStateStarted,
-    CMPViewControllerLifecycleStateStopped
-};
-
 #pragma mark - CMPViewController
 
 @implementation CMPViewController {
-    CMPViewControllerLifecycleState _lifecycleState;
-    id<CMPViewControllerLifecycleDelegate> _lifecycleDelegate;
+    CMPComposeContainerLifecycleState _lifecycleState;
+    id<CMPComposeContainerLifecycleDelegate> _lifecycleDelegate;
 }
 
-- (instancetype)initWithLifecycleDelegate:(id<CMPViewControllerLifecycleDelegate>)delegate {
+- (id)initWithLifecycleDelegate:(id<CMPComposeContainerLifecycleDelegate>)delegate {
     self = [super initWithNibName:nil bundle:nil];
     
     if (self) {
         _lifecycleDelegate = delegate;
-        _lifecycleState = CMPViewControllerLifecycleStateInitialized;
+        _lifecycleState = CMPComposeContainerLifecycleStateInitialized;
     }
     
     return self;
@@ -96,7 +89,7 @@ typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
     
     if (self) {
         _lifecycleDelegate = nil;
-        _lifecycleState = CMPViewControllerLifecycleStateInitialized;
+        _lifecycleState = CMPComposeContainerLifecycleStateInitialized;
     }
     
     return self;
@@ -106,28 +99,24 @@ typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
     [self transitLifecycleToStarted];
 
     [super viewWillAppear:animated];
-    [_lifecycleDelegate viewControllerWillAppear];
+    [_lifecycleDelegate composeContainerWillAppear];
 }
 
 - (void)viewDidDisappear:(BOOL)animated {
     [super viewDidDisappear:animated];
     
-    [_lifecycleDelegate viewControllerDidDisappear];
-}
-
-- (void)viewSafeAreaInsetsDidChange {
-    [super viewSafeAreaInsetsDidChange];
+    [_lifecycleDelegate composeContainerDidDisappear];
 }
 
 - (void)transitLifecycleToStarted {
     switch (_lifecycleState) {
-        case CMPViewControllerLifecycleStateInitialized:
-        case CMPViewControllerLifecycleStateStopped:
-            _lifecycleState = CMPViewControllerLifecycleStateStarted;
+        case CMPComposeContainerLifecycleStateInitialized:
+        case CMPComposeContainerLifecycleStateStopped:
+            _lifecycleState = CMPComposeContainerLifecycleStateStarted;
             [self viewControllerDidEnterWindowHierarchy];
             [self scheduleHierarchyContainmentCheck];
             break;
-        case CMPViewControllerLifecycleStateStarted:
+        case CMPComposeContainerLifecycleStateStarted:
             break;
     }
 }
@@ -137,17 +126,17 @@ typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
     
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         switch (self->_lifecycleState) {
-            case CMPViewControllerLifecycleStateInitialized:
-            case CMPViewControllerLifecycleStateStopped:
+            case CMPComposeContainerLifecycleStateInitialized:
+            case CMPComposeContainerLifecycleStateStopped:
                 assert(false);
                 break;
-            case CMPViewControllerLifecycleStateStarted:
+            case CMPComposeContainerLifecycleStateStarted:
                 // perform check
                 if ([self cmp_isInWindowHierarchy]) {
                     // everything is fine, schedule next one
                     [self scheduleHierarchyContainmentCheck];
                 } else {
-                    self->_lifecycleState = CMPViewControllerLifecycleStateStopped;
+                    self->_lifecycleState = CMPComposeContainerLifecycleStateStopped;
                     [self viewControllerDidLeaveWindowHierarchy];
                 }
                 break;
@@ -162,11 +151,11 @@ typedef NS_ENUM(NSInteger, CMPViewControllerLifecycleState) {
 }
 
 - (void)dealloc {
-    if (_lifecycleState == CMPViewControllerLifecycleStateStarted) {
+    if (_lifecycleState == CMPComposeContainerLifecycleStateStarted) {
         [self viewControllerDidLeaveWindowHierarchy];
     }
     
-    [_lifecycleDelegate viewControllerWillDealloc];
+    [_lifecycleDelegate composeContainerWillDealloc];
 }
 
 @end

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -79,6 +79,8 @@
     if (self) {
         _lifecycleDelegate = delegate;
         _lifecycleState = CMPComposeContainerLifecycleStateInitialized;
+        
+        [self addTraitCollectionObserverIfNeeded];
     }
     
     return self;
@@ -90,9 +92,22 @@
     if (self) {
         _lifecycleDelegate = nil;
         _lifecycleState = CMPComposeContainerLifecycleStateInitialized;
+
+        [self addTraitCollectionObserverIfNeeded];
     }
     
     return self;
+}
+
+- (void)addTraitCollectionObserverIfNeeded {
+    __weak typeof(self) weakSelf = self;
+    if (@available(iOS 17, *)) {
+        [self registerForTraitChanges:@[[UITraitUserInterfaceStyle class]]
+                          withHandler:^(__kindof id<UITraitEnvironment>  _Nonnull traitEnvironment,
+                                        UITraitCollection * _Nonnull previousCollection) {
+            [weakSelf userInterfaceStyleDidChange];
+        }];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -144,10 +159,23 @@
     });
 }
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+
+    if (@available(iOS 17, *)) {
+        // Do nothing
+    } else {
+        [self userInterfaceStyleDidChange];
+    }
+}
+
 - (void)viewControllerDidEnterWindowHierarchy {
 }
 
 - (void)viewControllerDidLeaveWindowHierarchy {
+}
+
+- (void)userInterfaceStyleDidChange {
 }
 
 - (void)dealloc {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPViewController.m
@@ -142,8 +142,9 @@
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         switch (self->_lifecycleState) {
             case CMPComposeContainerLifecycleStateInitialized:
+                NSAssert(false, @"Attempt to schedule hierarchy check without starting the container");
+                break;
             case CMPComposeContainerLifecycleStateStopped:
-                assert(false);
                 break;
             case CMPComposeContainerLifecycleStateStarted:
                 // perform check

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
@@ -321,19 +321,19 @@ final class CMPViewControllerTests: XCTestCase {
     }
 }
 
-private class LifecycleDelegate: CMPViewControllerLifecycleDelegate {
+private class LifecycleDelegate: CMPComposeContainerLifecycleDelegate {
     var viewControllerWillAppearCallsCount = 0
-    func viewControllerWillAppear() {
+    func composeContainerWillAppear() {
         viewControllerWillAppearCallsCount += 1
     }
     
     var viewControllerDidDisappearCallsCount = 0
-    func viewControllerDidDisappear() {
+    func composeContainerDidDisappear() {
         viewControllerDidDisappearCallsCount += 1
     }
     
     var viewControllerWillDeallocCallsCount = 0
-    func viewControllerWillDealloc() {
+    func composeContainerWillDealloc() {
         viewControllerWillDeallocCallsCount += 1
     }
 }
@@ -345,7 +345,7 @@ private class TestViewController: CMPViewController {
     
     public var viewIsInWindowHierarchy: Bool = false
 
-    init(delegate: CMPViewControllerLifecycleDelegate? = nil) {
+    init(delegate: CMPComposeContainerLifecycleDelegate? = nil) {
         id = TestViewController.counter
         TestViewController.counter += 1
         super.init(lifecycleDelegate: delegate)

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewControllerTests.swift
@@ -311,30 +311,30 @@ final class CMPViewControllerTests: XCTestCase {
             rootViewController = viewController
         }
         
-        await expect { delegate.viewControllerWillAppearCallsCount == 1 }
+        await expect { delegate.containerWillAppearCallsCount == 1 }
         
         rootViewController = UIViewController()
 
-        await expect { delegate.viewControllerWillAppearCallsCount == 1 }
-        await expect { delegate.viewControllerDidDisappearCallsCount == 1 }
-        await expect { delegate.viewControllerWillDeallocCallsCount == 1 }
+        await expect { delegate.containerWillAppearCallsCount == 1 }
+        await expect { delegate.containerDidDisappearCallsCount == 1 }
+        await expect { delegate.containerWillDeallocCallsCount == 1 }
     }
 }
 
-private class LifecycleDelegate: CMPComposeContainerLifecycleDelegate {
-    var viewControllerWillAppearCallsCount = 0
+class LifecycleDelegate: CMPComposeContainerLifecycleDelegate {
+    var containerWillAppearCallsCount = 0
     func composeContainerWillAppear() {
-        viewControllerWillAppearCallsCount += 1
+        containerWillAppearCallsCount += 1
     }
     
-    var viewControllerDidDisappearCallsCount = 0
+    var containerDidDisappearCallsCount = 0
     func composeContainerDidDisappear() {
-        viewControllerDidDisappearCallsCount += 1
+        containerDidDisappearCallsCount += 1
     }
     
-    var viewControllerWillDeallocCallsCount = 0
+    var containerWillDeallocCallsCount = 0
     func composeContainerWillDealloc() {
-        viewControllerWillDeallocCallsCount += 1
+        containerWillDeallocCallsCount += 1
     }
 }
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewTests.swift
@@ -102,30 +102,13 @@ final class CMPViewTests: XCTestCase {
             rootView = view
         }
         
-        await expect { delegate.viewWillAppearCallsCount == 1 }
+        await expect { delegate.containerWillAppearCallsCount == 1 }
         
         rootView = nil
 
-        await expect { delegate.viewWillAppearCallsCount == 1 }
-        await expect { delegate.viewDidDisappearCallsCount == 1 }
-        await expect { delegate.viewWillDeallocCallsCount == 1 }
-    }
-}
-
-private class LifecycleDelegate: CMPComposeContainerLifecycleDelegate {
-    var viewWillAppearCallsCount = 0
-    func composeContainerWillAppear() {
-        viewWillAppearCallsCount += 1
-    }
-    
-    var viewDidDisappearCallsCount = 0
-    func composeContainerDidDisappear() {
-        viewDidDisappearCallsCount += 1
-    }
-    
-    var viewWillDeallocCallsCount = 0
-    func composeContainerWillDealloc() {
-        viewWillDeallocCallsCount += 1
+        await expect { delegate.containerWillAppearCallsCount == 1 }
+        await expect { delegate.containerDidDisappearCallsCount == 1 }
+        await expect { delegate.containerWillDeallocCallsCount == 1 }
     }
 }
 

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewTests.swift
@@ -60,6 +60,17 @@ final class CMPViewTests: XCTestCase {
             view.viewIsInWindowHierarchy == inHierarchy
         }
     }
+
+    @MainActor
+    private func expect(
+        view: TestView,
+        toBeAppeared isAppeared: Bool,
+        line: Int = #line
+    ) async {
+        await expect(timeout: 5.0, line: line) {
+            view.isViewAppeared == isAppeared
+        }
+    }
     
     @MainActor
     public func testNotAttached() async {
@@ -110,6 +121,16 @@ final class CMPViewTests: XCTestCase {
         await expect { delegate.containerDidDisappearCallsCount == 1 }
         await expect { delegate.containerWillDeallocCallsCount == 1 }
     }
+    
+    @MainActor
+    public func testViewAppeared() async {
+        let view = TestView()
+        rootView = view
+        await expect(view: view, toBeAppeared: true)
+        
+        rootView = nil
+        await expect(view: view, toBeAppeared: false)
+    }
 }
 
 private class TestView: CMPView {
@@ -118,6 +139,7 @@ private class TestView: CMPView {
     private let id: Int
     
     public var viewIsInWindowHierarchy: Bool = false
+    public var isViewAppeared: Bool = false
 
     init(delegate: CMPComposeContainerLifecycleDelegate? = nil) {
         id = TestView.counter
@@ -127,6 +149,14 @@ private class TestView: CMPView {
     
     required init?(coder: NSCoder) {
         nil
+    }
+    
+    override func viewDidAppear() {
+        isViewAppeared = true
+    }
+    
+    override func viewDidDisappear() {
+        isViewAppeared = false
     }
     
     override func viewDidEnterWindowHierarchy() {

--- a/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewTests.swift
+++ b/compose/ui/ui-uikit/src/uikitMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPViewTests.swift
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import AVKit
+import XCTest
+
+final class CMPViewTests: XCTestCase {
+    var appDelegate: MockAppDelegate!
+    var rootView: UIView? {
+        get {
+            appDelegate.window!.rootViewController?.view.subviews.first
+        }
+        set {
+            appDelegate.window!.rootViewController?.view.subviews.forEach {
+                $0.removeFromSuperview()
+            }
+            if let newValue {
+                appDelegate.window!.rootViewController?.view.addSubview(newValue)
+                newValue.frame = appDelegate.window!.rootViewController?.view.bounds ?? .zero
+            }
+        }
+    }
+
+    override func setUpWithError() throws {
+        super.setUp()
+
+        appDelegate = MockAppDelegate()
+        UIApplication.shared.delegate = appDelegate
+        appDelegate.setUpClearWindow()
+        TestView.counter = 1
+    }
+
+    override func tearDownWithError() throws {
+        super.tearDown()
+
+        appDelegate?.cleanUp()
+        appDelegate = nil
+    }
+        
+    @MainActor
+    private func expect(
+        view: TestView,
+        toBeInHierarchy inHierarchy: Bool,
+        line: Int = #line
+    ) async {
+        await expect(timeout: 5.0, line: line) {
+            view.viewIsInWindowHierarchy == inHierarchy
+        }
+    }
+    
+    @MainActor
+    public func testNotAttached() async {
+        let view = TestView()
+        await expect(view: view, toBeInHierarchy: false)
+    }
+    
+    @MainActor
+    public func testViewAttach() async {
+        let view = TestView()
+        rootView = view
+        await expect(view: view, toBeInHierarchy: true)
+        
+        rootView = nil
+        await expect(view: view, toBeInHierarchy: false)
+    }
+
+    @MainActor
+    public func testViewThroughSuperviewAttach() async {
+        let view = TestView()
+        view.frame = .init(x: 0, y: 0, width: 100, height: 100)
+        let superview = UIView()
+        superview.addSubview(view)
+        
+        await expect(view: view, toBeInHierarchy: false)
+
+        rootView = superview
+        await expect(view: view, toBeInHierarchy: true)
+        
+        rootView = nil
+        await expect(view: view, toBeInHierarchy: false)
+    }
+
+    @MainActor
+    public func testLifecycleDelegate() async {
+        let delegate = LifecycleDelegate()
+
+        autoreleasepool {
+            let view = TestView(delegate: delegate)
+            rootView = view
+        }
+        
+        await expect { delegate.viewWillAppearCallsCount == 1 }
+        
+        rootView = nil
+
+        await expect { delegate.viewWillAppearCallsCount == 1 }
+        await expect { delegate.viewDidDisappearCallsCount == 1 }
+        await expect { delegate.viewWillDeallocCallsCount == 1 }
+    }
+}
+
+private class LifecycleDelegate: CMPComposeContainerLifecycleDelegate {
+    var viewWillAppearCallsCount = 0
+    func composeContainerWillAppear() {
+        viewWillAppearCallsCount += 1
+    }
+    
+    var viewDidDisappearCallsCount = 0
+    func composeContainerDidDisappear() {
+        viewDidDisappearCallsCount += 1
+    }
+    
+    var viewWillDeallocCallsCount = 0
+    func composeContainerWillDealloc() {
+        viewWillDeallocCallsCount += 1
+    }
+}
+
+private class TestView: CMPView {
+    public static var counter: Int = 1
+    
+    private let id: Int
+    
+    public var viewIsInWindowHierarchy: Bool = false
+
+    init(delegate: CMPComposeContainerLifecycleDelegate? = nil) {
+        id = TestView.counter
+        TestView.counter += 1
+        super.init(lifecycleDelegate: delegate)
+    }
+    
+    required init?(coder: NSCoder) {
+        nil
+    }
+    
+    override func viewDidEnterWindowHierarchy() {
+        print("TestView_\(id) didEnterWindowHierarchy")
+        XCTAssertFalse(viewIsInWindowHierarchy)
+        viewIsInWindowHierarchy = true
+    }
+
+    override func viewDidLeaveWindowHierarchy() {
+        super.viewDidLeaveWindowHierarchy()
+        print("TestView_\(id) didLeaveWindowHierarchy")
+        XCTAssertTrue(viewIsInWindowHierarchy)
+        viewIsInWindowHierarchy = false
+    }
+}

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -81,7 +81,6 @@ import platform.UIKit.UIAccessibilityIsReduceMotionEnabled
 import platform.UIKit.UIApplication
 import platform.UIKit.UIStatusBarAnimation
 import platform.UIKit.UIStatusBarStyle
-import platform.UIKit.UITraitCollection
 import platform.UIKit.UIUserInterfaceLayoutDirection
 import platform.UIKit.UIUserInterfaceStyle
 import platform.UIKit.UIViewControllerTransitionCoordinatorProtocol
@@ -201,9 +200,7 @@ internal class ComposeHostingViewController(
         windowContext.updateWindowContainerSize()
     }
 
-    override fun traitCollectionDidChange(previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
+    override fun userInterfaceStyleDidChange() {
         systemThemeState.value = traitCollection.userInterfaceStyle.asComposeSystemTheme()
     }
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.uikit.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.navigationevent.UIKitNavigationEventInput
 import androidx.compose.ui.platform.DefaultArchitectureComponentsOwner
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.MotionDurationScaleImpl
-import androidx.compose.ui.platform.PlatformArchitectureComponentsOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.uikit.ComposeUIViewControllerConfiguration
@@ -54,7 +53,7 @@ import androidx.compose.ui.window.FocusedViewsList
 import androidx.compose.ui.window.MetalRedrawer
 import androidx.compose.ui.window.MetalView
 import androidx.compose.ui.window.SceneActiveStateListener
-import androidx.compose.ui.window.ViewControllerLifecycleDelegate
+import androidx.compose.ui.window.ComposeContainerLifecycleDelegate
 import androidx.lifecycle.enableSavedStateHandles
 import androidx.savedstate.SavedState
 import kotlin.coroutines.CoroutineContext
@@ -97,7 +96,7 @@ internal class ComposeHostingViewController(
     private val configuration: ComposeUIViewControllerConfiguration,
     private val content: @Composable () -> Unit,
     coroutineContext: CoroutineContext = Dispatchers.Main,
-    private val lifecycleDelegate: ViewControllerLifecycleDelegate = ViewControllerLifecycleDelegate()
+    private val lifecycleDelegate: ComposeContainerLifecycleDelegate = ComposeContainerLifecycleDelegate()
 ) : CMPViewController(lifecycleDelegate = lifecycleDelegate) {
     private val hapticFeedback = CupertinoHapticFeedback()
 

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleDelegate.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/ComposeContainerLifecycleDelegate.uikit.kt
@@ -16,15 +16,15 @@
 
 package androidx.compose.ui.window
 
-import androidx.compose.ui.uikit.utils.CMPViewControllerLifecycleDelegateProtocol
+import androidx.compose.ui.uikit.utils.CMPComposeContainerLifecycleDelegateProtocol
 import androidx.lifecycle.Lifecycle
 import platform.Foundation.NSNotificationCenter
 import platform.UIKit.UIWindowScene
 import platform.darwin.NSObject
 
-internal class ViewControllerLifecycleDelegate(
+internal class ComposeContainerLifecycleDelegate(
     private val notificationCenter: NSNotificationCenter = NSNotificationCenter.defaultCenter
-): NSObject(), CMPViewControllerLifecycleDelegateProtocol {
+): NSObject(), CMPComposeContainerLifecycleDelegateProtocol {
     private var isViewAppeared = false
         set(value) {
             field = value
@@ -73,18 +73,18 @@ internal class ViewControllerLifecycleDelegate(
             this.isSceneActive = activeStateListener.isSceneActive
         }
 
-    override fun viewControllerWillDealloc() {
+    override fun composeContainerWillDealloc() {
         this.isDisposed = true
         activeStateListener.dispose()
         foregroundStateListener.dispose()
         windowScene = null
     }
 
-    override fun viewControllerWillAppear() {
+    override fun composeContainerWillAppear() {
         this.isViewAppeared = true
     }
 
-    override fun viewControllerDidDisappear() {
+    override fun composeContainerDidDisappear() {
         this.isViewAppeared = false
     }
 

--- a/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
@@ -32,7 +32,7 @@ class ViewControllerBasedLifecycleOwnerTest {
     fun allEvents() {
         val notificationCenter = NSNotificationCenter()
         val lifecycleOwner = DefaultArchitectureComponentsOwner()
-        val lifecycleDelegate = ViewControllerLifecycleDelegate(notificationCenter)
+        val lifecycleDelegate = ComposeContainerLifecycleDelegate(notificationCenter)
         lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
         val scene = UIWindowScene()
         lifecycleDelegate.windowScene = scene
@@ -72,7 +72,7 @@ class ViewControllerBasedLifecycleOwnerTest {
     fun foregroundThenViewWillAppear() {
         val notificationCenter = NSNotificationCenter()
         val lifecycleOwner = DefaultArchitectureComponentsOwner()
-        val lifecycleDelegate = ViewControllerLifecycleDelegate(notificationCenter)
+        val lifecycleDelegate = ComposeContainerLifecycleDelegate(notificationCenter)
         lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
         val scene = UIWindowScene()
         lifecycleDelegate.windowScene = scene
@@ -89,7 +89,7 @@ class ViewControllerBasedLifecycleOwnerTest {
     fun viewDidDisappearThenBackground() {
         val notificationCenter = NSNotificationCenter()
         val lifecycleOwner = DefaultArchitectureComponentsOwner()
-        val lifecycleDelegate = ViewControllerLifecycleDelegate(notificationCenter)
+        val lifecycleDelegate = ComposeContainerLifecycleDelegate(notificationCenter)
         lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
         val scene = UIWindowScene()
         lifecycleDelegate.windowScene = scene

--- a/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
+++ b/compose/ui/ui/src/uikitTest/kotlin/androidx/compose/ui/window/ViewControllerBasedLifecycleOwnerTest.kt
@@ -41,7 +41,7 @@ class ViewControllerBasedLifecycleOwnerTest {
         notificationCenter.postNotificationName(UISceneWillEnterForegroundNotification, scene)
         assertEquals(Lifecycle.State.CREATED, lifecycleOwner.lifecycle.currentState)
 
-        lifecycleDelegate.viewControllerWillAppear()
+        lifecycleDelegate.composeContainerWillAppear()
         assertEquals(Lifecycle.State.STARTED, lifecycleOwner.lifecycle.currentState)
 
         notificationCenter.postNotificationName(UISceneDidActivateNotification, scene)
@@ -61,10 +61,10 @@ class ViewControllerBasedLifecycleOwnerTest {
         notificationCenter.postNotificationName(UISceneWillEnterForegroundNotification, scene)
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
 
-        lifecycleDelegate.viewControllerDidDisappear()
+        lifecycleDelegate.composeContainerDidDisappear()
         assertEquals(Lifecycle.State.CREATED, lifecycleOwner.lifecycle.currentState)
 
-        lifecycleDelegate.viewControllerWillDealloc()
+        lifecycleDelegate.composeContainerWillDealloc()
         assertEquals(Lifecycle.State.DESTROYED, lifecycleOwner.lifecycle.currentState)
     }
 
@@ -81,7 +81,7 @@ class ViewControllerBasedLifecycleOwnerTest {
         notificationCenter.postNotificationName(UISceneWillEnterForegroundNotification, scene)
         assertEquals(Lifecycle.State.CREATED, lifecycleOwner.lifecycle.currentState)
 
-        lifecycleDelegate.viewControllerWillAppear()
+        lifecycleDelegate.composeContainerWillAppear()
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
     }
 
@@ -93,13 +93,13 @@ class ViewControllerBasedLifecycleOwnerTest {
         lifecycleDelegate.onLifecycleStateUpdated = lifecycleOwner::setLifecycleState
         val scene = UIWindowScene()
         lifecycleDelegate.windowScene = scene
-        lifecycleDelegate.viewControllerWillAppear()
+        lifecycleDelegate.composeContainerWillAppear()
 
         notificationCenter.postNotificationName(UISceneWillEnterForegroundNotification, scene)
         notificationCenter.postNotificationName(UISceneDidActivateNotification, scene)
         assertEquals(Lifecycle.State.RESUMED, lifecycleOwner.lifecycle.currentState)
 
-        lifecycleDelegate.viewControllerDidDisappear()
+        lifecycleDelegate.composeContainerDidDisappear()
         assertEquals(Lifecycle.State.CREATED, lifecycleOwner.lifecycle.currentState)
 
         // this should not happen, but let's protect against it anyway


### PR DESCRIPTION
Preliminary refactoring before the https://youtrack.jetbrains.com/issue/CMP-8478/Implement-UIView-based-compose-injection-API

- Rename `CMPViewControllerLifecycleDelegate` to `CMPComposeContainerLifecycleDelegate` as well as corresponding `ComposeContainerLifecycleDelegate` in Kotlin code.
- Implement UIView-based superclass `CMPView` that able to track visibility based on superview + window combination, similar to the `CMPViewController`.
- Exposes Obj-C interface `userInterfaceStyleDidChange` to monitor changes for various iOS versions

## Release Notes
N/A