### PR TITLE
Restore -Xlambdas=class in build.gradle 

### DIFF
--- a/compose/animation/animation/build.gradle
+++ b/compose/animation/animation/build.gradle
@@ -140,6 +140,7 @@ androidx {
 
 //TODO(b/407640608): Fix to work without this block for PaneMotionTest.test_allDefaultPaneMotionTransitions
 tasks.withType(KotlinCompile).configureEach {
+    if (it.name != "compileAndroidMain") return
     kotlinOptions {
         freeCompilerArgs += [
                 "-Xlambdas=class"

--- a/compose/animation/animation/build.gradle
+++ b/compose/animation/animation/build.gradle
@@ -137,3 +137,12 @@ androidx {
     description = "Compose animation library"
     samples(project(":compose:animation:animation:animation-samples"))
 }
+
+//TODO(b/407640608): Fix to work without this block for PaneMotionTest.test_allDefaultPaneMotionTransitions
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += [
+                "-Xlambdas=class"
+        ]
+    }
+}

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -181,6 +181,7 @@ androidx {
 
 // TODO(b/407640608): Task :compose:ui:ui-inspection:connectedCheck fails without this block
 tasks.withType(KotlinCompile).configureEach {
+    if (it.name != "compileAndroidMain") return
     kotlinOptions {
         freeCompilerArgs += [
                 "-Xlambdas=class"

--- a/compose/ui/ui-graphics/build.gradle
+++ b/compose/ui/ui-graphics/build.gradle
@@ -179,6 +179,15 @@ androidx {
     samples(project(":compose:ui:ui-graphics:ui-graphics-samples"))
 }
 
+// TODO(b/407640608): Task :compose:ui:ui-inspection:connectedCheck fails without this block
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += [
+                "-Xlambdas=class"
+        ]
+    }
+}
+
 tasks.findByName("desktopTest").configure {
     systemProperties["GOLDEN_PATH"] = project.rootDir.absolutePath + "/golden"
 }

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -329,6 +329,15 @@ if (!ProjectLayoutType.isPlayground(project)) {
     }
 }
 
+// TODO(b/407725586): Remove this block when AndroidAssistTest passes on API Level 21
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += [
+                "-Xlambdas=class"
+        ]
+    }
+}
+
 // This task updates the translations of the localizable strings for the desktopMain target.
 // It obtains them from Android's base repository.
 tasks.register("updateTranslations", UpdateTranslationsTask.class) {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -331,6 +331,7 @@ if (!ProjectLayoutType.isPlayground(project)) {
 
 // TODO(b/407725586): Remove this block when AndroidAssistTest passes on API Level 21
 tasks.withType(KotlinCompile).configureEach {
+    if (it.name != "compileAndroidMain") return
     kotlinOptions {
         freeCompilerArgs += [
                 "-Xlambdas=class"


### PR DESCRIPTION
Fixes [CMP-9734](https://youtrack.jetbrains.com/issue/CMP-9734) Sync build.gradle with AOSP/integration (excluding commonMain/commonTest dependencies)

Restore `-Xlambdas=class` that was reverted in 39981083 to avoid merge conflicts with AOSP.

Additionally apply this only to Android, as it is not needed for another targets unless something is broken.

According the comments and issues (https://issuetracker.google.com/issues/407725586 https://issuetracker.google.com/issues/407640608) it only affects tests and tooling in AOSP.

This flag [enables](https://kotlinlang.org/docs/whatsnew20.html#generation-of-lambda-functions-using-invokedynamic) the old Kotlin Compiler behavior for JVM targets - transforming a lambda to a class instead of using `invokedynamic` in byte code.

## Release Notes
N/A