### PR TITLE
Fix system theme change handling

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -170,7 +170,6 @@ internal class ComposeContainer(
 
         window ?: return
 
-        userInterfaceStyleDidChange()
         updateInterfaceOrientationState()
 
         layersHolder?.layersViewController?.referenceWindow = view.window
@@ -199,9 +198,8 @@ internal class ComposeContainer(
         navigationEventInput.onDidMoveToWindow(null, view)
     }
 
-    fun userInterfaceStyleDidChange() {
-        systemThemeState.value = view.traitCollection.userInterfaceStyle
-            .asComposeSystemTheme()
+    fun updateUserInterfaceStyle(style: UIUserInterfaceStyle) {
+        systemThemeState.value = style.asComposeSystemTheme()
     }
 
     fun initializeComposeScene() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingView.ios.kt
@@ -113,10 +113,12 @@ internal class ComposeHostingView(
     }
 
     override fun userInterfaceStyleDidChange() {
-        container.userInterfaceStyleDidChange()
+        container.updateUserInterfaceStyle(traitCollection.userInterfaceStyle)
     }
 
     override fun viewDidEnterWindowHierarchy() {
+        container.updateUserInterfaceStyle(traitCollection.userInterfaceStyle)
+
         container.initializeComposeScene()
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeHostingViewController.ios.kt
@@ -83,11 +83,11 @@ internal class ComposeHostingViewController(
         super.viewDidLoad()
 
         configuration.delegate.viewDidLoad()
-        container.userInterfaceStyleDidChange()
+        container.updateUserInterfaceStyle(traitCollection.userInterfaceStyle)
     }
 
     override fun userInterfaceStyleDidChange() {
-        container.userInterfaceStyleDidChange()
+        container.updateUserInterfaceStyle(traitCollection.userInterfaceStyle)
     }
 
     override fun viewWillTransitionToSize(

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/SystemThemeTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/platform/SystemThemeTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.LocalSystemTheme
+import androidx.compose.ui.SystemTheme
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import platform.UIKit.UIUserInterfaceStyle
+
+class SystemThemeTest {
+
+    @Test
+    fun testInitialOverrideUserInterfaceStyleLight() = runUIKitInstrumentedTest {
+        appDelegate.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle.UIUserInterfaceStyleLight
+        var systemTheme: SystemTheme? = null
+        setContent {
+            systemTheme = LocalSystemTheme.current
+        }
+
+        assertEquals(SystemTheme.Light, systemTheme)
+    }
+
+    @Test
+    fun testInitialOverrideUserInterfaceStyleDark() = runUIKitInstrumentedTest {
+        appDelegate.window?.overrideUserInterfaceStyle = UIUserInterfaceStyle.UIUserInterfaceStyleDark
+        var systemTheme: SystemTheme? = null
+        setContent {
+            systemTheme = LocalSystemTheme.current
+        }
+
+        assertEquals(SystemTheme.Dark, systemTheme)
+    }
+
+    @Test
+    fun testOverrideUserInterfaceStyle() = runUIKitInstrumentedTest {
+        var systemTheme: SystemTheme? = null
+        setContent {
+            systemTheme = LocalSystemTheme.current
+        }
+
+        assertNotNull(systemTheme)
+
+        appDelegate.window?.overrideUserInterfaceStyle =
+            UIUserInterfaceStyle.UIUserInterfaceStyleLight
+        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.Light }
+
+        appDelegate.window?.overrideUserInterfaceStyle =
+            UIUserInterfaceStyle.UIUserInterfaceStyleDark
+        waitUntil("System theme should eventually be Dark") { systemTheme == SystemTheme.Dark }
+
+        appDelegate.window?.overrideUserInterfaceStyle =
+            UIUserInterfaceStyle.UIUserInterfaceStyleLight
+        waitUntil("System theme should eventually be Light") { systemTheme == SystemTheme.Light }
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -434,7 +434,7 @@ internal class UIKitInstrumentedTest(
 
 @OptIn(ExperimentalForeignApi::class)
 internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
-    private var _window: UIWindow? = null
+    private var _window: UIWindow? = UIWindow(frame = UIScreen.mainScreen.bounds)
     override fun window(): UIWindow? = _window
 
     private var supportedInterfaceOrientations: UIInterfaceOrientationMask = UIInterfaceOrientationMaskAll
@@ -446,7 +446,7 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
             ?: error("No window scene found")
         val allWindows = scene.windows
 
-        _window = UIWindow(frame = UIScreen.mainScreen.bounds)
+        _window = _window ?: UIWindow(frame = UIScreen.mainScreen.bounds)
         _window?.backgroundColor = UIColor.systemBackgroundColor
         _window?.windowScene = scene
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -444,9 +444,8 @@ internal class MockAppDelegate: NSObject(), UIApplicationDelegateProtocol {
 
         val scene = UIApplication.sharedApplication().connectedScenes.first() as? UIWindowScene
             ?: error("No window scene found")
-        val allWindows = scene.windows
+        val allWindows = scene.windows - _window
 
-        _window = _window ?: UIWindow(frame = UIScreen.mainScreen.bounds)
         _window?.backgroundColor = UIColor.systemBackgroundColor
         _window?.windowScene = scene
 


### PR DESCRIPTION
- Read actual value of the `traitCollection.userInterfaceStyle` in `ComposeHostingView` and `ComposeHostingViewController`.
- Ensure that the initial system theme is propagated correctly.

Fixes https://youtrack.jetbrains.com/issue/CMP-9707/iOS-window-update-overrideUserInterfaceStyle-value-isSystemInDarkTheme-not-updating-correctly

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix an issue where manually overriding the user interface style does not propagate properly to the `LocalSystemTheme`.