### PR TITLE
Deprecate `.native*` extensions in favor to `.skia*` in `ui-graphics`

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/draganddrop/DragAndDropSource.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/draganddrop/DragAndDropSource.skiko.kt
@@ -27,14 +27,13 @@ import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.draw
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.input.pointer.PointerButton
 import androidx.compose.ui.input.pointer.PointerInputScope
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.Picture
 import org.jetbrains.skia.PictureRecorder
-import org.jetbrains.skia.Rect
 
 @Immutable
 internal actual object DragAndDropSourceDefaults {
@@ -71,7 +70,7 @@ internal actual class CacheDrawScopeDragShadowCallback {
                     throw IllegalArgumentException(
                         "No cached drag shadow. Check if Modifier.cacheDragShadow(painter) was called."
                     )
-                else -> drawIntoCanvas { canvas -> canvas.nativeCanvas.drawPicture(picture) }
+                else -> drawIntoCanvas { canvas -> canvas.skiaCanvas.drawPicture(picture) }
             }
         }
 
@@ -101,7 +100,7 @@ internal actual class CacheDrawScopeDragShadowCallback {
                 pictureRecorder.close()
                 cachedPicture = picture
 
-                drawIntoCanvas { canvas -> canvas.nativeCanvas.drawPicture(picture) }
+                drawIntoCanvas { canvas -> canvas.skiaCanvas.drawPicture(picture) }
             }
         }
 }

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/LottieAnimation.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/LottieAnimation.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
 import kotlin.math.roundToInt
 import org.jetbrains.skia.Rect
 import org.jetbrains.skia.skottie.Animation
