### PR TITLE
Fix bullet em units

### DIFF
--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -642,9 +642,10 @@ internal class ParagraphBuilder(
 
         pStyle.direction = textDirection.toSkDirection()
         textStyle.textIndent?.run {
-            with(density) {
-                pStyle.textIndent = SkTextIndent(firstLine.toPx(), restLine.toPx())
-            }
+            pStyle.textIndent = SkTextIndent(
+                firstLine.toPx(density, computedStyle.fontSize),
+                restLine.toPx(density, computedStyle.fontSize)
+            )
         }
         return pStyle
     }

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -20,8 +20,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDirection
+import androidx.compose.ui.text.style.TextIndent
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.em
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -431,27 +433,21 @@ class SkikoParagraphTest {
     fun bullet_withEmUnits_shouldNotCrash() {
         // Regression test for bug where Bullet with Em units caused crash:
         // "Only Sp can convert to Px" when textIndent used Em units
-        val annotatedString = buildAnnotatedString {
-            withBulletList {
-                withBulletListItem {
-                    append("First item")
-                }
-            }
-        }
+        val text = "First item"
 
-        // This should not crash
+        // Create a simple paragraph with textIndent using Em units (like Bullet.DefaultIndentation)
         val paragraph = Paragraph(
-            text = annotatedString.text,
-            spanStyles = annotatedString.spanStyles,
-            paragraphStyles = annotatedString.paragraphStyles,
-            style = TextStyle(),
+            text = text,
+            style = TextStyle(
+                textIndent = TextIndent(1.em, 1.em)
+            ),
             constraints = Constraints(maxWidth = maxWidthConstraint),
             density = defaultDensity,
             fontFamilyResolver = fontFamilyResolver
         )
 
-        // Verify paragraph was created successfully
-        assertEquals("First item", paragraph.text)
+        // Verify paragraph was created successfully without crashing
+        assertEquals(1, paragraph.lineCount)
     }
 
     private fun simpleParagraph(text: String, textStyle: TextStyle = TextStyle()) = Paragraph(

--- a/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
+++ b/compose/ui/ui-text/src/skikoTest/kotlin/androidx/compose/ui/text/SkikoParagraphTest.kt
@@ -427,6 +427,33 @@ class SkikoParagraphTest {
     }
 
 
+    @Test
+    fun bullet_withEmUnits_shouldNotCrash() {
+        // Regression test for bug where Bullet with Em units caused crash:
+        // "Only Sp can convert to Px" when textIndent used Em units
+        val annotatedString = buildAnnotatedString {
+            withBulletList {
+                withBulletListItem {
+                    append("First item")
+                }
+            }
+        }
+
+        // This should not crash
+        val paragraph = Paragraph(
+            text = annotatedString.text,
+            spanStyles = annotatedString.spanStyles,
+            paragraphStyles = annotatedString.paragraphStyles,
+            style = TextStyle(),
+            constraints = Constraints(maxWidth = maxWidthConstraint),
+            density = defaultDensity,
+            fontFamilyResolver = fontFamilyResolver
+        )
+
+        // Verify paragraph was created successfully
+        assertEquals("First item", paragraph.text)
+    }
+
     private fun simpleParagraph(text: String, textStyle: TextStyle = TextStyle()) = Paragraph(
         text = text,
         style = textStyle,


### PR DESCRIPTION
Changed the textIndent conversion to use the overloaded toPx(density, fontSize) extension function that properly handles both Em and Sp units. This matches the pattern already used for placeholder conversion in the same file (lines 566-572).

Fixes CMP-9453

## Testing
SkikoParagraphTest.bullet_withEmUnits_shouldNotCrash

## Release Notes
### Fixes - Multiple Platforms
- Fixed exception thrown when using `Bullets` with `Em` units
