### PR TITLE
Remove deprecated bindToNavigation API from k/js and k/wasm implementations

### DIFF
--- a/navigation/navigation-runtime/api/navigation-runtime.klib.api
+++ b/navigation/navigation-runtime/api/navigation-runtime.klib.api
@@ -111,6 +111,3 @@ open annotation class androidx.navigation/ExperimentalBrowserHistoryApi : kotlin
 
 // Targets: [js, wasmJs]
 final suspend fun (androidx.navigation/NavController).androidx.navigation/bindToBrowserNavigation(kotlin/Function1<androidx.navigation/NavBackStackEntry, kotlin/String>? = ...) // androidx.navigation/bindToBrowserNavigation|bindToBrowserNavigation@androidx.navigation.NavController(kotlin.Function1<androidx.navigation.NavBackStackEntry,kotlin.String>?){}[0]
-
-// Targets: [js, wasmJs]
-final suspend fun (org.w3c.dom/Window).androidx.navigation/bindToNavigation(androidx.navigation/NavController, kotlin/Function1<androidx.navigation/NavBackStackEntry, kotlin/String>? = ...) // androidx.navigation/bindToNavigation|bindToNavigation@org.w3c.dom.Window(androidx.navigation.NavController;kotlin.Function1<androidx.navigation.NavBackStackEntry,kotlin.String>?){}[0]

--- a/navigation/navigation-runtime/build.gradle
+++ b/navigation/navigation-runtime/build.gradle
@@ -128,6 +128,9 @@ androidXMultiplatform {
         nativeMain.dependsOn(nonJvmMain)
         nativeTest.dependsOn(nonJvmTest)
 
+        webMain.dependencies {
+            implementation(libs.kotlinXw3c)
+        }
         webMain.dependsOn(nonJvmMain)
         webTest.dependsOn(nonJvmTest)
 
@@ -140,12 +143,8 @@ androidXMultiplatform {
                 target.compilations["test"].defaultSourceSet.dependsOn(webTest)
             }
         }
-
-        wasmJsMain.dependencies {
-            implementation(libs.kotlinXw3c)
-        }
-
-        wasmJsTest.kotlin.srcDirs("src/jsTest/kotlin")
+        jsTest.dependsOn(webTest)
+        wasmJsTest.dependsOn(webTest)
     }
 }
 

--- a/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
+++ b/navigation/navigation-runtime/src/jsMain/kotlin/androidx/navigation/BrowserHistory.js.kt
@@ -16,39 +16,4 @@
 
 package androidx.navigation
 
-import org.w3c.dom.Window
-
-/**
- * Binds the browser window state to the given navigation controller.
- *
- * If `getBackStackEntryRoute` is null, then:
- *  1) if a browser url contains a destination route on a start then navigates to destination
- *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
- *
- * If there is a custom `getBackStackEntryRoute` implementation,
- * then we don't have a knowledge how to parse urls to support direct navigation via browser address input.
- * In that case, it should be done on the app's side:
- * ```
- * window.addEventListener("popstate") { event ->
- *     event as PopStateEvent
- *     if (event.state == null) { // empty state means manually entered address
- *         val url = window.location.toString()
- *         navController.navigate(...)
- *     }
- * }
- * ```
- *
- * @param navController The [NavController] instance to bind to browser window navigation.
- * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
- */
-@Suppress("UnusedReceiverParameter")
-@Deprecated(message = "Use bindToBrowserNavigation", replaceWith = ReplaceWith("navController.bindToBrowserNavigation(getBackStackEntryRoute)"))
-@ExperimentalBrowserHistoryApi
-public suspend fun Window.bindToNavigation(
-    navController: NavController,
-    getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
-) {
-    navController.bindToBrowserNavigation(getBackStackEntryRoute)
-}
-
 internal actual fun refBrowserWindow(): BrowserWindow = js("window")

--- a/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
+++ b/navigation/navigation-runtime/src/wasmJsMain/kotlin/androidx/navigation/BrowserHistory.wasmJs.kt
@@ -16,39 +16,4 @@
 
 package androidx.navigation
 
