### PR TITLE
Use the new numpad keys

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
@@ -81,12 +81,12 @@ internal fun DefaultOpenContextMenu(
         onKeyEvent = {
             if (it.type == KeyEventType.KeyDown) {
                 when (it.key) {
-                    Key.DirectionDown  -> {
+                    Key.DirectionDown, Key.NumPadDirectionUp  -> {
                         inputModeManager!!.requestInputMode(InputMode.Keyboard)
                         focusManager!!.moveFocus(FocusDirection.Next)
                         true
                     }
-                    Key.DirectionUp -> {
+                    Key.DirectionUp, Key.NumPadDirectionDown -> {
                         inputModeManager!!.requestInputMode(InputMode.Keyboard)
                         focusManager!!.moveFocus(FocusDirection.Previous)
                         true

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
@@ -29,8 +29,10 @@ internal object defaultSkikoKeyMapping : KeyMapping {
         return when {
             event.isCtrlPressed && event.isShiftPressed -> {
                 when (event.key) {
-                    Key.MoveHome -> KeyCommand.SELECT_HOME
-                    Key.MoveEnd -> KeyCommand.SELECT_END
+                    Key.MoveHome,
+                    Key.NumPadMoveHome -> KeyCommand.SELECT_HOME
+                    Key.MoveEnd,
+                    Key.NumPadMoveEnd -> KeyCommand.SELECT_END
                     else -> null
                 }
             }
@@ -52,28 +54,40 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
 
                 event.isShiftPressed && event.isAltPressed ->
                     when (event.key) {
-                        Key.DirectionLeft -> KeyCommand.SELECT_LEFT_WORD
-                        Key.DirectionRight -> KeyCommand.SELECT_RIGHT_WORD
-                        Key.DirectionUp -> KeyCommand.SELECT_PREV_PARAGRAPH
-                        Key.DirectionDown -> KeyCommand.SELECT_NEXT_PARAGRAPH
+                        Key.DirectionLeft,
+                        Key.NumPadDirectionLeft -> KeyCommand.SELECT_LEFT_WORD
+                        Key.DirectionRight,
+                        Key.NumPadDirectionRight -> KeyCommand.SELECT_RIGHT_WORD
+                        Key.DirectionUp,
+                        Key.NumPadDirectionUp -> KeyCommand.SELECT_PREV_PARAGRAPH
+                        Key.DirectionDown,
+                        Key.NumPadDirectionDown -> KeyCommand.SELECT_NEXT_PARAGRAPH
                         else -> null
                     }
 
                 event.isShiftPressed && event.isMetaPressed ->
                     when (event.key) {
-                        Key.DirectionLeft -> KeyCommand.SELECT_LINE_LEFT
-                        Key.DirectionRight -> KeyCommand.SELECT_LINE_RIGHT
-                        Key.DirectionUp -> KeyCommand.SELECT_HOME
-                        Key.DirectionDown -> KeyCommand.SELECT_END
+                        Key.DirectionLeft,
+                        Key.NumPadDirectionLeft -> KeyCommand.SELECT_LINE_LEFT
+                        Key.DirectionRight,
+                        Key.NumPadDirectionRight -> KeyCommand.SELECT_LINE_RIGHT
+                        Key.DirectionUp,
+                        Key.NumPadDirectionUp -> KeyCommand.SELECT_HOME
+                        Key.DirectionDown,
+                        Key.NumPadDirectionDown -> KeyCommand.SELECT_END
                         else -> null
                     }
 
                 event.isMetaPressed ->
                     when (event.key) {
-                        Key.DirectionLeft -> KeyCommand.LINE_LEFT
-                        Key.DirectionRight -> KeyCommand.LINE_RIGHT
-                        Key.DirectionUp -> KeyCommand.HOME
-                        Key.DirectionDown -> KeyCommand.END
+                        Key.DirectionLeft,
+                        Key.NumPadDirectionLeft -> KeyCommand.LINE_LEFT
+                        Key.DirectionRight,
+                        Key.NumPadDirectionRight -> KeyCommand.LINE_RIGHT
+                        Key.DirectionUp,
+                        Key.NumPadDirectionUp -> KeyCommand.HOME
+                        Key.DirectionDown,
+                        Key.NumPadDirectionDown -> KeyCommand.END
                         Key.Backspace -> KeyCommand.DELETE_FROM_LINE_START
                         else -> null
                     }
@@ -126,18 +140,25 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
 
                 event.isShiftPressed ->
                     when (event.key) {
-                        Key.MoveHome -> KeyCommand.SELECT_HOME
-                        Key.MoveEnd -> KeyCommand.SELECT_END
+                        Key.MoveHome,
+                        Key.NumPadMoveHome -> KeyCommand.SELECT_HOME
+                        Key.MoveEnd,
+                        Key.NumPadMoveEnd -> KeyCommand.SELECT_END
                         else -> null
                     }
 
                 event.isAltPressed ->
                     when (event.key) {
-                        Key.DirectionLeft -> KeyCommand.LEFT_WORD
-                        Key.DirectionRight -> KeyCommand.RIGHT_WORD
-                        Key.DirectionUp -> KeyCommand.PREV_PARAGRAPH
-                        Key.DirectionDown -> KeyCommand.NEXT_PARAGRAPH
-                        Key.Delete -> KeyCommand.DELETE_NEXT_WORD
+                        Key.DirectionLeft,
+                        Key.NumPadDirectionLeft -> KeyCommand.LEFT_WORD
+                        Key.DirectionRight,
+                        Key.NumPadDirectionRight -> KeyCommand.RIGHT_WORD
+                        Key.DirectionUp,
+                        Key.NumPadDirectionUp -> KeyCommand.PREV_PARAGRAPH
+                        Key.DirectionDown,
+                        Key.NumPadDirectionDown -> KeyCommand.NEXT_PARAGRAPH
+                        Key.Delete,
+                        Key.NumPadDelete -> KeyCommand.DELETE_NEXT_WORD
                         Key.Backspace -> KeyCommand.DELETE_PREV_WORD
                         else -> null
                     }

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
@@ -19,11 +19,7 @@ package androidx.compose.material
 
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.interaction.Interaction
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -146,12 +142,12 @@ internal fun handlePopupOnKeyEvent(
     inputModeManager: InputModeManager?
 ): Boolean = if (keyEvent.type == KeyEventType.KeyDown) {
     when (keyEvent.key) {
-        Key.DirectionDown -> {
+        Key.DirectionDown, Key.NumPadDirectionDown -> {
             inputModeManager?.requestInputMode(InputMode.Keyboard)
             focusManager?.moveFocus(FocusDirection.Next)
             true
         }
-        Key.DirectionUp -> {
+        Key.DirectionUp, Key.NumPadDirectionUp -> {
             inputModeManager?.requestInputMode(InputMode.Keyboard)
             focusManager?.moveFocus(FocusDirection.Previous)
             true

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
@@ -274,6 +274,22 @@ actual value class Key(val keyCode: Long) {
         actual val PrintScreen = Key(KeyEvent.VK_PRINTSCREEN)
 
         /**
+         * Home Movement key.
+         *
+         * Used for scrolling or moving the cursor around to the start of a line or to the top of a
+         * list.
+         */
+        actual val MoveHome = Key(KeyEvent.VK_HOME)
+
+        /**
+         * End Movement key.
+         *
+         * Used for scrolling or moving the cursor around to the end of a line or to the bottom of a
+         * list.
+         */
+        actual val MoveEnd = Key(KeyEvent.VK_END)
+
+        /**
          * Insert key.
          *
          * Toggles insert / overwrite edit mode.
@@ -423,8 +439,35 @@ actual value class Key(val keyCode: Long) {
         /** Numeric keypad ')' key. */
         actual val NumPadRightParenthesis = Key(KeyEvent.VK_RIGHT_PARENTHESIS, KEY_LOCATION_NUMPAD)
 
-        actual val MoveHome = Key(KeyEvent.VK_HOME)
-        actual val MoveEnd = Key(KeyEvent.VK_END)
+        /** Numeric keypad Up Arrow Key. */
+        actual val NumPadDirectionUp = Key(KeyEvent.VK_UP, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Down Arrow Key. */
+        actual val NumPadDirectionDown = Key(KeyEvent.VK_DOWN, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Left Arrow Key. */
+        actual val NumPadDirectionLeft = Key(KeyEvent.VK_LEFT, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Right Arrow Key. */
+        actual val NumPadDirectionRight = Key(KeyEvent.VK_RIGHT, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Home Key. */
+        actual val NumPadMoveHome: Key = Key(KeyEvent.VK_HOME, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad End Key. */
+        actual val NumPadMoveEnd = Key(KeyEvent.VK_END, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Page Up Key. */
+        actual val NumPadPageUp = Key(KeyEvent.VK_PAGE_UP, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Page Down Key. */
+        actual val NumPadPageDown = Key(KeyEvent.VK_PAGE_DOWN, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Insert Key. */
+        actual val NumPadInsert = Key(KeyEvent.VK_INSERT, KEY_LOCATION_NUMPAD)
+
+        /** Numeric keypad Delete Key. */
+        actual val NumPadDelete: Key = Key(KeyEvent.VK_DELETE, KEY_LOCATION_NUMPAD)
 
         // Unsupported Keys. These keys will never be sent by the desktop. However we need unique
         // keycodes so that these constants can be used in a when statement without a warning.
@@ -599,37 +642,7 @@ actual value class Key(val keyCode: Long) {
         actual val ThumbsUp = Key(-1000000181)
         actual val ThumbsDown = Key(-1000000182)
         actual val ProfileSwitch = Key(-1000000183)
-
-        /** Numeric keypad Up Arrow Key. */
-        actual val NumPadDirectionUp = Key(KeyEvent.VK_UP, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Down Arrow Key. */
-        actual val NumPadDirectionDown = Key(KeyEvent.VK_DOWN, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Left Arrow Key. */
-        actual val NumPadDirectionLeft = Key(KeyEvent.VK_LEFT, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Right Arrow Key. */
-        actual val NumPadDirectionRight = Key(KeyEvent.VK_RIGHT, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Home Key. */
-        actual val NumPadMoveHome: Key = Key(KeyEvent.VK_HOME, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad End Key. */
-        actual val NumPadMoveEnd = Key(KeyEvent.VK_END, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Page Up Key. */
-        actual val NumPadPageUp = Key(KeyEvent.VK_PAGE_UP, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Page Down Key. */
-        actual val NumPadPageDown = Key(KeyEvent.VK_PAGE_DOWN, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Insert Key. */
-        actual val NumPadInsert = Key(KeyEvent.VK_INSERT, KEY_LOCATION_NUMPAD)
-
-        /** Numeric keypad Delete Key. */
-        actual val NumPadDelete: Key = Key(KeyEvent.VK_DELETE, KEY_LOCATION_NUMPAD)
-    }
+}
 
     actual override fun toString(): String {
         return "Key: ${KeyEvent.getKeyText(nativeKeyCode)}"


### PR DESCRIPTION
Use the new numpad keys whenever their non-numpad equivalents are used.

Fixes https://youtrack.jetbrains.com/issue/CMP-8746/BTF-ignores-numpad-events-when-num-lock-is-off

## Testing
Tested manually

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Correctly react to numpad arrows, `NumPadPageUp`, `NumPadPageDown`, `NumPadHome` and `NumPadEnd` keys in text fields.
