### PR TITLE
Add Siri remote button mappings in KeyEvent.uikit.kt

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/KeyEvent.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/KeyEvent.ios.kt
@@ -51,7 +51,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
         UIPressTypeLeftArrow -> Key.DirectionLeft
         UIPressTypeRightArrow -> Key.DirectionRight
         UIPressTypeSelect -> Key.DirectionCenter
-        UIPressTypeMenu -> Key.Back
+        UIPressTypeMenu -> Key.Menu
         UIPressTypePlayPause -> Key.MediaPlayPause
         UIPressTypePageDown -> Key.PageDown
         UIPressTypePageUp -> Key.PageUp

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/KeyEvent.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/KeyEvent.ios.kt
@@ -27,9 +27,12 @@ import platform.UIKit.UIPressPhase.UIPressPhaseBegan
 import platform.UIKit.UIPressPhase.UIPressPhaseEnded
 import platform.UIKit.UIPressTypeDownArrow
 import platform.UIKit.UIPressTypeLeftArrow
+import platform.UIKit.UIPressTypeMenu
 import platform.UIKit.UIPressTypePageDown
 import platform.UIKit.UIPressTypePageUp
+import platform.UIKit.UIPressTypePlayPause
 import platform.UIKit.UIPressTypeRightArrow
+import platform.UIKit.UIPressTypeSelect
 import platform.UIKit.UIPressTypeUpArrow
 
 internal fun UIPress.toComposeEvent(): KeyEvent {
@@ -39,13 +42,17 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
         else -> KeyEventType.Unknown
     }
 
-    // UIPress has special types for arrow keys and page up/down and has null `key`
-    // In other cases the `type` returns an int value that doesn't match any UIPressType.
+    // UIPress has special types for arrow keys, page up/down, game controller buttons,
+    // and Siri remote buttons, and has null `key`. In other cases the `type` returns
+    // an int value that doesn't match any UIPressType.
     val specialTypeKey = when (type) {
         UIPressTypeUpArrow -> Key.DirectionUp
         UIPressTypeDownArrow -> Key.DirectionDown
         UIPressTypeLeftArrow -> Key.DirectionLeft
         UIPressTypeRightArrow -> Key.DirectionRight
+        UIPressTypeSelect -> Key.DirectionCenter
+        UIPressTypeMenu -> Key.Back
+        UIPressTypePlayPause -> Key.MediaPlayPause
         UIPressTypePageDown -> Key.PageDown
         UIPressTypePageUp -> Key.PageUp
         else -> null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/KeyEvent.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/KeyEvent.ios.kt
@@ -43,7 +43,7 @@ internal fun UIPress.toComposeEvent(): KeyEvent {
     }
 
     // UIPress has special types for arrow keys, page up/down, game controller buttons,
-    // and Siri remote buttons, and has null `key`. In other cases the `type` returns
+    // Siri remote buttons, and has null `key`. In other cases the `type` returns
     // an int value that doesn't match any UIPressType.
     val specialTypeKey = when (type) {
         UIPressTypeUpArrow -> Key.DirectionUp


### PR DESCRIPTION
  Add key mappings for tvOS Siri Remote buttons in UIPress.toComposeEvent().                                                                    
                                                                                                                                                
  This enables Compose applications to receive and handle button presses from the Siri Remote:                                                  
  - UIPressTypeSelect → Key.DirectionCenter                                                                                                     
  - UIPressTypeMenu → Key.Menu                                                                                                                  
  - UIPressTypePlayPause → Key.MediaPlayPause                                                                                                   
                                                                                                                                                
  Fixes https://youtrack.jetbrains.com/issue/CMP-9712/Support-Siri-remote-controls                                                              
                                                                                                                                                
  ## Testing                                                                                                                                    
  Tested with tvOS Siri Remote. Button presses are correctly converted to Compose key events and can be handled via `Modifier.onKeyEvent()`.    
                                                                                                                                                
  ## Release Notes                                                                                                                              
  ### Features - iOS                                                                                                                            
  - Add support for tvOS Siri Remote button events (Select, Menu, Play/Pause)                                                                 
                                                                                                                                                
  ## Google CLA                                                                                                                                 
  Already signed.  