### PR TITLE
Update TempWebVelocityTracker sample size logic

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/pointer/util/TempWebVelocityTracker.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/pointer/util/TempWebVelocityTracker.kt
@@ -185,9 +185,9 @@ private class TempWebVelocityTracker1D(
     constructor(isDataDifferential: Boolean) : this(isDataDifferential, Strategy.Impulse)
 
     private fun getStrategyForSampleSize(size: Int): Strategy? = when {
-        size > 2 -> strategy
-        //Lsq2 is not possible for 2 samples, so fallback to Impulse
-        size == 2 -> Strategy.Impulse
+        size > 4 -> strategy
+        //Lsq2 has downsides when the sample size is small, so we use Impulse for small samples.
+        size > 1 -> Strategy.Impulse
         else -> null
     }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -298,6 +298,9 @@ internal class ComposeWindow(
             override val viewConfiguration =
                 object : ViewConfiguration by PlatformContext.DefaultViewConfiguration {
                     override val touchSlop: Float get() = with(density) { 18.dp.toPx() }
+                    override val maximumFlingVelocity: Float
+                        //https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/ViewConfiguration.java;l=240;drc=733537294b158d22f2ae383f2ed77c93741798e9
+                        get() = with(density) { 8000.dp.toPx() }
                 }
 
             override fun setPointerIcon(pointerIcon: PointerIcon) {


### PR DESCRIPTION
And add maximum fling velocity for web

- Adjust sample size threshold in `TempWebVelocityTracker` to optimize strategy selection for small samples.
- Define `maximumFlingVelocity` in `ComposeWindowInternal.web.kt` to align with platform configuration.
- Update formatting in TempWebVelocityTracker filename

Fixes https://youtrack.jetbrains.com/issue/CMP-9727

## Release Notes
### Fixes - Web
- Fix scrolling sudden stops or speed-ups in web apps.
