### PR TITLE
Avoid extra text layout when null and default non-null values are mixed between calls

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -160,7 +160,7 @@ private sealed interface ComputedStyle {
             fontStyle?.let {
                 res.fontStyle = it.toSkFontStyle()
             }
-            textDecoration?.let {
+            textDecoration.takeUnless { it == TextDecoration.None }?.let {
                 res.decorationStyle =
                     it.toSkDecorationStyle(textForegroundStyle.color, textDecorationLineStyle)
             }
@@ -172,7 +172,7 @@ private sealed interface ComputedStyle {
             fontWeight?.let {
                 res.fontStyle = res.fontStyle.withWeight(it.weight)
             }
-            shadow?.let {
+            shadow.takeUnless { it == Shadow.None }?.let {
                 res.addShadow(it.toSkShadow())
             }
 

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.skiko.kt
@@ -163,8 +163,8 @@ internal class ParagraphLayouter(
         shadow: Shadow?,
         textDecoration: TextDecoration?,
     ) {
-        if (builder.textStyle.shadow != shadow ||
-            builder.textStyle.textDecoration != textDecoration
+        if (!builder.textStyle.shadow.sameValueAs(shadow) ||
+            !builder.textStyle.textDecoration.sameValueAs(textDecoration)
         ) {
             builder.textStyle = builder.textStyle.copy(
                 shadow = shadow,
@@ -219,6 +219,11 @@ internal class ParagraphLayouter(
     }
 }
 
-private fun Float.sameValueAs(other: Float) : Boolean {
-    return abs(this - other) < 0.00001f
-}
+private fun Shadow?.sameValueAs(other: Shadow?) =
+    (this ?: Shadow.None) == (other ?: Shadow.None)
+
+private fun TextDecoration?.sameValueAs(other: TextDecoration?) =
+    (this ?: TextDecoration.None) == (other ?: TextDecoration.None)
+
+private fun Float.sameValueAs(other: Float) =
+    abs(this - other) < 0.00001f


### PR DESCRIPTION
Follow up after debugging #2629/[CMP-8028](https://youtrack.jetbrains.com/issue/CMP-8028)
This fix reduces the number of skia paragraph layout calls from 3 to 2 for each label in the next example:
```kt
val textMeasurer = rememberTextMeasurer(cacheSize = 100)
Canvas(Modifier.fillMaxSize().background(Color.DarkGray)) {
    for (i in 0 until 100) {
        drawText(
            textMeasurer = textMeasurer,
            text = "$i",
            topLeft = Offset(x = i % 10 * 50f, y = i / 10 * 50f),
            style = TextStyle.Default.copy(color = Color.White)
        )
    }
}
```

Unfortunately, a unit test for this behavior is not trivial because we don't have infra to mock final classes even on JVM now

## Release Notes
N/A