### PR TITLE
Support semantics for links in text

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.platform.accessibility.canScroll
 import androidx.compose.ui.platform.accessibility.contentDescription
 import androidx.compose.ui.platform.accessibility.isRTL
 import androidx.compose.ui.platform.accessibility.isScreenReaderFocusable
+import androidx.compose.ui.platform.accessibility.linkTag
+import androidx.compose.ui.platform.accessibility.linkText
 import androidx.compose.ui.platform.accessibility.scrollIfPossible
 import androidx.compose.ui.platform.accessibility.scrollToCenterRectIfNeeded
 import androidx.compose.ui.platform.accessibility.sortFlattenChildren
@@ -224,6 +226,7 @@ private sealed interface AccessibilityNode {
 
         override val accessibilityIdentifier: String?
             get() = cachedConfig.getOrNull(SemanticsProperties.TestTag)
+                ?: semanticsNode.linkTag()
 
         override val accessibilityHint: String?
             get() = cachedConfig.getOrNull(SemanticsActions.OnClick)?.label
@@ -1388,9 +1391,10 @@ internal class AccessibilityMediator(
     ): Pair<AccessibilityElement, AccessibilityElementKey?> {
         val presentIds = MutableIntSet()
         presentIds.add(rootNode.id)
-        val nodes = owner.getAllUncoveredSemanticsNodesToIntObjectMap(rootNode.id) {
-            it.config.contains(SemanticsProperties.LinkTestMarker)
-        }
+        val nodes = owner.getAllUncoveredSemanticsNodesToIntObjectMap(
+            customRootNodeId = rootNode.id,
+            shouldIgnoreNode = { false }
+        )
         keyboardFocusedElementKey?.id?.let {
             if (!nodes.contains(it)) {
                 // The keyboard-focused node is removed. It's important to trigger focus reload
@@ -1889,7 +1893,7 @@ private fun AccessibilityElement.makeAccessibilityLabel(): String? {
         null
     }
 
-    return contentDescription ?: node.contentDescription
+    return contentDescription ?: node.contentDescription ?: node.semanticsNode.linkText()
 }
 
 /**

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.findClosestParentNode
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.semantics.sortByGeometryGroupings
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.toSize
 import platform.UIKit.UIAccessibilityScrollDirection
@@ -236,6 +238,53 @@ internal val SemanticsNode.isRTL: Boolean
 internal fun SemanticsNode.isScreenReaderFocusable(): Boolean {
     return !isTransparent && canBeAccessibilityElement()
 }
+
+internal fun SemanticsNode.linkText(): String? {
+    val (text, annotation) = this.findCorrespondingLinkAnnotations() ?: return null
+
+    return text.substring(annotation.start, annotation.end).takeIf { it.isNotBlank() }
+}
+
+internal fun SemanticsNode.linkTag(): String? {
+    val (_, annotation) = this.findCorrespondingLinkAnnotations() ?: return null
+
+    return annotation.item.getTag()
+}
+
+private fun SemanticsNode.findCorrespondingLinkAnnotations():
+    Pair<AnnotatedString, AnnotatedString.Range<LinkAnnotation>>? {
+    if (!isLink()) {
+        return null
+    }
+    val parentNode = parent ?: return null
+
+    // See [SemanticsNodeInteraction.performFirstLinkClick] for the logic of finding the
+    // corresponding link annotation to the child node
+    var linkIndex = parentNode.children
+        .asSequence()
+        .filter { it.isLink() }
+        .indexOfFirst { it.id == id }
+        .takeIf { it >= 0 } ?: return null
+    val texts = parentNode.config.getOrNull(SemanticsProperties.Text) ?: return null
+    for (text in texts) {
+        val annotations = text.getLinkAnnotations(0, text.length)
+        if (linkIndex < annotations.count()) {
+            return text to annotations[linkIndex]
+        } else {
+            linkIndex -= annotations.count()
+        }
+    }
+    return null
+}
+
+private fun SemanticsNode.isLink(): Boolean =
+    config.getOrNull(SemanticsProperties.LinkTestMarker) != null
+
+private fun LinkAnnotation.getTag(): String? =
+    when (this) {
+        is LinkAnnotation.Clickable -> this.tag
+        else -> null
+    }
 
 internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
     return !isHiddenFromAccessibility &&

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -61,7 +61,11 @@ import androidx.compose.ui.test.assertAccessibilityTree
 import androidx.compose.ui.test.findNodeWithTag
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.LinkInteractionListener
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withAnnotation
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitInteropProperties
 import androidx.compose.ui.viewinterop.UIKitView
@@ -1103,6 +1107,63 @@ class ComponentsAccessibilitySemanticTest {
                     label = "Second Text"
                     isAccessibilityElement = false
                 }
+            }
+        }
+    }
+
+    @Test
+    fun testTextLinks() = runUIKitInstrumentedTest {
+        setContent {
+            Text(text = buildAnnotatedString {
+                append("Text ")
+                withAnnotation(
+                    tag = "annotation tag",
+                    annotation = "annotation"
+                ) {
+                    append("annotation")
+                }
+                append(" ")
+                withLink(
+                    link = LinkAnnotation.Clickable(
+                        tag = "clickable tag",
+                        linkInteractionListener = object : LinkInteractionListener {
+                            override fun onClick(link: LinkAnnotation) {}
+                        }
+                    )
+                ) {
+                    append("clickable")
+                }
+                append(" ")
+                withLink(
+                    link = LinkAnnotation.Url(
+                        url = "https://example.com",
+                        linkInteractionListener = object : LinkInteractionListener {
+                            override fun onClick(link: LinkAnnotation) {}
+                        }
+                    )
+                ) {
+                    append("link")
+                }
+                append(".")
+            })
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                label = "Text annotation clickable link."
+                traits = listOf(UIAccessibilityTraitStaticText)
+            }
+            node {
+                isAccessibilityElement = true
+                label = "clickable"
+                identifier = "clickable tag"
+                traits = listOf(UIAccessibilityTraitButton)
+            }
+            node {
+                isAccessibilityElement = true
+                label = "link"
+                traits = listOf(UIAccessibilityTraitButton)
             }
         }
     }


### PR DESCRIPTION
Make links attributes in text be readable by the iOS Accessibility engine.

Fixes https://youtrack.jetbrains.com/issue/CMP-8981/Compose-UI-Test-performClick-doesnt-work-with-LinkAnnotation.Clickable

## Release Notes
### Features - iOS
- Support semantics for links in text