### PR TITLE
Intro SkikoFont abstraction for async font loading on all Skiko platforms

### DIFF
--- a/compose/mpp/demo/build.gradle.kts
+++ b/compose/mpp/demo/build.gradle.kts
@@ -113,6 +113,7 @@ kotlin {
                 implementation(libs.kotlinCoroutinesCore)
                 implementation(libs.kotlinSerializationCore)
                 implementation(libs.skiko.skottie)
+                implementation(libs.ktor.client.core)
 
                 implementation(project(":compose:foundation:foundation"))
                 implementation(project(":compose:foundation:foundation-layout"))
@@ -160,6 +161,7 @@ kotlin {
                 implementation(libs.kotlinCoroutinesSwing)
                 implementation(libs.skikoAwtRuntime)
                 implementation(libs.skikoSkottieAwtRuntime)
+                implementation(libs.ktor.client.cio)
             }
         }
 
@@ -168,6 +170,7 @@ kotlin {
 
             dependencies {
                 implementation(libs.kotlinSerializationJson)
+                implementation(libs.ktor.client.js)
             }
         }
 
@@ -178,7 +181,12 @@ kotlin {
         }
 
         val nativeMain by getting { dependsOn(skikoMain) }
-        val darwinMain by creating { dependsOn(nativeMain) }
+        val darwinMain by creating {
+            dependsOn(nativeMain)
+            dependencies {
+                implementation(libs.ktor.client.darwin)
+            }
+        }
         val macosMain by getting { dependsOn(darwinMain) }
         val iosMain by getting { dependsOn(darwinMain) }
     }

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/SkikoFontDemo.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/SkikoFontDemo.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.components.text
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFontFamilyResolver
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontLoadingStrategy
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontVariation
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.font.SkikoFont
+import androidx.compose.ui.text.font.toFontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.io.IOException
+import org.jetbrains.skia.Data
+import org.jetbrains.skia.FontMgr
+import org.jetbrains.skia.Typeface
+
+@Composable
+fun SkikoFontDemo() {
+    val downloader = remember { Downloader() }
+    DisposableEffect(downloader) {
+        onDispose { downloader.close() }
+    }
+
+    val fontUrl =
+        "https://fonts.gstatic.com/s/betaniapatmos/v2/9oRXNYMTrDYnkuhOrHhyQracaunDNbEH8qpU.ttf"
+    val fontFamilyResolver = LocalFontFamilyResolver.current
+    val fontFamily = remember {
+        // identity is the unvaried source key (URL/file id), not weight/style.
+        Font(
+            identity = fontUrl,
+            loadData = { downloader.downloadBytes(url = fontUrl) ?: error("download error") },
+            weight = FontWeight.Normal,
+            style = FontStyle.Normal,
+            loadingStrategy = FontLoadingStrategy.Async,
+        ).toFontFamily()
+    }
+    LaunchedEffect(Unit) {
+        fontFamilyResolver.preload(fontFamily)
+    }
+    Column {
+        val textFieldState =
+            rememberTextFieldState(
+                "Compose Multiplatform is a declarative framework for sharing UI code " +
+                    "across multiple platforms with Kotlin. It is based on Jetpack Compose " +
+                    "and developed by JetBrains and open-source contributors."
+            )
+        TextField(
+            state = textFieldState,
+            modifier = Modifier.fillMaxWidth().height(200.dp),
+            textStyle = TextStyle(
+                fontFamily = fontFamily,
+                fontSize = 30.sp
+            )
+        )
+    }
+}
+
+private fun Font(
+    identity: String,
+    loadData: suspend () -> ByteArray,
+    weight: FontWeight,
+    style: FontStyle,
+    loadingStrategy: FontLoadingStrategy,
+    variationSettings: FontVariation.Settings = FontVariation.Settings(weight, style)
+): Font = DataFont(identity, loadData, weight, style, loadingStrategy, variationSettings)
+
+private class DataFont(
+    override val identity: String,
+    loadData: suspend () -> ByteArray,
+    override val weight: FontWeight,
+    override val style: FontStyle,
+    loadingStrategy: FontLoadingStrategy,
+    variationSettings: FontVariation.Settings
+) : SkikoFont(loadingStrategy, ByteArrayTypefaceLoader(loadData), variationSettings) {
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is DataFont) return false
+        if (identity != other.identity) return false
+        if (weight != other.weight) return false
+        if (style != other.style) return false
+        if (loadingStrategy != other.loadingStrategy) return false
+        if (variationSettings != other.variationSettings) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = identity.hashCode()
+        result = 31 * result + weight.hashCode()
+        result = 31 * result + style.hashCode()
+        result = 31 * result + loadingStrategy.hashCode()
+        result = 31 * result + variationSettings.hashCode()
+        return result
+    }
+}
+
+private class ByteArrayTypefaceLoader(
+    private val loadData: suspend () -> ByteArray
+) : SkikoFont.TypefaceLoader {
+
+    override fun loadBlocking(font: SkikoFont): Typeface? = null
+
+    override suspend fun awaitLoad(font: SkikoFont): Typeface? {
+        val bytes = loadData()
+        val data = Data.makeFromBytes(bytes)
+        return try {
+            FontMgr.default.makeFromData(data)
+        } finally {
+            data.close()
+        }
+    }
+}
+
+private class Downloader {
+    private val client = HttpClient()
+    private val maxRetries = 3
+    private val retryDelay = 2.seconds
+
+    suspend fun downloadBytes(url: String): ByteArray? {
+        var attempt = 0
+        while (attempt <= maxRetries) {
+            try {
+                val response: HttpResponse = client.get(url)
+                return response.body()
+            } catch (e: Exception) {
+                if (isRetryableError(e) && attempt < maxRetries) {
+                    delay(retryDelay)
+                    attempt++
+                } else {
+                    return null
+                }
+            }
+        }
+        return null
+    }
+
+    fun close() {
+        client.close()
+    }
+
+    private fun isRetryableError(error: Throwable): Boolean {
+        return when (error) {
+            is IOException -> true
+            is io.ktor.client.plugins.HttpRequestTimeoutException -> true
+            is io.ktor.client.network.sockets.SocketTimeoutException -> true
+            is io.ktor.client.network.sockets.ConnectTimeoutException -> true
+            else -> false
+        }
+    }
+}

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDemos.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/text/TextDemos.kt
@@ -22,6 +22,7 @@ val TextDemos = Screen.Selection(
     "Text",
     Screen.Example("FontFamilies") { FontFamilies() },
     Screen.Example("VariableFonts") { VariableFonts() },
+    Screen.Example("SkikoFont") { SkikoFontDemo() },
     Screen.Example("FontRasterization") { FontRasterization() },
     Screen.Example("LineHeightStyle") { LineHeightStyleDemo() },
     Screen.Example("TextDirection") { TextDirection() },

--- a/compose/ui/ui-skiko/api/desktop/ui-skiko.api
+++ b/compose/ui/ui-skiko/api/desktop/ui-skiko.api
@@ -96,6 +96,21 @@ public final class androidx/compose/ui/graphics/SkiaTileMode_skikoKt {
 	public static final synthetic fun isSupported-0vamqd0 (I)Z
 }
 
+public abstract class androidx/compose/ui/text/font/SkikoFont : androidx/compose/ui/text/font/Font {
+	public static final field $stable I
+	public synthetic fun <init> (ILandroidx/compose/ui/text/font/SkikoFont$TypefaceLoader;Landroidx/compose/ui/text/font/FontVariation$Settings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILandroidx/compose/ui/text/font/SkikoFont$TypefaceLoader;Landroidx/compose/ui/text/font/FontVariation$Settings;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public abstract fun getIdentity ()Ljava/lang/String;
+	public final fun getLoadingStrategy-PKNRLFQ ()I
+	public final fun getTypefaceLoader ()Landroidx/compose/ui/text/font/SkikoFont$TypefaceLoader;
+	public final fun getVariationSettings ()Landroidx/compose/ui/text/font/FontVariation$Settings;
+}
+
+public abstract interface class androidx/compose/ui/text/font/SkikoFont$TypefaceLoader {
+	public abstract fun awaitLoad (Landroidx/compose/ui/text/font/SkikoFont;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun loadBlocking (Landroidx/compose/ui/text/font/SkikoFont;)Lorg/jetbrains/skia/Typeface;
+}
+
 public final class androidx/compose/ui/text/platform/DesktopFont_desktopKt {
 	public static final fun Font-Ej4NQ78 (Ljava/io/File;Landroidx/compose/ui/text/font/FontWeight;ILandroidx/compose/ui/text/font/FontVariation$Settings;)Landroidx/compose/ui/text/font/Font;
 	public static final fun Font-Ej4NQ78 (Ljava/lang/String;Landroidx/compose/ui/text/font/FontWeight;ILandroidx/compose/ui/text/font/FontVariation$Settings;)Landroidx/compose/ui/text/font/Font;

--- a/compose/ui/ui-skiko/api/ui-skiko.klib.api
+++ b/compose/ui/ui-skiko/api/ui-skiko.klib.api
@@ -6,6 +6,24 @@
 // - Show declarations: true
 
 // Library unique name: <org.jetbrains.compose.ui:ui-skiko>
+abstract class androidx.compose.ui.text.font/SkikoFont : androidx.compose.ui.text.font/Font { // androidx.compose.ui.text.font/SkikoFont|null[0]
+    constructor <init>(androidx.compose.ui.text.font/FontLoadingStrategy, androidx.compose.ui.text.font/SkikoFont.TypefaceLoader, androidx.compose.ui.text.font/FontVariation.Settings = ...) // androidx.compose.ui.text.font/SkikoFont.<init>|<init>(androidx.compose.ui.text.font.FontLoadingStrategy;androidx.compose.ui.text.font.SkikoFont.TypefaceLoader;androidx.compose.ui.text.font.FontVariation.Settings){}[0]
+
+    abstract val identity // androidx.compose.ui.text.font/SkikoFont.identity|{}identity[0]
+        abstract fun <get-identity>(): kotlin/String // androidx.compose.ui.text.font/SkikoFont.identity.<get-identity>|<get-identity>(){}[0]
+    final val loadingStrategy // androidx.compose.ui.text.font/SkikoFont.loadingStrategy|{}loadingStrategy[0]
+        final fun <get-loadingStrategy>(): androidx.compose.ui.text.font/FontLoadingStrategy // androidx.compose.ui.text.font/SkikoFont.loadingStrategy.<get-loadingStrategy>|<get-loadingStrategy>(){}[0]
+    final val typefaceLoader // androidx.compose.ui.text.font/SkikoFont.typefaceLoader|{}typefaceLoader[0]
+        final fun <get-typefaceLoader>(): androidx.compose.ui.text.font/SkikoFont.TypefaceLoader // androidx.compose.ui.text.font/SkikoFont.typefaceLoader.<get-typefaceLoader>|<get-typefaceLoader>(){}[0]
+    final val variationSettings // androidx.compose.ui.text.font/SkikoFont.variationSettings|{}variationSettings[0]
+        final fun <get-variationSettings>(): androidx.compose.ui.text.font/FontVariation.Settings // androidx.compose.ui.text.font/SkikoFont.variationSettings.<get-variationSettings>|<get-variationSettings>(){}[0]
+
+    abstract interface TypefaceLoader { // androidx.compose.ui.text.font/SkikoFont.TypefaceLoader|null[0]
+        abstract fun loadBlocking(androidx.compose.ui.text.font/SkikoFont): org.jetbrains.skia/Typeface? // androidx.compose.ui.text.font/SkikoFont.TypefaceLoader.loadBlocking|loadBlocking(androidx.compose.ui.text.font.SkikoFont){}[0]
+        abstract suspend fun awaitLoad(androidx.compose.ui.text.font/SkikoFont): org.jetbrains.skia/Typeface? // androidx.compose.ui.text.font/SkikoFont.TypefaceLoader.awaitLoad|awaitLoad(androidx.compose.ui.text.font.SkikoFont){}[0]
+    }
+}
+
 final class androidx.compose.ui.text.platform/FontLoadResult { // androidx.compose.ui.text.platform/FontLoadResult|null[0]
     constructor <init>(org.jetbrains.skia/Typeface?, kotlin.collections/List<kotlin/String>) // androidx.compose.ui.text.platform/FontLoadResult.<init>|<init>(org.jetbrains.skia.Typeface?;kotlin.collections.List<kotlin.String>){}[0]
 
@@ -35,6 +53,7 @@ final val androidx.compose.ui.graphics/skiaPaint // androidx.compose.ui.graphics
     final fun (androidx.compose.ui.graphics/Paint).<get-skiaPaint>(): org.jetbrains.skia/Paint // androidx.compose.ui.graphics/skiaPaint.<get-skiaPaint>|<get-skiaPaint>@androidx.compose.ui.graphics.Paint(){}[0]
 final val androidx.compose.ui.graphics/skiaShader // androidx.compose.ui.graphics/skiaShader|@androidx.compose.ui.graphics.Shader{}skiaShader[0]
     final fun (androidx.compose.ui.graphics/Shader).<get-skiaShader>(): org.jetbrains.skia/Shader // androidx.compose.ui.graphics/skiaShader.<get-skiaShader>|<get-skiaShader>@androidx.compose.ui.graphics.Shader(){}[0]
+final val androidx.compose.ui.text.font/androidx_compose_ui_text_font_SkikoFont$stableprop // androidx.compose.ui.text.font/androidx_compose_ui_text_font_SkikoFont$stableprop|#static{}androidx_compose_ui_text_font_SkikoFont$stableprop[0]
 final val androidx.compose.ui.text.platform/androidx_compose_ui_text_platform_ComputedStyle_Immutable$stableprop // androidx.compose.ui.text.platform/androidx_compose_ui_text_platform_ComputedStyle_Immutable$stableprop|#static{}androidx_compose_ui_text_platform_ComputedStyle_Immutable$stableprop[0]
 final val androidx.compose.ui.text.platform/androidx_compose_ui_text_platform_ComputedStyle_Mutable$stableprop // androidx.compose.ui.text.platform/androidx_compose_ui_text_platform_ComputedStyle_Mutable$stableprop|#static{}androidx_compose_ui_text_platform_ComputedStyle_Mutable$stableprop[0]
 final val androidx.compose.ui.text.platform/androidx_compose_ui_text_platform_FontLoadResult$stableprop // androidx.compose.ui.text.platform/androidx_compose_ui_text_platform_FontLoadResult$stableprop|#static{}androidx_compose_ui_text_platform_FontLoadResult$stableprop[0]
@@ -66,6 +85,7 @@ final fun (org.jetbrains.skia/PathMeasure).androidx.compose.ui.graphics/asCompos
 final fun (org.jetbrains.skia/Rect).androidx.compose.ui.graphics/toComposeRect(): androidx.compose.ui.geometry/Rect // androidx.compose.ui.graphics/toComposeRect|toComposeRect@org.jetbrains.skia.Rect(){}[0]
 final fun (org.jetbrains.skia/Shader).androidx.compose.ui.graphics/asComposeShader(): androidx.compose.ui.graphics/Shader // androidx.compose.ui.graphics/asComposeShader|asComposeShader@org.jetbrains.skia.Shader(){}[0]
 final fun androidx.compose.ui.graphics/androidx_compose_ui_graphics_SkiaGraphicsContext$stableprop_getter(): kotlin/Int // androidx.compose.ui.graphics/androidx_compose_ui_graphics_SkiaGraphicsContext$stableprop_getter|androidx_compose_ui_graphics_SkiaGraphicsContext$stableprop_getter(){}[0]
+final fun androidx.compose.ui.text.font/androidx_compose_ui_text_font_SkikoFont$stableprop_getter(): kotlin/Int // androidx.compose.ui.text.font/androidx_compose_ui_text_font_SkikoFont$stableprop_getter|androidx_compose_ui_text_font_SkikoFont$stableprop_getter(){}[0]
 final fun androidx.compose.ui.text.platform/Font(kotlin/String, kotlin/ByteArray, androidx.compose.ui.text.font/FontWeight = ..., androidx.compose.ui.text.font/FontStyle = ...): androidx.compose.ui.text.font/Font // androidx.compose.ui.text.platform/Font|Font(kotlin.String;kotlin.ByteArray;androidx.compose.ui.text.font.FontWeight;androidx.compose.ui.text.font.FontStyle){}[0]
 final fun androidx.compose.ui.text.platform/Font(kotlin/String, kotlin/ByteArray, androidx.compose.ui.text.font/FontWeight = ..., androidx.compose.ui.text.font/FontStyle = ..., androidx.compose.ui.text.font/FontVariation.Settings = ...): androidx.compose.ui.text.font/Font // androidx.compose.ui.text.platform/Font|Font(kotlin.String;kotlin.ByteArray;androidx.compose.ui.text.font.FontWeight;androidx.compose.ui.text.font.FontStyle;androidx.compose.ui.text.font.FontVariation.Settings){}[0]
 final fun androidx.compose.ui.text.platform/Font(kotlin/String, kotlin/Function0<kotlin/ByteArray>, androidx.compose.ui.text.font/FontWeight = ..., androidx.compose.ui.text.font/FontStyle = ...): androidx.compose.ui.text.font/Font // androidx.compose.ui.text.platform/Font|Font(kotlin.String;kotlin.Function0<kotlin.ByteArray>;androidx.compose.ui.text.font.FontWeight;androidx.compose.ui.text.font.FontStyle){}[0]

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/Cache.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/Cache.nonAndroid.kt
@@ -35,6 +35,15 @@ internal class ExpireAfterAccessCache<K, V>(
     internal val map = HashMap<K, V>()
     internal val accessTime = LinkedHashMap<K, Long>()
 
+    fun get(key: K): V? {
+        val value = map[key] ?: return null
+        val now = currentNanos()
+        accessTime.remove(key)
+        accessTime[key] = now
+        checkEvicted(now)
+        return value
+    }
+
     inline fun getOrPut(key: K, loader: (K) -> V): V {
         accessTime.remove(key)
         return map.getOrPut(key) {

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/font/SkiaFontLoader.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/font/SkiaFontLoader.nonAndroid.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.text.font.FontLoadingStrategy.Companion.OptionalLocal
 import androidx.compose.ui.text.platform.FontCache
 import androidx.compose.ui.text.platform.FontLoadResult
 import androidx.compose.ui.text.platform.PlatformFont
+import androidx.compose.ui.text.platform.cloneWithVariationSettings
+import org.jetbrains.skia.Typeface as SkTypeface
 
 /**
  * Skia-backed [PlatformTypefacesLoader]. ui-text adapts this into its internal `PlatformFontLoader`
@@ -34,7 +36,7 @@ internal class SkiaFontLoader(
     fontCacheProvider: () -> FontCache
 ) : PlatformTypefacesLoader {
 
-    constructor(fontCache: FontCache = FontCache()) : this (fontCacheProvider = { fontCache })
+    constructor(fontCache: FontCache = FontCache()) : this(fontCacheProvider = { fontCache })
 
     private val fontCache: FontCache by lazy(fontCacheProvider)
 
@@ -42,6 +44,13 @@ internal class SkiaFontLoader(
         get() = fontCache.fonts
 
     override fun loadBlocking(font: Font): FontLoadResult? {
+        if (font is SkikoFont) {
+            val unvaried = fontCache.get(font.baseCacheKey)
+                ?: font.typefaceLoader.loadBlocking(font)
+                ?: return null
+            return finishSkikoFont(font, unvaried)
+        }
+
         if (font !is PlatformFont) {
             if (font.loadingStrategy != OptionalLocal) {
                 throw IllegalArgumentException("Unsupported font type: $font")
@@ -66,13 +75,32 @@ internal class SkiaFontLoader(
     ): Any = fontCache.loadPlatformTypes(fontFamily, fontWeight, fontStyle)
 
     override suspend fun awaitLoad(font: Font): FontLoadResult? {
-        // TODO: This should actually do async loading, but for now desktop only supports local
-        //  fonts which are allowed to block during loading.
-
-        // When desktop is extended to allow async font resource declarations, this needs updated.
-        return loadBlocking(font)
+        return when (font) {
+            is SkikoFont -> {
+                val unvaried = fontCache.get(font.baseCacheKey)
+                    ?: font.typefaceLoader.awaitLoad(font)
+                    ?: return null
+                finishSkikoFont(font, unvaried)
+            }
+            // Built-in PlatformFont types remain blocking-only.
+            is PlatformFont -> loadBlocking(font)
+            else -> throw IllegalArgumentException("Unsupported font type: $font")
+        }
     }
 
     override val cacheKey: Any?
         get() = fontCache // results are valid for all shared caches
+
+    /**
+     * Two-Level cache for [SkikoFont]
+     * 1. Cache unvaried typeface under [SkikoFont.baseCacheKey]
+     * 2. Clone variation and cache it under [SkikoFont.cacheKey]
+     */
+    private fun finishSkikoFont(font: SkikoFont, unvaried: SkTypeface): FontLoadResult {
+        fontCache.put(font.baseCacheKey, unvaried)
+        return fontCache.register(
+            unvaried.cloneWithVariationSettings(font.variationSettings),
+            font.cacheKey,
+        )
+    }
 }

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/font/SkikoFont.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/font/SkikoFont.nonAndroid.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.font
+
+import org.jetbrains.skia.Typeface as SkTypeface
+
+/**
+ * Font for use on Skiko-based platforms (Desktop, iOS, macOS, Web).
+ *
+ * All [SkikoFont] produce an [org.jetbrains.skia.Typeface] which may be used to draw text.
+ * This is the main low-level API for introducing a new Font description to Compose on
+ * Skiko-based platforms for both blocking and async load.
+ *
+ * You may subclass this to add new types of font descriptions that may be used in
+ * [FontListFontFamily]. For example, you can add a [FontLoadingStrategy.Blocking] font that returns
+ * a Typeface from a local resource not supported by an existing [Font]. Or, you can create an
+ * [FontLoadingStrategy.Async] font that loads a font file from a server.
+ *
+ * Subclasses should implement [equals] and [hashCode] based on the values that uniquely identify
+ * the font (typically [identity], [weight], [style], [loadingStrategy], and [variationSettings]).
+ * Prefer globally unique [identity] values across all [SkikoFont] subclasses, because the internal
+ * registration key is shared under a common `SkikoFont|` prefix.
+ *
+ * @param loadingStrategy loading strategy this font will provide in fallback chains
+ * @param typefaceLoader a loader that knows how to load this [SkikoFont], may be shared between
+ *   several fonts
+ * @param variationSettings the settings that will be applied to this font, if supported by the font.
+ *   Defaults to empty settings. Prefer passing [FontVariation.Settings] built from [weight] and
+ *   [style] (for example `FontVariation.Settings(weight, style)`) when those axes should be applied
+ *   to variable fonts.
+ */
+abstract class SkikoFont(
+    final override val loadingStrategy: FontLoadingStrategy,
+    val typefaceLoader: TypefaceLoader,
+    /**
+     * The settings that will be applied to this font, if supported by the font.
+     *
+     * If the font does not support a [FontVariation.Setting], it has no effect.
+     *
+     * Unlike Android's AndroidFont, subclasses must **not** apply these settings themselves. The
+     * framework applies them after [TypefaceLoader] returns. Loaders should return an unvaried
+     * typeface.
+     */
+    val variationSettings: FontVariation.Settings = FontVariation.Settings()
+) : Font {
+
+    /**
+     * Unique identity for this font's source (file, URL, asset id, etc.).
+     *
+     * Used as the unvaried load cache key via [baseCacheKey]: fonts that share the same [identity]
+     * share one TypefaceLoader result. Use a distinct [identity] for each distinct font file;
+     * do not rely on [weight], [style], or [variationSettings] to select different sources.
+     *
+     * Also combined with [weight], [style], and [variationSettings] into [cacheKey] for
+     * font-collection registration / paragraph aliasing after variation is applied.
+     */
+    abstract val identity: String
+
+    /**
+     * Cache key for the unvaried typeface produced by [TypefaceLoader].
+     *
+     * Equal to `"SkikoFont|$identity"`. Weight, style, and variation settings are intentionally
+     * omitted so a single variable-font file can be loaded once and then cloned for different
+     * axes / matching metadata. [TypefaceLoader] implementations must select the source from
+     * [identity] (and any loader-private stable fields), not from weight, style, or variation.
+     */
+    internal val baseCacheKey: String
+        get() = "SkikoFont|$identity"
+
+    /**
+     * Registration / alias key for this font after variation settings are applied.
+     *
+     * Includes [baseCacheKey], [weight], [style], and [variationSettings] so different matching
+     * metadata and axis settings do not collide in the font collection.
+     */
+    internal val cacheKey: String
+        get() =
+            "$baseCacheKey|weight=${weight.weight}|style=$style|" +
+                "variationSettings=${variationSettings.settings}"
+
+    /**
+     * Loader for loading a [SkikoFont] and producing an [org.jetbrains.skia.Typeface].
+     *
+     * This interface is not intended to be used by application developers for text display. To load
+     * a typeface for display use [FontFamily.Resolver].
+     *
+     * [TypefaceLoader] allows the introduction of new types of font descriptors for use in
+     * [FontListFontFamily]. A [TypefaceLoader] allows a new subclass of [SkikoFont] to be used by
+     * normal compose text rendering methods.
+     *
+     * Examples of new types of fonts that [TypefaceLoader] can add:
+     * - [FontLoadingStrategy.Blocking] [Font] that loads Typeface from a local resource not
+     *   supported by an existing font
+     * - [FontLoadingStrategy.OptionalLocal] [Font] that "loads" a platform Typeface only available
+     *   on some platforms.
+     * - [FontLoadingStrategy.Async] [Font] that loads a font from a backend via a network request.
+     *
+     * During resolution from [FontFamily.Resolver], a [SkikoFont] subclass will be queried for
+     * an appropriate loader.
+     *
+     * The loader attached to an instance of a [SkikoFont] is only required to be able to load
+     * that instance, though it is advised to create one loader for all instances of the same
+     * subclass and share them between [SkikoFont] instances to avoid allocations or allow
+     * caching.
+     *
+     * Loaders should return an *unvaried* typeface: [FontVariation.Settings] from the [SkikoFont]
+     * are applied by the framework after loading completes.
+     *
+     * Select the font source from [SkikoFont.identity] (and loader-private fields). Do not branch
+     * on [SkikoFont.weight], [SkikoFont.style], or [SkikoFont.variationSettings] to pick different
+     * files; those are applied after load for matching and variation cloning.
+     */
+    interface TypefaceLoader {
+        /**
+         * Immediately load the font in a blocking manner such that it will be available this frame.
+         *
+         * This method will be called on a UI-critical thread, however it has been determined that
+         * this font is required for the current frame. This method is allowed to perform small
+         * amounts of I/O to load a font file from a local source.
+         *
+         * This method should never perform expensive I/O operations, such as loading from a remote
+         * source. If expensive operations are required to complete the font, this method may choose
+         * to throw. Note that this method will never be called for fonts with
+         * [FontLoadingStrategy.Async].
+         *
+         * It is possible for [loadBlocking] to be called for the same instance of [SkikoFont] in
+         * parallel. Implementations should support parallel concurrent loads, or de-dup.
+         *
+         * @param font the font to load which contains this loader as [SkikoFont.typefaceLoader]
+         * @return [org.jetbrains.skia.Typeface] for loaded font, or null if the font fails to load
+         */
+        fun loadBlocking(font: SkikoFont): SkTypeface?
+
+        /**
+         * Asynchronously load the font, from either local or remote sources such that it will cause
+         * text reflow when loading completes.
+         *
+         * This method will be called on a UI-critical thread, and should not block the thread for
+         * font loading from sources slower than the local filesystem. More expensive loads should
+         * dispatch to an appropriate thread.
+         *
+         * This method is always called in a timeout context and must return its final value within
+         * 15 seconds. If the Typeface is not resolved within 15 seconds, the async load is
+         * cancelled and considered a permanent failure. Implementations should use structured
+         * concurrency to cooperatively cancel work.
+         *
+         * Compose does not know what resources are required to satisfy a font load. Subclasses
+         * implementing [FontLoadingStrategy.Async] behavior should ensure requests are de-duped for
+         * the same resource.
+         *
+         * It is possible for [awaitLoad] to be called for the same instance of [SkikoFont] in
+         * parallel. Implementations should support parallel concurrent loads, or de-dup.
+         *
+         * @param font the font to load which contains this loader as [SkikoFont.typefaceLoader]
+         * @return [org.jetbrains.skia.Typeface] for loaded font, or null if not available
+         */
+        suspend fun awaitLoad(font: SkikoFont): SkTypeface?
+    }
+}

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/PlatformFont.nonAndroid.kt
@@ -170,7 +170,7 @@ private class SkiaBackedTypeface(
 /**
  * Returns a Compose [Typeface] from Skia [SkTypeface].
  *
- * @param typeface Android Typeface instance
+ * @param typeface Skia Typeface instance
  */
 fun Typeface(typeface: SkTypeface, alias: String? = null): Typeface {
     return SkiaBackedTypeface(alias, typeface)
@@ -229,6 +229,29 @@ internal class FontCache {
         }
         ensureRegistered(typeface, font.cacheKey)
         return FontLoadResult(typeface, listOf(font.cacheKey))
+    }
+
+    /** Cache lookup only — does not register with [FontCollection]. */
+    internal fun get(key: String): SkTypeface? = typefacesCache.get(key)
+
+    /**
+     * Cache put-if-absent only — does not register with [FontCollection].
+     *
+     * Used for unvaried [androidx.compose.ui.text.font.SkikoFont] faces shared across
+     * weight/style/variation clones (`baseCacheKey`).
+     */
+    internal fun put(key: String, typeface: SkTypeface): SkTypeface =
+        typefacesCache.getOrPut(key) { typeface }
+
+    /**
+     * Caches [typeface] under [key] and registers it with [FontCollection] as a paragraph alias.
+     *
+     * If [key] is already cached, the existing typeface is reused and [typeface] is ignored.
+     */
+    internal fun register(typeface: SkTypeface, key: String): FontLoadResult {
+        val cached = put(key, typeface)
+        ensureRegistered(cached, key)
+        return FontLoadResult(cached, listOf(key))
     }
 
     internal fun loadPlatformTypes(

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/font/SkiaFontLoaderSkikoFontTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/font/SkiaFontLoaderSkikoFontTest.kt
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.font
+
+import androidx.compose.ui.text.platform.FontLoadResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.test.IgnoreJsTarget
+import kotlinx.test.IgnoreWasmTarget
+import org.jetbrains.skia.Typeface as SkTypeface
+
+@IgnoreJsTarget
+@IgnoreWasmTarget
+class SkiaFontLoaderSkikoFontTest {
+
+    private val loader = SkiaFontLoader()
+
+    private fun createTestFont(
+        identity: String = "test-font",
+        weight: FontWeight = FontWeight.Normal,
+        style: FontStyle = FontStyle.Normal,
+        loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking,
+        typefaceLoader: SkikoFont.TypefaceLoader = BlockingTypefaceLoader(),
+        variationSettings: FontVariation.Settings = FontVariation.Settings()
+    ): TestSkikoFontImpl = TestSkikoFontImpl(
+        identity = identity,
+        weight = weight,
+        style = style,
+        loadingStrategy = loadingStrategy,
+        typefaceLoader = typefaceLoader,
+        variationSettings = variationSettings
+    )
+
+    // --- loadBlocking ---
+
+    @Test
+    fun loadBlocking_skikoFont_returnsNonNull() {
+        val font = createTestFont()
+        val result = loader.loadBlocking(font) as? FontLoadResult
+        assertNotNull(result)
+        assertNotNull(result.typeface)
+    }
+
+    @Test
+    fun loadBlocking_skikoFont_returnsNullWhenLoaderReturnsNull() {
+        val font = createTestFont(
+            typefaceLoader = object : SkikoFont.TypefaceLoader {
+                override fun loadBlocking(font: SkikoFont): SkTypeface? = null
+                override suspend fun awaitLoad(font: SkikoFont): SkTypeface? = null
+            }
+        )
+        val result = loader.loadBlocking(font)
+        assertNull(result)
+    }
+
+    @Test
+    fun loadBlocking_skikoFont_resultAliasesContainCacheKey() {
+        val font = createTestFont(identity = "my-font")
+        val result = loader.loadBlocking(font) as FontLoadResult
+        assertEquals(1, result.aliases.size)
+        assertEquals(font.cacheKey, result.aliases.first())
+    }
+
+    @Test
+    fun loadBlocking_skikoFont_cachedOnSecondCall() {
+        val font = createTestFont(identity = "cached-font")
+        val result1 = loader.loadBlocking(font) as FontLoadResult
+        val result2 = loader.loadBlocking(font) as FontLoadResult
+        assertSame(result1.typeface, result2.typeface)
+    }
+
+    @Test
+    fun loadBlocking_skikoFont_differentFontsProduceDifferentResults() {
+        val font1 = createTestFont(identity = "font-1")
+        val font2 = createTestFont(identity = "font-2")
+        val result1 = loader.loadBlocking(font1) as FontLoadResult
+        val result2 = loader.loadBlocking(font2) as FontLoadResult
+        assertEquals(
+            "SkikoFont|font-1|weight=400|style=Normal|variationSettings=[]",
+            result1.aliases.first()
+        )
+        assertEquals(
+            "SkikoFont|font-2|weight=400|style=Normal|variationSettings=[]",
+            result2.aliases.first()
+        )
+    }
+
+    @Test
+    fun loadBlocking_skikoFont_differentWeightsProduceDifferentCacheKeys() {
+        val font1 = createTestFont(identity = "font", weight = FontWeight.Normal)
+        val font2 = createTestFont(identity = "font", weight = FontWeight.Bold)
+        val result1 = loader.loadBlocking(font1) as FontLoadResult
+        val result2 = loader.loadBlocking(font2) as FontLoadResult
+        val alias1 = result1.aliases.first()
+        val alias2 = result2.aliases.first()
+        assertTrue(alias1.contains("weight=400"))
+        assertTrue(alias2.contains("weight=700"))
+    }
+
+    @Test
+    fun loadBlocking_skikoFont_withVariationSettings_returnsNonNull() {
+        val settings = FontVariation.Settings(FontVariation.Setting("wght", 600f))
+        val font = createTestFont(identity = "var-font", variationSettings = settings)
+        val result = loader.loadBlocking(font) as? FontLoadResult
+        assertNotNull(result)
+        assertNotNull(result.typeface)
+        assertEquals(font.cacheKey, result.aliases.first())
+    }
+
+    @Test
+    fun loadBlocking_sameBaseDifferentVariation_loadsUnvariedOnce() {
+        var loadCount = 0
+        val typefaceLoader = object : SkikoFont.TypefaceLoader {
+            override fun loadBlocking(font: SkikoFont): SkTypeface {
+                loadCount++
+                return SkTypeface.makeEmpty()
+            }
+
+            override suspend fun awaitLoad(font: SkikoFont): SkTypeface = SkTypeface.makeEmpty()
+        }
+        val fontA = createTestFont(
+            identity = "shared-base",
+            typefaceLoader = typefaceLoader,
+            variationSettings = FontVariation.Settings(FontVariation.Setting("wght", 400f)),
+        )
+        val fontB = createTestFont(
+            identity = "shared-base",
+            typefaceLoader = typefaceLoader,
+            variationSettings = FontVariation.Settings(FontVariation.Setting("wght", 700f)),
+        )
+        assertEquals(fontA.baseCacheKey, fontB.baseCacheKey)
+        val resultA = loader.loadBlocking(fontA) as FontLoadResult
+        val resultB = loader.loadBlocking(fontB) as FontLoadResult
+        assertEquals(1, loadCount)
+        assertEquals(fontA.cacheKey, resultA.aliases.first())
+        assertEquals(fontB.cacheKey, resultB.aliases.first())
+        assertNotEquals(resultA.aliases.first(), resultB.aliases.first())
+        assertNotNull(resultA.typeface)
+        assertNotNull(resultB.typeface)
+    }
+
+    @Test
+    fun loadBlocking_sameIdentityDifferentWeight_loadsUnvariedOnce() {
+        var loadCount = 0
+        val typefaceLoader = object : SkikoFont.TypefaceLoader {
+            override fun loadBlocking(font: SkikoFont): SkTypeface {
+                loadCount++
+                return SkTypeface.makeEmpty()
+            }
+
+            override suspend fun awaitLoad(font: SkikoFont): SkTypeface = SkTypeface.makeEmpty()
+        }
+        val regular = createTestFont(
+            identity = "variable-file",
+            weight = FontWeight.Normal,
+            typefaceLoader = typefaceLoader,
+        )
+        val bold = createTestFont(
+            identity = "variable-file",
+            weight = FontWeight.Bold,
+            typefaceLoader = typefaceLoader,
+        )
+        assertEquals(regular.baseCacheKey, bold.baseCacheKey)
+        loader.loadBlocking(regular)
+        loader.loadBlocking(bold)
+        assertEquals(1, loadCount)
+    }
+
+    @Test
+    fun awaitLoad_sameBaseDifferentVariation_loadsUnvariedOnce() {
+        runBlocking {
+            var loadCount = 0
+            val typefaceLoader = object : SkikoFont.TypefaceLoader {
+                override fun loadBlocking(font: SkikoFont): SkTypeface? =
+                    error("should not be called")
+
+                override suspend fun awaitLoad(font: SkikoFont): SkTypeface {
+                    loadCount++
+                    return SkTypeface.makeEmpty()
+                }
+            }
+            val fontA = createTestFont(
+                identity = "shared-base-async",
+                typefaceLoader = typefaceLoader,
+                variationSettings = FontVariation.Settings(FontVariation.Setting("wght", 400f)),
+            )
+            val fontB = createTestFont(
+                identity = "shared-base-async",
+                typefaceLoader = typefaceLoader,
+                variationSettings = FontVariation.Settings(FontVariation.Setting("wght", 700f)),
+            )
+            assertEquals(fontA.baseCacheKey, fontB.baseCacheKey)
+            val resultA = loader.awaitLoad(fontA) as FontLoadResult
+            val resultB = loader.awaitLoad(fontB) as FontLoadResult
+            assertEquals(1, loadCount)
+            assertEquals(fontA.cacheKey, resultA.aliases.first())
+            assertEquals(fontB.cacheKey, resultB.aliases.first())
+            assertNotNull(resultA.typeface)
+            assertNotNull(resultB.typeface)
+        }
+    }
+
+    @Test
+    fun loadBlocking_nullUnvaried_isNotCached() {
+        var loadCount = 0
+        val typefaceLoader = object : SkikoFont.TypefaceLoader {
+            override fun loadBlocking(font: SkikoFont): SkTypeface? {
+                loadCount++
+                return if (loadCount == 1) null else SkTypeface.makeEmpty()
+            }
+
+            override suspend fun awaitLoad(font: SkikoFont): SkTypeface? = null
+        }
+        val font = createTestFont(identity = "nullable-base", typefaceLoader = typefaceLoader)
+        assertNull(loader.loadBlocking(font))
+        val second = loader.loadBlocking(font) as? FontLoadResult
+        assertNotNull(second)
+        assertEquals(2, loadCount)
+    }
+
+    // --- awaitLoad ---
+
+    @Test
+    fun awaitLoad_skikoFont_returnsNonNull() {
+        runBlocking {
+            val font = createTestFont()
+            val result = loader.awaitLoad(font) as? FontLoadResult
+            assertNotNull(result)
+            assertNotNull(result.typeface)
+        }
+    }
+
+    @Test
+    fun awaitLoad_nullUnvaried_isNotCached() {
+        runBlocking {
+            var loadCount = 0
+            val typefaceLoader = object : SkikoFont.TypefaceLoader {
+                override fun loadBlocking(font: SkikoFont): SkTypeface? =
+                    error("should not be called")
+
+                override suspend fun awaitLoad(font: SkikoFont): SkTypeface? {
+                    loadCount++
+                    return if (loadCount == 1) null else SkTypeface.makeEmpty()
+                }
+            }
+            val font = createTestFont(
+                identity = "nullable-base-async",
+                typefaceLoader = typefaceLoader,
+            )
+            assertNull(loader.awaitLoad(font))
+            val second = loader.awaitLoad(font) as? FontLoadResult
+            assertNotNull(second)
+            assertEquals(2, loadCount)
+        }
+    }
+
+    @Test
+    fun awaitLoad_skikoFont_returnsNullWhenLoaderReturnsNull() {
+        runBlocking {
+            val font = createTestFont(
+                typefaceLoader = object : SkikoFont.TypefaceLoader {
+                    override fun loadBlocking(font: SkikoFont): SkTypeface? = null
+                    override suspend fun awaitLoad(font: SkikoFont): SkTypeface? = null
+                }
+            )
+            val result = loader.awaitLoad(font)
+            assertNull(result)
+        }
+    }
+
+    @Test
+    fun awaitLoad_skikoFont_resultAliasesContainCacheKey() {
+        runBlocking {
+            val font = createTestFont(identity = "async-font")
+            val result = loader.awaitLoad(font) as FontLoadResult
+            assertEquals(1, result.aliases.size)
+            assertEquals(font.cacheKey, result.aliases.first())
+        }
+    }
+
+    @Test
+    fun awaitLoad_skikoFont_usesAwaitLoadOfTypefaceLoader() {
+        runBlocking {
+            var awaitLoadCalled = false
+            val typefaceLoader = object : SkikoFont.TypefaceLoader {
+                override fun loadBlocking(font: SkikoFont): SkTypeface? =
+                    error("should not be called")
+
+                override suspend fun awaitLoad(font: SkikoFont): SkTypeface {
+                    awaitLoadCalled = true
+                    return SkTypeface.makeEmpty()
+                }
+            }
+            val font = createTestFont(typefaceLoader = typefaceLoader)
+            loader.awaitLoad(font)
+            assertTrue(
+                awaitLoadCalled,
+                "awaitLoad should call TypefaceLoader.awaitLoad, not loadBlocking"
+            )
+        }
+    }
+
+    @Test
+    fun awaitLoad_skikoFont_withVariationSettings_returnsNonNull() {
+        runBlocking {
+            val settings = FontVariation.Settings(FontVariation.Setting("wght", 600f))
+            val font = createTestFont(identity = "async-var-font", variationSettings = settings)
+            val result = loader.awaitLoad(font) as? FontLoadResult
+            assertNotNull(result)
+            assertNotNull(result.typeface)
+        }
+    }
+
+    @Test
+    fun awaitLoad_unknownFont_throws() {
+        runBlocking {
+            val font = object : Font {
+                override val weight: FontWeight = FontWeight.Normal
+                override val style: FontStyle = FontStyle.Normal
+                override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking
+            }
+            assertFailsWith<IllegalArgumentException> {
+                loader.awaitLoad(font)
+            }
+        }
+    }
+
+    @Test
+    fun loadBlocking_optionalLocalUnknownFont_returnsNull() {
+        val font = object : Font {
+            override val weight: FontWeight = FontWeight.Normal
+            override val style: FontStyle = FontStyle.Normal
+            override val loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.OptionalLocal
+        }
+        // loadBlocking path for OptionalLocal unknown fonts returns null without throwing.
+        assertNull(loader.loadBlocking(font))
+    }
+}
+
+private class TestSkikoFontImpl(
+    override val identity: String,
+    override val weight: FontWeight = FontWeight.Normal,
+    override val style: FontStyle = FontStyle.Normal,
+    loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking,
+    typefaceLoader: SkikoFont.TypefaceLoader = BlockingTypefaceLoader(),
+    variationSettings: FontVariation.Settings = FontVariation.Settings(),
+) : SkikoFont(loadingStrategy, typefaceLoader, variationSettings)
+
+private class BlockingTypefaceLoader : SkikoFont.TypefaceLoader {
+    override fun loadBlocking(font: SkikoFont): SkTypeface = SkTypeface.makeEmpty()
+    override suspend fun awaitLoad(font: SkikoFont): SkTypeface = SkTypeface.makeEmpty()
+}

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/font/SkikoFontTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/font/SkikoFontTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.font
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.jetbrains.skia.Typeface as SkTypeface
+
+private class TestSkikoFont(
+    override val identity: String,
+    override val weight: FontWeight = FontWeight.Normal,
+    override val style: FontStyle = FontStyle.Normal,
+    loadingStrategy: FontLoadingStrategy = FontLoadingStrategy.Blocking,
+    typefaceLoader: SkikoFont.TypefaceLoader = NoOpTypefaceLoader,
+    variationSettings: FontVariation.Settings = FontVariation.Settings()
+) : SkikoFont(loadingStrategy, typefaceLoader, variationSettings)
+
+private object NoOpTypefaceLoader : SkikoFont.TypefaceLoader {
+    override fun loadBlocking(font: SkikoFont): SkTypeface? = null
+    override suspend fun awaitLoad(font: SkikoFont): SkTypeface? = null
+}
+
+class SkikoFontTest {
+
+    @Test
+    fun baseCacheKey_isIdentityOnly() {
+        val settings = FontVariation.Settings(FontVariation.Setting("wght", 600f))
+        val bold = TestSkikoFont(
+            identity = "test-font",
+            weight = FontWeight.Bold,
+            style = FontStyle.Italic,
+            variationSettings = settings,
+        )
+        assertEquals("SkikoFont|test-font", bold.baseCacheKey)
+        assertTrue(
+            bold.cacheKey.startsWith(
+                "SkikoFont|test-font|weight=700|style=Italic|variationSettings="
+            )
+        )
+        assertTrue(bold.cacheKey.contains("wght"))
+        val normal = TestSkikoFont(identity = "test-font")
+        assertEquals(bold.baseCacheKey, normal.baseCacheKey)
+    }
+
+    @Test
+    fun baseCacheKey_sameIdentityDifferentWeight_shareBase() {
+        val normal = TestSkikoFont(identity = "vf", weight = FontWeight.Normal)
+        val bold = TestSkikoFont(identity = "vf", weight = FontWeight.Bold)
+        assertEquals(normal.baseCacheKey, bold.baseCacheKey)
+        assertNotEquals(normal.cacheKey, bold.cacheKey)
+    }
+
+    @Test
+    fun cacheKey_defaultWeightAndStyle() {
+        val font = TestSkikoFont(identity = "test-font")
+        assertEquals(
+            "SkikoFont|test-font|weight=400|style=Normal|variationSettings=[]",
+            font.cacheKey
+        )
+    }
+
+    @Test
+    fun cacheKey_boldWeight() {
+        val font = TestSkikoFont(identity = "bold-font", weight = FontWeight.Bold)
+        assertEquals(
+            "SkikoFont|bold-font|weight=700|style=Normal|variationSettings=[]",
+            font.cacheKey
+        )
+    }
+
+    @Test
+    fun cacheKey_italicStyle() {
+        val font = TestSkikoFont(identity = "italic-font", style = FontStyle.Italic)
+        assertEquals(
+            "SkikoFont|italic-font|weight=400|style=Italic|variationSettings=[]",
+            font.cacheKey
+        )
+    }
+
+    @Test
+    fun cacheKey_boldItalic() {
+        val font = TestSkikoFont(
+            identity = "bold-italic-font",
+            weight = FontWeight.Bold,
+            style = FontStyle.Italic,
+        )
+        assertEquals(
+            "SkikoFont|bold-italic-font|weight=700|style=Italic|variationSettings=[]",
+            font.cacheKey
+        )
+    }
+
+    @Test
+    fun cacheKey_withVariationSettings() {
+        val settings = FontVariation.Settings(
+            FontVariation.Setting("wght", 600f)
+        )
+        val font = TestSkikoFont(identity = "var-font", variationSettings = settings)
+        val key = font.cacheKey
+        assertTrue(key.startsWith("SkikoFont|var-font|weight=400|style=Normal|variationSettings="))
+        assertTrue(key.contains("wght"))
+    }
+
+    @Test
+    fun cacheKey_differentIdentities_produceDifferentKeys() {
+        val font1 = TestSkikoFont(identity = "font-a")
+        val font2 = TestSkikoFont(identity = "font-b")
+        assertNotEquals(font1.cacheKey, font2.cacheKey)
+    }
+
+    @Test
+    fun cacheKey_differentWeights_produceDifferentKeys() {
+        val font1 = TestSkikoFont(identity = "font", weight = FontWeight.Normal)
+        val font2 = TestSkikoFont(identity = "font", weight = FontWeight.Bold)
+        assertNotEquals(font1.cacheKey, font2.cacheKey)
+    }
+
+    @Test
+    fun cacheKey_differentStyles_produceDifferentKeys() {
+        val font1 = TestSkikoFont(identity = "font", style = FontStyle.Normal)
+        val font2 = TestSkikoFont(identity = "font", style = FontStyle.Italic)
+        assertNotEquals(font1.cacheKey, font2.cacheKey)
+    }
+
+    @Test
+    fun cacheKey_differentVariationSettings_produceDifferentKeys() {
+        val font1 = TestSkikoFont(
+            identity = "font",
+            variationSettings = FontVariation.Settings(FontVariation.Setting("wght", 400f)),
+        )
+        val font2 = TestSkikoFont(
+            identity = "font",
+            variationSettings = FontVariation.Settings(FontVariation.Setting("wght", 700f)),
+        )
+        assertNotEquals(font1.cacheKey, font2.cacheKey)
+    }
+
+    @Test
+    fun cacheKey_sameParameters_produceSameKey() {
+        val font1 = TestSkikoFont(
+            identity = "font",
+            weight = FontWeight.Bold,
+            style = FontStyle.Italic,
+        )
+        val font2 = TestSkikoFont(
+            identity = "font",
+            weight = FontWeight.Bold,
+            style = FontStyle.Italic,
+        )
+        assertEquals(font1.cacheKey, font2.cacheKey)
+    }
+
+    @Test
+    fun loadingStrategy_isPreserved() {
+        val blocking = TestSkikoFont(
+            identity = "font",
+            loadingStrategy = FontLoadingStrategy.Blocking,
+        )
+        assertEquals(FontLoadingStrategy.Blocking, blocking.loadingStrategy)
+
+        val async = TestSkikoFont(
+            identity = "font",
+            loadingStrategy = FontLoadingStrategy.Async,
+        )
+        assertEquals(FontLoadingStrategy.Async, async.loadingStrategy)
+
+        val optionalLocal = TestSkikoFont(
+            identity = "font",
+            loadingStrategy = FontLoadingStrategy.OptionalLocal,
+        )
+        assertEquals(FontLoadingStrategy.OptionalLocal, optionalLocal.loadingStrategy)
+    }
+
+    @Test
+    fun typefaceLoader_isPreserved() {
+        val loader = NoOpTypefaceLoader
+        val font = TestSkikoFont(identity = "font", typefaceLoader = loader)
+        assertSame(loader, font.typefaceLoader)
+    }
+
+    @Test
+    fun defaultVariationSettings_isEmpty() {
+        val font = TestSkikoFont(identity = "font")
+        assertTrue(font.variationSettings.settings.isEmpty())
+    }
+
+    @Test
+    fun variationSettings_isPreserved() {
+        val settings = FontVariation.Settings(
+            FontVariation.Setting("wght", 500f),
+            FontVariation.Setting("ital", 1f)
+        )
+        val font = TestSkikoFont(identity = "font", variationSettings = settings)
+        assertEquals(2, font.variationSettings.settings.size)
+        assertEquals("wght", font.variationSettings.settings[0].axisName)
+        assertEquals("ital", font.variationSettings.settings[1].axisName)
+    }
+}

--- a/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/platform/FontCacheRegisterTest.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidTest/kotlin/androidx/compose/ui/text/platform/FontCacheRegisterTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.text.platform
+
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.InternalTextApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlinx.test.IgnoreJsTarget
+import kotlinx.test.IgnoreWasmTarget
+import org.jetbrains.skia.FontStyle as SkFontStyle
+import org.jetbrains.skia.Typeface as SkTypeface
+
+@OptIn(ExperimentalTextApi::class, InternalTextApi::class)
+@IgnoreJsTarget
+@IgnoreWasmTarget
+class FontCacheRegisterTest {
+
+    @Test
+    fun register_returnsResultWithTypeface() {
+        val cache = FontCache()
+        val typeface = SkTypeface.makeEmpty()
+        val result = cache.register(typeface, "test-key")
+        assertNotNull(result.typeface)
+    }
+
+    @Test
+    fun register_returnsResultWithCorrectAlias() {
+        val cache = FontCache()
+        val typeface = SkTypeface.makeEmpty()
+        val result = cache.register(typeface, "my-unique-key")
+        assertEquals(1, result.aliases.size)
+        assertEquals("my-unique-key", result.aliases.first())
+    }
+
+    @Test
+    fun register_sameKey_reusesCachedTypeface() {
+        val cache = FontCache()
+        val typeface1 = SkTypeface.makeEmpty()
+        val typeface2 = SkTypeface.makeEmpty()
+
+        val result1 = cache.register(typeface1, "same-key")
+        val result2 = cache.register(typeface2, "same-key")
+
+        assertSame(result1.typeface, result2.typeface)
+    }
+
+    @Test
+    fun register_differentKeys_storesSeparateTypefaces() {
+        val cache = FontCache()
+        val typeface1 = SkTypeface.makeEmpty()
+        val typeface2 = SkTypeface.makeEmpty()
+
+        val result1 = cache.register(typeface1, "key-1")
+        val result2 = cache.register(typeface2, "key-2")
+
+        assertEquals("key-1", result1.aliases.first())
+        assertEquals("key-2", result2.aliases.first())
+    }
+
+    @Test
+    fun register_typefaceIsUsableInFontCollection() {
+        val cache = FontCache()
+        val typeface = SkTypeface.makeEmpty()
+        val key = "registered-font-key"
+
+        cache.register(typeface, key)
+
+        val found = cache.fonts.findTypefaces(arrayOf(key), SkFontStyle.NORMAL)
+        assertNotNull(found)
+        assertTrue(found.isNotEmpty(), "Registered typeface should be findable in FontCollection")
+    }
+
+    @Test
+    fun register_multipleCallsSameKey_onlyRegistersOnce() {
+        val cache = FontCache()
+        val typeface = SkTypeface.makeEmpty()
+        val key = "dedup-key"
+
+        val result1 = cache.register(typeface, key)
+        val result2 = cache.register(typeface, key)
+        val result3 = cache.register(typeface, key)
+
+        assertSame(result1.typeface, result2.typeface)
+        assertSame(result2.typeface, result3.typeface)
+    }
+
+    @Test
+    fun put_doesNotRegisterInFontCollection() {
+        val cache = FontCache()
+        val typeface = SkTypeface.makeEmpty()
+        val key = "unvaried-only-key"
+
+        val stored = cache.put(key, typeface)
+        assertSame(typeface, stored)
+        assertSame(typeface, cache.get(key))
+
+        // Default font managers may still resolve *some* face for an unknown family name, so
+        // assert our exact instance is not registered under the unvaried key.
+        val found = cache.fonts.findTypefaces(arrayOf(key), SkFontStyle.NORMAL)
+        val registeredOurFace = found?.any { it === typeface } == true
+        assertTrue(
+            !registeredOurFace,
+            "put() must not register the typeface in FontCollection"
+        )
+    }
+
+    @Test
+    fun get_returnsNullWhenMissing() {
+        val cache = FontCache()
+        assertNull(cache.get("missing"))
+    }
+
+    @Test
+    fun put_sameKey_reusesCachedTypeface() {
+        val cache = FontCache()
+        val typeface1 = SkTypeface.makeEmpty()
+        val typeface2 = SkTypeface.makeEmpty()
+        assertSame(typeface1, cache.put("k", typeface1))
+        assertSame(typeface1, cache.put("k", typeface2))
+        assertSame(typeface1, cache.get("k"))
+    }
+}

--- a/gradle/libs-fork.versions.toml
+++ b/gradle/libs-fork.versions.toml
@@ -79,6 +79,7 @@ paparazzi = "1.0.0"
 paparazziNative = "2022.1.1-canary-f5f9f71"
 shadow = "8.1.1"
 skiko = "0.151.0-alpha05"
+ktor = "3.4.0"
 spdxGradlePlugin = "0.6.0"
 sqldelight = "1.3.0"
 retrofit = "2.12.0"
@@ -305,6 +306,10 @@ skikoAwtRuntime = { module = "org.jetbrains.skiko:skiko-awt-runtime-all", versio
 skikoWasmJs = { module = "org.jetbrains.skiko:skiko-wasm-js", version.ref = "skiko" }
 skiko-skottie = { module = "org.jetbrains.skiko:skiko-skottie", version.ref = "skiko" }
 skikoSkottieAwtRuntime = { module = "org.jetbrains.skiko:skiko-skottie-awt-runtime-all", version.ref = "skiko" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 spdxGradlePluginz = { module = "org.spdx:spdx-gradle-plugin", version.ref = "spdxGradlePlugin" }
 sqldelightAndroid = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelightCoroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqldelight" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ paparazzi = "1.0.0"
 paparazziNative = "2022.1.1-canary-f5f9f71"
 shadow = "8.1.1"
 skiko = "0.150.1"
+ktor = "3.4.0"
 spdxGradlePlugin = "0.6.0"
 sqldelight = "1.3.0"
 retrofit = "2.12.0"
@@ -303,6 +304,10 @@ skikoAwtRuntimeLinuxX64 = { module = "org.jetbrains.skiko:skiko-awt-runtime-linu
 skikoAwtRuntimeLinuxArm64 = { module = "org.jetbrains.skiko:skiko-awt-runtime-linux-arm64", version.ref = "skiko" }
 skikoJsWasmRuntime = { module = "org.jetbrains.skiko:skiko-js-wasm-runtime", version.ref = "skiko" }
 skikoWasmJs = { module = "org.jetbrains.skiko:skiko-wasm-js", version.ref = "skiko" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 spdxGradlePluginz = { module = "org.spdx:spdx-gradle-plugin", version.ref = "spdxGradlePlugin" }
 sqldelightAndroid = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelightCoroutinesExt = { module = "com.squareup.sqldelight:coroutines-extensions", version.ref = "sqldelight" }


### PR DESCRIPTION
Previously, Skiko-based platforms lacked a public API for async font loading. While `PlatformFont` serves as the low-level font representation, it is not designed for extensibility by developers. By introducing `SkikoFont`, we provide a mechanism similar to `AndroidFont` on Android, allowing developers to:

- Load fonts asynchronously from remote sources (e.g., CDN, network)
- Implement custom font loading strategies
- Display fallback fonts during loading, with automatic text reflow when fonts arrive

Fixes [CMP-8231](https://youtrack.jetbrains.com/issue/CMP-8231) Async font loading support for iOS targets


## Testing
This should be tested by QA, but because the SkiaParagraphIntrinsics-related items lack a listener for TypefaceResult.Async, you need to resize the window so that the text can reflow and display correctly.
(If #2789 is merged, it will automatically display after loading, with no further action required.)

## Release Notes
### Features - Multiple Platforms
- Added a new SkikoFont abstract class to enable developers to implement asynchronously loaded fonts.
