### PR TITLE
Implement memory leaks tests for ComposeLayersViewController

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -175,9 +175,17 @@ jobs:
         working-directory: compose/ui/ui/src/uikitInstrumentedTest/launcher
         run: |
           xcodebuild test \
+            -resultBundlePath TestResults.xcresult \
             -scheme Launcher \
             -project Launcher.xcodeproj \
             -destination 'platform=iOS Simulator,id=${{ steps.get-simulator-udid.outputs.simulator-id }}'
+
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: TestResults-${{ github.run_number }}.xcresult
+          path: compose/ui/ui/src/uikitInstrumentedTest/launcher/TestResults.xcresult
 
       - name: Test Summary
         uses: test-summary/action@v2

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/leaks/MemoryLeaksTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/leaks/MemoryLeaksTest.kt
@@ -29,23 +29,28 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.node.WeakReference
+import androidx.compose.ui.scene.ComposeHostingView
+import androidx.compose.ui.scene.ComposeHostingViewController
 import androidx.compose.ui.window.ComposeUIView
 import androidx.compose.ui.test.MockAppDelegate
+import androidx.compose.ui.test.findLayersWindow
+import androidx.compose.ui.test.waitForIdle
 import androidx.compose.ui.uikit.embedSubview
 import androidx.compose.ui.window.ComposeUIViewController
+import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.IntermediateTextInputUIView
 import kotlin.native.runtime.GC
 import kotlin.native.runtime.NativeRuntimeApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import platform.CoreGraphics.CGRectMake
@@ -58,12 +63,8 @@ import platform.UIKit.UIView
 import platform.UIKit.UIViewController
 
 class MemoryLeaksTest {
-    companion object {
-        private val KeyboardAnimationDelay = 600.milliseconds
-    }
-
     @Test
-    fun testComposeUIViewControllerDisposal() = runRepeatingBlocking {
+    fun testComposeUIViewControllerDisposal() = runBlocking {
         val appDelegate = MockAppDelegate()
         var composeViewControllerRef: WeakReference<UIViewController>? = null
         var composeLoaded = false
@@ -76,25 +77,23 @@ class MemoryLeaksTest {
                 SideEffect {
                     composeLoaded = true
                 }
-            }
+            } as ComposeHostingViewController
             composeViewControllerRef = WeakReference(controller)
             appDelegate.setUpWindow(controller)
-        }
 
-        // Allow run loop to start the application
-        runApplicationLoop(1.milliseconds)
+            controller.waitForIdle()
+        }
 
         assertTrue(composeLoaded)
         assertNotNull(composeViewControllerRef?.get())
 
         appDelegate.cleanUp()
-        cleanupMemory()
 
-        assertNull(composeViewControllerRef.get())
+        assetDeallocated(composeViewControllerRef)
     }
 
     @Test
-    fun testComposeUIViewControllerSubviewsDisposal() = runRepeatingBlocking {
+    fun testComposeUIViewControllerSubviewsDisposal() = runBlocking {
         val appDelegate = MockAppDelegate()
         val subviewsReferences = mutableListOf<WeakReference<UIView>>()
 
@@ -103,14 +102,14 @@ class MemoryLeaksTest {
                 enforceStrictPlistSanityCheck = false
             }) {
                 Box(modifier = Modifier.fillMaxSize().background(Color.Blue))
-            }
+            } as ComposeHostingViewController
+
             appDelegate.setUpWindow(controller)
+
+            controller.waitForIdle()
         }
 
-        // Allow run loop to start the application
-        runApplicationLoop(1.milliseconds)
-
-        collectSubviewsRecursively(
+        collectComposeSubviewsRecursively(
             appDelegate.window?.rootViewController?.view!!,
             subviewsReferences
         )
@@ -120,16 +119,15 @@ class MemoryLeaksTest {
             actual = subviewsReferences.count(),
             message = "Expected 4 subviews: [ComposeView, UserInputView, MetalView, UIKitTransparentContainerView]" +
                 ", but given: ${
-                    subviewsReferences.mapNotNull {
-                        it.get()?.let { it::class.simpleName }
+                    subviewsReferences.mapNotNull { ref ->
+                        ref.get()?.let { it::class.simpleName }
                     }
                 }"
         )
 
         appDelegate.cleanUp()
-        cleanupMemory()
 
-        assertEquals(emptyList(), subviewsReferences.mapNotNull { it.get() })
+        assetDeallocated(subviewsReferences)
     }
 
     @Test
