### PR TITLE
Fix `ComposePanel` background

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -504,6 +504,7 @@ public final class androidx/compose/ui/awt/ComposePanel : javax/swing/JLayeredPa
 	public fun requestFocus (Z)Z
 	public fun requestFocusInWindow ()Z
 	public fun requestFocusInWindow (Ljava/awt/event/FocusEvent$Cause;)Z
+	public fun setBackground (Ljava/awt/Color;)V
 	public fun setBounds (IIII)V
 	public fun setComponentOrientation (Ljava/awt/ComponentOrientation;)V
 	public final fun setContent (Lkotlin/jvm/functions/Function2;)V

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -90,7 +90,6 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
                 " (use SwingUtilities.invokeLater).\n" +
                 "Creating from another thread isn't supported."
         }
-        background = Color.white
         layout = null
         focusTraversalPolicy = object : FocusTraversalPolicy() {
             override fun getComponentAfter(
@@ -212,6 +211,12 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
         _composeContainer?.preferredSize ?: Dimension(0, 0)
     }
 
+    override fun setBackground(bg: Color?) {
+        // Note that unless `setOpaque(true)` is called, JLayeredPane will not paint the background
+        super.setBackground(bg)
+        _composeContainer?.contentComponent?.background = bg
+    }
+
     /**
      * Sets Compose content of the ComposePanel.
      *
@@ -300,6 +305,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             setBounds(0, 0, width, height)
             contentComponent.isFocusable = isFocusable
             contentComponent.isRequestFocusEnabled = isRequestFocusEnabled
+            contentComponent.background = background
             exceptionHandler = this@ComposePanel.exceptionHandler
 
             _focusListeners.forEach(contentComponent::addFocusListener)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -140,16 +140,10 @@ internal class WindowSkiaLayerComponent(
         get() = contentComponent.transparency
         set(value) {
             contentComponent.transparency = value
-            if (value && !windowContext.isWindowTransparent && renderApi == GraphicsApi.METAL) {
-                /*
-                 * SkiaLayer sets background inside transparency setter, that is required for
-                 * cases like software rendering.
-                 * In case of transparent Metal canvas on opaque window, background values with
-                 * alpha == 0 will make the result color black after clearing the canvas.
-                 *
-                 * Reset it to null to keep the color default.
-                 */
-                contentComponent.background = null
+            contentComponent.background = if (value && windowContext.isWindowTransparent) {
+                 java.awt.Color(0, 0, 0, 0)
+            } else {
+                null  // This will use the parent's background
             }
         }
     override var fullscreen by contentComponent::fullscreen

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -140,10 +140,15 @@ internal class WindowSkiaLayerComponent(
         get() = contentComponent.transparency
         set(value) {
             contentComponent.transparency = value
-            contentComponent.background = if (value && windowContext.isWindowTransparent) {
-                 java.awt.Color(0, 0, 0, 0)
-            } else {
-                null  // This will use the parent's background
+            contentComponent.background = when {
+                !value -> null  // This will use the parent's background
+                // In case of transparent Metal canvas on an opaque window, background values with
+                // alpha == 0 will make the result color black after clearing the canvas.
+                // The case of `transparency = true` together with `!windowContext.isWindowTransparent`
+                // is needed for "Experimental interop on a regular (non-transparent) window"
+                // (per @MatkovIvan)
+                !windowContext.isWindowTransparent && (renderApi == GraphicsApi.METAL) -> null
+                else -> java.awt.Color(0, 0, 0, 0)
             }
         }
     override var fullscreen by contentComponent::fullscreen

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -41,8 +41,6 @@ import java.awt.image.MultiResolutionImage
 import java.text.AttributedString
 import javax.swing.Icon
 import javax.swing.ImageIcon
-import kotlin.math.abs
-import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
@@ -287,23 +285,4 @@ internal fun ImageComposeScene.runUntilIdle(
         render(time)
     }
     return time
-}
-
-/**
- * Asserts that the two colors are within the given tolerance of each other, on each component.
- */
-fun assertColorsWithinTolerance(expected: java.awt.Color, actual: java.awt.Color, tolerance: Int = 5) {
-    require(tolerance >= 0) { "Tolerance must be non-negative." }
-
-    fun assertDiffIsWithinTolerance(channelName: String, expected: Int, actual: Int) {
-        assertTrue(
-            abs(expected - actual) <= tolerance,
-            message = "Difference in $channelName component between expected ($expected) and actual ($actual) is greater than allowed ($tolerance)"
-        )
-    }
-
-    assertDiffIsWithinTolerance("alpha", expected.alpha, actual.alpha)
-    assertDiffIsWithinTolerance("red", expected.red, actual.red)
-    assertDiffIsWithinTolerance("green", expected.green, actual.green)
-    assertDiffIsWithinTolerance("blue", expected.blue, actual.blue)
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -41,6 +41,8 @@ import java.awt.image.MultiResolutionImage
 import java.text.AttributedString
 import javax.swing.Icon
 import javax.swing.ImageIcon
+import kotlin.math.abs
+import kotlin.test.assertTrue
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
@@ -285,4 +287,23 @@ internal fun ImageComposeScene.runUntilIdle(
         render(time)
     }
     return time
+}
+
+/**
+ * Asserts that the two colors are within the given tolerance of each other, on each component.
+ */
+fun assertColorsWithinTolerance(expected: java.awt.Color, actual: java.awt.Color, tolerance: Int = 5) {
+    require(tolerance >= 0) { "Tolerance must be non-negative." }
+
+    fun assertDiffIsWithinTolerance(channelName: String, expected: Int, actual: Int) {
+        assertTrue(
+            abs(expected - actual) <= tolerance,
+            message = "Difference in $channelName component between expected ($expected) and actual ($actual) is greater than allowed ($tolerance)"
+        )
+    }
+
+    assertDiffIsWithinTolerance("alpha", expected.alpha, actual.alpha)
+    assertDiffIsWithinTolerance("red", expected.red, actual.red)
+    assertDiffIsWithinTolerance("green", expected.green, actual.green)
+    assertDiffIsWithinTolerance("blue", expected.blue, actual.blue)
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.assertColorsWithinTolerance
 import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -895,6 +896,31 @@ class ComposePanelTest {
             assertThat(textFieldIsFocused).isEqualTo(!enabled)
         } finally {
             window.dispose()
+        }
+    }
+
+    @Test
+    fun `ComposePanel draws background correctly`() = runApplicationTest {
+        val composePanel = ComposePanel().apply {
+            size = Dimension(300, 300)
+            background = java.awt.Color.RED
+        }
+        composePanel.setContent { }
+
+        val frame = JFrame().apply {
+            contentPane = composePanel
+            size = Dimension(300, 300)
+        }
+
+        try {
+            frame.isVisible = true
+            awaitIdle()
+            val robot = java.awt.Robot()
+            val frameBounds = frame.bounds
+            val centerPixel = robot.getPixelColor(frameBounds.centerX.toInt(), frameBounds.centerY.toInt())
+            assertColorsWithinTolerance(expected = java.awt.Color.RED, actual = centerPixel)
+        } finally {
+            frame.dispose()
         }
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.assertColorsWithinTolerance
 import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -901,15 +900,30 @@ class ComposePanelTest {
 
     @Test
     fun `ComposePanel draws background correctly`() = runApplicationTest {
+        // Show a canvas and a `ComposePanel` with the same background and compare the two colors.
+        // Simply comparing to the set color doesn't work because Robot returns the color after
+        // the OS transforms it to the screen color space (which doesn't seem to be accessible from
+        // the JVM).
+
+        val bgColor = java.awt.Color.RED
+
+        val canvas = java.awt.Canvas().apply {
+            size = Dimension(300, 300)
+            background = bgColor
+        }
+
         val composePanel = ComposePanel().apply {
             size = Dimension(300, 300)
-            background = java.awt.Color.RED
+            background = bgColor
         }
         composePanel.setContent { }
 
+
         val frame = JFrame().apply {
-            contentPane = composePanel
-            size = Dimension(300, 300)
+            contentPane.layout = BoxLayout(contentPane, BoxLayout.Y_AXIS)
+            contentPane.add(canvas)
+            contentPane.add(composePanel)
+            size = Dimension(300, 600)
         }
 
         try {
@@ -917,8 +931,9 @@ class ComposePanelTest {
             awaitIdle()
             val robot = java.awt.Robot()
             val frameBounds = frame.bounds
-            val centerPixel = robot.getPixelColor(frameBounds.centerX.toInt(), frameBounds.centerY.toInt())
-            assertColorsWithinTolerance(expected = java.awt.Color.RED, actual = centerPixel)
+            val canvasPixel = robot.getPixelColor(frameBounds.centerX.toInt(), (0.25 * frameBounds.centerY).toInt())
+            val composePixel = robot.getPixelColor(frameBounds.centerX.toInt(), (0.75 * frameBounds.centerY).toInt())
+            assertThat(composePixel).isEqualTo(canvasPixel)
         } finally {
             frame.dispose()
         }


### PR DESCRIPTION
Fix `ComposePanel` drawing the background that was set on it.
This follows Skiko's [Fix SkiaLayer background drawing](https://github.com/JetBrains/skiko/pull/1141)

Fixes https://youtrack.jetbrains.com/issue/CMP-8738

## Testing
Added a unit test and tested manually.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed `ComposePanel` drawing the background that was set on it.
