### PR TITLE
Fix consuming window insets in system window insets padding

### DIFF
--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
@@ -384,9 +384,6 @@ private class InsetsPaddingModifierElement(
     }
 }
 
-internal const val InsetsConsumingModifierNodeKey =
-    "androidx.compose.foundation.lazy.layout.InsetsConsumingModifierNode"
-
 /** Base class for WindowInsets modifiers. */
 internal abstract class InsetsConsumingModifierNode : Modifier.Node(), TraversableNode {
 
@@ -395,7 +392,7 @@ internal abstract class InsetsConsumingModifierNode : Modifier.Node(), Traversab
         private set
 
     override val traverseKey: Any
-        get() = InsetsConsumingModifierNodeKey
+        get() = "androidx.compose.foundation.lazy.layout.InsetsConsumingModifierNode"
 
     /**
      * The [WindowInsets] consumed by this modifier, including any [WindowInsets] consumed by

--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
@@ -385,7 +385,7 @@ private class InsetsPaddingModifierElement(
 }
 
 internal const val InsetsConsumingModifierNodeKey =
-    "androidx.compose.foundation.lazy.layout.TraversablePrefetchStateNode"
+    "androidx.compose.foundation.lazy.layout.InsetsConsumingModifierNode"
 
 /** Base class for WindowInsets modifiers. */
 internal abstract class InsetsConsumingModifierNode : Modifier.Node(), TraversableNode {

--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
@@ -384,6 +384,9 @@ private class InsetsPaddingModifierElement(
     }
 }
 
+internal const val InsetsConsumingModifierNodeKey =
+    "androidx.compose.foundation.lazy.layout.TraversablePrefetchStateNode"
+
 /** Base class for WindowInsets modifiers. */
 internal abstract class InsetsConsumingModifierNode : Modifier.Node(), TraversableNode {
 
@@ -392,7 +395,7 @@ internal abstract class InsetsConsumingModifierNode : Modifier.Node(), Traversab
         private set
 
     override val traverseKey: Any
-        get() = "androidx.compose.foundation.layout.ConsumedInsetsProvider"
+        get() = InsetsConsumingModifierNodeKey
 
     /**
      * The [WindowInsets] consumed by this modifier, including any [WindowInsets] consumed by

--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.kt
@@ -392,7 +392,7 @@ internal abstract class InsetsConsumingModifierNode : Modifier.Node(), Traversab
         private set
 
     override val traverseKey: Any
-        get() = "androidx.compose.foundation.lazy.layout.InsetsConsumingModifierNode"
+        get() = "androidx.compose.foundation.layout.ConsumedInsetsProvider"
 
     /**
      * The [WindowInsets] consumed by this modifier, including any [WindowInsets] consumed by

--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsets.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsets.skiko.kt
@@ -94,4 +94,8 @@ internal fun PlatformInsets.toWindowInsets(): WindowInsets = object : WindowInse
     override fun getTop(density: Density): Int = top
     override fun getRight(density: Density, layoutDirection: LayoutDirection): Int = right
     override fun getBottom(density: Density): Int = bottom
+
+    override fun toString(): String {
+        return "PlatformInsets.toWindowInsets(getLeft=$left, getTop=$top, getRight=$right, getBottom=$bottom)"
+    }
 }

--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
@@ -235,7 +235,11 @@ private class PlatformInsetsPaddingModifierElement(
     override fun create(): PlatformInsetsPaddingModifierNode = PlatformInsetsPaddingModifierNode()
     override fun update(node: PlatformInsetsPaddingModifierNode) {}
     override fun hashCode(): Int = 0
-    override fun equals(other: Any?): Boolean = this === other
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlatformInsetsPaddingModifierElement) return false
+        return inspectorInfo === other.inspectorInfo
+    }
     override fun InspectorInfo.inspectableProperties() = inspectorInfo()
 }
 

--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
@@ -23,10 +23,8 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ObserverModifierNode
-import androidx.compose.ui.node.TraversableNode
 import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.node.traverseAncestors
-import androidx.compose.ui.node.traverseDescendants
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.PlatformWindowInsets
 import androidx.compose.ui.platform.PlatformWindowInsetsProviderNode

--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
@@ -242,4 +242,4 @@ private class PlatformInsetsPaddingModifierElement(
 private class PlatformInsetsPaddingModifierNode: InsetsPaddingModifierNode(WindowInsets())
 
 // TODO: https://youtrack.jetbrains.com/issue/CMP-9483 remove with a conflict after AOSP merge
-internal const val InsetsConsumingModifierNodeKey = "androidx.compose.foundation.lazy.layout.InsetsConsumingModifierNode"
+internal const val InsetsConsumingModifierNodeKey = "androidx.compose.foundation.layout.ConsumedInsetsProvider"

--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
@@ -23,7 +23,10 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.ObserverModifierNode
+import androidx.compose.ui.node.TraversableNode
 import androidx.compose.ui.node.observeReads
+import androidx.compose.ui.node.traverseAncestors
+import androidx.compose.ui.node.traverseDescendants
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.PlatformWindowInsets
 import androidx.compose.ui.platform.PlatformWindowInsetsProviderNode
@@ -155,9 +158,10 @@ private val mandatorySystemGesturesPaddingLambda: PlatformWindowInsets.() -> Win
 @Stable
 private fun Modifier.windowInsetsPadding(
     inspectorInfo: InspectorInfo.() -> Unit,
-    insetsCalculation: PlatformWindowInsets.() -> WindowInsets
-): Modifier =
-    this then PlatformWindowInsetsPaddingModifierElement(inspectorInfo, insetsCalculation)
+    insetsCalculation: PlatformWindowInsets.() -> WindowInsets,
+): Modifier = this then
+    PlatformInsetsPaddingModifierElement(inspectorInfo) then
+    PlatformWindowInsetsPaddingModifierElement(inspectorInfo, insetsCalculation)
 
 private class PlatformWindowInsetsPaddingModifierElement(
     private val inspectorInfo: InspectorInfo.() -> Unit,
@@ -178,9 +182,7 @@ private class PlatformWindowInsetsPaddingModifierNode(
     private var insetsGetter: PlatformWindowInsets.() -> WindowInsets,
 ): PlatformWindowInsetsProviderNode(), ObserverModifierNode {
 
-    private val insetsPaddingNode = delegate(
-        InsetsPaddingModifierNode(WindowInsets())
-    )
+    private var insetsPaddingNode: PlatformInsetsPaddingModifierNode? = null
 
     fun update(insetsGetter: (PlatformWindowInsets) -> WindowInsets) {
         if (this.insetsGetter !== insetsGetter) {
@@ -194,7 +196,24 @@ private class PlatformWindowInsetsPaddingModifierNode(
     override fun onAttach() {
         super.onAttach()
 
+        traverseAncestors(InsetsConsumingModifierNodeKey) { node ->
+            if (node is PlatformInsetsPaddingModifierNode) {
+                insetsPaddingNode = node
+                false
+            } else true
+        }
+
         onObservedReadsChanged()
+    }
+
+    override fun onReset() {
+        insetsPaddingNode = null
+        super.onReset()
+    }
+
+    override fun onDetach() {
+        insetsPaddingNode = null
+        super.onDetach()
     }
 
     override fun windowInsetsInvalidated() {
@@ -205,7 +224,19 @@ private class PlatformWindowInsetsPaddingModifierNode(
 
     override fun onObservedReadsChanged() {
         observeReads {
-            insetsPaddingNode.update(windowInsets.insetsGetter())
+            insetsPaddingNode?.update(windowInsets.insetsGetter())
         }
     }
 }
+
+private class PlatformInsetsPaddingModifierElement(
+    private val inspectorInfo: InspectorInfo.() -> Unit,
+): ModifierNodeElement<PlatformInsetsPaddingModifierNode>() {
+    override fun create(): PlatformInsetsPaddingModifierNode = PlatformInsetsPaddingModifierNode()
+    override fun update(node: PlatformInsetsPaddingModifierNode) {}
+    override fun hashCode(): Int = 0
+    override fun equals(other: Any?): Boolean = this === other
+    override fun InspectorInfo.inspectableProperties() = inspectorInfo()
+}
+
+private class PlatformInsetsPaddingModifierNode: InsetsPaddingModifierNode(WindowInsets())

--- a/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
+++ b/compose/foundation/foundation-layout/src/skikoMain/kotlin/androidx/compose/foundation/layout/WindowInsetsPadding.skiko.kt
@@ -240,3 +240,6 @@ private class PlatformInsetsPaddingModifierElement(
 }
 
 private class PlatformInsetsPaddingModifierNode: InsetsPaddingModifierNode(WindowInsets())
+
+// TODO: https://youtrack.jetbrains.com/issue/CMP-9483 remove with a conflict after AOSP merge
+internal const val InsetsConsumingModifierNodeKey = "androidx.compose.foundation.lazy.layout.InsetsConsumingModifierNode"

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/WindowInsetsTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/WindowInsetsTest.kt
@@ -16,9 +16,15 @@
 
 package androidx.compose.ui.layout
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
@@ -26,11 +32,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformWindowInsets
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -177,6 +185,154 @@ class WindowInsetsTest {
             assertEquals(1, compositionCount)
         }
     }
+
+    @Test
+    fun testConsumeWindowInsetsWithWindowInsetsPadding() = runInternalSkikoComposeUiTest {
+        var outerBoxRect = Rect.Zero
+        var innerBoxRect = Rect.Zero
+
+        setContent {
+            Box(Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(WindowInsets(top = 100.dp))
+                .background(Color.Red)
+                .onGloballyPositioned { outerBoxRect = it.boundsInRoot() }
+            ) {
+                Box(Modifier
+                    .fillMaxSize()
+                    .windowInsetsPadding(WindowInsets(top = 101.dp))
+                    .background(Color.Blue)
+                    .onGloballyPositioned { innerBoxRect = it.boundsInRoot() }
+                )
+            }
+        }
+
+        assertEquals(Rect(outerBoxRect.left, 1f, outerBoxRect.right, outerBoxRect.bottom), innerBoxRect)
+    }
+
+    @Test
+    fun testConsumeSystemWindowInsetsWithSystemPadding() = runInternalSkikoComposeUiTest(
+        windowInsets = TestWindowInsets(systemBarsInsets = mutableStateOf(PlatformInsets(top = 100)))
+    ) {
+        var outerBoxRect = Rect.Zero
+        var innerBoxRect = Rect.Zero
+
+        setContent {
+            Box(Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(WindowInsets.systemBars)
+                .background(Color.Red)
+                .onGloballyPositioned { outerBoxRect = it.boundsInRoot() }
+            ) {
+                Box(Modifier
+                    .fillMaxSize()
+                    .systemBarsPadding()
+                    .background(Color.Blue)
+                    .onGloballyPositioned { innerBoxRect = it.boundsInRoot() }
+                )
+            }
+        }
+
+        assertEquals(outerBoxRect, innerBoxRect)
+    }
+
+    @Test
+    fun testConsumeWindowInsetsWithSystemPadding() = runInternalSkikoComposeUiTest(
+        windowInsets = TestWindowInsets(systemBarsInsets = mutableStateOf(PlatformInsets(top = 101)))
+    ) {
+        var outerBoxRect = Rect.Zero
+        var innerBoxRect = Rect.Zero
+
+        setContent {
+            Box(Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(WindowInsets(top = 100.dp))
+                .background(Color.Red)
+                .onGloballyPositioned { outerBoxRect = it.boundsInRoot() }
+            ) {
+                Box(Modifier
+                    .fillMaxSize()
+                    .systemBarsPadding()
+                    .background(Color.Blue)
+                    .onGloballyPositioned { innerBoxRect = it.boundsInRoot() }
+                )
+            }
+        }
+
+        assertEquals(Rect(outerBoxRect.left, 1f, outerBoxRect.right, outerBoxRect.bottom), innerBoxRect)
+    }
+
+    @Test
+    fun testConsumeWindowInsetsPaddingOnSystemInsetsChange() {
+        val systemBarsInsets = mutableStateOf(PlatformInsets.Zero)
+
+        runInternalSkikoComposeUiTest(
+            windowInsets = TestWindowInsets(systemBarsInsets = systemBarsInsets)
+        ) {
+            var outerBoxRect = Rect.Zero
+            var innerBoxRect = Rect.Zero
+
+            setContent {
+                Box(Modifier
+                    .fillMaxSize()
+                    .consumeWindowInsets(WindowInsets(top = 100.dp))
+                    .background(Color.Red)
+                    .onGloballyPositioned { outerBoxRect = it.boundsInRoot() }
+                ) {
+                    Box(Modifier
+                        .fillMaxSize()
+                        .systemBarsPadding()
+                        .background(Color.Blue)
+                        .onGloballyPositioned { innerBoxRect = it.boundsInRoot() }
+                    )
+                }
+            }
+
+            assertEquals(outerBoxRect, innerBoxRect)
+
+            systemBarsInsets.value = PlatformInsets(top = 101)
+            waitForIdle()
+
+            assertEquals(Rect(outerBoxRect.left, 1f, outerBoxRect.right, outerBoxRect.bottom), innerBoxRect)
+        }
+    }
+
+    @Test
+    fun testConsumeSystemWindowInsetsPaddingOnSystemInsetsChange() {
+        val systemBarsInsets = mutableStateOf(PlatformInsets.Zero)
+
+        runInternalSkikoComposeUiTest(
+            windowInsets = TestWindowInsets(systemBarsInsets = systemBarsInsets)
+        ) {
+            var outerBoxRect = Rect.Zero
+            var innerBoxRect = Rect.Zero
+            val maxBottomInset = 100
+
+            setContent {
+                Box(Modifier
+                    .fillMaxSize()
+                    .consumeWindowInsets(WindowInsets.systemBars)
+                    .background(Color.Red)
+                    .onGloballyPositioned { outerBoxRect = it.boundsInRoot() }
+                ) {
+                    Box(Modifier
+                        .fillMaxSize()
+                        .systemBarsPadding()
+                        .background(Color.Blue)
+                        .onGloballyPositioned { innerBoxRect = it.boundsInRoot() }
+                    )
+                }
+            }
+
+            assertEquals(outerBoxRect, innerBoxRect)
+
+            for (i in 1..maxBottomInset) {
+                systemBarsInsets.value = PlatformInsets(bottom = i)
+                waitForIdle()
+                assertEquals(outerBoxRect, innerBoxRect)
+            }
+        }
+    }
 }
 
 @Composable
@@ -197,12 +353,20 @@ private fun TestContent(
 }
 
 private fun TestWindowInsets(
-    imeInsets: MutableState<PlatformInsets>
+    imeInsets: MutableState<PlatformInsets> = mutableStateOf(PlatformInsets.Zero),
+    systemBarsInsets: MutableState<PlatformInsets> = mutableStateOf(PlatformInsets.Zero)
 ): PlatformWindowInsets = object : PlatformWindowInsets {
     override val ime: PlatformInsets get() = PlatformInsets(
         getBottom = { imeInsets.value.bottom },
         getTop = { imeInsets.value.top },
         getLeft = { imeInsets.value.left },
         getRight = { imeInsets.value.right }
+    )
+
+    override val systemBars: PlatformInsets get() = PlatformInsets(
+        getBottom = { systemBarsInsets.value.bottom },
+        getTop = { systemBarsInsets.value.top },
+        getLeft = { systemBarsInsets.value.left },
+        getRight = { systemBarsInsets.value.right }
     )
 }


### PR DESCRIPTION
This PR fixes an issue where window insets (like `statusBarsPadding()`) did not correctly respect or propagate consumed window insets. The core problem was that the `InsetsPaddingModifierNode` logic was "hidden" from the layout traversal system because it was implemented via delegation.

The `Modifier.windowInsetsPadding` now applies two separate modifiers which create nodes of two types:
- `PlatformInsetsPaddingModifierNode` is an `InsetsPaddingModifierNode` that handles actual layout padding and correct resolve of window insets consumed by ancestors.
- `PlatformWindowInsetsPaddingModifierNode` is responsible for retrieving platform-specific `WindowInsets` values. On attachment, it traverses up the modifier chain to find the ancestor `PlatformInsetsPaddingModifierNode` and establishes a link. It provides the insets back up to this ancestor node.

Fixes [CMP-9390](https://youtrack.jetbrains.com/issue/CMP-9390) iOS seems to ignore consumeWindowInsets

## Testing

Adds skiko tests to `WindowInsetsTest`

This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Fix window insets consumption in system window insets padding modifiers.