-import org.w3c.dom.Window
-
-/**
- * Binds the browser window state to the given navigation controller.
- *
- * If `getBackStackEntryRoute` is null, then:
- *  1) if a browser url contains a destination route on a start then navigates to destination
- *  2) if a user puts a new destination route to the browser address field then navigates to the new destination
- *
- * If there is a custom `getBackStackEntryRoute` implementation,
- * then we don't have a knowledge how to parse urls to support direct navigation via browser address input.
- * In that case, it should be done on the app's side:
- * ```
- * window.addEventListener("popstate") { event ->
- *     event as PopStateEvent
- *     if (event.state == null) { // empty state means manually entered address
- *         val url = window.location.toString()
- *         navController.navigate(...)
- *     }
- * }
- * ```
- *
- * @param navController The [NavController] instance to bind to browser window navigation.
- * @param getBackStackEntryRoute An optional function that returns the route to show for a given [NavBackStackEntry].
- */
-@ExperimentalBrowserHistoryApi
-@Suppress("UnusedReceiverParameter")
-@Deprecated(message = "Use bindToBrowserNavigation", replaceWith = ReplaceWith("navController.bindToBrowserNavigation(getBackStackEntryRoute)"))
-public suspend fun Window.bindToNavigation(
-    navController: NavController,
-    getBackStackEntryRoute: ((entry: NavBackStackEntry) -> String)? = null
-) {
-    navController.bindToBrowserNavigation(getBackStackEntryRoute)
-}
-
 internal actual fun refBrowserWindow(): BrowserWindow = js("window")

--- a/navigation/navigation-runtime/src/webTest/kotlin/androidx/navigation/BrowserHistoryTest.kt
+++ b/navigation/navigation-runtime/src/webTest/kotlin/androidx/navigation/BrowserHistoryTest.kt
@@ -61,7 +61,7 @@ class BrowserHistoryTest {
         }
         val appAddress = with(window.location) { origin + pathname }
 
-        val bind = launch { window.bindToNavigation(navController) }
+        val bind = launch { navController.bindToBrowserNavigation() }
         navController.setGraph(navController.createGraph(), null)
         advanceUntilIdle()
 
@@ -112,7 +112,7 @@ class BrowserHistoryTest {
         navController.setGraph(navController.createGraph(), null)
 
         val appAddress = with(window.location) { origin + pathname }
-        val bind = launch { window.bindToNavigation(navController) }
+        val bind = launch { navController.bindToBrowserNavigation() }
         advanceUntilIdle()
 
         assertThat(window.history.length).isEqualTo(initHistoryLength)
@@ -211,7 +211,7 @@ class BrowserHistoryTest {
         navController.setGraph(navController.createGraph(), null)
 
         val appAddress = with(window.location) { origin + pathname }
-        val bind = launch { window.bindToNavigation(navController) { "" } }
+        val bind = launch { navController.bindToBrowserNavigation() { "" } }
         advanceUntilIdle()
 
         assertThat(window.history.length).isEqualTo(initHistoryLength)
@@ -286,7 +286,7 @@ class BrowserHistoryTest {
         val initAddress = "$appAddress#screen_4"
         window.history.replaceState(null, "", initAddress)
 
-        val bind = launch { window.bindToNavigation(navController) }
+        val bind = launch { navController.bindToBrowserNavigation() }
         advanceUntilIdle()
 
         assertThat(window.history.length).isEqualTo(initHistoryLength)
@@ -321,7 +321,7 @@ class BrowserHistoryTest {
         navController.setGraph(navController.createGraph(), null)
 
         val appAddress = with(window.location) { origin + pathname }
-        val bind = launch { window.bindToNavigation(navController) }
+        val bind = launch { navController.bindToBrowserNavigation() }
         advanceUntilIdle()
 
         assertThat(window.history.length).isEqualTo(initHistoryLength)


### PR DESCRIPTION
Fixes [CMP-8434](https://youtrack.jetbrains.com/issue/CMP-8434)

## Testing
N/A

## Release Notes
### Migration Notes - Navigation
- A deprecated `suspend fun Window.bindToNavigation` method has been removed
