### PR TITLE
[CMP-9329] Allow copying only when selection is not empty

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -236,7 +236,8 @@ private fun TextFieldSelectionState.textManager(coroutineScope: CoroutineScope):
 private val SelectionManager.textManager: TextManager get() = object : TextManager {
     override val selectedText get() = getSelectedText() ?: AnnotatedString("")
     override val cut = null
-    override val copy = { copy() }
+    override val copy
+        get() = if (selectedText.isNotEmpty()) this@textManager::copy else null
     override val paste = null
     override val selectAll = null
     override fun selectWordAtPositionIfNotAlreadySelected(offset: Offset) {

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -237,7 +237,7 @@ private val SelectionManager.textManager: TextManager get() = object : TextManag
     override val selectedText get() = getSelectedText() ?: AnnotatedString("")
     override val cut = null
     override val copy
-        get() = if (selectedText.isNotEmpty()) this@textManager::copy else null
+        get() = if (isNonEmptySelection()) this@textManager::copy else null
     override val paste = null
     override val selectAll = null
     override fun selectWordAtPositionIfNotAlreadySelected(offset: Offset) {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -17,8 +17,11 @@
 package androidx.compose.foundation
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -46,6 +49,7 @@ import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
 import androidx.navigationevent.DirectNavigationEventInput
 import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import java.awt.datatransfer.StringSelection
@@ -228,13 +232,38 @@ class ContextMenuTest {
             }
         }
 
-        onNodeWithTag("textfield").performMouseInput { rightClick(Offset(1f, height/2f)) }
+        onNodeWithTag("textfield").performMouseInput { rightClick(Offset(1f, height / 2f)) }
         onNodeWithText(localization.copy).apply {
             assertExists()
             performClick()
             assertDoesNotExist()
         }
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9329
+    @Test
+    fun `contextMenuArea does not show copy action for SelectionContainer with empty selection`() =
+        runContextMenuTest {
+            val localization = object : PlatformLocalization {
+                override val copy = "copy"
+                override val cut = "cut"
+                override val paste = "paste"
+                override val selectAll = "selectAll"
+            }
+
+            setContent {
+                CompositionLocalProvider(LocalLocalization provides localization) {
+                    SelectionContainer {
+                        BasicText("Hello, row 1")
+                        Box(Modifier.testTag("box").size(16.dp))
+                        BasicText("Hello, row 2")
+                    }
+                }
+            }
+
+            onNodeWithTag("box").performMouseInput { rightClick() }
+            onNodeWithText(localization.copy).assertDoesNotExist()
+        }
 
     private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
         DesktopPlatform.withOverriddenCurrent(DesktopPlatform.Unknown) {


### PR DESCRIPTION
This changes the `SelectionManager.textManager` implementation for `SelectionContainer`s in `ContextMenu.desktop.kt`, so that the copy action is only available when the selected text is not empty.

This lets implementors of `TextContextMenu` decide whether they want to show a disabled copy action in the menu, or not.

Describe proposed changes and the issue being fixed

Fixes CMP-9329

## Testing
```kotlin
fun main() = singleWindowApplication {
    SelectionContainer {
        Column(Modifier.padding(16.dp)) {
            Text("Hello hello")
            Spacer(Modifier.height(20.dp))
            Text("I am selectable, too")
        }
    }
}
```

Working as intended after the change (no menu showing when there is no selection), at the net of [CMP-9342](https://youtrack.jetbrains.com/issue/CMP-9342/Text-context-menus-pop-up-after-the-fact) — which is an existing issue, not a regression. It was only masked by the issue this fixes.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Only provide a copy action in `SelectionContainer` context menu when there is a non-empty selection