### PR TITLE
Use skiko's transparentWindowBackgroundHack

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -32,7 +32,9 @@ import java.awt.FocusTraversalPolicy
 import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
+import org.jetbrains.skiko.DelicateSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
+import org.jetbrains.skiko.transparentWindowBackgroundHack
 
 /**
  * A panel used as a main view in [ComposeWindow] and [ComposeDialog].
@@ -93,7 +95,9 @@ internal class ComposeWindowPanel(
                 field = value
                 composeContainer.onWindowTransparencyChanged(value)
                 isOpaque = !value
-                window.background = getTransparentWindowBackground(value, renderApi)
+
+                @OptIn(DelicateSkikoApi::class)
+                window.background = if (value) transparentWindowBackgroundHack(renderApi) else null
             }
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/Utils.desktop.kt
@@ -32,7 +32,6 @@ import javax.swing.JLayeredPane
 import kotlin.math.ceil
 import kotlin.math.floor
 import kotlin.math.roundToInt
-import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 
@@ -86,23 +85,6 @@ internal fun Rect.toAwtRectangleRounded(density: Density): Rectangle {
 }
 
 internal fun Color.toAwtColor() = java.awt.Color(red, green, blue, alpha)
-
-internal fun getTransparentWindowBackground(
-    isWindowTransparent: Boolean,
-    renderApi: GraphicsApi
-): java.awt.Color? {
-    /**
-     * There is a hack inside skiko OpenGL and Software redrawers for Windows that makes current
-     * window transparent without setting `background` to JDK's window. It's done by getting native
-     * component parent and calling `DwmEnableBlurBehindWindow`.
-     *
-     * FIXME: Make OpenGL work inside transparent window (background == Color(0, 0, 0, 0)) without this hack.
-     *
-     * See `enableTransparentWindow` (skiko/src/awtMain/cpp/windows/window_util.cc)
-     */
-    val skikoTransparentWindowHack = hostOs == OS.Windows && renderApi != GraphicsApi.DIRECT3D
-    return if (isWindowTransparent && !skikoTransparentWindowHack) java.awt.Color(0, 0, 0, 0) else null
-}
 
 // See https://developer.apple.com/library/archive/technotes/tn2007/tn2196.html#WINDOW_SHADOW
 private var JComponent.hasMacOsShadow: Boolean

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -19,7 +19,6 @@ package androidx.compose.ui.scene
 import androidx.compose.runtime.CompositionContext
 import androidx.compose.ui.awt.JLayeredPaneWithTransparencyHack
 import androidx.compose.ui.awt.RenderSettings
-import androidx.compose.ui.awt.getTransparentWindowBackground
 import androidx.compose.ui.awt.hasMacOsShadow
 import androidx.compose.ui.awt.toAwtRectangle
 import androidx.compose.ui.geometry.Rect
@@ -43,7 +42,9 @@ import java.awt.event.ComponentEvent
 import javax.swing.JDialog
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Rect as SkRect
+import org.jetbrains.skiko.DelicateSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
+import org.jetbrains.skiko.transparentWindowBackgroundHack
 
 internal class WindowComposeSceneLayer(
     composeContainer: ComposeContainer,
@@ -67,10 +68,10 @@ internal class WindowComposeSceneLayer(
         it.isAlwaysOnTop = true
         it.focusableWindowState = focusable
         it.isUndecorated = true
-        it.background = getTransparentWindowBackground(
-            isWindowTransparent = transparent,
-            renderApi = composeContainer.renderApi
-        )
+
+        @OptIn(DelicateSkikoApi::class)
+        it.background =
+            if (transparent) transparentWindowBackgroundHack(composeContainer.renderApi) else null
         if (transparent) {
             it.hasMacOsShadow = false
         }


### PR DESCRIPTION
Use skiko's `transparentWindowBackgroundHack`.

Fixes https://youtrack.jetbrains.com/issue/CMP-9485/Move-getTransparentWindowBackground-to-skiko

## Testing
N/A

## Release Notes
N/A