### PR TITLE
Remove presses handling from AccessibilityMediator

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -426,7 +426,6 @@ private object CachedAccessibilityPropertyKeys {
 @ExportObjCClass
 private class AccessibilityRoot(
     val mediator: AccessibilityMediator,
-    var onKeyboardPresses: (Set<*>) -> Unit = {}
 ) : CMPAccessibilityElement(DUMMY_UI_ACCESSIBILITY_CONTAINER),
     UIFocusItemContainerProtocol {
     var element: AccessibilityElement? = null
@@ -467,16 +466,6 @@ private class AccessibilityRoot(
         } else {
             emptyList<Any>()
         }
-    }
-
-    override fun pressesBegan(presses: Set<*>, withEvent: UIPressesEvent?) {
-        onKeyboardPresses(presses)
-        super.pressesBegan(presses, withEvent)
-    }
-
-    override fun pressesEnded(presses: Set<*>, withEvent: UIPressesEvent?) {
-        onKeyboardPresses(presses)
-        super.pressesEnded(presses, withEvent)
     }
 }
 
@@ -997,7 +986,6 @@ internal class AccessibilityMediator(
     val owner: SemanticsOwner,
     val coroutineContext: CoroutineContext,
     val performEscape: () -> Boolean,
-    onKeyboardPresses: (Set<*>) -> Unit,
     val onScreenReaderActive: (Boolean) -> Unit,
 ) {
     private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
@@ -1034,7 +1022,7 @@ internal class AccessibilityMediator(
      */
     private val coroutineScope = CoroutineScope(coroutineContext + job)
 
-    private val root = AccessibilityRoot(mediator = this, onKeyboardPresses = onKeyboardPresses)
+    private val root = AccessibilityRoot(mediator = this)
 
     /**
      * A map of all [AccessibilityElementKey] currently present in the tree to corresponding
@@ -1301,7 +1289,6 @@ internal class AccessibilityMediator(
 
         refocusKeyboardElementIfNeeded()
         view.accessibilityElements = listOf<NSObject>()
-        root.onKeyboardPresses = {}
 
         for (element in accessibilityElementsMap.values) {
             element.dispose()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -127,7 +127,6 @@ private class SemanticsOwnerListenerImpl(
     private val view: UIView,
     private val coroutineContext: CoroutineContext,
     private val performEscape: () -> Boolean,
-    private val onKeyboardPresses: (Set<*>) -> Unit,
     private val onScreenReaderActive: (Boolean) -> Unit,
 ) : PlatformContext.SemanticsOwnerListener {
 
@@ -146,7 +145,6 @@ private class SemanticsOwnerListenerImpl(
                 semanticsOwner,
                 coroutineContext,
                 performEscape,
-                onKeyboardPresses,
                 onScreenReaderActive
             ).also {
                 it.isEnabled = isEnabled
@@ -344,7 +342,6 @@ internal class ComposeSceneMediator(
 
                 down || up
             },
-            onKeyboardPresses = ::onKeyboardPresses,
             onScreenReaderActive = { platformScreenReader.isActive = it }
         )
     }


### PR DESCRIPTION
Remove duplicated keyboard events coming from accessibility.

Fixes https://youtrack.jetbrains.com/issue/CMP-9444/Crash-when-navigating-back-with-Esc-button

## Release Notes
### Fixes - iOS
- Fix crash when closing popup simultaneously with back navigation