### PR TITLE
[Cherry-pick] Trigger focus update when accessibility elements loaded (#2603)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -1037,6 +1037,8 @@ internal class AccessibilityMediator(
     private val accessibilityElementsMap =
         mutableMapOf<AccessibilityElementKey, AccessibilityElement>()
 
+    private var updateFocusOnAccessibilityElementsLoaded = false
+
     var isEnabled: Boolean = false
         set(value) {
             if (field != value) {
@@ -1044,6 +1046,8 @@ internal class AccessibilityMediator(
                 onSemanticsChange()
 
                 UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, null)
+
+                updateFocusOnAccessibilityElementsLoaded = value
             }
         }
 
@@ -1092,7 +1096,6 @@ internal class AccessibilityMediator(
                 )
             }
         }
-
     }
 
     /**
@@ -1563,6 +1566,12 @@ internal class AccessibilityMediator(
             focusedElementKey?.let {
                 focusMode = AccessibilityElementFocusMode.Focus(it)
             }
+        }
+
+        val isSemanticsTreeLoaded = accessibilityElementsMap.size > 1
+        if (isSemanticsTreeLoaded && updateFocusOnAccessibilityElementsLoaded) {
+            view.window?.setNeedsFocusUpdate()
+            updateFocusOnAccessibilityElementsLoaded = false
         }
 
         return updateFocusedElement()


### PR DESCRIPTION
Fixes
https://youtrack.jetbrains.com/issue/CMP-9339/iOS-With-an-external-keyboard.-Dialogs-Popups-dont-close-when-pressing-Esc

## Release Notes
### Fixes - iOS
- Fix focusing of `Dialog` and `Popup` when the Full Keyboard Mode is enabled