### PR TITLE
Disable default screen animation on desktop and web

### DIFF
--- a/navigation3/navigation3-ui/src/desktopMain/kotlin/androidx/navigation3/ui/NavDisplay.desktop.kt
+++ b/navigation3/navigation3-ui/src/desktopMain/kotlin/androidx/navigation3/ui/NavDisplay.desktop.kt
@@ -21,34 +21,31 @@ package androidx.navigation3.ui
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.navigation3.scene.Scene
 import androidx.navigationevent.NavigationEvent.SwipeEdge
-
-private const val DEFAULT_TRANSITION_DURATION_MILLISECOND = 700
 
 public actual fun <T : Any> defaultTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }
 
 public actual fun <T : Any> defaultPopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }
 
 public actual fun <T : Any> defaultPredictivePopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.(@SwipeEdge Int) -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }

--- a/navigation3/navigation3-ui/src/macosMain/kotlin/androidx/navigation3/ui/NavDisplay.macos.kt
+++ b/navigation3/navigation3-ui/src/macosMain/kotlin/androidx/navigation3/ui/NavDisplay.macos.kt
@@ -18,34 +18,31 @@ package androidx.navigation3.ui
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.navigation3.scene.Scene
 import androidx.navigationevent.NavigationEvent.SwipeEdge
-
-private const val DEFAULT_TRANSITION_DURATION_MILLISECOND = 700
 
 public actual fun <T : Any> defaultTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }
 
 public actual fun <T : Any> defaultPopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }
 
 public actual fun <T : Any> defaultPredictivePopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.(@SwipeEdge Int) -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }

--- a/navigation3/navigation3-ui/src/webMain/kotlin/androidx/navigation3/ui/NavDisplay.web.kt
+++ b/navigation3/navigation3-ui/src/webMain/kotlin/androidx/navigation3/ui/NavDisplay.web.kt
@@ -18,34 +18,31 @@ package androidx.navigation3.ui
 
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.ContentTransform
-import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.navigation3.scene.Scene
 import androidx.navigationevent.NavigationEvent.SwipeEdge
-
-private const val DEFAULT_TRANSITION_DURATION_MILLISECOND = 700
 
 public actual fun <T : Any> defaultTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }
 
 public actual fun <T : Any> defaultPopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.() -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }
 
 public actual fun <T : Any> defaultPredictivePopTransitionSpec():
     AnimatedContentTransitionScope<Scene<T>>.(@SwipeEdge Int) -> ContentTransform = {
     ContentTransform(
-        fadeIn(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
-        fadeOut(animationSpec = tween(DEFAULT_TRANSITION_DURATION_MILLISECOND)),
+        EnterTransition.None,
+        ExitTransition.None,
     )
 }


### PR DESCRIPTION
Replace default transition specs with `EnterTransition.None` and `ExitTransition.None` on desktop and web platforms.

Fixes https://youtrack.jetbrains.com/issue/CMP-9507

## Release Notes
N/A