### PR TITLE
Fix AwtPlatformClipboard.nativeClipboard crash in headless mode

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/internal/ClipboardUtils.desktop.kt
@@ -21,10 +21,10 @@ package androidx.compose.foundation.internal
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.NativeClipboard
+import androidx.compose.ui.platform.Clipboard
 import androidx.compose.ui.platform.asAwtTransferable
+import androidx.compose.ui.platform.awtClipboard
 import androidx.compose.ui.text.AnnotatedString
-import java.awt.datatransfer.Clipboard
 import java.awt.datatransfer.ClipboardOwner
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.Transferable
@@ -88,16 +88,14 @@ internal actual fun ClipEntry?.hasText(): Boolean {
     return transferable.isDataFlavorSupported(DataFlavor.stringFlavor)
 }
 
-internal actual fun androidx.compose.ui.platform.Clipboard.isReadSupported(): Boolean = true
-internal actual fun androidx.compose.ui.platform.Clipboard.isWriteSupported(): Boolean = true
+internal actual fun Clipboard.isReadSupported(): Boolean = true
+internal actual fun Clipboard.isWriteSupported(): Boolean = true
 
 // Here we rely on the NativeClipboard directly instead of using ClipEntry,
 // because getClipEntry is a suspend function, but in ContextMenu.desktop.kt we have older code
 // expecting a synchronous execution.
