### PR TITLE
[CMP-9342] Fix text context menus

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -104,12 +104,19 @@ class DefaultContextMenuRepresentation(
                     hoverColor = itemHoverColor,
                 )
             }
-            DefaultOpenContextMenu(
-                session = session,
-                components = components,
-                popupPositionProvider = rememberPopupPositionProviderAtPosition(status.rect.center),
-                colors = colors,
-            )
+
+            if (components.isNotEmpty()) {
+                DefaultOpenContextMenu(
+                    session = session,
+                    components = components,
+                    popupPositionProvider = rememberPopupPositionProviderAtPosition(status.rect.center),
+                    colors = colors,
+                )
+            } else {
+                // Prevent the menu from popping up as soon as there is a non-empty menu items list
+                // E.g., if you start typing, or select something.
+                session.close()
+            }
         }
     }
 }
@@ -143,26 +150,31 @@ class JPopupContextMenuRepresentation(
     override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
         val isOpen = state.status is ContextMenuState.Status.Open
         if (isOpen) {
+            // CMP-9343: should we key the remember on state, items, and createMenu?
+            // What about if it does recompute, how do we dismiss the previous menu?
             val menu = remember {
-                createMenu(items()).apply {
-                    addPopupMenuListener(object : PopupMenuListener {
-                        override fun popupMenuWillBecomeVisible(e: PopupMenuEvent?) = Unit
+                val menuItems = items()
+                if (menuItems.isNotEmpty()) {
+                    createMenu(menuItems).apply {
+                        addPopupMenuListener(object : PopupMenuListener {
+                            override fun popupMenuWillBecomeVisible(e: PopupMenuEvent?) = Unit
 
-                        override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent?) {
-                            state.status = ContextMenuState.Status.Closed
-                        }
+                            override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent?) {
+                                state.status = ContextMenuState.Status.Closed
+                            }
 
-                        override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
-                    })
-                }
+                            override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
+                        })
+                    }
+                } else null
             }
 
             DisposableEffect(Unit) {
                 val mousePosition = MouseInfo.getPointerInfo().location
                 SwingUtilities.convertPointFromScreen(mousePosition, owner)
-                menu.show(owner, mousePosition.x, mousePosition.y)
+                menu?.show(owner, mousePosition.x, mousePosition.y)
                 onDispose {
-                    menu.isVisible = false
+                    menu?.isVisible = false
                 }
             }
         }

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -236,7 +236,8 @@ private fun TextFieldSelectionState.textManager(coroutineScope: CoroutineScope):
 private val SelectionManager.textManager: TextManager get() = object : TextManager {
     override val selectedText get() = getSelectedText() ?: AnnotatedString("")
     override val cut = null
-    override val copy = { copy() }
+    override val copy
+        get() = if (selectedText.isNotEmpty()) this@textManager::copy else null
     override val paste = null
     override val selectAll = null
     override fun selectWordAtPositionIfNotAlreadySelected(offset: Offset) {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -17,8 +17,11 @@
 package androidx.compose.foundation
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -46,6 +49,7 @@ import androidx.compose.ui.test.rightClick
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
 import androidx.navigationevent.DirectNavigationEventInput
 import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import java.awt.datatransfer.StringSelection
@@ -228,13 +232,38 @@ class ContextMenuTest {
             }
         }
 
-        onNodeWithTag("textfield").performMouseInput { rightClick(Offset(1f, height/2f)) }
+        onNodeWithTag("textfield").performMouseInput { rightClick(Offset(1f, height / 2f)) }
         onNodeWithText(localization.copy).apply {
             assertExists()
             performClick()
             assertDoesNotExist()
         }
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9329
+    @Test
+    fun `contextMenuArea does not show copy action for SelectionContainer with empty selection`() =
+        runContextMenuTest {
+            val localization = object : PlatformLocalization {
+                override val copy = "copy"
+                override val cut = "cut"
+                override val paste = "paste"
+                override val selectAll = "selectAll"
+            }
+
+            setContent {
+                CompositionLocalProvider(LocalLocalization provides localization) {
+                    SelectionContainer {
+                        BasicText("Hello, row 1")
+                        Box(Modifier.testTag("box").size(16.dp))
+                        BasicText("Hello, row 2")
+                    }
+                }
+            }
+
+            onNodeWithTag("box").performMouseInput { rightClick() }
+            onNodeWithText(localization.copy).assertDoesNotExist()
+        }
 
     private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
         DesktopPlatform.withOverriddenCurrent(DesktopPlatform.Unknown) {

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -52,7 +52,10 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.navigationevent.DirectNavigationEventInput
 import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
 import kotlin.test.assertEquals
 import org.junit.Test
 
@@ -265,9 +268,133 @@ class ContextMenuTest {
             onNodeWithText(localization.copy).assertDoesNotExist()
         }
 
+    // https://youtrack.jetbrains.com/issue/CMP-9342
+    @Test
+    fun `contextMenuArea does not show context menu for SelectionContainer with empty selection`() =
+        runContextMenuTest {
+            setContent {
+                SelectionContainer {
+                    BasicText("Hello, row 1")
+                    Box(Modifier.testTag("box").size(16.dp))
+                    BasicText("Hello, row 2")
+                }
+            }
+
+            onNodeWithTag("box").performMouseInput { rightClick() }
+            onNodeWithTag(DefaultOpenContextMenuTestTag).assertDoesNotExist()
+        }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9342
+    @Test
+    fun `contextMenuArea does not show context menu for SelectionContainer after changing selection`() =
+        runContextMenuTest {
+            setContent {
+                SelectionContainer {
+                    BasicText("Hello, row 1")
+                    Box(Modifier.testTag("box").size(16.dp))
+                    BasicText("Hello, row 2", Modifier.testTag("text"))
+                }
+            }
+
+            onNodeWithTag("box").performMouseInput { rightClick() }
+            onNodeWithTag(DefaultOpenContextMenuTestTag).assertDoesNotExist()
+
+            // Create a selection by dragging over the second text
+            onNodeWithTag("text").performMouseInput {
+                moveTo(Offset(1f, 5f))
+                press()
+                moveBy(Offset(50f, 5f))
+                release()
+            }
+            onNodeWithTag(DefaultOpenContextMenuTestTag).assertDoesNotExist()
+        }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9342
+    @Test
+    fun `contextMenuArea does not show context menu for BTF with empty selection`() =
+        `contextMenuArea does not show context menu for text field with empty selection`(useBtf2 = false)
+
+    // https://youtrack.jetbrains.com/issue/CMP-9342
+    @Test
+    fun `contextMenuArea does not show context menu for BTF2 with empty selection`() =
+        `contextMenuArea does not show context menu for text field with empty selection`(useBtf2 = true)
+
+    private fun `contextMenuArea does not show context menu for text field with empty selection`(useBtf2: Boolean) = runContextMenuTest {
+        setContent {
+            if (useBtf2) {
+                BasicTextField(
+                    rememberTextFieldState("", initialSelection = TextRange(0, 4)),
+                    Modifier.testTag("textfield")
+                )
+            } else {
+                BasicTextField(
+                    value = TextFieldValue("", selection = TextRange(0, 4)),
+                    onValueChange = {},
+                    modifier = Modifier.testTag("textfield")
+                )
+            }
+        }
+
+        clearAwtClipboard() // Required to force no menu to show up
+
+        onNodeWithTag("textfield").performMouseInput { rightClick() }
+        onNodeWithTag(DefaultOpenContextMenuTestTag).assertDoesNotExist()
+    }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9342
+    @Test
+    fun `contextMenuArea does not show context menu for BTF after changing selection`() =
+        `contextMenuArea does not show context menu for text field after changing selection`(useBtf2 = false)
+
+    // https://youtrack.jetbrains.com/issue/CMP-9342
+    @Test
+    fun `contextMenuArea does not show context menu for BTF2 after changing selection`() =
+        `contextMenuArea does not show context menu for text field after changing selection`(useBtf2 = true)
+
+        private fun `contextMenuArea does not show context menu for text field after changing selection`(useBtf2: Boolean) = runContextMenuTest {
+            setContent {
+                if (useBtf2) {
+                    BasicTextField(
+                        rememberTextFieldState(""),
+                        Modifier.testTag("textfield")
+                    )
+                } else {
+                    BasicTextField(
+                        value = TextFieldValue(""),
+                        onValueChange = {},
+                        modifier = Modifier.testTag("textfield")
+                    )
+                }
+            }
+
+            clearAwtClipboard() // Required to force no menu to show up
+            
+            onNodeWithTag("textfield").performMouseInput { rightClick() }
+            onNodeWithTag(DefaultOpenContextMenuTestTag).assertDoesNotExist()
+
+            // Create a selection by dragging over the second text
+            onNodeWithTag("textfield").performMouseInput {
+                moveTo(Offset(1f, 5f))
+                press()
+                moveBy(Offset(50f, 5f))
+                release()
+            }
+            onNodeWithTag(DefaultOpenContextMenuTestTag).assertDoesNotExist()
+        }
+
     private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
         DesktopPlatform.withOverriddenCurrent(DesktopPlatform.Unknown) {
             block()
         }
+    }
+
+    private fun clearAwtClipboard() {
+        Toolkit.getDefaultToolkit().systemClipboard.setContents(object: Transferable {
+            override fun getTransferDataFlavors(): Array<out DataFlavor?>? = null
+
+            override fun isDataFlavorSupported(flavor: DataFlavor?): Boolean = false
+
+            override fun getTransferData(flavor: DataFlavor?): Any = error("not implemented")
+        }, null)
     }
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
@@ -104,6 +105,7 @@ internal fun DefaultOpenContextMenu(
                 .padding(vertical = 4.dp)
                 .width(IntrinsicSize.Max)
                 .verticalScroll(rememberScrollState())
+                .testTag(DefaultOpenContextMenuTestTag)
         ) {
             components.forEach { component ->
                 when (component) {
@@ -116,6 +118,8 @@ internal fun DefaultOpenContextMenu(
         }
     }
 }
+
+internal const val DefaultOpenContextMenuTestTag = "__DefaultOpenContextMenu"
 
 @Composable
 private fun MenuSeparator(color: Color) {


### PR DESCRIPTION
This fixes two issues with text context menus:

### 1. The menu should not show if it's empty
If the context menu has no items, it should not show. This is easily achieved by only popping up the menu if the items list is not empty.

### 2. The menu should not pop up "after the fact"
Once 1 is fixed, there is another issue that crops up: the menu which was not popped up initially, becomes visible as soon as there would be items in it. For example, if no menu pops up in a `SelectionContainer` if the user right-clicks an empty spot, but then does
a selection. Same for BTF, if the user types any text in an initially-empty BTF after right clicking it.

This is done by explicitly closing the menu session if it contains no items.

Note: `JPopupContextMenuRepresentation` works differently and this only explicitly fixes #1 for it. Due to it being a completely different implementation, this does not really suffer from #2

Fixes [CMP-9342](https://youtrack.jetbrains.com/issue/CMP-9342)

> [!IMPORTANT]
> This requires CMP-9229 (https://github.com/JetBrains/compose-multiplatform-core/pull/2595) to be merged first

## Testing
```kotlin
fun main() = singleWindowApplication {
    Column(Modifier.padding(16.dp)) {
        SelectionContainer {
            Column {
                Text("Hello hello")
                Spacer(Modifier.height(20.dp))
                Text("I am selectable, too")
            }
        }
        Spacer(Modifier.height(20.dp))
        BasicTextField(
            rememberTextFieldState(),
            Modifier.background(Color.White).border(1.dp, Color.Gray).padding(4.dp)
        )
    }
}
```

https://github.com/user-attachments/assets/cd75a170-35cd-4aac-be95-e4e561b3aadc

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed empty context menu showing up when right clicking an empty text selection, or an empty BTF when there is no text in the clipboard
