### PR TITLE
Don't send synthetic mouse move events after exit

### DIFF
--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -67,12 +67,6 @@ class ComposeSceneInputTest {
             independentPopup.Content()
         }
 
-        // Popup takes two iterations to complete its layout, so we need to run render an extra time
-        // TODO(maryanovsky): Remove this when https://github.com/JetBrains/compose-jb/issues/2726
-        //                    is completed.
-        while (scene.hasInvalidations())
-            scene.render()
-
         scene.sendPointerEvent(PointerEventType.Enter, Offset(5f, 5f))
         background.events.assertReceivedNoEvents()
         cutPopup.events.assertReceivedLast(
@@ -161,12 +155,6 @@ class ComposeSceneInputTest {
             overlappedPopup.Content()
             independentPopup.Content()
         }
-
-        // Popup takes two iterations to complete its layout, so we need to run render an extra time
-        // TODO(maryanovsky): Remove this when https://github.com/JetBrains/compose-jb/issues/2726
-        //                    is completed.
-        while (scene.hasInvalidations())
-            scene.render()
 
         scene.sendPointerEvent(PointerEventType.Enter, Offset(5f, 5f))
         scene.sendPointerEvent(PointerEventType.Press, Offset(5f, 5f))

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -458,6 +458,24 @@ class SyntheticEventSenderTest {
         )
     }
 
+    @Test
+    fun `should not re-enter after mouse exit`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+        sender.send(mouseEvent(Move, 10f, 20f, pressed = false))
+        sender.send(mouseEvent(Exit, 10f, 20f, pressed = false))
+
+        sender.needUpdatePointerPosition = true
+        sender.updatePointerPosition()
+
+        received positionAndDownShouldEqual listOf(
+            mouseEvent(Move, 10f, 20f, pressed = false),
+            mouseEvent(Exit, 10f, 20f, pressed = false)
+        )
+    }
+
     private fun eventsSentBy(
         vararg inputEvents: PointerInputEvent
     ): List<PointerInputEvent> {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
@@ -826,3 +827,20 @@ private class EventCollector {
         }
     }
 }
+
+/**
+ * Render the current content until there are no more invalidations.
+ *
+ * @param initialNanoTime The time to start rendering from.
+ * @param stepNanoTime The time to step rendering by.
+ */
+internal fun ImageComposeScene.renderUntilIdle(initialNanoTime: Long = 0, stepNanoTime: Long = 16L): Long {
+    var time = initialNanoTime
+    Snapshot.sendApplyNotifications()  // Needed for the scene to be notified of state changes
+    while (hasInvalidations()) {
+        render(time)
+        time += stepNanoTime
+    }
+    return time
+}
+

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -44,6 +44,9 @@ import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.scene.ComposeScene
+import androidx.compose.ui.scene.LocalComposeScene
+import androidx.compose.ui.scene.lastKnownPointerPosition
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Constraints
@@ -59,6 +62,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.util.concurrent.Executors
 import kotlin.random.Random
+import kotlin.test.assertNull
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
@@ -586,6 +590,51 @@ class MouseMoveTest {
                     "Actual: $enteredIndex"
             }
         }
