### PR TITLE
Propagate the coroutine context of `awaitApplication` to child windows and dialogs

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeDialog.desktop.kt
@@ -39,12 +39,13 @@ import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelListener
 import java.util.Locale
 import javax.swing.JDialog
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
 /**
- * ComposeDialog is a dialog for building UI using Compose for Desktop.
- * ComposeDialog inherits javax.swing.JDialog.
+ * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
  */
 class ComposeDialog : JDialog {
     private val composePanel: ComposeWindowPanel
@@ -52,21 +53,25 @@ class ComposeDialog : JDialog {
     private fun createComposePanel(
         skiaLayerAnalytics: SkiaLayerAnalytics,
         savedState: SavedState?,
+        coroutineContext: CoroutineContext
     ) = ComposeWindowPanel(
         window = this,
         isUndecorated = ::isUndecorated,
         skiaLayerAnalytics = skiaLayerAnalytics,
         savedState = savedState,
+        coroutineContext = coroutineContext
     )
 
     /**
-     * ComposeDialog is a dialog for building UI using Compose for Desktop.
-     * ComposeDialog inherits javax.swing.JDialog.
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
      *
-     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behavior.
-     * SkiaLayer is the underlying class used internally to draw Compose content.
-     * Implementation usually uses a third-party solution to send info to an analytics gatherer.
+     * @param owner the [java.awt.Window] from which the dialog is displayed or `null` if this dialog has no owner.
+     * @param modalityType specifies whether dialog blocks input to other windows when shown.
+     * @param graphicsConfiguration [GraphicsConfiguration] of the target screen device; if `null`, the default system
+     * [GraphicsConfiguration] is assumed.
+     * @param skiaLayerAnalytics Allows receiving notifications about the underlying Skia layer behavior.
      * @param savedState The saved state to restore the UI state from a previous instance.
+     * @param coroutineContext The coroutine context for Compose content rendering and effects.
      */
     // All constructors that want to call JDialog(Window?) should call this constructor.
     // On Windows, it will show a taskbar icon if the owner window is null
@@ -77,19 +82,22 @@ class ComposeDialog : JDialog {
         graphicsConfiguration: GraphicsConfiguration? = null,
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
         savedState: SavedState? = null,
+        coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ) : super(owner, "", modalityType, graphicsConfiguration) {
-        composePanel = createComposePanel(skiaLayerAnalytics, savedState)
+        composePanel = createComposePanel(skiaLayerAnalytics, savedState, coroutineContext)
         contentPane.add(composePanel)
     }
 
     /**
-     * ComposeDialog is a dialog for building UI using Compose for Desktop.
-     * ComposeDialog inherits javax.swing.JDialog.
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
      *
-     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behavior.
-     * SkiaLayer is the underlying class used internally to draw Compose content.
-     * Implementation usually uses a third-party solution to send info to an analytics gatherer.
+     * @param owner the [java.awt.Frame] from which the dialog is displayed or `null` if this dialog has no owner.
+     * @param modal Whether the dialog blocks input to other windows of the app.
+     * @param graphicsConfiguration [GraphicsConfiguration] of the target screen device; if `null`, the default system
+     * [GraphicsConfiguration] is assumed.
+     * @param skiaLayerAnalytics Allows receiving notifications about the underlying Skia layer behavior.
      * @param savedState The saved state to restore the UI state from a previous instance.
+     * @param coroutineContext The coroutine context for Compose content rendering and effects.
      */
     // All constructors that want to call JDialog(Frame?) should call this constructor first.
     // It will not show a taskbar icon if the owner frame is null
@@ -100,30 +108,39 @@ class ComposeDialog : JDialog {
         graphicsConfiguration: GraphicsConfiguration? = null,
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
         savedState: SavedState? = null,
+        coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ) : super(owner, "", modal, graphicsConfiguration) {
-        composePanel = createComposePanel(skiaLayerAnalytics, savedState)
+        composePanel = createComposePanel(skiaLayerAnalytics, savedState, coroutineContext)
         contentPane.add(composePanel)
     }
 
     /**
-     * ComposeDialog is a dialog for building UI using Compose for Desktop.
-     * ComposeDialog inherits javax.swing.JDialog.
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
      *
-     * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behavior.
-     * SkiaLayer is the underlying class used internally to draw Compose content.
-     * Implementation usually uses a third-party solution to send info to an analytics gatherer.
+     * @param skiaLayerAnalytics Allows receiving notifications about the underlying Skia layer behavior.
      * @param savedState The saved state to restore the UI state from a previous instance.
+     * @param coroutineContext The coroutine context for Compose content rendering and effects.
      */
     @ExperimentalComposeUiApi
     constructor(
         skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
         savedState: SavedState? = null,
+        coroutineContext: CoroutineContext = EmptyCoroutineContext,
     ): this(
         owner = null as Frame?,
         skiaLayerAnalytics = skiaLayerAnalytics,
-        savedState = savedState
+        savedState = savedState,
+        coroutineContext = coroutineContext
     )
 
+    /**
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
+     *
+     * @param owner the [java.awt.Window] from which the dialog is displayed or `null` if this dialog has no owner.
+     * @param modalityType specifies whether dialog blocks input to other windows when shown.
+     * @param graphicsConfiguration [GraphicsConfiguration] of the target screen device; if `null`, the default system
+     * [GraphicsConfiguration] is assumed.
+     */
     constructor(
         owner: Window?,
         modalityType: ModalityType = ModalityType.MODELESS,
@@ -133,18 +150,46 @@ class ComposeDialog : JDialog {
         modalityType = modalityType,
         graphicsConfiguration = graphicsConfiguration,
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-        savedState = null
+        savedState = null,
     )
 
+    /**
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
+     *
+     * @param graphicsConfiguration [GraphicsConfiguration] of the target screen device; if `null`, the default system
+     * [GraphicsConfiguration] is assumed.
+     * @param coroutineContext The coroutine context for Compose content rendering and effects.
+     */
+    @ExperimentalComposeUiApi
+    constructor(
+        graphicsConfiguration: GraphicsConfiguration? = null,
+        coroutineContext: CoroutineContext = EmptyCoroutineContext
+    ) : this(
+        owner = null as Frame?,
+        graphicsConfiguration = graphicsConfiguration,
+        skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
+        savedState = null,
+        coroutineContext = coroutineContext
+    )
+
+    /**
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
+     *
+     * @param graphicsConfiguration [GraphicsConfiguration] of the target screen device; if `null`, the default system
+     * [GraphicsConfiguration] is assumed.
+     */
     constructor(
         graphicsConfiguration: GraphicsConfiguration? = null,
     ) : this(
         owner = null as Frame?,
         graphicsConfiguration = graphicsConfiguration,
         skiaLayerAnalytics = SkiaLayerAnalytics.Empty,
-        savedState = null
+        savedState = null,
     )
 
+    /**
+     * System dialog for displaying Compose UI, inheriting [javax.swing.JDialog].
+     */
     constructor() : this(
         owner = null as Frame?,
     )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -55,6 +55,7 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
  * Implementation usually uses third-party solution to send info to some centralized analytics gatherer.
  * @param savedState The saved state to restore the UI state from a previous instance.
  * @param renderSettings Configuration class for rendering settings.
+ * @param coroutineContext The coroutine context for Compose content rendering and effects.
  */
 class ComposePanel @ExperimentalComposeUiApi constructor(
     private val skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposePanel.desktop.kt
@@ -42,6 +42,8 @@ import java.awt.event.FocusListener
 import java.util.*
 import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities.isEventDispatchThread
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
@@ -57,7 +59,8 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 class ComposePanel @ExperimentalComposeUiApi constructor(
     private val skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     private var savedState: SavedState? = null,
-    private val renderSettings: RenderSettings = DefaultRenderSettings
+    private val renderSettings: RenderSettings = DefaultRenderSettings,
+    private val coroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : JLayeredPane() {
     constructor() : this(
         savedState = null,
@@ -302,6 +305,7 @@ class ComposePanel @ExperimentalComposeUiApi constructor(
             savedState = savedState,
             windowContainer = windowContainer,
             renderSettings = renderSettings,
+            coroutineContext = coroutineContext,
         ).apply {
             setBounds(0, 0, width, height)
             contentComponent.isFocusable = isFocusable

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindow.desktop.kt
@@ -37,28 +37,28 @@ import java.awt.event.MouseMotionListener
 import java.awt.event.MouseWheelListener
 import java.util.Locale
 import javax.swing.JFrame
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import org.jetbrains.skiko.GraphicsApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
 
 /**
- * ComposeWindow is a window for building UI using Compose for Desktop.
- * ComposeWindow inherits javax.swing.JFrame.
+ * System window for displaying Compose UI, inheriting [javax.swing.JFrame].
  *
- * @param graphicsConfiguration the GraphicsConfiguration that is used to construct the new window.
- * If null, the system default GraphicsConfiguration is assumed.
- * @param skiaLayerAnalytics Analytics that helps to know more about SkiaLayer behaviour.
- * SkiaLayer is underlying class used internally to draw Compose content.
- * Implementation usually uses third-party solution to send info to some centralized analytics gatherer.
+ * @param graphicsConfiguration [GraphicsConfiguration] of the target screen device; if `null`, the default system
+ * [GraphicsConfiguration] is assumed.
+ * @param skiaLayerAnalytics Allows receiving notifications about the underlying Skia layer behavior.
  * @param savedState The saved state to restore the UI state from a previous instance.
+ * @param coroutineContext The coroutine context for Compose content rendering and effects.
  */
 class ComposeWindow @ExperimentalComposeUiApi constructor(
     graphicsConfiguration: GraphicsConfiguration? = null,
     skiaLayerAnalytics: SkiaLayerAnalytics = SkiaLayerAnalytics.Empty,
     savedState: SavedState? = null,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext
 ) : JFrame(graphicsConfiguration) {
     /**
-     * ComposeWindow is a window for building UI using Compose for Desktop.
-     * ComposeWindow inherits javax.swing.JFrame.
+     * System window for displaying Compose UI, inheriting [javax.swing.JFrame].
      *
      * @param graphicsConfiguration the GraphicsConfiguration that is used to construct the new window.
      * If null, the system default GraphicsConfiguration is assumed.
@@ -72,6 +72,7 @@ class ComposeWindow @ExperimentalComposeUiApi constructor(
         isUndecorated = ::isUndecorated,
         skiaLayerAnalytics = skiaLayerAnalytics,
         savedState = savedState,
+        coroutineContext = coroutineContext
     )
     private val undecoratedWindowResizer = UndecoratedWindowResizer(this)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/ComposeWindowPanel.desktop.kt
@@ -32,6 +32,8 @@ import java.awt.FocusTraversalPolicy
 import java.awt.Window
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import org.jetbrains.skiko.DelicateSkikoApi
 import org.jetbrains.skiko.SkiaLayerAnalytics
 import org.jetbrains.skiko.transparentWindowBackgroundHack
@@ -44,6 +46,7 @@ internal class ComposeWindowPanel(
     private val isUndecorated: () -> Boolean,
     skiaLayerAnalytics: SkiaLayerAnalytics,
     savedState: SavedState? = null,
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : JLayeredPaneWithTransparencyHack() {
     private var isDisposed = false
 
@@ -66,7 +69,8 @@ internal class ComposeWindowPanel(
         },
         // Swing graphics is not supposed to be used here.
         // TODO: Add isVsyncEnabled flag to ComposeWindowPanel constructor
-        renderSettings = RenderSettings.SkiaSurface()
+        renderSettings = RenderSettings.SkiaSurface(),
+        coroutineContext = coroutineContext
     )
     private val composeContainer
         get() = requireNotNull(_composeContainer) {

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.painter.Painter
@@ -39,7 +40,6 @@ import androidx.compose.ui.window.DialogModalityType
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.DialogWindowScope
-import androidx.compose.ui.window.LocalCoroutineContext
 import androidx.compose.ui.window.LocalWindow
 import androidx.compose.ui.window.LocalWindowExceptionHandlerFactory
 import androidx.compose.ui.window.UndecoratedWindowDecoration
@@ -234,7 +234,7 @@ fun SwingDialog(
         }
     }
 
-    val coroutineContext = LocalCoroutineContext.current
+    val coroutineContext = rememberCoroutineScope().coroutineContext
 
     SwingDialog(
         visible = visible,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.window.DialogModalityType
 import androidx.compose.ui.window.DialogState
 import androidx.compose.ui.window.DialogWindow
 import androidx.compose.ui.window.DialogWindowScope
+import androidx.compose.ui.window.LocalCoroutineContext
 import androidx.compose.ui.window.LocalWindow
 import androidx.compose.ui.window.LocalWindowExceptionHandlerFactory
 import androidx.compose.ui.window.UndecoratedWindowDecoration
@@ -233,6 +234,8 @@ fun SwingDialog(
         }
     }
 
+    val coroutineContext = LocalCoroutineContext.current
+
     SwingDialog(
         visible = visible,
         onPreviewKeyEvent = onPreviewKeyEvent,
@@ -243,10 +246,14 @@ fun SwingDialog(
                 ComposeDialog(
                     owner = owner,
                     modalityType = currentModalityType,
-                    graphicsConfiguration = graphicsConfiguration
+                    graphicsConfiguration = graphicsConfiguration,
+                    coroutineContext = coroutineContext
                 )
             } else {
-                ComposeDialog(graphicsConfiguration = graphicsConfiguration)
+                ComposeDialog(
+                    graphicsConfiguration = graphicsConfiguration,
+                    coroutineContext = coroutineContext
+                )
             }
             dialog.apply {
                 // close state is controlled by DialogState.isOpen

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
@@ -16,11 +16,7 @@
 
 package androidx.compose.ui.awt
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.currentCompositionLocalContext
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.*
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
@@ -28,26 +24,8 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.scene.LocalComposeSceneContext
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.ComponentUpdater
-import androidx.compose.ui.util.componentListenerRef
-import androidx.compose.ui.util.setIcon
-import androidx.compose.ui.util.setPositionSafely
-import androidx.compose.ui.util.setSizeSafely
-import androidx.compose.ui.util.setUndecoratedSafely
-import androidx.compose.ui.util.windowListenerRef
-import androidx.compose.ui.util.windowStateListenerRef
-import androidx.compose.ui.window.FrameWindowScope
-import androidx.compose.ui.window.LocalWindowExceptionHandlerFactory
-import androidx.compose.ui.window.UndecoratedWindowDecoration
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowDecoration
-import androidx.compose.ui.window.WindowLocationTracker
-import androidx.compose.ui.window.WindowPlacement
-import androidx.compose.ui.window.WindowPosition
-import androidx.compose.ui.window.WindowState
-import androidx.compose.ui.window.componentOrientation
-import androidx.compose.ui.window.rememberWindowState
-import androidx.compose.ui.window.resizerThickness
+import androidx.compose.ui.util.*
+import androidx.compose.ui.window.*
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.WindowAdapter
@@ -225,13 +203,18 @@ fun SwingWindow(
         }
     }
 
+    val coroutineContext = LocalCoroutineContext.current
+
     SwingWindow(
         visible = visible,
         onPreviewKeyEvent = onPreviewKeyEvent,
         onKeyEvent = onKeyEvent,
         create = {
             val graphicsConfiguration = WindowLocationTracker.lastActiveGraphicsConfiguration
-            ComposeWindow(graphicsConfiguration = graphicsConfiguration).apply {
+            ComposeWindow(
+                graphicsConfiguration = graphicsConfiguration,
+                coroutineContext = coroutineContext
+            ).apply {
                 // close state is controlled by WindowState.isOpen
                 defaultCloseOperation = JFrame.DO_NOTHING_ON_CLOSE
                 listeners.windowListenerRef.registerWithAndSet(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
@@ -203,7 +203,7 @@ fun SwingWindow(
         }
     }
 
-    val coroutineContext = LocalCoroutineContext.current
+    val coroutineContext = rememberCoroutineScope().coroutineContext
 
     SwingWindow(
         visible = visible,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
@@ -16,7 +16,12 @@
 
 package androidx.compose.ui.awt
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.currentCompositionLocalContext
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
@@ -24,8 +29,26 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.scene.LocalComposeSceneContext
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.*
-import androidx.compose.ui.window.*
+import androidx.compose.ui.util.ComponentUpdater
+import androidx.compose.ui.util.componentListenerRef
+import androidx.compose.ui.util.setIcon
+import androidx.compose.ui.util.setPositionSafely
+import androidx.compose.ui.util.setSizeSafely
+import androidx.compose.ui.util.setUndecoratedSafely
+import androidx.compose.ui.util.windowListenerRef
+import androidx.compose.ui.util.windowStateListenerRef
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.LocalWindowExceptionHandlerFactory
+import androidx.compose.ui.window.UndecoratedWindowDecoration
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.WindowDecoration
+import androidx.compose.ui.window.WindowLocationTracker
+import androidx.compose.ui.window.WindowPlacement
+import androidx.compose.ui.window.WindowPosition
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.componentOrientation
+import androidx.compose.ui.window.rememberWindowState
+import androidx.compose.ui.window.resizerThickness
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.WindowAdapter

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -56,6 +56,7 @@ import javax.swing.JLayeredPane
 import javax.swing.SwingUtilities
 import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.CoroutineExceptionHandler
 import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.skia.Canvas
@@ -90,6 +91,7 @@ internal class ComposeContainer(
 
     private val layerType: LayerType = ComposeFeatureFlags.layerType.value,
     private val renderSettings: RenderSettings = RenderSettings.SkiaSurface(),
+    coroutineContext: CoroutineContext = EmptyCoroutineContext,
 ) : WindowFocusListener,
     WindowListener {
     val windowContext = PlatformWindowContext()
@@ -127,9 +129,6 @@ internal class ComposeContainer(
     @VisibleForTesting
     val architectureComponentsOwner = DefaultArchitectureComponentsOwner(savedState)
 
-    private val coroutineExceptionHandler = DesktopCoroutineExceptionHandler()
-    private val coroutineContext = MainUIDispatcher + coroutineExceptionHandler
-
     private val mediator = ComposeSceneMediator(
         container = container,
         isWindowLevel = isWindowLevel,
@@ -142,7 +141,7 @@ internal class ComposeContainer(
             FocusableLayerEventFilter()
         ),
         architectureComponentsOwner = architectureComponentsOwner,
-        coroutineContext = coroutineContext,
+        coroutineContext = coroutineContext + MainUIDispatcher + DesktopCoroutineExceptionHandler(),
         skiaLayerComponentFactory = ::createSkiaLayerComponent,
         composeSceneFactory = ::createComposeScene,
     )

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposePanel
@@ -38,8 +37,6 @@ import androidx.compose.ui.configureSwingGlobalsForCompose
 import androidx.compose.ui.platform.GlobalSnapshotManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.system.exitProcess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -226,7 +223,6 @@ suspend fun awaitApplication(
                                 // density to calculate intrinsicSize
                                 LocalDensity provides GlobalDensity,
                                 LocalLayoutDirection provides GlobalLayoutDirection,
-                                LocalCoroutineContext provides coroutineContext
                             ) {
                                 applicationScope.content()
                             }
@@ -253,11 +249,6 @@ interface ApplicationScope {
      */
     fun exitApplication()
 }
-
-/**
- * Allows passing the coroutine context to child recomposers.
- */
-internal val LocalCoroutineContext = staticCompositionLocalOf<CoroutineContext> { EmptyCoroutineContext }
 
 private object YieldFrameClock : MonotonicFrameClock {
     override suspend fun <R> withFrameNanos(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Application.desktop.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposePanel
@@ -37,6 +38,8 @@ import androidx.compose.ui.configureSwingGlobalsForCompose
 import androidx.compose.ui.platform.GlobalSnapshotManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.system.exitProcess
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -223,6 +226,7 @@ suspend fun awaitApplication(
                                 // density to calculate intrinsicSize
                                 LocalDensity provides GlobalDensity,
                                 LocalLayoutDirection provides GlobalLayoutDirection,
+                                LocalCoroutineContext provides coroutineContext
                             ) {
                                 applicationScope.content()
                             }
@@ -249,6 +253,11 @@ interface ApplicationScope {
      */
     fun exitApplication()
 }
+
+/**
+ * Allows passing the coroutine context to child recomposers.
+ */
+internal val LocalCoroutineContext = staticCompositionLocalOf<CoroutineContext> { EmptyCoroutineContext }
 
 private object YieldFrameClock : MonotonicFrameClock {
     override suspend fun <R> withFrameNanos(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DialogWindowTest.kt
@@ -17,28 +17,14 @@
 package androidx.compose.ui.window
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
+import androidx.compose.ui.*
 import androidx.compose.ui.awt.ComposeDialog
 import androidx.compose.ui.awt.SwingDialog
-import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusTarget
@@ -50,34 +36,24 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.sendKeyEvent
-import androidx.compose.ui.sendMousePress
-import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
-import androidx.compose.ui.toInt
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.roundToIntSize
+import androidx.compose.ui.unit.*
+import androidx.compose.ui.window.window.animationsRunAtNonInfiniteRateIn
+import androidx.compose.ui.window.window.coroutineContextIsPropagatedTo
 import androidx.compose.ui.window.window.toSize
 import com.google.common.truth.Truth.assertThat
-import java.awt.Dialog
-import java.awt.Dimension
-import java.awt.Point
-import java.awt.Robot
-import java.awt.Window
+import java.awt.*
 import java.awt.event.KeyEvent
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import javax.swing.JFrame
 import kotlin.concurrent.thread
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.coroutines.delay
-import org.junit.Test
 
 class DialogWindowTest {
     @Test
@@ -838,6 +814,19 @@ class DialogWindowTest {
         }
     }
 
+    @Test
+    fun coroutineContextIsPropagatedToDialog() = coroutineContextIsPropagatedTo { content ->
+        DialogWindow(onCloseRequest = ::exitApplication) {
+            content()
+        }
+    }
+
+    @Test
+    fun animationsRunAtNonInfiniteRateInDialog() = animationsRunAtNonInfiniteRateIn { content ->
+        DialogWindow(onCloseRequest = ::exitApplication) {
+            content()
+        }
+    }
 }
 
 private fun assertDialogStateEquals(expected: DialogState, actual: DialogState) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -130,7 +130,7 @@ internal class WindowTestScope(
 
     private val robot = Robot()
 
-    fun launchTestApplication(
+    fun CoroutineScope.launchTestApplication(
         content: @Composable ApplicationScope.() -> Unit
     ) = realLaunchApplication {
         if (isOpen) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTest.kt
@@ -17,74 +17,36 @@
 package androidx.compose.ui.window.window
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.Button
 import androidx.compose.material.Slider
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.Recomposer
-import androidx.compose.runtime.compositionLocalOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.LeakDetector
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.*
+import androidx.compose.ui.*
 import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.awt.SwingWindow
-import androidx.compose.ui.background
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.isLinux
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.sendMousePress
-import androidx.compose.ui.sendMouseRelease
-import androidx.compose.ui.toInt
-import androidx.compose.ui.unit.Constraints
-import androidx.compose.ui.unit.Density
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.DpSize
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.roundToIntSize
-import androidx.compose.ui.window.FrameWindowScope
-import androidx.compose.ui.window.Popup
-import androidx.compose.ui.window.Window
-import androidx.compose.ui.window.WindowPlacement
-import androidx.compose.ui.window.WindowState
-import androidx.compose.ui.window.density
-import androidx.compose.ui.window.rememberWindowState
-import androidx.compose.ui.window.runApplicationTest
+import androidx.compose.ui.unit.*
+import androidx.compose.ui.window.*
 import com.google.common.truth.Truth.assertThat
-import java.awt.Dimension
-import java.awt.GraphicsEnvironment
-import java.awt.Point
-import java.awt.Robot
-import java.awt.Toolkit
-import java.awt.Window
+import java.awt.*
 import java.awt.event.WindowAdapter
 import java.awt.event.WindowEvent
 import kotlin.concurrent.thread
+import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.*
 import org.jetbrains.skiko.MainUIDispatcher
 import org.junit.Assume.assumeFalse
 import org.junit.Ignore
@@ -900,4 +862,84 @@ class WindowTest {
             window.dispose()
         }
     }
+
+    @Test
+    fun coroutineContextIsPropagatedToWindow() = coroutineContextIsPropagatedTo { content ->
+        Window(onCloseRequest = ::exitApplication) {
+            content()
+        }
+    }
+
+    @Test
+    fun animationsRunAtNonInfiniteRateInWindow() = animationsRunAtNonInfiniteRateIn { content ->
+        Window(onCloseRequest = ::exitApplication) {
+            content()
+        }
+    }
+}
+
+private object CtxElement : CoroutineContext.Element, CoroutineContext.Key<CtxElement> {
+    override val key: CoroutineContext.Key<*> = this
+}
+
+internal fun coroutineContextIsPropagatedTo(
+    window: @Composable ApplicationScope.(@Composable () -> Unit) -> Unit
+) = runApplicationTest {
+    var applicationContextElement: CtxElement? = null
+    var windowContextElement: CtxElement? = null
+    var innerWindowContextElement: CtxElement? = null
+    val scope = this + CtxElement
+    scope.launchTestApplication {
+        LaunchedEffect(Unit) {
+            applicationContextElement = currentCoroutineContext()[CtxElement]
+        }
+        window {
+            LaunchedEffect(Unit) {
+                windowContextElement = currentCoroutineContext()[CtxElement]
+            }
+
+            window {
+                LaunchedEffect(Unit) {
+                    innerWindowContextElement = currentCoroutineContext()[CtxElement]
+                }
+            }
+        }
+    }
+
+    awaitIdle()
+
+    assertThat(applicationContextElement).isNotNull()
+    assertThat(windowContextElement).isNotNull()
+    assertThat(innerWindowContextElement).isNotNull()
+}
+
+internal fun animationsRunAtNonInfiniteRateIn(
+    window: @Composable ApplicationScope.(@Composable () -> Unit) -> Unit
+) = runApplicationTest {
+    suspend fun countFramesForOneSecond(onFrame: () -> Unit) {
+        val startTime = System.nanoTime()
+        while (System.nanoTime() - startTime < 1.seconds.inWholeNanoseconds) {
+            withFrameNanos {
+                onFrame()
+            }
+        }
+    }
+
+    var appFrameCount = 0
+    var windowFrameCount = 0
+    launchTestApplication {
+        LaunchedEffect(Unit) {
+            countFramesForOneSecond { appFrameCount++ }
+        }
+        window {
+            LaunchedEffect(Unit) {
+                countFramesForOneSecond { windowFrameCount++ }
+            }
+        }
+    }
+
+    awaitIdle()
+
+    // Actually, just check that the application "frame rate" is significantly smaller than the window frame rate
+    assertThat(windowFrameCount * 10).isLessThan(appFrameCount)
 }


### PR DESCRIPTION
Propagate the coroutine context of `launchApplication` and `awaitApplication` to child windows and dialogs.

Fixes https://youtrack.jetbrains.com/issue/CMP-9163

## Testing
Added unit tests

## Release Notes
### Fixes - Desktop
- The coroutine context of `launchApplication` and `awaitApplication` is now correctly used in windows and dialogs of the application.