@@ -150,27 +148,25 @@ class MemoryLeaksTest {
                 LaunchedEffect(Unit) {
                     focusRequester.requestFocus()
                 }
-            }
+            } as ComposeHostingViewController
 
             composeViewControllerRef = WeakReference(controller)
             appDelegate.setUpWindow(controller)
-        }
 
-        // Allow run loop to start the application
-        runApplicationLoop(KeyboardAnimationDelay)
+            controller.waitForIdle()
+        }
 
         assertNotNull(composeViewControllerRef?.get())
 
         appDelegate.cleanUp()
-        cleanupMemory()
 
-        assertNull(composeViewControllerRef.get())
+        assetDeallocated(composeViewControllerRef)
     }
 
     @Test
-    fun testComposeUIViewControllerSubviewsWithTextInputDisposalAndOldContextMenu() =
-        runRepeatingBlocking(newContextMenuEnabled = false) {
-            val appDelegate = MockAppDelegate()
+    fun testComposeUIViewControllerSubviewsWithTextInputDisposalAndOldContextMenu() {
+        val appDelegate = MockAppDelegate()
+        runBlocking(newContextMenuEnabled = false) {
             val subviewsReferences = mutableListOf<WeakReference<UIView>>()
 
             run {
@@ -186,15 +182,14 @@ class MemoryLeaksTest {
                     LaunchedEffect(Unit) {
                         focusRequester.requestFocus()
                     }
-                }
+                } as ComposeHostingViewController
 
                 appDelegate.setUpWindow(controller)
+
+                controller.waitForIdle()
             }
 
-            // Allow run loop to start the application
-            runApplicationLoop(KeyboardAnimationDelay)
-
-            collectSubviewsRecursively(
+            collectComposeSubviewsRecursively(
                 appDelegate.window?.rootViewController?.view!!,
                 subviewsReferences
             )
@@ -204,8 +199,8 @@ class MemoryLeaksTest {
                 actual = subviewsReferences.count(),
                 message = "Expected 5 subviews: [ComposeView, UserInputView, MetalView, UIKitTransparentContainerView, IntermediateTextInputUIView]" +
                     ", but given: ${
-                        subviewsReferences.mapNotNull {
-                            it.get()?.let { it::class.simpleName }
+                        subviewsReferences.mapNotNull { ref ->
+                            ref.get()?.let { it::class.simpleName }
                         }
                     }"
             )
@@ -216,15 +211,14 @@ class MemoryLeaksTest {
             // to let UIKit release reference to the previous text input view.
             startFakeTextInputSession()
 
-            cleanupMemory()
-
-            assertEquals(emptyList(), subviewsReferences.mapNotNull { it.get() })
+            assetDeallocated(subviewsReferences)
         }
+    }
 
     @Test
-    fun testComposeUIViewControllerSubviewsWithTextInputDisposalAndNewContextMenu() =
-        runRepeatingBlocking(newContextMenuEnabled = true) {
-            val appDelegate = MockAppDelegate()
+    fun testComposeUIViewControllerSubviewsWithTextInputDisposalAndNewContextMenu() {
+        val appDelegate = MockAppDelegate()
+        runBlocking(newContextMenuEnabled = true) {
             val subviewsReferences = mutableListOf<WeakReference<UIView>>()
 
             run {
@@ -240,15 +234,14 @@ class MemoryLeaksTest {
                     LaunchedEffect(Unit) {
                         focusRequester.requestFocus()
                     }
-                }
+                } as ComposeHostingViewController
 
                 appDelegate.setUpWindow(controller)
+
+                controller.waitForIdle()
             }
 
-            // Allow run loop to start the application
-            runApplicationLoop(KeyboardAnimationDelay)
-
-            collectSubviewsRecursively(
+            collectComposeSubviewsRecursively(
                 appDelegate.window?.rootViewController?.view!!,
                 subviewsReferences
             )
@@ -258,8 +251,8 @@ class MemoryLeaksTest {
                 actual = subviewsReferences.count(),
                 message = "Expected 6 subviews: [ComposeView, UserInputView, MetalView, UIKitTransparentContainerView, CMPEditMenuView, IntermediateTextInputUIView]" +
                     ", but given: ${
-                        subviewsReferences.mapNotNull {
-                            it.get()?.let { it::class.simpleName }
+                        subviewsReferences.mapNotNull { ref ->
+                            ref.get()?.let { it::class.simpleName }
                         }
                     }"
             )
@@ -270,13 +263,12 @@ class MemoryLeaksTest {
             // to let UIKit release reference to the previous text input view.
             startFakeTextInputSession()
 
-            cleanupMemory()
-
-            assertEquals(emptyList(), subviewsReferences.mapNotNull { it.get() })
+            assetDeallocated(subviewsReferences)
         }
+    }
 
     @Test
-    fun testComposeUIViewDisposal() = runRepeatingBlocking {
+    fun testComposeUIViewDisposal() = runBlocking {
         val appDelegate = MockAppDelegate()
         var composeViewRef: WeakReference<UIView>? = null
         var composeLoaded = false
@@ -289,27 +281,25 @@ class MemoryLeaksTest {
                 SideEffect {
                     composeLoaded = true
                 }
-            }
+            } as ComposeHostingView
             composeViewRef = WeakReference(view)
             val controller = UIViewController()
             controller.view.embedSubview(view)
             appDelegate.setUpWindow(controller)
-        }
 
-        // Allow run loop to start the application
-        runApplicationLoop(1.milliseconds)
+            view.waitForIdle()
+        }
 
         assertTrue(composeLoaded)
         assertNotNull(composeViewRef?.get())
 
         appDelegate.cleanUp()
-        cleanupMemory()
 
-        assertNull(composeViewRef.get())
+        assetDeallocated(composeViewRef)
     }
 
     @Test
-    fun testComposeUIViewSubviewsDisposal() = runRepeatingBlocking {
+    fun testComposeUIViewSubviewsDisposal() = runBlocking {
         val appDelegate = MockAppDelegate()
         val subviewsReferences = mutableListOf<WeakReference<UIView>>()
 
@@ -318,35 +308,33 @@ class MemoryLeaksTest {
                 enforceStrictPlistSanityCheck = false
             }) {
                 Box(modifier = Modifier.fillMaxSize().background(Color.Blue))
-            }
+            } as ComposeHostingView
             val controller = UIViewController()
             controller.view.embedSubview(view)
             appDelegate.setUpWindow(controller)
+
+            view.waitForIdle()
         }
 
-        // Allow run loop to start the application
-        runApplicationLoop(1.milliseconds)
-
-        collectSubviewsRecursively(
+        collectComposeSubviewsRecursively(
             appDelegate.window?.rootViewController?.view!!,
             subviewsReferences
         )
 
         assertEquals(
-            expected = 6,
+            expected = 5,
             actual = subviewsReferences.count(),
-            message = "Expected 6 subviews: [UIView, ComposeHostingView, ComposeView, UserInputView, MetalView, UIKitTransparentContainerView]" +
+            message = "Expected 5 subviews: [ComposeHostingView, ComposeView, UserInputView, MetalView, UIKitTransparentContainerView]" +
                 ", but given: ${
-                    subviewsReferences.mapNotNull {
-                        it.get()?.let { it::class.simpleName }
+                    subviewsReferences.mapNotNull { ref ->
+                        ref.get()?.let { it::class.simpleName }
                     }
                 }"
         )
 
         appDelegate.cleanUp()
-        cleanupMemory()
 
-        assertEquals(emptyList(), subviewsReferences.mapNotNull { it.get() })
+        assetDeallocated(subviewsReferences)
     }
 
     @Test
@@ -367,28 +355,26 @@ class MemoryLeaksTest {
                 LaunchedEffect(Unit) {
                     focusRequester.requestFocus()
                 }
-            }
+            } as ComposeHostingView
             composeViewRef = WeakReference(view)
             val controller = UIViewController()
             controller.view.embedSubview(view)
             appDelegate.setUpWindow(controller)
