### PR TITLE
Send buttons from most recent pointerdown on mousewheel

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -706,9 +706,7 @@ internal class ComposeWindow(
 
         // wheels event own buttons property is unreliable in Safari and Firefox
         // see CMP-9900 [web] Wheel event resolves buttons state incorrectly in Safari and Firefox
-        val buttons = event.composeButtons.takeIf { it.packedValue != 0 }
-            ?: actualActivePointerButtons
-            ?: event.composeButtons
+        val buttons = actualActivePointerButtons ?: event.composeButtons
 
         val result = scene.sendPointerEvent(
             eventType = PointerEventType.Scroll,

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -643,7 +643,7 @@ internal class ComposeWindow(
             if (eventType == PointerEventType.Release) {
                 activeTouchPointers.remove(event.pointerId)
             }
-        } else if (isMouseEvent(event)) {
+        } else {
             keyboardModeState = KeyboardModeState.Hardware
 
             // validate event before sending it further - see
@@ -821,7 +821,6 @@ private fun clipTargetElement(canvas: HTMLCanvasElement): HTMLTextAreaElement {
 // strings checks are faster on a JS side
 // language=js
 private fun isTouchEvent(event: PointerEvent): Boolean = js("event.pointerType === 'touch'")
-private fun isMouseEvent(event: PointerEvent): Boolean = js("event.pointerType === 'mouse'")
 
 // strings checks are faster on a JS side
 // language=js

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -643,7 +643,7 @@ internal class ComposeWindow(
             if (eventType == PointerEventType.Release) {
                 activeTouchPointers.remove(event.pointerId)
             }
-        } else {
+        } else if (isMouseEvent(event)) {
             keyboardModeState = KeyboardModeState.Hardware
 
             // validate event before sending it further - see
@@ -704,6 +704,12 @@ internal class ComposeWindow(
 
         val verticalScroll = if (horizontalScroll == 0f) event.deltaY else 0f
 
+        // wheels event own buttons property is unreliable in Safari and Firefox
+        // see CMP-9900 [web] Wheel event resolves buttons state incorrectly in Safari and Firefox
+        val buttons = event.composeButtons.takeIf { it.packedValue != 0 }
+            ?: actualActivePointerButtons
+            ?: event.composeButtons
+
         val result = scene.sendPointerEvent(
             eventType = PointerEventType.Scroll,
             position = event.offset,
@@ -711,7 +717,7 @@ internal class ComposeWindow(
                 x = horizontalScroll.toFloat(),
                 y = verticalScroll.toFloat()
             ),
-            buttons = event.composeButtons,
+            buttons = buttons,
             keyboardModifiers = PointerKeyboardModifiers(
                 isCtrlPressed = event.ctrlKey,
                 isMetaPressed = event.metaKey,
@@ -817,6 +823,7 @@ private fun clipTargetElement(canvas: HTMLCanvasElement): HTMLTextAreaElement {
 // strings checks are faster on a JS side
 // language=js
 private fun isTouchEvent(event: PointerEvent): Boolean = js("event.pointerType === 'touch'")
+private fun isMouseEvent(event: PointerEvent): Boolean = js("event.pointerType === 'mouse'")
 
 // strings checks are faster on a JS side
 // language=js

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/window/MouseEventsTest.kt
@@ -33,6 +33,11 @@ import kotlinx.coroutines.test.runTest
 import org.w3c.dom.pointerevents.PointerEvent
 import org.w3c.dom.pointerevents.PointerEventInit
 import androidx.compose.ui.input.pointer.PointerEvent as ComposePointerEvent
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import org.w3c.dom.events.WheelEvent
+import org.w3c.dom.events.WheelEventInit
+
 
 class MouseEventsTest : OnCanvasTests {
 
@@ -147,5 +152,88 @@ class MouseEventsTest : OnCanvasTests {
         dispatchEvents(PointerEvent("pointerleave", PointerEventInit(clientX = 0, clientY = 0, pointerType = "mouse")))
         assertEquals(PointerEventType.Exit, event.type)
         assertEquals(null, event.button)
+    }
+
+    @Test
+    fun testWheelEventButtonsResolvedOnPointerDown() = runTest {
+        // CMP-9900 [web] Wheel event resolves buttons state incorrectly in Safari and Firefox
+        val pointerEvents = mutableListOf<ComposePointerEvent>()
+
+        createComposeWindow {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (isActive) {
+                                pointerEvents.add(awaitPointerEvent())
+                            }
+                        }
+                    }
+            ) {}
+        }
+
+        dispatchEvents(
+            PointerEvent("pointerenter", PointerEventInit(clientX = 100, clientY = 100, pointerType = "mouse")),
+            PointerEvent("pointerdown", PointerEventInit(clientX = 100, clientY = 100, button = 0, buttons = 1, pointerType = "mouse")),
+        )
+
+        dispatchEvents(WheelEvent("wheel", WheelEventInit(clientX = 100, clientY = 100, buttons = 0)))
+
+        assertEquals(3, pointerEvents.size)
+        assertEquals(PointerEventType.Enter, pointerEvents[0].type)
+        assertEquals(PointerEventType.Press, pointerEvents[1].type)
+        assertEquals(PointerEventType.Scroll, pointerEvents[2].type)
+        assertEquals(true, pointerEvents[2].buttons.isPrimaryPressed)
+
+        dispatchEvents(
+            PointerEvent("pointerdown", PointerEventInit(clientX = 100, clientY = 100, button = 2, buttons = 3, pointerType = "mouse")),
+        )
+        dispatchEvents(WheelEvent("wheel", WheelEventInit(clientX = 100, clientY = 100, buttons = 0)))
+
+        assertEquals(5, pointerEvents.size)
+        assertEquals(PointerEventType.Press, pointerEvents[3].type)
+        assertEquals(PointerEventType.Scroll, pointerEvents[4].type)
+        assertEquals(true, pointerEvents[4].buttons.isPrimaryPressed)
+        assertEquals(true, pointerEvents[4].buttons.isSecondaryPressed)
+    }
+
+    @Test
+    fun testPointerReleaseIsNotCorruptedByMouseWheel() = runTest {
+        // CMP-9891 [Web] Mouse. Incorrect click detectionCMP-9891 [Web] Mouse. Incorrect click detection
+        val pointerEvents = mutableListOf<ComposePointerEvent>()
+
+        createComposeWindow {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .pointerInput(Unit) {
+                        awaitPointerEventScope {
+                            while (isActive) {
+                                pointerEvents.add(awaitPointerEvent())
+                            }
+                        }
+                    }
+            ) {}
+        }
+
+        dispatchEvents(
+            PointerEvent("pointerenter", PointerEventInit(clientX = 100, clientY = 100, pointerType = "mouse")),
+            PointerEvent("pointerdown", PointerEventInit(clientX = 100, clientY = 100, button = 0, buttons = 1, pointerType = "mouse")),
+        )
+
+        dispatchEvents(WheelEvent("wheel", WheelEventInit(clientX = 100, clientY = 100, buttons = 0)))
+
+        dispatchEvents(
+            PointerEvent("pointermove", PointerEventInit(clientX = 101, clientY = 101, buttons = 1, pointerType = "mouse")),
+            PointerEvent("pointerup", PointerEventInit(clientX = 101, clientY = 101, button = 0, buttons = 0, pointerType = "mouse"))
+        )
+
+        assertEquals(5, pointerEvents.size)
+        assertEquals(PointerEventType.Enter, pointerEvents[0].type)
+        assertEquals(PointerEventType.Press, pointerEvents[1].type)
+        assertEquals(PointerEventType.Scroll, pointerEvents[2].type)
+        assertEquals(PointerEventType.Move, pointerEvents[3].type)
+        assertEquals(PointerEventType.Release, pointerEvents[4].type)
     }
 }


### PR DESCRIPTION
Pointer event resolved from mousewheel event should resolve buttons not from the mousewheel event but rather from the most recent pointerdown

Fixes
- [CMP-9891](https://youtrack.jetbrains.com/issue/CMP-9891)
- [CMP-9900](https://youtrack.jetbrains.com/issue/CMP-9900)

## Testing
gradlew testWeb (specifically, testWheelEventButtonsResolvedOnPointerDown and testPointerReleaseIsNotCorruptedByMouseWheel were added)

## Release Notes
### Fixes - Web
-  Fix incorrect mouse click detection
-  Fix an issue where wheel events reported incorrect mouse button state in Safari and Firefox