### PR TITLE
Add support for Pan and Scale trackpad events in ComposeScene

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/gestures/DesktopScrollable.desktop.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.ui.awt.awtEventOrNull
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.unit.Density
@@ -57,6 +58,11 @@ internal abstract class DesktopScrollConfig : ScrollConfig {
 internal object LinuxGnomeConfig : DesktopScrollConfig() {
     // the formula was determined experimentally based on Ubuntu Nautilus behaviour
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
+        // TODO: https://youtrack.jetbrains.com/issue/CMP-1610
+        if (event.type == PointerEventType.Pan) {
+            return event.totalPanGestureOffset
+        }
+
         return if (event.shouldScrollByPage) {
             calculateOffsetByPage(event, bounds)
         } else {
@@ -71,6 +77,11 @@ internal object LinuxGnomeConfig : DesktopScrollConfig() {
 internal object WindowsWinUIConfig : DesktopScrollConfig() {
     // the formula was determined experimentally based on Windows Start behaviour
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
+        // TODO: https://youtrack.jetbrains.com/issue/CMP-1610
+        if (event.type == PointerEventType.Pan) {
+            return event.totalPanGestureOffset
+        }
+
         return if (event.shouldScrollByPage) {
             calculateOffsetByPage(event, bounds)
         } else {
@@ -86,6 +97,11 @@ internal object MacOSCocoaConfig : DesktopScrollConfig() {
     // the formula was determined experimentally based on MacOS Finder behaviour
     // MacOS driver will send events with accelerating delta
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset {
+        // TODO: https://youtrack.jetbrains.com/issue/CMP-1610
+        if (event.type == PointerEventType.Pan) {
+            return event.totalPanGestureOffset
+        }
+
         return if (event.shouldScrollByPage) {
             calculateOffsetByPage(event, bounds)
         } else {
@@ -113,6 +129,9 @@ private val PointerEvent.shouldScrollByPage
 
 private val PointerEvent.totalScrollDelta
     get() = this.changes.fastFold(Offset.Zero) { acc, c -> acc + c.scrollDelta }
+
+private val PointerEvent.totalPanGestureOffset
+    get() = -this.changes.fastFold(Offset.Zero) { acc, c -> acc + c.panGestureOffset }
 
 private val PointerEvent.isPreciseWheelRotation
     get() = (awtEventOrNull as? MouseWheelEvent)?.isPreciseWheelRotation ?: false

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/gestures/UikitScrollable.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/gestures/UikitScrollable.ios.kt
@@ -18,20 +18,21 @@ package androidx.compose.foundation.gestures
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFold
 
 internal actual fun CompositionLocalConsumerModifierNode.platformScrollConfig(): ScrollConfig = UiKitScrollConfig
 
 internal object UiKitScrollConfig : ScrollConfig {
-    /*
-     * There are no scroll events produced on iOS,
-     * so in reality this function should not be ever called.
-     * The implementation is copied from androidMain just for testing purposes.
-     */
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset =
-        event.changes.fastFold(Offset.Zero) { acc, c -> acc + c.scrollDelta } * -64.dp.toPx()
+        -event.changes.fastFold(Offset.Zero) { acc, c ->
+            if (event.type == PointerEventType.Pan) {
+                acc + c.panGestureOffset
+            } else {
+                acc + c.scrollDelta
+            }
+        }
 }

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/gestures/UikitScrollable.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/gestures/UikitScrollable.ios.kt
@@ -22,17 +22,18 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.fastFold
 
 internal actual fun CompositionLocalConsumerModifierNode.platformScrollConfig(): ScrollConfig = UiKitScrollConfig
 
 internal object UiKitScrollConfig : ScrollConfig {
     override fun Density.calculateMouseWheelScroll(event: PointerEvent, bounds: IntSize): Offset =
-        -event.changes.fastFold(Offset.Zero) { acc, c ->
+        event.changes.fastFold(Offset.Zero) { acc, c ->
             if (event.type == PointerEventType.Pan) {
                 acc + c.panGestureOffset
             } else {
                 acc + c.scrollDelta
             }
-        }
+        } * -64.dp.toPx()
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/InputDispatcher.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/InputDispatcher.skiko.kt
@@ -225,37 +225,62 @@ internal class SkikoInputDispatcher(
         }
     }
 
-    // TODO: https://youtrack.jetbrains.com/issue/CMP-9457
     override fun CursorInputState.enqueueTrackpadPress(buttonId: Int) {
-        TODO("No yet implemented - CMP-9457")
+        // Except for special gestures, trackpad input works exactly the same as mouse input.
+        this.enqueueMousePress(buttonId)
     }
 
     override fun CursorInputState.enqueueTrackpadMove() {
-        TODO("No yet implemented - CMP-9457")
+        // Except for special gestures, trackpad input works exactly the same as mouse input.
+        this.enqueueMouseMove()
     }
 
     override fun CursorInputState.enqueueTrackpadRelease(buttonId: Int) {
-        TODO("No yet implemented - CMP-9457")
+        // Except for special gestures, trackpad input works exactly the same as mouse input.
+        this.enqueueMouseRelease(buttonId)
     }
 
     override fun CursorInputState.enqueueTrackpadEnter() {
-        TODO("No yet implemented - CMP-9457")
+        // Except for special gestures, trackpad input works exactly the same as mouse input.
+        this.enqueueMouseEnter()
     }
 
     override fun CursorInputState.enqueueTrackpadExit() {
-        TODO("No yet implemented - CMP-9457")
+        // Except for special gestures, trackpad input works exactly the same as mouse input.
+        this.enqueueMouseExit()
     }
 
     override fun CursorInputState.enqueueTrackpadCancel() {
-        TODO("No yet implemented - CMP-9457")
+        // Except for special gestures, trackpad input works exactly the same as mouse input.
+        this.enqueueMouseCancel()
     }
 
     override fun CursorInputState.enqueueTrackpadScroll(offset: Offset) {
-        TODO("No yet implemented - CMP-9457")
+        val position = lastPosition
+        val timeMillis = currentTime
+        enqueue(timeMillis) {
+            root.sendPointerEvent(
+                PointerEventType.Pan,
+                position = position,
+                type = PointerType.Mouse,
+                timeMillis = timeMillis,
+                panGestureOffset = offset
+            )
+        }
     }
 
     override fun CursorInputState.enqueueTrackpadPinch(scaleFactor: Float) {
-        TODO("No yet implemented - CMP-9457")
+        val position = lastPosition
+        val timeMillis = currentTime
+        enqueue(timeMillis) {
+            root.sendPointerEvent(
+                PointerEventType.Scale,
+                position = position,
+                type = PointerType.Mouse,
+                timeMillis = timeMillis,
+                scaleGestureFactor = scaleFactor
+            )
+        }
     }
 
     override fun KeyInputState.enqueueDown(key: Key) {

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TrackpadInputTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TrackpadInputTest.kt
@@ -1,0 +1,443 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.PointerMatcher
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.onClick
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.*
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests the trackpad-event sending functionality of the test framework.
+ */
+@OptIn(ExperimentalTestApi::class, ExperimentalFoundationApi::class)
+class TrackpadInputTest {
+
+    @Test
+    fun testPerformClick() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .clickable {
+                        clicked = true
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                click()
+            }
+            assertTrue(clicked, "Click event not received")
+        }
+    }
+
+    @Test
+    fun testMouseClick() = runComposeUiTest {
+        var clicked = false
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .clickable {
+                        clicked = true
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                click()
+            }
+            assertTrue(clicked, "Mouse click event not received")
+        }
+    }
+
+    @Test
+    fun testMousePressDragAndRelease() = runComposeUiTest {
+        var pressDetected = false
+        var dragDetected = false
+        var releaseDetected = false
+
+        fun assertState(expectedPress: Boolean, expectedDrag: Boolean, expectedRelease: Boolean) {
+            assertEquals(expectedPress, pressDetected, "Press detection mismatch")
+            assertEquals(expectedDrag, dragDetected, "Drag detection mismatch")
+            assertEquals(expectedRelease, releaseDetected, "Release detection mismatch")
+        }
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .pointerInput(Unit) {
+                        awaitEachGesture {
+                            val down = awaitFirstDown().also { it.consume() }
+                            pressDetected = true
+
+                            awaitDragOrCancellation(down.id) ?: return@awaitEachGesture
+                            dragDetected = true
+
+                            waitForUpOrCancellation() ?: return@awaitEachGesture
+                            releaseDetected = true
+                        }
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                press()
+            }
+            assertState(expectedPress = true, expectedDrag = false, expectedRelease = false)
+
+            performTrackpadInput {
+                moveBy(Offset(x = 50f, y = 50f))
+            }
+            assertState(expectedPress = true, expectedDrag = true, expectedRelease = false)
+
+            performTrackpadInput {
+                release()
+            }
+            assertState(expectedPress = true, expectedDrag = true, expectedRelease = true)
+        }
+    }
+
+    private fun Modifier.onPointerEvent(
+        eventType: PointerEventType,
+        onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
+    ) = pointerInput(eventType, onEvent) {
+        awaitPointerEventScope {
+            while (true) {
+                val event = awaitPointerEvent()
+                if (event.type == eventType) {
+                    onEvent(event)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testMouseEnterExit() = runComposeUiTest {
+        var mouseEnterDetected = false
+        var mouseExitDetected = false
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onPointerEvent(PointerEventType.Enter) {
+                        mouseEnterDetected = true
+                    }
+                    .onPointerEvent(PointerEventType.Exit) {
+                        mouseExitDetected = true
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                enter()
+            }
+            assertTrue(mouseEnterDetected, "Mouse entered event not detected")
+
+            performTrackpadInput {
+                exit()
+            }
+            assertTrue(mouseExitDetected, "Mouse exited event not detected")
+        }
+    }
+
+    @Test
+    fun updatePointerToDoesNotSendMoveEvent() = runComposeUiTest {
+        var mouseMoveDetected = false
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onPointerEvent(PointerEventType.Move) {
+                        mouseMoveDetected = true
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                updatePointerTo(Offset(10f, 10f))
+                press()
+                release()
+            }
+            assertFalse(mouseMoveDetected, "Mouse move detected")
+        }
+    }
+
+    @Test
+    fun testPan() = runComposeUiTest {
+        var panDelta = Offset.Unspecified
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .pointerInput(Unit) {
+                        awaitEachGesture {
+                            val event = awaitPointerEvent()
+                            if (event.type == PointerEventType.Pan) {
+                                panDelta = event.changes.first().panGestureOffset
+                            }
+                        }
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                scroll(Offset(0f, 50f))
+            }
+            assertEquals(Offset(0f, 50f), panDelta, "Wrong vertical scroll delta detected")
+
+            performTrackpadInput {
+                scroll(Offset(30f, 0f))
+            }
+            assertEquals(Offset(30f, 0f), panDelta, "Wrong horizontal scroll delta detected")
+        }
+    }
+
+    @Test
+    fun testPinch() = runComposeUiTest {
+        var scale: Float? = null
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .pointerInput(Unit) {
+                        awaitEachGesture {
+                            val event = awaitPointerEvent()
+                            if (event.type == PointerEventType.Scale) {
+                                scale = event.changes.first().scaleGestureFactor
+                            }
+                        }
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                pinch(0.5f)
+            }
+            assertEquals(0.5f, scale, "Wrong vertical scroll delta detected")
+
+            performTrackpadInput {
+                pinch(2.0f)
+            }
+            assertEquals(2.0f, scale, "Wrong horizontal scroll delta detected")
+        }
+    }
+
+    @Test
+    fun testClick() = runComposeUiTest {
+        var clickDetected = false
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onClick(matcher = PointerMatcher.mouse(PointerButton.Primary)) {
+                        clickDetected = true
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                click()
+            }
+            assertTrue(clickDetected, "Mouse click not detected")
+        }
+    }
+
+    @Test
+    fun testRightClick() = runComposeUiTest {
+        var rightClickDetected = false
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onClick(matcher = PointerMatcher.mouse(PointerButton.Secondary)) {
+                        rightClickDetected = true
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                rightClick()
+            }
+            assertTrue(rightClickDetected, "Mouse right-click not detected")
+        }
+    }
+
+    @Test
+    fun testDoubleClick() = runComposeUiTest {
+        var doubleClickDetected = false
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Primary),
+                        onDoubleClick = {
+                            doubleClickDetected = true
+                        },
+                        onClick = {}
+                    )
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                doubleClick()
+            }
+            assertTrue(doubleClickDetected, "Mouse double-click not detected")
+        }
+    }
+
+    @Test
+    fun testTripleClick() = runComposeUiTest {
+        var clickCount = 0
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Primary),
+                        onClick = {
+                            clickCount += 1
+                        }
+                    )
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                tripleClick()
+            }
+            assertEquals(3, clickCount, "Mouse triple-click not detected")
+        }
+    }
+
+    @Test
+    fun testLongClick() = runComposeUiTest {
+        var longClickDetected = false
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .onClick(
+                        matcher = PointerMatcher.mouse(PointerButton.Primary),
+                        onLongClick = {
+                            longClickDetected = true
+                        },
+                        onClick = {}
+                    )
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                longClick()
+            }
+            assertTrue(longClickDetected, "Mouse long-click not detected")
+        }
+    }
+
+    @Test
+    fun testDragAndDrop() = runComposeUiTest {
+        var dragOffset = Offset.Zero
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("tag")
+                    .size(100.dp)
+                    .pointerInput(Unit) {
+                        detectDragGestures { _, dragAmount ->
+                            dragOffset += dragAmount
+                        }
+                    }
+            )
+        }
+
+        onNodeWithTag("tag").apply {
+            performTrackpadInput {
+                dragAndDrop(
+                    start = Offset(10f, 10f),
+                    end = Offset(20f, 30f),
+                )
+            }
+            assertOffsetEquals(
+                expected = Offset(10f, 20f),
+                actual = dragOffset,
+                message = "Wrong drag-and-drop offset detected"
+            )
+        }
+    }
+
+    private fun assertOffsetEquals(
+        expected: Offset,
+        actual: Offset,
+        toleratedDistance: Float = 0.5f,
+        message: String? = null
+    ) {
+        assertTrue(
+            actual = (expected - actual).getDistance() < toleratedDistance,
+            message = (if (message == null) "" else "$message; ") +
+                "expected=$expected, actual=$actual, toleratedDistance=$toleratedDistance"
+        )
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/ComposeSceneInputTest.kt
@@ -283,6 +283,59 @@ class ComposeSceneInputTest {
     }
 
     @Test
+    fun pan() = ImageComposeScene(100, 100).useInUiThread { scene ->
+        val background = FillBox()
+
+        scene.setContent {
+            background.Content()
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(20f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(20f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Pan, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Move, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Pan, Offset(10f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Move, Offset(20f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Pan, Offset(20f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Pan, Offset(20f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Pan, Offset(30f, 10f))
+        background.events.assertReceived(PointerEventType.Move, Offset(30f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Pan, Offset(30f, 10f))
+    }
+
+    @Test
+    fun scale() = ImageComposeScene(100, 100).useInUiThread { scene ->
+        val background = FillBox()
+
+        scene.setContent {
+            background.Content()
+        }
+
+        scene.sendPointerEvent(PointerEventType.Enter, Offset(20f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Enter, Offset(20f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Scale, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Move, Offset(10f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Scale, Offset(10f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Move, Offset(20f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Scale, Offset(20f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Scale, Offset(20f, 10f))
+
+        scene.sendPointerEvent(PointerEventType.Scale, Offset(30f, 10f))
+        background.events.assertReceived(PointerEventType.Move, Offset(30f, 10f))
+        background.events.assertReceivedLast(PointerEventType.Scale, Offset(30f, 10f))
+    }
+
+
+    @Test
     fun touch() = ImageComposeScene(100, 100).useInUiThread { scene ->
         val background = FillBox()
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -16,15 +16,18 @@
 
 package androidx.compose.ui
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Enter
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Exit
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Move
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Press
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Release
+import androidx.compose.ui.input.pointer.PointerEventType.Companion.Scroll
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.SyntheticEventSender
 import androidx.compose.ui.scene.PointerEventResult
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -474,6 +477,81 @@ class SyntheticEventSenderTest {
             mouseEvent(Move, 10f, 20f, pressed = false),
             mouseEvent(Exit, 10f, 20f, pressed = false)
         )
+    }
+
+    @Test
+    fun `synthetic events should not duplicate scrollDelta`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+
+        sender.send(
+            mouseEvent(
+                Scroll,
+                10f,
+                20f,
+                pressed = false,
+                scrollDelta = Offset(0f, 5f)
+            )
+        )
+        sender.send(mouseEvent(Press, 10f, 30f, pressed = true))
+
+        assertEquals(3, received.size)
+        val totalScroll = received.fold(Offset.Zero) { acc, event ->
+            acc + event.pointers.fold(Offset.Zero) { a, p -> a + p.scrollDelta }
+        }
+        assertEquals(Offset(0f, 5f), totalScroll)
+    }
+
+    @Test
+    fun `synthetic events should not duplicate panGestureOffset`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+
+        sender.send(
+            mouseEvent(
+                Scroll,
+                10f,
+                20f,
+                pressed = false,
+                panGestureOffset = Offset(0f, 5f)
+            )
+        )
+        sender.send(mouseEvent(Press, 10f, 30f, pressed = true))
+
+        assertEquals(3, received.size)
+        val totalScroll = received.fold(Offset.Zero) { acc, event ->
+            acc + event.pointers.fold(Offset.Zero) { a, p -> a + p.panGestureOffset }
+        }
+        assertEquals(Offset(0f, 5f), totalScroll)
+    }
+
+    @Test
+    fun `synthetic events should not duplicate scaleGestureFactor`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSender {
+            PointerEventResult(received.add(it))
+        }
+
+        sender.send(
+            mouseEvent(
+                Scroll,
+                10f,
+                20f,
+                pressed = false,
+                scaleGestureFactor = 2.0f
+            )
+        )
+        sender.send(mouseEvent(Press, 10f, 30f, pressed = true))
+
+        assertEquals(3, received.size)
+        val totalScaleFactor = received.fold(1f) { acc, event ->
+            acc * event.pointers.fold(1f) { a, p -> a * p.scaleGestureFactor }
+        }
+        assertEquals(2f, totalScaleFactor)
     }
 
     private fun eventsSentBy(

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -845,8 +845,8 @@ private fun UIEvent.historicalChangesForTouch(
                 uptimeMillis = (historicalTouch.timestamp * 1e3).toLong(),
                 position = position,
                 originalEventPosition = position,
-                scaleGestureFactor = 1f, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
-                panGestureOffset = Offset.Zero, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
+                scaleGestureFactor = 1f,
+                panGestureOffset = Offset.Zero,
             )
         }
     } else {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -429,7 +429,7 @@ internal class ComposeSceneMediator(
         }
 
         scene.sendPointerEvent(
-            eventType = PointerEventType.Pan,
+            eventType = PointerEventType.Scroll,
             pointers = listOf(
                 ComposeScenePointer(
                     id = PointerId(0),
@@ -438,10 +438,10 @@ internal class ComposeSceneMediator(
                     type = PointerType.Mouse,
                 )
             ),
+            scrollDelta = delta.toOffset(composeSceneDensity),
             timeMillis = event.timeMillis,
             nativeEvent = event,
             keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero),
-            panGestureOffset = delta.toOffset(composeSceneDensity),
         )
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -429,7 +429,7 @@ internal class ComposeSceneMediator(
         }
 
         scene.sendPointerEvent(
-            eventType = PointerEventType.Scroll,
+            eventType = PointerEventType.Pan,
             pointers = listOf(
                 ComposeScenePointer(
                     id = PointerId(0),
@@ -438,10 +438,10 @@ internal class ComposeSceneMediator(
                     type = PointerType.Mouse,
                 )
             ),
-            scrollDelta = delta.toOffset(composeSceneDensity) * SCROLL_DELTA_MULTIPLIER,
             timeMillis = event.timeMillis,
             nativeEvent = event,
-            keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero)
+            keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero),
+            panGestureOffset = delta.toOffset(composeSceneDensity),
         )
     }
 
@@ -820,7 +820,6 @@ private val UIEvent?.timeMillis: Long get() {
 }
 
 private val FOCUS_CHANGE_ANIMATION_DURATION = 0.15.seconds
-private val SCROLL_DELTA_MULTIPLIER = 0.01f
 
 private fun TouchesEventKind.toPointerEventType(): PointerEventType =
     when (this) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -438,10 +438,10 @@ internal class ComposeSceneMediator(
                     type = PointerType.Mouse,
                 )
             ),
-            scrollDelta = delta.toOffset(composeSceneDensity),
+            scrollDelta = delta.toOffset(composeSceneDensity) * SCROLL_DELTA_MULTIPLIER,
             timeMillis = event.timeMillis,
             nativeEvent = event,
-            keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero),
+            keyboardModifiers = PointerKeyboardModifiers(event.modifierFlagsOrZero)
         )
     }
 
@@ -820,6 +820,7 @@ private val UIEvent?.timeMillis: Long get() {
 }
 
 private val FOCUS_CHANGE_ANIMATION_DURATION = 0.15.seconds
+private val SCROLL_DELTA_MULTIPLIER = 0.01f
 
 private fun TouchesEventKind.toPointerEventType(): PointerEventType =
     when (this) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -315,7 +315,9 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
-        button: PointerButton? = null
+        button: PointerButton? = null,
+        scaleGestureFactor: Float = 1f,
+        panGestureOffset: Offset = Offset.Zero,
     ) {
         scene.sendPointerEvent(
             eventType,
@@ -326,7 +328,9 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
             buttons,
             keyboardModifiers,
             nativeEvent,
-            button
+            button,
+            scaleGestureFactor,
+            panGestureOffset,
         )
     }
 
@@ -360,6 +364,8 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
         timeMillis: Long = (currentNanoTime() / 1E6).toLong(),
         nativeEvent: Any? = null,
         button: PointerButton? = null,
+        scaleGestureFactor: Float = 1f,
+        panGestureOffset: Offset = Offset.Zero,
     ) {
         scene.sendPointerEvent(
             eventType,
@@ -369,7 +375,9 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
             scrollDelta,
             timeMillis,
             nativeEvent,
-            button
+            button,
+            scaleGestureFactor,
+            panGestureOffset,
         )
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -316,8 +316,6 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
         button: PointerButton? = null,
-        scaleGestureFactor: Float = 1f,
-        panGestureOffset: Offset = Offset.Zero,
     ) {
         scene.sendPointerEvent(
             eventType,
@@ -328,9 +326,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
             buttons,
             keyboardModifiers,
             nativeEvent,
-            button,
-            scaleGestureFactor,
-            panGestureOffset,
+            button
         )
     }
 
@@ -347,12 +343,14 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      * @param buttons Contains the state of pointer buttons (e.g. mouse and stylus buttons) after the event.
      * @param keyboardModifiers Contains the state of modifier keys, such as Shift, Control,
      * and Alt, as well as the state of the lock keys, such as Caps Lock and Num Lock.
-     * @param scrollDelta scroll delta for the PointerEventType.Scroll event
+     * @param scrollDelta scroll delta for the PointerEventType.Scroll event.
      * @param timeMillis The time of the current pointer event, in milliseconds. The start (`0`) time
      * is platform-dependent.
      * @param nativeEvent The original native event.
      * @param button Represents the index of a button which state changed in this event. It's null
      * when there was no change of the buttons state or when button is not applicable (e.g. touch event).
+     * @param scaleGestureFactor The scale gesture factor for PointerEventType.Scale event.
+     * @param panGestureOffset The pan gesture offset for PointerEventType.Pan event.
      */
     @ExperimentalComposeUiApi
     fun sendPointerEvent(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -102,6 +102,8 @@ internal class SyntheticEventSender(
             PointerEventType.Move,
             PointerEventType.Press,
             PointerEventType.Scroll,
+            PointerEventType.Scale,
+            PointerEventType.Pan
                 -> isMousePointerInside = true
             PointerEventType.Exit
                 -> isMousePointerInside = false

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -276,7 +276,7 @@ internal class SyntheticEventSender(
         scrollDelta = Offset(0f, 0f),
         historical = emptyList(), // we don't copy historical for synthetic
         originalEventPosition = position,
-        scaleGestureFactor = 1f, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
-        panGestureOffset = Offset.Zero, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
+        scaleGestureFactor = scaleGestureFactor,
+        panGestureOffset = panGestureOffset,
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -275,10 +275,10 @@ internal class SyntheticEventSender(
         pressure = pressure,
         type = type,
         activeHover = activeHover,
-        scrollDelta = Offset(0f, 0f),
+        scrollDelta = Offset.Zero,
         historical = emptyList(), // we don't copy historical for synthetic
         scaleGestureFactor = 1.0f,
-        panGestureOffset = Offset(0f, 0f),
+        panGestureOffset = Offset.Zero,
         originalEventPosition = position,
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -267,18 +267,18 @@ internal class SyntheticEventSender(
         position: Offset = this.position,
         down: Boolean = this.down
     ) = PointerInputEventData(
-        id,
-        uptime,
-        position,
-        position,
-        down,
-        pressure,
-        type,
-        activeHover,
+        id = id,
+        uptime = uptime,
+        positionOnScreen = position,
+        position = position,
+        down = down,
+        pressure = pressure,
+        type = type,
+        activeHover = activeHover,
         scrollDelta = Offset(0f, 0f),
         historical = emptyList(), // we don't copy historical for synthetic
+        scaleGestureFactor = 1.0f,
+        panGestureOffset = Offset(0f, 0f),
         originalEventPosition = position,
-        scaleGestureFactor = scaleGestureFactor,
-        panGestureOffset = panGestureOffset,
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/TestPointerInputEventData.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/TestPointerInputEventData.skiko.kt
@@ -44,7 +44,7 @@ class TestPointerInputEventData(
             PointerType.Mouse,
             historical = listOf(),
             originalEventPosition = position,
-            scaleGestureFactor = 1f, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
-            panGestureOffset = Offset.Zero, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
+            scaleGestureFactor = 1f,
+            panGestureOffset = Offset.Zero,
         )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -755,7 +755,9 @@ internal class RootNodeOwner(
             buttons: PointerButtons?,
             keyboardModifiers: PointerKeyboardModifiers?,
             nativeEvent: Any?,
-            button: PointerButton?
+            button: PointerButton?,
+            scaleGestureFactor: Float,
+            panGestureOffset: Offset,
         ) {
             inputHandler.onPointerEvent(
                 eventType = eventType,
@@ -766,7 +768,9 @@ internal class RootNodeOwner(
                 buttons = buttons,
                 keyboardModifiers = keyboardModifiers,
                 nativeEvent = nativeEvent,
-                button = button
+                button = button,
+                scaleGestureFactor = scaleGestureFactor,
+                panGestureOffset = panGestureOffset,
             )
         }
 
@@ -782,6 +786,8 @@ internal class RootNodeOwner(
             timeMillis: Long,
             nativeEvent: Any?,
             button: PointerButton?,
+            scaleGestureFactor: Float,
+            panGestureOffset: Offset,
         ) {
             inputHandler.onPointerEvent(
                 eventType = eventType,
@@ -791,7 +797,9 @@ internal class RootNodeOwner(
                 scrollDelta = scrollDelta,
                 timeMillis = timeMillis,
                 nativeEvent = nativeEvent,
-                button = button
+                button = button,
+                scaleGestureFactor = scaleGestureFactor,
+                panGestureOffset = panGestureOffset,
             )
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformRootForTest.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformRootForTest.skiko.kt
@@ -64,7 +64,9 @@ interface PlatformRootForTest : RootForTest {
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
-        button: PointerButton? = null
+        button: PointerButton? = null,
+        scaleGestureFactor: Float = 1f,
+        panGestureOffset: Offset = Offset.Zero,
     )
 
     /**
@@ -82,5 +84,7 @@ interface PlatformRootForTest : RootForTest {
         timeMillis: Long = (currentNanoTime() / 1E6).toLong(),
         nativeEvent: Any? = null,
         button: PointerButton? = null,
+        scaleGestureFactor: Float = 1f,
+        panGestureOffset: Offset = Offset.Zero,
     )
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -207,7 +207,9 @@ internal abstract class BaseComposeScene(
         buttons: PointerButtons?,
         keyboardModifiers: PointerKeyboardModifiers?,
         nativeEvent: Any?,
-        button: PointerButton?
+        button: PointerButton?,
+        scaleGestureFactor: Float,
+        panGestureOffset: Offset
     ): PointerEventResult = postponeInvalidation(
         "BaseComposeScene:sendPointerEvent"
     ) {
@@ -220,7 +222,9 @@ internal abstract class BaseComposeScene(
             buttons = buttons,
             keyboardModifiers = keyboardModifiers,
             nativeEvent = nativeEvent,
-            button = button
+            button = button,
+            scaleGestureFactor = scaleGestureFactor,
+            panGestureOffset = panGestureOffset,
         ).also {
             recomposer.performScheduledEffects()
         }
@@ -236,6 +240,8 @@ internal abstract class BaseComposeScene(
         timeMillis: Long,
         nativeEvent: Any?,
         button: PointerButton?,
+        scaleGestureFactor: Float,
+        panGestureOffset: Offset,
     ): PointerEventResult = postponeInvalidation(
         "BaseComposeScene:sendPointerEvent"
     ) {
@@ -247,7 +253,9 @@ internal abstract class BaseComposeScene(
             scrollDelta = scrollDelta,
             timeMillis = timeMillis,
             nativeEvent = nativeEvent,
-            button = button
+            button = button,
+            scaleGestureFactor = scaleGestureFactor,
+            panGestureOffset = panGestureOffset,
         ).also {
             recomposer.performScheduledEffects()
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -240,7 +240,9 @@ private class CanvasLayersComposeSceneImpl(
             PointerEventType.Move -> processMove(event)
             PointerEventType.Enter -> processMove(event)
             PointerEventType.Exit -> processMove(event)
-            PointerEventType.Scroll -> processScroll(event)
+            PointerEventType.Scroll -> processHoveredEvent(event)
+            PointerEventType.Pan -> processHoveredEvent(event)
+            PointerEventType.Scale -> processHoveredEvent(event)
             else -> PointerEventResult(anyMovementConsumed = false)
         }
 
@@ -416,7 +418,7 @@ private class CanvasLayersComposeSceneImpl(
         return lastHoverOwnerResult.merging(ownerResult)
     }
 
-    private fun processScroll(event: PointerInputEvent): PointerEventResult {
+    private fun processHoveredEvent(event: PointerInputEvent): PointerEventResult {
         val owner = hoveredOwner(event)
         return if (isInteractive(owner)) {
             owner.onPointerInput(event)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -216,7 +216,9 @@ sealed interface ComposeScene : AutoCloseable {
         buttons: PointerButtons? = null,
         keyboardModifiers: PointerKeyboardModifiers? = null,
         nativeEvent: Any? = null,
-        button: PointerButton? = null
+        button: PointerButton? = null,
+        scaleGestureFactor: Float = 1f,
+        panGestureOffset: Offset = Offset.Zero,
     ): PointerEventResult
 
     /**
@@ -249,6 +251,8 @@ sealed interface ComposeScene : AutoCloseable {
         timeMillis: Long = currentTimeMillis(),
         nativeEvent: Any? = null,
         button: PointerButton? = null,
+        scaleGestureFactor: Float = 1f,
+        panGestureOffset: Offset = Offset.Zero,
     ): PointerEventResult
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -77,11 +77,13 @@ internal class ComposeSceneInputHandler(
         position: Offset,
         scrollDelta: Offset = Offset(0f, 0f),
         timeMillis: Long = (currentNanoTime() / 1E6).toLong(),
-        type: PointerType = PointerType.Mouse,
-        buttons: PointerButtons? = null,
-        keyboardModifiers: PointerKeyboardModifiers? = null,
-        nativeEvent: Any? = null,
-        button: PointerButton? = null
+        type: PointerType,
+        buttons: PointerButtons?,
+        keyboardModifiers: PointerKeyboardModifiers?,
+        nativeEvent: Any?,
+        button: PointerButton?,
+        scaleGestureFactor: Float,
+        panGestureOffset: Offset,
     ): PointerEventResult {
         defaultPointerStateTracker.onPointerEvent(button, eventType)
 
@@ -90,14 +92,16 @@ internal class ComposeSceneInputHandler(
             keyboardModifiers ?: defaultPointerStateTracker.keyboardModifiers
 
         return onPointerEvent(
-            eventType,
-            listOf(ComposeScenePointer(PointerId(0), position, actualButtons.areAnyPressed, type)),
-            actualButtons,
-            actualKeyboardModifiers,
-            scrollDelta,
-            timeMillis,
-            nativeEvent,
-            button
+            eventType = eventType,
+            pointers = listOf(ComposeScenePointer(PointerId(0), position, actualButtons.areAnyPressed, type)),
+            buttons = actualButtons,
+            keyboardModifiers = actualKeyboardModifiers,
+            scrollDelta = scrollDelta,
+            timeMillis = timeMillis,
+            nativeEvent = nativeEvent,
+            button = button,
+            scaleGestureFactor = scaleGestureFactor,
+            panGestureOffset = panGestureOffset,
         )
     }
 
@@ -113,18 +117,22 @@ internal class ComposeSceneInputHandler(
         keyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers(),
         scrollDelta: Offset = Offset(0f, 0f),
         timeMillis: Long = (currentNanoTime() / 1E6).toLong(),
-        nativeEvent: Any? = null,
-        button: PointerButton? = null,
+        nativeEvent: Any?,
+        button: PointerButton?,
+        scaleGestureFactor: Float,
+        panGestureOffset: Offset,
     ): PointerEventResult {
         val event = PointerInputEvent(
-            eventType,
-            pointers,
-            timeMillis,
-            nativeEvent,
-            scrollDelta,
-            buttons,
-            keyboardModifiers,
-            button,
+            eventType = eventType,
+            pointers = pointers,
+            timeMillis = timeMillis,
+            nativeEvent = nativeEvent,
+            scrollDelta = scrollDelta,
+            buttons = buttons,
+            keyboardModifiers = keyboardModifiers,
+            changedButton = button,
+            scaleGestureFactor = scaleGestureFactor,
+            panGestureOffset = panGestureOffset
         )
         prepareForPointerInputEvent()
         val updatePointerPositionResult = updatePointerPosition()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
-import org.jetbrains.skiko.currentNanoTime
 
 /**
  * Handles input events for [ComposeScene].
@@ -75,8 +74,8 @@ internal class ComposeSceneInputHandler(
     fun onPointerEvent(
         eventType: PointerEventType,
         position: Offset,
-        scrollDelta: Offset = Offset(0f, 0f),
-        timeMillis: Long = (currentNanoTime() / 1E6).toLong(),
+        scrollDelta: Offset,
+        timeMillis: Long,
         type: PointerType,
         buttons: PointerButtons?,
         keyboardModifiers: PointerKeyboardModifiers?,
@@ -113,10 +112,10 @@ internal class ComposeSceneInputHandler(
     fun onPointerEvent(
         eventType: PointerEventType,
         pointers: List<ComposeScenePointer>,
-        buttons: PointerButtons = PointerButtons(),
-        keyboardModifiers: PointerKeyboardModifiers = PointerKeyboardModifiers(),
-        scrollDelta: Offset = Offset(0f, 0f),
-        timeMillis: Long = (currentNanoTime() / 1E6).toLong(),
+        buttons: PointerButtons,
+        keyboardModifiers: PointerKeyboardModifiers,
+        scrollDelta: Offset,
+        timeMillis: Long,
         nativeEvent: Any?,
         button: PointerButton?,
         scaleGestureFactor: Float,
@@ -132,7 +131,7 @@ internal class ComposeSceneInputHandler(
             keyboardModifiers = keyboardModifiers,
             changedButton = button,
             scaleGestureFactor = scaleGestureFactor,
-            panGestureOffset = panGestureOffset
+            panGestureOffset = panGestureOffset,
         )
         prepareForPointerInputEvent()
         val updatePointerPositionResult = updatePointerPosition()

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.scene
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.HistoricalChange
@@ -36,7 +35,7 @@ import kotlin.jvm.JvmInline
  * Represents pointer such as mouse cursor, or touch/stylus press.
  * There can be multiple pointers on the screen at the same time.
  */
-@ExperimentalComposeUiApi
+@InternalComposeUiApi
 class ComposeScenePointer(
     /**
      * Unique id associated with the pointer. Used to distinguish between multiple pointers that can exist
@@ -107,16 +106,6 @@ class ComposeScenePointer(
     }
 }
 
-internal fun PointerInputEventData.toComposeScenePointer() = ComposeScenePointer(
-    id = id,
-    position = position,
-    pressed = down,
-    type = type,
-    pressure = pressure,
-    historical = historical
-)
-
-@OptIn(ExperimentalComposeUiApi::class)
 internal fun PointerInputEvent(
     eventType: PointerEventType,
     pointers: List<ComposeScenePointer>,
@@ -125,7 +114,9 @@ internal fun PointerInputEvent(
     scrollDelta: Offset,
     buttons: PointerButtons,
     keyboardModifiers: PointerKeyboardModifiers,
-    changedButton: PointerButton?
+    changedButton: PointerButton?,
+    scaleGestureFactor: Float,
+    panGestureOffset: Offset,
 ) = PointerInputEvent(
     eventType = eventType,
     uptime = timeMillis,
@@ -142,8 +133,8 @@ internal fun PointerInputEvent(
             historical = it.historical,
             scrollDelta = scrollDelta,
             originalEventPosition = it.position,
-            scaleGestureFactor = 1f, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
-            panGestureOffset = Offset.Zero, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
+            scaleGestureFactor = scaleGestureFactor,
+            panGestureOffset = panGestureOffset,
         )
     },
     buttons = buttons,

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -232,8 +232,8 @@ internal fun event(
             pointer.type,
             scrollDelta = Offset.Zero,
             historical = emptyList(),
-            scaleGestureFactor = 1f, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
-            panGestureOffset = Offset.Zero, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
+            scaleGestureFactor = 1f,
+            panGestureOffset = Offset.Zero,
         )
     },
 )
@@ -243,7 +243,7 @@ internal fun mouseEvent(
     type: PointerEventType,
     x: Float,
     y: Float,
-    pressed: Boolean
+    pressed: Boolean,
 ) = PointerInputEvent(
     type,
     0,
@@ -259,8 +259,8 @@ internal fun mouseEvent(
             scrollDelta = Offset.Zero,
             activeHover = true,
             historical = emptyList(),
-            scaleGestureFactor = 1f, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
-            panGestureOffset = Offset.Zero, // TODO https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API
+            scaleGestureFactor = 1f,
+            panGestureOffset = Offset.Zero,
         )
     ),
     buttons = PointerButtons(isPrimaryPressed = pressed)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -244,6 +244,9 @@ internal fun mouseEvent(
     x: Float,
     y: Float,
     pressed: Boolean,
+    scrollDelta: Offset = Offset.Zero,
+    scaleGestureFactor: Float = 1f,
+    panGestureOffset:Offset = Offset.Zero,
 ) = PointerInputEvent(
     type,
     0,
@@ -256,11 +259,11 @@ internal fun mouseEvent(
             down = pressed,
             pressure = 1f,
             type = PointerType.Mouse,
-            scrollDelta = Offset.Zero,
+            scrollDelta = scrollDelta,
             activeHover = true,
             historical = emptyList(),
-            scaleGestureFactor = 1f,
-            panGestureOffset = Offset.Zero,
+            scaleGestureFactor = scaleGestureFactor,
+            panGestureOffset = panGestureOffset,
         )
     ),
     buttons = PointerButtons(isPrimaryPressed = pressed)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -395,6 +395,58 @@ class RenderPhasesTest {
     }
 
     @Test
+    fun panPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
+        coroutineDispatcher = StandardTestDispatcher()
+    ) {
+        val scrollState = ScrollState(0)
+        setContent {
+            Box(modifier = Modifier.size(100.dp).verticalScroll(scrollState)) {
+                Box(Modifier.size(200.dp))
+            }
+        }
+
+        assertFalse(scene.hasInvalidations())
+        assertEquals(0, scrollState.value)
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Pan,
+            position = Offset(50f, 50f),
+            panGestureOffset = Offset(0f, 40f)
+        )
+
+        assertTrue(scene.hasInvalidations())
+        assertNotEquals(0, scrollState.value)
+    }
+
+    @Test
+    fun scalePointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
+        coroutineDispatcher = StandardTestDispatcher()
+    ) {
+        var scale = 1f
+        setContent {
+            Box(modifier = Modifier.size(100.dp).onPointerEvent(PointerEventType.Scale) {
+                it.changes.forEach { change ->
+                    scale *= change.scaleGestureFactor
+                }
+            }) {
+                Box(Modifier.size(200.dp))
+            }
+        }
+
+        assertFalse(scene.hasInvalidations())
+        assertEquals(1f, scale)
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Scale,
+            position = Offset(50f, 50f),
+            scaleGestureFactor = 2.0f
+        )
+
+        assertTrue(scene.hasInvalidations())
+        assertNotEquals(1f, scale)
+    }
+
+    @Test
     fun pointerPressEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
         coroutineDispatcher = StandardTestDispatcher()
     ) {
@@ -472,7 +524,7 @@ class RenderPhasesTest {
                 modifier = Modifier
                     .focusRequester(focusRequester)
                     .focusable(interactionSource = interactionSource)
-                    .onKeyEvent { keyEvent: KeyEvent ->
+                    .onKeyEvent {
                         coroutineScope.launch {
                             keyHandledAfterDelay = true
                         }
@@ -512,7 +564,7 @@ class RenderPhasesTest {
             val interactionSource = remember { MutableInteractionSource() }
             Box(
                 modifier = Modifier
-                    .onRotaryScrollEvent { event ->
+                    .onRotaryScrollEvent {
                         coroutineScope.launch {
                             eventHandledAfterDelay = true
                         }


### PR DESCRIPTION
Provide API to support `Pan` and `Scale` trackpad events.
Update `ComposeScene` to support `scaleGestureFactor` and `panGestureOffset` for pointer events.
Implement missing trackpad event dispatches in `SkikoInputDispatcher`.

Fixes https://youtrack.jetbrains.com/issue/CMP-9457/Implement-trackpad-testing-APIs-in-SkikoInputDispatcher
Fixes https://youtrack.jetbrains.com/issue/CMP-9506/Investigate-and-support-Trackpad-API

## Release Notes
N/A