### PR TITLE
Fix unnecessary invalidation and redraws on Desktop

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/ApplicationTest.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
-import org.junit.Ignore
 import org.junit.Test
 
 class ApplicationTest {
@@ -266,7 +265,6 @@ class ApplicationTest {
     }
 
     @Test
-    @Ignore // TODO: https://youtrack.jetbrains.com/issue/CMP-9385 , Ignored after merging 1.11.0-alpha01
     fun `onGloballyPositioned is not called repeatedly with same position on screen`() = runApplicationTest(useDelay = true) {
         lateinit var window: ComposeWindow
         val positionsOnScreen = mutableListOf<Offset>()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/WindowInsetsRulers.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/WindowInsetsRulers.skiko.kt
@@ -58,17 +58,10 @@ internal actual fun findInsetsAnimationProperties(
     return NoWindowInsetsAnimation
 }
 
-internal class RulerProviderModifierElement(
+internal data class RulerProviderModifierElement(
     val windowInsets: PlatformWindowInsets
 ): ModifierNodeElement<RulerProviderModifierNode>() {
     override fun create(): RulerProviderModifierNode = RulerProviderModifierNode(windowInsets)
-    override fun hashCode(): Int = windowInsets.hashCode()
-    override fun equals(other: Any?): Boolean {
-        if (other === this) {
-            return true
-        }
-        return (other as? RulerProviderModifierElement)?.windowInsets === windowInsets
-    }
     override fun update(node: RulerProviderModifierNode) {
         node.windowInsets = windowInsets
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/WindowInsetsRulers.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/WindowInsetsRulers.skiko.kt
@@ -83,9 +83,7 @@ internal class RulerProviderModifierNode(
             }
         }
 
-    val rulerLambda: RulerScope.() -> Unit = {
-        val (width, height) = coordinates.size
-
+    fun rulerLambda(width: Int, height: Int): RulerScope.() -> Unit = {
         provideInsetsValues(CaptionBar, windowInsets.captionBar, width, height)
         provideInsetsValues(DisplayCutout, windowInsets.displayCutout, width, height)
         provideInsetsValues(Ime, windowInsets.ime, width, height)
@@ -151,7 +149,7 @@ internal class RulerProviderModifierNode(
         val placeable = measurable.measure(constraints)
         val width = placeable.width
         val height = placeable.height
-        return layout(width, height, rulers = rulerLambda) { placeable.place(0, 0) }
+        return layout(width, height, rulers = rulerLambda(width, height)) { placeable.place(0, 0) }
     }
 
     override val traverseKey: Any

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformWindowInsetsProviderNode.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformWindowInsetsProviderNode.skiko.kt
@@ -70,25 +70,12 @@ abstract class PlatformWindowInsetsProviderNode(
 internal fun Modifier.excludeWindowInsets(safeInsets: Boolean, ime: Boolean) = this.then(
     ExcludedWindowInsetsProviderModifierElement(safeInsets, ime))
 
-private class ExcludedWindowInsetsProviderModifierElement(
+private data class ExcludedWindowInsetsProviderModifierElement(
     private val safeInsets: Boolean,
     private val ime: Boolean,
 ): ModifierNodeElement<ExcludedWindowInsetsProviderNode>() {
     override fun create(): ExcludedWindowInsetsProviderNode = ExcludedWindowInsetsProviderNode(safeInsets, ime)
-
     override fun update(node: ExcludedWindowInsetsProviderNode) = node.update(safeInsets, ime)
-
-    override fun hashCode(): Int {
-        var result = safeInsets.hashCode()
-        result = 31 * result + ime.hashCode()
-        return result
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is ExcludedWindowInsetsProviderModifierElement) return false
-        return safeInsets == other.safeInsets && ime == other.ime
-    }
 }
 
 private class ExcludedWindowInsetsProviderNode(


### PR DESCRIPTION
Fixes unnecessary invalidation and redraws on Desktop caused by WindowInsetsRulers

Fixes [CMP-9399](https://youtrack.jetbrains.com/issue/CMP-9399) WindowInsetsRulers cause invalidations on Desktop
Fixes [CMP-9385](https://youtrack.jetbrains.com/issue/CMP-9385) Fix Desktop ApplicationTest after merging 1.11.0-alpha01
Fixes [CMP-9405](https://youtrack.jetbrains.com/issue/CMP-9405) Investigate failing Desktop ApplicationTest after merging 1.11.0-alpha01

## Testing

`onGloballyPositioned is not called repeatedly with same position on screen` no longer ignored

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix unnecessary redraws caused by `WindowInsetsRulers` implementation using `RulerScope.coordinates.size`
