### PR TITLE
Clarify `hasInvalidations` 

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -228,8 +228,16 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
         set(value) { scene.size = value.toIntSize() }
 
     /**
-     * Returns true if there are pending recompositions, renders or dispatched tasks.
+     * Returns whether there are pending recompositions, renders, or dispatched tasks.
      * Can be called from any thread.
+     *
+     * Note that changes to snapshot state don't immediately trigger an invalidation.
+     * To guarantee that there are no changes expected in the scene use
+     * ```
+     * !Snapshot.current.hasPendingChanges()
+     *     && !Snapshot.isApplyObserverNotificationPending
+     *     && !scene.hasInvalidations()
+     * ```
      */
     fun hasInvalidations() = scene.hasInvalidations()
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -159,8 +159,16 @@ sealed interface ComposeScene : AutoCloseable {
     fun invalidatePositionOnScreen()
 
     /**
-     * Returns true if there are pending recompositions, renders or dispatched tasks.
+     * Returns whether there are pending recompositions, renders, or dispatched tasks.
      * Can be called from any thread.
+     *
+     * Note that changes to snapshot state don't immediately trigger an invalidation.
+     * To guarantee that there are no changes expected in the scene use
+     * ```
+     * !Snapshot.current.hasPendingChanges()
+     *     && !Snapshot.isApplyObserverNotificationPending
+     *     && !scene.hasInvalidations()
+     * ```
      */
     fun hasInvalidations(): Boolean
 


### PR DESCRIPTION
Add a note to the kdoc of `ComposeScene.hasInvalidations` and `ImageComposeScene.hasInvalidations` that they don't take `Snapshot.hasPendingChanges` into account.

## Testing
N/A

## Release Notes
N/A