+    }
+
+    @Test
+    fun `window exit followed by layout does not trigger mouse enter`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        val collector = EventCollector()
+        var boxSize by mutableStateOf(50.dp)
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .collectPointerEvents(collector)
+                    .size(boxSize)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0)
+
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
+        collector.assertCounts(enter = 1, exit = 1, move = 0)
+
+        // Trigger a layout, which then triggers SyntheticEventSender.updatePointerPosition
+        boxSize = 100.dp
+        scene.renderUntilIdle()
+
+        collector.assertCounts(enter = 1, exit = 1, move = 0)
+    }
+
+    @Test
+    fun `window exit clears lastKnownPointerPosition`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        lateinit var composeScene: ComposeScene
+        scene.setContent {
+            composeScene = LocalComposeScene.current!!
+            Box(Modifier.size(100.dp))
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
+
+        assertNull(composeScene.lastKnownPointerPosition)
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -598,26 +598,122 @@ class MouseMoveTest {
         height = 100,
     ).useInUiThread { scene ->
         val collector = EventCollector()
-        var boxSize by mutableStateOf(50.dp)
+        var yOffset by mutableStateOf(0.dp)
         scene.setContent {
             Box(
                 modifier = Modifier
+                    .size(50.dp)
+                    .offset(y = yOffset)
                     .collectPointerEvents(collector)
-                    .size(boxSize)
             )
         }
 
         scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
         collector.assertCounts(enter = 1, exit = 0, move = 0)
 
-        scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
+        // Deliberately send an exit event with coordinates still inside the box
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(10f, 20f))
         collector.assertCounts(enter = 1, exit = 1, move = 0)
 
         // Trigger a layout, which then triggers SyntheticEventSender.updatePointerPosition
-        boxSize = 100.dp
+        yOffset = 10.dp
         scene.renderUntilIdle()
 
         collector.assertCounts(enter = 1, exit = 1, move = 0)
+    }
+
+    @Test
+    fun `window exit while pressed followed by layout triggers mouse move`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        val collector = EventCollector()
+        var yOffset by mutableStateOf(0.dp)
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .size(50.dp)
+                    .offset(y = yOffset)
+                    .collectPointerEvents(collector)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0)
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0, press = 1)
+
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(-10f, 20f))
+        collector.assertCounts(enter = 1, exit = 1, move = 0, press = 1)
+
+        // Trigger a layout, which then triggers SyntheticEventSender.updatePointerPosition
+        yOffset = 10.dp
+        scene.renderUntilIdle()
+
+        collector.assertCounts(enter = 1, exit = 1, move = 1, press = 1)
+    }
+
+    @Test
+    fun `window exit while pressed followed by mouse up and layout does not trigger mouse move`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        val collector = EventCollector()
+        var yOffset by mutableStateOf(0.dp)
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .size(50.dp)
+                    .offset(y = yOffset)
+                    .collectPointerEvents(collector)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0)
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0, press = 1)
+
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(-10f, 20f))
+        collector.assertCounts(enter = 1, exit = 1, move = 0, press = 1)
+
+        scene.sendPointerEvent(PointerEventType.Release, Offset(-10f, 20f))
+        collector.assertCounts(enter = 1, exit = 1, move = 0, press = 1, release = 1)
+
+        // Trigger a layout, which then triggers SyntheticEventSender.updatePointerPosition
+        yOffset = 10.dp
+        scene.renderUntilIdle()
+
+        collector.assertCounts(enter = 1, exit = 1, move = 0, press = 1, release = 1)
+    }
+
+    @Test
+    fun `window exit while pressed continues to send mouse events to target element`() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        val collector = EventCollector()
+        scene.setContent {
+            Box(
+                modifier = Modifier
+                    .size(50.dp)
+                    .collectPointerEvents(collector)
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0)
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 20f))
+        collector.assertCounts(enter = 1, exit = 0, move = 0, press = 1)
+
+        scene.sendPointerEvent(PointerEventType.Exit, Offset(-10f, 20f))
+        collector.assertCounts(enter = 1, exit = 1, move = 0, press = 1)
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(-20f, 20f))
+        collector.assertCounts(enter = 1, exit = 1, move = 1, press = 1)
     }
 
     @Test
@@ -632,6 +728,7 @@ class MouseMoveTest {
         }
 
         scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
+        // Deliberately send an exit event with coordinates still inside the box
         scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
 
         assertNull(composeScene.lastKnownPointerPosition)
@@ -654,6 +751,7 @@ private class EventCollector {
     private var exitCount = 0
     private var moveCount = 0
     private var pressCount = 0
+    private var releaseCount = 0
     private var enterPosition: Offset? = null
     private var exitPosition: Offset? = null
     private var movePosition: Offset? = null
@@ -677,6 +775,10 @@ private class EventCollector {
                 pressCount++
                 pressPosition = event.changes[0].position
             }
+            PointerEventType.Release -> {
+                releaseCount++
+                pressPosition = null
+            }
         }
     }
 