-// Note: the name can't be just `hasText` because NativeClipboard is a typealias to Any,
-// so it would conflict with ClipEntry?.hasText declaration. Therefore, we need a unique name.
-internal fun NativeClipboard.nativeClipboardHasText(): Boolean {
-    val awtClipboard = this as? Clipboard ?: return false
+internal fun Clipboard.nativeClipboardHasText(): Boolean {
+    val awtClipboard = awtClipboard ?: return false
     return awtClipboard.isDataFlavorAvailable(DataFlavor.stringFlavor)
 }
 
@@ -118,7 +116,7 @@ internal class AnnotatedStringTransferable(
             else -> throw UnsupportedFlavorException(flavor)
         }
 
-    override fun lostOwnership(clipboard: Clipboard?, contents: Transferable?) {
+    override fun lostOwnership(clipboard: java.awt.datatransfer.Clipboard?, contents: Transferable?) {
         // Empty
     }
 

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/ContextMenu.desktop.kt
@@ -158,7 +158,7 @@ private val TextFieldSelectionManager.textManager: TextManager get() = object : 
         }
 
     override val paste: (() -> Unit)? get() =
-        if (editable && clipboard?.nativeClipboard?.nativeClipboardHasText() == true) {
+        if (editable && clipboard?.nativeClipboardHasText() == true) {
             {
                 paste()
                 focusRequester?.requestFocus()

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.desktop.kt
@@ -28,9 +28,11 @@ import androidx.compose.foundation.text.contextmenu.builder.TextContextMenuBuild
 import androidx.compose.foundation.text.contextmenu.builder.item
 import androidx.compose.foundation.text.contextmenu.modifier.addTextContextMenuComponentsWithLocalization
 import androidx.compose.foundation.text.selection.MouseSelectionObserver
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.awtClipboard
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
@@ -97,9 +99,9 @@ internal actual class ClipboardPasteState actual constructor(private val clipboa
     actual val hasText: Boolean get() = _hasText
     actual val hasClip: Boolean get() = _hasClip
 
+    @OptIn(ExperimentalComposeUiApi::class)
     actual suspend fun update() {
-        val nativeClipboard = (clipboard.nativeClipboard as? java.awt.datatransfer.Clipboard)
-        _hasClip = nativeClipboard?.availableDataFlavors?.isNotEmpty() ?: false
-        _hasText = nativeClipboard?.nativeClipboardHasText() ?: false
+        _hasClip = clipboard.awtClipboard?.availableDataFlavors?.isNotEmpty() ?: false
+        _hasText = clipboard.nativeClipboardHasText()
     }
 }

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -514,17 +514,16 @@ tasks.register("desktopHeadlessTest", Test) {
     testClassesDirs = sourceSets.desktopTest.output.classesDirs
     classpath = sourceSets.desktopTest.runtimeClasspath
 
-    filter {
-        includeTestsMatching("androidx.compose.ui.platform.HeadlessClipboardTest")
+    useJUnit {
+        includeCategories("androidx.compose.ui.HeadlessTest")
     }
     systemProperty("java.awt.headless", "true")
 }
 
 tasks.desktopTest {
-    filter {
-        excludeTestsMatching("androidx.compose.ui.platform.HeadlessClipboardTest")
+    useJUnit {
+        excludeCategories("androidx.compose.ui.HeadlessTest")
     }
-
     finalizedBy("desktopHeadlessTest")
 }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -510,6 +510,24 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
     }
 }
 
+tasks.register("desktopHeadlessTest", Test) {
+    testClassesDirs = sourceSets.desktopTest.output.classesDirs
+    classpath = sourceSets.desktopTest.runtimeClasspath
+
+    filter {
+        includeTestsMatching("androidx.compose.ui.platform.HeadlessClipboardTest")
+    }
+    systemProperty("java.awt.headless", "true")
+}
+
+tasks.desktopTest {
+    filter {
+        excludeTestsMatching("androidx.compose.ui.platform.HeadlessClipboardTest")
+    }
+
+    finalizedBy("desktopHeadlessTest")
+}
+
 android {
     testOptions.unitTests.includeAndroidResources = true
     buildTypes.all {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/PlatformClipboard.desktop.kt
@@ -57,12 +57,16 @@ internal class AwtPlatformClipboard internal constructor() : Clipboard {
      * See [awtClipboard] to access [java.awt.datatransfer.Clipboard].
      */
     override val nativeClipboard: NativeClipboard
-        get() = systemClipboard ?: error("systemClipboard is not available in headless mode")
+        get() = systemClipboard ?: NoClipboard
 }
 
 /**
+ * The object returned as the [NativeClipboard] when [AwtPlatformClipboard.systemClipboard] is null.
+ */
+private data object NoClipboard
+
+/**
  * Returns [java.awt.datatransfer.Clipboard] instance if it's available, or null otherwise.
- * It might throw an exception when accessed in a headless mode.
  */
 @ExperimentalComposeUiApi
 val Clipboard.awtClipboard: java.awt.datatransfer.Clipboard?

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/HeadlessTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/HeadlessTest.kt
@@ -14,46 +14,23 @@
  * limitations under the License.
  */
 
-package androidx.compose.ui.platform
+package androidx.compose.ui
 
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import java.awt.GraphicsEnvironment
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import org.junit.BeforeClass
-import org.junit.Test
+
+/**
+ * Marker interface for tests that should be run in headless mode.
+ */
+interface HeadlessTest
 
 
-@OptIn(ExperimentalTestApi::class)
-class HeadlessClipboardTest {
-
-    companion object {
-
-        // Typically this is set in Gradle, but also set it here to allow adhoc running the tests
-        // from the IDE
-        @JvmStatic
-        @BeforeClass
-        fun setUpHeadless() {
-            System.setProperty("java.awt.headless", "true")
-        }
-
-    }
-
-    @Test
-    fun nativeClipboardDoesNotCrash() = runHeadlessComposeUiTest {
-        lateinit var clipboard: Clipboard
-        setContent {
-            clipboard = LocalClipboard.current
-        }
-
-        clipboard.nativeClipboard  // Just check it doesn't crash
-        assertEquals(null, clipboard.awtClipboard)
-    }
-}
-
-
+/**
+ * Runs [runComposeUiTest] but first verifies that the test is executed in headless mode.
+ */
 @OptIn(ExperimentalTestApi::class)
 internal fun runHeadlessComposeUiTest(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
     assertTrue(GraphicsEnvironment.isHeadless(), "This is a headless test, but it's run not in headless mode")

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/ClipboardTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/ClipboardTest.kt
@@ -16,7 +16,10 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.ui.HeadlessTest
 import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.runHeadlessComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.window.WindowTestScope
 import androidx.compose.ui.window.runApplicationTest
 import java.awt.Dimension
@@ -28,7 +31,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 
+@OptIn(ExperimentalTestApi::class)
 class ClipboardTest {
 
     var clipboard: Clipboard? = null
@@ -91,5 +96,17 @@ class ClipboardTest {
         } finally {
             window.dispose()
         }
+    }
+
+    @Test
+    @Category(HeadlessTest::class)
+    fun nativeClipboardDoesNotCrash() = runHeadlessComposeUiTest {
+        lateinit var clipboard: Clipboard
+        setContent {
+            clipboard = LocalClipboard.current
+        }
+
+        clipboard.nativeClipboard  // Just check it doesn't crash
+        assertEquals(null, clipboard.awtClipboard)
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/HeadlessClipboardTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/HeadlessClipboardTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import java.awt.GraphicsEnvironment
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.BeforeClass
+import org.junit.Test
+
+
+@OptIn(ExperimentalTestApi::class)
+class HeadlessClipboardTest {
+
+    companion object {
+
+        // Typically this is set in Gradle, but also set it here to allow adhoc running the tests
+        // from the IDE
+        @JvmStatic
+        @BeforeClass
+        fun setUpHeadless() {
+            System.setProperty("java.awt.headless", "true")
+        }
+
+    }
+
+    @Test
+    fun nativeClipboardDoesNotCrash() = runHeadlessComposeUiTest {
+        lateinit var clipboard: Clipboard
+        setContent {
+            clipboard = LocalClipboard.current
+        }
+
+        clipboard.nativeClipboard  // Just check it doesn't crash
+        assertEquals(null, clipboard.awtClipboard)
+    }
+}
+
+
+@OptIn(ExperimentalTestApi::class)
+internal fun runHeadlessComposeUiTest(block: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
+    assertTrue(GraphicsEnvironment.isHeadless(), "This is a headless test, but it's run not in headless mode")
+    block()
+}


### PR DESCRIPTION
Fix `AwtPlatformClipboard.nativeClipboard` crashing in headless mode.

Fixes https://youtrack.jetbrains.com/issue/CMP-9335

## Testing
Added a unit test

## Release Notes
### Fixes - Desktop
- Fix exception/crash when pasting in `TextField` in headless mode.
