### PR TITLE
Fix first frame rendering

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.launch
 import platform.CoreGraphics.CGPoint
+import platform.CoreGraphics.CGRect
 import platform.CoreGraphics.CGRectEqualToRect
 import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIColor
@@ -132,6 +133,20 @@ internal class ComposeContainerView(
         updateLayout()
     }
 
+    override fun drawRect(rect: CValue<CGRect>) {
+        if (needsSynchronousDraw) {
+            metalView?.redrawer?.draw(waitUntilCompletion = true)
+
+            needsSynchronousDraw = false
+        }
+
+        if (needsDisablePresentWithTransactionOnNextDraw) {
+            needsDisablePresentWithTransactionOnNextDraw = false
+            metalView?.redrawer?.isForcedToPresentWithTransactionEveryFrame = false
+            metalView?.redrawer?.ongoingInteractionEventsCount--
+        }
+    }
+
     override fun safeAreaInsetsDidChange() {
         super.safeAreaInsetsDidChange()
 
@@ -140,6 +155,27 @@ internal class ComposeContainerView(
 
     private fun updateRedrawerState() {
         metalView?.redrawer?.isActive = foregroundStateListener?.isSceneInForeground ?: false
+    }
+
+    /**
+     * Indicates that the view needs to be drawn synchronously with the next layout pass to avoid
+     * flickering.
+     */
+    private var needsSynchronousDraw = true
+
+    /**
+     * Flag indicating whether the `presentWithTransaction` feature of the render pipeline
+     * should be disabled for the next draw operation. It causes a resizing issues when disabling
+     * this feature before the next draw operation.
+     */
+    private var needsDisablePresentWithTransactionOnNextDraw = false
+
+    /**
+     * Raise the flag to indicate that the view needs to be drawn synchronously with the next layout.
+     */
+    private fun setNeedsSynchronousDraw() {
+        needsSynchronousDraw = true
+        setNeedsDisplay()
     }
 
     private fun updateLayout() {
@@ -154,16 +190,16 @@ internal class ComposeContainerView(
                 max(oldSize.height.value, newSize.height.value).toDouble()
             )
             if (!CGRectEqualToRect(metalView.frame, targetRect)) {
+                setNeedsSynchronousDraw()
                 performWithoutAnimation {
                     metalView.setFrame(targetRect)
-                    metalView.setNeedsSynchronousDrawOnNextLayout()
                 }
             }
         } else {
             if (!CGRectEqualToRect(metalView.frame, bounds)) {
+                setNeedsSynchronousDraw()
                 performWithoutAnimation {
                     metalView.setFrame(bounds)
-                    metalView.setNeedsSynchronousDrawOnNextLayout()
                 }
             }
         }
@@ -204,8 +240,8 @@ internal class ComposeContainerView(
                 isAnimating = false
                 updateLayout()
                 metalView.layoutIfNeeded()
-                metalView.redrawer.isForcedToPresentWithTransactionEveryFrame = false
-                metalView.redrawer.ongoingInteractionEventsCount--
+                needsDisablePresentWithTransactionOnNextDraw = true
+                setNeedsSynchronousDraw()
             }
         }
     }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalView.ios.kt
