### PR TITLE
fix ComposeUiFlags delegate reference for areWindowInsetsRulersEnabled

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ComposeUiFlags.skiko.kt
@@ -76,4 +76,4 @@ var ComposeUiFlags.isDialogAnimationEnabled by SkikoComposeUiFlags::isDialogAnim
  * * `SafeContentRulers`
  */
 @ExperimentalComposeUiApi
-var ComposeUiFlags.areWindowInsetsRulersEnabled by SkikoComposeUiFlags::isDialogAnimationEnabled
+var ComposeUiFlags.areWindowInsetsRulersEnabled by SkikoComposeUiFlags::areWindowInsetsRulersEnabled


### PR DESCRIPTION
Fixing the incorrect mapping introduced earlier.

## Testing
N/A

## Release Notes
N/A
