### PR TITLE
Deprecate `WebElementView` in favor of `HtmlElementView`

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/InteropView.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/viewinterop/InteropView.web.kt
@@ -85,6 +85,7 @@ fun <T : HTMLElement> HtmlElementView(
  * containing [T] was reused. If null, [T] will not be reused, a new instance of [T] will be created
  * using [factory] every time this function enters the composition.
  */
+@Deprecated("Use HtmlElementView instead", replaceWith = ReplaceWith("HtmlElementView(factory, modifier, update, onRelease, onReset)"))
 @ExperimentalComposeUiApi
 @Composable
 fun <T : HTMLElement> WebElementView(


### PR DESCRIPTION
Add missing `@Deprecate` for WebElementView.

Fixes [CMP-9313](https://youtrack.jetbrains.com/issue/CMP-9313)

## Testing
N/A

## Release Notes
### Migration Notes - Web
- `WebElementView` has been deprecated in favor of `HtmlElementView`

