### PR TITLE
Don't trigger the accented char input hack when there's an active composition

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopTextInputService2.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.key
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.awt.toAwtRectangleRounded
 import androidx.compose.ui.scene.ComposeSceneMediator
@@ -155,7 +154,7 @@ private class InputMethodSession(
     // For our editor component we need this workaround.
     // After https://bugs.openjdk.java.net/browse/JDK-8074882 is fixed, this workaround should be replaced with a proper solution.
     var charKeyPressed: Boolean = false
-    var needToDeletePreviousChar: Boolean = false
+    private var needToDeletePreviousChar: Boolean = false
 
     override fun getLocationOffset(x: Int, y: Int): TextHitInfo? {
         if (composition != null) {
@@ -237,10 +236,10 @@ private class InputMethodSession(
     }
 
     fun inputMethodTextChanged(event: InputMethodEvent) {
-        val committed = event.committedText
-        val composing = event.composingText
+        val committedText = event.committedText
+        val composingText = event.composingText
 
-        imeComposingText = composing
+        imeComposingText = composingText
 
         if (ignoreNextInputMethodEvent) {
             ignoreNextInputMethodEvent = false
@@ -248,13 +247,15 @@ private class InputMethodSession(
         }
 
         request.editText {
-            if (needToDeletePreviousChar && selection.min > 0 && composing.isEmpty()) {
+            if (needToDeletePreviousChar) {
+                if ((selection.min > 0) && composingText.isEmpty() && (composition == null)) {
+                    deleteSurroundingTextInCodePoints(1, 0)
+                }
                 needToDeletePreviousChar = false
-                deleteSurroundingTextInCodePoints(1, 0)
             }
-            commitText(committed, 1)
-            if (composing.isNotEmpty()) {
-                setComposingText(composing, 1)
+            commitText(committedText, 1)
+            if (composingText.isNotEmpty()) {
+                setComposingText(composingText, 1)
             }
         }
     }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -30,8 +30,6 @@ import androidx.compose.ui.window.WindowPosition
 import java.awt.*
 import java.awt.event.InputMethodEvent
 import java.awt.event.KeyEvent
-import java.awt.event.KeyEvent.KEY_PRESSED
-import java.awt.event.KeyEvent.KEY_RELEASED
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
 import java.awt.font.TextHitInfo
@@ -106,10 +104,24 @@ fun Window.sendKeyTypedEvent(
     modifiers = modifiers
 )
 
-fun Window.sendCharTypedEvents(char: Char) {
-    sendKeyEvent(char.code, char, KEY_PRESSED)
+fun Window.sendCharTypedEvents(
+    char: Char,
+    triggerAccentedInputHack: Boolean = false
+) {
+    sendKeyEvent(char.code, char, KeyEvent.KEY_PRESSED)
     sendKeyTypedEvent(char)
-    sendKeyEvent(char.code, char, KEY_RELEASED)
+    if (triggerAccentedInputHack) {
+        triggerNeedsToDeletePreviousChar()
+    }
+    sendKeyEvent(char.code, char, KeyEvent.KEY_RELEASED)
+}
+
+fun Window.triggerNeedsToDeletePreviousChar() {
+    // This triggers the "needToDeletePreviousChar" hack in DesktopTextInputService(2).
+    // If the implementation of this ever changes, this test will need to change as well.
+    // Note that using java.awt.Robot to test this doesn't appear to work, as the accented
+    // characters toolbar isn't displayed.
+    focusOwner.inputMethodRequests.getSelectedText(null)
 }
 
 fun Window.sendInputMethodEvent(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldBuffer.ChangeList
 import androidx.compose.ui.isMacOs
+import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendInputMethodEvent
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendKeyTypedEvent
@@ -709,17 +710,11 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         assertStateEquals("請問", selection = TextRange(2), composition = null)
 
         // backspace
-        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
-        window.sendKeyTypedEvent(Char(8))
-        triggerNeedsToDeletePreviousChar()
-        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        window.sendCharTypedEvents(Char(8), triggerAccentedInputHack = true)
         assertStateEquals("請", selection = TextRange(1), composition = null)
 
         // backspace
-        window.sendKeyEvent(8, Char(8), KEY_PRESSED)
-        window.sendKeyTypedEvent(Char(8))
-        triggerNeedsToDeletePreviousChar()
-        window.sendKeyEvent(8, Char(8), KEY_RELEASED)
+        window.sendCharTypedEvents(Char(8), triggerAccentedInputHack = true)
         assertStateEquals("", selection = TextRange(0), composition = null)
 
         // q
@@ -799,6 +794,27 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         assertStateEquals("欠", selection = TextRange(1), composition = null)
     }
 
+    @Theory
+    internal fun `1, n, i, space (Chinese - Pinyin Simplified , macOS)`(
+        textFieldKind: TextFieldKind<*>
+    ) = runTextFieldTest(textFieldKind, "Chinese Wubi, macOS") {
+        // 1
+        window.sendCharTypedEvents('1', triggerAccentedInputHack = true)
+
+        // n
+        window.sendInputMethodEvent("n", 0)
+        window.sendKeyEvent(78, 'n', KEY_RELEASED)
+
+        // i
+        window.sendInputMethodEvent("ni", 0)
+        window.sendKeyEvent(73, 'i', KEY_RELEASED)
+
+        // space
+        window.sendInputMethodEvent("你", 1)
+        window.sendKeyEvent(32, ' ', KEY_RELEASED)
+
+        assertStateEquals("1你", selection = TextRange(2), composition = null)
+    }
 
     // Verifies that each typed character and character replaced by the input service is reported
     // (to `inputTransformation`) as a change in the last character only.
@@ -871,10 +887,7 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
         ) {
             if (!isMacOs) return@runTextFieldTest  // Assume.assumeTrue doesn't work with @Theory
 
-            window.sendKeyEvent('c'.code, 'c', KEY_PRESSED)
-            window.sendKeyTypedEvent('c')
-            triggerNeedsToDeletePreviousChar()
-            window.sendKeyEvent('c'.code, 'c', KEY_RELEASED)
+            window.sendCharTypedEvents('c', triggerAccentedInputHack = true)
             assertStateEquals("c", selection = TextRange(1), composition = null)
 
             window.sendInputMethodEvent("ç", 1)
@@ -890,12 +903,4 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
             window.sendInputMethodEvent("·", committedCharacterCount = 1)
             assertStateEquals("·", selection = TextRange(1), composition = null)
         }
-
-    private fun TextFieldTestScope.triggerNeedsToDeletePreviousChar() {
-        // This triggers the "needToDeletePreviousChar" hack in DesktopTextInputService(2).
-        // If the implementation of this ever changes, this test will need to change as well.
-        // Note that using java.awt.Robot to test this doesn't appear to work, as the accented
-        // characters toolbar isn't displayed.
-        window.focusOwner.inputMethodRequests.getSelectedText(null)
-    }
 }


### PR DESCRIPTION
Don't trigger the accented char input hack when there's an active composition.
Also clear `needToDeletePreviousChar` on every `InputMethodEvent` to prevent hanging on to it when the trigger was sent a long time ago.

Fixes https://youtrack.jetbrains.com/issue/CMP-9761

## Testing
Tested manually and added a unit test.

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Fix an issue with "Pinyin - Simplified" input in `BasicTextField(TextFieldState)` when the temporary (composed) english text was not removed when the composition is committed.
