### PR TITLE
Ignore desktop flaky tests

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -250,6 +250,7 @@ class DesktopScrollableTest {
         assertThat(column.offset).isEqualTo(0f)
     }
 
+    @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
     @Test
     fun multipleScrollingModifiers() = runSkikoComposeUiTest(
         size = size,

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.google.common.truth.Truth.assertThat
 import kotlin.math.sqrt
+import kotlin.test.Ignore
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -62,6 +63,7 @@ class DesktopScrollableTest {
     private fun scrollLineMacOs() = density.density * 10f
     private fun scrollPage(bounds: Dp) = bounds.value * density.density
 
+    @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
     @Test
     fun `linux, scroll vertical`() = runSkikoComposeUiTest(
         size = size,

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/gestures/DesktopScrollableTest.kt
@@ -107,6 +107,7 @@ class DesktopScrollableTest {
         assertThat(context.offset).isWithin(0.1f).of(-6 * scrollLineLinux(20.dp))
     }
 
+    @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
     @Test
     fun `windows, scroll vertical`() = runSkikoComposeUiTest(
         size = size,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComplexApplicationTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComplexApplicationTest.kt
@@ -125,6 +125,7 @@ import androidx.compose.ui.window.rememberWindowState
 import androidx.compose.ui.window.runApplicationTest
 import com.google.common.truth.Truth
 import kotlin.random.Random
+import kotlin.test.Ignore
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -691,6 +692,7 @@ class ComplexApplicationTest {
             .isLessThan(1.15)
     }
 
+    @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
     @Test
     fun `no memory leak when wait 3 minutes`() = runApplicationTest(
         timeoutMillis = 10 * 60 * 1000

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -612,6 +612,7 @@ class WindowTest {
         assertThat(isWindowEffectEnded).isTrue()
     }
 
+    @Ignore("Flaky https://youtrack.jetbrains.com/issue/CMP-9422")
     @Test
     fun `undecorated resizable window with unspecified size`() = runApplicationTest {
         lateinit var window: ComposeWindow


### PR DESCRIPTION
Created [CMP-9422](https://youtrack.jetbrains.com/issue/CMP-9422) Fix flaky tests disabled on 12-12-2025

Collected a few references that happened recently, there were more cases of such failures

Ignore `no memory leak when wait 3 minutes`
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20165185696
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20132064381
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20067912092
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20062774638
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20034472739
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20031102198
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20026423477

Ignore `linux, scroll vertical`
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20072880587
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20058996769
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/19506607573

Ignore `windows, scroll vertical`
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/20024454619

Ignore `multipleScrollingModifiers`
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/19279163491
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/19506607573/attempts/3

Ignore `undecorated resizable window with unspecified size`
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/19269526739
https://github.com/JetBrains/compose-multiplatform-core/actions/runs/19963268428

## Release Notes
N/A
