### PR TITLE
Enforce composable target diagnostics for menu applier boundaries

### DIFF
--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -4441,6 +4441,9 @@ public final class androidx/compose/ui/window/MenuBarScope {
 	public final fun Menu (Ljava/lang/String;Ljava/lang/Character;ZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
+public abstract interface annotation class androidx/compose/ui/window/MenuComposable : java/lang/annotation/Annotation {
+}
+
 public final class androidx/compose/ui/window/MenuScope {
 	public static final field $stable I
 	public final fun CheckboxItem (Ljava/lang/String;ZLandroidx/compose/ui/graphics/painter/Painter;ZLjava/lang/Character;Landroidx/compose/ui/input/key/KeyShortcut;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtWindow.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.node.Ref
@@ -56,6 +57,7 @@ import java.awt.Window
  */
 @OptIn(DelicateCoroutinesApi::class)
 @Composable
+@ComposableOpenTarget(-1)
 fun <T : Window> AwtWindow(
     visible: Boolean = true,
     create: () -> T,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingDialog.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -102,6 +103,7 @@ import javax.swing.JDialog
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
+@ComposableOpenTarget(-1)
 fun SwingDialog(
     visible: Boolean = true,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
@@ -180,6 +182,7 @@ fun SwingDialog(
  */
 @ExperimentalComposeUiApi
 @Composable
+@ComposableOpenTarget(-1)
 fun SwingDialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.currentCompositionLocalContext
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -93,6 +94,7 @@ import javax.swing.JFrame
  */
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
+@ComposableOpenTarget(-1)
 fun SwingWindow(
     visible: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -172,6 +174,7 @@ fun SwingWindow(
  */
 @ExperimentalComposeUiApi
 @Composable
+@ComposableOpenTarget(-1)
 fun SwingWindow(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -320,4 +323,3 @@ fun SwingWindow(
         content = content
     )
 }
-

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/AwtWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/AwtWindow.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import java.awt.Window
 
 /**
@@ -52,6 +53,7 @@ import java.awt.Window
     )
 )
 @Composable
+@ComposableOpenTarget(-1)
 fun <T : Window> AwtWindow(
     visible: Boolean = true,
     create: () -> T,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Dialog.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposeDialog
@@ -33,6 +34,7 @@ import java.awt.Window
         "onPreviewKeyEvent, onKeyEvent, content)")
 )
 @Composable
+@ComposableOpenTarget(-1)
 fun Dialog(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -70,6 +72,7 @@ fun Dialog(
     message = "Replaced by DialogWindow with alwaysOnTop parameter",
 )
 @Composable
+@ComposableOpenTarget(-1)
 fun DialogWindow(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -164,6 +167,7 @@ fun DialogWindow(
  * @param content Composable content of the dialog.
  */
 @Composable
+@ComposableOpenTarget(-1)
 fun DialogWindow(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -261,6 +265,7 @@ fun DialogWindow(
  */
 @ExperimentalComposeUiApi
 @Composable
+@ComposableOpenTarget(-1)
 fun DialogWindow(
     onCloseRequest: () -> Unit,
     state: DialogState = rememberDialogState(),
@@ -306,6 +311,7 @@ fun DialogWindow(
     )
 )
 @Composable
+@ComposableOpenTarget(-1)
 fun Dialog(
     visible: Boolean = true,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },
@@ -372,6 +378,7 @@ fun Dialog(
     )
 )
 @Composable
+@ComposableOpenTarget(-1)
 fun DialogWindow(
     visible: Boolean = true,
     onPreviewKeyEvent: ((KeyEvent) -> Boolean) = { false },

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Menu.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Menu.desktop.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.input.key.toSwingKeyStroke
 import androidx.compose.ui.node.Ref
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.util.AddRemoveMutableList
 import java.awt.CheckboxMenuItem
 import java.awt.Menu
 import java.awt.MenuItem
@@ -70,7 +69,7 @@ fun JMenuBar.setContent(
     parentComposition: CompositionContext,
     content: @Composable @MenuComposable (MenuBarScope.() -> Unit)
 ): Composition {
-    val applier = MutableListApplier(asMutableList())
+    val applier = SwingApplier(this)
     val composition = Composition(applier, parentComposition)
     val scope = MenuBarScope()
     composition.setContent {
@@ -162,7 +161,7 @@ class MenuBarScope internal constructor() {
             }
         }
 
-        ComposeNode<JMenu, MutableListApplier<JComponent>>(
+        ComposeNode<JMenu, SwingApplier>(
             factory = { menu },
             update = {
                 set(text, JMenu::setText)
@@ -633,33 +632,6 @@ class MenuScope internal constructor(private val impl: MenuScopeImpl) {
     )
 }
 
-private class MutableListApplier<T>(
-    private val list: MutableList<T>
-) : AbstractApplier<T?>(null) {
-    override fun insertTopDown(index: Int, instance: T?) {
-        list.add(index, instance!!)
-    }
-
-    override fun insertBottomUp(index: Int, instance: T?) {
-        // Ignore, we have plain list
-    }
-
-    override fun remove(index: Int, count: Int) {
-        for (i in index + count - 1 downTo index) {
-            list.removeAt(i)
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun move(from: Int, to: Int, count: Int) {
-        (list as MutableList<T?>).move(from, to, count)
-    }
-
-    override fun onClear() {
-        list.clear()
-    }
-}
-
 // Copied from androidx/compose/ui/graphics/vector/Vector.kt
 private inline fun <T> performMove(
     from: Int,
@@ -686,7 +658,7 @@ private inline fun <T> performMove(
     }
 }
 
-internal abstract class JComponentApplier(root: JComponent) : AbstractApplier<JComponent>(root) {
+internal open class SwingApplier(root: JComponent) : AbstractApplier<JComponent>(root) {
     override fun onClear() {
         root.removeAll()
     }
@@ -718,7 +690,7 @@ internal abstract class JComponentApplier(root: JComponent) : AbstractApplier<JC
     }
 }
 
-internal class JMenuItemApplier(root: JMenu) : JComponentApplier(root) {
+internal class JMenuItemApplier(root: JMenu) : SwingApplier(root) {
     override fun onEndChanges() {
         // If the menu is changed while the popup is open, we need to ask the popup to remeasure
         // itself.
@@ -775,21 +747,6 @@ internal class MenuItemApplier(private val root: Menu) : Applier<MenuItem> {
         return when (this) {
             is Menu -> this
             else -> error("Can only insert MenuItem into Menu, not ${this::class}")
-        }
-    }
-}
-
-private fun JMenuBar.asMutableList(): MutableList<JComponent> {
-    return object : AddRemoveMutableList<JComponent>() {
-        override val size: Int get() = this@asMutableList.menuCount
-        override fun get(index: Int) = this@asMutableList.getMenu(index)
-
-        override fun performAdd(element: JComponent) {
-            this@asMutableList.add(element)
-        }
-
-        override fun performRemove(index: Int) {
-            this@asMutableList.remove(index)
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Menu.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Menu.desktop.kt
@@ -68,7 +68,7 @@ private val DefaultIconSize = Size(16f, 16f)
  */
 fun JMenuBar.setContent(
     parentComposition: CompositionContext,
-    content: @Composable (MenuBarScope.() -> Unit)
+    content: @Composable @MenuComposable (MenuBarScope.() -> Unit)
 ): Composition {
     val applier = MutableListApplier(asMutableList())
     val composition = Composition(applier, parentComposition)
@@ -93,7 +93,7 @@ fun JMenuBar.setContent(
  */
 fun Menu.setContent(
     parentComposition: CompositionContext,
-    content: @Composable (MenuScope.() -> Unit)
+    content: @Composable @MenuComposable (MenuScope.() -> Unit)
 ): Composition {
     val applier = MenuItemApplier(this)
     val composition = Composition(applier, parentComposition)
@@ -118,7 +118,7 @@ fun Menu.setContent(
  */
 fun JMenu.setContent(
     parentComposition: CompositionContext,
-    content: @Composable (MenuScope.() -> Unit)
+    content: @Composable @MenuComposable (MenuScope.() -> Unit)
 ): Composition {
     val applier = JMenuItemApplier(this)
     val composition = Composition(applier, parentComposition)
@@ -129,8 +129,6 @@ fun JMenu.setContent(
     return composition
 }
 
-// TODO(demin): consider making MenuBarScope/MenuScope as an interface
-//  after b/165812010 will be fixed
 /**
  * Receiver scope which is used by [JMenuBar.setContent] and [FrameWindowScope.MenuBar].
  */
@@ -147,11 +145,12 @@ class MenuBarScope internal constructor() {
      * @param content content of the menu (sub menus, items, separators, etc)
      */
     @Composable
+    @MenuComposable
     fun Menu(
         text: String,
         mnemonic: Char? = null,
         enabled: Boolean = true,
-        content: @Composable MenuScope.() -> Unit
+        content: @Composable @MenuComposable MenuScope.() -> Unit
     ) {
         val menu = remember(::JMenu)
         val compositionContext = rememberCompositionContext()
@@ -176,17 +175,20 @@ class MenuBarScope internal constructor() {
 
 internal interface MenuScopeImpl {
     @Composable
+    @MenuComposable
     fun Menu(
         text: String,
         enabled: Boolean,
         mnemonic: Char?,
-        content: @Composable MenuScope.() -> Unit
+        content: @Composable @MenuComposable MenuScope.() -> Unit
     )
 
     @Composable
+    @MenuComposable
     fun Separator()
 
     @Composable
+    @MenuComposable
     fun Item(
         text: String,
         icon: Painter?,
@@ -197,6 +199,7 @@ internal interface MenuScopeImpl {
     )
 
     @Composable
+    @MenuComposable
     fun CheckboxItem(
         text: String,
         checked: Boolean,
@@ -208,6 +211,7 @@ internal interface MenuScopeImpl {
     )
 
     @Composable
+    @MenuComposable
     fun RadioButtonItem(
         text: String,
         selected: Boolean,
@@ -228,11 +232,12 @@ private class AwtMenuScope : MenuScopeImpl {
      * @param content content of the menu (sub menus, items, separators, etc)
      */
     @Composable
+    @MenuComposable
     override fun Menu(
         text: String,
         enabled: Boolean,
         mnemonic: Char?,
-        content: @Composable MenuScope.() -> Unit
+        content: @Composable @MenuComposable MenuScope.() -> Unit
     ) {
         if (mnemonic != null) {
             throw UnsupportedOperationException("java.awt.Menu doesn't support mnemonic")
@@ -252,6 +257,7 @@ private class AwtMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun Separator() {
         ComposeNode<MenuItem, MenuItemApplier>(
             // item with name "-" has different look
@@ -261,6 +267,7 @@ private class AwtMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun Item(
         text: String,
         icon: Painter?,
@@ -297,6 +304,7 @@ private class AwtMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun CheckboxItem(
         text: String,
         checked: Boolean,
@@ -340,6 +348,7 @@ private class AwtMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun RadioButtonItem(
         text: String,
         selected: Boolean,
@@ -362,11 +371,12 @@ private class SwingMenuScope : MenuScopeImpl {
      * @param content content of the menu (sub menus, items, separators, etc)
      */
     @Composable
+    @MenuComposable
     override fun Menu(
         text: String,
         enabled: Boolean,
         mnemonic: Char?,
-        content: @Composable MenuScope.() -> Unit
+        content: @Composable @MenuComposable MenuScope.() -> Unit
     ) {
         ComposeNode<JMenu, JMenuItemApplier>(
             factory = { JMenu() },
@@ -383,6 +393,7 @@ private class SwingMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun Separator() {
         ComposeNode<JPopupMenu.Separator, JMenuItemApplier>(
             // item with name "-" has different look
@@ -392,6 +403,7 @@ private class SwingMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun Item(
         text: String,
         icon: Painter?,
@@ -422,6 +434,7 @@ private class SwingMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun CheckboxItem(
         text: String,
         checked: Boolean,
@@ -459,6 +472,7 @@ private class SwingMenuScope : MenuScopeImpl {
     }
 
     @Composable
+    @MenuComposable
     override fun RadioButtonItem(
         text: String,
         selected: Boolean,
@@ -514,11 +528,12 @@ class MenuScope internal constructor(private val impl: MenuScopeImpl) {
      * @param content content of the menu (sub menus, items, separators, etc)
      */
     @Composable
+    @MenuComposable
     fun Menu(
         text: String,
         enabled: Boolean = true,
         mnemonic: Char? = null,
-        content: @Composable MenuScope.() -> Unit
+        content: @Composable @MenuComposable MenuScope.() -> Unit
     ): Unit = impl.Menu(
         text,
         enabled,
@@ -530,6 +545,7 @@ class MenuScope internal constructor(private val impl: MenuScopeImpl) {
      * Adds separator to the menu
      */
     @Composable
+    @MenuComposable
     fun Separator() = impl.Separator()
 
     /**
@@ -547,6 +563,7 @@ class MenuScope internal constructor(private val impl: MenuScopeImpl) {
      * @param onClick action that should be performed when the user clicks on the item
      */
     @Composable
+    @MenuComposable
     fun Item(
         text: String,
         icon: Painter? = null,
@@ -573,6 +590,7 @@ class MenuScope internal constructor(private val impl: MenuScopeImpl) {
      * therefore the change of checked state in requested
      */
     @Composable
+    @MenuComposable
     fun CheckboxItem(
         text: String,
         checked: Boolean,
@@ -601,6 +619,7 @@ class MenuScope internal constructor(private val impl: MenuScopeImpl) {
      * @param onClick callback to be invoked when the radio button is being clicked
      */
     @Composable
+    @MenuComposable
     fun RadioButtonItem(
         text: String,
         selected: Boolean,

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/MenuComposable.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/MenuComposable.desktop.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.window
+
+import androidx.compose.runtime.ComposableTargetMarker
+
+/**
+ * An annotation that can be used to mark a composable function as being expected to be used in a
+ * composable function that is also marked or inferred to be marked as [MenuComposable].
+ *
+ * Using this annotation explicitly is rarely necessary as the Compose compiler plugin will infer
+ * the necessary equivalent annotations automatically. See
+ * [androidx.compose.runtime.ComposableTarget] for details.
+ */
+@Retention(AnnotationRetention.BINARY)
+@ComposableTargetMarker(description = "Menu Composable")
+@Target(
+    AnnotationTarget.FILE,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.TYPE,
+    AnnotationTarget.TYPE_PARAMETER,
+)
+annotation class MenuComposable()

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Tray.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Tray.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
@@ -82,7 +83,7 @@ fun ApplicationScope.Tray(
     state: TrayState = rememberTrayState(),
     tooltip: String? = null,
     onAction: () -> Unit = {},
-    menu: @Composable MenuScope.() -> Unit = {}
+    menu: @Composable @MenuComposable MenuScope.() -> Unit = {}
 ) {
     if (!isTraySupported) {
         DisposableEffect(Unit) {
@@ -136,9 +137,7 @@ fun ApplicationScope.Tray(
     DisposableEffect(Unit) {
         tray.popupMenu = popupMenu
 
-        val menuComposition = popupMenu.setContent(composition) {
-            currentMenu()
-        }
+        val menuComposition = popupMenu.setContent(composition, currentMenu)
 
         SystemTray.getSystemTray().add(tray)
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Tray.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Tray.desktop.kt
@@ -78,6 +78,7 @@ val isTraySupported: Boolean get() = SystemTray.isSupported()
  */
 @Suppress("unused")
 @Composable
+@ComposableOpenTarget(-1)
 fun ApplicationScope.Tray(
     icon: Painter,
     state: TrayState = rememberTrayState(),

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.window
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposableOpenTarget
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
@@ -102,6 +103,7 @@ import javax.swing.JMenuBar
  */
 @ExperimentalComposeUiApi
 @Composable
+@ComposableOpenTarget(-1)
 fun Window(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -207,6 +209,7 @@ fun Window(
  * @param content Composable content of the window.
  */
 @Composable
+@ComposableOpenTarget(-1)
 fun Window(
     onCloseRequest: () -> Unit,
     state: WindowState = rememberWindowState(),
@@ -552,6 +555,7 @@ fun singleWindowApplication(
     )
 )
 @Composable
+@ComposableOpenTarget(-1)
 fun Window(
     visible: Boolean = true,
     onPreviewKeyEvent: (KeyEvent) -> Boolean = { false },
@@ -607,6 +611,7 @@ private fun SingleWindowApplicationScope(
  * @param content content of the menu bar (list of menus)
  */
 @Composable
+@ComposableOpenTarget(-1)
 fun FrameWindowScope.MenuBar(content: @Composable @MenuComposable MenuBarScope.() -> Unit) {
     val parentComposition = rememberCompositionContext()
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/Window.desktop.kt
@@ -607,7 +607,7 @@ private fun SingleWindowApplicationScope(
  * @param content content of the menu bar (list of menus)
  */
 @Composable
-fun FrameWindowScope.MenuBar(content: @Composable MenuBarScope.() -> Unit) {
+fun FrameWindowScope.MenuBar(content: @Composable @MenuComposable MenuBarScope.() -> Unit) {
     val parentComposition = rememberCompositionContext()
 
     DisposableEffect(Unit) {


### PR DESCRIPTION
[CMP-7106](https://youtrack.jetbrains.com/issue/CMP-7106) Use separate `ComposableTargetMarker` for desktop menu API
Invalid API mixing such as putting UI composables into menu DSL (or vice versa) can fail at runtime due to applier mismatch. This change improves compile-time detection and reduces runtime-only failures.

- Added desktop-specific marker annotations: `MenuComposable`
- Marked menu APIs with `MenuComposable` where menu applier is expected
- Kept applier-creating entrypoints open where appropriate with `@ComposableOpenTarget(-1)`.
- Refactored menu bar composition internals: replaced list adapter usage with direct `JMenuBar` applier (`SwingApplier`-based path)

## Testing

```kt
Window(onCloseRequest = ::exitApplication) {
    MenuBar {
        Text("Label 1")
    }
}
Tray(icon) {
    Text("Label 2")
}
```

Now produces
```
Calling a UI Composable composable function where a Menu Composable composable was expected
```

## Release Notes
### Features - Desktop
- New compile-time warnings for invalid ui/menu composable mixing that previously failed only at runtime.
