### PR TITLE
Fix Accessible hierarchy and initial focus

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -55,7 +55,7 @@ import kotlinx.coroutines.launch
 internal class AccessibilityController(
     val owner: SemanticsOwner,
     val desktopComponent: PlatformComponent,
-    val parent: ComposeSceneAccessible,
+    val parentAccessible: ComposeSceneAccessible,
     private val onFocusReceived: (ComposeAccessible) -> Unit,
 ) {
 
@@ -74,18 +74,24 @@ internal class AccessibilityController(
      * Returns the [ComposeAccessible] associated with the given semantics node id.
      */
     fun accessibleByNodeId(nodeId: Int): ComposeAccessible? {
+        syncNodesIfInvalid()
+        return accessibleByNodeId[nodeId]
+    }
+
+    /**
+     * Syncs the accessible nodes if the current mapping is invalid.
+     */
+    private fun syncNodesIfInvalid() {
         if (!nodeMappingIsValid) {
             syncNodes()
         }
-
-        return accessibleByNodeId[nodeId]
     }
 
     /**
      * Returns the index of this [AccessibilityController]'s root node in the scene.
      */
     fun indexInScene(): Int {
-        return parent.indexOfChild(this)
+        return parentAccessible.indexOfChild(this)
     }
 
     /**
@@ -191,10 +197,7 @@ internal class AccessibilityController(
                         if (entry.value as Boolean) {
                             notifyOnFocusReceived(accessible)
                         } else {
-                            accessibleContext.firePropertyChange(
-                                ACCESSIBLE_STATE_PROPERTY,
-                                AccessibleState.FOCUSED, null
-                            )
+                            notifyOnFocusLost(accessible)
                         }
 
                     SemanticsProperties.ToggleableState -> {
@@ -235,6 +238,16 @@ internal class AccessibilityController(
             null, AccessibleState.FOCUSED
         )
         onFocusReceived(accessible)
+    }
+
+    /**
+     * Notifies the system when the given accessible loses focused.
+     */
+    private fun notifyOnFocusLost(accessible: ComposeAccessible) {
+        accessible.accessibleContext?.firePropertyChange(
+            ACCESSIBLE_STATE_PROPERTY,
+            AccessibleState.FOCUSED, null
+        )
     }
 
     /**
@@ -381,6 +394,36 @@ internal class AccessibilityController(
         // TODO: Only recompute the layout-related properties of the node
         nodeMappingIsValid = false
         scheduleNodeSyncIfNeeded()
+    }
+
+    /**
+     * Returns the [ComposeAccessible] associated with the currently focused node.
+     */
+    private fun focusedAccessible(): ComposeAccessible? {
+        syncNodesIfInvalid()
+        accessibleByNodeId.forEachValue { accessible ->
+            if (accessible.semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true) {
+                return accessible
+            }
+        }
+
+        return null
+    }
+
+    /**
+     * Invoked when the AWT component of the Compose content gains focus.
+     */
+    fun onFocusGained() {
+        if (!AccessibilityUsage.recentlyUsed) return
+        focusedAccessible()?.let { notifyOnFocusReceived(it) }
+    }
+
+    /**
+     * Invoked when the AWT component of the Compose content loses focus.
+     */
+    fun onFocusLost() {
+        if (!AccessibilityUsage.recentlyUsed) return
+        focusedAccessible()?.let { notifyOnFocusLost(it) }
     }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -53,7 +53,8 @@ import kotlinx.coroutines.launch
 internal class AccessibilityController(
     val owner: SemanticsOwner,
     val desktopComponent: PlatformComponent,
-    private val onFocusReceived: (ComposeAccessible) -> Unit
+    val parent: ComposeSceneAccessible,
+    private val onFocusReceived: (ComposeAccessible) -> Unit,
 ) {
 
     /**
@@ -76,6 +77,13 @@ internal class AccessibilityController(
         }
 
         return accessibleByNodeId[nodeId]
+    }
+
+    /**
+     * Returns the index of this [AccessibilityController]'s root node in the scene.
+     */
+    fun indexInScene(): Int {
+        return parent.indexOfChild(this)
     }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -126,6 +126,7 @@ internal class AccessibilityController(
         nodeId: Int,
         action: (ComposeAccessible, SemanticsConfiguration) -> Unit
     ) = SwingUtilities.invokeLater {
+        if (disposed) return@invokeLater
         val accessible = accessibleByNodeId(nodeId) ?: return@invokeLater
         action(accessible, accessible.semanticsNode.config)
     }
@@ -283,10 +284,17 @@ internal class AccessibilityController(
     private var syncingJob: Job? = null
 
     /**
+     * Whether this [AccessibilityController] has been disposed.
+     */
+    @Volatile
+    private var disposed = false
+
+    /**
      * Disposes of this [AccessibilityController], releasing any resources associated with it.
      */
     fun dispose() {
         syncingJob?.cancel()
+        disposed = true
     }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui.platform.a11y
 import androidx.collection.mutableScatterMapOf
 import androidx.compose.ui.platform.PlatformComponent
 import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.semantics.SemanticsProperties
@@ -33,6 +34,7 @@ import javax.accessibility.AccessibleContext.ACCESSIBLE_STATE_PROPERTY
 import javax.accessibility.AccessibleContext.ACCESSIBLE_TEXT_PROPERTY
 import javax.accessibility.AccessibleContext.ACCESSIBLE_VALUE_PROPERTY
 import javax.accessibility.AccessibleState
+import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CoroutineScope
@@ -89,8 +91,38 @@ internal class AccessibilityController(
     /**
      * Invoked when a new [ComposeAccessible] is created.
      */
-    @Suppress("UNUSED_PARAMETER")
-    private fun onNodeAdded(accessible: ComposeAccessible) {}
+    private fun onNodeAdded(accessible: ComposeAccessible) {
+        for (entry in accessible.semanticsNode.config) {
+            when (entry.key) {
+                SemanticsProperties.Focused -> {
+                    if (entry.value as Boolean) {
+                        invokeLaterOnAccessible(accessible.semanticsNode.id) { accessible, config ->
+                            // Check that it's still focused
+                            if (config.getOrNull(SemanticsProperties.Focused) == true) {
+                                notifyOnFocusReceived(accessible)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Invoke [action] on the next EDT iteration, if the node still exists then.
+     *
+     * This is needed when firing property change events on newly created nodes because [syncNodes],
+     * and consequently [onNodeAdded], can be called as the result of the accessibility system
+     * trying to obtain the [Accessible]. If we fire the event directly in [onNodeAdded], it will
+     * fire before the system had a chance to register the property listener to the event.
+     */
+    private fun invokeLaterOnAccessible(
+        nodeId: Int,
+        action: (ComposeAccessible, SemanticsConfiguration) -> Unit
+    ) = SwingUtilities.invokeLater {
+        val accessible = accessibleByNodeId(nodeId) ?: return@invokeLater
+        action(accessible, accessible.semanticsNode.config)
+    }
 
     /**
      * Invoked when a [ComposeAccessible] is removed.
@@ -103,11 +135,11 @@ internal class AccessibilityController(
      * Invoked when the [SemanticsNode] a [ComposeAccessible] represents changes.
      */
     private fun onNodeChanged(
-        component: ComposeAccessible,
+        accessible: ComposeAccessible,
         previousSemanticsNode: SemanticsNode,
         newSemanticsNode: SemanticsNode
     ) {
-        val accessibleContext by lazy { component.composeAccessibleContext }
+        val accessibleContext by lazy { accessible.composeAccessibleContext }
         for (entry in newSemanticsNode.config) {
             val prev = previousSemanticsNode.config.getOrNull(entry.key)
             if (entry.value != prev) {
@@ -157,13 +189,9 @@ internal class AccessibilityController(
 
                     SemanticsProperties.Focused ->
                         if (entry.value as Boolean) {
-                            component.composeAccessibleContext.firePropertyChange(
-                                ACCESSIBLE_STATE_PROPERTY,
-                                null, AccessibleState.FOCUSED
-                            )
-                            onFocusReceived(component)
+                            notifyOnFocusReceived(accessible)
                         } else {
-                            component.composeAccessibleContext.firePropertyChange(
+                            accessibleContext.firePropertyChange(
                                 ACCESSIBLE_STATE_PROPERTY,
                                 AccessibleState.FOCUSED, null
                             )
@@ -172,13 +200,13 @@ internal class AccessibilityController(
                     SemanticsProperties.ToggleableState -> {
                         when (entry.value as ToggleableState) {
                             ToggleableState.On ->
-                                component.composeAccessibleContext.firePropertyChange(
+                                accessibleContext.firePropertyChange(
                                     ACCESSIBLE_STATE_PROPERTY,
                                     null, AccessibleState.CHECKED
                                 )
 
                             ToggleableState.Off, ToggleableState.Indeterminate ->
-                                component.composeAccessibleContext.firePropertyChange(
+                                accessibleContext.firePropertyChange(
                                     ACCESSIBLE_STATE_PROPERTY,
                                     AccessibleState.CHECKED, null
                                 )
@@ -187,7 +215,7 @@ internal class AccessibilityController(
 
                     SemanticsProperties.ProgressBarRangeInfo -> {
                         val value = entry.value as ProgressBarRangeInfo
-                        component.composeAccessibleContext.firePropertyChange(
+                        accessibleContext.firePropertyChange(
                             ACCESSIBLE_VALUE_PROPERTY,
                             (prev as? ProgressBarRangeInfo)?.current,
                             value.current
@@ -196,6 +224,17 @@ internal class AccessibilityController(
                 }
             }
         }
+    }
+
+    /**
+     * Notifies the system when the given accessible becomes focused.
+     */
+    private fun notifyOnFocusReceived(accessible: ComposeAccessible) {
+        accessible.accessibleContext?.firePropertyChange(
+            ACCESSIBLE_STATE_PROPERTY,
+            null, AccessibleState.FOCUSED
+        )
+        onFocusReceived(accessible)
     }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -259,9 +259,13 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleParent(): Accessible? {
-            return semanticsNode.parent?.id?.let { id ->
-                controller.accessibleByNodeId(id)!!
-            } ?: accessibleParent
+            val parentNode = semanticsNode.parent ?: return controller.parent
+            return controller.accessibleByNodeId(parentNode.id)!!
+        }
+
+        override fun getAccessibleIndexInParent(): Int {
+            val parent = semanticsNode.parent ?: return controller.indexInScene()
+            return parent.traversalOrderedChildren().indexOfFirst { it.id == semanticsNode.id }
         }
 
         override fun getAccessibleComponent(): AccessibleComponent? {
@@ -320,11 +324,6 @@ internal class ComposeAccessible(
                 progressBarRangeInfo != null -> ProgressBarAccessibleValue(this)
                 else -> null
             }
-        }
-
-        override fun getAccessibleIndexInParent(): Int {
-            val parentChildren = semanticsNode.parent?.traversalOrderedChildren()
-            return (parentChildren?.indexOfFirst { it.id == semanticsNode.id } ?: -1)
         }
 
         override fun getAccessibleChildrenCount(): Int {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -259,7 +259,7 @@ internal class ComposeAccessible(
         }
 
         override fun getAccessibleParent(): Accessible? {
-            val parentNode = semanticsNode.parent ?: return controller.parent
+            val parentNode = semanticsNode.parent ?: return controller.parentAccessible
             return controller.accessibleByNodeId(parentNode.id)!!
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -428,6 +428,7 @@ internal class ComposeAccessible(
             // Check semantics role
             val role = semanticsConfig.getOrNull(SemanticsProperties.Role)
             val accessibleRole = when (role) {
+                null -> null  // Quickly return null
                 Role.Button -> AccessibleRole.PUSH_BUTTON
                 Role.Checkbox, Role.Switch -> AccessibleRole.CHECK_BOX
                 Role.RadioButton -> AccessibleRole.RADIO_BUTTON

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -30,9 +30,8 @@ import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
 import javax.accessibility.AccessibleRole
+import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleStateSet
-import org.jetbrains.skiko.OS
-import org.jetbrains.skiko.hostOs
 
 /**
  * This is a root [Accessible] for a [ComposeScene]
@@ -54,6 +53,7 @@ import org.jetbrains.skiko.hostOs
  */
 internal class ComposeSceneAccessible(
     private val forceEnableA11y: Boolean = false,
+    private val parent: () -> Accessible,
     private val accessibilityControllersProvider: () -> List<AccessibilityController>,
 ) : Accessible {
     private val a11yEnabled by lazy {
@@ -75,6 +75,10 @@ internal class ComposeSceneAccessible(
         return _accessibleContext
     }
 
+    fun indexOfChild(controller: AccessibilityController): Int {
+        return accessibilityControllersProvider().indexOf(controller)
+    }
+
     inner class ComposeSceneAccessibleContext : AccessibleContext(), AccessibleComponent {
         // Internal for testing
         internal val accessibilityControllers: List<AccessibilityController>
@@ -91,10 +95,10 @@ internal class ComposeSceneAccessible(
          * This function is used by Swing accessibility support to get accessible under a [Point]
          * For example, it is used by screen reader to read text under a cursor.
          *
-         * To support that [ComposeSceneAccessibleContext] goes through all skia roots in a [androidx.compose.ui.ComposeScene]
-         * and finds the best [Accessible] under the pointer.
+         * To support that [ComposeSceneAccessibleContext] goes through all skia roots in a
+         * [ComposeScene] and finds the best [Accessible] under the pointer.
          */
-        override fun getAccessibleAt(p: Point): Accessible? {
+        override fun getAccessibleAt(p: Point): Accessible {
             for (controller in accessibilityControllers) {
                 val rootAccessible = controller.rootAccessible
                 val context = rootAccessible.composeAccessibleContext
@@ -109,13 +113,17 @@ internal class ComposeSceneAccessible(
                 }
             }
 
-            return null
+            return this@ComposeSceneAccessible
         }
 
         override fun contains(p: Point): Boolean = true
 
         override fun getAccessibleIndexInParent(): Int {
-            return -1
+            return 0
+        }
+
+        override fun getAccessibleParent(): Accessible {
+            return parent()
         }
 
         override fun getAccessibleChildrenCount(): Int {
@@ -144,10 +152,8 @@ internal class ComposeSceneAccessible(
 
         override fun isShowing(): Boolean = true
 
-        override fun isFocusTraversable(): Boolean = true
-
-        override fun getAccessibleParent(): Accessible? {
-            return null
+        override fun isFocusTraversable(): Boolean {
+            return false
         }
 
         override fun getAccessibleComponent(): AccessibleComponent {
@@ -165,20 +171,17 @@ internal class ComposeSceneAccessible(
         }
 
         override fun getAccessibleRole(): AccessibleRole {
-            // We want to return a role that makes the ComposeScene container "transparent" to
-            // accessibility, as if its contents are inside the parent directly.
-            // On macOS, PANEL is ignored by Java's a11y (see CAccessibility.ignoredRoles), but on
-            // Windows, it makes NVDA read it as "panel".
-            // On Windows, NVDA ignores UNKNOWN, but on macOS UNKNOWN causes VoiceOver to highlight
-            // the entire component when traversing via VoiceOver shortcuts.
-            return when (hostOs) {
-                OS.MacOS -> AccessibleRole.PANEL
-                else -> AccessibleRole.UNKNOWN
-            }
+            return AccessibleRole.UNKNOWN
+        }
+
+        private val _accessibleStateSet = AccessibleStateSet().apply {
+            add(AccessibleState.ENABLED)
+            add(AccessibleState.VISIBLE)
+            add(AccessibleState.SHOWING)
         }
 
         override fun getAccessibleStateSet(): AccessibleStateSet {
-            return AccessibleStateSet()
+            return _accessibleStateSet
         }
 
         override fun setLocation(p: Point?) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -53,7 +53,7 @@ import javax.accessibility.AccessibleStateSet
  */
 internal class ComposeSceneAccessible(
     private val forceEnableA11y: Boolean = false,
-    private val parent: () -> Accessible,
+    private val parent: () -> Accessible?,
     private val accessibilityControllersProvider: () -> List<AccessibilityController>,
 ) : Accessible {
     private val a11yEnabled by lazy {
@@ -122,7 +122,7 @@ internal class ComposeSceneAccessible(
             return 0
         }
 
-        override fun getAccessibleParent(): Accessible {
+        override fun getAccessibleParent(): Accessible? {
             return parent()
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -32,6 +32,8 @@ import javax.accessibility.AccessibleContext
 import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleStateSet
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.hostOs
 
 /**
  * This is a root [Accessible] for a [ComposeScene]
@@ -152,9 +154,7 @@ internal class ComposeSceneAccessible(
 
         override fun isShowing(): Boolean = true
 
-        override fun isFocusTraversable(): Boolean {
-            return false
-        }
+        override fun isFocusTraversable() = false
 
         override fun getAccessibleComponent(): AccessibleComponent {
             return this
@@ -171,7 +171,16 @@ internal class ComposeSceneAccessible(
         }
 
         override fun getAccessibleRole(): AccessibleRole {
-            return AccessibleRole.UNKNOWN
+            // We want to return a role that makes the ComposeScene container "transparent" to
+            // accessibility, as if its contents are inside the parent directly.
+            // On macOS, PANEL is ignored by Java's a11y (see CAccessibility.ignoredRoles), but on
+            // Windows, it makes NVDA read it as "panel" when clicked.
+            // On Windows, NVDA ignores UNKNOWN, but on macOS UNKNOWN causes VoiceOver to highlight
+            // the entire component when traversing via VoiceOver shortcuts.
+            return when (hostOs) {
+                OS.MacOS -> AccessibleRole.PANEL
+                else -> AccessibleRole.UNKNOWN
+            }
         }
 
         private val _accessibleStateSet = AccessibleStateSet().apply {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -93,7 +93,6 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
 import java.awt.im.InputMethodRequests
-import javax.accessibility.Accessible
 import javax.swing.JComponent
 import javax.swing.SwingUtilities
 import kotlin.coroutines.CoroutineContext
@@ -138,9 +137,10 @@ internal class ComposeSceneMediator(
 
     private val semanticsOwnerListener = DesktopSemanticsOwnerListener()
     var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
-    val accessible: Accessible = ComposeSceneAccessible {
-        semanticsOwnerListener.accessibilityControllers
-    }
+    val accessible: ComposeSceneAccessible = ComposeSceneAccessible(
+        parent = { contentComponent },
+        accessibilityControllersProvider = { semanticsOwnerListener.accessibilityControllers }
+    )
 
     private val navigationEventInput = BackNavigationEventInput()
 
@@ -767,9 +767,10 @@ internal class ComposeSceneMediator(
             _accessibilityControllers[semanticsOwner] = AccessibilityController(
                 owner = semanticsOwner,
                 desktopComponent = platformComponent,
+                parent = accessible,
                 onFocusReceived = {
                     skiaLayerComponent.requestNativeFocusOnAccessible(it)
-                }
+                },
             ).also {
                 it.launchSyncLoop(coroutineContext)
             }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -135,11 +135,11 @@ internal class ComposeSceneMediator(
     private var isComponentAttached = false
     private val invisibleComponent = InvisibleComponent()
 
-    private val semanticsOwnerListener = DesktopSemanticsOwnerListener()
+    private val semanticsOwnerManager = DesktopSemanticsOwnerManager()
     var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
     val accessible: ComposeSceneAccessible = ComposeSceneAccessible(
         parent = { skiaLayerComponent.sceneAccessibleParent },
-        accessibilityControllersProvider = { semanticsOwnerListener.accessibilityControllers }
+        accessibilityControllersProvider = { semanticsOwnerManager.accessibilityControllers }
     )
 
     private val navigationEventInput = BackNavigationEventInput()
@@ -155,7 +155,7 @@ internal class ComposeSceneMediator(
     var fullscreen by skiaLayerComponent::fullscreen
     val windowHandle by skiaLayerComponent::windowHandle
     val renderApi by skiaLayerComponent::renderApi
-    val semanticsOwners: Collection<SemanticsOwner> by semanticsOwnerListener::semanticsOwners
+    val semanticsOwners: Collection<SemanticsOwner> by semanticsOwnerManager::semanticsOwners
 
     /**
      * @see ComposeFeatureFlags.useInteropBlending
@@ -267,9 +267,13 @@ internal class ComposeSceneMediator(
                     else -> Unit
                 }
             }
+
+            semanticsOwnerManager.onContentComponentGainedFocus()
         }
 
         override fun focusLost(e: FocusEvent) {
+            semanticsOwnerManager.onContentComponentLostFocus()
+
             // We don't reset focus for Compose when the component loses focus temporarily.
             // Partially because we don't support restoring focus after clearing it.
             // Focus can be lost temporarily when another window or popup takes focus.
@@ -752,7 +756,7 @@ internal class ComposeSceneMediator(
             }
     }
 
-    private inner class DesktopSemanticsOwnerListener : PlatformContext.SemanticsOwnerListener {
+    private inner class DesktopSemanticsOwnerManager : PlatformContext.SemanticsOwnerListener {
         /**
          * A new [SemanticsOwner] is always created above existing ones. So, usage of [LinkedHashMap]
          * is required here to keep insertion-order (that equal to [SemanticsOwner]s order).
@@ -762,14 +766,24 @@ internal class ComposeSceneMediator(
 
         val semanticsOwners = mutableStateSetOf<SemanticsOwner>()
 
+        private var requestingNativeFocus = false
+
         override fun onSemanticsOwnerAppended(semanticsOwner: SemanticsOwner) {
             check(semanticsOwner !in _accessibilityControllers)
             _accessibilityControllers[semanticsOwner] = AccessibilityController(
                 owner = semanticsOwner,
                 desktopComponent = platformComponent,
-                parent = accessible,
+                parentAccessible = accessible,
                 onFocusReceived = {
-                    skiaLayerComponent.requestNativeFocusOnAccessible(it)
+                    // requestNativeFocusOnAccessible fires focusGained events, which in turn
+                    // can call this method themselves, so we need to prevent infinite recursion
+                    if (requestingNativeFocus) return@AccessibilityController
+                    requestingNativeFocus = true
+                    try {
+                        skiaLayerComponent.requestNativeFocusOnAccessible(it)
+                    } finally {
+                        requestingNativeFocus = false
+                    }
                 },
             ).also {
                 it.launchSyncLoop(coroutineContext)
@@ -788,6 +802,14 @@ internal class ComposeSceneMediator(
 
         override fun onLayoutChange(semanticsOwner: SemanticsOwner, semanticsNodeId: Int) {
             _accessibilityControllers[semanticsOwner]?.onLayoutChanged(nodeId = semanticsNodeId)
+        }
+
+        fun onContentComponentGainedFocus() {
+            _accessibilityControllers.values.lastOrNull()?.onFocusGained()
+        }
+
+        fun onContentComponentLostFocus() {
+            _accessibilityControllers.values.lastOrNull()?.onFocusLost()
         }
     }
 
@@ -838,7 +860,7 @@ internal class ComposeSceneMediator(
         override val rootForTestListener
             get() = this@ComposeSceneMediator.rootForTestListener
         override val semanticsOwnerListener
-            get() = this@ComposeSceneMediator.semanticsOwnerListener
+            get() = this@ComposeSceneMediator.semanticsOwnerManager
         override val isClearFocusOnMouseDownEnabled: Boolean
             get() = this@ComposeSceneMediator.isClearFocusOnMouseDownEnabled
     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -138,7 +138,7 @@ internal class ComposeSceneMediator(
     private val semanticsOwnerListener = DesktopSemanticsOwnerListener()
     var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
     val accessible: ComposeSceneAccessible = ComposeSceneAccessible(
-        parent = { contentComponent },
+        parent = { skiaLayerComponent.sceneAccessibleParent },
         accessibilityControllersProvider = { semanticsOwnerListener.accessibilityControllers }
     )
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.awt.RenderSettings
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeSceneMediator
 import javax.accessibility.Accessible
-import javax.swing.JComponent
+import javax.swing.JPanel
 import org.jetbrains.skiko.ClipRectangle
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayer
@@ -34,7 +34,7 @@ import org.jetbrains.skiko.swing.SkiaSwingLayer
  * It's implemented as adapter to [SkiaLayer] or [SkiaSwingLayer].
  */
 internal interface SkiaLayerComponent {
-    val contentComponent: JComponent
+    val contentComponent: JPanel
     val interopBlendingSupported: Boolean
     val renderApi: GraphicsApi
     val clipComponents: MutableList<ClipRectangle>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.awt.RenderSettings
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.ComposeSceneMediator
 import javax.accessibility.Accessible
-import javax.swing.JPanel
+import javax.swing.JComponent
 import org.jetbrains.skiko.ClipRectangle
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayer
@@ -34,7 +34,10 @@ import org.jetbrains.skiko.swing.SkiaSwingLayer
  * It's implemented as adapter to [SkiaLayer] or [SkiaSwingLayer].
  */
 internal interface SkiaLayerComponent {
-    val contentComponent: JPanel
+    val contentComponent: JComponent
+    // The Accessible that will be reported as the accessible parent of
+    // ComposeSceneMediator.accessible (ComposeSceneAccessible)
+    val sceneAccessibleParent: Accessible?
     val interopBlendingSupported: Boolean
     val renderApi: GraphicsApi
     val clipComponents: MutableList<ClipRectangle>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -102,6 +102,16 @@ internal class SwingSkiaLayerComponent(
             }
         }
 
+    override val sceneAccessibleParent: Accessible?
+        get() = run {
+            var parent = contentComponent.parent
+            while (parent != null) {
+                if (parent is Accessible) return@run parent
+                parent = parent.parent
+            }
+            null
+        }
+
     override val renderApi by contentComponent::renderApi
 
     override val interopBlendingSupported: Boolean

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -122,6 +122,10 @@ internal class WindowSkiaLayerComponent(
         }
     }
 
+    override val sceneAccessibleParent: Accessible
+        // SkiaLayer passes externalAccessibleFactory to a child component of itself.
+        get() = contentComponent
+
     override val renderApi by contentComponent::renderApi
 
     override val interopBlendingSupported

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -95,6 +95,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayerAnalytics
@@ -660,6 +661,11 @@ class AccessibilityTest {
             assertFalse(textFieldHasFocus)
             window.toFront()
             awaitIdle()
+            @Suppress("unused")
+            for (i in 1..10) {
+                if (window.isFocused) break
+                delay(10)
+            }
             assertTrue(textFieldHasFocus)
             assertSceneAccessibleIsTextField()
         } finally {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -28,11 +28,17 @@ import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.assertThat
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.platform.a11y.AccessibilityController
 import androidx.compose.ui.platform.a11y.ComposeAccessible
@@ -62,9 +68,14 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.runApplicationTest
 import java.awt.Point
+import java.awt.event.HierarchyEvent
+import java.awt.event.HierarchyListener
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
+import javax.accessibility.AccessibleContext.ACCESSIBLE_STATE_PROPERTY
 import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleText
@@ -75,6 +86,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -521,6 +533,42 @@ class AccessibilityTest {
             child = parent
         }
         assertEquals(window, child)
+    }
+
+    @Test
+    fun initiallyFocusedElementFiresFocusedPropertyEvent() = runApplicationTest {
+        val deferredWindow = CompletableDeferred<ComposeWindow>()
+        launchTestWindowApplication {
+            val focusRequester = remember { FocusRequester() }
+            TextField(rememberTextFieldState("text"), Modifier.focusRequester(focusRequester))
+            LaunchedEffect(Unit) { focusRequester.requestFocus() }
+            LaunchedEffect(Unit) { deferredWindow.complete(this@launchTestWindowApplication.window) }
+        }
+
+        val window = deferredWindow.await()
+        var textFieldHasFocus = false
+        window.addHierarchyListener(object : HierarchyListener {
+            override fun hierarchyChanged(e: HierarchyEvent?) {
+                if (window.isDisplayable) {
+                    val textFieldAccessible = window.findAccessibleNamed("text")!!
+                    println("Registering property change listener on ${textFieldAccessible.accessibleContext}")
+                    textFieldAccessible.accessibleContext.addPropertyChangeListener { evt ->
+                        if (evt.propertyName == ACCESSIBLE_STATE_PROPERTY) {
+                            if (evt.newValue == AccessibleState.FOCUSED) {
+                                textFieldHasFocus = true
+                            } else if (evt.oldValue == AccessibleState.FOCUSED) {
+                                textFieldHasFocus = false
+                            }
+                        }
+                    }
+                    window.removeHierarchyListener(this)
+                }
+            }
+        })
+
+        awaitIdle()
+
+        assertTrue(textFieldHasFocus)
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -74,11 +74,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.runApplicationTest
 import java.awt.Dimension
 import java.awt.Point
+import java.awt.Toolkit
 import java.awt.Window
 import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
-import java.io.BufferedReader
-import java.io.InputStreamReader
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
@@ -589,14 +588,9 @@ class AccessibilityTest {
 
     @Test
     fun printWindowManager() {
-        val process = ProcessBuilder("wmctrl", "-m")
-            .redirectErrorStream(true)
-            .start()
-
-        val reader = process.inputStream.reader().buffered()
-        val output = reader.readText()
-        process.waitFor()
-        fail(output)
+        val toolkit = Toolkit.getDefaultToolkit()
+        val wmName = toolkit.getDesktopProperty("win.wm.name") as String?
+        fail("Window manager: $wmName")
     }
 
     @Test

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -662,6 +662,7 @@ class AccessibilityTest {
             anotherWindow.dispose()
             window.toFront()
             awaitIdle()
+            window.requestFocus()
             @Suppress("unused")
             for (i in 1..10) {
                 if (window.isFocused) break

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -96,7 +96,8 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.withTimeout
 import org.jetbrains.skiko.OS
@@ -608,7 +609,7 @@ class AccessibilityTest {
         val window = deferredWindow.await()
         var textFieldAccessible: Accessible? = null
         var textFieldHasFocus = false
-        val receivedFocusEvent = CompletableDeferred<Boolean>()
+        val receivedFocus = Channel<Unit>(CONFLATED)
         window.addHierarchyListener(object : HierarchyListener {
             override fun hierarchyChanged(e: HierarchyEvent?) {
                 if (window.isDisplayable) {
@@ -620,29 +621,38 @@ class AccessibilityTest {
                             } else if (evt.oldValue == AccessibleState.FOCUSED) {
                                 textFieldHasFocus = false
                             }
+                            receivedFocus.trySend(Unit)
                         }
                     }
                     window.removeHierarchyListener(this)
-                    receivedFocusEvent.complete(true)
                 }
             }
         })
 
-        // If we do awaitIdle here, we'll sometimes fail the assertSceneAccessibleIsTextField
-        // check because the NativeAccessibleFocusHelper.focusedAccessible is re-set after 100ms,
-        // and awaitIdle sometimes takes longer.
-        withTimeout(1000) {
-            receivedFocusEvent.await()
+        suspend fun waitForTextFieldToBecomeFocused() {
+            // If we do awaitIdle here, we'll sometimes fail the assertSceneAccessibleIsTextField
+            // check because the NativeAccessibleFocusHelper.focusedAccessible is reset to null
+            // after 100ms, and awaitIdle sometimes takes longer.
+            withTimeout(1000) {
+                while (!(window.isFocused && textFieldHasFocus)) {
+                    receivedFocus.receive()
+                }
+            }
+            assertTrue(window.isFocused, "Could not make original window focused")
+            assertTrue(textFieldHasFocus, "TextField accessible did not send focused event")
         }
-        assertTrue(window.isDisplayable)
+
+        waitForTextFieldToBecomeFocused()
         assertNotNull(textFieldAccessible)
-        assertTrue(textFieldHasFocus)
 
         // What really causes Java's accessibility to report the correct element (on Windows;
         // possibly on macOS too) is not actually the property change event, but a trick in
         // Skiko's NativeAccessibleFocusHelper which reports the focused Accessible following
         // a call to requestNativeFocusOnAccessible
         fun assertSceneAccessibleIsTextField() {
+            // On Linux, NativeAccessibleFocusHelper doesn't do its trick with focusedAccessible
+            if ((hostOs != OS.Windows) && (hostOs != OS.MacOS)) return
+
             // Find the ComposeSceneAccessible
             var composeSceneAccessible = textFieldAccessible
             while (composeSceneAccessible != null) {
@@ -662,10 +672,7 @@ class AccessibilityTest {
             }
             fail("Did not find ancestor with correct accessible context")
         }
-        // On Linux, NativeAccessibleFocusHelper doesn't do its trick with focusedAccessible
-        if ((hostOs == OS.Windows) || (hostOs == OS.MacOS)) {
-            assertSceneAccessibleIsTextField()
-        }
+        assertSceneAccessibleIsTextField()
 
         // De-focus, then re-focus the window and check that another focus gained property change
         // event was sent
@@ -675,22 +682,15 @@ class AccessibilityTest {
             anotherWindow.isVisible = true
             anotherWindow.toFront()
             awaitIdle()
+            assertFalse(window.isFocused)
             assertFalse(textFieldHasFocus)
-            anotherWindow.dispose()
             window.toFront()
-            awaitIdle()
-            window.requestFocus()
-            @Suppress("unused")
-            for (i in 1..10) {
-                if (window.isFocused) break
-                delay(10)
-            }
-            assertTrue(window.isFocused)
-            assertTrue(textFieldHasFocus)
+            waitForTextFieldToBecomeFocused()
             assertSceneAccessibleIsTextField()
         } finally {
-            if (anotherWindow.isShowing)
+            if (anotherWindow.isShowing) {
                 anotherWindow.dispose()
+            }
         }
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -60,7 +60,9 @@ import androidx.compose.ui.toDpSize
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.runApplicationTest
 import java.awt.Point
+import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
 import javax.accessibility.AccessibleRole
@@ -484,6 +486,42 @@ class AccessibilityTest {
         assertThat(test.onNodeWithTag("button").fetchAccessible().accessibleContext?.accessibleRole)
             .isEqualTo(AccessibleRole.PUSH_BUTTON)
     }
+
+    @Test
+    fun verifyA11yHierarchy() = runApplicationTest {
+        launchTestWindowApplication {
+            Text("text")
+        }
+        awaitIdle()
+
+        // Relies on ComposeAccessible.getAccessibleName returning the text
+        val textAccessible = window.findAccessibleNamed("text")
+        assertNotNull(textAccessible)
+
+        // Validate the chain from the text accessible to the window
+        var child: Accessible = textAccessible
+        while (true) {
+            val parent = child.accessibleContext.accessibleParent ?: break
+
+            // Check that the index reported by the child matches what the parent says is the
+            // child at that index.
+            val childIndexInParent = child.accessibleContext.accessibleIndexInParent
+            val childAtIndex = parent.accessibleContext.getAccessibleChild(childIndexInParent)
+            // Note that we can't compare child with childAtIndex itself because the
+            // Accessible instances themselves are different at the seam between Swing and Compose.
+            // The child Accessible of SkiaLayer is the Canvas/HardwareLayer inside it, but the
+            // Accessible at the root of the scene is ComposeSceneAccessible. The trick is that they
+            // both return the same AccessibleContext (HardwareLayer does it via
+            // `externalAccessibleFactory`).
+            assertEquals(
+                expected = child.accessibleContext,
+                actual = childAtIndex.accessibleContext
+            )
+
+            child = parent
+        }
+        assertEquals(window, child)
+    }
 }
 
 
@@ -492,6 +530,11 @@ class AccessibilityTest {
  */
 @OptIn(ExperimentalTestApi::class, InternalTestApi::class)
 private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
+
+    val parentAccessible = Accessible { null }
+
+    lateinit var composeSceneAccessible: ComposeSceneAccessible
+
     // A SemanticsOwnerListener to manage the AccessibilityControllers
     val semanticsOwnerListener = object : PlatformContext.SemanticsOwnerListener {
         private val _accessibilityControllers = linkedMapOf<SemanticsOwner, AccessibilityController>()
@@ -502,6 +545,7 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
             _accessibilityControllers[semanticsOwner] = AccessibilityController(
                 owner = semanticsOwner,
                 desktopComponent = PlatformComponent.Empty,
+                parent = composeSceneAccessible,
                 onFocusReceived = { }
             )
         }
@@ -520,9 +564,11 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
     }
 
     // The root (scene) accessible
-    val composeSceneAccessible = ComposeSceneAccessible(forceEnableA11y = true) {
-        semanticsOwnerListener.accessibilityControllers
-    }
+    composeSceneAccessible = ComposeSceneAccessible(
+        forceEnableA11y = true,
+        parent = { parentAccessible },
+        accessibilityControllersProvider = { semanticsOwnerListener.accessibilityControllers }
+    )
 
     // Reset the a11y usage, to avoid having one test affect the next
     AccessibilityController.AccessibilityUsage.reset()
@@ -634,4 +680,13 @@ internal class ComposeA11yTestScope(
         assertNotNull(text, "Text is null")
         assertTrue(value in text, "Text does not contain $value")
     }
+}
+
+private fun Accessible.findAccessibleNamed(name: String): Accessible? {
+    if (accessibleContext.accessibleName == name) return this
+    for (index in 0 until accessibleContext.accessibleChildrenCount) {
+        val child = accessibleContext.getAccessibleChild(index)
+        child.findAccessibleNamed(name)?.let { return it }
+    }
+    return null
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -85,6 +85,7 @@ import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleText
 import javax.accessibility.AccessibleValue
+import javax.swing.JFrame
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities
 import kotlin.test.assertEquals
@@ -580,9 +581,10 @@ class AccessibilityTest {
         }
     }
 
-
     @Test
-    fun initiallyFocusedElementFiresFocusedPropertyEvent() = runApplicationTest {
+    fun initiallyFocusedElementNotifiesSystemOfFocus() = runApplicationTest {
+        AccessibilityController.AccessibilityUsage.notifyInUse()
+
         val deferredWindow = CompletableDeferred<ComposeWindow>()
         launchTestWindowApplication {
             val focusRequester = remember { FocusRequester() }
@@ -592,12 +594,12 @@ class AccessibilityTest {
         }
 
         val window = deferredWindow.await()
+        var textFieldAccessible: Accessible? = null
         var textFieldHasFocus = false
         window.addHierarchyListener(object : HierarchyListener {
             override fun hierarchyChanged(e: HierarchyEvent?) {
                 if (window.isDisplayable) {
-                    val textFieldAccessible = window.findAccessibleNamed("text")!!
-                    println("Registering property change listener on ${textFieldAccessible.accessibleContext}")
+                    textFieldAccessible = window.findAccessibleNamed("text")!!
                     textFieldAccessible.accessibleContext.addPropertyChangeListener { evt ->
                         if (evt.propertyName == ACCESSIBLE_STATE_PROPERTY) {
                             if (evt.newValue == AccessibleState.FOCUSED) {
@@ -613,8 +615,51 @@ class AccessibilityTest {
         })
 
         awaitIdle()
-
+        assertNotNull(textFieldAccessible)
         assertTrue(textFieldHasFocus)
+
+        // What really causes Java's accessibility to report the correct element (on Windows;
+        // possibly on macOS too) is not actually the property change event, but a trick in
+        // Skiko's NativeAccessibleFocusHelper which reports the focused Accessible following
+        // a call to requestNativeFocusOnAccessible
+        fun assertSceneAccessibleIsTextField() {
+            // Find the ComposeSceneAccessible
+            var composeSceneAccessible = textFieldAccessible
+            while (composeSceneAccessible != null) {
+                if (composeSceneAccessible is ComposeSceneAccessible) break
+                composeSceneAccessible = composeSceneAccessible.accessibleContext?.accessibleParent
+            }
+            assertNotNull(composeSceneAccessible)
+
+            // We want to check the accessibleContext of SkiaLayer.HardwareLayer or SkiaSwingLayer
+            val sceneParent = composeSceneAccessible.accessibleContext.accessibleParent
+            val childCount = sceneParent.accessibleContext.accessibleChildrenCount
+            for (i in 0 until childCount) {
+                val child = sceneParent.accessibleContext.getAccessibleChild(i)
+                if (child.accessibleContext == textFieldAccessible.accessibleContext) {
+                    return  // Found it!
+                }
+            }
+            fail("Did not find ancestor with correct accessible context")
+        }
+        assertSceneAccessibleIsTextField()
+
+        // De-focus, then re-focus the window and check that another focus gained property change
+        // event was sent
+        val anotherWindow = JFrame()
+        try {
+            anotherWindow.size = Dimension(800, 600)
+            anotherWindow.isVisible = true
+            anotherWindow.toFront()
+            awaitIdle()
+            assertFalse(textFieldHasFocus)
+            window.toFront()
+            awaitIdle()
+            assertTrue(textFieldHasFocus)
+            assertSceneAccessibleIsTextField()
+        } finally {
+            anotherWindow.dispose()
+        }
     }
 
     // This test asserts that the component corresponding to ComposeSceneAccessible when using
@@ -684,7 +729,7 @@ private fun runDesktopA11yTest(block: ComposeA11yTestScope.() -> Unit) {
             _accessibilityControllers[semanticsOwner] = AccessibilityController(
                 owner = semanticsOwner,
                 desktopComponent = PlatformComponent.Empty,
-                parent = composeSceneAccessible,
+                parentAccessible = composeSceneAccessible,
                 onFocusReceived = { }
             )
         }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -74,7 +74,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.runApplicationTest
 import java.awt.Dimension
 import java.awt.Point
-import java.awt.Toolkit
 import java.awt.Window
 import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
@@ -98,8 +97,9 @@ import kotlin.test.fail
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.CONFLATED
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.jetbrains.skiko.hostOs
@@ -588,13 +588,6 @@ class AccessibilityTest {
     }
 
     @Test
-    fun printWindowManager() {
-        val toolkit = Toolkit.getDefaultToolkit()
-        val wmName = toolkit.getDesktopProperty("win.wm.name") as String?
-        fail("Window manager: $wmName")
-    }
-
-    @Test
     fun initiallyFocusedElementNotifiesSystemOfFocus() = runApplicationTest {
         AccessibilityController.AccessibilityUsage.notifyInUse()
 
@@ -629,20 +622,21 @@ class AccessibilityTest {
             }
         })
 
-        suspend fun waitForTextFieldToBecomeFocused() {
+        suspend fun waitForTextFieldFocusedState(focused: Boolean) {
             // If we do awaitIdle here, we'll sometimes fail the assertSceneAccessibleIsTextField
             // check because the NativeAccessibleFocusHelper.focusedAccessible is reset to null
             // after 100ms, and awaitIdle sometimes takes longer.
-            withTimeout(1000) {
-                while (!(window.isFocused && textFieldHasFocus)) {
+            withTimeoutOrNull(1000) {
+                while ((window.isFocused != focused) || (textFieldHasFocus != focused)) {
                     receivedFocus.receive()
                 }
             }
-            assertTrue(window.isFocused, "Could not make original window focused")
-            assertTrue(textFieldHasFocus, "TextField accessible did not send focused event")
+            val focusStateString = if (focused) "focused" else "unfocused"
+            assertEquals(focused, window.isFocused, "Could not make original window $focusStateString")
+            assertEquals(focused, textFieldHasFocus, "TextField accessible did not send $focusStateString event")
         }
 
-        waitForTextFieldToBecomeFocused()
+        waitForTextFieldFocusedState(true)
         assertNotNull(textFieldAccessible)
 
         // What really causes Java's accessibility to report the correct element (on Windows;
@@ -681,11 +675,12 @@ class AccessibilityTest {
             anotherWindow.size = Dimension(800, 600)
             anotherWindow.isVisible = true
             anotherWindow.toFront()
-            awaitIdle()
+            waitForTextFieldFocusedState(false)
             assertFalse(window.isFocused)
             assertFalse(textFieldHasFocus)
+            delay(100)  // Helps test to be more reliable
             window.toFront()
-            waitForTextFieldToBecomeFocused()
+            waitForTextFieldFocusedState(true)
             assertSceneAccessibleIsTextField()
         } finally {
             if (anotherWindow.isShowing) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -77,6 +77,8 @@ import java.awt.Point
 import java.awt.Window
 import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
+import java.io.BufferedReader
+import java.io.InputStreamReader
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
@@ -583,6 +585,18 @@ class AccessibilityTest {
                 verifyA11yHierarchyWithComposePanel()
             }
         }
+    }
+
+    @Test
+    fun printWindowManager() {
+        val process = ProcessBuilder("wmctrl", "-m")
+            .redirectErrorStream(true)
+            .start()
+
+        val reader = process.inputStream.reader().buffered()
+        val output = reader.readText()
+        process.waitFor()
+        fail(output)
     }
 
     @Test

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -34,15 +34,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ComposeFeatureFlags
+import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.assertThat
+import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.awt.RenderSettings
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.isEqualTo
 import androidx.compose.ui.platform.a11y.AccessibilityController
 import androidx.compose.ui.platform.a11y.ComposeAccessible
 import androidx.compose.ui.platform.a11y.ComposeSceneAccessible
+import androidx.compose.ui.scene.ComposeContainer
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -67,11 +72,11 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.runApplicationTest
+import java.awt.Dimension
 import java.awt.Point
+import java.awt.Window
 import java.awt.event.HierarchyEvent
 import java.awt.event.HierarchyListener
-import java.awt.event.WindowAdapter
-import java.awt.event.WindowEvent
 import javax.accessibility.Accessible
 import javax.accessibility.AccessibleComponent
 import javax.accessibility.AccessibleContext
@@ -80,6 +85,8 @@ import javax.accessibility.AccessibleRole
 import javax.accessibility.AccessibleState
 import javax.accessibility.AccessibleText
 import javax.accessibility.AccessibleValue
+import javax.swing.JLayeredPane
+import javax.swing.SwingUtilities
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFalse
@@ -88,13 +95,13 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.StandardTestDispatcher
+import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 
 @OptIn(ExperimentalTestApi::class)
 class AccessibilityTest {
-
     @Test
     fun accessibleText() = runDesktopA11yTest {
         test.setContent {
@@ -499,19 +506,15 @@ class AccessibilityTest {
             .isEqualTo(AccessibleRole.PUSH_BUTTON)
     }
 
-    @Test
-    fun verifyA11yHierarchy() = runApplicationTest {
-        launchTestWindowApplication {
-            Text("text")
-        }
-        awaitIdle()
+    private fun verifyA11yHierarchyFromAccessible(
+        window: Window,
+        @Suppress("SameParameterValue") accessibleName: String
+    ) {
+        val accessible = window.findAccessibleNamed(accessibleName)
+        assertNotNull(accessible)
 
-        // Relies on ComposeAccessible.getAccessibleName returning the text
-        val textAccessible = window.findAccessibleNamed("text")
-        assertNotNull(textAccessible)
-
-        // Validate the chain from the text accessible to the window
-        var child: Accessible = textAccessible
+        // Validate the chain from the accessible to the window
+        var child: Accessible = accessible
         while (true) {
             val parent = child.accessibleContext.accessibleParent ?: break
 
@@ -527,13 +530,56 @@ class AccessibilityTest {
             // `externalAccessibleFactory`).
             assertEquals(
                 expected = child.accessibleContext,
-                actual = childAtIndex.accessibleContext
+                actual = childAtIndex.accessibleContext,
+                message = "Wrong actual child of ${parent.accessibleContext}"
             )
 
             child = parent
         }
         assertEquals(window, child)
     }
+
+    @Test
+    fun verifyA11yHierarchy() = runApplicationTest {
+        launchTestWindowApplication {
+            Text("text")
+        }
+        awaitIdle()
+
+        // Relies on ComposeAccessible.getAccessibleName returning the text
+        verifyA11yHierarchyFromAccessible(window = window, accessibleName = "text")
+    }
+
+    @Test
+    fun verifyA11yHierarchyWithComposePanel() = runApplicationTest {
+        val composePanel = ComposePanel().apply {
+            setContent {
+                Text("text")
+            }
+        }
+        val window = ComposeWindow()
+        window.contentPane.add(composePanel)
+        window.size = Dimension(800, 600)
+
+        try {
+            window.isVisible = true
+            awaitIdle()
+            // Relies on ComposeAccessible.getAccessibleName returning the text
+            verifyA11yHierarchyFromAccessible(window = window, accessibleName = "text")
+        } finally {
+            window.dispose()
+        }
+    }
+
+    @Test
+    fun verifyA11yHierarchyWithComposePanelAndOnComponentLayerType() {
+        ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {
+            ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
+                verifyA11yHierarchyWithComposePanel()
+            }
+        }
+    }
+
 
     @Test
     fun initiallyFocusedElementFiresFocusedPropertyEvent() = runApplicationTest {
@@ -569,6 +615,51 @@ class AccessibilityTest {
         awaitIdle()
 
         assertTrue(textFieldHasFocus)
+    }
+
+    // This test asserts that the component corresponding to ComposeSceneAccessible when using
+    // WindowComposeSceneLayer is a child of ComposeSceneMediator.contentComponent (SkiaLayer),
+    // which is assumed by WindowSkiaLayerComponent.sceneAccessibleParent
+    // The purpose of this test is to make sure that if this implementation detail of SkiaLayer
+    // ever changes, the test will fail and indicate that
+    // WindowSkiaLayerComponent.sceneAccessibleParent needs to be updated.
+    @Test
+    fun assertWindowsSkiaLayerComponentsChildIsAccessibleRoot() = SwingUtilities.invokeAndWait {
+        val container = ComposeContainer(
+            container = JLayeredPane(),
+            skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+            window = null,
+            layerType = LayerType.OnWindow
+        )
+
+        val composeSceneAccessible = container.accessible
+        val matchingChild = container.contentComponent.components.find { // contentComponent is SkiaLayer
+            it.accessibleContext == composeSceneAccessible.accessibleContext
+        }
+        assertNotNull(matchingChild)
+    }
+
+    // This test asserts that the component corresponding to ComposeSceneAccessible when using
+    // SwingComposeSceneLayer is ComposeSceneMediator.contentComponent itself (SkiaSwingLayer),
+    // which is assumed by SwingSkiaLayerComponent.sceneAccessibleParent
+    // The purpose of this test is to make sure that if this implementation detail of SkiaLayer
+    // ever changes, the test will fail and indicate that
+    // SwingSkiaLayerComponent.sceneAccessibleParent needs to be updated.
+    @Test
+    fun assertSwingSkiaLayerComponentIsAccessibleRoot() = SwingUtilities.invokeAndWait {
+        val container = ComposeContainer(
+            container = JLayeredPane(),
+            skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+            window = null,
+            layerType = LayerType.OnComponent,
+            renderSettings = RenderSettings.SwingGraphics()
+        )
+
+        val composeSceneAccessible = container.accessible
+        assertEquals(
+            composeSceneAccessible.accessibleContext,
+            container.contentComponent.accessibleContext
+        )
     }
 }
 
@@ -731,6 +822,7 @@ internal class ComposeA11yTestScope(
 }
 
 private fun Accessible.findAccessibleNamed(name: String): Accessible? {
+    val accessibleContext = this.accessibleContext
     if (accessibleContext.accessibleName == name) return this
     for (index in 0 until accessibleContext.accessibleChildrenCount) {
         val child = accessibleContext.getAccessibleChild(index)

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -666,6 +666,7 @@ class AccessibilityTest {
                 if (window.isFocused) break
                 delay(10)
             }
+            assertTrue(window.isFocused)
             assertTrue(textFieldHasFocus)
             assertSceneAccessibleIsTextField()
         } finally {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -97,6 +97,7 @@ import kotlin.test.fail
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.withTimeout
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.jetbrains.skiko.hostOs
@@ -599,6 +600,7 @@ class AccessibilityTest {
         val window = deferredWindow.await()
         var textFieldAccessible: Accessible? = null
         var textFieldHasFocus = false
+        val receivedFocusEvent = CompletableDeferred<Boolean>()
         window.addHierarchyListener(object : HierarchyListener {
             override fun hierarchyChanged(e: HierarchyEvent?) {
                 if (window.isDisplayable) {
@@ -613,11 +615,18 @@ class AccessibilityTest {
                         }
                     }
                     window.removeHierarchyListener(this)
+                    receivedFocusEvent.complete(true)
                 }
             }
         })
 
-        awaitIdle()
+        // If we do awaitIdle here, we'll sometimes fail the assertSceneAccessibleIsTextField
+        // check because the NativeAccessibleFocusHelper.focusedAccessible is re-set after 100ms,
+        // and awaitIdle sometimes takes longer.
+        withTimeout(1000) {
+            receivedFocusEvent.await()
+        }
+        assertTrue(window.isDisplayable)
         assertNotNull(textFieldAccessible)
         assertTrue(textFieldHasFocus)
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -668,6 +668,9 @@ class AccessibilityTest {
         }
         assertSceneAccessibleIsTextField()
 
+        // The additional check below actually works on Linux, but unfortunately, not on our CI
+        if (hostOs == OS.Linux) return@runApplicationTest
+
         // De-focus, then re-focus the window and check that another focus gained property change
         // event was sent
         val anotherWindow = JFrame()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -96,7 +96,9 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.StandardTestDispatcher
+import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.SkiaLayerAnalytics
+import org.jetbrains.skiko.hostOs
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -642,7 +644,10 @@ class AccessibilityTest {
             }
             fail("Did not find ancestor with correct accessible context")
         }
-        assertSceneAccessibleIsTextField()
+        // On Linux, NativeAccessibleFocusHelper doesn't do its trick with focusedAccessible
+        if ((hostOs == OS.Windows) || (hostOs == OS.MacOS)) {
+            assertSceneAccessibleIsTextField()
+        }
 
         // De-focus, then re-focus the window and check that another focus gained property change
         // event was sent

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -659,6 +659,7 @@ class AccessibilityTest {
             anotherWindow.toFront()
             awaitIdle()
             assertFalse(textFieldHasFocus)
+            anotherWindow.dispose()
             window.toFront()
             awaitIdle()
             @Suppress("unused")
@@ -670,7 +671,8 @@ class AccessibilityTest {
             assertTrue(textFieldHasFocus)
             assertSceneAccessibleIsTextField()
         } finally {
-            anotherWindow.dispose()
+            if (anotherWindow.isShowing)
+                anotherWindow.dispose()
         }
     }
 


### PR DESCRIPTION
Fix the parent/child link between `ComposeSceneAccessible` and `SkiaLayer` (and `SwingSkiaLayer`).
Also make sure to fire a focused property change event when a newly created focused node.

Fixes https://youtrack.jetbrains.com/issue/CMP-9209
Fixes https://youtrack.jetbrains.com/issue/CMP-9236

## Testing
Added several unit tests, and also tested with the following:
```
fun main() {
//    System.setProperty("compose.layers.type", "COMPONENT")
//    System.setProperty("compose.swing.render.on.graphics", "true")
//    swingMain()
    composeMain()
}

@Composable
private fun AppContent() {
    Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
        Text("Hello, World!")
        Text("Hello, Compose!")

        val focusRequester = remember { FocusRequester() }
        Button(onClick = {}, Modifier.focusRequester(focusRequester)) { Text("Button 1") }
//        LaunchedEffect(Unit) { focusRequester.requestFocus() }
        Button(onClick = {}) { Text("Button 2") }
    }
}

fun composeMain() = singleWindowApplication {
    AppContent()
}

fun swingMain() = SwingUtilities.invokeLater {
    val frame = JFrame()
    val panel = ComposePanel()
    panel.setContent {
        AppContent()
    }
    frame.contentPane.add(panel)
    frame.size = Dimension(500, 500)
    frame.isVisible = true
}
```

This should be tested by QA

## Release Notes
### Fixes - Desktop
- [A11y, Windows] Fixed the accessibility hierarchy, allowing NVDA traversal commands to work correctly.
- [A11y] Correctly report focused status of a newly created, but already focused, node.
- [A11y] Correctly re-report focused state of focused node when the Compose container becomes focused, such as when the window is brought to the foreground.
