### PR TITLE
Fix traversal order of semantic descendants

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.accessibility.isRTL
 import androidx.compose.ui.platform.accessibility.isScreenReaderFocusable
 import androidx.compose.ui.platform.accessibility.scrollIfPossible
 import androidx.compose.ui.platform.accessibility.scrollToCenterRectIfNeeded
+import androidx.compose.ui.platform.accessibility.sortFlattenChildren
 import androidx.compose.ui.platform.accessibility.unclippedBoundsInWindow
 import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.SemanticsActions
@@ -1485,7 +1486,7 @@ internal class AccessibilityMediator(
                     flatten = flattenChildren
                 )
 
-                val sortedChildren = node.sortByGeometryGroupings(visibleChildren)
+                val sortedChildren = node.sortFlattenChildren(visibleChildren)
                 beforeChildren.sortWith(BeyondBoundsComparator(node.isRTL))
                 afterChildren.sortWith(BeyondBoundsComparator(node.isRTL))
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.SemanticsProperties.InvisibleToUser
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.findClosestParentNode
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.semantics.sortByGeometryGroupings
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toSize
 import platform.UIKit.UIAccessibilityScrollDirection
@@ -293,4 +294,24 @@ internal val SemanticsNode.contentDescription: String? get() {
     } else {
         config.getOrNull(SemanticsProperties.Text)?.joinToString(", ") { it.text }
     }
+}
+
+internal fun SemanticsNode.sortFlattenChildren(children: List<SemanticsNode>): List<SemanticsNode> {
+    val sortedChildren = sortByGeometryGroupings(children) as MutableList<SemanticsNode>
+
+    // Fix the specifics of nodes sorting where a parent node may go after a child in the sorted list.
+    // Swapping them if the order is not specified by other criteria as TraversalIndex.
+    repeat(sortedChildren.count() - 1) { index ->
+        val first = sortedChildren[index]
+        val second = sortedChildren[index + 1]
+        if (!first.unmergedConfig.contains(SemanticsProperties.TraversalIndex) &&
+            !second.unmergedConfig.contains(SemanticsProperties.TraversalIndex) &&
+            first.layoutNode.parent != second.layoutNode.parent &&
+            first.layoutNode.findClosestParentNode({ it == second.layoutNode }) != null
+        ) {
+            sortedChildren[index] = second
+            sortedChildren[index + 1] = first
+        }
+    }
+    return sortedChildren
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -301,6 +301,8 @@ internal fun SemanticsNode.sortFlattenChildren(children: List<SemanticsNode>): L
 
     // Fix the specifics of nodes sorting where a parent node may go after a child in the sorted list.
     // Swapping them if the order is not specified by other criteria as TraversalIndex.
+    // In case of other sort issues, consider copy and re-implementing the `sortByGeometryGroupings`
+    // method to match TalkBack application traversal order.
     repeat(sortedChildren.count() - 1) { index ->
         val first = sortedChildren[index]
         val second = sortedChildren[index + 1]

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Button
@@ -52,6 +53,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.state.ToggleableState
@@ -852,12 +854,12 @@ class ComponentsAccessibilitySemanticTest {
                     isAccessibilityElement = true
                 }
                 node {
-                    label = "Description 1"
-                    isAccessibilityElement = true
-                }
-                node {
                     identifier = "Tag 1"
                     isAccessibilityElement = false
+                }
+                node {
+                    label = "Description 1"
+                    isAccessibilityElement = true
                 }
                 node {
                     label = "Details 1"
@@ -917,11 +919,11 @@ class ComponentsAccessibilitySemanticTest {
 
         assertAccessibilityTree {
             node {
-                label = "Text"
+                label = "Description"
                 isAccessibilityElement = true
             }
             node {
-                label = "Description"
+                label = "Text"
                 isAccessibilityElement = true
             }
         }
@@ -943,6 +945,103 @@ class ComponentsAccessibilitySemanticTest {
             isAccessibilityElement = true
             node {
                 identifier = "Child"
+            }
+        }
+    }
+
+    @Test
+    fun testEnclosedSemanticsContainersOrder() = runUIKitInstrumentedTest {
+        setContent {
+            Box(modifier = Modifier.semantics { contentDescription = "Box 1" }) {
+                Box(modifier = Modifier.semantics { contentDescription = "Box 2" }) {
+                    Column(modifier = Modifier.padding(1.dp).semantics { contentDescription = "Column 3" }) {
+                        Text("Text 1")
+                        Text("Text 2")
+                    }
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                label = "Box 1"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Box 2"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Column 3"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 1"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 2"
+                isAccessibilityElement = true
+            }
+        }
+    }
+
+    @Test
+    fun testMergedTextContentWithMergeDescendants() = runUIKitInstrumentedTest {
+        setContent {
+            Column(
+                modifier = Modifier.semantics(mergeDescendants = true) {
+                    contentDescription = "Content description"
+                    stateDescription = "State description"
+                }
+            ) {
+                Text("Text 1")
+                Text("Text 2")
+            }
+        }
+
+        assertAccessibilityTree {
+            label = "Content description, Text 1, Text 2"
+            value = "State description"
+            isAccessibilityElement = true
+            node {
+                label = "Text 1"
+                isAccessibilityElement = false
+            }
+            node {
+                label = "Text 2"
+                isAccessibilityElement = false
+            }
+        }
+    }
+
+    @Test
+    fun testMergedTextContentWithoutMergeDescendants() = runUIKitInstrumentedTest {
+        setContent {
+            Column(
+                modifier = Modifier.semantics(mergeDescendants = false) {
+                    contentDescription = "Content description"
+                    stateDescription = "State description"
+                }
+            ) {
+                Text("Text 1")
+                Text("Text 2")
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                label = "Content description"
+                value = "State description"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 1"
+                isAccessibilityElement = true
+            }
+            node {
+                label = "Text 2"
+                isAccessibilityElement = true
             }
         }
     }
@@ -974,14 +1073,6 @@ class ComponentsAccessibilitySemanticTest {
 
         assertAccessibilityTree {
             node {
-                isAccessibilityElement = true
-                label = "Label"
-                node {
-                    label = "Label"
-                    isAccessibilityElement = false
-                }
-            }
-            node {
                 label = "Description, Inner, Text"
                 isAccessibilityElement = true
                 node {
@@ -990,6 +1081,14 @@ class ComponentsAccessibilitySemanticTest {
                 }
                 node {
                     label = "Text"
+                    isAccessibilityElement = false
+                }
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Label"
+                node {
+                    label = "Label"
                     isAccessibilityElement = false
                 }
             }


### PR DESCRIPTION
As the TalkBack app on Android also adjusts the traversal order and semantics, the actual order differs from that returned by the function `sortByGeometryGroupings`.
The change fixes some cases where the parent semantics node may go after the child node in the result list.

Fixes https://youtrack.jetbrains.com/issue/CMP-9417/Incorrect-traversal-order-of-semantic-descendants

## Release Notes
### Fixes - iOS
- Fix the traversal order of accessibility nodes where a parent node may follow its child node