### PR TITLE
Fix AwtCursor's equals and hashCode implementation for custom cursors

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/pointer/PointerIcon.desktop.kt
@@ -28,12 +28,19 @@ internal class AwtCursor(val cursor: Cursor) : PointerIcon {
         // AwtCursor doesn't implement equals
         if (cursor.type != other.cursor.type) return false
 
+        // All custom cursors have the type CUSTOM_CURSOR, so we can only use the type if it's
+        // not CUSTOM_CURSOR
+        if (cursor.type == Cursor.CUSTOM_CURSOR) return cursor === other.cursor
+
         return true
     }
 
     override fun hashCode(): Int {
         // AwtCursor doesn't implement hashCode
-        return cursor.type
+        // Aso, all custom cursors have the type CUSTOM_CURSOR, so we can only use the type if it's
+        // not CUSTOM_CURSOR
+        val type = cursor.type
+        return if (type == Cursor.CUSTOM_CURSOR) System.identityHashCode(cursor) else type.hashCode()
     }
 
     override fun toString(): String {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/pointer/PointerTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/pointer/PointerTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.input.pointer
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toAwtImage
+import androidx.compose.ui.platform.LocalPointerIconService
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import java.awt.Point
+import java.awt.Toolkit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+@OptIn(ExperimentalTestApi::class)
+class PointerTest {
+
+    @Test
+    fun customPointerChanges() = runComposeUiTest {
+        val toolkit = Toolkit.getDefaultToolkit()
+        val icon1 = PointerIcon(
+            toolkit.createCustomCursor(
+                ImageBitmap(32, 32).toAwtImage(),
+                Point(16, 16),
+                "cursor1")
+        )
+        val icon2 = PointerIcon(
+            toolkit.createCustomCursor(
+                ImageBitmap(32, 32).toAwtImage(),
+                Point(0, 0),
+                "cursor2"
+            )
+        )
+
+        var requestedPointer by mutableStateOf(icon1)
+        var pointerService: PointerIconService? = null
+        setContent {
+            pointerService = LocalPointerIconService.current
+            Box(
+                Modifier
+                    .size(100.dp)
+                    .pointerHoverIcon(requestedPointer)
+                    .testTag("box")
+            )
+        }
+
+        assertEquals(PointerIcon.Default, pointerService?.getIcon())
+
+        onNodeWithTag("box").performMouseInput {
+            moveTo(center)
+        }
+        assertSame(icon1, pointerService?.getIcon())
+        requestedPointer = icon2
+        waitForIdle()
+        assertSame(icon2, pointerService?.getIcon())
+    }
+
+}


### PR DESCRIPTION
Fix AwtCursor's equals and hashCode implementation for custom cursors, which prevented changing from one custom cursor to another (because they were `equal`).

Fixes https://youtrack.jetbrains.com/issue/CMP-9371

## Testing
Added a unit test.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix changing the pointer from one custom cursor to another.
