### PR TITLE
Move onClick from composed API to Modifier.Node

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -21,12 +21,8 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.FocusRequesterModifierNode
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.requestFocus
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -20,16 +20,21 @@ import androidx.compose.foundation.gestures.PressGestureScope
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.runtime.*
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusRequesterModifierNode
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -100,7 +105,6 @@ fun Modifier.onClick(
  * @param onDoubleClick will be called when user double clicks on the element
  * @param onClick will be called when user clicks on the element
  */
-// TODO(https://youtrack.jetbrains.com/issue/COMPOSE-156) rewrite to Modifier.Node
 @ExperimentalFoundationApi
 fun Modifier.onClick(
     enabled: Boolean = true,
@@ -109,69 +113,114 @@ fun Modifier.onClick(
     keyboardModifiers: PointerKeyboardModifiers.() -> Boolean = { true },
     onDoubleClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
-    onClick: () -> Unit
-) = composed(
-    inspectorInfo = {
+    onClick: () -> Unit,
+): Modifier = if (enabled) {
+        composed {
+            val focusRequester = remember { FocusRequester() }
+            this.then(
+                OnClickModifierElement(
+                    interactionSource = interactionSource,
+                    matcher = matcher,
+                    keyboardModifiers = keyboardModifiers,
+                    onDoubleClick = onDoubleClick,
+                    onLongClick = onLongClick,
+                    onClick = onClick,
+                    focusRequester = focusRequester
+                ).focusRequester(focusRequester)
+            )
+        }
+    } else {
+        this
+    }
+
+
+private class OnClickModifierElement(
+    private val focusRequester: FocusRequester,
+    private val interactionSource: MutableInteractionSource,
+    private val matcher: PointerMatcher,
+    private val keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
+    private val onDoubleClick: (() -> Unit)?,
+    private val onLongClick: (() -> Unit)?,
+    private val onClick: () -> Unit,
+): ModifierNodeElement<OnClickModifierNode>() {
+    override fun create(): OnClickModifierNode = OnClickModifierNode(
+        interactionSource = interactionSource,
+        matcher = matcher,
+        keyboardModifiers = keyboardModifiers,
+        onDoubleClick = onDoubleClick,
+        onLongClick = onLongClick,
+        onClick = onClick,
+        focusRequester = focusRequester
+    )
+    override fun InspectorInfo.inspectableProperties() {
         name = "onClick"
-        properties["enabled"] = enabled
         properties["matcher"] = matcher
         properties["keyboardModifiers"] = keyboardModifiers
         properties["onDoubleClick"] = onDoubleClick
         properties["onLongClick"] = onLongClick
         properties["onClick"] = onClick
         properties["interactionSource"] = interactionSource
-    },
-    factory = {
+    }
+    override fun update(node: OnClickModifierNode) = node.update(
+        interactionSource = interactionSource,
+        matcher = matcher,
+        keyboardModifiers = keyboardModifiers,
+        onDoubleClick = onDoubleClick,
+        onLongClick = onLongClick,
+        onClick = onClick
+    )
 
-        val gestureModifier = if (enabled) {
-            val interactionData = remember { InteractionData() }
-            val onClickState = rememberUpdatedState(onClick)
-            val on2xClickState = rememberUpdatedState(onDoubleClick)
-            val onLongClickState = rememberUpdatedState(onLongClick)
-            val keyboardModifiersState = rememberUpdatedState(keyboardModifiers)
-            val focusRequester = remember { FocusRequester() }
-            val currentKeyPressInteractions = remember { mutableMapOf<Key, PressInteraction.Press>() }
+    override fun hashCode(): Int {
+        var result = interactionSource.hashCode()
+        result = 31 * result + matcher.hashCode()
+        result = 31 * result + keyboardModifiers.hashCode()
+        result = 31 * result + (onDoubleClick?.hashCode() ?: 0)
+        result = 31 * result + (onLongClick?.hashCode() ?: 0)
+        result = 31 * result + onClick.hashCode()
+        return result
+    }
 
-            val hasLongClick = onLongClick != null
-            val hasDoubleClick = onDoubleClick != null
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OnClickModifierElement) return false
+        return interactionSource == other.interactionSource &&
+            matcher == other.matcher &&
+            keyboardModifiers == other.keyboardModifiers &&
+            onDoubleClick == other.onDoubleClick &&
+            onLongClick == other.onLongClick &&
+            onClick == other.onClick
+    }
+}
 
-            DisposableEffect(hasLongClick) {
-                onDispose {
-                    interactionData.pressInteraction?.let { oldValue ->
-                        val interaction = PressInteraction.Cancel(oldValue)
-                        interactionSource.tryEmit(interaction)
-                        interactionData.pressInteraction = null
-                    }
-                }
-            }
-            DisposableEffect(interactionSource) {
-                onDispose {
-                    interactionData.pressInteraction?.let { oldValue ->
-                        val interaction = PressInteraction.Cancel(oldValue)
-                        interactionSource.tryEmit(interaction)
-                        interactionData.pressInteraction = null
-                    }
-                    currentKeyPressInteractions.values.forEach {
-                        interactionSource.tryEmit(PressInteraction.Cancel(it))
-                    }
-                    currentKeyPressInteractions.clear()
-                }
-            }
+private class OnClickModifierNode(
+    private val focusRequester: FocusRequester,
+    private var interactionSource: MutableInteractionSource,
+    private var keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
+    private var matcher: PointerMatcher,
+    private var onClick: () -> Unit,
+    private var onDoubleClick: (() -> Unit)?,
+    private var onLongClick: (() -> Unit)?,
+): DelegatingNode() {
+    // TODO: never populated with values, only cleared is this intended?
+    private val currentKeyPressInteractions = mutableMapOf<Key, PressInteraction.Press>()
+    private val hasDoubleClick: Boolean get() = onDoubleClick != null
+    private val hasLongClick: Boolean get() =  onLongClick != null
+    private val interactionData = InteractionData()
+    private val pointerInputEventHandlerResetTick = mutableStateOf(0)
 
-            val matcherState = rememberUpdatedState(matcher)
-
-            Modifier.pointerInput(interactionSource, hasLongClick, hasDoubleClick) {
+    private val pointerInputNode = delegate(
+        SuspendingPointerInputModifierNode(
+            pointerInputEventHandler = {
+                pointerInputEventHandlerResetTick.value
                 detectTapGestures(
-                    matcher = matcherState.value,
-                    keyboardModifiers = {
-                        keyboardModifiersState.value(this)
-                    },
+                    matcher = matcher,
+                    keyboardModifiers = { keyboardModifiers(this) },
                     onDoubleTap = if (hasDoubleClick) {
                         {
                             if (isRequestFocusOnClickEnabled()) {
                                 focusRequester.requestFocus()
                             }
-                            on2xClickState.value!!.invoke()
+                            onDoubleClick?.invoke()
                         }
                     } else {
                         null
@@ -181,7 +230,7 @@ fun Modifier.onClick(
                             if (isRequestFocusOnClickEnabled()) {
                                 focusRequester.requestFocus()
                             }
-                            onLongClickState.value!!.invoke()
+                            onLongClick?.invoke()
                         }
                     } else {
                         null
@@ -190,7 +239,7 @@ fun Modifier.onClick(
                         if (isRequestFocusOnClickEnabled()) {
                             focusRequester.requestFocus()
                         }
-                        onClickState.value()
+                        onClick()
                     },
                     onPress = {
                         handlePressInteraction(
@@ -201,14 +250,91 @@ fun Modifier.onClick(
                         )
                     }
                 )
-            }.focusRequester(focusRequester)
-        } else {
-            Modifier
+            }
+        )
+    )
+
+    override fun onDetach() {
+        cancelAllPressInteractions()
+        super.onDetach()
+    }
+
+    fun update(
+        interactionSource: MutableInteractionSource,
+        matcher: PointerMatcher,
+        keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
+        onDoubleClick: (() -> Unit)?,
+        onLongClick: (() -> Unit)?,
+        onClick: () -> Unit,
+    ) {
+        var pointerInputNodeNeedsReset = false
+        var pointerInputEventHandlerNeedsResetTick = false
+
+        if (this.interactionSource != interactionSource) {
+            pointerInputNodeNeedsReset = true
+            cancelAllPressInteractions()
+        }
+        this.interactionSource = interactionSource
+
+        if (this.onDoubleClick != onDoubleClick) {
+            pointerInputEventHandlerNeedsResetTick = true
+        }
+        val hadDoubleClick = hasDoubleClick
+        if (hasDoubleClick != hadDoubleClick) {
+            pointerInputNodeNeedsReset = true
+        }
+        this.onDoubleClick = onDoubleClick
+
+        if (this.onLongClick != onLongClick) {
+            pointerInputEventHandlerNeedsResetTick = true
+        }
+        val hadLongClick = hasLongClick
+        if (hasLongClick != hadLongClick) {
+            pointerInputNodeNeedsReset = true
+            cancelPressInteraction()
+        }
+        this.onLongClick = onLongClick
+
+        if (this.onClick != onClick) {
+            pointerInputEventHandlerNeedsResetTick = true
+        }
+        this.onClick = onClick
+
+        if (this.matcher != matcher) {
+            pointerInputEventHandlerNeedsResetTick = true
+        }
+        this.matcher = matcher
+
+        if (this.keyboardModifiers != keyboardModifiers) {
+            pointerInputEventHandlerNeedsResetTick = true
+        }
+        this.keyboardModifiers = keyboardModifiers
+
+        if (pointerInputNodeNeedsReset) {
+            pointerInputNode.resetPointerInputHandler()
         }
 
-        gestureModifier
+        if (pointerInputEventHandlerNeedsResetTick) {
+            pointerInputEventHandlerResetTick.value++
+        }
     }
-)
+
+    private fun cancelPressInteraction() {
+        interactionData.pressInteraction?.let { oldValue ->
+            val interaction = PressInteraction.Cancel(oldValue)
+            interactionSource.tryEmit(interaction)
+            interactionData.pressInteraction = null
+        }
+    }
+
+    private fun cancelAllPressInteractions() {
+        cancelPressInteraction()
+        currentKeyPressInteractions.values.forEach {
+            interactionSource.tryEmit(PressInteraction.Cancel(it))
+        }
+        currentKeyPressInteractions.clear()
+    }
+}
 
 // todo https://youtrack.jetbrains.com/issue/COMPOSE-1268/Refactor-Modifier.onClick-get-rid-of-InteractionData Refactor the same way as in 2e1799e0
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.FocusRequesterModifierNode
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
@@ -69,17 +68,15 @@ fun Modifier.onClick(
     onDoubleClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onClick: () -> Unit
-) = composed {
-    Modifier.onClick(
-        enabled = enabled,
-        matcher = matcher,
-        keyboardModifiers = keyboardModifiers,
-        interactionSource = remember { MutableInteractionSource() },
-        onDoubleClick = onDoubleClick,
-        onLongClick = onLongClick,
-        onClick = onClick
-    )
-}
+) = onClickImpl(
+    enabled = enabled,
+    matcher = matcher,
+    keyboardModifiers = keyboardModifiers,
+    interactionSource = null,
+    onDoubleClick = onDoubleClick,
+    onLongClick = onLongClick,
+    onClick = onClick
+)
 
 /**
  * Configure component to receive clicks, double clicks and long clicks via input only (no accessibility "click" event)
@@ -114,29 +111,48 @@ fun Modifier.onClick(
     onDoubleClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onClick: () -> Unit,
-): Modifier = if (enabled) {
-        composed {
-            val focusRequester = remember { FocusRequester() }
-            this.then(
-                OnClickModifierElement(
-                    interactionSource = interactionSource,
-                    matcher = matcher,
-                    keyboardModifiers = keyboardModifiers,
-                    onDoubleClick = onDoubleClick,
-                    onLongClick = onLongClick,
-                    onClick = onClick,
-                    focusRequester = focusRequester
-                ).focusRequester(focusRequester)
-            )
-        }
-    } else {
-        this
-    }
+): Modifier = onClickImpl(
+    enabled = enabled,
+    interactionSource = interactionSource,
+    matcher = matcher,
+    keyboardModifiers = keyboardModifiers,
+    onDoubleClick = onDoubleClick,
+    onLongClick = onLongClick,
+    onClick = onClick
+)
 
+@ExperimentalFoundationApi
+private fun Modifier.onClickImpl(
+    enabled: Boolean = true,
+    interactionSource: MutableInteractionSource?,
+    matcher: PointerMatcher = PointerMatcher.Primary,
+    keyboardModifiers: PointerKeyboardModifiers.() -> Boolean = { true },
+    onDoubleClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+    onClick: () -> Unit,
+): Modifier = if (enabled) {
+    composed {
+        val focusRequester = remember { FocusRequester() }
+
+        this.then(
+            OnClickModifierElement(
+                interactionSource = interactionSource,
+                matcher = matcher,
+                keyboardModifiers = keyboardModifiers,
+                onDoubleClick = onDoubleClick,
+                onLongClick = onLongClick,
+                onClick = onClick,
+                focusRequester = focusRequester
+            ).focusRequester(focusRequester)
+        )
+    }
+} else {
+    this
+}
 
 private class OnClickModifierElement(
     private val focusRequester: FocusRequester,
-    private val interactionSource: MutableInteractionSource,
+    private val interactionSource: MutableInteractionSource?,
     private val matcher: PointerMatcher,
     private val keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
     private val onDoubleClick: (() -> Unit)?,
@@ -144,7 +160,7 @@ private class OnClickModifierElement(
     private val onClick: () -> Unit,
 ): ModifierNodeElement<OnClickModifierNode>() {
     override fun create(): OnClickModifierNode = OnClickModifierNode(
-        interactionSource = interactionSource,
+        interactionSource = interactionSource ?: MutableInteractionSource(),
         matcher = matcher,
         keyboardModifiers = keyboardModifiers,
         onDoubleClick = onDoubleClick,
@@ -171,7 +187,7 @@ private class OnClickModifierElement(
     )
 
     override fun hashCode(): Int {
-        var result = interactionSource.hashCode()
+        var result = (interactionSource?.hashCode() ?: 0)
         result = 31 * result + matcher.hashCode()
         result = 31 * result + keyboardModifiers.hashCode()
         result = 31 * result + (onDoubleClick?.hashCode() ?: 0)
@@ -185,10 +201,10 @@ private class OnClickModifierElement(
         if (other !is OnClickModifierElement) return false
         return interactionSource == other.interactionSource &&
             matcher == other.matcher &&
-            keyboardModifiers == other.keyboardModifiers &&
-            onDoubleClick == other.onDoubleClick &&
-            onLongClick == other.onLongClick &&
-            onClick == other.onClick
+            keyboardModifiers === other.keyboardModifiers &&
+            onDoubleClick === other.onDoubleClick &&
+            onLongClick === other.onLongClick &&
+            onClick === other.onClick
     }
 }
 
@@ -260,7 +276,7 @@ private class OnClickModifierNode(
     }
 
     fun update(
-        interactionSource: MutableInteractionSource,
+        interactionSource: MutableInteractionSource?,
         matcher: PointerMatcher,
         keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
         onDoubleClick: (() -> Unit)?,
@@ -274,7 +290,9 @@ private class OnClickModifierNode(
             pointerInputNodeNeedsReset = true
             cancelAllPressInteractions()
         }
-        this.interactionSource = interactionSource
+        if (interactionSource != null) {
+            this.interactionSource = interactionSource
+        }
 
         if (this.onDoubleClick != onDoubleClick) {
             pointerInputEventHandlerNeedsResetTick = true

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -188,8 +188,6 @@ private class OnClickModifierNode(
     private var onDoubleClick: (() -> Unit)?,
     private var onLongClick: (() -> Unit)?,
 ): DelegatingNode(), FocusRequesterModifierNode {
-    // TODO: never populated with values, only cleared is this intended?
-    private val currentKeyPressInteractions = mutableMapOf<Key, PressInteraction.Press>()
     private val hasDoubleClick: Boolean get() = onDoubleClick != null
     private val hasLongClick: Boolean get() =  onLongClick != null
     private val interactionData = InteractionData()
@@ -242,7 +240,7 @@ private class OnClickModifierNode(
     )
 
     override fun onDetach() {
-        cancelAllPressInteractions()
+        cancelPressInteraction()
         super.onDetach()
     }
 
@@ -259,7 +257,7 @@ private class OnClickModifierNode(
 
         if (this.interactionSource != interactionSource) {
             pointerInputNodeNeedsReset = true
-            cancelAllPressInteractions()
+            cancelPressInteraction()
         }
         if (interactionSource != null) {
             this.interactionSource = interactionSource
@@ -314,14 +312,6 @@ private class OnClickModifierNode(
             interactionSource.tryEmit(interaction)
             interactionData.pressInteraction = null
         }
-    }
-
-    private fun cancelAllPressInteractions() {
-        cancelPressInteraction()
-        currentKeyPressInteractions.values.forEach {
-            interactionSource.tryEmit(PressInteraction.Cancel(it))
-        }
-        currentKeyPressInteractions.clear()
     }
 }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -25,7 +25,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusRequesterModifierNode
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.requestFocus
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.PointerEvent
@@ -130,27 +132,21 @@ private fun Modifier.onClickImpl(
     onLongClick: (() -> Unit)? = null,
     onClick: () -> Unit,
 ): Modifier = if (enabled) {
-    composed {
-        val focusRequester = remember { FocusRequester() }
-
-        this.then(
-            OnClickModifierElement(
-                interactionSource = interactionSource,
-                matcher = matcher,
-                keyboardModifiers = keyboardModifiers,
-                onDoubleClick = onDoubleClick,
-                onLongClick = onLongClick,
-                onClick = onClick,
-                focusRequester = focusRequester
-            ).focusRequester(focusRequester)
+    this.then(
+        OnClickModifierElement(
+            interactionSource = interactionSource,
+            matcher = matcher,
+            keyboardModifiers = keyboardModifiers,
+            onDoubleClick = onDoubleClick,
+            onLongClick = onLongClick,
+            onClick = onClick
         )
-    }
+    )
 } else {
     this
 }
 
 private class OnClickModifierElement(
-    private val focusRequester: FocusRequester,
     private val interactionSource: MutableInteractionSource?,
     private val matcher: PointerMatcher,
     private val keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
@@ -165,7 +161,6 @@ private class OnClickModifierElement(
         onDoubleClick = onDoubleClick,
         onLongClick = onLongClick,
         onClick = onClick,
-        focusRequester = focusRequester
     )
     override fun InspectorInfo.inspectableProperties() {
         name = "onClick"
@@ -208,14 +203,13 @@ private class OnClickModifierElement(
 }
 
 private class OnClickModifierNode(
-    private val focusRequester: FocusRequester,
     private var interactionSource: MutableInteractionSource,
     private var keyboardModifiers: PointerKeyboardModifiers.() -> Boolean,
     private var matcher: PointerMatcher,
     private var onClick: () -> Unit,
     private var onDoubleClick: (() -> Unit)?,
     private var onLongClick: (() -> Unit)?,
-): DelegatingNode() {
+): DelegatingNode(), FocusRequesterModifierNode {
     // TODO: never populated with values, only cleared is this intended?
     private val currentKeyPressInteractions = mutableMapOf<Key, PressInteraction.Press>()
     private val hasDoubleClick: Boolean get() = onDoubleClick != null
@@ -233,7 +227,7 @@ private class OnClickModifierNode(
                     onDoubleTap = if (hasDoubleClick) {
                         {
                             if (isRequestFocusOnClickEnabled()) {
-                                focusRequester.requestFocus()
+                                requestFocus()
                             }
                             onDoubleClick?.invoke()
                         }
@@ -243,7 +237,7 @@ private class OnClickModifierNode(
                     onLongPress = if (hasLongClick) {
                         {
                             if (isRequestFocusOnClickEnabled()) {
-                                focusRequester.requestFocus()
+                                requestFocus()
                             }
                             onLongClick?.invoke()
                         }
@@ -252,7 +246,7 @@ private class OnClickModifierNode(
                     },
                     onTap = {
                         if (isRequestFocusOnClickEnabled()) {
-                            focusRequester.requestFocus()
+                            requestFocus()
                         }
                         onClick()
                     },

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -66,11 +66,11 @@ fun Modifier.onClick(
     onDoubleClick: (() -> Unit)? = null,
     onLongClick: (() -> Unit)? = null,
     onClick: () -> Unit
-) = onClickImpl(
+) = onClick(
     enabled = enabled,
+    interactionSource = null,
     matcher = matcher,
     keyboardModifiers = keyboardModifiers,
-    interactionSource = null,
     onDoubleClick = onDoubleClick,
     onLongClick = onLongClick,
     onClick = onClick
@@ -102,24 +102,6 @@ fun Modifier.onClick(
  */
 @ExperimentalFoundationApi
 fun Modifier.onClick(
-    enabled: Boolean = true,
-    interactionSource: MutableInteractionSource,
-    matcher: PointerMatcher = PointerMatcher.Primary,
-    keyboardModifiers: PointerKeyboardModifiers.() -> Boolean = { true },
-    onDoubleClick: (() -> Unit)? = null,
-    onLongClick: (() -> Unit)? = null,
-    onClick: () -> Unit,
-): Modifier = onClickImpl(
-    enabled = enabled,
-    interactionSource = interactionSource,
-    matcher = matcher,
-    keyboardModifiers = keyboardModifiers,
-    onDoubleClick = onDoubleClick,
-    onLongClick = onLongClick,
-    onClick = onClick
-)
-
-private fun Modifier.onClickImpl(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource?,
     matcher: PointerMatcher = PointerMatcher.Primary,

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -121,7 +121,6 @@ fun Modifier.onClick(
     onClick = onClick
 )
 
-@ExperimentalFoundationApi
 private fun Modifier.onClickImpl(
     enabled: Boolean = true,
     interactionSource: MutableInteractionSource?,


### PR DESCRIPTION
Move onClick from composed API to Modifier.Node. 

Fixes https://youtrack.jetbrains.com/issue/CMP-9832

## Testing

Tested in`OnClickTest` suite

This should be tested by QA

## Release Notes
N/A