### PR TITLE
Batch commands together when editing text in LegacyPlatformTextInputServiceAdapter

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/LegacyPlatformTextInputServiceAdapter.skiko.kt
@@ -114,44 +114,11 @@ internal actual fun createLegacyPlatformTextInputServiceAdapter():
             }
 
             val editBlock: (block: TextEditingScope.() -> Unit) -> Unit = { block ->
-                object : TextEditingScope {
-                    fun runOnEditCommand(command: EditCommand) {
-                        onEditCommand(listOf(command))
-                    }
-
-                    override fun deleteSurroundingTextInCodePoints(
-                        lengthBeforeCursor: Int,
-                        lengthAfterCursor: Int
-                    ) {
-                        runOnEditCommand(
-                            DeleteSurroundingTextCommand(lengthBeforeCursor, lengthAfterCursor)
-                        )
-                    }
-
-                    override fun commitText(
-                        text: CharSequence,
-                        newCursorPosition: Int
-                    ) {
-                        runOnEditCommand(
-                            CommitTextCommand(text.toString(), newCursorPosition)
-                        )
-                    }
-
-                    override fun setComposingText(
-                        text: CharSequence,
-                        newCursorPosition: Int
-                    ) {
-                        runOnEditCommand(
-                            SetComposingTextCommand(text.toString(), newCursorPosition)
-                        )
-                    }
-
-                    override fun finishComposingText() {
-                        runOnEditCommand(
-                            FinishComposingTextCommand()
-                        )
-                    }
-                }.block()
+                val commands = mutableListOf<EditCommand>()
+                with(TextEditingScope(commands)) {
+                    block()
+                    onEditCommand(commands)
+                }
             }
 
             return SkikoPlatformTextInputMethodRequest(
@@ -167,5 +134,41 @@ internal actual fun createLegacyPlatformTextInputServiceAdapter():
                 editText = editBlock
             )
         }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun TextEditingScope(commands: MutableList<EditCommand>) = object : TextEditingScope {
+    override fun deleteSurroundingTextInCodePoints(
+        lengthBeforeCursor: Int,
+        lengthAfterCursor: Int
+    ) {
+        commands.add(
+            DeleteSurroundingTextCommand(lengthBeforeCursor, lengthAfterCursor)
+        )
+    }
+
+    override fun commitText(
+        text: CharSequence,
+        newCursorPosition: Int
+    ) {
+        commands.add(
+            CommitTextCommand(text.toString(), newCursorPosition)
+        )
+    }
+
+    override fun setComposingText(
+        text: CharSequence,
+        newCursorPosition: Int
+    ) {
+        commands.add(
+            SetComposingTextCommand(text.toString(), newCursorPosition)
+        )
+    }
+
+    override fun finishComposingText() {
+        commands.add(
+            FinishComposingTextCommand()
+        )
     }
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -145,7 +145,6 @@ private inline fun (() -> TextFieldCharSequence).asTextEditorState() = object : 
 
 @OptIn(ExperimentalComposeUiApi::class)
 private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScope {
-
     private var TextFieldBuffer.cursor: Int
         get() = if (selection.collapsed) selection.end else -1
         set(value) {

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/LegacyPlatformTextInputServiceAdapterTest.kt
@@ -62,7 +62,7 @@ class LegacyPlatformTextInputServiceAdapterTest {
         var textClippingRectInRoot: Rect? = null
 
         setContent {
-            InterceptPlatformTextInput({ request, nextHandler ->
+            InterceptPlatformTextInput({ request, _ ->
                 coroutineScope {
                     launch {
                         snapshotFlow { request.value() }.collect { value = it }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.platform
 
+import androidx.compose.runtime.key
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.awt.toAwtRectangleRounded
 import androidx.compose.ui.scene.ComposeSceneMediator

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -214,7 +215,7 @@ open class BaseWindowTextFieldTest {
             object : TextField1Scope(windowTestScope, window) {
                 @Composable
                 override fun TextField() {
-                    val focusRequester = FocusRequester()
+                    val focusRequester = remember { FocusRequester() }
                     BasicTextField(
                         value = textFieldValue,
                         onValueChange = {
@@ -243,7 +244,7 @@ open class BaseWindowTextFieldTest {
             object : TextField2Scope(windowTestScope, window) {
                 @Composable
                 override fun TextField() {
-                    val focusRequester = FocusRequester()
+                    val focusRequester = remember { FocusRequester() }
                     BasicTextField(
                         state = textFieldState,
                         inputTransformation = inputTransformation,
@@ -270,7 +271,7 @@ open class BaseWindowTextFieldTest {
             object : SecureTextFieldScope(windowTestScope, window, TextObfuscationMode.Hidden) {
                 @Composable
                 override fun TextField() {
-                    val focusRequester = FocusRequester()
+                    val focusRequester = remember { FocusRequester() }
 
                     BasicSecureTextField(
                         state = textFieldState,

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -69,24 +69,24 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         window.sendKeyTypedEvent(Char(8))
         window.sendKeyEvent(8, Char(8), KEY_RELEASED)
         assertStateEquals("qw", selection = TextRange(2), composition = null)
-//
-//        // backspace
-//        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
-//        window.sendKeyTypedEvent(Char(8))
-//        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
-//        assertStateEquals("q", selection = TextRange(1), composition = null)
-//
-//        // backspace
-//        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
-//        window.sendKeyTypedEvent(Char(8))
-//        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
-//        assertStateEquals("", selection = TextRange(0), composition = null)
-//
-//        // backspace
-//        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
-//        window.sendKeyTypedEvent(Char(8))
-//        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
-//        assertStateEquals("", selection = TextRange(0), composition = null)
+
+        // backspace
+        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window.sendKeyTypedEvent(Char(8))
+        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assertStateEquals("q", selection = TextRange(1), composition = null)
+
+        // backspace
+        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window.sendKeyTypedEvent(Char(8))
+        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assertStateEquals("", selection = TextRange(0), composition = null)
+
+        // backspace
+        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
+        window.sendKeyTypedEvent(Char(8))
+        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        assertStateEquals("", selection = TextRange(0), composition = null)
     }
 
     @Theory
@@ -770,6 +770,35 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         window.sendInputMethodEvent("ㅌ", 1)
         assertStateEquals("ㅌvㅌ", selection = TextRange(3), composition = null)
     }
+
+    @Theory
+    internal fun `q, w, space (Chinese Wubi, macOS)`(
+        textFieldKind: TextFieldKind<*>
+    ) = runTextFieldTest(textFieldKind, "Chinese Wubi, macOS") {
+        // Wubi input method sends each composing InputMethodEvent twice for some reason
+        suspend fun sendInputMethodEventTwice(text: String?, committedCharacterCount: Int = 0) {
+            repeat(2) {
+                window.sendInputMethodEvent(text, committedCharacterCount)
+                awaitIdle()  // Wait for recomposition
+            }
+        }
+
+        // q
+        sendInputMethodEventTwice("q", 0)
+        window.sendKeyEvent(81, 'q', KEY_RELEASED)
+        assertStateEquals("q", selection = TextRange(1), composition = TextRange(0, 1))
+
+        // w
+        sendInputMethodEventTwice("qw", 0)
+        window.sendKeyEvent(87, 'w', KEY_RELEASED)
+        assertStateEquals("qw", selection = TextRange(2), composition = TextRange(0, 2))
+
+        // space
+        window.sendInputMethodEvent("欠", 1)
+        window.sendKeyEvent(32, ' ', KEY_RELEASED)
+        assertStateEquals("欠", selection = TextRange(1), composition = null)
+    }
+
 
     // Verifies that each typed character and character replaced by the input service is reported
     // (to `inputTransformation`) as a change in the last character only.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformTextInputMethodRequest.skiko.kt
@@ -84,6 +84,14 @@ actual interface PlatformTextInputMethodRequest {
 
     /**
      * Allows the text input service to edit the text.
+     *
+     * Note that changes requested in the [TextEditingScope] are buffered and applied, together, to
+     * the [TextEditorState] only after `block` returns. It is therefore wrong to assume inside
+     * `block` that the [TextEditorState] has changed following an invocation of a method on
+     * [TextEditingScope].
+     *
+     * If, in the future, the editing `block` requires access to the intermediate state, this state
+     * should be exposed via [TextEditingScope] itself.
      */
     @ExperimentalComposeUiApi
     val editText: (block: TextEditingScope.() -> Unit) -> Unit


### PR DESCRIPTION
The skiko implementation of `LegacyPlatformTextInputServiceAdapter` currently runs each `EditCommand` immediately as it is requested. 

This is problematic because:
- It differs from the implementation for `BasicTextField(TextFieldState)` (in `TextInputSession.skiko.kt`) which buffers the commands in `TransformedTextFieldState.editUntransformedTextAsUser`.
- In the case of `BasicTextField(TextFieldValue)` it causes calls to `onValueChange` with intermediate states. Combined with the `if (value != it)` check in `BasicTextField(TextFieldValue)` before calling the upstream `onValueChange` this makes the final state (even more) dependent on the order and timing of recompositions. See the scenario detailed below for an example.

This PR changes the behavior of `LegacyPlatformTextInputServiceAdapter` to instead buffer commands and commit them together once the editing block returns.

This change also semi-accidentally fixes [CMP-9380 Wubi input method; first letter vanishes on 2nd keystroke](https://youtrack.jetbrains.com/issue/CMP-9380). The issue there is that for Wubi input, the [JVM sends each composing `InputMethodEvent` twice](https://youtrack.jetbrains.com/issue/JBR-9928/macOS-Wubi-input-causes-two-InputMethodEvents-to-be-sent-for-each-key). Each such an event tells us the committed text is empty, and adds a character to the composing text. For example, when the user presses 'q', the event sent is `InputMethodEvent[committed="", composing="q"]`. For each such event `DesktopTextInputService2` performs two editing commands:
- Commit the committed text.
- Set the composing text.

When two such events are sent, with a recomposition between them, the state changes as follows:
1. First `InputMethodEvent[committed="", composing="q"]` is received by `DesktopTextInputService2`, and it:
    1. Commits "", which doesn't change the text state, and so isn't delivered to `onValueChange`.
    2. Sets the composing text to "q", which is delivered to `onValueChange`. The hoisted value is now `TextFieldValue(text='q', selection=TextRange(1, 1), composition=TextRange(0, 1))`
3. A recomposition occurs, which calls `BasicTextField` with the new hoisted value.
4. Second `InputMethodEvent[committed="", composing="q"]` is received by `DesktopTextInputService2`, and it:
    1. Commits "", which is delivered to `onValueChange`, changing the hoisted value to `TextFieldValue(text='', selection=TextRange(0, 0), composition=null)`
    2. Sets the composing text to "q", which attempts to deliver the new `TextFieldValue(text='q', selection=TextRange(1, 1), composition=TextRange(0, 1))` to `onValueChange`, but actually fails to do so because this value is identical to the last recomposed value in `BasicTextField` which only calls the "upstream" `onValueChange` if the value is actually changed:
```
CoreTextField(
    value = value,
    onValueChange = {
        if (value != it) {
            onValueChange(it)
        }
    },
    ...
)
```
So the final state ends up being the value delivered in 3.1, which is just the empty text value.

When instead each pair of changes (commit + setComposition) are grouped:
- The state after 1.2 is the same (correct state)
- `onValueChange` is not called in step 3.1. This is the crucial difference.
- `onValueChange` is attempted to be called in step 3.2, but isn't because the new value is identical to the recomposed one.

Altogether, the final state is the correct `TextFieldValue(text='q', selection=TextRange(1, 1), composition=TextRange(0, 1))`

Fixes https://youtrack.jetbrains.com/issue/CMP-9380

## Testing
Tested manually and added unit tests.

## Release Notes
### Fixes - Desktop
- [macOS] Fix Wubi input for `(Basic)TextField(TextFieldValue)`.
