### PR TITLE
Align `PlatformTextInputService` deprecation status with AOSP

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/CoreTextFieldInputServiceIntegrationTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/text/CoreTextFieldInputServiceIntegrationTest.kt
@@ -45,9 +45,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.TextInputService
 import kotlin.test.Ignore
 import kotlin.test.Test
 
@@ -57,7 +55,8 @@ class CoreTextFieldInputServiceIntegrationTest {
 
     private lateinit var focusManager: FocusManager
     private val platformTextInputService = FakePlatformTextInputService()
-    private val textInputService = TextInputService(platformTextInputService)
+    @Suppress("DEPRECATION")
+    private val textInputService = androidx.compose.ui.text.input.TextInputService(platformTextInputService)
 
     @Test
     fun textField_ImeOptions_isPassedTo_platformTextInputService() = runSkikoComposeUiTest {
@@ -323,7 +322,8 @@ class CoreTextFieldInputServiceIntegrationTest {
         }
     }
 
-    private class FakePlatformTextInputService : PlatformTextInputService {
+    @Suppress("DEPRECATION")
+    private class FakePlatformTextInputService : androidx.compose.ui.text.input.PlatformTextInputService {
         var startInputCalls = 0
         var stopInputCalls = 0
         var inputStarted = false

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldUndoTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldUndoTest.kt
@@ -94,6 +94,7 @@ class TextFieldUndoTest {
         }
     }
 
+    @Suppress("DEPRECATION")
     private val mock = object : PlatformTextInputService {
         override fun startInput(
             value: TextFieldValue,

--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/TextInputService.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/TextInputService.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.TextLayoutResult
  * it with [stopInput].
  */
 // Open for testing purposes.
+@Deprecated("Use PlatformTextInputModifierNode instead.")
 open class TextInputService(private val platformTextInputService: PlatformTextInputService) {
     private val _currentInputSession: AtomicReference<TextInputSession?> = AtomicReference(null)
 
@@ -285,6 +286,7 @@ class TextInputSession(
 }
 
 /** Platform specific text input service. */
+@Deprecated("Use PlatformTextInputModifierNode instead.")
 interface PlatformTextInputService {
     /**
      * Start text input session for given client.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/DesktopPlatformInput.desktop.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.text.input.DeleteSurroundingTextInCodePointsCommand
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.substring
@@ -38,8 +37,9 @@ import kotlin.math.min
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 
+@Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
 internal class DesktopTextInputService(private val component: PlatformComponent) :
-    PlatformTextInputService {
+    androidx.compose.ui.text.input.PlatformTextInputService {
     data class CurrentInput(
         var value: TextFieldValue,
         val onEditCommand: ((List<EditCommand>) -> Unit),

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.text.input.EditProcessor
 import androidx.compose.ui.text.input.FinishComposingTextCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.SetComposingRegionCommand
 import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.SetSelectionCommand
@@ -80,6 +79,7 @@ import platform.UIKit.UIViewAutoresizingFlexibleWidth
 // Adding a delay to the 'resignFirstResponder' function call to eliminate this issue.
 private val CLEAR_FOCUS_DELAY: Long = 10L
 
+@Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
 internal class UIKitTextInputService(
     private val updateView: UIKitTextInputService.() -> Unit,
     private val view: UIView,
@@ -93,7 +93,7 @@ internal class UIKitTextInputService(
     private var onKeyboardPresses: (Set<*>) -> Unit,
     private var focusManager: () -> ComposeSceneFocusManager?,
     coroutineContext: kotlin.coroutines.CoroutineContext
-) : PlatformTextInputService, TextToolbar, UIKitNativeTextInputContext {
+) : androidx.compose.ui.text.input.PlatformTextInputService, TextToolbar, UIKitNativeTextInputContext {
 
     private val coroutineScope = CoroutineScope(coroutineContext)
 

--- a/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/platform/MacosTextInputService.macos.kt
+++ b/compose/ui/ui/src/macosMain/kotlin/androidx/compose/ui/platform/MacosTextInputService.macos.kt
@@ -19,10 +19,10 @@ package androidx.compose.ui.platform
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 
-internal class MacosTextInputService : PlatformTextInputService {
+@Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
+internal class MacosTextInputService : androidx.compose.ui.text.input.PlatformTextInputService {
 
     data class CurrentInput(
         var value: TextFieldValue,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformContext.skiko.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -137,7 +136,8 @@ interface PlatformContext {
 
     val viewConfiguration: ViewConfiguration get() = DefaultViewConfiguration
     val inputModeManager: InputModeManager
-    val textInputService: PlatformTextInputService get() = EmptyPlatformTextInputService
+    @Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
+    val textInputService: androidx.compose.ui.text.input.PlatformTextInputService get() = EmptyPlatformTextInputService
 
     suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
         awaitCancellation()
@@ -283,7 +283,8 @@ internal class DefaultInputModeManager(
         }
 }
 
-private object EmptyPlatformTextInputService : PlatformTextInputService {
+@Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
+private object EmptyPlatformTextInputService : androidx.compose.ui.text.input.PlatformTextInputService {
     override fun startInput(
         value: TextFieldValue,
         imeOptions: ImeOptions,

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/RootNodeOwnerTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/node/RootNodeOwnerTest.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextEditingScope
 import androidx.compose.ui.text.input.TextEditorState
 import androidx.compose.ui.text.input.TextFieldValue
@@ -54,7 +53,8 @@ class RootNodeOwnerTest {
         var inputStarted = false
         var inputStopped = false
 
-        val textInputService = object : PlatformTextInputService {
+        @Suppress("DEPRECATION")
+        val textInputService = object : androidx.compose.ui.text.input.PlatformTextInputService {
             override fun startInput(
                 value: TextFieldValue,
                 imeOptions: ImeOptions,
@@ -77,7 +77,8 @@ class RootNodeOwnerTest {
         }
         val owner = RootNodeOwner(
             platformContext = object : PlatformContext.Empty() {
-                override val textInputService: PlatformTextInputService = textInputService
+                @Suppress("DEPRECATION")
+                override val textInputService: androidx.compose.ui.text.input.PlatformTextInputService = textInputService
                 override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
                     sessionStarted = true
                     awaitCancellation()
@@ -107,7 +108,8 @@ class RootNodeOwnerTest {
         var keyboardShowCalled = false
         var keyboardHideCalled = false
 
-        val textInputService = object : PlatformTextInputService {
+        @Suppress("DEPRECATION")
+        val textInputService = object : androidx.compose.ui.text.input.PlatformTextInputService {
             override fun startInput(
                 value: TextFieldValue,
                 imeOptions: ImeOptions,
@@ -128,7 +130,8 @@ class RootNodeOwnerTest {
         }
         val owner = RootNodeOwner(
             platformContext = object : PlatformContext.Empty() {
-                override val textInputService: PlatformTextInputService = textInputService
+                @Suppress("DEPRECATION")
+                override val textInputService: androidx.compose.ui.text.input.PlatformTextInputService = textInputService
                 override suspend fun startInputMethod(request: PlatformTextInputMethodRequest): Nothing {
                     awaitCancellation()
                 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
-import androidx.compose.ui.text.input.PlatformTextInputService
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.height
@@ -41,7 +40,9 @@ internal interface InputAwareInputService {
     fun getNewGeometryForBackingInput(rect: Rect): DpRect
 }
 
-internal abstract class WebTextInputService : PlatformTextInputService, InputAwareInputService {
+@Suppress("DEPRECATION") // TODO https://youtrack.jetbrains.com/issue/CMP-9858
+internal abstract class WebTextInputService :
+    androidx.compose.ui.text.input.PlatformTextInputService, InputAwareInputService {
 
     private var backingDomInput: BackingDomInput? = null
         set(value) {


### PR DESCRIPTION
[CMP-9421](https://youtrack.jetbrains.com/issue/CMP-9421) Align `PlatformTextInputService` public common API

We "temporarily" [removed](https://github.com/JetBrains/compose-multiplatform-core/pull/1496) deprecation for 1.7, but forgot about it after that. We need to align `commonMain` with AOSP state

## Release Notes
N/A