### PR TITLE
Update `TapIndicationDelay` on web to 150ms

### DIFF
--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/Clickable.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/Clickable.web.kt
@@ -17,4 +17,4 @@
 package androidx.compose.foundation
 
 // TODO: b/168524931 - should this depend on the input device?
-internal actual val TapIndicationDelay: Long = 0L
+internal actual val TapIndicationDelay: Long = 150L


### PR DESCRIPTION
Fixes [CMP-9727](https://youtrack.jetbrains.com/issue/CMP-9727)

## Release Notes
### Fixes - Web
- Fix too early tap detection on web during scrolling