### PR TITLE
Adopt upstream deprecations in `ui-graphics`

### DIFF
--- a/compose/ui/ui-graphics/api/desktop/ui-graphics.api
+++ b/compose/ui/ui-graphics/api/desktop/ui-graphics.api
@@ -997,6 +997,7 @@ public final class androidx/compose/ui/graphics/SkiaBackedCanvas_skikoKt {
 public final class androidx/compose/ui/graphics/SkiaBackedPaint_skikoKt {
 	public static final fun Paint ()Landroidx/compose/ui/graphics/Paint;
 	public static final fun asComposePaint (Lorg/jetbrains/skia/Paint;)Landroidx/compose/ui/graphics/Paint;
+	public static final fun getNativePaint (Landroidx/compose/ui/graphics/Paint;)Lorg/jetbrains/skia/Paint;
 	public static final fun isSupported-s9anfk8 (I)Z
 }
 

--- a/compose/ui/ui-graphics/api/ui-graphics.klib.api
+++ b/compose/ui/ui-graphics/api/ui-graphics.klib.api
@@ -2024,6 +2024,8 @@ final val androidx.compose.ui.graphics/isUnspecified // androidx.compose.ui.grap
     final inline fun (androidx.compose.ui.graphics/Color).<get-isUnspecified>(): kotlin/Boolean // androidx.compose.ui.graphics/isUnspecified.<get-isUnspecified>|<get-isUnspecified>@androidx.compose.ui.graphics.Color(){}[0]
 final val androidx.compose.ui.graphics/nativeCanvas // androidx.compose.ui.graphics/nativeCanvas|@androidx.compose.ui.graphics.Canvas{}nativeCanvas[0]
     final fun (androidx.compose.ui.graphics/Canvas).<get-nativeCanvas>(): org.jetbrains.skia/Canvas // androidx.compose.ui.graphics/nativeCanvas.<get-nativeCanvas>|<get-nativeCanvas>@androidx.compose.ui.graphics.Canvas(){}[0]
+final val androidx.compose.ui.graphics/nativePaint // androidx.compose.ui.graphics/nativePaint|@androidx.compose.ui.graphics.Paint{}nativePaint[0]
+    final fun (androidx.compose.ui.graphics/Paint).<get-nativePaint>(): org.jetbrains.skia/Paint // androidx.compose.ui.graphics/nativePaint.<get-nativePaint>|<get-nativePaint>@androidx.compose.ui.graphics.Paint(){}[0]
 final val androidx.compose.ui.graphics/reverseDifference // androidx.compose.ui.graphics/reverseDifference|@androidx.compose.ui.graphics.PathOperation.Companion{}reverseDifference[0]
     final fun (androidx.compose.ui.graphics/PathOperation.Companion).<get-reverseDifference>(): androidx.compose.ui.graphics/PathOperation // androidx.compose.ui.graphics/reverseDifference.<get-reverseDifference>|<get-reverseDifference>@androidx.compose.ui.graphics.PathOperation.Companion(){}[0]
 final val androidx.compose.ui.graphics/union // androidx.compose.ui.graphics/union|@androidx.compose.ui.graphics.PathOperation.Companion{}union[0]

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopColorFilter.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopColorFilter.desktop.kt
@@ -16,16 +16,24 @@
 
 package androidx.compose.ui.graphics
 
-import org.jetbrains.skia.ColorFilter as SkiaColorFilter
+import org.jetbrains.skia.ColorFilter as SkColorFilter
 
 /**
  * Obtain a reference to the desktop ColorFilter type
  */
-@Deprecated("Use asSkiaColorFilter()", replaceWith = ReplaceWith("asSkiaColorFilter()"))
-fun ColorFilter.asDesktopColorFilter(): SkiaColorFilter = nativeColorFilter
+@Deprecated(
+    message = "Use asSkiaColorFilter()",
+    replaceWith = ReplaceWith("asSkiaColorFilter()"),
+    level = DeprecationLevel.ERROR,
+)
+fun ColorFilter.asDesktopColorFilter(): SkColorFilter = nativeColorFilter
 
 /**
  * Obtain a [org.jetbrains.skia.ColorFilter] instance from this [ColorFilter]
  */
-@Deprecated("Use asComposeColorFilter()", replaceWith = ReplaceWith("asComposeColorFilter()"))
-fun SkiaColorFilter.toComposeColorFilter(): ColorFilter = ColorFilter(this)
+@Deprecated(
+    message = "Use asComposeColorFilter()",
+    replaceWith = ReplaceWith("asComposeColorFilter()"),
+    level = DeprecationLevel.ERROR,
+)
+fun SkColorFilter.toComposeColorFilter(): ColorFilter = ColorFilter(this)

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageAsset.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageAsset.desktop.kt
@@ -26,20 +26,32 @@ import org.jetbrains.skia.Image
  * not create a copy of the original [Bitmap] and changes to it
  * will modify the returned [ImageBitmap]
  */
-@Deprecated("Use asComposeImageBitmap", replaceWith = ReplaceWith("asComposeImageBitmap()"))
+@Deprecated(
+    message = "Use asComposeImageBitmap",
+    replaceWith = ReplaceWith("asComposeImageBitmap()"),
+    level = DeprecationLevel.ERROR,
+)
 fun Bitmap.asImageBitmap(): ImageBitmap = asComposeImageBitmap()
 
 /**
  * Create an [ImageBitmap] from the given [Image].
  */
-@Deprecated("Use toComposeImageBitmap", replaceWith = ReplaceWith("toComposeImageBitmap()"))
+@Deprecated(
+    message = "Use toComposeImageBitmap",
+    replaceWith = ReplaceWith("toComposeImageBitmap()"),
+    level = DeprecationLevel.ERROR,
+)
 fun Image.asImageBitmap(): ImageBitmap = toComposeImageBitmap()
 
 /**
  * @Throws UnsupportedOperationException if this [ImageBitmap] is not backed by an
  * org.jetbrains.skia.Image
  */
-@Deprecated("Use asSkiaBitmap()", replaceWith = ReplaceWith("asSkiaBitmap()"))
+@Deprecated(
+    message = "Use asSkiaBitmap()",
+    replaceWith = ReplaceWith("asSkiaBitmap()"),
+    level = DeprecationLevel.ERROR,
+)
 fun ImageBitmap.asDesktopBitmap(): Bitmap = asSkiaBitmap()
 
 internal actual fun ByteArray.putBytesInto(array: IntArray, offset: Int, length: Int) {

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageConverters.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopImageConverters.desktop.kt
@@ -48,7 +48,11 @@ import org.jetbrains.skia.ImageInfo
  * functions. Don't mutate [BufferedImage] after converting it to [Painter], it will lead to
  * undefined behavior.
  */
-@Deprecated("Use toPainter", replaceWith = ReplaceWith("toPainter()"))
+@Deprecated(
+    message = "Use toPainter",
+    replaceWith = ReplaceWith("toPainter()"),
+    level = DeprecationLevel.ERROR,
+)
 fun BufferedImage.asPainter(): Painter = BufferedImagePainter(this)
 
 /**
@@ -89,7 +93,8 @@ private class BufferedImagePainter(val image: BufferedImage) : Painter() {
  */
 @Deprecated(
     "Use toAwtImage",
-    replaceWith = ReplaceWith("toAwtImage(density, layoutDirection, size)")
+    replaceWith = ReplaceWith("toAwtImage(density, layoutDirection, size)"),
+    level = DeprecationLevel.ERROR,
 )
 fun Painter.asAwtImage(
     density: Density,
@@ -204,7 +209,11 @@ private class PainterImage(
  * Convert Compose [ImageBitmap] to AWT [BufferedImage]
  */
 
-@Deprecated("use toAwtImage", replaceWith = ReplaceWith("toAwtImage"))
+@Deprecated(
+    message = "use toAwtImage",
+    replaceWith = ReplaceWith("toAwtImage"),
+    level = DeprecationLevel.ERROR,
+)
 fun ImageBitmap.asAwtImage(): BufferedImage = toAwtImage()
 
 /**
@@ -231,7 +240,11 @@ fun ImageBitmap.toAwtImage(): BufferedImage {
 /**
  * Convert AWT [BufferedImage] to Compose [ImageBitmap]
  */
-@Deprecated("use toComposeImageBitmap()", replaceWith = ReplaceWith("toComposeImageBitmap()"))
+@Deprecated(
+    message = "use toComposeImageBitmap()",
+    replaceWith = ReplaceWith("toComposeImageBitmap()"),
+    level = DeprecationLevel.ERROR,
+)
 fun BufferedImage.toComposeBitmap(): ImageBitmap = toComposeImageBitmap()
 
 /**

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPath.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPath.desktop.kt
@@ -17,5 +17,9 @@
 package androidx.compose.ui.graphics
 
 @Suppress("NOTHING_TO_INLINE")
-@Deprecated("Use asSkiaPath()", replaceWith = ReplaceWith("asSkiaPath()"))
+@Deprecated(
+    message = "Use asSkiaPath()",
+    replaceWith = ReplaceWith("asSkiaPath()"),
+    level = DeprecationLevel.ERROR,
+)
 inline fun Path.asDesktopPath(): org.jetbrains.skia.Path = asSkiaPath()

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPathEffect.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/DesktopPathEffect.desktop.kt
@@ -21,5 +21,9 @@ import org.jetbrains.skia.PathEffect as SkPathEffect
 /**
  * Obtain a reference to the desktop PathEffect type
  */
-@Deprecated("Use asSkiaPathEffect()", replaceWith = ReplaceWith("asSkiaPathEffect()"))
+@Deprecated(
+    message = "Use asSkiaPathEffect()",
+    replaceWith = ReplaceWith("asSkiaPathEffect()"),
+    level = DeprecationLevel.ERROR,
+)
 fun PathEffect.asDesktopPathEffect(): SkPathEffect = asSkiaPathEffect()

--- a/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/RenderEffect.desktop.kt
+++ b/compose/ui/ui-graphics/src/desktopMain/kotlin/androidx/compose/ui/graphics/RenderEffect.desktop.kt
@@ -18,5 +18,9 @@ package androidx.compose.ui.graphics
 
 import org.jetbrains.skia.ImageFilter
 
-@Deprecated("Use asSkiaImageFilter()", replaceWith = ReplaceWith("asSkiaImageFilter()"))
+@Deprecated(
+    message = "Use asSkiaImageFilter()",
+    replaceWith = ReplaceWith("asSkiaImageFilter()"),
+    level = DeprecationLevel.ERROR,
+)
 fun RenderEffect.asDesktopImageFilter(): ImageFilter = asSkiaImageFilter()

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.util.fastForEach
+import org.jetbrains.skia.Canvas as SkCanvas
 import org.jetbrains.skia.ClipMode as SkClipMode
 import org.jetbrains.skia.CubicResampler
 import org.jetbrains.skia.FilterMipmap
@@ -29,30 +30,36 @@ import org.jetbrains.skia.FilterMode
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.Matrix44
 import org.jetbrains.skia.MipmapMode
+import org.jetbrains.skia.Paint as SkPaint
 import org.jetbrains.skia.SamplingMode
 import org.jetbrains.skia.impl.use
 
 @Deprecated(
     message = "Use direct reference to org.jetbrains.skia.Canvas instead of typealias",
-    replaceWith = ReplaceWith("Canvas", "org.jetbrains.skia.Canvas")
+    replaceWith = ReplaceWith("Canvas", "org.jetbrains.skia.Canvas"),
 )
-actual typealias NativeCanvas = org.jetbrains.skia.Canvas
+actual typealias NativeCanvas = SkCanvas
 
 internal actual fun ActualCanvas(image: ImageBitmap): Canvas {
     val skiaBitmap = image.asSkiaBitmap()
     require(!skiaBitmap.isImmutable) {
         "Cannot draw on immutable ImageBitmap"
     }
-    return SkiaBackedCanvas(org.jetbrains.skia.Canvas(skiaBitmap))
+    return SkiaBackedCanvas(SkCanvas(skiaBitmap))
 }
 
 /**
  * Convert the [org.jetbrains.skia.Canvas] instance into a Compose-compatible Canvas
  */
-fun org.jetbrains.skia.Canvas.asComposeCanvas(): Canvas = SkiaBackedCanvas(this)
+fun SkCanvas.asComposeCanvas(): Canvas = SkiaBackedCanvas(this)
 
-val Canvas.nativeCanvas: org.jetbrains.skia.Canvas
-    get() = (this as SkiaBackedCanvas).skia
+val Canvas.nativeCanvas: SkCanvas
+    get() {
+        requirePrecondition(this is SkiaBackedCanvas) {
+            "Extracting skia canvas reference is only supported from androidx.compose.ui.graphics.SkiaBackedCanvas instances but received ${this::class}"
+        }
+        return skiaCanvas
+    }
 
 // This was added for internal usage from old render layers (another submodule),
 // but wasn't properly marked as internal. Keep it as deprecated for some time to be safe.
@@ -65,56 +72,60 @@ var Canvas.alphaMultiplier: Float
     get() = (this as SkiaBackedCanvas).alphaMultiplier
     set(value) { (this as SkiaBackedCanvas).alphaMultiplier = value }
 
-internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
+internal class SkiaBackedCanvas(
+    val skiaCanvas: SkCanvas,
+) : Canvas {
     internal var alphaMultiplier: Float = 1.0f
 
-    private val Paint.skia get() = (this as SkiaBackedPaint).apply {
+    private fun Paint.asSkiaPaintWithAppliedAlphaMultiplier(): SkPaint {
+        require(this is SkiaBackedPaint)
         this.alphaMultiplier = this@SkiaBackedCanvas.alphaMultiplier
-    }.skia
+        return skiaPaint
+    }
 
     override fun save() {
-        skia.save()
+        skiaCanvas.save()
     }
 
     override fun restore() {
-        skia.restore()
+        skiaCanvas.restore()
     }
 
     override fun saveLayer(bounds: Rect, paint: Paint) {
-        skia.saveLayer(
+        skiaCanvas.saveLayer(
             bounds.left,
             bounds.top,
             bounds.right,
             bounds.bottom,
-            paint.skia
+            paint.asSkiaPaintWithAppliedAlphaMultiplier()
         )
     }
 
     override fun translate(dx: Float, dy: Float) {
-        skia.translate(dx, dy)
+        skiaCanvas.translate(dx, dy)
     }
 
     override fun scale(sx: Float, sy: Float) {
-        skia.scale(sx, sy)
+        skiaCanvas.scale(sx, sy)
     }
 
     override fun rotate(degrees: Float) {
-        skia.rotate(degrees)
+        skiaCanvas.rotate(degrees)
     }
 
     override fun skew(sx: Float, sy: Float) {
-        skia.skew(sx, sy)
+        skiaCanvas.skew(sx, sy)
     }
 
     override fun concat(matrix: Matrix) {
         if (!matrix.isIdentity()) {
-            skia.concat(matrix.toSkia())
+            skiaCanvas.concat(matrix.toSkia())
         }
     }
 
     override fun clipRect(left: Float, top: Float, right: Float, bottom: Float, clipOp: ClipOp) {
         val antiAlias = true
-        skia.clipRect(
+        skiaCanvas.clipRect(
             left = left,
             top = top,
             right = right,
@@ -126,15 +137,27 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
 
     override fun clipPath(path: Path, clipOp: ClipOp) {
         val antiAlias = true
-        skia.clipPath(path.asSkiaPath(), clipOp.toSkia(), antiAlias)
+        skiaCanvas.clipPath(path.asSkiaPath(), clipOp.toSkia(), antiAlias)
     }
 
     override fun drawLine(p1: Offset, p2: Offset, paint: Paint) {
-        skia.drawLine(p1.x, p1.y, p2.x, p2.y, paint.skia)
+        skiaCanvas.drawLine(
+            x0 = p1.x,
+            y0 = p1.y,
+            x1 = p2.x,
+            y1 = p2.y,
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
+        )
     }
 
     override fun drawRect(left: Float, top: Float, right: Float, bottom: Float, paint: Paint) {
-        skia.drawRect(left = left, top = top, right = right, bottom = bottom, paint = paint.skia)
+        skiaCanvas.drawRect(
+            left = left,
+            top = top,
+            right = right,
+            bottom = bottom,
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
+        )
     }
 
     override fun drawRoundRect(
@@ -146,22 +169,33 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
         radiusY: Float,
         paint: Paint
     ) {
-        skia.drawRRect(
+        skiaCanvas.drawRRect(
             left = left,
             top = top,
             right = right,
             bottom = bottom,
             radii = floatArrayOf(radiusX, radiusY),
-            paint = paint.skia
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
         )
     }
 
     override fun drawOval(left: Float, top: Float, right: Float, bottom: Float, paint: Paint) {
-        skia.drawOval(left = left, top = top, right = right, bottom = bottom, paint = paint.skia)
+        skiaCanvas.drawOval(
+            left = left,
+            top = top,
+            right = right,
+            bottom = bottom,
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
+        )
     }
 
     override fun drawCircle(center: Offset, radius: Float, paint: Paint) {
-        skia.drawCircle(center.x, center.y, radius, paint.skia)
+        skiaCanvas.drawCircle(
+            x = center.x,
+            y = center.y,
+            radius = radius,
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
+        )
     }
 
     override fun drawArc(
@@ -174,34 +208,37 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
         useCenter: Boolean,
         paint: Paint
     ) {
-        skia.drawArc(
-            left,
-            top,
-            right,
-            bottom,
-            startAngle,
-            sweepAngle,
-            useCenter,
-            paint.skia
+        skiaCanvas.drawArc(
+            left = left,
+            top = top,
+            right = right,
+            bottom = bottom,
+            startAngle = startAngle,
+            sweepAngle = sweepAngle,
+            includeCenter = useCenter,
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
         )
     }
 
     override fun drawPath(path: Path, paint: Paint) {
-        skia.drawPath(path.asSkiaPath(), paint.skia)
+        skiaCanvas.drawPath(
+            path = path.asSkiaPath(),
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
+        )
     }
 
     override fun drawImage(image: ImageBitmap, topLeftOffset: Offset, paint: Paint) {
         drawImageRect(
-            image,
-            0f,
-            0f,
-            image.width.toFloat(),
-            image.height.toFloat(),
-            topLeftOffset.x,
-            topLeftOffset.y,
-            topLeftOffset.x + image.width.toFloat(),
-            topLeftOffset.y + image.height.toFloat(),
-            paint
+            image = image,
+            srcLeft = 0f,
+            srcTop = 0f,
+            srcRight = image.width.toFloat(),
+            srcBottom = image.height.toFloat(),
+            dstLeft = topLeftOffset.x,
+            dstTop = topLeftOffset.y,
+            dstRight = topLeftOffset.x + image.width.toFloat(),
+            dstBottom = topLeftOffset.y + image.height.toFloat(),
+            paint = paint,
         )
     }
 
@@ -223,7 +260,7 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
             dstTop = dstOffset.y.toFloat(),
             dstRight = dstOffset.x.toFloat() + dstSize.width.toFloat(),
             dstBottom = dstOffset.y.toFloat() + dstSize.height.toFloat(),
-            paint = paint
+            paint = paint,
         )
     }
 
@@ -243,19 +280,19 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
         val bitmap = image.asSkiaBitmap()
 
         Image.makeFromBitmap(bitmap).use { skiaImage ->
-            skia.drawImageRect(
-                skiaImage,
-                srcLeft,
-                srcTop,
-                srcRight,
-                srcBottom,
-                dstLeft,
-                dstTop,
-                dstRight,
-                dstBottom,
-                paint.filterQuality.toSkia(),
-                paint.skia,
-                true
+            skiaCanvas.drawImageRect(
+                image = skiaImage,
+                srcLeft = srcLeft,
+                srcTop = srcTop,
+                srcRight = srcRight,
+                srcBottom = srcBottom,
+                dstLeft = dstLeft,
+                dstTop = dstTop,
+                dstRight = dstRight,
+                dstBottom = dstBottom,
+                samplingMode = paint.filterQuality.toSkia(),
+                paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
+                strict = true,
             )
         }
     }
@@ -279,12 +316,12 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
     override fun disableZ() = Unit
 
     private fun drawPoints(points: List<Offset>, paint: Paint) {
-        val skiaPaint = paint.skia
+        val skiaPaint = paint.asSkiaPaintWithAppliedAlphaMultiplier()
         points.fastForEach { point ->
-            skia.drawPoint(
-                point.x,
-                point.y,
-                skiaPaint
+            skiaCanvas.drawPoint(
+                x = point.x,
+                y = point.y,
+                paint = skiaPaint,
             )
         }
     }
@@ -303,12 +340,12 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
      */
     private fun drawLines(points: List<Offset>, paint: Paint, stepBy: Int) {
         if (points.size >= 2) {
-            val skiaPaint = paint.skia
+            val skiaPaint = paint.asSkiaPaintWithAppliedAlphaMultiplier()
             var i = 0
             while (i < points.size - 1) {
                 val p1 = points[i]
                 val p2 = points[i + 1]
-                skia.drawLine(p1.x, p1.y, p2.x, p2.y, skiaPaint)
+                skiaCanvas.drawLine(p1.x, p1.y, p2.x, p2.y, skiaPaint)
                 i += stepBy
             }
         }
@@ -330,12 +367,12 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
 
     private fun drawRawPoints(points: FloatArray, paint: Paint, stepBy: Int) {
         if (points.size % 2 == 0) {
-            val skiaPaint = paint.skia
+            val skiaPaint = paint.asSkiaPaintWithAppliedAlphaMultiplier()
             var i = 0
             while (i < points.size - 1) {
                 val x = points[i]
                 val y = points[i + 1]
-                skia.drawPoint(x, y, skiaPaint)
+                skiaCanvas.drawPoint(x, y, skiaPaint)
                 i += stepBy
             }
         }
@@ -358,28 +395,28 @@ internal class SkiaBackedCanvas(val skia: org.jetbrains.skia.Canvas) : Canvas {
         // Float array is treated as alternative set of x and y coordinates
         // x1, y1, x2, y2, x3, y3, ... etc.
         if (points.size >= 4 && points.size % 2 == 0) {
-            val skiaPaint = paint.skia
+            val skiaPaint = paint.asSkiaPaintWithAppliedAlphaMultiplier()
             var i = 0
             while (i < points.size - 3) {
                 val x1 = points[i]
                 val y1 = points[i + 1]
                 val x2 = points[i + 2]
                 val y2 = points[i + 3]
-                skia.drawLine(x1, y1, x2, y2, skiaPaint)
+                skiaCanvas.drawLine(x1, y1, x2, y2, skiaPaint)
                 i += stepBy * 2
             }
         }
     }
 
     override fun drawVertices(vertices: Vertices, blendMode: BlendMode, paint: Paint) {
-        skia.drawVertices(
-            vertices.vertexMode.toSkiaVertexMode(),
-            vertices.positions,
-            vertices.colors,
-            vertices.textureCoordinates,
-            vertices.indices,
-            blendMode.toSkia(),
-            paint.asFrameworkPaint()
+        skiaCanvas.drawVertices(
+            vertexMode = vertices.vertexMode.toSkiaVertexMode(),
+            positions = vertices.positions,
+            colors = vertices.colors,
+            texCoords = vertices.textureCoordinates,
+            indices = vertices.indices,
+            blendMode = blendMode.toSkia(),
+            paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
         )
     }
 

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
@@ -16,26 +16,43 @@
 
 package androidx.compose.ui.graphics
 
+import org.jetbrains.skia.Paint as SkPaint
 import org.jetbrains.skia.PaintMode as SkPaintMode
 import org.jetbrains.skia.PaintStrokeCap as SkPaintStrokeCap
 import org.jetbrains.skia.PaintStrokeJoin as SkPaintStrokeJoin
 
-// TODO: https://youtrack.jetbrains.com/issue/CMP-9776/Adapt-the-sources-for-expect-class-NativePaint-deprecation
-@Deprecated("Use direct reference to platform type instead of typealias")
-actual typealias NativePaint = org.jetbrains.skia.Paint
+@Deprecated(
+    message = "Use org.jetbrains.skia.Paint directly instead",
+    replaceWith = ReplaceWith("org.jetbrains.skia.Paint"),
+)
+actual typealias NativePaint = SkPaint
 
 actual fun Paint(): Paint = SkiaBackedPaint()
 
 /**
  * Convert the [org.jetbrains.skia.Paint] instance into a Compose-compatible Paint
  */
-fun org.jetbrains.skia.Paint.asComposePaint(): Paint = SkiaBackedPaint(this)
+// TODO: Multiple calls will NOT return the same instance,
+//  consider to replace to `fun Paint(skiaPaint: org.jetbrains.skia.Paint)`
+fun SkPaint.asComposePaint(): Paint = SkiaBackedPaint(this)
+
+/** Convert a Compose [Paint] instance into an [org.jetbrains.skia.Paint]. */
+val Paint.nativePaint: SkPaint
+    get() {
+        requirePrecondition(this is SkiaBackedPaint) {
+            "Extracting skia paint reference is only supported from androidx.compose.ui.graphics.SkiaBackedPaint instances but received ${this::class}"
+        }
+        return skiaPaint
+    }
 
 internal class SkiaBackedPaint(
-    val skia: org.jetbrains.skia.Paint = org.jetbrains.skia.Paint()
+    val skiaPaint: SkPaint = SkPaint()
 ) : Paint {
-    // TODO: https://youtrack.jetbrains.com/issue/CMP-9776/Adapt-the-sources-for-expect-class-NativePaint-deprecation
-    override fun asFrameworkPaint(): NativePaint = skia
+    @Deprecated(
+        message = "Use [nativePaint] extension instead",
+        replaceWith = ReplaceWith("nativePaint"),
+    )
+    override fun asFrameworkPaint(): SkPaint = skiaPaint
 
     private var mAlphaMultiplier = 1.0f
 
@@ -48,60 +65,60 @@ internal class SkiaBackedPaint(
         }
 
     private fun updateAlpha(alpha: Float = this.alpha, multiplier: Float = this.mAlphaMultiplier) {
-        skia.color = Color(skia.color).copy(alpha = alpha * multiplier).toArgb()
+        skiaPaint.color = Color(skiaPaint.color).copy(alpha = alpha * multiplier).toArgb()
     }
 
     override var alpha: Float
-        get() = Color(skia.color).alpha
+        get() = Color(skiaPaint.color).alpha
         set(value) {
             updateAlpha(alpha = value)
         }
 
     override var isAntiAlias: Boolean
-        get() = skia.isAntiAlias
+        get() = skiaPaint.isAntiAlias
         set(value) {
-            skia.isAntiAlias = value
+            skiaPaint.isAntiAlias = value
         }
 
     override var color: Color
-        get() = Color(skia.color)
+        get() = Color(skiaPaint.color)
         set(color) {
-            skia.color = color.toArgb()
+            skiaPaint.color = color.toArgb()
         }
 
     override var blendMode: BlendMode = BlendMode.SrcOver
         set(value) {
-            skia.blendMode = value.toSkia()
+            skiaPaint.blendMode = value.toSkia()
             field = value
         }
 
     override var style: PaintingStyle = PaintingStyle.Fill
         set(value) {
-            skia.mode = value.toSkia()
+            skiaPaint.mode = value.toSkia()
             field = value
         }
 
     override var strokeWidth: Float
-        get() = skia.strokeWidth
+        get() = skiaPaint.strokeWidth
         set(value) {
-            skia.strokeWidth = value
+            skiaPaint.strokeWidth = value
         }
 
     override var strokeCap: StrokeCap = StrokeCap.Butt
         set(value) {
-            skia.strokeCap = value.toSkia()
+            skiaPaint.strokeCap = value.toSkia()
             field = value
         }
 
     override var strokeJoin: StrokeJoin = StrokeJoin.Round
         set(value) {
-            skia.strokeJoin = value.toSkia()
+            skiaPaint.strokeJoin = value.toSkia()
             field = value
         }
 
     override var strokeMiterLimit: Float = 0f
         set(value) {
-            skia.strokeMiter = value
+            skiaPaint.strokeMiter = value
             field = value
         }
 
@@ -109,19 +126,19 @@ internal class SkiaBackedPaint(
 
     override var shader: Shader? = null
         set(value) {
-            skia.shader = value
+            skiaPaint.shader = value
             field = value
         }
 
     override var colorFilter: ColorFilter? = null
         set(value) {
-            skia.colorFilter = value?.asSkiaColorFilter()
+            skiaPaint.colorFilter = value?.asSkiaColorFilter()
             field = value
         }
 
     override var pathEffect: PathEffect? = null
         set(value) {
-            skia.pathEffect = (value as SkiaBackedPathEffect?)?.asSkiaPathEffect()
+            skiaPaint.pathEffect = (value as SkiaBackedPathEffect?)?.asSkiaPathEffect()
             field = value
         }
 

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaColorFilter.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaColorFilter.skiko.kt
@@ -16,22 +16,23 @@
 
 package androidx.compose.ui.graphics
 
-import org.jetbrains.skia.ColorFilter as SkiaColorFilter
+import org.jetbrains.skia.ColorFilter as SkColorFilter
+import org.jetbrains.skia.ColorMatrix as SkColorMatrix
 
-internal actual typealias NativeColorFilter = SkiaColorFilter
+internal actual typealias NativeColorFilter = SkColorFilter
 
 /**
  * Obtain a [org.jetbrains.skia.ColorFilter] instance from this [ColorFilter]
  */
-fun ColorFilter.asSkiaColorFilter(): SkiaColorFilter = nativeColorFilter
+fun ColorFilter.asSkiaColorFilter(): SkColorFilter = nativeColorFilter
 
 /**
  * Create a [ColorFilter] from the given [org.jetbrains.skia.ColorFilter] instance
  */
-fun org.jetbrains.skia.ColorFilter.asComposeColorFilter(): ColorFilter = ColorFilter(this)
+fun SkColorFilter.asComposeColorFilter(): ColorFilter = ColorFilter(this)
 
 internal actual fun actualTintColorFilter(color: Color, blendMode: BlendMode): NativeColorFilter =
-    SkiaColorFilter.makeBlend(color.toArgb(), blendMode.toSkia())
+    SkColorFilter.makeBlend(color.toArgb(), blendMode.toSkia())
 
 /**
  * Remaps compose [ColorMatrix] to [org.jetbrains.skia.ColorMatrix] and returns [ColorFilter]
@@ -44,14 +45,14 @@ internal actual fun actualColorMatrixColorFilter(colorMatrix: ColorMatrix): Nati
     remappedValues[14] *= (1f / 255f)
     remappedValues[19] *= (1f / 255f)
 
-    return SkiaColorFilter.makeMatrix(
-        org.jetbrains.skia.ColorMatrix(remappedValues)
+    return SkColorFilter.makeMatrix(
+        SkColorMatrix(remappedValues)
     )
 }
 
 internal actual fun actualLightingColorFilter(multiply: Color, add: Color): NativeColorFilter =
-    SkiaColorFilter.makeLighting(multiply.toArgb(), add.toArgb())
+    SkColorFilter.makeLighting(multiply.toArgb(), add.toArgb())
 
-// TODO(https://youtrack.jetbrains.com/issue/COMPOSE-739/Merge-1.6.-Implement-actualColorMatrixFromFilter) implement
+// TODO: https://youtrack.jetbrains.com/issue/CMP-739
 internal actual fun actualColorMatrixFromFilter(filter: NativeColorFilter): ColorMatrix =
     ColorMatrix()

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/ParagraphBuilder.skiko.kt
@@ -140,9 +140,9 @@ private sealed interface ComputedStyle {
     ) : ComputedStyle {
         private val _foregroundPaint = SkiaTextPaint()
         fun getForegroundPaint(): SkPaint {
-            // `asFrameworkPaint` doesn't create a copy,
+            // `skiaPaint` doesn't create a copy,
             // so all the changes will be applied to skia paint.
-            val paint = _foregroundPaint.asFrameworkPaint()
+            val paint = _foregroundPaint.skiaPaint
             paint.reset()
             _foregroundPaint.color = textForegroundStyle.color
             _foregroundPaint.setBrush(textForegroundStyle.brush, brushSize, textForegroundStyle.alpha)

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.PaintingStyle
 import androidx.compose.ui.graphics.Shader
 import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.nativePaint
 import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -35,7 +36,12 @@ import androidx.compose.ui.text.style.modulate
 
 // Copied from AndroidTextPaint.
 
-internal class SkiaTextPaint : Paint by Paint() {
+internal class SkiaTextPaint(
+    private val original: Paint = Paint(),
+) : Paint by original {
+    internal val skiaPaint
+        get() = original.nativePaint
+
     @VisibleForTesting
     internal var brush: Brush? = null
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.nativePaint
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.skiko.OverlayRenderDecorator
@@ -193,7 +194,7 @@ internal class WindowComposeSceneLayer(
         val paint = Paint().apply {
             color = scrimColor
             blendMode = getDialogScrimBlendMode(transparent)
-        }.asFrameworkPaint()
+        }.nativePaint
         canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/LegacyRenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/LegacyRenderNodeLayer.skiko.kt
@@ -41,9 +41,10 @@ import androidx.compose.ui.graphics.alphaMultiplier
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.nativePaint
 import androidx.compose.ui.graphics.prepareTransformationMatrix
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
@@ -331,7 +332,7 @@ internal class LegacyRenderNodeLayer(
                     bounds,
                     Paint().apply {
                         alpha = this@LegacyRenderNodeLayer.alpha
-                        asFrameworkPaint().imageFilter = currentRenderEffect?.asSkiaImageFilter()
+                        nativePaint.imageFilter = currentRenderEffect?.asSkiaImageFilter()
                     }
                 )
             } else {


### PR DESCRIPTION
[CMP-9776](https://youtrack.jetbrains.com/issue/CMP-9776) Adapt the sources for expect class NativePaint deprecation

## Release Notes
### Migration Notes - Multiple Platforms
- `androidx.compose.ui.graphics.NativePaint` and `androidx.compose.ui.graphics.NativeCanvas` typealiases are deprecated, use direct references to native types instead.
- `Paint.asFrameworkPaint()` was replaced with `Paint.skiaPaint` extension to avoid exposing a platform type into `commonMain` sourceset via `typealias`