### PR TITLE
Fix NPE in KeyboardVisibilityListener when userInfo is nil

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/KeyboardVisibilityListener.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/KeyboardVisibilityListener.ios.kt
@@ -143,6 +143,6 @@ private class NativeKeyboardVisibilityListener : NSObject() {
     private val NSNotification.animationOptions: UIViewAnimationOptions
         get() {
             val value = userInfo?.get(UIKeyboardAnimationCurveUserInfoKey) as? NSNumber
-            return value?.unsignedIntegerValue() as UIViewAnimationOptions
+            return (value?.unsignedIntegerValue() ?: 0UL) as UIViewAnimationOptions
         }
 }


### PR DESCRIPTION
## Description
Fix NullPointerException in `KeyboardVisibilityListener` when a keyboard notification is posted without `userInfo`.

## Problem
When native iOS code manually posts a keyboard notification without `userInfo` (e.g., `NotificationCenter.default.post(name: UIKeyboardWillHideNotification, object: nil)`), the `animationOptions` property crashes due to an unsafe cast.

The current implementation:
```kotlin
return value?.unsignedIntegerValue() as UIViewAnimationOptions
```
When userInfo is nil, value becomes null, and casting null to `UIViewAnimationOptions` throws a NullPointerException.

### Crash stack trace
<img width="688" height="93" alt="image" src="https://github.com/user-attachments/assets/44bb0672-8eaa-45a9-ab1e-6277fe8db95f" />

```
kfun:androidx.compose.ui.window.NativeKeyboardVisibilityListener.<get-animationOptions>#internal
kfun:androidx.compose.ui.window.NativeKeyboardVisibilityListener.$imp:keyboardWillHide:#internal
```

## Solution
Add null-safe handling with a default value, consistent with the duration and endFrame properties in the same file.

Fixes https://youtrack.jetbrains.com/issue/CMP-9548

## Testing
1. Integrate a Compose Multiplatform library that uses ComposeUIViewController in an iOS app
2. From native iOS code, post a keyboard hide notification without userInfo:
```swift
NotificationCenter.default.post(
    name: UIResponder.keyboardWillHideNotification,
    object: nil
    // userInfo is nil
)
```
4. Before fix: App crashes with NullPointerException
5. After fix: No crash, gracefully handles nil userInfo

## Release Notes
###  Fixes - iOS
- Fixed crash in KeyboardVisibilityListener when keyboard notification has nil userInfo

## Google CLA
Sign the Google Contributor's License Agreement at https://cla.developers.google.com to let us upstream your code to Google's AOSP repository
