### PR TITLE
[web] correct isCheckpointScheduled rescheduling in NativeInputEventsProcessor

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -46,8 +46,12 @@ internal abstract class NativeInputEventsProcessor(
 ) {
 
     private val collectedEvents = mutableListOf<UIEvent>()
-    private var isCheckpointScheduled = false
-    private var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
+
+    @get:TestOnly
+    @set:TestOnly
+    internal var isCheckpointScheduled = false
+
+    internal var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
     var lastProcessedEventIsBackspace: Boolean = false
 
     /**
@@ -63,6 +67,7 @@ internal abstract class NativeInputEventsProcessor(
     private fun internalScheduleCheckpoint() {
         if (!isCheckpointScheduled) {
             scheduleCheckpoint()
+            isCheckpointScheduled = true
         }
     }
 

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -84,14 +84,13 @@ class NativeInputEventsProcessorTest {
     private class TestNativeInputEventsProcessor(
         composeSender: ComposeCommandCommunicator
     ) : NativeInputEventsProcessor(composeSender) {
-        var checkpointScheduled = false
 
         override fun scheduleCheckpoint() {
-            checkpointScheduled = true
+            isCheckpointScheduled = true
         }
 
         fun manuallyRunCheckpoint(currentTextFieldValue: TextFieldValue) {
-            checkpointScheduled = false
+            isCheckpointScheduled = false
             runCheckpoint(currentTextFieldValue)
         }
     }
@@ -100,19 +99,19 @@ class NativeInputEventsProcessorTest {
     fun testCheckpointScheduling() {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
-        assertFalse(processor.checkpointScheduled)
+        assertFalse(processor.isCheckpointScheduled)
 
         processor.registerEvent(keyEvent("a"))
-        assertTrue(processor.checkpointScheduled)
+        assertTrue(processor.isCheckpointScheduled)
 
-        processor.checkpointScheduled = false
+        processor.isCheckpointScheduled = false
         val compositionEvent = compositionStart()
         processor.registerEvent(compositionEvent)
-        assertTrue(processor.checkpointScheduled)
+        assertTrue(processor.isCheckpointScheduled)
 
-        processor.checkpointScheduled = false
+        processor.isCheckpointScheduled = false
         processor.registerEvent(beforeInput("insertText", "") as InputEvent)
-        assertTrue(processor.checkpointScheduled)
+        assertTrue(processor.isCheckpointScheduled)
 
         assertEquals(3, processor.getCollectedEvents().size)
         processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())


### PR DESCRIPTION
This is a minimal PR that contains only checkpoint syn chronisation fix 

## Testing
`gradlew testWeb`

## Release Notes
N/A