### PR TITLE
add commonMain expect fun String.toClipEntry()

### DIFF
--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/AndroidClipboardManager.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/AndroidClipboardManager.android.kt
@@ -108,6 +108,8 @@ actual class ClipEntry(val clipData: ClipData) {
         get() = clipData.description.toClipMetadata()
 }
 
+actual fun String.toClipEntry(): ClipEntry = ClipData.newPlainText(PLAIN_TEXT_LABEL, this).toClipEntry()
+
 fun ClipData.toClipEntry(): ClipEntry = ClipEntry(this)
 
 /**

--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/ClipboardManager.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/platform/ClipboardManager.kt
@@ -86,6 +86,8 @@ expect class ClipEntry {
     val clipMetadata: ClipMetadata
 }
 
+expect fun String.toClipEntry(): ClipEntry
+
 /**
  * Platform specific protocol that describes an item in the native Clipboard. This object should not
  * contain any actual piece of data.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
@@ -21,6 +21,7 @@ import java.awt.HeadlessException
 import java.awt.Toolkit
 import java.awt.datatransfer.ClipboardOwner
 import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
 import java.awt.datatransfer.UnsupportedFlavorException
 
@@ -86,6 +87,8 @@ constructor(
     actual val clipMetadata: ClipMetadata
         get() = TODO("ClipMetadata is not implemented. Consider using nativeClipboard")
 }
+
+actual fun String.toClipEntry(): ClipEntry = ClipEntry(StringSelection(this))
 
 /**
  * Returns a [Transferable] instance if the [ClipEntry.nativeClipEntry]

--- a/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
+++ b/compose/ui/ui/src/jsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.js.kt
@@ -125,6 +125,8 @@ constructor(
     }
 }
 
+actual fun String.toClipEntry(): ClipEntry = ClipEntry.withPlainText(this)
+
 @Suppress("UNUSED_PARAMETER")
 private fun createClipboardItemWithPlainText(text: String): Array<ClipboardItem> =
     js("[new ClipboardItem({'text/plain': new Blob([text], { type: 'text/plain' })})]")

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.macos.kt
@@ -72,3 +72,5 @@ actual class ClipEntry internal constructor() {
         }
     }
 }
+
+actual fun String.toClipEntry(): ClipEntry = ClipEntry.withPlainText(this)

--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.uikit.kt
@@ -81,3 +81,5 @@ actual class ClipEntry internal constructor() {
         }
     }
 }
+
+actual fun String.toClipEntry(): ClipEntry = ClipEntry.withPlainText(this)

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.wasm.kt
@@ -127,6 +127,8 @@ constructor(
     }
 }
 
+actual fun String.toClipEntry(): ClipEntry = ClipEntry.withPlainText(this)
+
 @Suppress("UNUSED_PARAMETER")
 private fun createClipboardItemWithPlainText(text: String): JsArray<ClipboardItem> =
     js("[new ClipboardItem({'text/plain': new Blob([text], { type: 'text/plain' })})]")


### PR DESCRIPTION
When using LocalClipboard, I discovered that different platforms require different ClipEntry implementations, so I extracted this String.toClipEntry() extension function
