### PR TITLE
Fix navigation labels in mpp sample

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
@@ -35,16 +35,16 @@ import androidx.compose.mpp.demo.textfield.TextFields
 
 private val MaterialComponents = Screen.Selection(
     "material",
-    Screen.Example("AlertDialog") { AlertDialogExample() },
-    Screen.Example("DropdownMenu") { DropdownMenuExample() },
+    Screen.Example("AlertDialog2") { AlertDialogExample() },
+    Screen.Example("DropdownMenu2") { DropdownMenuExample() },
 )
 
 private val Material3Components = Screen.Selection(
     "material3",
-    Screen.Example("AlertDialog") { AlertDialog3Example() },
+    Screen.Example("AlertDialog3") { AlertDialog3Example() },
     Screen.Example("BottomSheetScaffold") { BottomSheetScaffoldExample() },
     Screen.Example("Date & Time Pickers") { DateTimePickerExample() },
-    Screen.Example("DropdownMenu") { DropdownMenu3Example() },
+    Screen.Example("DropdownMenu3") { DropdownMenu3Example() },
     Screen.Example("ModalBottomSheet") { ModalBottomSheet3Example() },
     Screen.Example("ModalNavigationDrawer") { ModalNavigationDrawerExample() },
     Screen.Example("SearchBar") { SearchBarExample() },


### PR DESCRIPTION
In mpp, titles are used as navigation labels that are supposed to be unique. Currently, it's not possible to open material sample pages because they are overwritten by material3 samples. These labels are not supposed to be reused in UI, but for simplicity reasons we can just make them unique

## Release Notes
N/A
