### PR TITLE
Implement WeakKeysCache for web

### DIFF
--- a/compose/ui/ui-text/build.gradle
+++ b/compose/ui/ui-text/build.gradle
@@ -235,8 +235,10 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
                 dependsOn(skikoTest)
             }
             nativeTest.dependsOn(nonJvmTest)
-            jsTest.dependsOn(nonJvmTest)
-            wasmJsTest.dependsOn(nonJvmTest)
+
+            webTest.dependsOn(nonJvmTest)
+            jsTest.dependsOn(webTest)
+            wasmJsTest.dependsOn(webTest)
 
             configureEach {
                 languageSettings.optIn("androidx.compose.ui.text.ExperimentalTextApi")

--- a/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/Cache.jvm.kt
+++ b/compose/ui/ui-text/src/desktopMain/kotlin/androidx/compose/ui/text/Cache.jvm.kt
@@ -17,9 +17,9 @@
 package androidx.compose.ui.text
 
 
-internal actual class WeakKeysCache<K : Any, V> : Cache<K, V> {
+internal actual class WeakKeysCache<K : Any, V: Any> {
     private val cache =  java.util.WeakHashMap<K, V>()
 
-    actual override fun get(key: K, loader: (K) -> V): V =
+    actual inline fun getOrPut(key: K, loader: (K) -> V): V =
         cache.getOrPut(key) { loader(key) }
 }

--- a/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
+++ b/compose/ui/ui-text/src/desktopTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
@@ -26,10 +26,10 @@ class WeakKeysCacheTest {
     fun clearOnGC() {
         val cache = WeakKeysCache<MyKey, Int>()
         var created = 0
-        assertEquals(1, cache.get(MyKey(42)) { ++created })
-        assertEquals(1, cache.get(MyKey(42)) { ++created })
+        assertEquals(1, cache.getOrPut(MyKey(42)) { ++created })
+        assertEquals(1, cache.getOrPut(MyKey(42)) { ++created })
         System.gc()
-        assertEquals(2, cache.get(MyKey(42)) { ++created })
-        assertEquals(2, cache.get(MyKey(42)) { ++created })
+        assertEquals(2, cache.getOrPut(MyKey(42)) { ++created })
+        assertEquals(2, cache.getOrPut(MyKey(42)) { ++created })
     }
 }

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/Cache.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/Cache.native.kt
@@ -19,17 +19,17 @@ package androidx.compose.ui.text
 import kotlin.experimental.ExperimentalNativeApi
 import kotlin.native.ref.WeakReference
 
-internal actual class WeakKeysCache<K : Any, V> : Cache<K, V> {
+internal actual class WeakKeysCache<K : Any, V: Any> {
     // TODO Use WeakHashMap once available https://youtrack.jetbrains.com/issue/KT-48075
     private val cache = HashMap<Key<K>, V>()
 
-    actual override fun get(key: K, loader: (K) -> V): V {
+    actual inline fun getOrPut(key: K, loader: (K) -> V): V {
         cache.entries.removeAll { !it.key.isAvailable }
         return cache.getOrPut(Key(key)) { loader(key) }
     }
 
     @OptIn(ExperimentalNativeApi::class)
-    private class Key<K : Any>(key: K) {
+    internal class Key<K : Any>(key: K) {
         private val ref = WeakReference(key)
         private val hash: Int = key.hashCode()
 

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/Cache.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/Cache.native.kt
@@ -37,12 +37,12 @@ internal actual class WeakKeysCache<K : Any, V: Any> {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
+            if (other == null) return false
             other as Key<*>
             val a = ref.get()
             val b = other.ref.get()
             if (a == null || b == null) {
-                // If either side is cleared, they should not be considered equal,
-                // unless they're literally the same Key instance, which is already handled above.
+                // If either side is cleared, they should not be considered equal
                 return false
             }
             return a == b

--- a/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/Cache.native.kt
+++ b/compose/ui/ui-text/src/nativeMain/kotlin/androidx/compose/ui/text/Cache.native.kt
@@ -38,7 +38,14 @@ internal actual class WeakKeysCache<K : Any, V: Any> {
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             other as Key<*>
-            return ref.value == other.ref.value
+            val a = ref.get()
+            val b = other.ref.get()
+            if (a == null || b == null) {
+                // If either side is cleared, they should not be considered equal,
+                // unless they're literally the same Key instance, which is already handled above.
+                return false
+            }
+            return a == b
         }
 
         override fun hashCode(): Int = hash

--- a/compose/ui/ui-text/src/nativeTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
+++ b/compose/ui/ui-text/src/nativeTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
@@ -33,8 +33,8 @@ class WeakKeysCacheTest {
         // Accessing to weak reference creates strong one in stack now.
         // So to make GC work, wrap it into separate function.
         fun checkCache(expected: Int) {
-            assertEquals(expected, cache.get(MyKey(42)) { ++created })
-            assertEquals(expected, cache.get(MyKey(42)) { ++created })
+            assertEquals(expected, cache.getOrPut(MyKey(42)) { ++created })
+            assertEquals(expected, cache.getOrPut(MyKey(42)) { ++created })
         }
         checkCache(1)
         GC.collect()

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/Cache.skiko.kt
@@ -18,17 +18,11 @@ package androidx.compose.ui.text
 
 import org.jetbrains.skiko.currentNanoTime
 
-// Extremely simple Cache interface which is enough for ui.text needs
-internal interface Cache<K, V> {
-    // get a value for [key] or load it by [loader] if it doesn't exist
-    fun get(key: K, loader: (K) -> V): V
-}
-
 /**
  * Cache with weak keys.
  */
-internal expect class WeakKeysCache<K : Any, V>() : Cache<K, V> {
-    override fun get(key: K, loader: (K) -> V): V
+internal expect class WeakKeysCache<K : Any, V: Any>()  {
+    inline fun getOrPut(key: K, loader: (K) -> V): V
 }
 
 /**
@@ -37,11 +31,11 @@ internal expect class WeakKeysCache<K : Any, V>() : Cache<K, V> {
 internal class ExpireAfterAccessCache<K, V>(
     val expireAfterNanos: Long,
     val currentNanos: () -> Long = ::currentNanoTime
-) : Cache<K, V> {
+) {
     internal val map = HashMap<K, V>()
     internal val accessTime = LinkedHashMap<K, Long>()
 
-    override fun get(key: K, loader: (K) -> V): V {
+    inline fun getOrPut(key: K, loader: (K) -> V): V {
         accessTime.remove(key)
         return map.getOrPut(key) {
             loader(key)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -435,7 +435,13 @@ internal class ParagraphBuilder(
                         op.style.fontStyle ?: FontStyle.Normal,
                         op.style.fontSynthesis ?: FontSynthesis.All
                     )
-                    pb.pushStyle(makeSkTextStyle(op.style.toImmutable()))
+
+                    // It's always mutable at this point, so we can safely cast
+                    val style = (op.style as ComputedStyle.Mutable).toImmutable()
+                    // Store immutable reference because it's used as a weak reference key
+                    op.style = style
+
+                    pb.pushStyle(makeSkTextStyle(style))
                 }
                 is Op.PutPlaceholder -> {
                     val placeholderStyle =
@@ -471,7 +477,7 @@ internal class ParagraphBuilder(
 
         data class StyleAdd(
             override val position: Int,
-            val style: ComputedStyle.Mutable
+            var style: ComputedStyle
         ) : Op()
 
         data class PutPlaceholder(
@@ -544,7 +550,9 @@ internal class ParagraphBuilder(
                             )
                         )
                     } else {
-                        prev.style.merge(density, cut.style)
+                        // It's always mutable at this point, so we can safely cast
+                        val style = prev.style as ComputedStyle.Mutable
+                        style.merge(density, cut.style)
                     }
                 }
                 is Cut.StyleRemove -> {

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -642,7 +642,7 @@ internal class ParagraphBuilder(
     }
 
     private fun makeSkTextStyle(style: ComputedStyle.Immutable): SkTextStyle {
-        return skTextStylesCache.get(style) {
+        return skTextStylesCache.getOrPut(style) {
             it.toSkTextStyle(fontFamilyResolver)
         }
     }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.skiko.kt
@@ -16,7 +16,6 @@
 package androidx.compose.ui.text.platform
 
 import org.jetbrains.skia.Typeface as SkTypeface
-import androidx.compose.ui.text.Cache
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.ExpireAfterAccessCache
 import androidx.compose.ui.text.InternalTextApi
@@ -296,7 +295,7 @@ internal class FontCache {
     internal val fonts = FontCollection()
     private val fontProvider = TypefaceFontProviderWithFallback()
     private val registered: MutableSet<String> = HashSet()
-    private val typefacesCache: Cache<String, SkTypeface> = ExpireAfterAccessCache(
+    private val typefacesCache = ExpireAfterAccessCache<String, SkTypeface>(
         60_000_000_000 // 1 minute
     )
 
@@ -306,7 +305,7 @@ internal class FontCache {
     }
 
     internal fun load(font: PlatformFont): FontLoadResult {
-        val typeface = typefacesCache.get(font.cacheKey) {
+        val typeface = typefacesCache.getOrPut(font.cacheKey) {
             loadTypeface(font)
         }
         ensureRegistered(typeface, font.cacheKey)

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/ExpireAfterAccessCacheTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/ExpireAfterAccessCacheTest.kt
@@ -34,21 +34,21 @@ class ExpireAfterAccessCacheTest {
 
     @Test
     fun singleKey() {
-        assertEquals("v1_1", cache.get("k1") { "v1_1" })
+        assertEquals("v1_1", cache.getOrPut("k1") { "v1_1" })
         assertEquals(setOf("k1"), cache.map.keys)
         assertEquals(setOf("k1"), cache.accessTime.keys)
         assertEquals(0, cache.accessTime["k1"])
 
         time += 10.millisToNanos()
 
-        assertEquals("v1_1", cache.get("k1") { "v1_2" })
+        assertEquals("v1_1", cache.getOrPut("k1") { "v1_2" })
         assertEquals(setOf("k1"), cache.map.keys)
         assertEquals(setOf("k1"), cache.accessTime.keys)
         assertEquals(time, cache.accessTime["k1"])
 
         time += 2.secondsToNanos()
 
-        assertEquals("v1_1", cache.get("k1") { "v1_3" })
+        assertEquals("v1_1", cache.getOrPut("k1") { "v1_3" })
         assertEquals(setOf("k1"), cache.map.keys)
         assertEquals(setOf("k1"), cache.accessTime.keys)
         assertEquals(time, cache.accessTime["k1"])
@@ -56,14 +56,14 @@ class ExpireAfterAccessCacheTest {
 
     @Test
     fun manyKeys() {
-        assertEquals("v1_1", cache.get("k1") { "v1_1" })
+        assertEquals("v1_1", cache.getOrPut("k1") { "v1_1" })
         assertEquals(setOf("k1"), cache.map.keys)
         assertEquals(cache.map.keys, cache.accessTime.keys)
         assertEquals(0, cache.accessTime["k1"])
 
         time += 10.millisToNanos()
 
-        assertEquals("v2_1", cache.get("k2") { "v2_1" })
+        assertEquals("v2_1", cache.getOrPut("k2") { "v2_1" })
         assertEquals(setOf("k1", "k2"), cache.map.keys)
         assertEquals(cache.map.keys, cache.accessTime.keys)
         assertEquals(0, cache.accessTime["k1"])
@@ -71,8 +71,8 @@ class ExpireAfterAccessCacheTest {
 
         time += 10.millisToNanos()
 
-        assertEquals("v2_1", cache.get("k2") { "v2_2" })
-        assertEquals("v3_1", cache.get("k3") { "v3_1" })
+        assertEquals("v2_1", cache.getOrPut("k2") { "v2_2" })
+        assertEquals("v3_1", cache.getOrPut("k3") { "v3_1" })
         assertEquals(setOf("k1", "k2", "k3"), cache.map.keys)
         assertEquals(cache.map.keys, cache.accessTime.keys)
         assertEquals(0, cache.accessTime["k1"])
@@ -81,7 +81,7 @@ class ExpireAfterAccessCacheTest {
 
         time += 2.secondsToNanos()
 
-        assertEquals("v2_1", cache.get("k2") { "v2_3" })
+        assertEquals("v2_1", cache.getOrPut("k2") { "v2_3" })
         assertEquals(setOf("k2"), cache.map.keys)
         assertEquals(setOf("k2"), cache.accessTime.keys)
         assertEquals(time, cache.accessTime["k2"])

--- a/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/Cache.web.kt
+++ b/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/Cache.web.kt
@@ -16,9 +16,83 @@
 
 package androidx.compose.ui.text
 
-// TODO Use WeakMap once available https://youtrack.jetbrains.com/issue/KT-44309
-internal actual typealias WeakKeysCache<K, V> = NoCache<K, V>
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlin.js.JsAny
+import kotlin.js.JsReference
+import kotlin.js.get
+import kotlin.js.toJsReference
+import kotlin.js.unsafeCast
 
-internal class NoCache<K : Any, V> : Cache<K, V> {
-    override fun get(key: K, loader: (K) -> V): V = loader(key)
+// We can't use Js WeakMap https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap
+// because it uses identity equality for keys, but the usage of WeakKeysCache in SkikoParagraph requires that the
+// keys would have structural equality.
+@OptIn(ExperimentalWasmJsInterop::class)
+internal actual class WeakKeysCache<K : Any, V: Any>  {
+
+    private val cache = HashMap<Key<K>, V>()
+
+    // When K is finalized, we'll eventually receive a callback.
+    // And we use it to remove the Key(WeakReference<K>) from the HashMap.
+    private val registry = FinalizationRegistry { keyJsReference ->
+        @Suppress("RemoveExplicitTypeArguments") // frontend glitch for js compilation?
+        val key = keyJsReference.unsafeCast<JsReference<Key<K>>>().get<Key<K>>()
+        cache.remove(key)
+    }
+
+    actual inline fun getOrPut(key: K, loader: (K) -> V): V {
+        // Here we don't run a loop over the cache keys to clear the unavailable (after GC) keys.
+        // The loop would be not ignorably cheap, because it would make a js-interop call for deref on
+        // every iteration - a concern for scrolls with different text items (getOrPut is called often).
+        // Here we rely on FinalizationRegistry to clean the unavailable (after GC) keys.
+        val weakKey = Key(key)
+
+        val existing = cache[weakKey]
+        if (existing != null) return existing
+
+        val value = loader(key)
+        cache[weakKey] = value
+
+        registry.register(key.toJsReference(), weakKey.toJsReference())
+
+        return value
+    }
+
+    internal class Key<K : Any>(key: K) {
+        private val ref = WeakReference(key)
+        private val hash: Int = key.hashCode()
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            other as Key<*>
+            val a = ref.get()
+            val b = other.ref.get()
+            if (a == null || b == null) {
+                // If either side is cleared, they should not be considered equal,
+                // unless they're literally the same Key instance, which is already handled above.
+                return false
+            }
+            return a == b
+        }
+
+        override fun hashCode(): Int = hash
+    }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef
+@OptIn(ExperimentalWasmJsInterop::class)
+private external class WeakRef {
+    constructor(target: JsAny)
+    fun deref(): JsAny?
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private class WeakReference<T : Any>(reference: T) {
+    private var weakRef: WeakRef? = WeakRef(reference.toJsReference())
+    fun get(): T? = weakRef?.deref()?.unsafeCast<JsReference<T>>()?.get()
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
+@OptIn(ExperimentalWasmJsInterop::class)
+internal external class FinalizationRegistry(cleanup: (JsAny) -> Unit) {
+    fun register(target: JsAny, heldValue: JsAny)
 }

--- a/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/Cache.web.kt
+++ b/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/Cache.web.kt
@@ -62,12 +62,12 @@ internal actual class WeakKeysCache<K : Any, V: Any>  {
 
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
+            if (other == null) return false
             other as Key<*>
             val a = ref.get()
             val b = other.ref.get()
             if (a == null || b == null) {
-                // If either side is cleared, they should not be considered equal,
-                // unless they're literally the same Key instance, which is already handled above.
+                // If either side is cleared, they should not be considered equal
                 return false
             }
             return a == b

--- a/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/Cache.web.kt
+++ b/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/Cache.web.kt
@@ -34,8 +34,7 @@ internal actual class WeakKeysCache<K : Any, V: Any>  {
     // When K is finalized, we'll eventually receive a callback.
     // And we use it to remove the Key(WeakReference<K>) from the HashMap.
     private val registry = FinalizationRegistry { keyJsReference ->
-        @Suppress("RemoveExplicitTypeArguments") // frontend glitch for js compilation?
-        val key = keyJsReference.unsafeCast<JsReference<Key<K>>>().get<Key<K>>()
+        val key: Key<K> = keyJsReference.unsafeCast<JsReference<Key<K>>>().get()
         cache.remove(key)
     }
 

--- a/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
+++ b/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class WeakKeysCacheTest {
-    class MyKey(val key: Int)
+    data class MyKey(val key: Int)
     data class MyValue(val value: String)
 
     @Test
@@ -43,13 +43,22 @@ class WeakKeysCacheTest {
         assertEquals("100", value2.value, "Should use cached")
         assertEquals(1, created, "Should use cached")
 
-        val key2 = MyKey(1) // equal but different instance
+        val key2 = MyKey(1) // equal key
         val value3 = cache.getOrPut(key2) {
             created++
             MyValue("300")
         }
         // WeakMap uses identity, so k2 is a different key.
-        assertEquals("300", value3.value)
+        assertEquals("100", value3.value)
+        assertEquals(1, created)
+
+        val key3 = MyKey(2) // equal key
+        val value4 = cache.getOrPut(key3) {
+            created++
+            MyValue("200")
+        }
+
+        assertEquals("200", value4.value)
         assertEquals(2, created)
     }
 }

--- a/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
+++ b/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
@@ -23,8 +23,9 @@ class WeakKeysCacheTest {
     data class MyKey(val key: Int)
     data class MyValue(val value: String)
 
+    // We can't call GC manually, so just testing the basic correctness
     @Test
-    fun testCachingWithIdentity() {
+    fun testCaching() {
         val cache = WeakKeysCache<MyKey, MyValue>()
         val key1 = MyKey(1)
         var created = 0
@@ -52,7 +53,7 @@ class WeakKeysCacheTest {
         assertEquals("100", value3.value)
         assertEquals(1, created)
 
-        val key3 = MyKey(2) // equal key
+        val key3 = MyKey(2) // new key
         val value4 = cache.getOrPut(key3) {
             created++
             MyValue("200")

--- a/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
+++ b/compose/ui/ui-text/src/webTest/kotlin/androidx/compose/ui/text/WeakKeysCacheTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WeakKeysCacheTest {
+    class MyKey(val key: Int)
+    data class MyValue(val value: String)
+
+    @Test
+    fun testCachingWithIdentity() {
+        val cache = WeakKeysCache<MyKey, MyValue>()
+        val key1 = MyKey(1)
+        var created = 0
+
+        val value1 = cache.getOrPut(key1) {
+            created++
+            MyValue("100")
+        }
+        assertEquals("100", value1.value)
+        assertEquals(1, created)
+
+        val value2 = cache.getOrPut(key1) { // using the same key1
+            created++
+            MyValue("200")
+        }
+        assertEquals("100", value2.value, "Should use cached")
+        assertEquals(1, created, "Should use cached")
+
+        val key2 = MyKey(1) // equal but different instance
+        val value3 = cache.getOrPut(key2) {
+            created++
+            MyValue("300")
+        }
+        // WeakMap uses identity, so k2 is a different key.
+        assertEquals("300", value3.value)
+        assertEquals(2, created)
+    }
+}


### PR DESCRIPTION
Implement WeakKeysCache for web 

Fixes [CMP-9410](https://youtrack.jetbrains.com/issue/CMP-9410)

Other changes:
- Also change the constraint of Values types from Any? to Any, as WeakKeysCache is used only with non-nullable values
- Get rid of `interface Cache` and make `fun getOrPut` inline to avoid lambda instantiation on every getOrPut call

## Testing
Added the related tests. But without explcit GC calls - it's not exposed. 

## Release Notes
N/A

