### PR TITLE
Migrate scrollOnPressTrack from composed to Modifier.Node

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
@@ -20,7 +20,11 @@ package androidx.compose.foundation
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.TweenSpec
-import androidx.compose.foundation.gestures.*
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalDragOrCancellation
+import androidx.compose.foundation.gestures.awaitVerticalDragOrCancellation
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.interaction.DragInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -48,13 +52,11 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.input.pointer.PointerInputScope
 import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.MeasurePolicy
@@ -932,16 +934,104 @@ private fun Modifier.scrollOnPressTrack(
     isVertical: Boolean,
     reverseLayout: Boolean,
     sliderAdapter: SliderAdapter,
-) = composed {
-    val coroutineScope = rememberCoroutineScope()
-    val scroller = remember(sliderAdapter, coroutineScope, reverseLayout) {
-        TrackPressScroller(coroutineScope, sliderAdapter, reverseLayout)
+): Modifier = this.then(
+    ScrollOnPressTrackElement(
+        isVertical = isVertical,
+        reverseLayout = reverseLayout,
+        sliderAdapter = sliderAdapter,
+    )
+)
+
+private class ScrollOnPressTrackElement(
+    private val isVertical: Boolean,
+    private val reverseLayout: Boolean,
+    private val sliderAdapter: SliderAdapter,
+): ModifierNodeElement<ScrollOnPressTrackNode>() {
+    override fun create(): ScrollOnPressTrackNode = ScrollOnPressTrackNode(
+        isVertical = isVertical,
+        reverseLayout = reverseLayout,
+        sliderAdapter = sliderAdapter,
+    )
+
+    override fun update(node: ScrollOnPressTrackNode) = node.update(
+        isVertical = isVertical,
+        reverseLayout = reverseLayout,
+        sliderAdapter = sliderAdapter,
+    )
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "scrollOnPressTrack"
+        properties["isVertical"] = isVertical
+        properties["reverseLayout"] = reverseLayout
+        properties["sliderAdapter"] = sliderAdapter
     }
-    Modifier.pointerInput(scroller) {
-        detectScrollViaTrackGestures(
-            isVertical = isVertical,
-            scroller = scroller
+
+    override fun hashCode(): Int {
+        var result = isVertical.hashCode()
+        result = 31 * result + reverseLayout.hashCode()
+        result = 31 * result + sliderAdapter.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is ScrollOnPressTrackElement) return false
+        return isVertical == other.isVertical &&
+            reverseLayout == other.reverseLayout &&
+            sliderAdapter == other.sliderAdapter
+    }
+}
+
+private class ScrollOnPressTrackNode(
+    private var isVertical: Boolean,
+    private var reverseLayout: Boolean,
+    private var sliderAdapter: SliderAdapter,
+): DelegatingNode() {
+    private var scroller: TrackPressScroller = TrackPressScroller(coroutineScope, sliderAdapter, reverseLayout)
+
+    private val pointerInputNode = delegate(
+        SuspendingPointerInputModifierNode(
+            pointerInputEventHandler = {
+                detectScrollViaTrackGestures(
+                    isVertical = isVertical,
+                    scroller = scroller,
+                )
+            }
         )
+    )
+
+    fun update(
+        isVertical: Boolean,
+        reverseLayout: Boolean,
+        sliderAdapter: SliderAdapter,
+    ) {
+        var needsReset = false
+        var needsResetScroller = false
+
+        if (this.isVertical != isVertical) {
+            this.isVertical = isVertical
+            needsReset = true
+        }
+
+        if (this.reverseLayout != reverseLayout) {
+            this.reverseLayout = reverseLayout
+            needsReset = true
+            needsResetScroller = true
+        }
+
+        if (this.sliderAdapter != sliderAdapter) {
+            this.sliderAdapter = sliderAdapter
+            needsReset = true
+            needsResetScroller = true
+        }
+
+        if (needsResetScroller) {
+            scroller = TrackPressScroller(coroutineScope, this.sliderAdapter, this.reverseLayout)
+        }
+
+        if (needsReset) {
+            pointerInputNode.resetPointerInputHandler()
+        }
     }
 }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
@@ -987,14 +987,13 @@ private class ScrollOnPressTrackNode(
     private var reverseLayout: Boolean,
     private var sliderAdapter: SliderAdapter,
 ): DelegatingNode() {
-    private var scroller: TrackPressScroller = TrackPressScroller(coroutineScope, sliderAdapter, reverseLayout)
 
     private val pointerInputNode = delegate(
         SuspendingPointerInputModifierNode(
             pointerInputEventHandler = {
                 detectScrollViaTrackGestures(
                     isVertical = isVertical,
-                    scroller = scroller,
+                    scroller = TrackPressScroller(coroutineScope, sliderAdapter, reverseLayout),
                 )
             }
         )
@@ -1005,33 +1004,15 @@ private class ScrollOnPressTrackNode(
         reverseLayout: Boolean,
         sliderAdapter: SliderAdapter,
     ) {
-        var needsReset = false
-        var needsResetScroller = false
-
-        if (this.isVertical != isVertical) {
-            this.isVertical = isVertical
-            needsReset = true
-        }
-
-        if (this.reverseLayout != reverseLayout) {
-            this.reverseLayout = reverseLayout
-            needsReset = true
-            needsResetScroller = true
-        }
-
-        if (this.sliderAdapter != sliderAdapter) {
-            this.sliderAdapter = sliderAdapter
-            needsReset = true
-            needsResetScroller = true
-        }
-
-        if (needsResetScroller) {
-            scroller = TrackPressScroller(coroutineScope, this.sliderAdapter, this.reverseLayout)
-        }
+        var needsReset = this.isVertical != isVertical || this.reverseLayout != reverseLayout || this.sliderAdapter != sliderAdapter
 
         if (needsReset) {
             pointerInputNode.resetPointerInputHandler()
         }
+
+        this.isVertical = isVertical
+        this.reverseLayout = reverseLayout
+        this.sliderAdapter = sliderAdapter
     }
 }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
@@ -989,32 +989,43 @@ private class ScrollOnPressTrackNode(
     private var reverseLayout: Boolean,
     private var sliderAdapter: SliderAdapter,
 ): DelegatingNode() {
+    private lateinit var scroller: TrackPressScroller
+    private lateinit var pointerInputNode: SuspendingPointerInputModifierNode
 
-    private val pointerInputNode = delegate(
-        SuspendingPointerInputModifierNode(
-            pointerInputEventHandler = {
-                detectScrollViaTrackGestures(
-                    isVertical = isVertical,
-                    scroller = TrackPressScroller(coroutineScope, sliderAdapter, reverseLayout),
-                )
-            }
+    override fun onAttach() {
+        super.onAttach()
+
+        recreateScroller()
+
+        pointerInputNode = delegate(
+            SuspendingPointerInputModifierNode(
+                pointerInputEventHandler = {
+                    detectScrollViaTrackGestures(
+                        isVertical = isVertical,
+                        scroller = scroller,
+                    )
+                }
+            )
         )
-    )
+    }
 
     fun update(
         isVertical: Boolean,
         reverseLayout: Boolean,
         sliderAdapter: SliderAdapter,
     ) {
-        var needsReset = this.isVertical != isVertical || this.reverseLayout != reverseLayout || this.sliderAdapter != sliderAdapter
-
-        if (needsReset) {
-            pointerInputNode.resetPointerInputHandler()
-        }
-
         this.isVertical = isVertical
         this.reverseLayout = reverseLayout
         this.sliderAdapter = sliderAdapter
+
+        if (this.isVertical != isVertical || this.reverseLayout != reverseLayout || this.sliderAdapter != sliderAdapter) {
+            recreateScroller()
+            pointerInputNode.resetPointerInputHandler()
+        }
+    }
+
+    private fun recreateScroller() {
+        scroller = TrackPressScroller(coroutineScope, sliderAdapter, reverseLayout)
     }
 }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
@@ -894,30 +894,32 @@ private class ScrollbarDragModifierNode(
     private var sliderAdapter: SliderAdapter,
 ) : DelegatingNode() {
 
-    private val pointerInputNode = delegate(
-        SuspendingPointerInputModifierNode(
-            pointerInputEventHandler = {
-                awaitEachGesture {
-                    val down = awaitFirstDown(requireUnconsumed = false)
-                    val interaction = DragInteraction.Start()
-                    interactionSource.tryEmit(interaction)
-                    draggedInteraction.value = interaction
-                    sliderAdapter.onDragStarted()
-                    val isSuccess = drag(down.id) { change ->
-                        sliderAdapter.onDragDelta(change.positionChange())
-                        change.consume()
+    init {
+        delegate(
+            SuspendingPointerInputModifierNode(
+                pointerInputEventHandler = {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val interaction = DragInteraction.Start()
+                        interactionSource.tryEmit(interaction)
+                        draggedInteraction.value = interaction
+                        sliderAdapter.onDragStarted()
+                        val isSuccess = drag(down.id) { change ->
+                            sliderAdapter.onDragDelta(change.positionChange())
+                            change.consume()
+                        }
+                        val finishInteraction = if (isSuccess) {
+                            DragInteraction.Stop(interaction)
+                        } else {
+                            DragInteraction.Cancel(interaction)
+                        }
+                        interactionSource.tryEmit(finishInteraction)
+                        draggedInteraction.value = null
                     }
-                    val finishInteraction = if (isSuccess) {
-                        DragInteraction.Stop(interaction)
-                    } else {
-                        DragInteraction.Cancel(interaction)
-                    }
-                    interactionSource.tryEmit(finishInteraction)
-                    draggedInteraction.value = null
                 }
-            }
+            )
         )
-    )
+    }
 
     fun update(
         interactionSource: MutableInteractionSource,

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/Scrollbar.skiko.kt
@@ -1014,11 +1014,13 @@ private class ScrollOnPressTrackNode(
         reverseLayout: Boolean,
         sliderAdapter: SliderAdapter,
     ) {
+        val needsReset = isVertical != this.isVertical || reverseLayout != this.reverseLayout || sliderAdapter != this.sliderAdapter
+
         this.isVertical = isVertical
         this.reverseLayout = reverseLayout
         this.sliderAdapter = sliderAdapter
 
-        if (this.isVertical != isVertical || this.reverseLayout != reverseLayout || this.sliderAdapter != sliderAdapter) {
+        if (needsReset) {
             recreateScroller()
             pointerInputNode.resetPointerInputHandler()
         }


### PR DESCRIPTION
Migrate `Modifier.scrollOnPressTrack` from `Modifier.composed` to `Modifier.Node`

Fixes [CMP-9910](https://youtrack.jetbrains.com/issue/CMP-9910)

## Release Notes
N/A
