### PR TITLE
Implement NumPad movement keys across all platforms

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
@@ -593,25 +593,32 @@ actual value class Key(val keyCode: Long) {
         actual val ThumbsDown = Key(-1000000182)
         actual val ProfileSwitch = Key(-1000000183)
 
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9751/Implement-actuals-from-Add-NumPad-movement-keys-CL-in-CMP
-        actual val NumPadDirectionUp: Key
-            get() = Unknown
-        actual val NumPadDirectionDown: Key
-            get() = Unknown
-        actual val NumPadDirectionLeft: Key
-            get() = Unknown
-        actual val NumPadDirectionRight: Key
-            get() = Unknown
-        actual val NumPadMoveHome: Key
-            get() = Unknown
-        actual val NumPadMoveEnd: Key
-            get() = Unknown
-        actual val NumPadPageUp: Key
-            get() = Unknown
-        actual val NumPadPageDown: Key
-            get() = Unknown
-        actual val NumPadInsert: Key
-            get() = Unknown
+        /** Numeric keypad Up Arrow Key. */
+        actual val NumPadDirectionUp = Key(KeyEvent.VK_UP, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Down Arrow Key. */
+        actual val NumPadDirectionDown = Key(KeyEvent.VK_DOWN, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Left Arrow Key. */
+        actual val NumPadDirectionLeft = Key(KeyEvent.VK_LEFT, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Right Arrow Key. */
+        actual val NumPadDirectionRight = Key(KeyEvent.VK_RIGHT, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Home Key. */
+        actual val NumPadMoveHome: Key = Key(KeyEvent.VK_HOME, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad End Key. */
+        actual val NumPadMoveEnd = Key(KeyEvent.VK_END, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Page Up Key. */
+        actual val NumPadPageUp = Key(KeyEvent.VK_PAGE_UP, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Page Down Key. */
+        actual val NumPadPageDown = Key(KeyEvent.VK_PAGE_DOWN, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Insert Key. */
+        actual val NumPadInsert = Key(KeyEvent.VK_INSERT, KEY_LOCATION_NUMPAD)
     }
 
     actual override fun toString(): String {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/Key.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/Key.ios.kt
@@ -555,26 +555,15 @@ actual value class Key(val keyCode: Long) {
         actual val NumPadEquals = Key(-1000000195)
         actual val NumPadLeftParenthesis = Key(-1000000196)
         actual val NumPadRightParenthesis = Key(-1000000197)
-
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9751/Implement-actuals-from-Add-NumPad-movement-keys-CL-in-CMP
-        actual val NumPadDirectionUp: Key
-            get() = Unknown
-        actual val NumPadDirectionDown: Key
-            get() = Unknown
-        actual val NumPadDirectionLeft: Key
-            get() = Unknown
-        actual val NumPadDirectionRight: Key
-            get() = Unknown
-        actual val NumPadMoveHome: Key
-            get() = Unknown
-        actual val NumPadMoveEnd: Key
-            get() = Unknown
-        actual val NumPadPageUp: Key
-            get() = Unknown
-        actual val NumPadPageDown: Key
-            get() = Unknown
-        actual val NumPadInsert: Key
-            get() = Unknown
+        actual val NumPadDirectionUp = Key(-1000000198)
+        actual val NumPadDirectionDown = Key(-1000000199)
+        actual val NumPadDirectionLeft = Key(-1000000200)
+        actual val NumPadDirectionRight = Key(-1000000201)
+        actual val NumPadMoveHome = Key(-1000000202)
+        actual val NumPadMoveEnd = Key(-1000000203)
+        actual val NumPadPageUp = Key(-1000000204)
+        actual val NumPadPageDown = Key(-1000000205)
+        actual val NumPadInsert = Key(-1000000206)
     }
 
     actual override fun toString() = "Key keyCode: $keyCode"

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/key/Key.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/key/Key.macos.kt
@@ -553,26 +553,15 @@ actual value class Key(val keyCode: Long) {
         actual val NumPadEquals = Key(-1000000195)
         actual val NumPadLeftParenthesis = Key(-1000000196)
         actual val NumPadRightParenthesis = Key(-1000000197)
-
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9751/Implement-actuals-from-Add-NumPad-movement-keys-CL-in-CMP
-        actual val NumPadDirectionUp: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadDirectionDown: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadDirectionLeft: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadDirectionRight: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadMoveHome: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadMoveEnd: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadPageUp: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadPageDown: Key
-            get() = TODO("Not yet implemented")
-        actual val NumPadInsert: Key
-            get() = TODO("Not yet implemented")
+        actual val NumPadDirectionUp = Key(-1000000198)
+        actual val NumPadDirectionDown = Key(-1000000199)
+        actual val NumPadDirectionLeft = Key(-1000000200)
+        actual val NumPadDirectionRight = Key(-1000000201)
+        actual val NumPadMoveHome = Key(-1000000202)
+        actual val NumPadMoveEnd = Key(-1000000203)
+        actual val NumPadPageUp = Key(-1000000204)
+        actual val NumPadPageDown = Key(-1000000205)
+        actual val NumPadInsert = Key(-1000000206)
     }
 
     actual override fun toString() = "Key keyCode: $keyCode"

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/key/Key.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/key/Key.web.kt
@@ -554,26 +554,15 @@ actual value class Key(val keyCode: Long) {
         actual val NumPadEquals = Key(-1000000195)
         actual val NumPadLeftParenthesis = Key(-1000000196)
         actual val NumPadRightParenthesis = Key(-1000000197)
-
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9751/Implement-actuals-from-Add-NumPad-movement-keys-CL-in-CMP
-        actual val NumPadDirectionUp: Key
-            get() = Unknown
-        actual val NumPadDirectionDown: Key
-            get() = Unknown
-        actual val NumPadDirectionLeft: Key
-            get() = Unknown
-        actual val NumPadDirectionRight: Key
-            get() = Unknown
-        actual val NumPadMoveHome: Key
-            get() = Unknown
-        actual val NumPadMoveEnd: Key
-            get() = Unknown
-        actual val NumPadPageUp: Key
-            get() = Unknown
-        actual val NumPadPageDown: Key
-            get() = Unknown
-        actual val NumPadInsert: Key
-            get() = Unknown
+        actual val NumPadDirectionUp = Key(-1000000198)
+        actual val NumPadDirectionDown = Key(-1000000199)
+        actual val NumPadDirectionLeft = Key(-1000000200)
+        actual val NumPadDirectionRight = Key(-1000000201)
+        actual val NumPadMoveHome = Key(-1000000202)
+        actual val NumPadMoveEnd = Key(-1000000203)
+        actual val NumPadPageUp = Key(-1000000204)
+        actual val NumPadPageDown = Key(-1000000205)
+        actual val NumPadInsert = Key(-1000000206)
     }
 
     actual override fun toString() = "Key keyCode: $keyCode"


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9751/Implement-actuals-from-Add-NumPad-movement-keys-CL-in-CMP
 
The incorrect (stubbed) implementation of the new Keys introduced a bug on web:
Fixes https://youtrack.jetbrains.com/issue/CMP-9792 - [Web] Mobile. Android. Autocomplete isn't working properly on 1.11.0-alpha03



## Testing
This should be tested by QA

## Release Notes
N/A
