### PR TITLE
Fix runParametrizedTest implementation

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/BorderTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/BorderTest.kt
@@ -79,15 +79,14 @@ class BorderTest {
     private var shape: Shape? = null
 
     private val sceneSize = Size(40f, 40f)
-    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) {
-        params.forEach {
-            shape = it
-            runSkikoComposeUiTest(sceneSize) {
+    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) =
+        runSkikoComposeUiTest(sceneSize) {
+            params.forEach {
+                shape = it
                 test()
             }
             shape = null
         }
-    }
 
     @BeforeTest
     fun reset() {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableFocusableInteractionTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableFocusableInteractionTest.kt
@@ -90,11 +90,11 @@ class ScrollableFocusableInteractionTest {
     private var reverseScrolling: Boolean? = null
 
     private val parameters = initParameters()
-    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) {
+    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) = runSkikoComposeUiTest {
         parameters.forEach {
             orientation = it[0] as Orientation
             reverseScrolling = it[1] as Boolean
-            runSkikoComposeUiTest { test() }
+            test()
         }
     }
 

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListAnimateItemPlacementTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListAnimateItemPlacementTest.kt
@@ -101,14 +101,12 @@ class LazyListAnimateItemPlacementTest {
     private lateinit var state: LazyListState
     
     private val density = Density(1f)
-    
-    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) {
-        params().forEach { 
+
+    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) = runSkikoComposeUiTest {
+        params().forEach {
             config = it
-            runSkikoComposeUiTest {
-                mainClock.autoAdvance = false
-                test()
-            }
+            mainClock.autoAdvance = false
+            test()
         }
     }
 

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListBeyondBoundsTest.kt
@@ -98,10 +98,10 @@ class LazyListBeyondBoundsTest {
     private lateinit var lazyListState: LazyListState
     private lateinit var scope: CoroutineScope
 
-    private fun runParametrizedTest(test: suspend ComposeUiTest.() -> Unit) {
+    private fun runParametrizedTest(test: suspend ComposeUiTest.() -> Unit) = runComposeUiTest {
         ParamsToTest.forEach {
             param = it
-            runComposeUiTest { test() }
+            test()
             param = null
         }
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListFocusMoveTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/lazy/list/LazyListFocusMoveTest.kt
@@ -99,14 +99,12 @@ class LazyListFocusMoveTest {
     private lateinit var lazyListState: LazyListState
     private lateinit var focusManager: FocusManager
 
-    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) {
+    private fun runParametrizedTest(test: SkikoComposeUiTest.() -> Unit) = runSkikoComposeUiTest {
         initParameters().forEach {
             param = it
-            runSkikoComposeUiTest {
-                test()
-            }
-            param = null
+            test()
         }
+        param = null
     }
 
     companion object {


### PR DESCRIPTION
The existing implementation violated the requirement that a test method must return the TestResult - https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/run-test.html

> On JS, this function creates a Promise that executes the test body with the delay-skipping behavior.
The platform difference entails that, in order to use this function correctly in common code, one must always immediately return the produced [TestResult](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-result/index.html) from the test method, without doing anything else afterwards.

## Testing
Existing tests

## Release Notes
N/A
