### PR TITLE
Align the text selection haptic feedback with the iOS

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.isSpecified
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
@@ -63,35 +64,18 @@ internal val MagnifierPositionInWindow =
 
 internal fun Modifier.magnifier(
     sourceCenter: Density.() -> Offset,
-    magnifierCenter: (Density.() -> Offset)? = null,
+    onSizeChanged: ((DpSize) -> Unit)?,
     color: Color = Color.Unspecified,
-    onSizeChanged: ((DpSize) -> Unit)? = null,
-): Modifier {
-    return magnifier(
-        sourceCenter = sourceCenter,
-        magnifierCenter = magnifierCenter,
-        onSizeChanged = onSizeChanged,
-        color = color,
-        platformMagnifierFactory = null
-    )
-}
-
-internal fun Modifier.magnifier(
-    sourceCenter: Density.() -> Offset,
-    magnifierCenter: (Density.() -> Offset)? = null,
-    onSizeChanged: ((DpSize) -> Unit)? = null,
-    color: Color = Color.Unspecified,
-    platformMagnifierFactory: PlatformMagnifierFactory? = null
+    hapticFeedback: HapticFeedback?,
 ): Modifier {
     return if (isPlatformMagnifierSupported()) {
         then(
             MagnifierElement(
                 sourceCenter = sourceCenter,
-                magnifierCenter = magnifierCenter,
                 onSizeChanged = onSizeChanged,
                 color = color,
-                platformMagnifierFactory = platformMagnifierFactory
-                    ?: PlatformMagnifierFactory.getForCurrentPlatform() // this doesn't do an alloc
+                platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform(),
+                hapticFeedback = hapticFeedback,
             )
         )
     } else {
@@ -100,7 +84,6 @@ internal fun Modifier.magnifier(
             inspectorInfo = debugInspectorInfo {
                 name = "magnifier (not supported)"
                 properties["sourceCenter"] = sourceCenter
-                properties["magnifierCenter"] = magnifierCenter
                 properties["color"] = color
             }
         ) { this }
@@ -109,29 +92,29 @@ internal fun Modifier.magnifier(
 
 internal class MagnifierElement(
     private val sourceCenter: Density.() -> Offset,
-    private val magnifierCenter: (Density.() -> Offset)? = null,
-    private val onSizeChanged: ((DpSize) -> Unit)? = null,
+    private val onSizeChanged: ((DpSize) -> Unit)?,
     private val color : Color = Color.Unspecified,
-    private val platformMagnifierFactory: PlatformMagnifierFactory
+    private val platformMagnifierFactory: PlatformMagnifierFactory,
+    private val hapticFeedback: HapticFeedback?,
 ) : ModifierNodeElement<MagnifierNode>() {
 
     override fun create(): MagnifierNode {
         return MagnifierNode(
             sourceCenter = sourceCenter,
-            magnifierCenter = magnifierCenter,
             onSizeChanged = onSizeChanged,
             platformMagnifierFactory = platformMagnifierFactory,
-            color = color
+            color = color,
+            hapticFeedback = hapticFeedback,
         )
     }
 
     override fun update(node: MagnifierNode) {
         node.update(
             sourceCenter = sourceCenter,
-            magnifierCenter = magnifierCenter,
             onSizeChanged = onSizeChanged,
             color = color,
-            platformMagnifierFactory = platformMagnifierFactory
+            platformMagnifierFactory = platformMagnifierFactory,
+            hapticFeedback = hapticFeedback,
         )
     }
 
@@ -140,38 +123,36 @@ internal class MagnifierElement(
         if (other !is MagnifierElement) return false
 
         if (sourceCenter != other.sourceCenter) return false
-        if (magnifierCenter != other.magnifierCenter) return false
         if (onSizeChanged != other.onSizeChanged) return false
         if (color != other.color) return false
         if (platformMagnifierFactory != other.platformMagnifierFactory) return false
+        if (hapticFeedback != other.hapticFeedback) return false
 
         return true
     }
 
     override fun hashCode(): Int {
         var result = sourceCenter.hashCode()
-        result = 31 * result + magnifierCenter.hashCode()
         result = 31 * result + (onSizeChanged?.hashCode() ?: 0)
         result = 31 * result + color.hashCode()
         result = 31 * result + platformMagnifierFactory.hashCode()
+        result = 31 * result + hapticFeedback.hashCode()
         return result
     }
 
     override fun InspectorInfo.inspectableProperties() {
         name = "magnifier"
         properties["sourceCenter"] = sourceCenter
-        properties["magnifierCenter"] = magnifierCenter
         properties["color"] = color
     }
 }
 
 internal class MagnifierNode(
     var sourceCenter: Density.() -> Offset,
-    var magnifierCenter: (Density.() -> Offset)? = null,
-    var onSizeChanged: ((DpSize) -> Unit)? = null,
+    var onSizeChanged: ((DpSize) -> Unit)?,
     var color : Color = Color.Unspecified,
-    var platformMagnifierFactory: PlatformMagnifierFactory =
-        PlatformMagnifierFactory.getForCurrentPlatform()
+    var platformMagnifierFactory: PlatformMagnifierFactory,
+    var hapticFeedback: HapticFeedback?,
 ) : Modifier.Node(),
     CompositionLocalConsumerModifierNode,
     GlobalPositionAwareModifierNode,
@@ -214,19 +195,19 @@ internal class MagnifierNode(
 
     fun update(
         sourceCenter: Density.() -> Offset = this.sourceCenter,
-        magnifierCenter: (Density.() -> Offset)? = this.magnifierCenter,
         onSizeChanged: ((DpSize) -> Unit)? = this.onSizeChanged,
         color: Color = this.color,
-        platformMagnifierFactory: PlatformMagnifierFactory = this.platformMagnifierFactory
+        platformMagnifierFactory: PlatformMagnifierFactory = this.platformMagnifierFactory,
+        hapticFeedback: HapticFeedback?,
     ) {
         val previousPlatformMagnifierFactory = this.platformMagnifierFactory
         val previousColor = this.color
 
         this.sourceCenter = sourceCenter
-        this.magnifierCenter = magnifierCenter
         this.onSizeChanged = onSizeChanged
         this.color = color
         this.platformMagnifierFactory = platformMagnifierFactory
+        this.hapticFeedback = hapticFeedback
 
         if (
             magnifier == null ||
@@ -268,7 +249,6 @@ internal class MagnifierNode(
             updateMagnifier()
         }
     }
-
 
     private fun recreateMagnifier() {
         magnifier?.dismiss()

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldMagnifierNode.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldMagnifierNode.ios.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation.text.input.internal.selection
 
 import androidx.compose.foundation.MagnifierNode
+import androidx.compose.foundation.PlatformMagnifierFactory
 import androidx.compose.foundation.isPlatformMagnifierSupported
 import androidx.compose.foundation.text.Handle
 import androidx.compose.foundation.text.input.internal.TextLayoutState
@@ -95,6 +96,8 @@ internal class TextFieldMagnifierNodeImpl(
         MagnifierNode(
             sourceCenter = { sourceCenter },
             onSizeChanged = { magnifierSize = it },
+            platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform(),
+            hapticFeedback = textFieldSelectionState.hapticFeedBack,
         )
     )
 
@@ -111,7 +114,10 @@ internal class TextFieldMagnifierNodeImpl(
             color = currentValueOf(LocalTextSelectionColors).handleColor
             density = currentValueOf(LocalDensity)
 
-            magnifierNode.update(color = color)
+            magnifierNode.update(
+                color = color,
+                hapticFeedback = textFieldSelectionState.hapticFeedBack,
+            )
         }
     }
 

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/input/internal/selection/TextFieldSelectionState.ios.kt
@@ -278,8 +278,7 @@ private fun doRepeatingTapSelection(
         selectionOffset,
         isStartHandle = false,
         adjustment = selectionAdjustment,
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9694/Pass-correct-values-to-haptic-feedback-type-in-TextFieldSelectionState.ios.kt
-        hapticFeedbackType = null,
+        hapticFeedbackType = HapticFeedbackType.TextHandleMove,
     )
 
     selectionState.textFieldState.selectCharsIn(newSelection)
@@ -299,8 +298,7 @@ private fun clearSelection(
         selectionOffset,
         isStartHandle = false,
         adjustment = SelectionAdjustment.None,
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9694/Pass-correct-values-to-haptic-feedback-type-in-TextFieldSelectionState.ios.kt
-        hapticFeedbackType = null,
+        hapticFeedbackType = HapticFeedbackType.TextHandleMove,
     )
     selectionState.textFieldState.selectCharsIn(clearedSelection)
 }
@@ -340,7 +338,7 @@ private class UIKitTextFieldTextDragObserver(
         dragBeginPosition = startPoint
         dragTotalDistance = Offset.Zero
 
-        textFieldSelectionState.hapticFeedBack?.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+        textFieldSelectionState.hapticFeedBack?.performHapticFeedback(HapticFeedbackType.LongPress)
         // Long Press at the blank area, the cursor should show up at the end of the line.
         if (!textFieldSelectionState.textLayoutState.isPositionOnText(startPoint)) {
             val offset = textFieldSelectionState.textLayoutState.getOffsetForPosition(startPoint)

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.ios.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -39,7 +41,7 @@ import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.isShiftPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.LayoutCoordinates
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastForEach
 import kotlin.coroutines.cancellation.CancellationException
@@ -234,6 +236,7 @@ private fun Modifier.selectionGestureInput(
     // TODO(https://youtrack.jetbrains.com/issue/COMPOSE-79) how we can rewrite this without `composed`?
     val currentMouseSelectionObserver by rememberUpdatedState(mouseSelectionObserver)
     val currentTextDragObserver by rememberUpdatedState(textDragObserver)
+    val hapticFeedback = LocalHapticFeedback.current
     this.pointerInput(Unit) {
         val clicksCounter = ClicksCounter(viewConfiguration)
         awaitEachGesture {
@@ -245,7 +248,7 @@ private fun Modifier.selectionGestureInput(
             ) {
                 mouseSelection(currentMouseSelectionObserver, clicksCounter, down)
             } else if (!down.isMouseOrTouchPad()) {
-                touchSelection(currentTextDragObserver, clicksCounter, down)
+                touchSelection(currentTextDragObserver, clicksCounter, down, hapticFeedback)
             }
         }
     }
@@ -254,7 +257,8 @@ private fun Modifier.selectionGestureInput(
 private suspend fun AwaitPointerEventScope.touchSelection(
     observer: CupertinoTextDragObserver,
     clicksCounter: ClicksCounter,
-    down: PointerEvent
+    down: PointerEvent,
+    hapticFeedback: HapticFeedback?,
 ) {
     try {
         val firstDown = down.changes.first()
@@ -274,6 +278,7 @@ private suspend fun AwaitPointerEventScope.touchSelection(
 
         if (drag != null) {
             observer.onStart(firstDown.position, SelectionAdjustment.Word)
+            hapticFeedback?.performHapticFeedback(HapticFeedbackType.LongPress)
             if (
                 drag(drag.id) {
                     observer.onDrag(it.position, SelectionAdjustment.CharacterWithWordAccelerate)

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.foundation.text.selection
 
-import androidx.compose.foundation.PlatformMagnifierFactory
 import androidx.compose.foundation.isPlatformMagnifierSupported
 import androidx.compose.foundation.magnifier
 import androidx.compose.foundation.text.addTextContextMenuComponents
@@ -56,8 +55,8 @@ internal actual fun Modifier.selectionMagnifier(manager: SelectionManager): Modi
                     IntSize(size.width.roundToPx(), size.height.roundToPx())
                 }
             },
-            color = color.handleColor, // align magnifier border color with selection handleColor
-            platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform()
+            color = color.handleColor, // align magnifier border color with selection handleColor,
+            hapticFeedback = manager.hapticFeedBack,
         )
     }
 }

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.ios.kt
@@ -64,7 +64,7 @@ internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManag
                 }
             },
             color = color.handleColor, // align magnifier border color with selection handleColor
-            platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform()
+            hapticFeedback = manager.hapticFeedBack
         )
     }
 }

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.ios.kt
@@ -64,7 +64,7 @@ internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManag
                 }
             },
             color = color.handleColor, // align magnifier border color with selection handleColor
-            hapticFeedback = manager.hapticFeedBack
+            hapticFeedback = manager.hapticFeedBack,
         )
     }
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/CupertinoTextFieldPointerModifier.skiko.kt
@@ -184,6 +184,8 @@ private fun getLongPressHandlerModifier(
                     currentManager.draggingHandle = Handle.SelectionEnd
                     currentManager.currentDragPosition = startPoint
 
+                    currentManager.hapticFeedBack?.performHapticFeedback(HapticFeedbackType.LongPress)
+
                     currentState.layoutResult?.let { layoutResult ->
                         TextFieldDelegate.setCursorOffset(
                             startPoint,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/hapticfeedback/HapticFeedback.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/hapticfeedback/HapticFeedback.ios.kt
@@ -29,7 +29,6 @@ internal class CupertinoHapticFeedback : HapticFeedback {
 
     private val mediumImpactGenerator = UIImpactFeedbackGenerator()
     private val lightImpactGenerator = UIImpactFeedbackGenerator(UIImpactFeedbackStyle.UIImpactFeedbackStyleLight)
-    private val selectionGenerator = UISelectionFeedbackGenerator()
     private val notificationGenerator = UINotificationFeedbackGenerator()
 
     override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
@@ -47,7 +46,10 @@ internal class CupertinoHapticFeedback : HapticFeedback {
             HapticFeedbackType.VirtualKey -> lightImpactGenerator.impactOccurred()
             HapticFeedbackType.SegmentFrequentTick,
             HapticFeedbackType.SegmentTick,
-            HapticFeedbackType.TextHandleMove -> selectionGenerator.selectionChanged()
+            HapticFeedbackType.TextHandleMove -> {
+                // iOS does not produce haptic feedback for these types
+                return
+            }
         }
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/HapticFeedbackSelectionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/HapticFeedbackSelectionTest.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.hold
+import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HapticFeedbackSelectionTest {
+
+    private class TestHapticFeedback : HapticFeedback {
+        val performedHaptics = mutableListOf<HapticFeedbackType>()
+
+        override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
+            if (hapticFeedbackType == HapticFeedbackType.TextHandleMove) {
+                // Ignored for iOS
+                return
+            }
+
+            performedHaptics.add(hapticFeedbackType)
+        }
+
+        fun assertLongPressHapticPerformed() {
+            assertTrue(
+                performedHaptics.contains(HapticFeedbackType.LongPress),
+                "Expected LongPress haptic feedback, but got: $performedHaptics"
+            )
+            assertTrue(
+                performedHaptics.none { it != HapticFeedbackType.LongPress },
+                "Expected LongPress haptic feedback, but got: $performedHaptics"
+            )
+        }
+
+        fun assertNoHaptic() {
+            assertTrue(
+                performedHaptics.isEmpty(),
+                "Did not expect LongPress haptic feedback, but got: $performedHaptics"
+            )
+        }
+    }
+
+    @Composable
+    private fun WithTestHapticFeedback(
+        hapticFeedback: TestHapticFeedback,
+        content: @Composable () -> Unit
+    ) {
+        CompositionLocalProvider(LocalHapticFeedback provides hapticFeedback) {
+            content()
+        }
+    }
+
+    @Test
+    fun testBasicTextFieldValue_LongPress_TriggersHapticFeedback() = runUIKitInstrumentedTest {
+        val hapticFeedback = TestHapticFeedback()
+        var textFieldValue by mutableStateOf(TextFieldValue("Hello World"))
+
+        setContent {
+            WithTestHapticFeedback(hapticFeedback) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    BasicTextField(
+                        value = textFieldValue,
+                        onValueChange = { textFieldValue = it },
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("TextField")
+                            .padding(16.dp)
+                    )
+                }
+            }
+        }
+
+        // Perform long press
+        val textFieldNode = findNodeWithTag("TextField")
+        val touch = textFieldNode.touchDown()
+        delay(600) // Wait for long press timeout
+        touch.hold()
+        delay(100)
+        touch.up()
+
+        waitForIdle()
+
+        // Verify that LongPress haptic feedback was triggered
+        hapticFeedback.assertLongPressHapticPerformed()
+    }
+
+    @Test
+    fun testBasicTextFieldValue_DoubleTap_DoesNotTriggerHaptic() = runUIKitInstrumentedTest {
+        val hapticFeedback = TestHapticFeedback()
+        var textFieldValue by mutableStateOf(TextFieldValue("Hello World"))
+
+        setContent {
+            WithTestHapticFeedback(hapticFeedback) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    BasicTextField(
+                        value = textFieldValue,
+                        onValueChange = { textFieldValue = it },
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("TextField")
+                            .padding(16.dp)
+                    )
+                }
+            }
+        }
+
+        // Perform double tap
+        findNodeWithTag("TextField").doubleTap()
+
+        waitForIdle()
+
+        // Verify that haptic feedback was NOT triggered
+        hapticFeedback.assertNoHaptic()
+
+        assertFalse(textFieldValue.selection.collapsed)
+    }
+
+    @Test
+    fun testBasicTextFieldState_LongPress_TriggersHapticFeedback() = runUIKitInstrumentedTest {
+        val hapticFeedback = TestHapticFeedback()
+        val textFieldState = TextFieldState("Hello World")
+
+        setContent {
+            WithTestHapticFeedback(hapticFeedback) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    BasicTextField(
+                        state = textFieldState,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("TextField")
+                            .padding(16.dp)
+                    )
+                }
+            }
+        }
+
+        // Perform long press
+        val textFieldNode = findNodeWithTag("TextField")
+        val touch = textFieldNode.touchDown()
+        delay(600) // Wait for long press timeout
+        touch.hold()
+        delay(100)
+        touch.up()
+
+        waitForIdle()
+
+        // Verify that LongPress haptic feedback was triggered
+        hapticFeedback.assertLongPressHapticPerformed()
+    }
+
+    @Test
+    fun testBasicTextFieldState_DoubleTap_DoesNotTriggerHaptic() = runUIKitInstrumentedTest {
+        val hapticFeedback = TestHapticFeedback()
+        val textFieldState = TextFieldState("Hello World")
+
+        setContent {
+            WithTestHapticFeedback(hapticFeedback) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    BasicTextField(
+                        state = textFieldState,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("TextField")
+                            .padding(16.dp)
+                    )
+                }
+            }
+        }
+
+        findNodeWithTag("TextField").doubleTap()
+
+        waitForIdle()
+
+        // Verify that haptic feedback was NOT triggered
+        hapticFeedback.assertNoHaptic()
+
+        assertFalse(textFieldState.selection.collapsed)
+    }
+
+    @Test
+    fun testSelectionContainer_LongPress_TriggersHapticFeedback() = runUIKitInstrumentedTest {
+        val hapticFeedback = TestHapticFeedback()
+
+        setContent {
+            WithTestHapticFeedback(hapticFeedback) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    SelectionContainer(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("SelectionContainer")
+                    ) {
+                        Text(
+                            text = "Hello World",
+                            modifier = Modifier.padding(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+
+        // Perform long press
+        val textNode = findNodeWithTag("SelectionContainer")
+        val touch = textNode.touchDown()
+        delay(600) // Wait for long press timeout
+        touch.hold()
+        delay(100)
+        touch.up()
+
+        waitForIdle()
+
+        // Verify that LongPress haptic feedback was triggered
+        hapticFeedback.assertLongPressHapticPerformed()
+    }
+
+    @Test
+    fun testSelectionContainer_DoubleTap_DoesNotTriggerHaptic() = runUIKitInstrumentedTest {
+        val hapticFeedback = TestHapticFeedback()
+
+        setContent {
+            WithTestHapticFeedback(hapticFeedback) {
+                Box(modifier = Modifier.fillMaxSize()) {
+                    SelectionContainer(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .testTag("SelectionContainer")
+                    ) {
+                        Text(
+                            text = "Hello World",
+                            modifier = Modifier.padding(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+
+        findNodeWithTag("SelectionContainer").doubleTap()
+
+        waitForIdle()
+
+        // Verify that haptic feedback was NOT triggered
+        hapticFeedback.assertNoHaptic()
+    }
+}


### PR DESCRIPTION
Generate haptic feedback on long press actions for text fields and selection container.
Disable the generation of haptic feedback for the `TextHandleMove` event because iOS does not trigger it.

Fixes https://youtrack.jetbrains.com/issue/CMP-9694/Pass-correct-values-to-haptic-feedback-type-in-TextFieldSelectionState.ios.kt
Fixes: https://youtrack.jetbrains.com/issue/CMP-9255/iOS-Haptic-feedback-doesnt-depend-on-the-settings

## Release Notes
### Fixes - iOS
- The haptic feedback when selecting text now works closer to the way it does with iOS text fields