### PR TITLE
Fix race conditions in MetalRedrawer (#2672)

### DIFF
--- a/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
+++ b/compose/ui/ui/src/uikitMain/kotlin/androidx/compose/ui/window/MetalRedrawer.uikit.kt
@@ -277,6 +277,14 @@ internal class MetalRedrawer(
         caDisplayLink?.invalidate()
         caDisplayLink = null
 
+        // Wait until all scheduled rendering tasks are completed to eliminate race conditions
+        // when clearing the resources
+        if (useSeparateRenderThreadWhenPossible) {
+            trace("MetalRedrawer:dispose:waitForAsyncRenderingTasks") {
+                dispatch_sync(renderingDispatchQueue) {}
+            }
+        }
+
         pictureRecorder.close()
         context.close()
     }
@@ -430,6 +438,9 @@ internal class MetalRedrawer(
                     picture.close()
                     surface.flushAndSubmit()
 
+                    surface.close()
+                    renderTarget.close()
+
                     if (useSeparateRenderThreadWhenPossible) {
                         dispatch_semaphore_signal(drawCanvasSemaphore)
                     }
@@ -468,9 +479,6 @@ internal class MetalRedrawer(
                             isInteropActive = false
                         }
                     }
-
-                    surface.close()
-                    renderTarget.close()
 
                     // Track current inflight command buffers to synchronously wait for their schedule in case app goes background
                     inflightCommandBuffers.add(commandBuffer)


### PR DESCRIPTION
Await when all scheduled tasks in async rendering queue are completed before clearing resources.
Move surface and renderTarget closing to the critical section.

Fixes:
https://youtrack.jetbrains.com/issue/CMP-8144/Crash-when-enabling-parallel-rendering-in-MetalRedrawer-for-iOS
Fixes:
https://youtrack.jetbrains.com/issue/CMP-7598/Skia-crash-on-iOS-GrResourceCachenotifyARefCntReachedZero

## Release Notes
### Fixes - iOS
- Fix the crash that may occur when the Compose container disposes.
