### PR TITLE
Remove truth library from ui-test

### DIFF
--- a/compose/ui/ui-test-junit4/build.gradle
+++ b/compose/ui/ui-test-junit4/build.gradle
@@ -146,7 +146,6 @@ if(AndroidXComposePlugin.isMultiplatformEnabled(project)) {
             desktopMain.dependsOn(skikoMain)
 
             desktopMain.dependencies {
-                implementation(libs.truth)
                 implementation(libs.skiko)
             }
 

--- a/compose/ui/ui-test/build.gradle
+++ b/compose/ui/ui-test/build.gradle
@@ -179,7 +179,6 @@ if (AndroidXComposePlugin.isMultiplatformEnabled(project)) {
 
             desktopMain.dependencies {
                 implementation(libs.junit)
-                implementation(libs.truth)
                 implementation(libs.skiko)
             }
 


### PR DESCRIPTION
Fixes [CMP-9438](https://youtrack.jetbrains.com/issue/CMP-9438) Remove Truth library from ui-test-desktop and ui-test-junit4-desktop dependencies.

It was added from the beginning to desktopMain by mistake.

See also that commonMain/androidMain don't have them ([1](https://github.com/androidx/androidx/blob/62b715d4b67cac54ca00e3d2760b901cf640b1cc/compose/ui/ui-test/build.gradle) [2](https://github.com/androidx/androidx/blob/62b715d4b67cac54ca00e3d2760b901cf640b1cc/compose/ui/ui-test-junit4/build.gradle))

## Release Notes
### Fixes - Desktop
`org.jetbrains.compose.ui:ui-test` no longer depends on `com.google.truth:truth`