@@ -78,7 +78,7 @@ private fun InfiniteAnimation(animation: Animation, modifier: Modifier) {
 
         drawIntoCanvas {
             animation.render(
-                canvas = it.nativeCanvas,
+                canvas = it.skiaCanvas,
                 dst = Rect.makeWH(size.width, size.height)
             )
         }

--- a/compose/ui/ui-graphics/api/desktop/ui-graphics.api
+++ b/compose/ui/ui-graphics/api/desktop/ui-graphics.api
@@ -75,8 +75,6 @@ public final class androidx/compose/ui/graphics/BlurEffect : androidx/compose/ui
 }
 
 public final class androidx/compose/ui/graphics/BlurEffect$Companion {
-	public final fun convertRadiusToSigma (F)F
-	public final fun getBlurSigmaScale ()F
 }
 
 public abstract class androidx/compose/ui/graphics/Brush {
@@ -992,12 +990,13 @@ public abstract interface class androidx/compose/ui/graphics/Shape {
 public final class androidx/compose/ui/graphics/SkiaBackedCanvas_skikoKt {
 	public static final fun asComposeCanvas (Lorg/jetbrains/skia/Canvas;)Landroidx/compose/ui/graphics/Canvas;
 	public static final fun getNativeCanvas (Landroidx/compose/ui/graphics/Canvas;)Lorg/jetbrains/skia/Canvas;
+	public static final fun getSkiaCanvas (Landroidx/compose/ui/graphics/Canvas;)Lorg/jetbrains/skia/Canvas;
 }
 
 public final class androidx/compose/ui/graphics/SkiaBackedPaint_skikoKt {
 	public static final fun Paint ()Landroidx/compose/ui/graphics/Paint;
 	public static final fun asComposePaint (Lorg/jetbrains/skia/Paint;)Landroidx/compose/ui/graphics/Paint;
-	public static final fun getNativePaint (Landroidx/compose/ui/graphics/Paint;)Lorg/jetbrains/skia/Paint;
+	public static final fun getSkiaPaint (Landroidx/compose/ui/graphics/Paint;)Lorg/jetbrains/skia/Paint;
 	public static final fun isSupported-s9anfk8 (I)Z
 }
 
@@ -1020,6 +1019,7 @@ public final class androidx/compose/ui/graphics/SkiaBackedPath_skikoKt {
 
 public final class androidx/compose/ui/graphics/SkiaBackedRenderEffect_skikoKt {
 	public static final fun asComposeRenderEffect (Lorg/jetbrains/skia/ImageFilter;)Landroidx/compose/ui/graphics/RenderEffect;
+	public static final fun getSkiaImageFilter (Landroidx/compose/ui/graphics/RenderEffect;)Lorg/jetbrains/skia/ImageFilter;
 }
 
 public final class androidx/compose/ui/graphics/SkiaColorFilter_skikoKt {

--- a/compose/ui/ui-graphics/api/ui-graphics.klib.api
+++ b/compose/ui/ui-graphics/api/ui-graphics.klib.api
@@ -785,12 +785,7 @@ final class androidx.compose.ui.graphics/BlurEffect : androidx.compose.ui.graphi
     final fun hashCode(): kotlin/Int // androidx.compose.ui.graphics/BlurEffect.hashCode|hashCode(){}[0]
     final fun toString(): kotlin/String // androidx.compose.ui.graphics/BlurEffect.toString|toString(){}[0]
 
-    final object Companion { // androidx.compose.ui.graphics/BlurEffect.Companion|null[0]
-        final val BlurSigmaScale // androidx.compose.ui.graphics/BlurEffect.Companion.BlurSigmaScale|{}BlurSigmaScale[0]
-            final fun <get-BlurSigmaScale>(): kotlin/Float // androidx.compose.ui.graphics/BlurEffect.Companion.BlurSigmaScale.<get-BlurSigmaScale>|<get-BlurSigmaScale>(){}[0]
-
-        final fun convertRadiusToSigma(kotlin/Float): kotlin/Float // androidx.compose.ui.graphics/BlurEffect.Companion.convertRadiusToSigma|convertRadiusToSigma(kotlin.Float){}[0]
-    }
+    final object Companion // androidx.compose.ui.graphics/BlurEffect.Companion|null[0]
 }
 
 final class androidx.compose.ui.graphics/ColorMatrixColorFilter : androidx.compose.ui.graphics/ColorFilter { // androidx.compose.ui.graphics/ColorMatrixColorFilter|null[0]
@@ -2024,10 +2019,14 @@ final val androidx.compose.ui.graphics/isUnspecified // androidx.compose.ui.grap
     final inline fun (androidx.compose.ui.graphics/Color).<get-isUnspecified>(): kotlin/Boolean // androidx.compose.ui.graphics/isUnspecified.<get-isUnspecified>|<get-isUnspecified>@androidx.compose.ui.graphics.Color(){}[0]
 final val androidx.compose.ui.graphics/nativeCanvas // androidx.compose.ui.graphics/nativeCanvas|@androidx.compose.ui.graphics.Canvas{}nativeCanvas[0]
     final fun (androidx.compose.ui.graphics/Canvas).<get-nativeCanvas>(): org.jetbrains.skia/Canvas // androidx.compose.ui.graphics/nativeCanvas.<get-nativeCanvas>|<get-nativeCanvas>@androidx.compose.ui.graphics.Canvas(){}[0]
-final val androidx.compose.ui.graphics/nativePaint // androidx.compose.ui.graphics/nativePaint|@androidx.compose.ui.graphics.Paint{}nativePaint[0]
-    final fun (androidx.compose.ui.graphics/Paint).<get-nativePaint>(): org.jetbrains.skia/Paint // androidx.compose.ui.graphics/nativePaint.<get-nativePaint>|<get-nativePaint>@androidx.compose.ui.graphics.Paint(){}[0]
 final val androidx.compose.ui.graphics/reverseDifference // androidx.compose.ui.graphics/reverseDifference|@androidx.compose.ui.graphics.PathOperation.Companion{}reverseDifference[0]
     final fun (androidx.compose.ui.graphics/PathOperation.Companion).<get-reverseDifference>(): androidx.compose.ui.graphics/PathOperation // androidx.compose.ui.graphics/reverseDifference.<get-reverseDifference>|<get-reverseDifference>@androidx.compose.ui.graphics.PathOperation.Companion(){}[0]
+final val androidx.compose.ui.graphics/skiaCanvas // androidx.compose.ui.graphics/skiaCanvas|@androidx.compose.ui.graphics.Canvas{}skiaCanvas[0]
+    final fun (androidx.compose.ui.graphics/Canvas).<get-skiaCanvas>(): org.jetbrains.skia/Canvas // androidx.compose.ui.graphics/skiaCanvas.<get-skiaCanvas>|<get-skiaCanvas>@androidx.compose.ui.graphics.Canvas(){}[0]
+final val androidx.compose.ui.graphics/skiaImageFilter // androidx.compose.ui.graphics/skiaImageFilter|@androidx.compose.ui.graphics.RenderEffect{}skiaImageFilter[0]
+    final fun (androidx.compose.ui.graphics/RenderEffect).<get-skiaImageFilter>(): org.jetbrains.skia/ImageFilter // androidx.compose.ui.graphics/skiaImageFilter.<get-skiaImageFilter>|<get-skiaImageFilter>@androidx.compose.ui.graphics.RenderEffect(){}[0]
+final val androidx.compose.ui.graphics/skiaPaint // androidx.compose.ui.graphics/skiaPaint|@androidx.compose.ui.graphics.Paint{}skiaPaint[0]
+    final fun (androidx.compose.ui.graphics/Paint).<get-skiaPaint>(): org.jetbrains.skia/Paint // androidx.compose.ui.graphics/skiaPaint.<get-skiaPaint>|<get-skiaPaint>@androidx.compose.ui.graphics.Paint(){}[0]
 final val androidx.compose.ui.graphics/union // androidx.compose.ui.graphics/union|@androidx.compose.ui.graphics.PathOperation.Companion{}union[0]
     final fun (androidx.compose.ui.graphics/PathOperation.Companion).<get-union>(): androidx.compose.ui.graphics/PathOperation // androidx.compose.ui.graphics/union.<get-union>|<get-union>@androidx.compose.ui.graphics.PathOperation.Companion(){}[0]
 final val androidx.compose.ui.graphics/xor // androidx.compose.ui.graphics/xor|@androidx.compose.ui.graphics.PathOperation.Companion{}xor[0]

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/Rects.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/Rects.skiko.kt
@@ -17,9 +17,11 @@ package androidx.compose.ui.graphics
 
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
+import org.jetbrains.skia.Rect as SkRect
+import org.jetbrains.skia.RRect as SkRRect
 
-fun Rect.toSkiaRect(): org.jetbrains.skia.Rect {
-    return org.jetbrains.skia.Rect.makeLTRB(
+fun Rect.toSkiaRect(): SkRect {
+    return SkRect.makeLTRB(
         left,
         top,
         right,
@@ -27,10 +29,10 @@ fun Rect.toSkiaRect(): org.jetbrains.skia.Rect {
     )
 }
 
-fun org.jetbrains.skia.Rect.toComposeRect() =
-    androidx.compose.ui.geometry.Rect(left, top, right, bottom)
+fun SkRect.toComposeRect() =
+    Rect(left, top, right, bottom)
 
-fun RoundRect.toSkiaRRect(): org.jetbrains.skia.RRect {
+fun RoundRect.toSkiaRRect(): SkRRect {
     val radii = FloatArray(8)
 
     radii[0] = topLeftCornerRadius.x
@@ -45,5 +47,5 @@ fun RoundRect.toSkiaRRect(): org.jetbrains.skia.RRect {
     radii[6] = bottomLeftCornerRadius.x
     radii[7] = bottomLeftCornerRadius.y
 
-    return org.jetbrains.skia.RRect.makeComplexLTRB(left, top, right, bottom, radii)
+    return SkRRect.makeComplexLTRB(left, top, right, bottom, radii)
 }

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
@@ -53,13 +53,26 @@ internal actual fun ActualCanvas(image: ImageBitmap): Canvas {
  */
 fun SkCanvas.asComposeCanvas(): Canvas = SkiaBackedCanvas(this)
 
-val Canvas.nativeCanvas: SkCanvas
+/**
+ * Provides access to the underlying [org.jetbrains.skia.Canvas] instance.
+ *
+ * It throws an exception if accessed on unsupported types.
+ */
+val Canvas.skiaCanvas: SkCanvas
     get() {
         requirePrecondition(this is SkiaBackedCanvas) {
             "Extracting skia canvas reference is only supported from androidx.compose.ui.graphics.SkiaBackedCanvas instances but received ${this::class}"
         }
-        return skiaCanvas
+        return internalSkiaCanvas
     }
+
+@Deprecated(
+    message = "Naming alignment to avoid ambiguity: use [Canvas.skiaCanvas] extension instead",
+    replaceWith = ReplaceWith("skiaCanvas", "androidx.compose.ui.graphics.skiaCanvas"),
+)
+@Suppress("DEPRECATION")
+val Canvas.nativeCanvas: NativeCanvas
+    get() = skiaCanvas
 
 // This was added for internal usage from old render layers (another submodule),
 // but wasn't properly marked as internal. Keep it as deprecated for some time to be safe.
@@ -73,26 +86,26 @@ var Canvas.alphaMultiplier: Float
     set(value) { (this as SkiaBackedCanvas).alphaMultiplier = value }
 
 internal class SkiaBackedCanvas(
-    val skiaCanvas: SkCanvas,
+    internal val internalSkiaCanvas: SkCanvas,
 ) : Canvas {
     internal var alphaMultiplier: Float = 1.0f
 
     private fun Paint.asSkiaPaintWithAppliedAlphaMultiplier(): SkPaint {
         require(this is SkiaBackedPaint)
         this.alphaMultiplier = this@SkiaBackedCanvas.alphaMultiplier
-        return skiaPaint
+        return internalSkiaPaint
     }
 
     override fun save() {
-        skiaCanvas.save()
+        internalSkiaCanvas.save()
     }
 
     override fun restore() {
-        skiaCanvas.restore()
+        internalSkiaCanvas.restore()
     }
 
     override fun saveLayer(bounds: Rect, paint: Paint) {
-        skiaCanvas.saveLayer(
+        internalSkiaCanvas.saveLayer(
             bounds.left,
             bounds.top,
             bounds.right,
@@ -102,30 +115,30 @@ internal class SkiaBackedCanvas(
     }
 
     override fun translate(dx: Float, dy: Float) {
-        skiaCanvas.translate(dx, dy)
+        internalSkiaCanvas.translate(dx, dy)
     }
 
     override fun scale(sx: Float, sy: Float) {
-        skiaCanvas.scale(sx, sy)
+        internalSkiaCanvas.scale(sx, sy)
     }
 
     override fun rotate(degrees: Float) {
-        skiaCanvas.rotate(degrees)
+        internalSkiaCanvas.rotate(degrees)
     }
 
     override fun skew(sx: Float, sy: Float) {
-        skiaCanvas.skew(sx, sy)
+        internalSkiaCanvas.skew(sx, sy)
     }
 
     override fun concat(matrix: Matrix) {
         if (!matrix.isIdentity()) {
-            skiaCanvas.concat(matrix.toSkia())
+            internalSkiaCanvas.concat(matrix.toSkia())
         }
     }
 
     override fun clipRect(left: Float, top: Float, right: Float, bottom: Float, clipOp: ClipOp) {
         val antiAlias = true
-        skiaCanvas.clipRect(
+        internalSkiaCanvas.clipRect(
             left = left,
             top = top,
             right = right,
@@ -137,11 +150,11 @@ internal class SkiaBackedCanvas(
 
     override fun clipPath(path: Path, clipOp: ClipOp) {
         val antiAlias = true
-        skiaCanvas.clipPath(path.asSkiaPath(), clipOp.toSkia(), antiAlias)
+        internalSkiaCanvas.clipPath(path.asSkiaPath(), clipOp.toSkia(), antiAlias)
     }
 
     override fun drawLine(p1: Offset, p2: Offset, paint: Paint) {
-        skiaCanvas.drawLine(
+        internalSkiaCanvas.drawLine(
             x0 = p1.x,
             y0 = p1.y,
             x1 = p2.x,
@@ -151,7 +164,7 @@ internal class SkiaBackedCanvas(
     }
 
     override fun drawRect(left: Float, top: Float, right: Float, bottom: Float, paint: Paint) {
-        skiaCanvas.drawRect(
+        internalSkiaCanvas.drawRect(
             left = left,
             top = top,
             right = right,
@@ -169,7 +182,7 @@ internal class SkiaBackedCanvas(
         radiusY: Float,
         paint: Paint
     ) {
-        skiaCanvas.drawRRect(
+        internalSkiaCanvas.drawRRect(
             left = left,
             top = top,
             right = right,
@@ -180,7 +193,7 @@ internal class SkiaBackedCanvas(
     }
 
     override fun drawOval(left: Float, top: Float, right: Float, bottom: Float, paint: Paint) {
-        skiaCanvas.drawOval(
+        internalSkiaCanvas.drawOval(
             left = left,
             top = top,
             right = right,
@@ -190,7 +203,7 @@ internal class SkiaBackedCanvas(
     }
 
     override fun drawCircle(center: Offset, radius: Float, paint: Paint) {
-        skiaCanvas.drawCircle(
+        internalSkiaCanvas.drawCircle(
             x = center.x,
             y = center.y,
             radius = radius,
@@ -208,7 +221,7 @@ internal class SkiaBackedCanvas(
         useCenter: Boolean,
         paint: Paint
     ) {
-        skiaCanvas.drawArc(
+        internalSkiaCanvas.drawArc(
             left = left,
             top = top,
             right = right,
@@ -221,7 +234,7 @@ internal class SkiaBackedCanvas(
     }
 
     override fun drawPath(path: Path, paint: Paint) {
-        skiaCanvas.drawPath(
+        internalSkiaCanvas.drawPath(
             path = path.asSkiaPath(),
             paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
         )
@@ -280,7 +293,7 @@ internal class SkiaBackedCanvas(
         val bitmap = image.asSkiaBitmap()
 
         Image.makeFromBitmap(bitmap).use { skiaImage ->
-            skiaCanvas.drawImageRect(
+            internalSkiaCanvas.drawImageRect(
                 image = skiaImage,
                 srcLeft = srcLeft,
                 srcTop = srcTop,
@@ -318,7 +331,7 @@ internal class SkiaBackedCanvas(
     private fun drawPoints(points: List<Offset>, paint: Paint) {
         val skiaPaint = paint.asSkiaPaintWithAppliedAlphaMultiplier()
         points.fastForEach { point ->
-            skiaCanvas.drawPoint(
+            internalSkiaCanvas.drawPoint(
                 x = point.x,
                 y = point.y,
                 paint = skiaPaint,
@@ -345,7 +358,7 @@ internal class SkiaBackedCanvas(
             while (i < points.size - 1) {
                 val p1 = points[i]
                 val p2 = points[i + 1]
-                skiaCanvas.drawLine(p1.x, p1.y, p2.x, p2.y, skiaPaint)
+                internalSkiaCanvas.drawLine(p1.x, p1.y, p2.x, p2.y, skiaPaint)
                 i += stepBy
             }
         }
@@ -372,7 +385,7 @@ internal class SkiaBackedCanvas(
             while (i < points.size - 1) {
                 val x = points[i]
                 val y = points[i + 1]
-                skiaCanvas.drawPoint(x, y, skiaPaint)
+                internalSkiaCanvas.drawPoint(x, y, skiaPaint)
                 i += stepBy
             }
         }
@@ -402,14 +415,14 @@ internal class SkiaBackedCanvas(
                 val y1 = points[i + 1]
                 val x2 = points[i + 2]
                 val y2 = points[i + 3]
-                skiaCanvas.drawLine(x1, y1, x2, y2, skiaPaint)
+                internalSkiaCanvas.drawLine(x1, y1, x2, y2, skiaPaint)
                 i += stepBy * 2
             }
         }
     }
 
     override fun drawVertices(vertices: Vertices, blendMode: BlendMode, paint: Paint) {
-        skiaCanvas.drawVertices(
+        internalSkiaCanvas.drawVertices(
             vertexMode = vertices.vertexMode.toSkiaVertexMode(),
             positions = vertices.positions,
             colors = vertices.colors,

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPaint.skiko.kt
@@ -36,23 +36,27 @@ actual fun Paint(): Paint = SkiaBackedPaint()
 //  consider to replace to `fun Paint(skiaPaint: org.jetbrains.skia.Paint)`
 fun SkPaint.asComposePaint(): Paint = SkiaBackedPaint(this)
 
-/** Convert a Compose [Paint] instance into an [org.jetbrains.skia.Paint]. */
-val Paint.nativePaint: SkPaint
+/**
+ * Provides access to the underlying [org.jetbrains.skia.Paint] instance.
+ *
+ * It throws an exception if accessed on unsupported types.
+ */
+val Paint.skiaPaint: SkPaint
     get() {
         requirePrecondition(this is SkiaBackedPaint) {
             "Extracting skia paint reference is only supported from androidx.compose.ui.graphics.SkiaBackedPaint instances but received ${this::class}"
         }
-        return skiaPaint
+        return internalSkiaPaint
     }
 
 internal class SkiaBackedPaint(
-    val skiaPaint: SkPaint = SkPaint()
+    val internalSkiaPaint: SkPaint = SkPaint()
 ) : Paint {
     @Deprecated(
-        message = "Use [nativePaint] extension instead",
-        replaceWith = ReplaceWith("nativePaint"),
+        message = "Use [Paint.nativePaint] extension instead",
+        replaceWith = ReplaceWith("skiaPaint", "androidx.compose.ui.graphics.skiaPaint"),
     )
-    override fun asFrameworkPaint(): SkPaint = skiaPaint
+    override fun asFrameworkPaint(): SkPaint = internalSkiaPaint
 
     private var mAlphaMultiplier = 1.0f
 
@@ -65,60 +69,60 @@ internal class SkiaBackedPaint(
         }
 
     private fun updateAlpha(alpha: Float = this.alpha, multiplier: Float = this.mAlphaMultiplier) {
-        skiaPaint.color = Color(skiaPaint.color).copy(alpha = alpha * multiplier).toArgb()
+        internalSkiaPaint.color = Color(internalSkiaPaint.color).copy(alpha = alpha * multiplier).toArgb()
     }
 
     override var alpha: Float
-        get() = Color(skiaPaint.color).alpha
+        get() = Color(internalSkiaPaint.color).alpha
         set(value) {
             updateAlpha(alpha = value)
         }
 
     override var isAntiAlias: Boolean
-        get() = skiaPaint.isAntiAlias
+        get() = internalSkiaPaint.isAntiAlias
         set(value) {
-            skiaPaint.isAntiAlias = value
+            internalSkiaPaint.isAntiAlias = value
         }
 
     override var color: Color
-        get() = Color(skiaPaint.color)
+        get() = Color(internalSkiaPaint.color)
         set(color) {
-            skiaPaint.color = color.toArgb()
+            internalSkiaPaint.color = color.toArgb()
         }
 
     override var blendMode: BlendMode = BlendMode.SrcOver
         set(value) {
-            skiaPaint.blendMode = value.toSkia()
+            internalSkiaPaint.blendMode = value.toSkia()
             field = value
         }
 
     override var style: PaintingStyle = PaintingStyle.Fill
         set(value) {
-            skiaPaint.mode = value.toSkia()
+            internalSkiaPaint.mode = value.toSkia()
             field = value
         }
 
     override var strokeWidth: Float
-        get() = skiaPaint.strokeWidth
+        get() = internalSkiaPaint.strokeWidth
         set(value) {
-            skiaPaint.strokeWidth = value
+            internalSkiaPaint.strokeWidth = value
         }
 
     override var strokeCap: StrokeCap = StrokeCap.Butt
         set(value) {
-            skiaPaint.strokeCap = value.toSkia()
+            internalSkiaPaint.strokeCap = value.toSkia()
             field = value
         }
 
     override var strokeJoin: StrokeJoin = StrokeJoin.Round
         set(value) {
-            skiaPaint.strokeJoin = value.toSkia()
+            internalSkiaPaint.strokeJoin = value.toSkia()
             field = value
         }
 
     override var strokeMiterLimit: Float = 0f
         set(value) {
-            skiaPaint.strokeMiter = value
+            internalSkiaPaint.strokeMiter = value
             field = value
         }
 
@@ -126,19 +130,19 @@ internal class SkiaBackedPaint(
 
     override var shader: Shader? = null
         set(value) {
-            skiaPaint.shader = value
+            internalSkiaPaint.shader = value
             field = value
         }
 
     override var colorFilter: ColorFilter? = null
         set(value) {
-            skiaPaint.colorFilter = value?.asSkiaColorFilter()
+            internalSkiaPaint.colorFilter = value?.asSkiaColorFilter()
             field = value
         }
 
     override var pathEffect: PathEffect? = null
         set(value) {
-            skiaPaint.pathEffect = (value as SkiaBackedPathEffect?)?.asSkiaPathEffect()
+            internalSkiaPaint.pathEffect = (value as SkiaBackedPathEffect?)?.asSkiaPathEffect()
             field = value
         }
 

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPath.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPath.skiko.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
 import org.jetbrains.skia.Matrix33
+import org.jetbrains.skia.Path as SkPath
 import org.jetbrains.skia.PathDirection
 import org.jetbrains.skia.PathBuilder
 import org.jetbrains.skia.PathFillMode
@@ -30,41 +31,41 @@ actual fun Path(): Path = SkiaBackedPath()
 /**
  * Convert the [org.jetbrains.skia.Path] instance into a Compose-compatible Path
  */
-fun org.jetbrains.skia.Path.asComposePath(): Path = SkiaBackedPath(this)
+fun SkPath.asComposePath(): Path = SkiaBackedPath(this)
 
 /**
- * Obtain a reference to the [org.jetbrains.skia.Path]
+ * Obtain a reference to the underlying [org.jetbrains.skia.Path] instance.
  *
- * @Throws UnsupportedOperationException if this Path is not backed by an org.jetbrains.skia.Path
+ * It throws an exception if accessed on unsupported types.
  */
-fun Path.asSkiaPath(): org.jetbrains.skia.Path =
-    if (this is SkiaBackedPath) {
-        internalPath
-    } else {
-        throw UnsupportedOperationException("Unable to obtain org.jetbrains.skia.Path")
+fun Path.asSkiaPath(): SkPath {
+    requirePrecondition(this is SkiaBackedPath) {
+        "Extracting skia path reference is only supported from androidx.compose.ui.graphics.SkiaBackedPath instances but received ${this::class}"
     }
+    return internalSkiaPath
+}
 
 @Suppress("OVERRIDE_DEPRECATION")
 internal class SkiaBackedPath(
-    internalPath: org.jetbrains.skia.Path = org.jetbrains.skia.Path()
+    internalSkiaPath: SkPath = SkPath()
 ) : Path {
-    var internalPath = internalPath
+    internal var internalSkiaPath = internalSkiaPath
         private set
-    private var pathBuilder = PathBuilder(internalPath)
+    private var pathBuilder = PathBuilder(internalSkiaPath)
 
     private inline fun mutatePath(block: PathBuilder.() -> Unit) {
         pathBuilder.apply(block)
-        internalPath = pathBuilder.snapshot()
+        internalSkiaPath = pathBuilder.snapshot()
     }
 
-    private fun replacePath(path: org.jetbrains.skia.Path) {
-        internalPath = path
+    private fun replacePath(path: SkPath) {
+        internalSkiaPath = path
         pathBuilder = PathBuilder(path)
     }
 
     override var fillType: PathFillType
         get() {
-            return if (internalPath.fillMode == PathFillMode.EVEN_ODD) {
+            return if (internalSkiaPath.fillMode == PathFillMode.EVEN_ODD) {
                 PathFillType.EvenOdd
             } else {
                 PathFillType.NonZero
@@ -79,7 +80,7 @@ internal class SkiaBackedPath(
                     PathFillMode.WINDING
                 }
             )
-            internalPath = pathBuilder.snapshot()
+            internalSkiaPath = pathBuilder.snapshot()
         }
 
     override fun moveTo(x: Float, y: Float) = mutatePath {
@@ -270,26 +271,26 @@ internal class SkiaBackedPath(
     }
 
     override fun reset() {
-        val fillMode = internalPath.fillMode
+        val fillMode = internalSkiaPath.fillMode
         pathBuilder.reset().setFillType(fillMode)
-        internalPath = pathBuilder.snapshot()
+        internalSkiaPath = pathBuilder.snapshot()
     }
 
     override fun translate(offset: Offset) {
-        pathBuilder = PathBuilder(internalPath.fillMode)
-            .addPath(internalPath, offset.x, offset.y)
-        internalPath = pathBuilder.snapshot()
+        pathBuilder = PathBuilder(internalSkiaPath.fillMode)
+            .addPath(internalSkiaPath, offset.x, offset.y)
+        internalSkiaPath = pathBuilder.snapshot()
     }
 
     override fun transform(matrix: Matrix) {
         val skiaMatrix = Matrix33.makeTranslate(0f, 0f).apply { setFrom(matrix) }
-        pathBuilder = PathBuilder(internalPath.fillMode)
-            .addPath(internalPath, skiaMatrix)
-        internalPath = pathBuilder.snapshot()
+        pathBuilder = PathBuilder(internalSkiaPath.fillMode)
+            .addPath(internalSkiaPath, skiaMatrix)
+        internalSkiaPath = pathBuilder.snapshot()
     }
 
     override fun getBounds(): Rect {
-        val bounds = internalPath.bounds
+        val bounds = internalSkiaPath.bounds
         return Rect(
             bounds.left,
             bounds.top,
@@ -303,7 +304,7 @@ internal class SkiaBackedPath(
         path2: Path,
         operation: PathOperation
     ): Boolean {
-        val path = org.jetbrains.skia.Path.makeCombining(
+        val path = SkPath.makeCombining(
             path1.asSkiaPath(),
             path2.asSkiaPath(),
             operation.toSkiaOperation()
@@ -324,9 +325,9 @@ internal class SkiaBackedPath(
         else -> PathOp.XOR
     }
 
-    override val isConvex: Boolean get() = internalPath.isConvex
+    override val isConvex: Boolean get() = internalSkiaPath.isConvex
 
-    override val isEmpty: Boolean get() = internalPath.isEmpty
+    override val isEmpty: Boolean get() = internalSkiaPath.isEmpty
 }
 
 private fun Path.Direction.toSkiaPathDirection() = when (this) {

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathEffect.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathEffect.skiko.kt
@@ -18,7 +18,9 @@ package androidx.compose.ui.graphics
 
 import org.jetbrains.skia.PathEffect as SkPathEffect
 
-internal class SkiaBackedPathEffect(val nativePathEffect: SkPathEffect) : PathEffect
+internal class SkiaBackedPathEffect(
+    internal val internalSkiaPathEffect: SkPathEffect,
+) : PathEffect
 
 /**
  * Convert the [org.jetbrains.skia.PathEffect] instance into a Compose-compatible PathEffect
@@ -26,10 +28,16 @@ internal class SkiaBackedPathEffect(val nativePathEffect: SkPathEffect) : PathEf
 fun SkPathEffect.asComposePathEffect(): PathEffect = SkiaBackedPathEffect(this)
 
 /**
- * Obtain a reference to skia PathEffect type
+ * Obtain a reference the underlying [org.jetbrains.skia.PathEffect] instance.
+ *
+ * It throws an exception if accessed on unsupported types.
  */
-fun PathEffect.asSkiaPathEffect(): SkPathEffect =
-    (this as SkiaBackedPathEffect).nativePathEffect
+fun PathEffect.asSkiaPathEffect(): SkPathEffect {
+    requirePrecondition(this is SkiaBackedPathEffect) {
+        "Extracting skia path effect reference is only supported from androidx.compose.ui.graphics.SkiaBackedPathEffect instances but received ${this::class}"
+    }
+    return internalSkiaPathEffect
+}
 
 internal actual fun actualCornerPathEffect(radius: Float): PathEffect =
     SkiaBackedPathEffect(SkPathEffect.makeCorner(radius))

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathMeasure.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathMeasure.skiko.kt
@@ -17,23 +17,31 @@
 package androidx.compose.ui.graphics
 
 import androidx.compose.ui.geometry.Offset
+import org.jetbrains.skia.PathMeasure as SkPathMeasure
+
 /**
  * Convert the [org.jetbrains.skia.PathMeasure] instance into a Compose-compatible PathMeasure
  */
-fun org.jetbrains.skia.PathMeasure.asComposePathEffect(): PathMeasure = SkiaBackedPathMeasure(this)
+fun SkPathMeasure.asComposePathEffect(): PathMeasure = SkiaBackedPathMeasure(this)
 
 /**
- * Obtain a reference to skia PathMeasure type
+ * Obtain a reference the underlying [org.jetbrains.skia.PathMeasure] instance.
+ *
+ * It throws an exception if accessed on unsupported types.
  */
-fun PathMeasure.asSkiaPathMeasure(): org.jetbrains.skia.PathMeasure =
-    (this as SkiaBackedPathMeasure).skia
+fun PathMeasure.asSkiaPathMeasure(): SkPathMeasure {
+    requirePrecondition(this is SkiaBackedPathMeasure) {
+        "Extracting skia path measure reference is only supported from androidx.compose.ui.graphics.SkiaBackedPathMeasure instances but received ${this::class}"
+    }
+    return internalSkiaPathMeasure
+}
 
 internal class SkiaBackedPathMeasure(
-    internal val skia: org.jetbrains.skia.PathMeasure = org.jetbrains.skia.PathMeasure()
+    internal val internalSkiaPathMeasure: SkPathMeasure = SkPathMeasure()
 ) : PathMeasure {
 
     override fun setPath(path: Path?, forceClosed: Boolean) {
-        skia.setPath(path?.asSkiaPath(), forceClosed)
+        internalSkiaPathMeasure.setPath(path?.asSkiaPath(), forceClosed)
     }
 
     override fun getSegment(
@@ -41,7 +49,7 @@ internal class SkiaBackedPathMeasure(
         stopDistance: Float,
         destination: Path,
         startWithMoveTo: Boolean
-    ) = skia.getSegment(
+    ) = internalSkiaPathMeasure.getSegment(
         startDistance,
         stopDistance,
         destination.asSkiaPath(),
@@ -49,12 +57,12 @@ internal class SkiaBackedPathMeasure(
     )
 
     override val length: Float
-        get() = skia.length
+        get() = internalSkiaPathMeasure.length
 
     override fun getPosition(
         distance: Float
     ): Offset {
-        val result = skia.getPosition(distance)
+        val result = internalSkiaPathMeasure.getPosition(distance)
         return if (result != null) {
             Offset(result.x, result.y)
         } else {
@@ -65,7 +73,7 @@ internal class SkiaBackedPathMeasure(
     override fun getTangent(
         distance: Float
     ): Offset {
-        val result = skia.getTangent(distance)
+        val result = internalSkiaPathMeasure.getTangent(distance)
         return if (result != null) {
             Offset(result.x, result.y)
         } else {

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedRenderEffect.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedRenderEffect.skiko.kt
@@ -17,14 +17,23 @@
 package androidx.compose.ui.graphics
 
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import org.jetbrains.skia.ImageFilter
 
 /**
- * Convert the [ImageFilter] instance into a Compose-compatible [RenderEffect]
+ * Convert the [org.jetbrains.skia.ImageFilter] instance into a Compose-compatible [RenderEffect]
  */
 fun ImageFilter.asComposeRenderEffect(): RenderEffect =
     SkiaBackedRenderEffect(this)
+
+/**
+ * Provides access to the underlying [org.jetbrains.skia.ImageFilter] instance.
+ *
+ * It throws an exception if accessed on unsupported types.
+ */
+val RenderEffect.skiaImageFilter: ImageFilter
+    get() = internalSkiaImageFilter
 
 /**
  * Intermediate rendering step used to render drawing commands with a corresponding
@@ -34,10 +43,15 @@ fun ImageFilter.asComposeRenderEffect(): RenderEffect =
 @Immutable
 actual sealed class RenderEffect actual constructor() {
 
-    private var internalImageFilter: ImageFilter? = null
+    private var _internalSkiaImageFilter: ImageFilter? = null
+    internal val internalSkiaImageFilter: ImageFilter
+        get() = _internalSkiaImageFilter ?: createImageFilter().also { _internalSkiaImageFilter = it }
 
-    fun asSkiaImageFilter(): ImageFilter =
-        internalImageFilter ?: createImageFilter().also { internalImageFilter = it }
+    @Deprecated(
+        message = "Use [RenderEffect.skiaImageFilter] extension instead",
+        replaceWith = ReplaceWith("skiaImageFilter", "androidx.compose.ui.graphics.skiaImageFilter"),
+    )
+    fun asSkiaImageFilter(): ImageFilter = internalSkiaImageFilter
 
     protected abstract fun createImageFilter(): ImageFilter
 
@@ -63,6 +77,7 @@ actual class BlurEffect actual constructor(
     private val edgeTreatment: TileMode
 ) : RenderEffect() {
 
+    @OptIn(InternalComposeUiApi::class)
     override fun createImageFilter(): ImageFilter =
         if (renderEffect == null) {
             ImageFilter.makeBlur(
@@ -75,7 +90,7 @@ actual class BlurEffect actual constructor(
                 convertRadiusToSigma(radiusX),
                 convertRadiusToSigma(radiusY),
                 edgeTreatment.toSkiaTileMode(),
-                renderEffect.asSkiaImageFilter(),
+                renderEffect.skiaImageFilter,
                 null
             )
         }
@@ -111,8 +126,10 @@ actual class BlurEffect actual constructor(
         // for the gaussian blur algorithm used within SkImageFilter.
         // This constant approximates the scaling done in the software path's
         // "high quality" mode, in SkBlurMask::Blur() (1 / sqrt(3)).
+        @InternalComposeUiApi // Never supposed to be used public. Will be hidden in future versions
         val BlurSigmaScale = 0.57735f
 
+        @InternalComposeUiApi // Never supposed to be used public. Will be hidden in future versions
         fun convertRadiusToSigma(radius: Float) =
             if (radius > 0) {
                 BlurSigmaScale * radius + 0.5f
@@ -129,7 +146,7 @@ actual class OffsetEffect actual constructor(
 ) : RenderEffect() {
 
     override fun createImageFilter(): ImageFilter =
-        ImageFilter.makeOffset(offset.x, offset.y, renderEffect?.asSkiaImageFilter(), null)
+        ImageFilter.makeOffset(offset.x, offset.y, renderEffect?.skiaImageFilter, null)
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
@@ -37,7 +37,8 @@ import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.draw
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
+import androidx.compose.ui.graphics.skiaImageFilter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toSkia
 import androidx.compose.ui.unit.Density
@@ -353,7 +354,7 @@ actual class GraphicsLayer internal constructor(
         if (isReleased) return
         configureOutlineAndClip()
         parentLayer?.addSubLayer(this)
-        renderNode?.drawInto(canvas.nativeCanvas)
+        renderNode?.drawInto(canvas.skiaCanvas)
     }
 
     private fun onAddedToParentLayer() {
@@ -443,7 +444,7 @@ actual class GraphicsLayer internal constructor(
         renderNode?.layerPaint = if (requiresLayer()) {
             SkPaint().also {
                 it.setAlphaf(alpha)
-                it.imageFilter = renderEffect?.asSkiaImageFilter()
+                it.imageFilter = renderEffect?.skiaImageFilter
                 it.colorFilter = colorFilter?.asSkiaColorFilter()
                 it.blendMode = blendMode.toSkia()
             }

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/shadow/Blur.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/shadow/Blur.skiko.kt
@@ -16,11 +16,14 @@
 
 package androidx.compose.ui.graphics.shadow
 
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.graphics.BlurEffect.Companion.convertRadiusToSigma
 import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.skiaPaint
 import org.jetbrains.skia.FilterBlurMode
 import org.jetbrains.skia.MaskFilter
 
+@OptIn(InternalComposeUiApi::class)
 internal actual fun BlurFilter(radius: Float): BlurFilter {
     val sigma = convertRadiusToSigma(radius);
     return MaskFilter.makeBlur(FilterBlurMode.NORMAL, sigma)
@@ -31,5 +34,5 @@ internal actual fun BlurFilter(radius: Float): BlurFilter {
 internal actual typealias BlurFilter = MaskFilter // Only the base type is available
 
 internal actual fun Paint.setBlurFilter(blur: BlurFilter?) {
-    asFrameworkPaint().maskFilter = blur
+    skiaPaint.maskFilter = blur
 }

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/SkiaParagraph.skiko.kt
@@ -27,9 +27,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.graphics.asComposePath
-import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.drawscope.DrawStyle
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.graphics.toComposeRect
 import androidx.compose.ui.text.internal.requirePrecondition
 import androidx.compose.ui.text.platform.SkiaParagraphIntrinsics
@@ -601,7 +600,7 @@ internal class SkiaParagraph(
                 width = width
             )
         }
-        paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
     }
 
     @ExperimentalTextApi
@@ -625,7 +624,7 @@ internal class SkiaParagraph(
                 width = width
             )
         }
-        paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
     }
 
     @ExperimentalTextApi
@@ -654,7 +653,7 @@ internal class SkiaParagraph(
                 width = width
             )
         }
-        paragraph.paint(canvas.nativeCanvas, 0.0f, 0.0f)
+        paragraph.paint(canvas.skiaCanvas, 0.0f, 0.0f)
     }
 
     /**

--- a/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
+++ b/compose/ui/ui-text/src/skikoMain/kotlin/androidx/compose/ui/text/platform/SkiaTextPaint.skiko.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.graphics.PaintingStyle
 import androidx.compose.ui.graphics.Shader
 import androidx.compose.ui.graphics.ShaderBrush
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.nativePaint
+import androidx.compose.ui.graphics.skiaPaint
 import androidx.compose.ui.graphics.drawscope.DrawStyle
 import androidx.compose.ui.graphics.drawscope.Fill
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -40,7 +40,7 @@ internal class SkiaTextPaint(
     private val original: Paint = Paint(),
 ) : Paint by original {
     internal val skiaPaint
-        get() = original.nativePaint
+        get() = original.skiaPaint
 
     @VisibleForTesting
     internal var brush: Brush? = null

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/res/DesktopSvgResources.desktop.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.DrawCache
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import java.io.InputStream
@@ -132,7 +132,7 @@ private class SVGPainter(
             root?.width = SVGLength(size.width, SVGLengthUnit.PX)
             root?.height = SVGLength(size.height, SVGLengthUnit.PX)
             root?.preserveAspectRatio = SVGPreserveAspectRatio(SVGPreserveAspectRatioAlign.NONE)
-            dom.render(canvas.nativeCanvas)
+            dom.render(canvas.skiaCanvas)
         }
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Paint
-import androidx.compose.ui.graphics.nativePaint
+import androidx.compose.ui.graphics.skiaPaint
 import androidx.compose.ui.platform.PlatformWindowContext
 import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.skiko.OverlayRenderDecorator
@@ -194,7 +194,7 @@ internal class WindowComposeSceneLayer(
         val paint = Paint().apply {
             color = scrimColor
             blendMode = getDialogScrimBlendMode(transparent)
-        }.nativePaint
+        }.skiaPaint
         canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), paint)
     }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/RenderingTestScope.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
@@ -86,7 +86,7 @@ internal class RenderingTestScope(
     }
 
     private fun onRender(timeNanos: Long) {
-        canvas.nativeCanvas.clear(Color.Transparent.toArgb())
+        canvas.skiaCanvas.clear(Color.Transparent.toArgb())
         scene.render(canvas, timeNanos)
         onRender.complete(Unit)
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/LegacyRenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/LegacyRenderNodeLayer.skiko.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.FrameRateCategory
 import androidx.compose.ui.geometry.MutableRect
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
@@ -41,9 +40,10 @@ import androidx.compose.ui.graphics.alphaMultiplier
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.layer.GraphicsLayer
-import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.graphics.nativePaint
+import androidx.compose.ui.graphics.skiaCanvas
+import androidx.compose.ui.graphics.skiaPaint
 import androidx.compose.ui.graphics.prepareTransformationMatrix
+import androidx.compose.ui.graphics.skiaImageFilter
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.unit.Density
@@ -51,7 +51,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toRect
-import androidx.compose.ui.unit.toSize
 import kotlin.math.abs
 import kotlin.math.max
 import org.jetbrains.skia.ClipMode
@@ -262,7 +261,7 @@ internal class LegacyRenderNodeLayer(
         canvas.save()
         canvas.concat(matrix)
         canvas.translate(position.x.toFloat(), position.y.toFloat())
-        canvas.nativeCanvas.drawPicture(picture!!, null, null)
+        canvas.skiaCanvas.drawPicture(picture!!, null, null)
         canvas.restore()
     }
 
@@ -295,7 +294,7 @@ internal class LegacyRenderNodeLayer(
                     )
                     is Outline.Rounded -> {
                         val antiAlias = true
-                        canvas.nativeCanvas.clipRRect(
+                        canvas.skiaCanvas.clipRRect(
                             outline.roundRect.left,
                             outline.roundRect.top,
                             outline.roundRect.right,
@@ -332,7 +331,7 @@ internal class LegacyRenderNodeLayer(
                     bounds,
                     Paint().apply {
                         alpha = this@LegacyRenderNodeLayer.alpha
-                        nativePaint.imageFilter = currentRenderEffect?.asSkiaImageFilter()
+                        skiaPaint.imageFilter = currentRenderEffect?.skiaImageFilter
                     }
                 )
             } else {
@@ -364,10 +363,7 @@ internal class LegacyRenderNodeLayer(
             else -> return
         }
 
-        // TODO: perspective?
         val zParams = Point3(0f, 0f, shadowElevation)
-
-        // TODO: configurable?
         val lightPos = Point3(0f, -300.dp.toPx(), 600.dp.toPx())
         val lightRad = 800.dp.toPx()
 
@@ -377,19 +373,13 @@ internal class LegacyRenderNodeLayer(
         val spotColor = spotShadowColor.copy(alpha = spotAlpha)
 
         ShadowUtils.drawShadow(
-            canvas.nativeCanvas, path.asSkiaPath(), zParams, lightPos,
+            canvas.skiaCanvas, path.asSkiaPath(), zParams, lightPos,
             lightRad,
             ambientColor.toArgb(),
             spotColor.toArgb(), alpha < 1f, false
         )
     }
 }
-
-// Copy from Android's frameworks/base/libs/hwui/utils/MathUtils.h
-private const val NON_ZERO_EPSILON = 0.001f
-
-@Suppress("NOTHING_TO_INLINE")
-private inline fun Float.isZero(): Boolean = abs(this) <= NON_ZERO_EPSILON
 
 // The goal with selecting the size of the rectangle here is to avoid limiting the
 // drawable area as much as possible.


### PR DESCRIPTION
#2802's follow-up
[CMP-9836](https://youtrack.jetbrains.com/issue/CMP-9836) Deprecate `.native*` extensions in favor to `.skia*` in `ui-graphics`

## Release Notes
### Migration Notes - Multiple Platforms
- `RenderEffect.asSkiaImageFilter()` was replaced with `RenderEffect.skiaImageFilter` extension to avoid exposing a platform type into `commonMain` types
- Deprecate `Canvas.nativeCanvas` extension in favor of `Canvas.skiaCanvas` to avoid ambiguity.