### PR TITLE
Fix crash in Accessibility when SemanticNode is not attached

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/platform/Accessibility.uikit.kt
@@ -508,11 +508,12 @@ private class AccessibilityElement(
 
     val key: AccessibilityElementKey get() = node.key
 
+    private var disposed = false
+
     /**
      * Indicates whether this element is still present in the tree.
      */
-    var isAlive = true
-        private set
+    private val isAlive get() = !disposed && node.semanticsNode.isValid
 
     init {
         setAccessibilityElements(children + nodeSemanticsElements())
@@ -547,11 +548,11 @@ private class AccessibilityElement(
     }
 
     fun dispose() {
-        check(isAlive) {
+        check(!disposed) {
             "AccessibilityElement is already disposed"
         }
 
-        isAlive = false
+        disposed = true
         setAccessibilityContainer(null)
         setAccessibilityElements(emptyList<Any>())
         if (available(OS.Ios to OSVersion(major = 17))) {
@@ -698,6 +699,10 @@ private class AccessibilityElement(
         context: UIFocusUpdateContext,
         withAnimationCoordinator: UIFocusAnimationCoordinator
     ) {
+        if (!isAlive) {
+            return
+        }
+
         if (context.previouslyFocusedItem === this) {
             node.didResignFocused()
         }


### PR DESCRIPTION
Do not send actions to the semantics elements that are not attached or disposed.
Fixes [https://youtrack.jetbrains.com/issue/CMP-9359/Crash-in-Accessibility-Cannot-read-Composi[…]Local-because-the-Modifier-node-is-not-currently-attached](https://youtrack.jetbrains.com/issue/CMP-9359/Crash-in-Accessibility-Cannot-read-CompositionLocal-because-the-Modifier-node-is-not-currently-attached)

## Release Notes
### Fixes - iOS
- Fix crash in Accessibility when SemanticNode is not attached
