### PR TITLE
Fix TextFieldState restoration on iOS

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/undo/UndoManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/undo/UndoManager.kt
@@ -139,7 +139,9 @@ internal class UndoManager<T>(
                 @Suppress("UNCHECKED_CAST")
                 override fun restore(value: Any): UndoManager<T> {
                     val list = value as List<Any>
-                    val (capacity, undoSize, redoSize) = (list as List<Int>)
+                    val capacity = list[0] as Int
+                    val undoSize = list[1] as Int
+                    val redoSize = list[2] as Int
                     var i = 3
                     val undoStackItems = buildList {
                         while (i < undoSize + 3) {


### PR DESCRIPTION
When experimenting with implementing state restoration on iOS with custom SaveableStateRegistry I ran into a crash when trying to restore TextFieldState using its default saver. 

Fixes: https://youtrack.jetbrains.com/issue/CMP-9949/Crash-when-restoring-TextFieldState-on-iOS

```
Uncaught Kotlin exception: kotlin.ClassCastException: class kotlin.collections.ArrayList cannot       
  be cast to class kotlin.Int                                                                           
      at 0   KotlinProject.debug.dylib           0x10524ceeb                                            
  kfun:kotlin.Throwable#<init>(kotlin.String?){} + 99                                                   
      at 1   KotlinProject.debug.dylib           0x1052472d3                                            
  kfun:kotlin.Exception#<init>(kotlin.String?){} + 95                                                   
      at 2   KotlinProject.debug.dylib           0x105247493                                            
  kfun:kotlin.RuntimeException#<init>(kotlin.String?){} + 95                                            
      at 3   KotlinProject.debug.dylib           0x105247c03                                            
  kfun:kotlin.ClassCastException#<init>(kotlin.String?){} + 95                                          
      at 4   KotlinProject.debug.dylib           0x10527d3bb        ThrowClassCastException + 627       
      at 5   KotlinProject.debug.dylib           0x105effbeb                                            
  kfun:androidx.compose.foundation.text.input.TextUndoManager.Companion.Saver.TextUndoManager$Compa     
  nion$Saver$inlined$createSaver$1.restore#internal + 1471                                              
      at 6   KotlinProject.debug.dylib           0x10584db07                                            
  kfun:androidx.compose.runtime.saveable.Saver#restore(1:1){}1:0?-trampoline + 107                      
      at 7   KotlinProject.debug.dylib           0x105efebc7                                            
  kfun:androidx.compose.foundation.text.input.TextUndoManager.Companion.Saver#restore(kotlin.Any){}     
  androidx.compose.foundation.text.input.TextUndoManager? + 1539                                        
      at 8   KotlinProject.debug.dylib           0x105efb14f                                            
  kfun:androidx.compose.foundation.text.input.TextFieldState.Saver#restore(kotlin.Any){}androidx.co     
  mpose.foundation.text.input.TextFieldState? + 1367                                                    
      at 9   KotlinProject.debug.dylib           0x10584db07                                            
  kfun:androidx.compose.runtime.saveable.Saver#restore(1:1){}1:0?-trampoline + 107 
``` 

I've tracked the issue down to how `UndoManager` restores its state by using destructive declaration casting the whole `List<Any>` to `List<Int>` and reading from it. This works fine on Android and Jvm but crashes on iOS and, I presume, other Kotlin/Native targets.

The fix is to replace the destructive declaration and list cast with direct access by index.

## Testing
- Clone the project's https://github.com/HarukeyUA/kmp-architecture-template `text-field-state-restoration-crash` branch
- Run the iOS app, click login, tap on the "Search" in the bottom navigation and enter any text in the text field
- Dismiss the app from the resents and relaunch the app. The app crashes when trying to restore the field's state
- Apply the fix, build CMP with the fix, point the test app to the maven local version and retest the scenario - app no longer crashes and state is correctly restored

## Release Notes
### Fixes - iOS
- Fix `TextFieldState.Saver` restoration crash

## Google CLA
Signed
