### PR TITLE
Fallback to empty line metrics in case if skia doesn't return real metrics

### DIFF
--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/DesktopParagraphTest.kt
@@ -484,6 +484,56 @@ class DesktopParagraphTest {
     }
 
     @Test
+    fun getLineForOffset_empty() {
+        val text = ""
+        val paragraph = simpleParagraph(
+            text = text,
+            style = TextStyle(fontSize = 50.sp)
+        )
+
+        assertThat(paragraph.getLineForOffset(0))
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun getLineForOffset_withOnlyPlaceholder() {
+        val text = buildAnnotatedString {
+            pushStringAnnotation("test", "a")
+            append("\uFFFD")
+            pop()
+        }
+
+        val intrinsics = ParagraphIntrinsics(
+            text = text.text,
+            style = TextStyle(
+                fontSize = 50.sp,
+                fontFamily = fontFamilyMeasureFont,
+            ),
+            annotations = listOf(
+                AnnotatedString.Range(
+                    item = StringAnnotation("a"),
+                    start = 0,
+                    end = 1,
+                    tag = "test",
+                )
+            ),
+            placeholders = listOf(
+                AnnotatedString.Range(
+                    item = Placeholder(40.0.sp, 16.0.sp, PlaceholderVerticalAlign.Center),
+                    start = 0,
+                    end = 1,
+                    tag = "test",
+                )
+            ),
+            density = defaultDensity,
+            fontFamilyResolver = fontFamilyResolver,
+        )
+        val paragraph = simpleParagraph(intrinsics)
+        assertThat(paragraph.getLineForOffset(0))
+            .isEqualTo(0)
+    }
+
+    @Test
     fun getLineEnd() {
         with(defaultDensity) {
             val text = ""

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -332,17 +332,18 @@ internal class SkiaParagraph(
         val lineMetrics = if (text.isEmpty()) {
             layouter.emptyLineMetrics(paragraph)
         } else {
-            // This creates a new objects every time
+            // This getter creates a new object every time
             paragraph.lineMetrics
+                // In the case of annotated text where everything is replaced by placeholders,
+                // the line metrics may be empty
+                .ifEmpty { layouter.emptyLineMetrics(paragraph) }
         }
 
         val fontMetrics = defaultFont.metrics
-        if (lineMetrics.isNotEmpty()) {
-            lineMetrics[0] = lineMetrics[0]
-                .trimFirstAscent(fontMetrics, layouter.textStyle)
-            lineMetrics[lineMetrics.size - 1] = lineMetrics[lineMetrics.size - 1]
-                .trimLastDescent(fontMetrics, layouter.textStyle)
-        }
+        lineMetrics[0] = lineMetrics[0]
+            .trimFirstAscent(fontMetrics, layouter.textStyle)
+        lineMetrics[lineMetrics.size - 1] = lineMetrics[lineMetrics.size - 1]
+            .trimLastDescent(fontMetrics, layouter.textStyle)
 
         return lineMetrics
     }


### PR DESCRIPTION
[CMP-9345](https://youtrack.jetbrains.com/issue/CMP-9345) Compose application crashes when selecting text that only contains inline content

## Release Notes
### Fixes - Multiple Platforms
- Fix crash when selecting text that only contains inline content
