### PR TITLE
Fix possible text styles cache corruption

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -273,7 +273,7 @@ internal class ParagraphBuilder(
     var drawStyle: DrawStyle? = null,
     var blendMode: BlendMode = DrawScope.DefaultBlendMode
 ) {
-    private val defaultStyle = ComputedStyle()
+    private var defaultStyle = ComputedStyle()
     private lateinit var initialStyle: SpanStyle
     private lateinit var ops: List<Op>
 
@@ -281,7 +281,7 @@ internal class ParagraphBuilder(
         initialStyle = textStyle.toSpanStyle().copyWithDefaultFontSize(
             drawStyle = drawStyle
         )
-        defaultStyle.set(
+        defaultStyle = ComputedStyle(
             density = density,
             spanStyle = initialStyle,
             brushSize = brushSize,


### PR DESCRIPTION
Fixes [CMP-8028](https://youtrack.jetbrains.com/issue/CMP-8028) Text color is sometimes randomly black on iOS when using Compose Multiplatform (BasicText)

It's a minimal, simplified version of #2629

## Testing
- Existing tests on CI
- Reproducer from [CMP-8028](https://youtrack.jetbrains.com/issue/CMP-8028)
```kt
val textMeasurer = rememberTextMeasurer(cacheSize = 100)
Canvas(Modifier.background(Color.DarkGray)) {
    for (i in 0 until 100) {
        drawText(
            textLayoutResult = textMeasurer.measure(text = "$i"),
            color = Color.White,
            topLeft = Offset(x = i % 10 * 50f, y = i / 10 * 50f)
        )
    }
}
```

## Release Notes
### Fixes - iOS
- Fix possible text styles cache corruption (text color is sometimes randomly black)