### PR TITLE
Deprecate Key.Home and use Key.MoveHome

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt
@@ -217,7 +217,7 @@ class TextSelectionTests {
     fun `Select till text start with DesktopPlatform-MacOs`() {
         DesktopPlatform.MacOS.selectTextStart {
             keyDown(Key.ShiftLeft)
-            pressKey(Key.Home)
+            pressKey(Key.MoveHome)
             keyUp(Key.ShiftLeft)
         }
     }

--- a/compose/foundation/foundation/src/webTest/kotlin/selection/KeyboardActions.kt
+++ b/compose/foundation/foundation/src/webTest/kotlin/selection/KeyboardActions.kt
@@ -89,7 +89,7 @@ internal object MacosKeyboardActions : KeyboardActions {
 
     override fun KeyInjectionScope.selectTextStart() {
         keyDown(Key.ShiftLeft)
-        pressKey(Key.Home)
+        pressKey(Key.MoveHome)
         keyUp(Key.ShiftLeft)
     }
 

--- a/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SliderTest.kt
+++ b/compose/material/material/src/desktopTest/kotlin/androidx/compose/material/SliderTest.kt
@@ -130,8 +130,8 @@ class SliderTest {
             Assert.assertEquals(1f, state.value)
         }
 
-        rule.onRoot().performKeyPress(KeyEvent(Key.Home, KeyEventType.KeyDown))
-        rule.onRoot().performKeyPress(KeyEvent(Key.Home, KeyEventType.KeyUp))
+        rule.onRoot().performKeyPress(KeyEvent(Key.MoveHome, KeyEventType.KeyDown))
+        rule.onRoot().performKeyPress(KeyEvent(Key.MoveHome, KeyEventType.KeyUp))
         rule.runOnIdle {
             Assert.assertEquals(0f, state.value)
         }
@@ -271,8 +271,8 @@ class SliderTest {
             Assert.assertEquals(30f, state.value)
         }
 
-        rule.onRoot().performKeyPress(KeyEvent(Key.Home, KeyEventType.KeyDown))
-        rule.onRoot().performKeyPress(KeyEvent(Key.Home, KeyEventType.KeyUp))
+        rule.onRoot().performKeyPress(KeyEvent(Key.MoveHome, KeyEventType.KeyDown))
+        rule.onRoot().performKeyPress(KeyEvent(Key.MoveHome, KeyEventType.KeyUp))
         rule.runOnIdle {
             Assert.assertEquals(0f, state.value)
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/input/key/Key.desktop.kt
@@ -41,10 +41,17 @@ actual value class Key(val keyCode: Long) {
         actual val Unknown = Key(KeyEvent.VK_UNDEFINED)
 
         /**
-         * Home key.
+         * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
+        @Deprecated(
+            "`Key.Home` was mapped to the keyboard \"Home\" key in error. It is meant to be the" +
+                " \"system\" home key on Android, and should never be delivered to applications. " +
+                "For the keyboard \"Home\" key use `Key.MoveHome`. For the Android system " +
+                "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
+            level = DeprecationLevel.ERROR,
+        )
         actual val Home = Key(KeyEvent.VK_HOME)
 
         /**

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/Key.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/input/key/Key.ios.kt
@@ -31,10 +31,17 @@ actual value class Key(val keyCode: Long) {
         actual val Unknown = Key(-1)
 
         /**
-         * Home key.
+         * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
+        @Deprecated(
+            "`Key.Home` was mapped to the keyboard \"Home\" key in error. It is meant to be the" +
+                " \"system\" home key on Android, and should never be delivered to applications. " +
+                "For the keyboard \"Home\" key use `Key.MoveHome`. For the Android system " +
+                "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
+            level = DeprecationLevel.ERROR,
+        )
         actual val Home = Key(UIKeyboardHIDUsageKeyboardHome)
 
         /**

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/key/Key.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/input/key/Key.macos.kt
@@ -30,10 +30,17 @@ actual value class Key(val keyCode: Long) {
         actual val Unknown = Key(-1)
 
         /**
-         * Home key.
+         * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
+        @Deprecated(
+            "`Key.Home` was mapped to the keyboard \"Home\" key in error. It is meant to be the" +
+                " \"system\" home key on Android, and should never be delivered to applications. " +
+                "For the keyboard \"Home\" key use `Key.MoveHome`. For the Android system " +
+                "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
+            level = DeprecationLevel.ERROR,
+        )
         actual val Home = Key(115)
 
         /**

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/key/Key.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/input/key/Key.web.kt
@@ -30,10 +30,17 @@ actual value class Key(val keyCode: Long) {
         actual val Unknown = Key(-1)
 
         /**
-         * Home key.
+         * System Home key.
          *
          * This key is handled by the framework and is never delivered to applications.
          */
+        @Deprecated(
+            "`Key.Home` was mapped to the keyboard \"Home\" key in error. It is meant to be the" +
+                " \"system\" home key on Android, and should never be delivered to applications. " +
+                "For the keyboard \"Home\" key use `Key.MoveHome`. For the Android system " +
+                "\"Home\" key (unlikely to be needed), use `Key.SystemHome`",
+            level = DeprecationLevel.ERROR,
+        )
         actual val Home = Key(36)
 
         /**


### PR DESCRIPTION
Following https://android-review.googlesource.com/c/platform/frameworks/support/+/3935894, deprecate `Key.Home` and stop using it.

Fixes https://youtrack.jetbrains.com/issue/CMP-9137/Deprecate-Key.Home-in-favor-of-new-Key.SystemHome

## Testing
N/A

## Release Notes
### Migration Notes - Multiple Platforms
- `Key.Home` has been deprecated, as it has been incorrectly mapped to the keyboard "Home" key. Use `Key.MoveHome` instead.
