### PR TITLE
Fix Magic mouse behavour on web targets

### DIFF
--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/BugsScreen.kt
@@ -25,6 +25,9 @@ val BugsScreen = Screen.Selection("Web Bug Reproducers", screens = listOf(
     Screen.Example("Touch events") {
         // https://youtrack.jetbrains.com/issue/CMP-9030/wasm-canvas-incorrect-handling-of-multi-touch-input
         PointerInputDebugOverlay()
+    },
+    Screen.Example("MagicMouse") {
+        MagicMouse()
     }
 ))
 

--- a/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/MagicMouse.kt
+++ b/compose/mpp/demo/src/webMain/kotlin/androidx/compose/mpp/demo/bugs/MagicMouse.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.mpp.demo.bugs
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+// https://youtrack.jetbrains.com/issue/CMP-7576
+@Composable
+fun MagicMouse() {
+    var count by remember { mutableStateOf(0) }
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(300.dp)
+                .background(Color.LightGray)
+                .clickable { count++ },
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Clicks: $count")
+        }
+    }
+}

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -204,6 +204,8 @@ internal class ComposeWindow(
 ) {
     private var isDisposed = false
 
+    private var actualActivePointerButtons: PointerButtons? = null
+
     private val density: Density = Density(
         density = actualDensity.toFloat(),
         fontScale = 1f
@@ -628,6 +630,25 @@ internal class ComposeWindow(
             }
         } else {
             keyboardModeState = KeyboardModeState.Hardware
+
+            // validate event before sending it further - see
+            // https://youtrack.jetbrains.com/issue/CMP-8430/Sequence-of-Move-PointerInputEvents-cancel-out-press-PointerInputEvent-under-certain-conditions
+
+            var isValidEvent = true
+            when (eventType) {
+                PointerEventType.Press -> {
+                    actualActivePointerButtons = event.composeButtons
+                }
+                PointerEventType.Release -> {
+                    actualActivePointerButtons = null
+                }
+                PointerEventType.Move -> {
+                    isValidEvent = actualActivePointerButtons == event.composeButtons
+                }
+            }
+
+            if (!isValidEvent) return
+
             result = scene.sendPointerEvent(
                 eventType = eventType,
                 position = event.offset,

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -643,7 +643,7 @@ internal class ComposeWindow(
                     actualActivePointerButtons = null
                 }
                 PointerEventType.Move -> {
-                    isValidEvent = actualActivePointerButtons == event.composeButtons
+                    isValidEvent = actualActivePointerButtons == null || actualActivePointerButtons == event.composeButtons
                 }
             }
 


### PR DESCRIPTION
This is quickfix for an issue that ideally should be approached again in a more thorough fashion  - as of now we just filter out move event that caused troubles

## Testing
manual plus `./gradlew webTest`

## Release Notes
### Fixes - Web
- Fix Magic mouse behaviour in Safari and Firefox