### PR TITLE
Fix `ModalBottomSheetDialog` content insets

### DIFF
--- a/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
+++ b/compose/material3/material3/src/skikoMain/kotlin/androidx/compose/material3/ModalBottomSheet.skiko.kt
@@ -69,6 +69,7 @@ internal actual fun ModalBottomSheetDialog(
             dismissOnClickOutside = properties.shouldDismissOnClickOutside,
             usePlatformDefaultWidth = false,
             usePlatformInsets = false,
+            useSoftwareKeyboardInset = false,
             scrimColor = Color.Transparent,
             animateTransition = false,
         ),

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/Components.kt
@@ -26,6 +26,7 @@ import androidx.compose.mpp.demo.components.material3.DateTimePickerExample
 import androidx.compose.mpp.demo.components.material3.DropdownMenu3Example
 import androidx.compose.mpp.demo.components.material3.ListDetailPaneScaffoldExample
 import androidx.compose.mpp.demo.components.material3.ModalBottomSheet3Example
+import androidx.compose.mpp.demo.components.material3.ModalBottomSheetExample
 import androidx.compose.mpp.demo.components.material3.ModalNavigationDrawerExample
 import androidx.compose.mpp.demo.components.material3.SearchBarExample
 import androidx.compose.mpp.demo.components.material3.WindowSizeClassExample
@@ -45,7 +46,7 @@ private val Material3Components = Screen.Selection(
     Screen.Example("BottomSheetScaffold") { BottomSheetScaffoldExample() },
     Screen.Example("Date & Time Pickers") { DateTimePickerExample() },
     Screen.Example("DropdownMenu3") { DropdownMenu3Example() },
-    Screen.Example("ModalBottomSheet") { ModalBottomSheet3Example() },
+    ModalBottomSheetExample,
     Screen.Example("ModalNavigationDrawer") { ModalNavigationDrawerExample() },
     Screen.Example("SearchBar") { SearchBarExample() },
     Screen.Example("WindowSizeClass") { WindowSizeClassExample() },

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/material3/ModalBottomSheetExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/material3/ModalBottomSheetExample.kt
@@ -52,7 +52,7 @@ internal val ModalBottomSheetExample = Screen.Selection(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ModalBottomSheet3Example() {
+private fun ModalBottomSheet3Example() {
     var openBottomSheet by rememberSaveable { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     val bottomSheetState = rememberModalBottomSheetState()
@@ -83,7 +83,7 @@ fun ModalBottomSheet3Example() {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ModalBottomSheetImeExample() {
+private fun ModalBottomSheetImeExample() {
     var openBottomSheet by rememberSaveable { mutableStateOf(false) }
     Button(onClick = { openBottomSheet = true }) {
         Text(text = "ModalBottomSheet+IME")

--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/material3/ModalBottomSheetExample.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/material3/ModalBottomSheetExample.kt
@@ -16,20 +16,39 @@
 
 package androidx.compose.mpp.demo.components.material3
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.mpp.demo.Screen
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
+
+internal val ModalBottomSheetExample = Screen.Selection(
+    "ModalBottomSheet",
+    Screen.Example("ModalBottomSheet3") { ModalBottomSheet3Example() },
+    Screen.Example("ModalBottomSheet+IME") { ModalBottomSheetImeExample() }
+)
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -59,5 +78,42 @@ fun ModalBottomSheet3Example() {
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ModalBottomSheetImeExample() {
+    var openBottomSheet by rememberSaveable { mutableStateOf(false) }
+    Button(onClick = { openBottomSheet = true }) {
+        Text(text = "ModalBottomSheet+IME")
+    }
+    if (openBottomSheet) {
+        ModalBottomSheet(
+            onDismissRequest = { openBottomSheet = false },
+            contentWindowInsets = { BottomSheetDefaults.modalWindowInsets },
+            content = {
+                Column(modifier = Modifier.height(300.dp).fillMaxWidth()) {
+                    Column(Modifier.weight(1f).padding(16.dp)) {
+                        OutlinedTextField(
+                            value = "",
+                            onValueChange = {},
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
+                    Box(modifier = Modifier
+                        .height(30.dp)
+                        .fillMaxWidth()
+                        .background(color = Color.Yellow)
+                    ) {
+                        Text(
+                            modifier = Modifier.align(Alignment.Center),
+                            text = "Pinned above safe drawing inset"
+                        )
+                    }
+                }
+            }
+        )
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/ModalBottomSheetTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/ModalBottomSheetTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.layers
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.TextField
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.DpRectZero
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpRect
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ModalBottomSheetTest {
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun testContentBottomInset() = runUIKitInstrumentedTest {
+        var contentRect = DpRectZero()
+
+        setContent {
+            ModalBottomSheet(
+                onDismissRequest = {},
+                content = {
+                    Box(
+                        Modifier
+                            .fillMaxWidth()
+                            .height(10.dp)
+                            .onGloballyPositioned { contentRect = it.boundsInWindow().toDpRect(density) }
+                    )
+                }
+            )
+        }
+
+        assertEquals(safeDrawingRect.bottom, contentRect.bottom)
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun testContentBottomInsetWithKeyboardOpen() = runUIKitInstrumentedTest {
+        val focusRequester = FocusRequester()
+        var contentRect = DpRectZero()
+
+        setContent {
+            ModalBottomSheet(
+                onDismissRequest = {},
+                content = {
+                    TextField(
+                        value = "",
+                        onValueChange = { },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester)
+                            .onGloballyPositioned { contentRect = it.boundsInWindow().toDpRect(density) }
+                    )
+
+                }
+            )
+        }
+
+        focusRequester.requestFocus()
+
+        waitForIdle()
+
+        assertEquals(screenSize.height - keyboardHeight, contentRect.bottom)
+    }
+}


### PR DESCRIPTION
Fix `ModalBottomSheetDialog` content insets by not excluding IME insets from inner content

Fixes https://youtrack.jetbrains.com/issue/CMP-9846

## Testing
Add `ModalBottomSheetTest` test suite

I have also added an example screen as part of this PR to demonstrate `ModalBottomSheet` with `IME`.

This should be tested by QA

## Release Notes
### Fixes - iOS
- Fix `ModalBottomSheetDialog` content inset calculation
