### PR TITLE
Add flags to run Chrome with WebGL on CI (#2721)

### DIFF
--- a/.github/workflows/compose-tests.yml
+++ b/.github/workflows/compose-tests.yml
@@ -191,7 +191,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chrome: [ '118', 'stable' ]
+        chrome: [ '134', 'stable' ]
         task: [ 'Js', 'Wasm' ]
     steps:
       - name: Checkout Repository
@@ -208,6 +208,7 @@ jobs:
 
       - name: Setup Google Chrome
         uses: browser-actions/setup-chrome@v2
+        id: setup-chrome
         with:
           chrome-version: ${{ matrix.chrome }}
           install-chromedriver: true
@@ -220,7 +221,8 @@ jobs:
 
       - name: Run Web Chrome Tests
         run: |
-          ./gradlew :mpp:testWeb${{ matrix.task }} \
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns && \
+          CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }} ./gradlew :mpp:testWeb${{ matrix.task }} \
             --no-daemon --stacktrace --no-parallel \
             -Pjetbrains.androidx.web.tests.enableFirefox=false \
             -Pjetbrains.androidx.web.tests.enableChrome=true

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/ATestToCheckWebGLContext.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/ATestToCheckWebGLContext.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.browser.document
+import org.w3c.dom.HTMLCanvasElement
+
+class ATestToCheckWebGLContext {
+
+    @Test
+    fun test() {
+        val canvas = document.createElement("canvas") as HTMLCanvasElement
+        document.body!!.appendChild(canvas)
+        val webGl2 = canvas.getContext("webgl2")
+        println("WebGl2 = " + webGl2 + "\n")
+
+        var hasWeglContext = webGl2 != null
+        if (webGl2 == null) {
+            println("WebGl2 is not supported")
+            val webgl1 = canvas.getContext("webgl")
+            println("WebGl1 = " + webgl1 + "\n")
+            hasWeglContext = webgl1 != null
+        }
+
+        canvas.remove()
+
+        assertTrue(hasWeglContext, "Expected hasWeglContext to be true, but was - $hasWeglContext")
+    }
+}

--- a/mpp/karma.config.d/web/commonKarmaConfig.js
+++ b/mpp/karma.config.d/web/commonKarmaConfig.js
@@ -3,7 +3,16 @@ function configLaunchers(config) {
     config.customLaunchers = {
         ChromeForComposeTests: {
             base: "Chrome",
-            flags: ["--no-sandbox", "--disable-search-engine-choice-screen"]
+            flags: [
+                "--no-sandbox",
+                "--disable-search-engine-choice-screen",
+
+                // "CI-stabilizer" :D - otherwise webgl2 context is null:
+                "--disable-setuid-sandbox",
+                "--enable-webgl",
+                "--ignore-gpu-blocklist",
+                "--in-process-gpu"
+            ]
         },
         ChromiumForComposeTests: {
             base: "Chromium"


### PR DESCRIPTION
Cherry-pick https://github.com/JetBrains/compose-multiplatform-core/pull/2721

> Today the tests CI running in Chrome started to fail with such an error:
> ```
> TypeError: Cannot read properties of undefined (reading 'getParameter') at <global>._glGetString(skiko.mjs:8)
> ``` 
> We noticed that github runner got an updated Chrome version. But downgrading didn't help.
> 
> So we set additional flags for Chrome launcher.


## Testing
N/A

## Release Notes
N/A

