### PR TITLE
Move the `initializeAccessible` call into `AccessibleFocusHelper`

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/Accessibility.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/Accessibility.desktop.kt
@@ -11,6 +11,7 @@ import org.jetbrains.skiko.MainUIDispatcher
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 import org.jetbrains.skiko.initializeCAccessible
+import androidx.compose.ui.scene.skia.SkiaLayerComponent
 
 /**
  * A helper class for requesting accessibility focus on a given accessible.
@@ -29,6 +30,8 @@ internal class AccessibleFocusHelper(
 
     @OptIn(DelicateCoroutinesApi::class)
     fun requestFocusOnAccessible(accessible: Accessible?) {
+        initializeAccessible(accessible)
+
         focusedAccessible = accessible
 
         when (hostOs) {
@@ -83,29 +86,22 @@ internal class AccessibleFocusHelper(
 }
 
 /**
- * This method should be called on custom [Accessible] creation (or its context if context is
- * created lazily).
+ * [sun.lwawt.macosx.CAccessible.getCAccessible] builds a mapping of [AccessibleContext] to
+ * [sun.lwawt.macosx.CAccessible] instances (which wrap the corresponding [Accessible]).
+ * If it is called with the Skia layer content [Accessible] (=[SkiaLayerComponent.contentRoot])
+ * while the [AccessibleFocusHelper] hack is active ([AccessibleFocusHelper.focusedAccessible] is
+ * not `null`), it builds an incorrect mapping, associating the focused [AccessibleContext] with
+ * [SkiaLayerComponent.contentRoot].
  *
- * JDK's accessibility support (at least for macOS) builds mapping AccessibleContext -> Accessible.
- * Some [Accessible]s are built only when focus is settled and
- * since we have a hack [AccessibleFocusHelper.requestFocusOnAccessible], wrong mapping
- * can be built (ComponentAccessibleContext -> SkiaLayer instead of
- * ComponentAccessibleContext -> ComponentAccessible).
+ * To work around this problem, [initializeAccessible] explicitly calls
+ * [sun.lwawt.macosx.CAccessible.getCAccessible] on the focused [Accessible], forcing the correct
+ * association to be made. Future calls then just retrieve the already stored value.
  *
- * This method forces JDK's accessibility support to cache mapping
- * ComponentAccessibleContext -> ComponentAccessible, if it is called on
- * ComponentAccessibleContext creation.
- *
- * Related to the [issue](https://youtrack.jetbrains.com/issue/COMPOSE-176).
+ * See also [Error when following the instructions of
+ * VoiceOver](https://youtrack.jetbrains.com/issue/CMP-176).
  */
-internal fun initializeAccessible(accessible: Accessible) {
-    when (hostOs) {
-        OS.MacOS -> {
-            initializeCAccessible(accessible)
-        }
-
-        else -> {
-            // TODO: do we need something for Windows?
-        }
+private fun initializeAccessible(accessible: Accessible?) {
+    if ((accessible != null) && (hostOs == OS.MacOS)) {
+        initializeCAccessible(accessible)
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/a11y/ComposeAccessible.kt
@@ -65,7 +65,6 @@ import javax.accessibility.AccessibleValue
 import javax.swing.text.AttributeSet
 import javax.swing.text.SimpleAttributeSet
 import kotlin.math.roundToInt
-import kotlinx.atomicfu.atomic
 import org.jetbrains.skia.BreakIterator
 
 private typealias ActionKey = SemanticsPropertyKey<AccessibilityAction<() -> Boolean>>
@@ -108,8 +107,6 @@ internal class ComposeAccessible(
             }
         }
 
-    private val isNativelyInitialized = atomic(false)
-
     val composeAccessibleContext: ComposeAccessibleComponent by lazy { ComposeAccessibleComponent() }
 
     private var disposed = false
@@ -121,14 +118,10 @@ internal class ComposeAccessible(
     override fun getAccessibleContext(): AccessibleContext? {
         if (disposed) {
             // The accessibility system keeps calling functions on the context even after the node
-            // has been removed. We return null so it doesn't do that.
+            // has been removed. We return `null` so it doesn't do that.
             return null
         }
 
-        // see doc for [nativeInitializeAccessible] for details, why this initialization is needed
-        if (isNativelyInitialized.compareAndSet(expect = false, update = true)) {
-            initializeAccessible(this)
-        }
         return composeAccessibleContext
     }
 


### PR DESCRIPTION
Move the `initializeAccessible` call into `AccessibleFocusHelper`.

`initializeAccessible` is a workaround needed due to the `AccessibleFocusHelper` hack, so it's better if `AccessibleFocusHelper` calls it.

## Testing
Tested manually the scenario in https://youtrack.jetbrains.com/issue/CMP-176 via this code:
```
fun main() = singleWindowApplication {
    Column(Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
        var showButton2 by remember { mutableStateOf(false) }
        val focusRequester = remember { FocusRequester() }
        Button(
            onClick = {
                println("Button 1 click")
                showButton2 = true
            },
            modifier = Modifier.focusRequester(focusRequester)
        ) {
            Text("Button 1")
        }
        LaunchedEffect(Unit) {
            focusRequester.requestFocus()
        }

        if (showButton2) {
            Button(onClick = {
                println("Button 2 click")
            }) {
                Text("Button 2")
            }
        }
    }
}
```

## Release Notes
N/A