### PR TITLE
Fix a11y focus continuing to highlight a removed element

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/AccessibilityController.kt
@@ -47,7 +47,8 @@ import kotlinx.coroutines.launch
  * so that each [SemanticsNode] has [ComposeAccessible].
  *
  * @param onFocusReceived a callback that will be called with [ComposeAccessible]
- * when a [SemanticsNode] from [owner] received a focus
+ * when a [SemanticsNode] from [owner] received a focus. `null` is passed when no nodes in the scene
+ * are focused.
  *
  * @see ComposeSceneAccessible
  * @see ComposeAccessible
@@ -56,7 +57,7 @@ internal class AccessibilityController(
     val owner: SemanticsOwner,
     val desktopComponent: PlatformComponent,
     val parentAccessible: ComposeSceneAccessible,
-    private val onFocusReceived: (ComposeAccessible) -> Unit,
+    private val onFocusReceived: (ComposeAccessible?) -> Unit,
 ) {
 
     /**
@@ -66,7 +67,7 @@ internal class AccessibilityController(
     private var accessibleByNodeId = mutableScatterMapOf<Int, ComposeAccessible>()
 
     /**
-     * Whether [accessibleByNodeId] is up-to-date.
+     * Whether [accessibleByNodeId] is up to date.
      */
     private var nodeMappingIsValid = false
 
@@ -135,6 +136,27 @@ internal class AccessibilityController(
      * Invoked when a [ComposeAccessible] is removed.
      */
     private fun onNodeRemoved(accessible: ComposeAccessible) {
+        if (accessible.composeAccessibleContext.focused == true) {
+            notifyOnFocusLost(accessible)
+
+            // Testing showed that when focus is transferred manually when a node is removed (e.g.,
+            // via FocusRequester), the removed node doesn't report it's focused at this point, but
+            // just in case, check that no other nodes are focused before calling
+            // onFocusReceived(null)
+            val anyNodeFocused = accessibleByNodeId.any { _, accessible ->
+                accessible.composeAccessibleContext.focused == true
+            }
+            if (!anyNodeFocused) {
+                onFocusReceived(null)
+            }
+        }
+        if (accessible.composeAccessibleContext.isVisible) {
+            accessible.accessibleContext?.firePropertyChange(
+                ACCESSIBLE_STATE_PROPERTY,
+                AccessibleState.VISIBLE, null
+            )
+        }
+
         accessible.dispose()
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -133,6 +133,14 @@ internal class ComposeAccessible(
         return composeAccessibleContext
     }
 
+    override fun toString(): String {
+        if (disposed) return "ComposeAccessible(disposed)"
+        return with(composeAccessibleContext) {
+            val description = (accessibleDescription ?: text)?.let { "\"$it\"" } ?: "unknown"
+            "ComposeAccessible(role='$accessibleRole', $description)"
+        }
+    }
+
     open inner class ComposeAccessibleComponent : AccessibleContext(), AccessibleComponent, AccessibleAction {
         val textSelectionRange
             get() = semanticsConfig.getOrNull(SemanticsProperties.TextSelectionRange)
@@ -543,6 +551,11 @@ internal class ComposeAccessible(
             }
             if (state != null)
                 add(state)
+        }
+
+        override fun toString(): String {
+            val description = (accessibleDescription ?: text)?.let { "\"$it\"" } ?: "unknown"
+            return "ComposeAccessibleComponent(role='$accessibleRole', $description)"
         }
 
         open inner class ComposeAccessibleText : AccessibleText,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -109,7 +109,7 @@ internal class ComposeSceneAccessible(
             val childCount = context.accessibleChildrenCount
             for (index in 0 until childCount) {
                 val child = context.getAccessibleChild(index)
-                queue.addFirst(child as ComposeAccessible)
+                queue.addFirst(child)
             }
         }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeSceneAccessible.kt
@@ -82,6 +82,40 @@ internal class ComposeSceneAccessible(
         return accessibilityControllersProvider().indexOf(controller)
     }
 
+    /**
+     * Finds and returns a descendant [Accessible] that should receive accessibility focus when
+     * no element is actually focused.
+     *
+     * This is used, for example, to transfer focus when the currently focused [Accessible] is
+     * removed from the hierarchy.
+     */
+    fun defaultAccessibilityFocusTarget(): Accessible? {
+        val ignoredRoles = setOf(
+            AccessibleRole.PANEL,
+            AccessibleRole.GROUP_BOX,
+            AccessibleRole.UNKNOWN
+        )
+
+        // DFS over the Accessible hierarchy
+        val queue = ArrayDeque<Accessible>()
+        queue.addAll(accessibilityControllersProvider().map { it.rootAccessible })
+        while (queue.isNotEmpty()) {
+            val accessible = queue.removeFirst()
+            val context = accessible.accessibleContext ?: continue
+            if (context.accessibleRole !in ignoredRoles) {
+                return accessible
+            }
+
+            val childCount = context.accessibleChildrenCount
+            for (index in 0 until childCount) {
+                val child = context.getAccessibleChild(index)
+                queue.addFirst(child as ComposeAccessible)
+            }
+        }
+
+        return null
+    }
+
     inner class ComposeSceneAccessibleContext : AccessibleContext(), AccessibleComponent {
         // Internal for testing
         internal val accessibilityControllers: List<AccessibilityController>

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -784,7 +784,8 @@ internal class ComposeSceneMediator(
                     if (requestingNativeFocus) return@AccessibilityController
                     requestingNativeFocus = true
                     try {
-                        skiaLayerComponent.requestNativeFocusOnAccessible(it)
+                        val target = it ?: accessible.defaultAccessibilityFocusTarget()
+                        skiaLayerComponent.requestNativeFocusOnAccessible(target)
                     } finally {
                         requestingNativeFocus = false
                     }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SkiaLayerComponent.desktop.kt
@@ -47,7 +47,7 @@ internal interface SkiaLayerComponent {
     val windowHandle: Long
 
     fun dispose()
-    fun requestNativeFocusOnAccessible(accessible: Accessible)
+    fun requestNativeFocusOnAccessible(accessible: Accessible?)
 
     fun onComposeInvalidation()
     fun renderImmediately()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/SwingSkiaLayerComponent.desktop.kt
@@ -133,7 +133,7 @@ internal class SwingSkiaLayerComponent(
         contentComponent.dispose()
     }
 
-    override fun requestNativeFocusOnAccessible(accessible: Accessible) {
+    override fun requestNativeFocusOnAccessible(accessible: Accessible?) {
         contentComponent.requestNativeFocusOnAccessible(accessible)
     }
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -163,8 +163,10 @@ internal class WindowSkiaLayerComponent(
         contentComponent.dispose()
     }
 
-    override fun requestNativeFocusOnAccessible(accessible: Accessible) =
+    override fun requestNativeFocusOnAccessible(accessible: Accessible?) {
+        println("Requesting native focus on accessible: $accessible")
         contentComponent.requestNativeFocusOnAccessible(accessible)
+    }
 
     override fun onComposeInvalidation() {
         contentComponent.needRender()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/skia/WindowSkiaLayerComponent.desktop.kt
@@ -164,7 +164,6 @@ internal class WindowSkiaLayerComponent(
     }
 
     override fun requestNativeFocusOnAccessible(accessible: Accessible?) {
-        println("Requesting native focus on accessible: $accessible")
         contentComponent.requestNativeFocusOnAccessible(accessible)
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneFocusManager.skiko.kt
@@ -38,7 +38,7 @@ class ComposeSceneFocusManager internal constructor(
      */
     val hasFocus: Boolean get() = focusOwner().rootState.hasFocus
 
-    private inline fun <T: Any?> measureAndLayoutThen(request: () -> T): T {
+    private inline fun <T> measureAndLayoutThen(request: () -> T): T {
         measureAndLayout()
         return request()
     }


### PR DESCRIPTION
Currently, when a focused element is removed, a11y systems (VoiceOver and NVDA) continue highlighting the element.

This PR moves the a11y focus (but not the Compose focus) to a different suitable element when this happens.

Fixes https://youtrack.jetbrains.com/issue/CMP-9520/VoiceOver-continues-to-highlight-removed-element

## Testing
Tested manually on macOS (VoiceOver) and Windows (NVDA).

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix accessibility focus continuing to highlight a removed element.
