### PR TITLE
Disable scrollsToTop on OverlayInputView

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/InputViews.ios.kt
@@ -558,6 +558,7 @@ internal class OverlayInputView(
         panGestureRecognizer.delaysTouchesBegan = false
         panGestureRecognizer.delaysTouchesEnded = false
         bounces = false
+        scrollsToTop = false
     }
 
     override fun canBecomeFirstResponder() = true


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9569/iOS-scrollsToTop-status-bar-tap-to-return-to-top-functionality-broken-by-Compose-1.10s-OverlayInputView

## Release Notes
### Fixes - iOS
- Fix an ability to use `scrollsToTop` for native `UIScrollView`s