@@ -50,7 +50,7 @@ internal class MetalView(
         MTLCreateSystemDefaultDevice()
             ?: throw IllegalStateException("Metal is not supported on this system")
 
-    private val metalLayer: CAMetalLayer get() = layer as CAMetalLayer
+    val metalLayer: CAMetalLayer get() = layer as CAMetalLayer
     private var canvasBackground: Int = Color.TRANSPARENT
 
     val redrawer = MetalRedrawer(
@@ -71,19 +71,6 @@ internal class MetalView(
             redrawer.canBeOpaque = value
             updateCanvasBackgroundColor()
         }
-
-    /**
-     * Indicates that the view needs to be drawn synchronously with the next layout pass to avoid
-     * flickering.
-     */
-    private var needsSynchronousDraw = true
-
-    /**
-     * Raise the flag to indicate that the view needs to be drawn synchronously with the next layout.
-     */
-    fun setNeedsSynchronousDrawOnNextLayout() {
-        needsSynchronousDraw = true
-    }
 
     init {
         userInteractionEnabled = false
@@ -131,8 +118,6 @@ internal class MetalView(
         contentScaleFactor = screen.scale
         redrawer.maximumFramesPerSecond = screen.maximumFramesPerSecond
         redrawer.preferredFramesPerSecond = screen.maximumFramesPerSecond
-
-        updateMetalLayerSize()
     }
 
     override fun layoutSubviews() {
@@ -151,12 +136,6 @@ internal class MetalView(
                 width = size.width * contentScaleFactor,
                 height = size.height * contentScaleFactor
             )
-        }
-
-        if (needsSynchronousDraw) {
-            redrawer.draw(waitUntilCompletion = true)
-
-            needsSynchronousDraw = false
         }
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeLaunchTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeLaunchTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.integrations
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.MockAppDelegate
+import androidx.compose.ui.test.utils.forEachPixel
+import androidx.compose.ui.uikit.embedSubview
+import androidx.compose.ui.window.ComposeUIView
+import androidx.compose.ui.window.ComposeUIViewController
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIColor
+import platform.UIKit.UIGraphicsImageRenderer
+import platform.UIKit.UIViewController
+
+class ComposeLaunchTest {
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testViewControllerRenderFirstFrameWhenParallelRenderingDisabled() {
+        runViewControllerRenderFirstFrameTest(parallelRenderingEnabled = false)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testViewControllerRenderFirstFrameWhenParallelRenderingEnabled() {
+        runViewControllerRenderFirstFrameTest(parallelRenderingEnabled = true)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testViewRenderFirstFrameWhenParallelRenderingDisabled() {
+        runViewRenderFirstFrameTest(parallelRenderingEnabled = false)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testViewRenderFirstFrameWhenParallelRenderingEnabled() {
+        runViewRenderFirstFrameTest(parallelRenderingEnabled = true)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun runViewControllerRenderFirstFrameTest(parallelRenderingEnabled: Boolean) {
+        val appDelegate = MockAppDelegate()
+        var drawsCount = 0
+
+        val controller = ComposeUIViewController({
+            enforceStrictPlistSanityCheck = false
+            parallelRendering = parallelRenderingEnabled
+        }) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Blue).drawWithContent {
+                drawsCount++
+                this.drawContent()
+            })
+        }
+
+        appDelegate.setUpWindow(controller)
+        val window = appDelegate.window!!
+        controller.view.backgroundColor = UIColor.redColor
+        window.backgroundColor = UIColor.yellowColor
+
+        val renderer = UIGraphicsImageRenderer(bounds = window.bounds)
+        val image = renderer.imageWithActions {
+            window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
+        }
+
+        assertEquals(1, drawsCount, "Expected to draw only one frame on startup")
+
+        image.forEachPixel { _, _, color ->
+            assertEquals(Color.Blue, color, "Expected to draw blue background")
+        }
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun runViewRenderFirstFrameTest(parallelRenderingEnabled: Boolean) {
+        val appDelegate = MockAppDelegate()
+        var drawsCount = 0
+
+        val view = ComposeUIView({
+            enforceStrictPlistSanityCheck = false
+            parallelRendering = parallelRenderingEnabled
+        }) {
+            Box(modifier = Modifier.fillMaxSize().background(Color.Blue).drawWithContent {
+                drawsCount++
+                this.drawContent()
+            })
+        }
+
+        val controller = UIViewController()
+        appDelegate.setUpWindow(controller)
+        val window = appDelegate.window!!
+        controller.view.backgroundColor = UIColor.redColor
+        window.backgroundColor = UIColor.yellowColor
+
+        controller.view.embedSubview(view)
+
+        val renderer = UIGraphicsImageRenderer(bounds = window.bounds)
+        val image = renderer.imageWithActions {
+            window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
+        }
+
+        assertEquals(1, drawsCount, "Expected to draw only one frame on startup")
+
+        image.forEachPixel { _, _, color ->
+            assertEquals(Color.Blue, color, "Expected to draw blue background")
+        }
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIImage+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIImage+Utils.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test.utils
+
+import androidx.compose.ui.graphics.Color
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
+import platform.CoreGraphics.CGContextDrawImage
+import platform.CoreGraphics.CGImageAlphaInfo
+import platform.CoreGraphics.CGImageGetHeight
+import platform.CoreGraphics.CGImageGetWidth
+import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIImage
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun UIImage.forEachPixel(onPixel: (x: Int, y: Int, color: Color) -> Unit) {
+    val cgImage = this.CGImage
+    val width = CGImageGetWidth(cgImage).toInt()
+    val height = CGImageGetHeight(cgImage).toInt()
+    val colorSpace = CGColorSpaceCreateDeviceRGB()
+    val bytesPerPixel = 4
+    val bytesPerRow = bytesPerPixel * width
+    val rawData = ByteArray(height * bytesPerRow)
+
+    rawData.usePinned { pinned ->
+        val context = CGBitmapContextCreate(
+            data = pinned.addressOf(0),
+            width = width.toULong(),
+            height = height.toULong(),
+            bitsPerComponent = 8UL,
+            bytesPerRow = bytesPerRow.toULong(),
+            space = colorSpace,
+            bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
+        )
+
+        CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), cgImage)
+
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val offset = (y * bytesPerRow) + (x * bytesPerPixel)
+                val r = pinned.get()[offset].toUByte().toInt()
+                val g = pinned.get()[offset + 1].toUByte().toInt()
+                val b = pinned.get()[offset + 2].toUByte().toInt()
+                val a = pinned.get()[offset + 3].toUByte().toInt()
+
+                onPixel(x, y, Color(r, g, b, a))
+            }
+        }
+    }
+}


### PR DESCRIPTION
As we were relying on `didMoveToWindow()` and `layoutSubviews()` to configure components, MetalLayer may receive a call to `layoutSubviews()` and, consequently, fire a draw call before the ComposeSceneMediator is properly initialised. Moving the synchronous frame draw to the `drawRect` fixes the issue. Note: `drawRect` does not work when used in `MetalView` (a view that uses `CAMetalLayer`).

Fixes https://youtrack.jetbrains.com/issue/CMP-9471/iOS-Flash-on-toggling-between-views

## Release Notes
### Fixes - iOS
- Fix issue where the first frame may not be rendered on Compose container appearance