### PR TITLE
Fix traversal groups hierarchy

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -1548,23 +1548,25 @@ internal class AccessibilityMediator(
                     traverseChildren(it, isBeyondBounds = true, flatten = flattenChildren, container = node)
                 }
 
+                val allElements = beforeElements + visibleElements + afterElements
                 if (node.isTraversalGroup || node.id == rootNode.id) {
-                    val containerElements = if (node.isImportantForAccessibility() ||
+                    val hasSemanticsNode = node.isImportantForAccessibility() ||
                         node.config.contains(SemanticsProperties.TestTag)
-                    ) {
-                        listOf(makeSemanticsNode(emptyList()))
+
+                    val containerChildren = if (hasSemanticsNode) {
+                        listOf(makeSemanticsNode(allElements))
                     } else {
-                        emptyList()
+                        allElements
                     }
 
                     createOrUpdateAccessibilityElement(
                         node = AccessibilityNode.Container(semanticsNode = node),
                         container = container,
-                        children = beforeElements + containerElements + visibleElements + afterElements,
+                        children = containerChildren,
                         frame = frame
                     )
                 } else {
-                    makeSemanticsNode(beforeElements + visibleElements + afterElements)
+                    makeSemanticsNode(allElements)
                 }
             } else {
                 makeSemanticsNode(emptyList())

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -612,10 +612,8 @@ class ComponentsAccessibilitySemanticTest {
 
         assertAccessibilityTree {
             node {
-                node {
-                    identifier = "Container"
-                    isAccessibilityElement = false
-                }
+                identifier = "Container"
+                isAccessibilityElement = false
                 node {
                     label = "Text 1"
                     isAccessibilityElement = true
@@ -1112,6 +1110,83 @@ class ComponentsAccessibilitySemanticTest {
     }
 
     @Test
+    fun testTestTagsHierarchy() = runUIKitInstrumentedTest {
+        setContent {
+            Column(
+                modifier = Modifier.semantics {
+                    testTag = "column"
+                    isTraversalGroup = true // Should add a new tree level
+                }
+            ) {
+                Button(
+                    onClick = {},
+                    modifier = Modifier.semantics {
+                        testTag = "button"
+                    }
+                ) {
+                    Text("Button text", modifier = Modifier.semantics { testTag = "button text" })
+                }
+            }
+        }
+        assertAccessibilityTree {
+            identifier = "column"
+            node {
+                identifier = "button"
+                node {
+                    identifier = "button text"
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testMergeDescendantsWithButton() = runUIKitInstrumentedTest {
+        setContent {
+            Column(
+                modifier = Modifier
+                    .semantics(mergeDescendants = true) {},
+            ) {
+                Text(
+                    text = "Hello",
+                )
+                Text(
+                    text = "World",
+                )
+
+                Button(
+                    onClick = {},
+                    modifier = Modifier,
+                ) {
+                    Text("Button")
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                node {
+                    label = "Hello"
+                    isAccessibilityElement = false
+                }
+                node {
+                    label = "World"
+                    isAccessibilityElement = false
+                }
+            }
+            node {
+                label = "Button"
+                isAccessibilityElement = true
+                traits(UIAccessibilityTraitButton)
+                node {
+                    label = "Button"
+                    isAccessibilityElement = false
+                }
+            }
+        }
+    }
+
+    @Test
     fun testTextLinks() = runUIKitInstrumentedTest {
         setContent {
             Text(text = buildAnnotatedString {
@@ -1126,9 +1201,7 @@ class ComponentsAccessibilitySemanticTest {
                 withLink(
                     link = LinkAnnotation.Clickable(
                         tag = "clickable tag",
-                        linkInteractionListener = object : LinkInteractionListener {
-                            override fun onClick(link: LinkAnnotation) {}
-                        }
+                        linkInteractionListener = LinkInteractionListener { }
                     )
                 ) {
                     append("clickable")
@@ -1137,9 +1210,7 @@ class ComponentsAccessibilitySemanticTest {
                 withLink(
                     link = LinkAnnotation.Url(
                         url = "https://example.com",
-                        linkInteractionListener = object : LinkInteractionListener {
-                            override fun onClick(link: LinkAnnotation) {}
-                        }
+                        linkInteractionListener = LinkInteractionListener { }
                     )
                 ) {
                     append("link")


### PR DESCRIPTION
Update accessibility items hierarchy for traversal groups

Fixes https://youtrack.jetbrains.com/issue/CMP-9556/Traversal-groups-does-not-change-accessibility-tree-structure
Fixes https://youtrack.jetbrains.com/issue/CMP-9719/iOS-VoiceOver-Cant-manually-find-element-in-parent-with-mergeDescendants

## Release Notes
### Fixes - iOS
- Traversal groups now convert into an additional node in the accessibility hierarchy.
