### PR TITLE
Add ComposePanel.redispatchUnconsumedMouseWheelEvents flag

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/ComposeFeatureFlags.desktop.kt
@@ -19,6 +19,7 @@ package androidx.compose.ui
 import androidx.compose.ui.awt.RenderSettings.SkiaSurface
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.awt.ComposePanel
 
 internal enum class LayerType {
     OnSameCanvas,
@@ -93,8 +94,13 @@ internal object ComposeFeatureFlags {
      * Whether to redispatch unconsumed mouse wheel events to the parent heavyweight component.
      * This allows any scrollable components beneath Compose to be scrolled.
      *
+     * To configure this behavior per [ComposePanel], set
+     * [ComposePanel.redispatchUnconsumedMouseWheelEvents].
+     *
      * This flag will be removed in the future, and the default behavior will correspond to a value
      * of `true`.
+     *
+     * @see ComposePanel.redispatchUnconsumedMouseWheelEvents
      */
     val redispatchUnconsumedMouseWheelEvents = FeatureFlag {
         System.getProperty("compose.swing.redispatchMouseWheelEvents", "true").toBoolean()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -140,8 +140,8 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      *
      * If it is set to false, it is developer's responsibility to call [dispose] function
      * when Compose state and all related to [ComposePanel] resources are no longer needed.
-     * It can be useful for cases when [ComposePanel] can be attached/detached to Swing hierarchy multiple times,
-     * so with [isDisposeOnRemove] = `false` state will be preserved.
+     * It can be useful for cases when [ComposePanel] can be attached/detached to Swing hierarchy
+     * multiple times, so with [isDisposeOnRemove] = `false` state will be preserved.
      *
      * On the other hand, [isDisposeOnRemove] = `true` can be useful for stateless components,
      * that can be recreated for each attaching to Swing hierarchy.
@@ -150,6 +150,29 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
      */
     @ExperimentalComposeUiApi
     var isDisposeOnRemove: Boolean = true
+
+    /**
+     * Determines whether unconsumed mouse wheel events will be propagated to the parent component.
+     *
+     * When set to `true`, mouse wheel events that are not consumed by the Compose UI will be passed
+     * to Swing for further processing. This is useful when placing [ComposePanel] inside a
+     * scrollable Swing container (i.e. [javax.swing.JScrollPane]).
+     *
+     * When set to `false`, [ComposePanel] will behave like [javax.swing.JScrollPane], consuming all
+     * mouse wheel events that occur over it.
+     *
+     * To configure this behavior globally, set
+     * [ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents].
+     *
+     * @see ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents
+     */
+    @ExperimentalComposeUiApi
+    var redispatchUnconsumedMouseWheelEvents: Boolean =
+        ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.value
+        set(value) {
+            field = value
+            _composeContainer?.redispatchUnconsumedMouseWheelEvents = value
+        }
 
     /**
      * Saves the current UI state into a [SavedState] object. The returned state can be used
@@ -254,6 +277,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         // content.
         val composeContainer = _composeContainer ?: createComposeContainer().also {
             _composeContainer = it
+            it.redispatchUnconsumedMouseWheelEvents = redispatchUnconsumedMouseWheelEvents
             @OptIn(InternalCoreApi::class)
             it.showLayoutBounds = showLayoutBounds
             val composeContent = _composeContent

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -176,6 +176,7 @@ internal class ComposeContainer(
     val preferredSize by mediator::preferredSize
     val semanticsOwners by mediator::semanticsOwners
 
+    var redispatchUnconsumedMouseWheelEvents by mediator::redispatchUnconsumedMouseWheelEvents
     var showLayoutBounds by mediator::showLayoutBounds
 
     private var isDisposed = false

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -335,6 +335,8 @@ internal class ComposeSceneMediator(
             scene.showLayoutBounds = value
         }
 
+    var redispatchUnconsumedMouseWheelEvents: Boolean =
+        ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.value
 
     /**
      * Provides the size of ComposeScene content inside infinity constraints
@@ -497,7 +499,7 @@ internal class ComposeSceneMediator(
         processMouseEvent {
             val processingResult = scene.onMouseWheelEvent(event.position, event)
             if (!processingResult.anyChangeConsumed) {
-                if (ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.value) {
+                if (redispatchUnconsumedMouseWheelEvents) {
                     redispatchUnconsumedMouseEvent(event)
                 }
             }
@@ -517,7 +519,7 @@ internal class ComposeSceneMediator(
     }
 
     /**
-     * (Re)Dispatches the given mouse event to the component that would have received it had
+     * (Re)dispatches the given mouse event to the component that would have received it had
      * this [ComposeSceneMediator] not been listening to the corresponding type of mouse events.
      *
      * The problem this attempts to solve is that [ComposeSceneMediator] has to register listeners

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -700,117 +700,149 @@ class ComposePanelTest {
 
     @Test
     fun `ComposePanel propagates unconsumed mouse wheel scroll events to parent`() =
-        ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.withOverride(true) {
-            runApplicationTest {
-                val composePanel = ComposePanel()
-                composePanel.preferredSize = Dimension(200, 200)
-                val scrollState = ScrollState(0)
-                composePanel.setContent {
-                    Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Yellow)) {
-                        Column(Modifier.fillMaxWidth().height(400.dp)) {
-                            Text("Hello World")
-                            Text("Hello World")
-                            Text("Hello World")
-                            Text("Hello World")
-                            Text("Hello World")
-                        }
+        runApplicationTest {
+            val composePanel = ComposePanel()
+            composePanel.preferredSize = Dimension(200, 200)
+            composePanel.redispatchUnconsumedMouseWheelEvents = true
+            val scrollState = ScrollState(0)
+            composePanel.setContent {
+                Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Yellow)) {
+                    Column(Modifier.fillMaxWidth().height(400.dp)) {
+                        Text("Hello World")
+                        Text("Hello World")
+                        Text("Hello World")
+                        Text("Hello World")
+                        Text("Hello World")
                     }
                 }
+            }
 
-                val window = JFrame()
-                try {
-                    window.size = Dimension(200, 200)
-                    val scrollPane = JScrollPane(
-                        JPanel().apply {
-                            layout = BoxLayout(this, BoxLayout.Y_AXIS)
-                            add(composePanel)
-                            add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
-                        }
-                    )
-                    scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
-                    window.contentPane.add(scrollPane, BorderLayout.CENTER)
-                    window.isVisible = true
+            val window = JFrame()
+            try {
+                window.size = Dimension(200, 200)
+                val scrollPane = JScrollPane(
+                    JPanel().apply {
+                        layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                        add(composePanel)
+                        add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
+                    }
+                )
+                scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+                window.contentPane.add(scrollPane, BorderLayout.CENTER)
+                window.isVisible = true
 
-                    awaitIdle()
+                awaitIdle()
 
-                    // Scroll a little and check that compose content was scrolled
-                    composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
-                    awaitIdle()
-                    assertThat(scrollState.value).isGreaterThan(0)
+                // Scroll a little and check that compose content was scrolled
+                window.sendMouseWheelEvent(wheelRotation = 1.0)
+                awaitIdle()
+                assertThat(scrollState.value).isGreaterThan(0)
+                assertThat(scrollPane.viewport.viewPosition.y).isEqualTo(0)
 
-                    // Scroll a lot and check that the Swing JScrollPane was scrolled
-                    // Note that we need two scroll events for now because Compose can't partially consume
-                    // scroll events. So one event is needed to scroll Compose content to the end, and
-                    // another one to scroll JScrollPane.
-                    window.sendMouseWheelEvent(wheelRotation = 1000.0)
-                    awaitIdle()
-                    window.sendMouseWheelEvent(wheelRotation = 1000.0)
-                    assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
-                } finally {
-                    window.dispose()
-                }
+                // Scroll a lot and check that the Swing JScrollPane was scrolled
+                // Note that we need two scroll events for now because Compose can't partially consume
+                // scroll events. So one event is needed to scroll Compose content to the end, and
+                // another one to scroll JScrollPane.
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                awaitIdle()
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                println("New scroll position: ${scrollPane.viewport.viewPosition.y}")
+                assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
+
+                // Scroll back to the top to reset the state
+                window.sendMouseWheelEvent(wheelRotation = -1000.0)
+                awaitIdle()
+                window.sendMouseWheelEvent(wheelRotation = -1000.0)
+                awaitIdle()
+                assertThat(scrollState.value).isEqualTo(0)
+                assertThat(scrollPane.viewport.viewPosition.y).isEqualTo(0)
+
+                // Now set redispatchUnconsumedMouseWheelEvents = false and check that the scroll
+                // event is *not* propagated.
+                composePanel.redispatchUnconsumedMouseWheelEvents = false
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                awaitIdle()
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                assertThat(scrollPane.viewport.viewPosition.y).isEqualTo(0)
+            } finally {
+                window.dispose()
             }
         }
 
     @Test
     fun `ComposePanel propagates unconsumed mouse wheel scroll events to sibling`() =
-        ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.withOverride(true) {
-            runApplicationTest {
-                val composePanel = ComposePanel()
-                val scrollState = ScrollState(0)
-                composePanel.setContent {
-                    Box(Modifier.size(200.dp).verticalScroll(scrollState).background(Color.Green)) {
-                        Column(Modifier.fillMaxWidth().height(400.dp)) {
-                            Text("Hello World")
-                            Text("Hello World")
-                            Text("Hello World")
-                            Text("Hello World")
-                            Text("Hello World")
-                        }
+        runApplicationTest {
+            val composePanel = ComposePanel()
+            composePanel.redispatchUnconsumedMouseWheelEvents = true
+            val scrollState = ScrollState(0)
+            composePanel.setContent {
+                Box(Modifier.size(200.dp, 300.dp).verticalScroll(scrollState).background(Color.Green)) {
+                    Column(Modifier.fillMaxWidth().height(400.dp)) {
+                        Text("Hello World")
+                        Text("Hello World")
+                        Text("Hello World")
+                        Text("Hello World")
+                        Text("Hello World")
                     }
                 }
+            }
 
-                val container = JPanel(null)
-                container.size = Dimension(200, 200)
+            val container = JPanel(null)
+            container.size = Dimension(200, 200)
 
-                val scrollPane = JScrollPane(
-                    JPanel().apply {
-                        layout = BoxLayout(this, BoxLayout.Y_AXIS)
-                        add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
-                    }
-                )
-                scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
-
-                composePanel.size = Dimension(200, 200)
-                scrollPane.size = Dimension(200, 400)
-
-                val window = JFrame()
-                try {
-                    window.size = Dimension(200, 400)
-                    container.add(composePanel)
-                    container.add(scrollPane)
-
-                    window.contentPane.add(container, BorderLayout.CENTER)
-                    window.isVisible = true
-
-                    awaitIdle()
-
-                    // Scroll a little and check that compose content was scrolled
-                    composePanel.sendMouseWheelEvent(wheelRotation = 1.0)
-                    awaitIdle()
-                    assertThat(scrollState.value).isGreaterThan(0)
-
-                    // Scroll a lot and check that the Swing JScrollPane was scrolled
-                    // Note that we need two scroll events for now because Compose can't partially consume
-                    // scroll events. So one event is needed to scroll Compose content to the end, and
-                    // another one to scroll JScrollPane.
-                    composePanel.sendMouseWheelEvent(wheelRotation = 1000.0)
-                    awaitIdle()
-                    window.sendMouseWheelEvent(wheelRotation = 1000.0)
-                    assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
-                } finally {
-                    window.dispose()
+            val scrollPane = JScrollPane(
+                JPanel().apply {
+                    layout = BoxLayout(this, BoxLayout.Y_AXIS)
+                    add(javax.swing.Box.createVerticalStrut(1000), BorderLayout.CENTER)
                 }
+            )
+            scrollPane.horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+
+            composePanel.size = Dimension(200, 300)
+            scrollPane.size = Dimension(200, 400)
+
+            val window = JFrame()
+            try {
+                window.size = Dimension(200, 400)
+                container.add(composePanel)
+                container.add(scrollPane)
+
+                window.contentPane.add(container, BorderLayout.CENTER)
+                window.isVisible = true
+
+                awaitIdle()
+
+                // Scroll a little and check that compose content was scrolled
+                window.sendMouseWheelEvent(wheelRotation = 1.0)
+                awaitIdle()
+                assertThat(scrollState.value).isGreaterThan(0)
+
+                // Scroll a lot and check that the Swing JScrollPane was scrolled
+                // Note that we need two scroll events for now because Compose can't partially consume
+                // scroll events. So one event is needed to scroll Compose content to the end, and
+                // another one to scroll JScrollPane.
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                awaitIdle()
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                assertThat(scrollPane.viewport.viewPosition.y).isGreaterThan(0)
+
+                // Scroll back to the top to reset the state
+                window.sendMouseWheelEvent(wheelRotation = -1000.0)
+                awaitIdle()
+                window.sendMouseWheelEvent(wheelRotation = -1000.0)
+                awaitIdle()
+                assertThat(scrollState.value).isEqualTo(0)
+                assertThat(scrollPane.viewport.viewPosition.y).isEqualTo(0)
+
+                // Now set redispatchUnconsumedMouseWheelEvents = false and check that the scroll
+                // event is *not* propagated.
+                composePanel.redispatchUnconsumedMouseWheelEvents = false
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                awaitIdle()
+                window.sendMouseWheelEvent(wheelRotation = 1000.0)
+                assertThat(scrollPane.viewport.viewPosition.y).isEqualTo(0)
+            } finally {
+                window.dispose()
             }
         }
 


### PR DESCRIPTION
Add `ComposePanel.redispatchUnconsumedMouseWheelEvents` flag to control the behavior on a per instance level.

Fixes https://youtrack.jetbrains.com/issue/CMP-9346

## Testing
Changed the existing mouse-wheel propagation tests to use this flag and to verify that propagation doesn't occur when it's `false`.

## Release Notes
### Features - Desktop
- It is now possible to configure the mouse-wheel propagation-to-parent behavior per `ComposePanel` via `ComposePanel.redispatchUnconsumedMouseWheelEvents` flag.
