### PR TITLE
Aign skiko `Matrix33` mapping/conversion with Android

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/Matrices.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/Matrices.skiko.kt
@@ -26,19 +26,38 @@ internal fun identityMatrix33() = Matrix33(
     0f, 0f, 1f
 )
 
-internal fun Matrix33.setFrom(matrix: Matrix) {
-    require(
-        matrix[0, 2] == 0f &&
-            matrix[1, 2] == 0f &&
-            matrix[2, 2] == 1f &&
-            matrix[3, 2] == 0f &&
-            matrix[2, 0] == 0f &&
-            matrix[2, 1] == 0f &&
-            matrix[2, 3] == 0f
-    ) {
-        "Matrix33 does not support arbitrary transforms"
-    }
+internal fun Matrix.setFrom(matrix: Matrix33) {
+    val v = values
+    val m = matrix.mat
+    val scaleX = m[0] // MSCALE_X
+    val skewX = m[1] // MSKEW_X
+    val translateX = m[2] // MTRANS_X
+    val skewY = m[3] // MSKEW_Y
+    val scaleY = m[4] // MSCALE_Y
+    val translateY = m[5] // MTRANS_Y
+    val persp0 = m[6] // MPERSP_0
+    val persp1 = m[7] // MPERSP_1
+    val persp2 = m[8] // MPERSP_2
 
+    v[Matrix.ScaleX] = scaleX // 0
+    v[Matrix.SkewY] = skewY // 1
+    v[2] = 0f // 2
+    v[Matrix.Perspective0] = persp0 // 3
+    v[Matrix.SkewX] = skewX // 4
+    v[Matrix.ScaleY] = scaleY // 5
+    v[6] = 0f // 6
+    v[Matrix.Perspective1] = persp1 // 7
+    v[8] = 0f // 8
+    v[9] = 0f // 9
+    v[Matrix.ScaleZ] = 1.0f // 10
+    v[11] = 0f // 11
+    v[Matrix.TranslateX] = translateX // 12
+    v[Matrix.TranslateY] = translateY // 13
+    v[14] = 0f // 14
+    v[Matrix.Perspective2] = persp2 // 15
+}
+
+internal fun Matrix33.setFrom(matrix: Matrix) {
     // We'll reuse the array used in Matrix to avoid allocation by temporarily
     // setting it to the 3x3 matrix used by android.graphics.Matrix
     // Store the values of the 4 x 4 matrix into temporary variables

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/SkikoMatrixTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/SkikoMatrixTest.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.graphics
+
+import androidx.compose.ui.geometry.Offset
+import androidx.kruth.assertThat
+import androidx.kruth.assertWithMessage
+import kotlin.math.abs
+import kotlin.math.sqrt
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.jetbrains.skia.Matrix33
+
+// Adopted copy of androidDeviceTest/kotlin/androidx/compose/ui/graphics/AndroidMatrixTest.kt
+
+private const val delta = 0.01f
+
+class SkikoMatrixTest {
+
+    @Test
+    fun rotate90() {
+        val point = FloatArray(2)
+        val m = Matrix()
+        m.rotateZ(90f)
+        val p = identityMatrix33().apply { setFrom(m) }
+        p.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(0f)
+        assertThat(point[1]).isWithin(delta).of(0f)
+        p.mapPoints(point, floatArrayOf(100f, 100f))
+        assertThat(point[0]).isWithin(delta).of(-100f)
+        assertThat(point[1]).isWithin(delta).of(100f)
+
+        val composeMatrix = Matrix().apply { setFrom(p) }
+        assertTrue(composeMatrix.values.contentAlmostEquals(m.values))
+    }
+
+    @Test
+    fun rotate30() {
+        val point = FloatArray(2)
+        val m = Matrix()
+        m.rotateZ(30f)
+        val p = identityMatrix33().apply { setFrom(m) }
+        p.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(0f)
+        assertThat(point[1]).isWithin(delta).of(0f)
+        p.mapPoints(point, floatArrayOf(100f, 0f))
+        assertThat(point[0]).isWithin(delta).of(86.60254f)
+        assertThat(point[1]).isWithin(delta).of(50f)
+
+        val composeMatrix = Matrix().apply { setFrom(p) }
+        assertTrue(composeMatrix.values.contentAlmostEquals(m.values))
+    }
+
+    @Test
+    fun translateX() {
+        val point = FloatArray(2)
+        val m = Matrix()
+        m.translate(10f, 0f)
+        val p = identityMatrix33().apply { setFrom(m) }
+        p.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(10f)
+        assertThat(point[1]).isWithin(delta).of(0f)
+        p.mapPoints(point, floatArrayOf(100f, 100f))
+        assertThat(point[0]).isWithin(delta).of(110f)
+        assertThat(point[1]).isWithin(delta).of(100f)
+
+        val composeMatrix = Matrix().apply { setFrom(p) }
+        assertTrue(composeMatrix.values.contentAlmostEquals(m.values))
+    }
+
+    @Test
+    fun translateY() {
+        val point = FloatArray(2)
+        val m = Matrix()
+        m.translate(0f, 10f)
+        val p = identityMatrix33().apply { setFrom(m) }
+        p.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(0f)
+        assertThat(point[1]).isWithin(delta).of(10f)
+        p.mapPoints(point, floatArrayOf(100f, 100f))
+        val message = "Matrix:\n$m\nPlatform:\n$p"
+        assertWithMessage(message).that(point[0]).isWithin(delta).of(100f)
+        assertWithMessage(message).that(point[1]).isWithin(delta).of(110f)
+        m.translate(0f, 10f)
+        val q = identityMatrix33().apply { setFrom(m) }
+        q.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(0f)
+        assertThat(point[1]).isWithin(delta).of(20f)
+
+        val composeMatrix = Matrix().apply { setFrom(q) }
+        assertTrue(composeMatrix.values.contentAlmostEquals(m.values))
+    }
+
+    @Test
+    fun scale() {
+        val point = FloatArray(2)
+        val m = Matrix()
+        m.scale(2f, 3f)
+        val p = identityMatrix33().apply { setFrom(m) }
+        p.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(0f)
+        assertThat(point[1]).isWithin(delta).of(0f)
+        p.mapPoints(point, floatArrayOf(100f, 100f))
+        assertThat(point[0]).isWithin(delta).of(200f)
+        assertThat(point[1]).isWithin(delta).of(300f)
+
+        val composeMatrix = Matrix().apply { setFrom(p) }
+        assertTrue(composeMatrix.values.contentAlmostEquals(m.values))
+    }
+
+    @Test
+    fun rotate90Scale() {
+        val point = FloatArray(2)
+        val m = Matrix()
+        m.rotateZ(90f)
+        m.scale(2f, 3f)
+        val p = identityMatrix33().apply { setFrom(m) }
+        p.mapPoints(point, floatArrayOf(0f, 0f))
+        assertThat(point[0]).isWithin(delta).of(0f)
+        assertThat(point[1]).isWithin(delta).of(0f)
+        p.mapPoints(point, floatArrayOf(100f, 100f))
+        assertThat(point[0]).isWithin(delta).of(-300f)
+        assertThat(point[1]).isWithin(delta).of(200f)
+
+        val composeMatrix = Matrix().apply { setFrom(p) }
+        assertTrue(composeMatrix.values.contentAlmostEquals(m.values))
+    }
+
+    @Test
+    fun rotateX45() {
+        val m = Matrix().apply { rotateX(45f) }
+        val mapped00 = m.map(Offset(0f, 0f))
+        assertThat(mapped00.x).isWithin(delta).of(0f)
+        assertThat(mapped00.y).isWithin(delta).of(0f)
+        val mapped11 = m.map(Offset(1f, 1f))
+        assertThat(mapped11.x).isWithin(delta).of(1f)
+        assertThat(mapped11.y).isWithin(delta).of(sqrt(2f) / 2f)
+
+        val androidMatrix = identityMatrix33().apply { setFrom(m) }
+        val points = floatArrayOf(0f, 0f, 1f, 1f)
+        androidMatrix.mapPoints(points)
+        assertThat(points[0]).isWithin(delta).of(0f)
+        assertThat(points[1]).isWithin(delta).of(0f)
+        assertThat(points[2]).isWithin(delta).of(1f)
+        assertThat(points[3]).isWithin(delta).of(sqrt(2f) / 2f)
+    }
+
+    @Test
+    fun rotateY45() {
+        val m = Matrix().apply { rotateY(45f) }
+        val mapped00 = m.map(Offset(0f, 0f))
+        assertThat(mapped00.x).isWithin(delta).of(0f)
+        assertThat(mapped00.y).isWithin(delta).of(0f)
+        val mapped11 = m.map(Offset(1f, 1f))
+        assertThat(mapped11.x).isWithin(delta).of(sqrt(2f) / 2f)
+        assertThat(mapped11.y).isWithin(delta).of(1f)
+
+        val androidMatrix = identityMatrix33().apply { setFrom(m) }
+        val points = floatArrayOf(0f, 0f, 1f, 1f)
+        androidMatrix.mapPoints(points)
+        assertThat(points[0]).isWithin(delta).of(0f)
+        assertThat(points[1]).isWithin(delta).of(0f)
+        assertThat(points[2]).isWithin(delta).of(sqrt(2f) / 2f)
+        assertThat(points[3]).isWithin(delta).of(1f)
+    }
+}
+
+private fun FloatArray.contentAlmostEquals(values: FloatArray, tolerance: Float = 1e-4f): Boolean {
+    if (size != values.size) return false
+    for (i in indices) {
+        if (abs(this[i] - values[i]) > tolerance) return false
+    }
+    return true
+}
+
+// TODO: https://youtrack.jetbrains.com/issue/SKIKO-1124
+private fun Matrix33.mapPoints(dst: FloatArray, src: FloatArray) {
+    require(dst.size == src.size) { "dst and src must have the same size" }
+    require(dst.size % 2 == 0) { "point arrays must contain pairs of x/y values" }
+
+    val m = mat
+    var i = 0
+    while (i < src.size) {
+        val sx = src[i]
+        val sy = src[i + 1]
+
+        val x = sx * m[0] + sy * m[1] + m[2]
+        val y = sx * m[3] + sy * m[4] + m[5]
+        var z = sx * m[6] + sy * m[7] + m[8]
+        if (z != 0f) {
+            z = 1f / z
+        }
+
+        dst[i] = x * z
+        dst[i + 1] = y * z
+        i += 2
+    }
+}
+
+// TODO: https://youtrack.jetbrains.com/issue/SKIKO-1124
+private fun Matrix33.mapPoints(points: FloatArray) {
+    mapPoints(points, points.copyOf())
+}


### PR DESCRIPTION
Fixes [CMP-9445](https://youtrack.jetbrains.com/issue/CMP-9445) TooltipBox crashes in Compose Multiplatform 1.9.3 with “Matrix33 does not support arbitrary transforms"
[2880465](https://android-review.googlesource.com/c/platform/frameworks/support/+/2880465): Matrix: remove check for arbitrary transforms

The check was removed on Android, but we didn't apply this change on other platforms

## Release Notes
### Fixes - Multiple Platforms
- Remove check for arbitrary transforms in `Matrix` conversions due to incorrect detection of regular rotation. Now the behaviour is aligned with Android.
