### PR TITLE
Code style. Make the same style in IDEA as in Android Studio

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="100" />
     <GroovyCodeStyleSettings>
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
@@ -90,6 +91,8 @@
           <package name="" alias="false" withSubpackages="true" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">


### PR DESCRIPTION
Code style. Make the same style in IDEA as in Android Studio

Specify explicit:
- 100 symbols line limit

<img width="374" height="242" alt="image" src="https://github.com/user-attachments/assets/01d18f42-ca2b-4ff5-b7d8-875d076377b1" />

- don't collapse imports

<img width="399" height="313" alt="image" src="https://github.com/user-attachments/assets/b120a789-2892-491a-9d04-0110addd54bf" />

Without specifying explicitly, there are different defaults when we open the project in IDEA. But we need to use the style from Android Studio.

This is as it was before https://github.com/JetBrains/compose-multiplatform-core/pull/2709

# Release Notes
N/A