### PR TITLE
Fix keyboard focusing after closing popups

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
@@ -562,6 +562,8 @@ internal class OverlayInputView(
 
     override fun canBecomeFirstResponder() = true
 
+    override fun canBecomeFocused(): Boolean = false
+
     override fun pressesBegan(presses: Set<*>, withEvent: UIPressesEvent?) {
         onKeyboardPresses(presses)
         super.pressesBegan(presses, withEvent)
@@ -662,6 +664,8 @@ internal class BackgroundInputView(
             onAppeared?.invoke()
         }
     }
+
+    override fun canBecomeFocused(): Boolean = false
 
     override fun layoutSubviews() {
         super.layoutSubviews()


### PR DESCRIPTION
Disable the focus of the `OverlayInputView` and `BackgroundInputView` to prevent the focus system from targeting them.

Fixes https://youtrack.jetbrains.com/issue/CMP-9391/iOS-A11y.-Full-Keyboard-Access.-Cannot-navigate-after-closing-popups-with-Esc

## Release Notes
### Fixes - iOS
- Fix the issue where the keyboard may focus on the wrong container and become stuck.