### PR TITLE
Fix re-entrance in draw function

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeLayersViewController.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeLayersViewController.ios.kt
@@ -180,9 +180,6 @@ internal class ComposeLayersViewController(
             hide()
 
             transaction.actions.fastForEach { it.invoke() }
-
-            // If the layers list is empty, the draw call will clear the canvas.
-            metalView.redrawer.draw(waitUntilCompletion = false)
         } else {
             // It wasn't the last layer, pending transactions should be added to the list
             removedLayersTransactions.add(transaction)

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/ComposeContainerView.ios.kt
@@ -115,6 +115,7 @@ internal class ComposeContainerView(
         onDidMoveToWindow(window)
 
         updateRedrawerState()
+        setNeedsSynchronousDraw()
 
         // To avoid a situation where a user decided to call [layoutIfNeeded] on the detached view
         // using a certain frame and it will be attached to the window later, so there is a chance

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
@@ -334,6 +334,7 @@ internal class MetalRedrawer(
             }
 
             if (width <= 0 || height <= 0) {
+                isDrawRecursiveCall = false
                 return@autoreleasepool
             }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
@@ -321,7 +321,7 @@ internal class MetalRedrawer(
     @OptIn(BetaInteropApi::class)
     private fun draw(waitUntilCompletion: Boolean, targetTimestamp: NSTimeInterval) = trace("MetalRedrawer:draw") {
         check(NSThread.isMainThread)
-        assert(!isDrawRecursiveCall) {
+        check(!isDrawRecursiveCall) {
             "Attempt to call MetalRedrawer.draw() recursively which may lead to the PictureRecorder corruption."
         }
         isDrawRecursiveCall = true

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
@@ -326,157 +326,161 @@ internal class MetalRedrawer(
         }
         isDrawRecursiveCall = true
 
-        lastRenderTimestamp = maxOf(targetTimestamp, lastRenderTimestamp)
+        try {
+            lastRenderTimestamp = maxOf(targetTimestamp, lastRenderTimestamp)
 
-        autoreleasepool {
-            val (width, height) = metalLayer.drawableSize.useContents {
-                width.roundToInt() to height.roundToInt()
-            }
-
-            if (width <= 0 || height <= 0) {
-                isDrawRecursiveCall = false
-                return@autoreleasepool
-            }
-
-            // Perform timestep and record all draw commands into [Picture]
-            val picture = trace("MetalRedrawer:draw:pictureRecording") {
-                pictureRecorder.beginRecording(
-                    left = 0f,
-                    top = 0f,
-                    width.toFloat(),
-                    height.toFloat()
-                ).also { canvas ->
-                    render(canvas, lastRenderTimestamp)
+            autoreleasepool {
+                val (width, height) = metalLayer.drawableSize.useContents {
+                    width.roundToInt() to height.roundToInt()
                 }
 
-                pictureRecorder.finishRecordingAsPicture()
-            }
+                if (width <= 0 || height <= 0) {
+                    return@autoreleasepool
+                }
 
-            if (!currentFrameRate.isNaN()) {
-                preferredFramesPerSecond = currentFrameRate.toLong()
-                currentFrameRate = Float.NaN
-            }
-
-            val metalDrawable = trace("MetalRedrawer:draw:nextDrawable") {
-                metalDrawablesHandler.nextDrawable()
-            }
-
-            if (metalDrawable == null) {
-                // TODO: anomaly, log
-                // Logger.warn { "'metalLayer.nextDrawable()' returned null. 'metalLayer.allowsNextDrawableTimeout' should be set to false. Skipping the frame." }
-                picture.close()
-                isDrawRecursiveCall = false
-                return@autoreleasepool
-            }
-
-            val renderTarget = BackendRenderTarget.makeMetal(
-                width,
-                height,
-                texturePtr = metalDrawablesHandler.drawableTexture(metalDrawable).rawValue
-            )
-
-            val surface = Surface.makeFromBackendRenderTarget(
-                context,
-                renderTarget,
-                SurfaceOrigin.TOP_LEFT,
-                SurfaceColorFormat.BGRA_8888,
-                ColorSpace.sRGB,
-                SurfaceProps(pixelGeometry = PixelGeometry.UNKNOWN)
-            )
-
-            if (surface == null) {
-                // TODO: anomaly, log
-                // Logger.warn { "'Surface.makeFromBackendRenderTarget' returned null. Skipping the frame." }
-                picture.close()
-                renderTarget.close()
-                metalDrawablesHandler.releaseDrawable(metalDrawable)
-                isDrawRecursiveCall = false
-                return@autoreleasepool
-            }
-
-            val interopTransaction = retrieveInteropTransaction()
-
-            val presentsWithTransaction =
-                isForcedToPresentWithTransactionEveryFrame
-                    || interopTransaction.actions.isNotEmpty()
-                    || isInteropActive != interopTransaction.isInteropActive
-            metalLayer.presentsWithTransaction = presentsWithTransaction
-
-            if (interopTransaction.isInteropActive) {
-                isInteropActive = true
-            }
-
-            val mustEncodeAndPresentOnMainThread = presentsWithTransaction || waitUntilCompletion || !useSeparateRenderThreadWhenPossible
-
-            val encodeAndPresentBlock = {
-                trace("MetalRedrawer:draw:encodeAndPresent") {
-                    if (useSeparateRenderThreadWhenPossible) {
-                        dispatch_semaphore_wait(drawCanvasSemaphore, DISPATCH_TIME_FOREVER)
+                // Perform timestep and record all draw commands into [Picture]
+                val picture = trace("MetalRedrawer:draw:pictureRecording") {
+                    pictureRecorder.beginRecording(
+                        left = 0f,
+                        top = 0f,
+                        width.toFloat(),
+                        height.toFloat()
+                    ).also { canvas ->
+                        render(canvas, lastRenderTimestamp)
                     }
 
-                    surface.canvas.drawPicture(picture)
+                    pictureRecorder.finishRecordingAsPicture()
+                }
+
+                if (!currentFrameRate.isNaN()) {
+                    preferredFramesPerSecond = currentFrameRate.toLong()
+                    currentFrameRate = Float.NaN
+                }
+
+                val metalDrawable = trace("MetalRedrawer:draw:nextDrawable") {
+                    metalDrawablesHandler.nextDrawable()
+                }
+
+                if (metalDrawable == null) {
+                    // TODO: anomaly, log
+                    // Logger.warn { "'metalLayer.nextDrawable()' returned null. 'metalLayer.allowsNextDrawableTimeout' should be set to false. Skipping the frame." }
                     picture.close()
-                    surface.flushAndSubmit()
+                    return@autoreleasepool
+                }
 
-                    surface.close()
+                val renderTarget = BackendRenderTarget.makeMetal(
+                    width,
+                    height,
+                    texturePtr = metalDrawablesHandler.drawableTexture(metalDrawable).rawValue
+                )
+
+                val surface = Surface.makeFromBackendRenderTarget(
+                    context,
+                    renderTarget,
+                    SurfaceOrigin.TOP_LEFT,
+                    SurfaceColorFormat.BGRA_8888,
+                    ColorSpace.sRGB,
+                    SurfaceProps(pixelGeometry = PixelGeometry.UNKNOWN)
+                )
+
+                if (surface == null) {
+                    // TODO: anomaly, log
+                    // Logger.warn { "'Surface.makeFromBackendRenderTarget' returned null. Skipping the frame." }
+                    picture.close()
                     renderTarget.close()
+                    metalDrawablesHandler.releaseDrawable(metalDrawable)
+                    return@autoreleasepool
+                }
 
-                    if (useSeparateRenderThreadWhenPossible) {
-                        dispatch_semaphore_signal(drawCanvasSemaphore)
-                    }
+                val interopTransaction = retrieveInteropTransaction()
 
-                    val commandBuffer = queue.commandBuffer()!!
-                    commandBuffer.label = "Present"
+                val presentsWithTransaction =
+                    isForcedToPresentWithTransactionEveryFrame
+                        || interopTransaction.actions.isNotEmpty()
+                        || isInteropActive != interopTransaction.isInteropActive
+                metalLayer.presentsWithTransaction = presentsWithTransaction
 
-                    if (!presentsWithTransaction) {
-                        // scheduleDrawablePresentation consumes metalDrawable
-                        // don't use metalDrawable after this call
-                        metalDrawablesHandler.scheduleDrawablePresentation(metalDrawable, commandBuffer)
-                    }
+                if (interopTransaction.isInteropActive) {
+                    isInteropActive = true
+                }
 
-                    dispatch_group_enter(inflightCommandBuffersGroup)
-                    commandBuffer.addCompletedHandler {
-                        dispatch_group_leave(inflightCommandBuffersGroup)
-                    }
-                    commandBuffer.commit()
+                val mustEncodeAndPresentOnMainThread =
+                    presentsWithTransaction || waitUntilCompletion || !useSeparateRenderThreadWhenPossible
 
-                    if (presentsWithTransaction) {
-                        // If there are pending changes in UIKit interop, [waitUntilScheduled](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1443036-waituntilscheduled) is called
-                        // to ensure that transaction is available
-                        trace("MetalRedrawer:draw:waitTransaction") {
-                            commandBuffer.waitUntilScheduled()
+                val encodeAndPresentBlock = {
+                    trace("MetalRedrawer:draw:encodeAndPresent") {
+                        if (useSeparateRenderThreadWhenPossible) {
+                            dispatch_semaphore_wait(drawCanvasSemaphore, DISPATCH_TIME_FOREVER)
                         }
 
-                        // presentDrawable consumes metalDrawable
-                        // don't use metalDrawable after this call
-                        metalDrawablesHandler.presentDrawable(metalDrawable)
+                        surface.canvas.drawPicture(picture)
+                        picture.close()
+                        surface.flushAndSubmit()
 
-                        interopTransaction.actions.fastForEach {
-                            it.invoke()
+                        surface.close()
+                        renderTarget.close()
+
+                        if (useSeparateRenderThreadWhenPossible) {
+                            dispatch_semaphore_signal(drawCanvasSemaphore)
                         }
 
-                        if (interopTransaction.isInteropActive.not()) {
-                            isInteropActive = false
-                        }
-                    }
+                        val commandBuffer = queue.commandBuffer()!!
+                        commandBuffer.label = "Present"
 
-                    if (waitUntilCompletion) {
-                        trace("MetalRedrawer:draw:waitUntilCompleted") {
-                            commandBuffer.waitUntilCompleted()
+                        if (!presentsWithTransaction) {
+                            // scheduleDrawablePresentation consumes metalDrawable
+                            // don't use metalDrawable after this call
+                            metalDrawablesHandler.scheduleDrawablePresentation(
+                                metalDrawable,
+                                commandBuffer
+                            )
+                        }
+
+                        dispatch_group_enter(inflightCommandBuffersGroup)
+                        commandBuffer.addCompletedHandler {
+                            dispatch_group_leave(inflightCommandBuffersGroup)
+                        }
+                        commandBuffer.commit()
+
+                        if (presentsWithTransaction) {
+                            // If there are pending changes in UIKit interop, [waitUntilScheduled](https://developer.apple.com/documentation/metal/mtlcommandbuffer/1443036-waituntilscheduled) is called
+                            // to ensure that transaction is available
+                            trace("MetalRedrawer:draw:waitTransaction") {
+                                commandBuffer.waitUntilScheduled()
+                            }
+
+                            // presentDrawable consumes metalDrawable
+                            // don't use metalDrawable after this call
+                            metalDrawablesHandler.presentDrawable(metalDrawable)
+
+                            interopTransaction.actions.fastForEach {
+                                it.invoke()
+                            }
+
+                            if (interopTransaction.isInteropActive.not()) {
+                                isInteropActive = false
+                            }
+                        }
+
+                        if (waitUntilCompletion) {
+                            trace("MetalRedrawer:draw:waitUntilCompleted") {
+                                commandBuffer.waitUntilCompleted()
+                            }
                         }
                     }
                 }
-            }
 
-            if (mustEncodeAndPresentOnMainThread) {
-                encodeAndPresentBlock()
-            } else {
-                dispatch_async(renderingDispatchQueue) {
+                if (mustEncodeAndPresentOnMainThread) {
                     encodeAndPresentBlock()
+                } else {
+                    dispatch_async(renderingDispatchQueue) {
+                        encodeAndPresentBlock()
+                    }
                 }
             }
+        } finally {
+            isDrawRecursiveCall = false
         }
-        isDrawRecursiveCall = false
     }
 
     companion object {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/MetalRedrawer.ios.kt
@@ -128,6 +128,8 @@ internal class MetalRedrawer(
 
     private val inflightCommandBuffersGroup = dispatch_group_create()
     private val drawCanvasSemaphore = dispatch_semaphore_create(1)
+    // A guard flag to have proper assertion when draw() method is called recursively.
+    private var isDrawRecursiveCall = false
 
     var isForcedToPresentWithTransactionEveryFrame = false
 
@@ -319,6 +321,10 @@ internal class MetalRedrawer(
     @OptIn(BetaInteropApi::class)
     private fun draw(waitUntilCompletion: Boolean, targetTimestamp: NSTimeInterval) = trace("MetalRedrawer:draw") {
         check(NSThread.isMainThread)
+        assert(!isDrawRecursiveCall) {
+            "Attempt to call MetalRedrawer.draw() recursively which may lead to the PictureRecorder corruption."
+        }
+        isDrawRecursiveCall = true
 
         lastRenderTimestamp = maxOf(targetTimestamp, lastRenderTimestamp)
 
@@ -358,6 +364,7 @@ internal class MetalRedrawer(
                 // TODO: anomaly, log
                 // Logger.warn { "'metalLayer.nextDrawable()' returned null. 'metalLayer.allowsNextDrawableTimeout' should be set to false. Skipping the frame." }
                 picture.close()
+                isDrawRecursiveCall = false
                 return@autoreleasepool
             }
 
@@ -382,6 +389,7 @@ internal class MetalRedrawer(
                 picture.close()
                 renderTarget.close()
                 metalDrawablesHandler.releaseDrawable(metalDrawable)
+                isDrawRecursiveCall = false
                 return@autoreleasepool
             }
 
@@ -467,6 +475,7 @@ internal class MetalRedrawer(
                 }
             }
         }
+        isDrawRecursiveCall = false
     }
 
     companion object {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeLaunchTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/integrations/ComposeLaunchTest.kt
@@ -86,7 +86,7 @@ class ComposeLaunchTest {
 
         assertEquals(1, drawsCount, "Expected to draw only one frame on startup")
 
-        image.forEachPixel { _, _, color ->
+        image.forEachPixel(step = 4) { _, _, color ->
             assertEquals(Color.Blue, color, "Expected to draw blue background")
         }
 
@@ -123,7 +123,7 @@ class ComposeLaunchTest {
 
         assertEquals(1, drawsCount, "Expected to draw only one frame on startup")
 
-        image.forEachPixel { _, _, color ->
+        image.forEachPixel(step = 4) { _, _, color ->
             assertEquals(Color.Blue, color, "Expected to draw blue background")
         }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LayersRenderingTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LayersRenderingTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.layers
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.background
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.forEachPixel
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIGraphicsImageRenderer
+import platform.UIKit.UIImage
+import platform.UIKit.UIWindow
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
+
+class LayersRenderingTest {
+    @Test
+    fun testPopupDismissOnClickOutsideEnabled() = runUIKitInstrumentedTest {
+        var showRed by mutableStateOf(false)
+        var showGreen by mutableStateOf(false)
+        var onRender = {}
+        var frameImage: UIImage? = null
+
+        fun prepareForCaptureNextFrame() {
+            frameImage = null
+            onRender = {
+                dispatch_async(dispatch_get_main_queue()) {
+                    frameImage = captureTopLayerImage()
+                }
+                onRender = {}
+            }
+        }
+
+        setContent {
+            Box(Modifier.fillMaxSize().background(Color.Blue).drawBehind {
+                onRender()
+            })
+            if (showRed) {
+                Popup(
+                    onDismissRequest = {},
+                    properties = PopupProperties(usePlatformInsets = false)
+                ) {
+                    Box(Modifier.fillMaxSize().background(Color.Red))
+                }
+            }
+            if (showGreen) {
+                Popup(
+                    onDismissRequest = {},
+                    properties = PopupProperties(usePlatformInsets = false)
+                ) {
+                    Box(Modifier.fillMaxSize().background(Color.Green))
+                }
+            }
+        }
+
+        fun assertNextFrameColor(expectedColor: Color) {
+            prepareForCaptureNextFrame()
+            waitForIdle()
+
+            assertNotNull(frameImage)
+            frameImage!!.forEachPixel(step = 4) { _, _, actualColor ->
+                assertEquals(expectedColor, actualColor, "Expected to draw $expectedColor background")
+            }
+        }
+
+        showRed = true
+        assertNextFrameColor(Color.Red)
+
+        showRed = false
+        assertNextFrameColor(Color.Blue)
+
+        showGreen = true
+        assertNextFrameColor(Color.Green)
+
+        showGreen = false
+        assertNextFrameColor(Color.Blue)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    private fun UIKitInstrumentedTest.captureTopLayerImage(): UIImage {
+        val windows = appDelegate.window?.windowScene?.windows ?: error("No active window found")
+        val window = windows
+            .mapNotNull { it as? UIWindow }
+            .filter { !it.hidden }
+            .maxBy { it.windowLevel }
+
+        val renderer = UIGraphicsImageRenderer(bounds = window.bounds)
+        val image = renderer.imageWithActions {
+            window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
+        }
+        return image
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LayersRenderingTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/LayersRenderingTest.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.background
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.test.UIKitInstrumentedTest
+import androidx.compose.ui.test.captureScreenshot
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import androidx.compose.ui.test.utils.forEachPixel
 import androidx.compose.ui.window.Popup
@@ -33,16 +33,13 @@ import androidx.compose.ui.window.PopupProperties
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlinx.cinterop.ExperimentalForeignApi
-import platform.UIKit.UIGraphicsImageRenderer
 import platform.UIKit.UIImage
-import platform.UIKit.UIWindow
 import platform.darwin.dispatch_async
 import platform.darwin.dispatch_get_main_queue
 
 class LayersRenderingTest {
     @Test
-    fun testPopupDismissOnClickOutsideEnabled() = runUIKitInstrumentedTest {
+    fun testLayerContentOnFirstRender() = runUIKitInstrumentedTest {
         var showRed by mutableStateOf(false)
         var showGreen by mutableStateOf(false)
         var onRender = {}
@@ -52,7 +49,7 @@ class LayersRenderingTest {
             frameImage = null
             onRender = {
                 dispatch_async(dispatch_get_main_queue()) {
-                    frameImage = captureTopLayerImage()
+                    frameImage = captureScreenshot()
                 }
                 onRender = {}
             }
@@ -86,7 +83,11 @@ class LayersRenderingTest {
 
             assertNotNull(frameImage)
             frameImage!!.forEachPixel(step = 4) { _, _, actualColor ->
-                assertEquals(expectedColor, actualColor, "Expected to draw $expectedColor background")
+                assertEquals(
+                    expectedColor,
+                    actualColor,
+                    "Expected to draw $expectedColor background"
+                )
             }
         }
 
@@ -101,20 +102,5 @@ class LayersRenderingTest {
 
         showGreen = false
         assertNextFrameColor(Color.Blue)
-    }
-
-    @OptIn(ExperimentalForeignApi::class)
-    private fun UIKitInstrumentedTest.captureTopLayerImage(): UIImage {
-        val windows = appDelegate.window?.windowScene?.windows ?: error("No active window found")
-        val window = windows
-            .mapNotNull { it as? UIWindow }
-            .filter { !it.hidden }
-            .maxBy { it.windowLevel }
-
-        val renderer = UIGraphicsImageRenderer(bounds = window.bounds)
-        val image = renderer.imageWithActions {
-            window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
-        }
-        return image
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -562,24 +562,6 @@ internal fun ComposeHostingView.waitForIdle() {
     UIKitInstrumentedTest.waitUntil { !this.hasInvalidations() }
 }
 
-
-@OptIn(ExperimentalForeignApi::class)
-private fun UIKitInstrumentedTest.captureTopLayerImage(): UIImage {
-
-
-    val windows = appDelegate.window?.windowScene?.windows ?: error("No active window found")
-    val window = windows
-        .mapNotNull { it as? UIWindow }
-        .filter { !it.hidden }
-        .maxBy { it.windowLevel }
-
-    val renderer = UIGraphicsImageRenderer(bounds = window.bounds)
-    val image = renderer.imageWithActions {
-        window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
-    }
-    return image
-}
-
 @OptIn(ExperimentalForeignApi::class)
 internal fun UIKitInstrumentedTest.captureScreenshot(): UIImage? {
     val scale = UIScreen.mainScreen.scale

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -54,6 +54,7 @@ import kotlin.time.TimeSource
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.Dispatchers
+import platform.CoreGraphics.CGSizeMake
 import platform.Foundation.NSDate
 import platform.Foundation.NSRunLoop
 import platform.Foundation.dateWithTimeIntervalSinceNow
@@ -61,6 +62,12 @@ import platform.Foundation.runUntilDate
 import platform.UIKit.UIApplication
 import platform.UIKit.UIApplicationDelegateProtocol
 import platform.UIKit.UIColor
+import platform.UIKit.UIGraphicsBeginImageContextWithOptions
+import platform.UIKit.UIGraphicsEndImageContext
+import platform.UIKit.UIGraphicsGetCurrentContext
+import platform.UIKit.UIGraphicsGetImageFromCurrentImageContext
+import platform.UIKit.UIGraphicsImageRenderer
+import platform.UIKit.UIImage
 import platform.UIKit.UIInterfaceOrientationLandscapeLeft
 import platform.UIKit.UIInterfaceOrientationLandscapeRight
 import platform.UIKit.UIInterfaceOrientationMask
@@ -553,4 +560,44 @@ internal fun ComposeHostingViewController.waitForIdle() {
 
 internal fun ComposeHostingView.waitForIdle() {
     UIKitInstrumentedTest.waitUntil { !this.hasInvalidations() }
+}
+
+
+@OptIn(ExperimentalForeignApi::class)
+private fun UIKitInstrumentedTest.captureTopLayerImage(): UIImage {
+
+
+    val windows = appDelegate.window?.windowScene?.windows ?: error("No active window found")
+    val window = windows
+        .mapNotNull { it as? UIWindow }
+        .filter { !it.hidden }
+        .maxBy { it.windowLevel }
+
+    val renderer = UIGraphicsImageRenderer(bounds = window.bounds)
+    val image = renderer.imageWithActions {
+        window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
+    }
+    return image
+}
+
+@OptIn(ExperimentalForeignApi::class)
+internal fun UIKitInstrumentedTest.captureScreenshot(): UIImage? {
+    val scale = UIScreen.mainScreen.scale
+    val size = UIScreen.mainScreen.bounds.useContents { CGSizeMake(size.width, size.height) }
+
+    UIGraphicsBeginImageContextWithOptions(size, false, scale)
+    UIGraphicsGetCurrentContext() ?: return null
+
+    val scene = appDelegate.window()?.windowScene ?: return null
+    scene.windows.mapNotNull { it as? UIWindow }
+        .filter { !it.hidden && it.alpha > 0.0 }
+        .sortedBy { it.windowLevel }
+        .forEach { window ->
+            window.drawViewHierarchyInRect(window.bounds, afterScreenUpdates = true)
+        }
+
+    val screenshot = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+
+    return screenshot
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIImage+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIImage+Utils.kt
@@ -30,7 +30,7 @@ import platform.CoreGraphics.CGRectMake
 import platform.UIKit.UIImage
 
 @OptIn(ExperimentalForeignApi::class)
-internal fun UIImage.forEachPixel(onPixel: (x: Int, y: Int, color: Color) -> Unit) {
+internal fun UIImage.forEachPixel(step: Int = 1, onPixel: (x: Int, y: Int, color: Color) -> Unit) {
     val cgImage = this.CGImage
     val width = CGImageGetWidth(cgImage).toInt()
     val height = CGImageGetHeight(cgImage).toInt()
@@ -52,8 +52,8 @@ internal fun UIImage.forEachPixel(onPixel: (x: Int, y: Int, color: Color) -> Uni
 
         CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), cgImage)
 
-        for (y in 0 until height) {
-            for (x in 0 until width) {
+    c    for (y in 0 until height step step) {
+            for (x in 0 until width step step) {
                 val offset = (y * bytesPerRow) + (x * bytesPerPixel)
                 val r = pinned.get()[offset].toUByte().toInt()
                 val g = pinned.get()[offset + 1].toUByte().toInt()

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIImage+Utils.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/utils/UIImage+Utils.kt
@@ -52,7 +52,7 @@ internal fun UIImage.forEachPixel(step: Int = 1, onPixel: (x: Int, y: Int, color
 
         CGContextDrawImage(context, CGRectMake(0.0, 0.0, width.toDouble(), height.toDouble()), cgImage)
 
-    c    for (y in 0 until height step step) {
+        for (y in 0 until height step step) {
             for (x in 0 until width step step) {
                 val offset = (y * bytesPerRow) + (x * bytesPerPixel)
                 val r = pinned.get()[offset].toUByte().toInt()


### PR DESCRIPTION
Fix an issue where the `ComposeScene` in the platform layer may be forced to re-render drawing function during the render call under specific conditions.
Remove the force-render call when the last layer is removed, but use it when the layer first appears to clear its content. 

Fixes https://youtrack.jetbrains.com/issue/CMP-9455
Fixes https://youtrack.jetbrains.com/issue/CMP-9755

## Release Notes
### Fixes - iOS
- Fix crash in `MetalRedrawer` that occurs when `Popup` or `Dialog` box opens and closes quickly