### PR TITLE
Fix a11y role of window-level compose content in VoiceOver

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -292,6 +292,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
     private fun createComposeContainer(): ComposeContainer {
         return ComposeContainer(
             container = this,
+            isWindowLevel = false,
             skiaLayerAnalytics = skiaLayerAnalytics,
             savedState = savedState,
             windowContainer = windowContainer,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -51,6 +51,7 @@ internal class ComposeWindowPanel(
     // big objects in memory (like the whole LayoutNode tree of the window)
     private var _composeContainer: ComposeContainer? = ComposeContainer(
         container = this,
+        isWindowLevel = true,
         skiaLayerAnalytics = skiaLayerAnalytics,
         window = window,
         windowContainer = this,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -54,6 +54,7 @@ import org.jetbrains.skiko.hostOs
  * @see ComposeAccessible
  */
 internal class ComposeSceneAccessible(
+    private val isWindowLevel: Boolean = false,
     private val forceEnableA11y: Boolean = false,
     private val parent: () -> Accessible?,
     private val accessibilityControllersProvider: () -> List<AccessibilityController>,
@@ -173,12 +174,16 @@ internal class ComposeSceneAccessible(
         override fun getAccessibleRole(): AccessibleRole {
             // We want to return a role that makes the ComposeScene container "transparent" to
             // accessibility, as if its contents are inside the parent directly.
-            // On macOS, PANEL is ignored by Java's a11y (see CAccessibility.ignoredRoles), but on
-            // Windows, it makes NVDA read it as "panel" when clicked.
-            // On Windows, NVDA ignores UNKNOWN, but on macOS UNKNOWN causes VoiceOver to highlight
-            // the entire component when traversing via VoiceOver shortcuts.
+            // - On Windows, NVDA ignores UNKNOWN, but on macOS UNKNOWN causes VoiceOver to highlight
+            //   the entire component when traversing via VoiceOver shortcuts.
+            // - On macOS, PANEL is ignored by Java's a11y (see CAccessibility.ignoredRoles), but on
+            //   Windows, it makes NVDA read it as "panel" when clicked. The exception to this is
+            //   when the scene is for the entire window (with, e.g., Composable Window), returning
+            //   PANEL when nothing else is focused makes VoiceOver highlight it because it is
+            //   the focused Swing component. UNKNOWN prevents that, and because it's top-level,
+            //   the case with traversing via VoiceOver shortcuts doesn't apply.
             return when (hostOs) {
-                OS.MacOS -> AccessibleRole.PANEL
+                OS.MacOS -> if (isWindowLevel) AccessibleRole.UNKNOWN else AccessibleRole.PANEL
                 else -> AccessibleRole.UNKNOWN
             }
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -68,6 +68,8 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * It binds Skia canvas and [ComposeScene] to [container].
  *
  * @property container A container for the [ComposeScene].
+ * @property isWindowLevel Whether the container is for the entire window (e.g.,
+ * [androidx.compose.ui.awt.ComposeWindowPanel], not [androidx.compose.ui.awt.ComposePanel]).
  * @param skiaLayerAnalytics The analytics for the Skia layer.
  * @param window The window ancestor of the [container].
  * @param windowContainer A container used for additional layers and as a reference
@@ -78,6 +80,7 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  */
 internal class ComposeContainer(
     val container: JLayeredPane,
+    private val isWindowLevel: Boolean = false,
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
 
     window: Window? = null,
@@ -129,6 +132,7 @@ internal class ComposeContainer(
 
     private val mediator = ComposeSceneMediator(
         container = container,
+        isWindowLevel = isWindowLevel,
         windowContext = windowContext,
         exceptionHandler = {
             exceptionHandler?.onException(it) ?: throw it

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -116,6 +116,7 @@ import org.jetbrains.skiko.swing.SkiaSwingLayer
  */
 internal class ComposeSceneMediator(
     private val container: JComponent,
+    private val isWindowLevel: Boolean,
     private val windowContext: PlatformWindowContext,
     private var exceptionHandler: WindowExceptionHandler?,
     eventListener: AwtEventListener? = null,
@@ -138,6 +139,7 @@ internal class ComposeSceneMediator(
     private val semanticsOwnerManager = DesktopSemanticsOwnerManager()
     var rootForTestListener: PlatformContext.RootForTestListener? by DelegateRootForTestListener()
     val accessible: ComposeSceneAccessible = ComposeSceneAccessible(
+        isWindowLevel = isWindowLevel,
         parent = { skiaLayerComponent.sceneAccessibleParent },
         accessibilityControllersProvider = { semanticsOwnerManager.accessibilityControllers }
     )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -101,6 +101,7 @@ internal class SwingComposeSceneLayer(
         drawBounds = boundsInPx.roundToIntRect()
         mediator = ComposeSceneMediator(
             container = container,
+            isWindowLevel = false,
             windowContext = composeContainer.windowContext,
             exceptionHandler = {
                 composeContainer.exceptionHandler?.onException(it) ?: throw it

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -117,6 +117,7 @@ internal class WindowComposeSceneLayer(
         drawBounds = boundsInPx.roundToIntRect()
         mediator = ComposeSceneMediator(
             container = container,
+            isWindowLevel = true,
             windowContext = windowContext,
             exceptionHandler = {
                 composeContainer.exceptionHandler?.onException(it) ?: throw it


### PR DESCRIPTION
When the Compose content container is focused, but nothing *in* compose is focused, VoiceOver will highlight the content container and call its role "JavaAxIgnore". This PR changes the role of `ComposeSceneAccessible` for this case to UNKNOWN, which seems to fix the issue. VoiceOver instead picks and highlights the first element of interest (e.g. button or text) inside Compose.

Fixes https://youtrack.jetbrains.com/issue/CMP-9503/Voice-Over-focuses-on-WindowSkiaLayerComponent-says-JavaAxIgnore

## Testing
Tested manually

## Release Notes
### Fixes - Desktop
- _(prerelease fix)_ Fixed VoiceOver highlighting the entire Compose content and calling it "JavaAxIgnore" when using a composable `Window`.