### PR TITLE
Use `KeyModifiers` when implementing `KeyMapping` to match keyboard modifiers exactly

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
@@ -31,6 +31,6 @@ private val _platformDefaultKeyMapping: KeyMapping =
 internal fun createPlatformDefaultKeyMapping(platform: DesktopPlatform): KeyMapping {
     return when (platform) {
         DesktopPlatform.MacOS -> createMacosDefaultKeyMapping()
-        else -> defaultSkikoKeyMapping
+        else -> DefaultSkikoKeyMapping
     }
 }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
@@ -18,16 +18,12 @@ package androidx.compose.foundation.text
 
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.isAltPressed
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 
-internal object defaultSkikoKeyMapping : KeyMapping {
+internal object DefaultSkikoKeyMapping : KeyMapping {
     override fun map(event: KeyEvent): KeyCommand? {
-        return when {
-            event.isCtrlPressed && event.isShiftPressed -> {
+        return when (event.modifiers) {
+            KeyModifiers.CtrlShift -> {
                 when (event.key) {
                     Key.MoveHome,
                     Key.NumPadMoveHome -> KeyCommand.SELECT_HOME
@@ -45,14 +41,15 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
     val common = commonKeyMapping(KeyModifiers.Meta)
     return object : KeyMapping {
         override fun map(event: KeyEvent): KeyCommand? {
-            return when {
-                event.isMetaPressed && event.isCtrlPressed ->
+            return when (event.modifiers) {
+                KeyModifiers.CtrlMeta -> {
                     when (event.key) {
                         Key.Spacebar -> KeyCommand.CHARACTER_PALETTE
                         else -> null
                     }
+                }
 
-                event.isShiftPressed && event.isAltPressed ->
+                KeyModifiers.AltShift -> {
                     when (event.key) {
                         Key.DirectionLeft,
                         Key.NumPadDirectionLeft -> KeyCommand.SELECT_LEFT_WORD
@@ -64,8 +61,9 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                         Key.NumPadDirectionDown -> KeyCommand.SELECT_NEXT_PARAGRAPH
                         else -> null
                     }
+                }
 
-                event.isShiftPressed && event.isMetaPressed ->
+                KeyModifiers.ShiftMeta -> {
                     when (event.key) {
                         Key.DirectionLeft,
                         Key.NumPadDirectionLeft -> KeyCommand.SELECT_LINE_LEFT
@@ -77,8 +75,9 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                         Key.NumPadDirectionDown -> KeyCommand.SELECT_END
                         else -> null
                     }
+                }
 
-                event.isMetaPressed ->
+                KeyModifiers.Meta -> {
                     when (event.key) {
                         Key.DirectionLeft,
                         Key.NumPadDirectionLeft -> KeyCommand.LINE_LEFT
@@ -91,9 +90,10 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                         Key.Backspace -> KeyCommand.DELETE_FROM_LINE_START
                         else -> null
                     }
+                }
 
                 // Emacs-like shortcuts
-                event.isCtrlPressed && event.isShiftPressed && event.isAltPressed -> {
+                KeyModifiers.CtrlShiftAlt -> {
                     when (event.key) {
                         Key.F -> KeyCommand.SELECT_RIGHT_WORD
                         Key.B -> KeyCommand.SELECT_LEFT_WORD
@@ -101,7 +101,7 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                     }
                 }
 
-                event.isCtrlPressed && event.isAltPressed -> {
+                KeyModifiers.CtrlAlt -> {
                     when (event.key) {
                         Key.F -> KeyCommand.RIGHT_WORD
                         Key.B -> KeyCommand.LEFT_WORD
@@ -109,7 +109,7 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                     }
                 }
 
-                event.isCtrlPressed && event.isShiftPressed -> {
+                KeyModifiers.CtrlShift -> {
                     when (event.key) {
                         Key.F -> KeyCommand.SELECT_RIGHT_CHAR
                         Key.B -> KeyCommand.SELECT_LEFT_CHAR
@@ -121,7 +121,7 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                     }
                 }
 
-                event.isCtrlPressed -> {
+                KeyModifiers.Ctrl -> {
                     when (event.key) {
                         Key.F -> KeyCommand.LEFT_CHAR
                         Key.B -> KeyCommand.RIGHT_CHAR
@@ -138,7 +138,7 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                 }
                 // end of emacs-like shortcuts
 
-                event.isShiftPressed ->
+                KeyModifiers.Shift ->
                     when (event.key) {
                         Key.MoveHome,
                         Key.NumPadMoveHome -> KeyCommand.SELECT_HOME
@@ -147,7 +147,7 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
                         else -> null
                     }
 
-                event.isAltPressed ->
+                KeyModifiers.Alt ->
                     when (event.key) {
                         Key.DirectionLeft,
                         Key.NumPadDirectionLeft -> KeyCommand.LEFT_WORD
@@ -168,3 +168,6 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
         }
     }
 }
+
+private val KeyModifiers.Companion.CtrlShiftAlt
+    get() = KeyModifiers.Ctrl + KeyModifiers.Shift + KeyModifiers.Alt

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextFieldKeyEventHandler.skiko.kt
@@ -21,8 +21,6 @@ import androidx.compose.foundation.text.KeyModifiers
 import androidx.compose.foundation.text.commonKeyMapping
 import androidx.compose.foundation.text.input.internal.selection.TextFieldSelectionState
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.platform.SoftwareKeyboardController
 
 /**
@@ -43,12 +41,7 @@ internal fun createIOSTextFieldKeyEventHandler() = object : TextFieldKeyEventHan
         singleLine: Boolean,
         onSubmit: () -> Boolean
     ): Boolean {
-        return when (commonKeyMapping(
-            KeyModifiers(
-                isMetaPressed = true,
-                isShiftPressed = true
-            )
-        ).map(event)) {
+        return when (commonKeyMapping(KeyModifiers.ShiftMeta).map(event)) {
             // iOS has its own Key Input handler for these keys:
             KeyCommand.LEFT_CHAR,
             KeyCommand.RIGHT_CHAR,
@@ -57,7 +50,7 @@ internal fun createIOSTextFieldKeyEventHandler() = object : TextFieldKeyEventHan
             KeyCommand.SELECT_LEFT_CHAR,
             KeyCommand.SELECT_RIGHT_CHAR,
             KeyCommand.SELECT_UP,
-            KeyCommand.SELECT_DOWN -> return false
+            KeyCommand.SELECT_DOWN -> false
             else -> {
                 super.onKeyEvent(
                     event,

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
@@ -29,7 +29,7 @@ internal actual val platformDefaultKeyMapping: KeyMapping = createPlatformDefaul
 internal fun createPlatformDefaultKeyMapping(platform: OS): KeyMapping {
     val keyMapping = when (platform) {
         OS.MacOS -> createMacosDefaultKeyMapping()
-        else -> defaultSkikoKeyMapping
+        else -> DefaultSkikoKeyMapping
     }
     return object : KeyMapping {
         private val clipboardKeys = setOf(Key.C, Key.V, Key.X)


### PR DESCRIPTION
Following https://android-review.googlesource.com/c/platform/frameworks/support/+/3940279 use `KeyModifiers` to match shortcuts exactly in CMP too.

Fixes https://youtrack.jetbrains.com/issue/CMP-7506

Note that technically, the windows bug was fixed in the AOSP CL, as the default (Windows/Linux) KeyMapping is defined in common.

## Testing
Tested manually

This should be tested by QA

## Release Notes
### Fixes - Desktop
- Match key modifiers exactly (without ignoring the state of other modifiers) when determining the corresponding text field action/command. This also fixes inputting 'a' and 'z' diacritics (e.g. 'ą' and 'ż') in text fields on Windows.
