### PR TITLE
Copy Jetpack window-core `1.5.1`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -119,7 +119,7 @@ artifactRedirection.version.androidx.navigation3=1.0.0-rc01
 artifactRedirection.version.androidx.navigationevent=1.0.0-rc01
 artifactRedirection.version.androidx.performance=1.0.0-alpha01
 artifactRedirection.version.androidx.savedstate=1.4.0
-artifactRedirection.version.androidx.window=1.5.0
+artifactRedirection.version.androidx.window=1.5.1
 
 # Enable atomicfu IR transformations
 kotlinx.atomicfu.enableJvmIrTransformation=true

--- a/libraryversions.toml
+++ b/libraryversions.toml
@@ -170,7 +170,7 @@ WEAR_TOOLING_PREVIEW = "1.0.0-rc01"
 WEAR_WATCHFACE = "1.3.0-alpha04"
 WEBKIT = "1.12.0-beta01"
 # Adding a comment to prevent merge conflicts for Window artifact
-WINDOW = "1.5.0"
+WINDOW = "1.5.1"
 WINDOW_EXTENSIONS = "1.4.0-beta01"
 WINDOW_EXTENSIONS_CORE = "1.1.0-alpha01"
 WINDOW_SIDECAR = "1.0.0-rc01"


### PR DESCRIPTION
[CMP-9298](https://youtrack.jetbrains.com/issue/CMP-9298) Merge Jetpack window-core 1.5.1

| GroupId | ReleaseVersion | ReleaseSHA | ReleaseBuildId | ReleaseDate |
| --- | --- | --- | --- | --- |
| androidx.window | 1.5.1 | be8b763fe78ab805aa1c9a3bff09f1ff8081dbb2 | 14377426 | 11/19/2025 |

## Release Notes
N/A
