### PR TITLE
Implement proper WeakReference on Web using JS WeakRef

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/node/WeakReference.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/node/WeakReference.web.kt
@@ -16,13 +16,27 @@
 
 package androidx.compose.ui.node
 
-// TODO: https://youtrack.jetbrains.com/issue/COMPOSE-1286/Properly-implement-WeakReference-on-Web
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.JsReference
+import kotlin.js.get
+import kotlin.js.toJsReference
+import kotlin.js.unsafeCast
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+@OptIn(ExperimentalWasmJsInterop::class)
+private external class WeakRef {
+    constructor(target: JsAny)
+    fun deref(): JsAny?
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
 internal actual class WeakReference<T : Any> actual constructor(referent: T) {
-    private var instance: T? = null
+    private var weakRef: WeakRef? = WeakRef(referent.toJsReference())
+    actual fun get(): T? = weakRef?.deref()?.unsafeCast<JsReference<T>>()?.get()
 
+    // Js WeakRef doesn't have a method for clearing it. So we just drop the WeakRef itself.
     actual fun clear() {
-        instance = null
+        weakRef = null
     }
-
-    actual fun get(): T? = instance
 }

--- a/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/internal/WeakReference.web.kt
+++ b/navigation/navigation-compose/src/webMain/kotlin/androidx/navigation/compose/internal/WeakReference.web.kt
@@ -16,9 +16,27 @@
 
 package androidx.navigation.compose.internal
 
-// TODO: https://youtrack.jetbrains.com/issue/CMP-1286
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.JsReference
+import kotlin.js.get
+import kotlin.js.toJsReference
+import kotlin.js.unsafeCast
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+@OptIn(ExperimentalWasmJsInterop::class)
+private external class WeakRef {
+    constructor(target: JsAny)
+    fun deref(): JsAny?
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
 internal actual class WeakReference<T : Any> actual constructor(reference: T) {
-    private var reference: T? = reference
-    actual fun get(): T? = reference
-    actual fun clear() { reference = null }
+    private var weakRef: WeakRef? = WeakRef(reference.toJsReference())
+    actual fun get(): T? = weakRef?.deref()?.unsafeCast<JsReference<T>>()?.get()
+
+    // Js WeakRef doesn't have a method for clearing it. So we just drop the WeakRef itself.
+    actual fun clear() {
+        weakRef = null
+    }
 }


### PR DESCRIPTION
This PR updates the implementations only in the modules which we publish from our fork:
- `androidx.compose.ui.node`
- `androidx.navigation.compose.internal`

There are more dumb web WeakRef implementations in modules published by Jetpack Compose. They will be fixed directly in the upstream repo: https://android-review.googlesource.com/c/platform/frameworks/support/+/3882821

Fixes [CMP-1286](https://youtrack.jetbrains.com/issue/CMP-1286)

## Testing
N/A

## Release Notes
N/A
