### PR TITLE
Track stale resolved fonts in SkiaParagraphIntrinsics

### DIFF
--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/ParagraphLayouter.nonAndroid.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.text.platform
 
 import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.runtime.State
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.isUnspecified
 import androidx.compose.ui.graphics.BlendMode
@@ -71,7 +72,8 @@ internal class ParagraphLayouter(
     placeholders: List<AnnotatedString.Range<Placeholder>>,
     density: Density,
     fontFamilyResolver: FontFamily.Resolver,
-    private val onFontStale: () -> Unit
+    private val onFontStale: () -> Unit,
+    onFontResolved: ((State<Any>) -> Unit)? = null,
 ) {
     private val builder = ParagraphBuilder(
         fontFamilyResolver = fontFamilyResolver,
@@ -80,7 +82,8 @@ internal class ParagraphLayouter(
         annotations = annotations,
         placeholders = placeholders,
         density = density,
-        textDirection = textDirection
+        textDirection = textDirection,
+        onFontResolved = onFontResolved,
     )
     private var paragraphCache: SkParagraph? = null
     private var updateForeground = false

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphBuilder.nonAndroid.kt
@@ -18,6 +18,7 @@
 
 package androidx.compose.ui.text.platform
 
+import androidx.compose.runtime.State
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
@@ -380,7 +381,8 @@ internal class ParagraphBuilder(
     val density: Density,
     val textDirection: ResolvedTextDirection,
     var drawStyle: DrawStyle? = null,
-    var blendMode: BlendMode = DrawScope.DefaultBlendMode
+    var blendMode: BlendMode = DrawScope.DefaultBlendMode,
+    val onFontResolved: ((State<Any>) -> Unit)? = null,
 ) {
     private var defaultStyle = ComputedStyle.Immutable()
     private lateinit var initialStyle: SpanStyle
@@ -451,7 +453,9 @@ internal class ParagraphBuilder(
                         op.style.fontWeight ?: FontWeight.Normal,
                         op.style.fontStyle ?: FontStyle.Normal,
                         op.style.fontSynthesis ?: FontSynthesis.All
-                    )
+                    ).let { resolveResult ->
+                        onFontResolved?.invoke(resolveResult)
+                    }
 
                     // It's always mutable at this point, so we can safely cast
                     val style = (op.style as ComputedStyle.Mutable).toImmutable()

--- a/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphIntrinsics.nonAndroid.kt
+++ b/compose/ui/ui-skiko/src/nonAndroidMain/kotlin/androidx/compose/ui/text/platform/SkikoParagraphIntrinsics.nonAndroid.kt
@@ -17,6 +17,7 @@
  */
 package androidx.compose.ui.text.platform
 
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -45,11 +46,16 @@ internal class SkikoParagraphIntrinsics(
     private val density: Density,
     private val fontFamilyResolver: FontFamily.Resolver
 ) : ParagraphIntrinsics {
+    private var resolvedTypefaces: TypefaceDirtyTrackerLinkedList? = null
+
     val textDirection = resolveTextDirection(text, style.textDirection, style.localeList)
 
     //we need to track it reactively to invalidate the UI
-    override var hasStaleResolvedFonts: Boolean by mutableStateOf(false)
-        private set
+    // Async typeface updates are tracked separately via [resolvedTypefaces].
+    private var hasUnresolvedFontStale by mutableStateOf(false)
+
+    override val hasStaleResolvedFonts: Boolean
+        get() = hasUnresolvedFontStale || (resolvedTypefaces?.isStaleResolvedFont ?: false)
 
     private var layouter: ParagraphLayouter? = newLayouter()
 
@@ -67,7 +73,10 @@ internal class SkikoParagraphIntrinsics(
         placeholders = placeholders,
         density = density,
         fontFamilyResolver = fontFamilyResolver,
-        onFontStale = { hasStaleResolvedFonts = true }
+        onFontStale = { hasUnresolvedFontStale = true },
+        onFontResolved = { state ->
+            resolvedTypefaces = TypefaceDirtyTrackerLinkedList(state, resolvedTypefaces)
+        },
     )
 
     override var minIntrinsicWidth = 0f
@@ -80,6 +89,16 @@ internal class SkikoParagraphIntrinsics(
         minIntrinsicWidth = ceil(para.minIntrinsicWidth)
         maxIntrinsicWidth = ceil(para.maxIntrinsicWidth)
     }
+}
+
+private class TypefaceDirtyTrackerLinkedList(
+    private val resolveResult: State<Any>,
+    private val next: TypefaceDirtyTrackerLinkedList? = null,
+) {
+    private val initial = resolveResult.value
+
+    val isStaleResolvedFont: Boolean
+        get() = resolveResult.value !== initial || (next?.isStaleResolvedFont == true)
 }
 
 internal fun resolveTextDirection(


### PR DESCRIPTION
This PR improves stale font detection in Skiko text layout by tracking non-immutable font resolution states.

- Adds an optional `onFontResolved` callback path from `ParagraphLayouter` to `ParagraphBuilder`.
- Reports non-immutable typeface resolution results during style conversion and span pre-resolution.
- Tracks resolved typeface states in `SkiaParagraphIntrinsics` and implements `hasStaleResolvedFonts` to detect when previously resolved fonts become stale.

Fixes [CMP-8231](https://youtrack.jetbrains.com/issue/CMP-8231) Async font loading support for iOS targets

## Release Notes
### Fixes - Multiple Platforms
- Detect stale resolved fonts in Skia paragraph intrinsics to better handle async font resolution updates.
  - Propagate font resolution callbacks through paragraph building and layout layers.

