### PR TITLE
Make canvas focused when Compose handles pointer events

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -114,6 +114,7 @@ import org.w3c.dom.Touch
 import org.w3c.dom.TouchEvent
 import org.w3c.dom.asList
 import org.w3c.dom.events.Event
+import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
@@ -364,6 +365,8 @@ internal class ComposeWindow(
 
     private val isMacOS = hostOs.isMacOS
 
+    private var canvasFocused = false
+
     private fun processClipKeyDown(keyEvent: KeyEvent) {
         val mod = if (isMacOS) keyEvent.isMetaPressed else keyEvent.isCtrlPressed
         if (!mod) return
@@ -436,6 +439,14 @@ internal class ComposeWindow(
 
         addTypedEvent<KeyboardEvent>("keyup") { event ->
             processKeyboardEvent(event)
+        }
+
+        addTypedEvent<FocusEvent>("focus") { event ->
+            canvasFocused = true
+        }
+
+        addTypedEvent<FocusEvent>("blur") { event ->
+            canvasFocused = false
         }
 
         state.globalEvents.addDisposableEvent("focus") {
@@ -635,6 +646,12 @@ internal class ComposeWindow(
 
         if (result.anyChangeConsumed && event.cancelable) {
             event.preventDefault()
+
+            // Since we call preventDefault, the browser will not focus the canvas automatically,
+            // but it should be focused to receive key events
+            if (!canvasFocused && eventType == PointerEventType.Press) {
+                canvas.focus()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-9797

In https://github.com/JetBrains/compose-multiplatform-core/commit/8d814d7340fb7fdb701c016b74c2330e1553cc4b we started to `preventDefault` mouse events processed by Compose.  `preventDefault` prevents a browser from focusing the canvas - that's why ESC stopped working.

Fixes https://youtrack.jetbrains.com/issue/CMP-9797/Web-Dialogs-Popups-dont-close-on-the-first-attempt-when-pressing-Esc

## Testing
This should be tested by QA

## Release Notes
### Fixes - Web
- _(prerelease fix)_  Make canvas focused so it receives key events (e.g. ESC)