-        }
 
-        // Allow run loop to start the application
-        runApplicationLoop(KeyboardAnimationDelay)
+            view.waitForIdle()
+        }
 
         assertNotNull(composeViewRef?.get())
 
         appDelegate.cleanUp()
-        cleanupMemory()
 
-        assertNull(composeViewRef.get())
+        assetDeallocated(composeViewRef)
     }
 
     @Test
-    fun testComposeUIViewSubviewsWithTextInputDisposalAndNewContextMenu() =
-        runRepeatingBlocking(newContextMenuEnabled = true) {
-            val appDelegate = MockAppDelegate()
+    fun testComposeUIViewSubviewsWithTextInputDisposalAndNewContextMenu() {
+        val appDelegate = MockAppDelegate()
+        runBlocking(newContextMenuEnabled = true) {
             val subviewsReferences = mutableListOf<WeakReference<UIView>>()
 
             run {
@@ -404,27 +390,26 @@ class MemoryLeaksTest {
                     LaunchedEffect(Unit) {
                         focusRequester.requestFocus()
                     }
-                }
+                } as ComposeHostingView
                 val controller = UIViewController()
                 controller.view.embedSubview(view)
                 appDelegate.setUpWindow(controller)
+
+                view.waitForIdle()
             }
 
-            // Allow run loop to start the application
-            runApplicationLoop(KeyboardAnimationDelay)
-
-            collectSubviewsRecursively(
+            collectComposeSubviewsRecursively(
                 appDelegate.window?.rootViewController?.view!!,
                 subviewsReferences
             )
 
             assertEquals(
-                expected = 8,
+                expected = 7,
                 actual = subviewsReferences.count(),
-                message = "Expected 8 subviews: [UIView, ComposeHostingView, ComposeView, UserInputView, MetalView, UIKitTransparentContainerView, CMPEditMenuView, IntermediateTextInputUIView]" +
+                message = "Expected 7 subviews: [UIView, ComposeHostingView, ComposeView, UserInputView, MetalView, UIKitTransparentContainerView, CMPEditMenuView, IntermediateTextInputUIView]" +
                     ", but given: ${
-                        subviewsReferences.mapNotNull {
-                            it.get()?.let { it::class.simpleName }
+                        subviewsReferences.mapNotNull { ref ->
+                            ref.get()?.let { it::class.simpleName }
                         }
                     }"
             )
@@ -435,27 +420,114 @@ class MemoryLeaksTest {
             // to let UIKit release reference to the previous text input view.
             startFakeTextInputSession()
 
-            cleanupMemory()
-
-            assertEquals(emptyList(), subviewsReferences.mapNotNull { it.get() })
-        }
-
-    private fun collectSubviewsRecursively(
-        view: UIView,
-        result: MutableList<WeakReference<UIView>>
-    ) {
-        result.add(WeakReference(view))
-        for (subview in view.subviews) {
-            collectSubviewsRecursively(subview as UIView, result)
+            assetDeallocated(subviewsReferences)
         }
     }
 
     @OptIn(NativeRuntimeApi::class)
-    private suspend fun cleanupMemory() {
-        // Wait until the Compose view controller leaves the view hierarchy.
-        repeat(6) {
-            runApplicationLoop(100.milliseconds)
+    @Test
+    fun testComposeLayersViewControllerDisposal() = runBlocking {
+        val appDelegate = MockAppDelegate()
+        var layersViewControllerRef: WeakReference<UIViewController>? = null
+        var dialogLoaded = false
+
+        run {
+            val controller = ComposeUIViewController({
+                enforceStrictPlistSanityCheck = false
+            }) {
+                Dialog({}) {
+                    Box(modifier = Modifier.fillMaxSize().background(Color.Blue))
+                    SideEffect {
+                        dialogLoaded = true
+                    }
+                }
+            } as ComposeHostingViewController
+
+            appDelegate.setUpWindow(controller)
+
+            controller.waitForIdle()
+
+            val layersWindow = appDelegate.findLayersWindow()
+            layersViewControllerRef = WeakReference(layersWindow.rootViewController!!)
+        }
+
+        assertTrue(dialogLoaded)
+        assertNotNull(layersViewControllerRef?.get())
+
+        appDelegate.cleanUp()
+
+        assetDeallocated(layersViewControllerRef)
+    }
+
+    @Test
+    fun testComposeLayersViewControllerSubviewsDisposal() {
+        val appDelegate = MockAppDelegate()
+        runBlocking(newContextMenuEnabled = true) {
+            val subviewsReferences = mutableListOf<WeakReference<UIView>>()
+
+            run {
+                val controller = ComposeUIViewController({
+                    enforceStrictPlistSanityCheck = false
+                }) {
+                    Dialog({}) {
+                        Box(modifier = Modifier.fillMaxSize().background(Color.Blue))
+                    }
+                } as ComposeHostingViewController
+
+                appDelegate.setUpWindow(controller)
+
+                controller.waitForIdle()
+            }
+
+            val layersWindow = appDelegate.findLayersWindow()
+            collectComposeSubviewsRecursively(
+                layersWindow.rootViewController?.view!!,
+                subviewsReferences
+            )
+
+            assertEquals(
+                expected = 5,
+                actual = subviewsReferences.count(),
+                message = "Expected 5 subviews: [ComposeContainerView, UIKitComposeSceneLayerView, BackgroundInputView, MetalView, OverlayInputView]" +
+                    ", but given: ${
+                        subviewsReferences.mapNotNull { ref ->
+                            ref.get()?.let { it::class.simpleName }
+                        }
+                    }"
+            )
+
+            appDelegate.cleanUp()
+
+            assetDeallocated(subviewsReferences)
+        }
+    }
+
+    @OptIn(NativeRuntimeApi::class)
+    internal suspend fun assetDeallocated(reference: List<WeakReference<*>>) {
+        val duration = 100.milliseconds
+        repeat((5.seconds / duration).toInt()) {
+            runApplicationLoop(duration)
             GC.collect()
+            if (reference.all { it.get() == null }) return
+        }
+
+        fail("Memory leak detected: references ${reference.mapNotNull { it.get() }} where not collected")
+    }
+
+    @OptIn(NativeRuntimeApi::class)
+    internal suspend fun assetDeallocated(reference: WeakReference<*>) {
+        assetDeallocated(listOf(reference))
+    }
+
+    private fun collectComposeSubviewsRecursively(
+        view: UIView,
+        result: MutableList<WeakReference<UIView>>
+    ) {
+        if (view::class != UIView::class) {
+            result.add(WeakReference(view))
+        }
+        for (subview in view.subviews) {
+            collectComposeSubviewsRecursively(subview as UIView, result)
         }
     }
 
@@ -469,7 +541,7 @@ class MemoryLeaksTest {
     }
 
     @OptIn(ExperimentalForeignApi::class)
-    private suspend fun startFakeTextInputSession() {
+    private fun startFakeTextInputSession() {
         val input = IntermediateTextInputUIView(0)
         UIApplication.sharedApplication.keyWindow?.rootViewController?.view?.addSubview(input)
         input.setFrame(CGRectMake(0.0, 0.0, 100.0, 100.0))
@@ -477,37 +549,13 @@ class MemoryLeaksTest {
     }
 
     @OptIn(ExperimentalFoundationApi::class)
-    private fun runRepeatingBlocking(newContextMenuEnabled: Boolean, block: suspend () -> Unit) {
+    private fun runBlocking(newContextMenuEnabled: Boolean, block: suspend () -> Unit) {
         val defaultValue = ComposeFoundationFlags.isNewContextMenuEnabled
         try {
             ComposeFoundationFlags.isNewContextMenuEnabled = newContextMenuEnabled
-            runRepeatingBlocking { block() }
+            runBlocking { block() }
         } finally {
             ComposeFoundationFlags.isNewContextMenuEnabled = defaultValue
-        }
-    }
-
-    private fun runRepeatingBlocking(
-        total: Int = 10,
-        successRequired: Int = 2,
-        testBlock: suspend CoroutineScope.(Int) -> Unit
-    ) = runBlocking {
-        var successCount = 0
-        var failureCount = 0
-        repeat(total) {
-            try {
-                testBlock(successCount + failureCount)
-                successCount++
-                if (successCount >= successRequired) {
-                    return@runBlocking
-                }
-            } catch (e: Throwable) {
-                failureCount++
-                if (failureCount > total - successRequired) {
-                    throw e
-                }
-                cleanupMemory()
-            }
         }
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/leaks/MemoryLeaksTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/leaks/MemoryLeaksTest.kt
@@ -89,7 +89,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(composeViewControllerRef)
+        assertDeallocated(composeViewControllerRef)
     }
 
     @Test
@@ -127,7 +127,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(subviewsReferences)
+        assertDeallocated(subviewsReferences)
     }
 
     @Test
@@ -160,7 +160,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(composeViewControllerRef)
+        assertDeallocated(composeViewControllerRef)
     }
 
     @Test
@@ -211,7 +211,7 @@ class MemoryLeaksTest {
             // to let UIKit release reference to the previous text input view.
             startFakeTextInputSession()
 
-            assetDeallocated(subviewsReferences)
+            assertDeallocated(subviewsReferences)
         }
     }
 
@@ -263,7 +263,7 @@ class MemoryLeaksTest {
             // to let UIKit release reference to the previous text input view.
             startFakeTextInputSession()
 
-            assetDeallocated(subviewsReferences)
+            assertDeallocated(subviewsReferences)
         }
     }
 
@@ -295,7 +295,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(composeViewRef)
+        assertDeallocated(composeViewRef)
     }
 
     @Test
@@ -334,7 +334,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(subviewsReferences)
+        assertDeallocated(subviewsReferences)
     }
 
     @Test
@@ -368,7 +368,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(composeViewRef)
+        assertDeallocated(composeViewRef)
     }
 
     @Test
