### PR TITLE
Never cache test results

### DIFF
--- a/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/org/jetbrains/androidx/build/JetBrainsAndroidXRootImplPlugin.kt
@@ -22,6 +22,8 @@ import javax.inject.Inject
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.component.SoftwareComponentFactory
+import org.gradle.api.tasks.testing.AbstractTestTask
+import org.gradle.kotlin.dsl.withType
 
 class JetBrainsAndroidXRootImplPlugin @Inject constructor(
     val componentFactory: SoftwareComponentFactory
@@ -31,6 +33,11 @@ class JetBrainsAndroidXRootImplPlugin @Inject constructor(
             it.tasks.configureEach {
                 if (it.name == "kotlinStoreYarnLock") it.enabled = false
                 if (it.name == "kotlinWasmStoreYarnLock") it.enabled = false
+            }
+
+            // Never cache test results
+            it.tasks.withType<AbstractTestTask>().configureEach {
+                it.outputs.upToDateWhen { false }
             }
         }
     }


### PR DESCRIPTION
Never cache test results, since we DO want to always re-run it.
It's better than `--rerun-tasks` because allows to re-use **build** cache

## Release Notes
N/A