@@ -685,6 +787,7 @@ private class EventCollector {
         exit: Int = -1,
         move: Int = -1,
         press: Int = -1,
+        release: Int = -1,
     ) {
         if (enter >= 0) {
             assertWithMessage("enter count").that(this.enterCount).isEqualTo(enter)
@@ -697,6 +800,9 @@ private class EventCollector {
         }
         if (press >= 0) {
             assertWithMessage("press count").that(this.pressCount).isEqualTo(press)
+        }
+        if (release >= 0) {
+            assertWithMessage("release count").that(this.releaseCount).isEqualTo(release)
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asComposeCanvas
@@ -48,6 +49,7 @@ import androidx.compose.ui.unit.toSize
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmName
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit.NANOSECONDS
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.Dispatchers
@@ -243,7 +245,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
 
     /**
      * Update the composition with the content described by the [content] composable. After this
-     * has been called the changes to produce the initial composition has been calculated and
+     * has been called, the changes to produce the initial composition have been calculated and
      * applied to the composition.
      *
      * Will throw an [IllegalStateException] if the composition has been disposed.
@@ -289,6 +291,40 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     fun render(time: Duration): Image =
         render(time.toLong(NANOSECONDS))
 
+    /**
+     * Render the current content until there are no more invalidations.
+     *
+     * @param initialNanoTime The time to start rendering from.
+     * @param stepNanoTime The time to step rendering by.
+     */
+    @ExperimentalComposeUiApi
+    fun renderUntilIdle(initialNanoTime: Long = 0, stepNanoTime: Long = 16L): Long {
+        var time = initialNanoTime
+        Snapshot.sendApplyNotifications()
+        while (hasInvalidations()) {
+            render(time)
+            time += stepNanoTime
+            Snapshot.sendApplyNotifications()
+        }
+        return time
+    }
+
+    /**
+     * Render the current content until there are no more invalidations.
+     *
+     * @param initialNanoTime The time to start rendering from.
+     * @param stepNanoTime The time to step rendering by.
+     */
+    @ExperimentalComposeUiApi
+    fun renderUntilIdle(
+        initialNanoTime: Duration,
+        stepNanoTime: Duration = 16.milliseconds
+    ): Long {
+        return renderUntilIdle(
+            initialNanoTime = initialNanoTime.inWholeNanoseconds,
+            stepNanoTime = stepNanoTime.inWholeNanoseconds
+        )
+    }
     /**
      * Send pointer event to the content.
      *

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateSetOf
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.asComposeCanvas
@@ -49,7 +48,6 @@ import androidx.compose.ui.unit.toSize
 import kotlin.coroutines.CoroutineContext
 import kotlin.jvm.JvmName
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.DurationUnit.NANOSECONDS
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.Dispatchers
@@ -291,40 +289,6 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
     fun render(time: Duration): Image =
         render(time.toLong(NANOSECONDS))
 
-    /**
-     * Render the current content until there are no more invalidations.
-     *
-     * @param initialNanoTime The time to start rendering from.
-     * @param stepNanoTime The time to step rendering by.
-     */
-    @ExperimentalComposeUiApi
-    fun renderUntilIdle(initialNanoTime: Long = 0, stepNanoTime: Long = 16L): Long {
-        var time = initialNanoTime
-        Snapshot.sendApplyNotifications()
-        while (hasInvalidations()) {
-            render(time)
-            time += stepNanoTime
-            Snapshot.sendApplyNotifications()
-        }
-        return time
-    }
-
-    /**
-     * Render the current content until there are no more invalidations.
-     *
-     * @param initialNanoTime The time to start rendering from.
-     * @param stepNanoTime The time to step rendering by.
-     */
-    @ExperimentalComposeUiApi
-    fun renderUntilIdle(
-        initialNanoTime: Duration,
-        stepNanoTime: Duration = 16.milliseconds
-    ): Long {
-        return renderUntilIdle(
-            initialNanoTime = initialNanoTime.inWholeNanoseconds,
-            stepNanoTime = stepNanoTime.inWholeNanoseconds
-        )
-    }
     /**
      * Send pointer event to the content.
      *

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -58,7 +58,7 @@ internal class SyntheticEventSender(
 ) {
     private val _send: (PointerInputEvent) -> PointerEventResult = send
     private var previousEvent: PointerInputEvent? = null
-    private var isMouseInside: Boolean = false
+    private var isMousePointerInside: Boolean = false
 
     /**
      * If something happened with Compose content (it relayouted), we need to send an
@@ -79,13 +79,12 @@ internal class SyntheticEventSender(
      * Send [event] and synthetic events before it if needed. On each sent event we just call [send]
      */
     fun send(event: PointerInputEvent): PointerEventResult {
+        trackMousePointerState(event)
+
         val syntheticMoveForHoverResult = sendMissingMoveForHover(event)
         val syntheticReleasesResult = sendMissingReleases(event)
         val syntheticPressesResult = sendMissingPresses(event)
         val eventResult = sendInternal(event)
-
-        trackPointerState(event)
-
         return syntheticMoveForHoverResult.merging(
             syntheticReleasesResult,
             syntheticPressesResult,
@@ -93,41 +92,40 @@ internal class SyntheticEventSender(
         )
     }
 
-    private fun trackPointerState(event: PointerInputEvent) {
+    private fun trackMousePointerState(event: PointerInputEvent) {
+        if (!event.pointers.fastAny { it.type == PointerType.Mouse }) return
+
         when (event.eventType) {
-            // Mark isMouseInside as true not just on Enter, just in case the system didn't send
+            // Mark as true not just on Enter, just in case the system didn't send
             // us an Enter event (also, some tests don't bother sending it)
             PointerEventType.Enter,
             PointerEventType.Move,
             PointerEventType.Press,
             PointerEventType.Scroll,
-                -> isMouseInside = true
-            PointerEventType.Exit ->
-                isMouseInside = false
-        }
-
-        val mouseChange = event.pointers.fastFirstOrNull { it.type == PointerType.Mouse } ?: return
-        val isTargetOfMouseEvents = isMouseInside || mouseChange.down
-        if (!isTargetOfMouseEvents) {
-            // Clear `previousEvent` when we're no longer the target of mouse events, to prevent any
-            // synthetic events from being sent accidentally.
-            previousEvent = null
+                -> isMousePointerInside = true
+            PointerEventType.Exit
+                -> isMousePointerInside = false
         }
     }
 
     fun updatePointerPosition(): PointerEventResult {
-        if (needUpdatePointerPosition) {
-            needUpdatePointerPosition = false
+        val nothingConsumed = PointerEventResult(anyMovementConsumed = false)
 
-            previousEvent?.let { event ->
-                // Re-send pointer position update only for hover mouse events.
-                // Aligned with [AndroidComposeView.resendMotionEventOnLayout], but fixing b/397352507.
-                if (event.pointers.fastAny { it.type == PointerType.Mouse }) {
-                    return sendSyntheticMove(event)
-                }
-            }
+        if (!needUpdatePointerPosition) return nothingConsumed
+        needUpdatePointerPosition = false
+
+        // Re-send pointer position update only for mouse events.
+        // Aligned with [AndroidComposeView.resendMotionEventOnLayout], but fixing b/397352507.
+        val previousEvent = previousEvent ?: return nothingConsumed
+        val mousePointer = previousEvent.pointers.fastFirstOrNull { it.type == PointerType.Mouse }
+            ?: return nothingConsumed
+
+        // Send synthetic move only if the scene is the current "target" of mouse events
+        return if (isMousePointerInside || mousePointer.down) {
+            sendSyntheticMove(previousEvent)
+        } else {
+            nothingConsumed
         }
-        return PointerEventResult(anyMovementConsumed = false)
     }
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.scene.PointerEventResult
 import androidx.compose.ui.scene.merging
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastAny
+import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastMap
 import androidx.compose.ui.util.fastMapNotNull
 
@@ -57,6 +58,7 @@ internal class SyntheticEventSender(
 ) {
     private val _send: (PointerInputEvent) -> PointerEventResult = send
     private var previousEvent: PointerInputEvent? = null
+    private var isMouseInside: Boolean = false
 
     /**
      * If something happened with Compose content (it relayouted), we need to send an
@@ -82,18 +84,35 @@ internal class SyntheticEventSender(
         val syntheticPressesResult = sendMissingPresses(event)
         val eventResult = sendInternal(event)
 
-        // Clear `previousEvent` when the mouse exits to prevent any synthetic events from being
-        // sent accidentally.
-        if ((event.eventType == PointerEventType.Exit) &&
-            (event.pointers.fastAll { it.type == PointerType.Mouse })) {
-            previousEvent = null
-        }
+        trackPointerState(event)
 
         return syntheticMoveForHoverResult.merging(
             syntheticReleasesResult,
             syntheticPressesResult,
             eventResult
         )
+    }
+
+    private fun trackPointerState(event: PointerInputEvent) {
+        when (event.eventType) {
+            // Mark isMouseInside as true not just on Enter, just in case the system didn't send
+            // us an Enter event (also, some tests don't bother sending it)
+            PointerEventType.Enter,
+            PointerEventType.Move,
+            PointerEventType.Press,
+            PointerEventType.Scroll,
+                -> isMouseInside = true
+            PointerEventType.Exit ->
+                isMouseInside = false
+        }
+
+        val mouseChange = event.pointers.fastFirstOrNull { it.type == PointerType.Mouse } ?: return
+        val isTargetOfMouseEvents = isMouseInside || mouseChange.down
+        if (!isTargetOfMouseEvents) {
+            // Clear `previousEvent` when we're no longer the target of mouse events, to prevent any
+            // synthetic events from being sent accidentally.
+            previousEvent = null
+        }
     }
 
     fun updatePointerPosition(): PointerEventResult {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -39,7 +39,7 @@ import androidx.compose.ui.util.fastMapNotNull
  * The alternative of sending synthetic moves is to send a native press/release as
  * Enter/Exit separately from Press/Release.
  * But this approach requires more changes - we need a separate HitPathTracker for Enter/Exit.
- * The user code  won't see anything new with this approach
+ * The user code won't see anything new with this approach
  * (besides that Enter/Exit event will have nativeEvent.type == Release/Press)
  *
  * We don't send synthetic events for touch, as it doesn't have Enter/Exit, and it will be
@@ -81,6 +81,14 @@ internal class SyntheticEventSender(
         val syntheticReleasesResult = sendMissingReleases(event)
         val syntheticPressesResult = sendMissingPresses(event)
         val eventResult = sendInternal(event)
+
+        // Clear `previousEvent` when the mouse exits to prevent any synthetic events from being
+        // sent accidentally.
+        if ((event.eventType == PointerEventType.Exit) &&
+            (event.pointers.fastAll { it.type == PointerType.Mouse })) {
+            previousEvent = null
+        }
+
         return syntheticMoveForHoverResult.merging(
             syntheticReleasesResult,
             syntheticPressesResult,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -66,9 +66,6 @@ internal abstract class BaseComposeScene(
             processKeyEvent = ::processKeyEvent,
         )
 
-    // Store this to avoid creating a lambda every frame
-    private val updatePointerPosition = inputHandler::updatePointerPosition
-
     private val frameClock = BroadcastFrameClock(onNewAwaiters = ::updateInvalidations)
     private val recomposer: ComposeSceneRecomposer =
         ComposeSceneRecomposer(coroutineContext, frameClock)
@@ -179,7 +176,9 @@ internal abstract class BaseComposeScene(
 
             // Schedule synthetic events to be sent after `render` completes
             if (inputHandler.needUpdatePointerPosition) {
-                recomposer.scheduleAsEffect { updatePointerPosition() }
+                recomposer.scheduleAsEffect {
+                    inputHandler.updatePointerPosition()
+                }
             }
 
             // Between layout and draw, Android's Choreographer flushes the main dispatcher.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -159,8 +159,9 @@ internal class ComposeSceneInputHandler(
                 pointerPositions[pointer.id] = pointer.position
             }
         }
-        // touches/styluses positions should be removed from [pointerPositions] if they are not down anymore
-        // also, mouse exited ComposeScene should be removed
+
+        // touches/styluses positions should be removed from [pointerPositions] if they are not down
+        // anymore also, mouse exited ComposeScene should be removed
         val iterator = pointerPositions.iterator()
         while (iterator.hasNext()) {
             val pointerId = iterator.next().key


### PR DESCRIPTION
Don't send a synthetic move event on layout change if the mouse pointer is outside the scene (and all buttons are not pressed). This is needed because the pointer position in a `MOUSE_EXIT` event may nevertheless be inside the scene, so sending a synthetic move will trigger a synthetic mouse-enter (but according to AWT, the mouse pointer is outside the scene, so we won't be receiving any more events).

Partially
Fixes https://youtrack.jetbrains.com/issue/CMP-8739

## Testing
Added unit tests

## Release Notes
### Fixes - Desktop
- Fix incorrect pointer Enter/Move events sometimes being sent immediately following the mouse pointer exiting the compose scene.
