### PR TITLE
Fix tooltip hiding condition in `TooltipArea`

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/TooltipArea.desktop.kt
@@ -18,11 +18,13 @@ package androidx.compose.foundation
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
@@ -45,6 +47,7 @@ import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
 import androidx.compose.ui.window.rememberComponentRectPositionProvider
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -105,25 +108,26 @@ fun TooltipArea(
     var cursorPosition by remember { mutableStateOf(Offset.Zero) }
     var isVisible by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
-    var job: Job? by remember { mutableStateOf(null) }
+    var showTooltipJob: Job? by remember { mutableStateOf(null) }
 
     fun startShowing() {
-        if (job?.isActive == true) {  // Don't restart the job if it's already active
+        if (showTooltipJob?.isActive == true) {  // Don't restart the job if it's already active
             return
         }
-        job = scope.launch {
+        showTooltipJob = scope.launch {
             delay(delayMillis.toLong())
             isVisible = true
         }
     }
 
     fun hide() {
-        job?.cancel()
-        job = null
+        showTooltipJob?.cancel()
+        showTooltipJob = null
         isVisible = false
     }
 
     fun hideIfNotHovered(localBounds: LayoutBoundsHolder, localPointerPosition: Offset) {
+        if (!isVisible) return
         val offsetInRoot = localBounds.bounds?.positionInRoot ?: return
         val pointerPositionInRoot = offsetInRoot + localPointerPosition.round()
         val parentBoundsInRoot = parentBounds.bounds?.boundsInRoot ?: return
@@ -132,10 +136,30 @@ fun TooltipArea(
         }
     }
 
+    var tooltipHidingScheduled by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) {
+        snapshotFlow { tooltipHidingScheduled }
+            .collectLatest {
+                if (tooltipHidingScheduled) {
+                    hide()
+                    tooltipHidingScheduled = false
+                }
+            }
+    }
+    fun scheduleCancelableHiding() {
+        // Set `tooltipHidingScheduled = true` even if the tooltip is not showing, because it may
+        // already be scheduled to be shown later (and hide() will cancel that job).
+        tooltipHidingScheduled = true
+    }
+    fun cancelScheduledHiding() {
+        tooltipHidingScheduled = false
+    }
+
     Box(
         modifier = modifier
             .layoutBounds(parentBounds)
             .onPointerEvent(PointerEventType.Enter) {
+                cancelScheduledHiding()
                 cursorPosition = it.position
                 if (!isVisible && !it.buttons.areAnyPressed) {
                     startShowing()
@@ -148,7 +172,7 @@ fun TooltipArea(
                 }
             }
             .onPointerEvent(PointerEventType.Exit) {
-                hideIfNotHovered(parentBounds, it.position)
+                scheduleCancelableHiding()
             }
             .onPointerEvent(PointerEventType.Press, pass = PointerEventPass.Initial) {
                 hide()
@@ -165,11 +189,15 @@ fun TooltipArea(
                 Box(
                     Modifier
                         .layoutBounds(popupLayoutBounds)
+                        .onPointerEvent(PointerEventType.Enter) {
+                            cancelScheduledHiding()
+                        }
                         .onPointerEvent(PointerEventType.Move) {
+                            // The pointer could be moving outside the area while inside the tooltip
                             hideIfNotHovered(popupLayoutBounds, it.position)
                         }
                         .onPointerEvent(PointerEventType.Exit) {
-                            hideIfNotHovered(popupLayoutBounds, it.position)
+                            scheduleCancelableHiding()
                         }
                 ) {
                     tooltip()

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -20,17 +20,27 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.test.MainTestClock
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import kotlin.test.assertFalse
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Test
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class)
@@ -38,17 +48,17 @@ internal class TooltipAreaTest {
 
     // https://github.com/JetBrains/compose-jb/issues/2821
     @Test
-    fun `simple tooltip is shown`() = runComposeUiTest {
+    fun simpleTooltipIsShown() = runComposeUiTest {
         setContent {
             SimpleTooltipArea()
         }
 
         onNodeWithTag("tooltip").assertDoesNotExist()
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
-        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
+        mainClock.advanceTimeToAfterTooltipDelay()
         onNodeWithTag("tooltip").assertExists()
     }
 
@@ -61,13 +71,13 @@ internal class TooltipAreaTest {
             SimpleTooltipArea()
         }
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
-        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
+        mainClock.advanceTimeToAfterTooltipDelay()
         onNodeWithTag("tooltip").assertExists()
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             press()
         }
         onNodeWithTag("tooltip").assertDoesNotExist()
@@ -82,13 +92,13 @@ internal class TooltipAreaTest {
             SimpleTooltipArea()
         }
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
-        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
+        mainClock.advanceTimeToAfterTooltipDelay()
         onNodeWithTag("tooltip").assertExists()
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(150f, 150f))
         }
         onNodeWithTag("tooltip").assertDoesNotExist()
@@ -99,7 +109,7 @@ internal class TooltipAreaTest {
      * still also inside the tooltip.
      */
     @Test
-    fun tooltipNotHiddenOnMoveIntoTooltip() = runComposeUiTest {
+    fun tooltipNotHiddenOnMoveIntoTooltip() = runComposeUiTestWithStandardTestDispatcher {
         var tooltipHidden = false
         setContent {
             TooltipArea(
@@ -107,7 +117,6 @@ internal class TooltipAreaTest {
                     Box(Modifier.size(100.dp).testTag("tooltip"))
                     DisposableEffect(Unit) {
                         onDispose {
-                            println("Tooltip disposed")
                             tooltipHidden = true
                         }
                     }
@@ -116,15 +125,15 @@ internal class TooltipAreaTest {
                     offset = DpOffset(x = 0.dp, y = 10.dp)
                 ),
             ) {
-                Box(Modifier.size(100.dp).testTag("elementWithTooltip"))
+                Box(Modifier.size(100.dp).testTag("tooltipArea"))
             }
         }
 
         // Move into the tooltip area
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
-        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
+        mainClock.advanceTimeToAfterTooltipDelay()
 
         // Move into the tooltip, but still inside the area
         onNodeWithTag("tooltip").let {
@@ -160,7 +169,7 @@ internal class TooltipAreaTest {
             SimpleTooltipArea(delayMillis = 200)
         }
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
         mainClock.advanceTimeBy(100)
@@ -178,38 +187,231 @@ internal class TooltipAreaTest {
             SimpleTooltipArea()
         }
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             moveTo(Offset(30f, 40f))
         }
-        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
+        mainClock.advanceTimeToAfterTooltipDelay()
         onNodeWithTag("tooltip").assertExists()
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             press()
         }
         onNodeWithTag("tooltip").assertDoesNotExist()
 
-        onNodeWithTag("elementWithTooltip").performMouseInput {
+        onNodeWithTag("tooltipArea").performMouseInput {
             release()
             moveBy(Offset(10f, 10f))
         }
-        mainClock.advanceTimeBy(TooltipDelayMillis + 1L)
+        mainClock.advanceTimeToAfterTooltipDelay()
         onNodeWithTag("tooltip").assertExists()
+    }
+
+    /**
+     * Verify that the tooltip is hidden on exit, even if the pointer is "inside" the tooltip area.
+     */
+    @Test
+    fun tooltipHiddenOnExitEvenIfPointerInside() = runComposeUiTest {
+        setContent {
+            SimpleTooltipArea()
+        }
+
+        onNodeWithTag("tooltipArea").performMouseInput {
+            moveTo(Offset(1f, 1f))
+        }
+        mainClock.advanceTimeToAfterTooltipDelay()
+        onNodeWithTag("tooltip").assertExists()
+
+        onNodeWithTag("tooltipArea").performMouseInput {
+            exit(Offset(0f, 0f))
+        }
+        onNodeWithTag("tooltip").assertDoesNotExist()
+    }
+
+    /**
+     * Verify that the tooltip is hidden when the pointer exits into an overlapping element.
+     */
+    @Test
+    fun tooltipHiddenOnExitIntoOverlappingElement() = runComposeUiTest {
+        setContent {
+            Box(Modifier.size(100.dp)) {
+                SimpleTooltipArea()
+                Box(Modifier.size(50.dp).align(Alignment.BottomEnd).pointerInput(Unit) {})
+            }
+        }
+
+        onNodeWithTag("tooltipArea").performMouseInput {
+            moveTo(Offset(1f, 1f))
+        }
+        mainClock.advanceTimeToAfterTooltipDelay()
+        onNodeWithTag("tooltip").assertExists()
+
+        onNodeWithTag("tooltipArea").performMouseInput {
+            moveTo(Offset(75f, 75f))
+        }
+        onNodeWithTag("tooltip").assertDoesNotExist()
+    }
+
+    /**
+     * Verify that the tooltip is hidden on exit from the tooltip, even if the pointer is "inside"
+     * the tooltip area, and the tooltip area itself didn't receive an "enter" event.
+     */
+    @Test
+    fun tooltipHiddenOnExitFromTooltipEvenIfPointerInsideTooltipAreaWithoutEnterEvent() =
+        runComposeUiTestWithStandardTestDispatcher() {
+            setContent {
+                SimpleTooltipArea(
+                    tooltipPlacement = TooltipPlacement.ComponentRect(
+                        anchor = Alignment.TopStart,
+                        alignment = Alignment.BottomEnd,
+                    )
+                )
+            }
+
+            onNodeWithTag("tooltipArea").performMouseInput {
+                moveTo(Offset(50f, 50f))
+            }
+            mainClock.advanceTimeToAfterTooltipDelay()
+            onNodeWithTag("tooltip").assertExists()
+
+            onNodeWithTag("tooltip").performMouseInput {
+                moveTo(Offset(1f, 1f))
+            }
+            onNodeWithTag("tooltip").assertExists()
+
+            onNodeWithTag("tooltip").performMouseInput {
+                exit(Offset(0f, 0f))
+            }
+            onNodeWithTag("tooltip").assertDoesNotExist()
+        }
+
+    /**
+     * Verify that the tooltip is not hidden on exit from the tooltip if the pointer is "inside"
+     * the tooltip area and the area itself receives an "enter" event.
+     */
+    @Test
+    fun tooltipNotHiddenOnExitFromTooltipIfPointerInsideTooltipAreaAndReceivedEnterEvent() =
+        runComposeUiTestWithStandardTestDispatcher {
+            setContent {
+                SimpleTooltipArea(
+                    tooltipPlacement = TooltipPlacement.ComponentRect(
+                        anchor = Alignment.TopStart,
+                        alignment = Alignment.BottomEnd,
+                    )
+                )
+            }
+
+            onNodeWithTag("tooltipArea").performMouseInput {
+                moveTo(Offset(50f, 50f))
+            }
+            mainClock.advanceTimeToAfterTooltipDelay()
+            onNodeWithTag("tooltip").assertExists()
+
+            onNodeWithTag("tooltip").performMouseInput {
+                moveTo(Offset(1f, 1f))
+            }
+            onNodeWithTag("tooltip").assertExists()
+
+            onNodeWithTag("tooltip").performMouseInput {
+                moveTo(Offset(width + 1f, height.toFloat()))
+            }
+            onNodeWithTag("tooltip").assertExists()
+        }
+
+    /**
+     * Verify that the tooltip is hidden when the pointer is moved inside the tooltip, but outside
+     * the tooltip area.
+     */
+    @Test
+    fun tooltipHiddenOnExitFromTooltipAreaBoundsWhileInsideTooltip() =
+        runComposeUiTestWithStandardTestDispatcher {
+            setContent {
+                Box(Modifier.size(200.dp)) {
+                    SimpleTooltipArea(
+                        tooltipPlacement = TooltipPlacement.ComponentRect(
+                            anchor = Alignment.TopEnd,
+                            alignment = Alignment.TopStart,
+                            offset = DpOffset(x = 10.dp, y = 0.dp)
+                        )
+                    )
+                }
+            }
+
+            onNodeWithTag("tooltipArea").performMouseInput {
+                moveTo(Offset(50f, 50f))
+            }
+            mainClock.advanceTimeToAfterTooltipDelay()
+            onNodeWithTag("tooltip").assertExists()
+
+            // Move into the tooltip while still inside the tooltip area
+            onNodeWithTag("tooltip").performMouseInput {
+                moveTo(Offset(1f, 1f))
+            }
+            onNodeWithTag("tooltip").assertExists()
+
+            // Move inside the tooltip but outside the bounds of the tooltip area
+            onNodeWithTag("tooltip").performMouseInput {
+                moveTo(Offset(15f, 1f))
+            }
+            onNodeWithTag("tooltip").assertDoesNotExist()
+        }
+
+    /**
+     * Verify that the tooltip is hidden when the pointer is moved inside the area and then outside
+     * before the tooltip is actually shown.
+     */
+    @Test
+    fun tooltipHiddenOnExitFromTooltipAreaBeforeTooltipIsShown() =
+        runComposeUiTestWithStandardTestDispatcher {
+            setContent {
+                Box(Modifier.size(200.dp)) {
+                    SimpleTooltipArea(
+                        tooltipPlacement = TooltipPlacement.ComponentRect(
+                            anchor = Alignment.Center,
+                            alignment = Alignment.Center,
+                        )
+                    )
+                }
+            }
+
+            // Move into the tooltip area
+            onNodeWithTag("tooltipArea").performMouseInput {
+                moveTo(Offset(50f, 50f))
+            }
+            // Move outside the tooltip area without waiting
+            onNodeWithTag("tooltipArea").performMouseInput {
+                exit(Offset(0f, 0f))
+            }
+            mainClock.advanceTimeToAfterTooltipDelay()
+            onNodeWithTag("tooltip").assertDoesNotExist()
+        }
+
+    private fun MainTestClock.advanceTimeToAfterTooltipDelay() =
+        advanceTimeBy(TooltipDelayMillis + 1L)
+
+    @OptIn(InternalComposeUiApi::class, InternalTestApi::class)
+    private fun runComposeUiTestWithStandardTestDispatcher(
+        block: suspend ComposeUiTest.() -> Unit
+    ) = runInternalSkikoComposeUiTest(coroutineDispatcher = StandardTestDispatcher()) {
+        block()
     }
 
     @Composable
     private fun SimpleTooltipArea(
         areaSize: Dp = 100.dp,
         tooltipSize: Dp = 20.dp,
-        delayMillis: Int = TooltipDelayMillis
+        delayMillis: Int = TooltipDelayMillis,
+        tooltipPlacement: TooltipPlacement = TooltipPlacement.CursorPoint(
+            offset = DpOffset(0.dp, 16.dp)
+        )
     ) {
         TooltipArea(
             tooltip = {
                 Box(Modifier.size(tooltipSize).testTag("tooltip"))
             },
-            delayMillis = delayMillis
+            delayMillis = delayMillis,
+            tooltipPlacement = tooltipPlacement
         ) {
-            Box(Modifier.size(areaSize).testTag("elementWithTooltip"))
+            Box(Modifier.size(areaSize).testTag("tooltipArea"))
         }
     }
 }


### PR DESCRIPTION
`TooltipArea` currently attempts to detect the pointer exiting "into the tooltip" (to avoid hiding the tooltip in this case) by checking whether the location of the pointer is inside the `TooltipArea`. This is wrong, however, because:
1. There could be a real exit event (not into the tooltip) while the pointer is still inside the bounds of the tooltip area. For example, when exiting through the left edge, the exit event could be at x=0.
2. The pointer could exit into another, overlapping, element. Here too, the tooltip should be hidden even though the pointer is inside the bounds of the tooltip area.

Fixes https://youtrack.jetbrains.com/issue/CMP-8739

## Testing
Tested manually and added several unit tests.
```
@OptIn(ExperimentalComposeUiApi::class)
fun main() = singleWindowApplication {
    Box(Modifier.size(200.dp)) {
        BoxWithTooltip(text = "Red", color = Color.Red, Modifier.size(150.dp))
        BoxWithTooltip(text = "Blue", color = Color.Blue, Modifier.align(Alignment.BottomEnd).size(150.dp))
    }
}

@OptIn(ExperimentalFoundationApi::class)
@Composable
fun BoxWithTooltip(
    text: String,
    color: Color,
    modifier: Modifier = Modifier,
    content: @Composable BoxScope.() -> Unit = {}
) {
    TooltipArea(
        tooltip = { Text(text, Modifier.background(Color.White).border(1.dp, Color.Black).padding(8.dp)) },
        modifier = modifier
    ) {
        Box(modifier = Modifier.fillMaxSize().background(color)) {
            content()
        }
    }
}
```

## Release Notes
### Fixes - Desktop
- Fix the condition for hiding the tooltip in a `TooltipArea` on a pointer-exit event while the pointer is still inside the area.
