### PR TITLE
Update MULTIPLATFORM.md. Actualize `publishComposeJbToMavenLocal`

### DIFF
--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -102,7 +102,7 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 2. Publish core libraries
 
    ```bash
-   ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=0.1.0-dev1000 -Pjetbrains.publication.version.LIFECYCLE=0.1.0-dev1000
+   ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=999.0.0-alpha01+dev1000 -Pjetbrains.publication.version.LIFECYCLE=999.0.0-alpha01+dev1000
    ```
 
    `-Pcompose.platforms=all` could be replace with comma-separated list of platforms, such as `js,jvm,androidDebug,androidRelease,macosx64,ios`.
@@ -179,7 +179,7 @@ To use a locally built compose in [KMP with Compose wizard project](https://kmp.
 
 - Checkout <https://github.com/JetBrains/compose-multiplatform>.
 - Open `gradle-plugins` in `compose-multiplatform`.
-- Update `gradle.properties` by setting `compose.version` and `deploy.version` to the version you've published (`0.1.0-dev1000` in example above).
+- Update `gradle.properties` by setting `compose.version` and `deploy.version` to the version you've published (999.0.0-alpha01+dev1000` in example above).
 - Run `./gradlew publishToMavenLocal`.
 - Open `components` in `compose-multiplatform`.
 - Update `gradle.properties` by setting `compose.useMavenLocal` to `true` and `compose.version` to the version you've published.

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -102,7 +102,7 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 2. Publish core libraries
 
    ```bash
-   ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=9999.0.0-alpha01+dev1000 -Pjetbrains.publication.version.LIFECYCLE=9999.0.0-alpha01+dev1000
+   ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=9999.0.0-alpha01 -Pjetbrains.publication.version.LIFECYCLE=9999.0.0-alpha01
    ```
 
    `-Pcompose.platforms=all` could be replace with comma-separated list of platforms, such as `js,jvm,androidDebug,androidRelease,macosx64,ios`.
@@ -179,7 +179,7 @@ To use a locally built compose in [KMP with Compose wizard project](https://kmp.
 
 - Checkout <https://github.com/JetBrains/compose-multiplatform>.
 - Open `gradle-plugins` in `compose-multiplatform`.
-- Update `gradle.properties` by setting `compose.version` and `deploy.version` to the version you've published (`9999.0.0-alpha01+dev1000` in example above).
+- Update `gradle.properties` by setting `compose.version` and `deploy.version` to the version you've published (`9999.0.0-alpha01` in example above).
 - Run `./gradlew publishToMavenLocal`.
 - Open `components` in `compose-multiplatform`.
 - Update `gradle.properties` by setting `compose.useMavenLocal` to `true` and `compose.version` to the version you've published.

--- a/MULTIPLATFORM.md
+++ b/MULTIPLATFORM.md
@@ -102,7 +102,7 @@ Compose Multiplatform core libraries can be published to local Maven with the fo
 2. Publish core libraries
 
    ```bash
-   ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=999.0.0-alpha01+dev1000 -Pjetbrains.publication.version.LIFECYCLE=999.0.0-alpha01+dev1000
+   ./gradlew :mpp:publishComposeJbToMavenLocal -Pcompose.platforms=all -Pjetbrains.publication.version.COMPOSE=9999.0.0-alpha01+dev1000 -Pjetbrains.publication.version.LIFECYCLE=9999.0.0-alpha01+dev1000
    ```
 
    `-Pcompose.platforms=all` could be replace with comma-separated list of platforms, such as `js,jvm,androidDebug,androidRelease,macosx64,ios`.
@@ -179,7 +179,7 @@ To use a locally built compose in [KMP with Compose wizard project](https://kmp.
 
 - Checkout <https://github.com/JetBrains/compose-multiplatform>.
 - Open `gradle-plugins` in `compose-multiplatform`.
-- Update `gradle.properties` by setting `compose.version` and `deploy.version` to the version you've published (999.0.0-alpha01+dev1000` in example above).
+- Update `gradle.properties` by setting `compose.version` and `deploy.version` to the version you've published (`9999.0.0-alpha01+dev1000` in example above).
 - Run `./gradlew publishToMavenLocal`.
 - Open `components` in `compose-multiplatform`.
 - Update `gradle.properties` by setting `compose.useMavenLocal` to `true` and `compose.version` to the version you've published.


### PR DESCRIPTION
The old command doesn't no longer work:
- don't use `dev` as release stage after `-`
- set `9999.0.0` to always win over pinned dependencies
- set `-alpha01` to not fail with `Project with version may not take a dependency on less-stable artifact`

## Release Notes
N/A