### PR TITLE
Migrate Modifier.onPointerEvent from Modifier.composed to Modifier.Node

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
@@ -16,11 +16,11 @@
 
 package androidx.compose.ui.input.pointer
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
 
 /**
  * Create a modifier for processing pointer input within the region of the modified element.
@@ -36,17 +36,96 @@ fun Modifier.onPointerEvent(
     eventType: PointerEventType,
     pass: PointerEventPass = PointerEventPass.Main,
     onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
-): Modifier = composed {
-    val currentEventType by rememberUpdatedState(eventType)
-    val currentOnEvent by rememberUpdatedState(onEvent)
-    pointerInput(pass) {
-        awaitPointerEventScope {
-            while (true) {
-                val event = awaitPointerEvent(pass)
-                if (event.type == currentEventType) {
-                    currentOnEvent(event)
+): Modifier = this.then(
+    OnPointerEventModifierElement(
+        eventType = eventType,
+        pass = pass,
+        onEvent = onEvent
+    )
+)
+
+private class OnPointerEventModifierElement(
+    private val eventType: PointerEventType,
+    private val pass: PointerEventPass,
+    private val onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
+) : ModifierNodeElement<OnPointerEventModifierNode>() {
+    override fun create() = OnPointerEventModifierNode(
+        eventType = eventType,
+        pass = pass,
+        onEvent = onEvent
+    )
+
+    override fun update(node: OnPointerEventModifierNode) = node.update(
+        eventType = eventType,
+        pass = pass,
+        onEvent = onEvent
+    )
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "onPointerEvent"
+        properties["eventType"] = eventType
+        properties["pass"] = pass
+        properties["onEvent"] = onEvent
+    }
+
+    override fun hashCode(): Int {
+        var result = eventType.hashCode()
+        result = 31 * result + pass.hashCode()
+        result = 31 * result + onEvent.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is OnPointerEventModifierElement) return false
+        return eventType == other.eventType &&
+            pass == other.pass &&
+            onEvent === other.onEvent
+    }
+}
+
+private class OnPointerEventModifierNode(
+    private var eventType: PointerEventType,
+    private var pass: PointerEventPass,
+    private var onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
+) : DelegatingNode() {
+    private val pointerInputNode = delegate(
+        SuspendingPointerInputModifierNode(
+            pointerInputEventHandler = {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent(pass)
+                        if (event.type == eventType) {
+                            onEvent(event)
+                        }
+                    }
                 }
             }
+        )
+    )
+
+    fun update(
+        eventType: PointerEventType,
+        pass: PointerEventPass,
+        onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
+    ) {
+        var needsReset = false
+
+        if (this.eventType != eventType) {
+            this.eventType = eventType
+            needsReset = true
+        }
+        if (this.pass != pass) {
+            this.pass = pass
+            needsReset = true
+        }
+        if (this.onEvent !== onEvent) {
+            this.onEvent = onEvent
+            needsReset = true
+        }
+
+        if (needsReset) {
+            pointerInputNode.resetPointerInputHandler()
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
@@ -95,6 +95,7 @@ private class OnPointerEventModifierNode(
     private val pointerInputNode = delegate(
         SuspendingPointerInputModifierNode(
             pointerInputEventHandler = {
+                pointerInputEventHandlerResetTick.value
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(pass)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
@@ -90,12 +90,10 @@ private class OnPointerEventModifierNode(
     private var pass: PointerEventPass,
     private var onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
 ) : DelegatingNode() {
-    private val pointerInputEventHandlerResetTick = mutableStateOf(0)
 
     private val pointerInputNode = delegate(
         SuspendingPointerInputModifierNode(
             pointerInputEventHandler = {
-                pointerInputEventHandlerResetTick.value
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent(pass)
@@ -114,31 +112,17 @@ private class OnPointerEventModifierNode(
         onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
     ) {
         var pointerInputNodeNeedsReset = false
-        var pointerInputEventHandlerNeedsResetTick = false
 
-        if (this.eventType != eventType) {
-            this.eventType = eventType
-            pointerInputEventHandlerNeedsResetTick = true
-        }
+        this.eventType = eventType
+        this.onEvent = onEvent
+
         if (this.pass != pass) {
             this.pass = pass
             pointerInputNodeNeedsReset = true
         }
-        if (this.onEvent !== onEvent) {
-            this.onEvent = onEvent
-            pointerInputEventHandlerNeedsResetTick = true
-        }
-
-        if (pointerInputEventHandlerNeedsResetTick) {
-            pointerInputEventHandlerResetTick.value++
-        }
 
         if (pointerInputNodeNeedsReset) {
             pointerInputNode.resetPointerInputHandler()
-        }
-
-        if (pointerInputEventHandlerNeedsResetTick) {
-            pointerInputEventHandlerResetTick.value++
         }
     }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SuspendingPointerInputFilter.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.input.pointer
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.node.DelegatingNode
@@ -89,6 +90,8 @@ private class OnPointerEventModifierNode(
     private var pass: PointerEventPass,
     private var onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
 ) : DelegatingNode() {
+    private val pointerInputEventHandlerResetTick = mutableStateOf(0)
+
     private val pointerInputNode = delegate(
         SuspendingPointerInputModifierNode(
             pointerInputEventHandler = {
@@ -109,23 +112,32 @@ private class OnPointerEventModifierNode(
         pass: PointerEventPass,
         onEvent: AwaitPointerEventScope.(event: PointerEvent) -> Unit
     ) {
-        var needsReset = false
+        var pointerInputNodeNeedsReset = false
+        var pointerInputEventHandlerNeedsResetTick = false
 
         if (this.eventType != eventType) {
             this.eventType = eventType
-            needsReset = true
+            pointerInputEventHandlerNeedsResetTick = true
         }
         if (this.pass != pass) {
             this.pass = pass
-            needsReset = true
+            pointerInputNodeNeedsReset = true
         }
         if (this.onEvent !== onEvent) {
             this.onEvent = onEvent
-            needsReset = true
+            pointerInputEventHandlerNeedsResetTick = true
         }
 
-        if (needsReset) {
+        if (pointerInputEventHandlerNeedsResetTick) {
+            pointerInputEventHandlerResetTick.value++
+        }
+
+        if (pointerInputNodeNeedsReset) {
             pointerInputNode.resetPointerInputHandler()
+        }
+
+        if (pointerInputEventHandlerNeedsResetTick) {
+            pointerInputEventHandlerResetTick.value++
         }
     }
 }


### PR DESCRIPTION
Migrate `Modifier.onPointerEvent` from `Modifier.composed` to `Modifier.Node`

Fixes [CMP-9907](https://youtrack.jetbrains.com/issue/CMP-9907) Move Modifier.onPointerEvent from composed API to Modifier.Node

## Release Notes
N/A
