### PR TITLE
Cache languageTag in Locale for Darwin and Web platforms.

### DIFF
--- a/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.darwin.kt
+++ b/compose/ui/ui-text/src/darwinMain/kotlin/androidx/compose/ui/text/intl/NativePlatformLocale.darwin.kt
@@ -38,6 +38,8 @@ internal fun NSLocale.isRtl(): Boolean =
 // TODO: https://youtrack.jetbrains.com/issue/CMP-9697/Add-public-API-to-create-a-Compose-Locale-instance-via-NSLocale
 @Immutable
 actual class Locale internal constructor(internal val platformLocale: NSLocale) {
+    private val languageTag: String = platformLocale.languageIdentifier
+
     actual val language: String
         get() = platformLocale.languageCode
     actual val script: String
@@ -45,8 +47,7 @@ actual class Locale internal constructor(internal val platformLocale: NSLocale) 
     actual val region: String
         get() = platformLocale.countryCode ?: "US"
 
-    actual fun toLanguageTag(): String =
-        platformLocale.languageIdentifier
+    actual fun toLanguageTag(): String = languageTag
 
     actual override operator fun equals(other: Any?): Boolean {
         if (other == null) return false

--- a/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
+++ b/compose/ui/ui-text/src/webMain/kotlin/androidx/compose/ui/text/intl/PlatformLocale.web.kt
@@ -23,6 +23,8 @@ import kotlin.js.js
 
 @Immutable
 actual class Locale internal constructor(internal val platformLocale: IntlLocale) {
+    private val languageTag = platformLocale._baseName
+
     actual val language: String
         get() = platformLocale._language
     actual val script: String
@@ -30,7 +32,7 @@ actual class Locale internal constructor(internal val platformLocale: IntlLocale
     actual val region: String
         get() = platformLocale._region.orEmpty()
 
-    actual fun toLanguageTag(): String = platformLocale._baseName
+    actual fun toLanguageTag(): String = languageTag
 
     actual override operator fun equals(other: Any?): Boolean {
         if (other == null) return false


### PR DESCRIPTION
Cache `languageTag` in Locale for Darwin and Web platforms, because `toLanguageTag` is on the hot path.

Fixes [CMP-9695](https://youtrack.jetbrains.com/issue/CMP-9695)

## Testing
Benchmarks were run for the fix to see that the degradation has gone.

## Release Notes
N/A