@@ -406,7 +406,7 @@ class MemoryLeaksTest {
             assertEquals(
                 expected = 7,
                 actual = subviewsReferences.count(),
-                message = "Expected 7 subviews: [UIView, ComposeHostingView, ComposeView, UserInputView, MetalView, UIKitTransparentContainerView, CMPEditMenuView, IntermediateTextInputUIView]" +
+                message = "Expected 7 subviews: [ComposeHostingView, ComposeView, UserInputView, MetalView, UIKitTransparentContainerView, CMPEditMenuView, IntermediateTextInputUIView]" +
                     ", but given: ${
                         subviewsReferences.mapNotNull { ref ->
                             ref.get()?.let { it::class.simpleName }
@@ -420,7 +420,7 @@ class MemoryLeaksTest {
             // to let UIKit release reference to the previous text input view.
             startFakeTextInputSession()
 
-            assetDeallocated(subviewsReferences)
+            assertDeallocated(subviewsReferences)
         }
     }
 
@@ -456,7 +456,7 @@ class MemoryLeaksTest {
 
         appDelegate.cleanUp()
 
-        assetDeallocated(layersViewControllerRef)
+        assertDeallocated(layersViewControllerRef)
     }
 
     @Test
@@ -498,12 +498,12 @@ class MemoryLeaksTest {
 
             appDelegate.cleanUp()
 
-            assetDeallocated(subviewsReferences)
+            assertDeallocated(subviewsReferences)
         }
     }
 
     @OptIn(NativeRuntimeApi::class)
-    internal suspend fun assetDeallocated(reference: List<WeakReference<*>>) {
+    internal suspend fun assertDeallocated(reference: List<WeakReference<*>>) {
         val duration = 100.milliseconds
         repeat((5.seconds / duration).toInt()) {
             runApplicationLoop(duration)
@@ -511,12 +511,12 @@ class MemoryLeaksTest {
             if (reference.all { it.get() == null }) return
         }
 
-        fail("Memory leak detected: references ${reference.mapNotNull { it.get() }} where not collected")
+        fail("Memory leak detected: references ${reference.mapNotNull { it.get() }} were not collected")
     }
 
     @OptIn(NativeRuntimeApi::class)
-    internal suspend fun assetDeallocated(reference: WeakReference<*>) {
-        assetDeallocated(listOf(reference))
+    internal suspend fun assertDeallocated(reference: WeakReference<*>) {
+        assertDeallocated(listOf(reference))
     }
 
     private fun collectComposeSubviewsRecursively(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scene/ComposeLayersViewControllerTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/scene/ComposeLayersViewControllerTest.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.MockAppDelegate
 import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.findLayersWindow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.uikit.utils.CMPComposeContainerLifecycleDelegateProtocol
 import androidx.compose.ui.uikit.utils.CMPViewController
@@ -193,15 +194,6 @@ class ComposeLayersViewControllerTest {
         )
 
         appDelegate.cleanUp()
-    }
-
-    private fun MockAppDelegate.findLayersWindow(): LayersWindow {
-        val window = this@findLayersWindow.window?.windowScene?.windows?.mapNotNull {
-            it as? LayersWindow
-        }?.single { !it.isHidden() }
-
-        assertNotNull(window, "${LayersWindow::class} not found in scene")
-        return window
     }
 }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.platform.InfiniteAnimationPolicy
 import androidx.compose.ui.scene.ComposeHostingView
 import androidx.compose.ui.scene.ComposeHostingViewController
+import androidx.compose.ui.scene.LayersWindow
 import androidx.compose.ui.test.utils.center
 import androidx.compose.ui.test.utils.getTouchesEvent
 import androidx.compose.ui.test.utils.mouseDown
@@ -45,6 +46,7 @@ import androidx.compose.ui.unit.lerp
 import androidx.compose.ui.window.KeyboardVisibilityListener
 import androidx.compose.ui.window.MetalRedrawer
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.test.assertNotNull
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -441,7 +443,7 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
         UIApplication.sharedApplication().setDelegate(this)
 
         val scene = UIApplication.sharedApplication().connectedScenes.first() as? UIWindowScene
-                ?: error("No window scene found")
+            ?: error("No window scene found")
         val allWindows = scene.windows
 
         _window = UIWindow(frame = UIScreen.mainScreen.bounds)
@@ -460,6 +462,7 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
         val scene = UIApplication.sharedApplication().connectedScenes.first() as? UIWindowScene
         val allWindows = scene?.windows ?: emptyList<UIWindow>()
 
+        UIApplication.sharedApplication().setDelegate(null)
         val window = UIWindow(frame = UIScreen.mainScreen.bounds)
         window.rootViewController = UIViewController()
         window.makeKeyAndVisible()
@@ -515,6 +518,15 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
     }
 }
 
+internal fun MockAppDelegate.findLayersWindow(): LayersWindow {
+    val window = this@findLayersWindow.window?.windowScene?.windows?.mapNotNull {
+        it as? LayersWindow
+    }?.single { !it.isHidden() }
+
+    assertNotNull(window, "${LayersWindow::class} not found in scene")
+    return window
+}
+
 internal fun UIKitInstrumentedTest.findFocusedUITextInput(): UITextInputProtocol? {
     val windowScene = viewController.view.window?.windowScene ?: return null
 
@@ -534,4 +546,12 @@ internal fun UIKitInstrumentedTest.findFocusedUITextInput(): UITextInputProtocol
     }.firstNotNullOfOrNull {
         findFirstResponder(view = it as UIView)
     } as? UITextInputProtocol
+}
+
+internal fun ComposeHostingViewController.waitForIdle() {
+    UIKitInstrumentedTest.waitUntil { !this.hasInvalidations() }
+}
+
+internal fun ComposeHostingView.waitForIdle() {
+    UIKitInstrumentedTest.waitUntil { !this.hasInvalidations() }
 }


### PR DESCRIPTION
- Implement memory leaks tests for ComposeLayersViewController
- Remove tests repeats
- Await for expected result instead of using fixed delay

Fixes https://youtrack.jetbrains.com/issue/CMP-9489/Implement-memory-leak-tests-for-ComposeLayersViewController

## Release Notes
N/A