### PR TITLE
Fix `JPopupContextMenuRepresentation.Representation` reacting to changes in arguments

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/swingexample/Main.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/swingexample/Main.jvm.kt
@@ -69,7 +69,7 @@ import androidx.compose.ui.window.launchApplication
 import androidx.compose.ui.window.rememberWindowState
 import androidx.savedstate.SavedState
 import java.awt.BorderLayout
-import java.awt.Color as awtColor
+import java.awt.Color as AwtColor
 import java.awt.Component
 import java.awt.Dimension
 import java.awt.Graphics
@@ -106,7 +106,7 @@ private val globalSavedState = mutableMapOf<String, SavedState?>()
 fun createGreenComposePanel(
     savedState: SavedState? = null,
 ) = ComposePanel(savedState = savedState).also {
-    it.background = awtColor(55, 155, 55)
+    it.background = AwtColor(55, 155, 55)
     it.setContent {
         JPopupTextMenuProvider(it) {
             ComposeContent(background = Color(55, 155, 55))
@@ -117,7 +117,7 @@ fun createGreenComposePanel(
 fun createBlueComposePanel(
     savedState: SavedState? = null,
 ) = ComposePanel(savedState = savedState).also {
-    it.background = awtColor(55, 55, 155)
+    it.background = AwtColor(55, 55, 155)
     it.setContent {
         CustomTextMenuProvider {
             ComposeContent(background = Color(55, 55, 155))
@@ -206,17 +206,17 @@ fun JPopupTextMenuProvider(owner: Component, content: @Composable () -> Unit) {
         LocalTextContextMenu provides JPopupTextMenu(owner) { textManager, items ->
             JPopupMenu().apply {
                 textManager.cut?.also {
-                    add(swingItem(localization.cut, java.awt.Color.RED, KeyEvent.VK_X, it))
+                    add(swingItem(localization.cut, AwtColor.RED, KeyEvent.VK_X, it))
                 }
                 textManager.copy?.also {
-                    add(swingItem(localization.copy, java.awt.Color.GREEN, KeyEvent.VK_C, it))
+                    add(swingItem(localization.copy, AwtColor.GREEN, KeyEvent.VK_C, it))
                 }
                 textManager.paste?.also {
-                    add(swingItem(localization.paste, java.awt.Color.BLUE, KeyEvent.VK_V, it))
+                    add(swingItem(localization.paste, AwtColor.BLUE, KeyEvent.VK_V, it))
                 }
                 textManager.selectAll?.also {
                     add(Separator())
-                    add(swingItem(localization.selectAll, java.awt.Color.BLACK, KeyEvent.VK_A, it))
+                    add(swingItem(localization.selectAll, AwtColor.BLACK, KeyEvent.VK_A, it))
                 }
                 for (item in items) {
                     add(
@@ -268,7 +268,7 @@ private fun AnnotatedString.crop() = if (length <= 5) toString() else "${take(5)
 @OptIn(ExperimentalFoundationApi::class)
 private fun swingItem(
     label: String,
-    color: java.awt.Color,
+    color: AwtColor,
     key: Int,
     menuItemAction: TextContextMenu.Action
 ) = JMenuItem(label).apply {
@@ -278,7 +278,7 @@ private fun swingItem(
     addActionListener { menuItemAction.execute() }
 }
 
-private fun circleIcon(color: java.awt.Color) = object : Icon {
+private fun circleIcon(color: AwtColor) = object : Icon {
     override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
         g.create().apply {
             this.color = color

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.desktop.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.awt.ComposeWindow
@@ -32,6 +33,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
 import java.awt.Component
 import java.awt.MouseInfo
+import java.awt.Point
 import javax.swing.JMenuItem
 import javax.swing.JPopupMenu
 import javax.swing.SwingUtilities
@@ -150,25 +152,41 @@ class JPopupContextMenuRepresentation(
     override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
         val isOpen = state.status is ContextMenuState.Status.Open
         if (isOpen) {
-            val menu = remember {
-                createMenu(items()).apply {
-                    addPopupMenuListener(object : PopupMenuListener {
-                        override fun popupMenuWillBecomeVisible(e: PopupMenuEvent?) = Unit
+            val menu = remember(createMenu) {
+                createMenu(items())
+            }
 
-                        override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent?) {
-                            state.status = ContextMenuState.Status.Closed
-                        }
+            // Remember the state to avoid closing the menu when the state object (but not the
+            // status) changes.
+            val currentState by rememberUpdatedState(state)
 
-                        override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
-                    })
+            // Remember the screen mouse position for as long as the menu is open to avoid having
+            // the popup move when recreating the menu due to other changes.
+            val mouseScreenPosition = remember { MouseInfo.getPointerInfo().location }
+
+            // The mouse position changes only when the owner changes.
+            val mousePosition = remember(owner) {
+                Point(mouseScreenPosition).also {
+                    SwingUtilities.convertPointFromScreen(it, owner)
                 }
             }
 
-            DisposableEffect(Unit) {
-                val mousePosition = MouseInfo.getPointerInfo().location
-                SwingUtilities.convertPointFromScreen(mousePosition, owner)
+            DisposableEffect(menu, owner, mousePosition) {
+                val popupMenuListener = object : PopupMenuListener {
+                    override fun popupMenuWillBecomeVisible(e: PopupMenuEvent?) = Unit
+
+                    override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent?) {
+                        currentState.status = ContextMenuState.Status.Closed
+                    }
+
+                    override fun popupMenuCanceled(e: PopupMenuEvent?) = Unit
+                }
+                menu.addPopupMenuListener(popupMenuListener)
+
                 menu.show(owner, mousePosition.x, mousePosition.y)
+
                 onDispose {
+                    menu.removePopupMenuListener(popupMenuListener)
                     menu.isVisible = false
                 }
             }


### PR DESCRIPTION
Fix `JPopupContextMenuRepresentation.Representation` reacting to changes in arguments

Fixes [JPopupContextMenuRepresentation should key its remember {}](https://youtrack.jetbrains.com/issue/CMP-9343)

## Testing
Unfortunately unit tests are not possible because
- `runComposeUiTest` doesn't work because `JPopupTextMenu` needs an actual AWT window.
- `runApplicationTest` is `internal` in `ui`.

Tested with
```
fun main() = singleWindowApplication {
    var background by remember { mutableStateOf(Color.WHITE) }
    val coroutineScope = rememberCoroutineScope()
    JPopupContextMenu(
        background = background,
        onContextMenuCreated = {
            coroutineScope.launch {
                delay(2000)
                background = Color(Random.nextInt())
            }
        }
    ) {
        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
            TextField(rememberTextFieldState("abc"), lineLimits = TextFieldLineLimits.SingleLine)
        }
    }
}

@OptIn(ExperimentalFoundationApi::class)
@Composable
private fun WindowScope.JPopupContextMenu(
    background: java.awt.Color,
    onContextMenuCreated: () -> Unit,
    content: @Composable () -> Unit
) {
    CompositionLocalProvider(
        LocalTextContextMenu provides JPopupTextMenu(window) { textManager, items ->
            onContextMenuCreated()

            fun swingMenuItem(text: String, action: TextContextMenu.Action) = JMenuItem(text).also {
                it.background = background
                it.addActionListener { action.execute() }
            }
            JPopupMenu().apply {
                textManager.cut?.also {
                    add(swingMenuItem("Cut", it))
                }
                textManager.copy?.also {
                    add(swingMenuItem("Copy", it))
                }
                textManager.paste?.also {
                    add(swingMenuItem("Paste", it))
                }
                textManager.selectAll?.also {
                    add(swingMenuItem("Select All", it))
                }
            }
        },
        content = content
    )
}
```

Open a context menu in the text field and observe the background change.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fixed `JPopupContextMenuRepresentation` to correctly recreate the menu when the `createMenu` argument changes.
