### PR TITLE
Remove pointerInputEventHandlerResetTick from onClick

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -191,12 +191,10 @@ private class OnClickModifierNode(
     private val hasDoubleClick: Boolean get() = onDoubleClick != null
     private val hasLongClick: Boolean get() =  onLongClick != null
     private val interactionData = InteractionData()
-    private val pointerInputEventHandlerResetTick = mutableStateOf(0)
 
     private val pointerInputNode = delegate(
         SuspendingPointerInputModifierNode(
             pointerInputEventHandler = {
-                pointerInputEventHandlerResetTick.value
                 detectTapGestures(
                     matcher = matcher,
                     keyboardModifiers = { keyboardModifiers(this) },
@@ -253,7 +251,6 @@ private class OnClickModifierNode(
         onClick: () -> Unit,
     ) {
         var pointerInputNodeNeedsReset = false
-        var pointerInputEventHandlerNeedsResetTick = false
 
         if (this.interactionSource != interactionSource) {
             pointerInputNodeNeedsReset = true
@@ -263,18 +260,12 @@ private class OnClickModifierNode(
             this.interactionSource = interactionSource
         }
 
-        if (this.onDoubleClick != onDoubleClick) {
-            pointerInputEventHandlerNeedsResetTick = true
-        }
         val hadDoubleClick = hasDoubleClick
         if (hasDoubleClick != hadDoubleClick) {
             pointerInputNodeNeedsReset = true
         }
         this.onDoubleClick = onDoubleClick
 
-        if (this.onLongClick != onLongClick) {
-            pointerInputEventHandlerNeedsResetTick = true
-        }
         val hadLongClick = hasLongClick
         if (hasLongClick != hadLongClick) {
             pointerInputNodeNeedsReset = true
@@ -282,27 +273,12 @@ private class OnClickModifierNode(
         }
         this.onLongClick = onLongClick
 
-        if (this.onClick != onClick) {
-            pointerInputEventHandlerNeedsResetTick = true
-        }
         this.onClick = onClick
-
-        if (this.matcher != matcher) {
-            pointerInputEventHandlerNeedsResetTick = true
-        }
         this.matcher = matcher
-
-        if (this.keyboardModifiers != keyboardModifiers) {
-            pointerInputEventHandlerNeedsResetTick = true
-        }
         this.keyboardModifiers = keyboardModifiers
 
         if (pointerInputNodeNeedsReset) {
             pointerInputNode.resetPointerInputHandler()
-        }
-
-        if (pointerInputEventHandlerNeedsResetTick) {
-            pointerInputEventHandlerResetTick.value++
         }
     }
 

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/OnClick.skiko.kt
@@ -20,12 +20,10 @@ import androidx.compose.foundation.gestures.PressGestureScope
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequesterModifierNode
 import androidx.compose.ui.focus.requestFocus
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode


### PR DESCRIPTION
Remove redundant `pointerInputEventHandlerResetTick`

Fixes [CMP-9832](https://youtrack.jetbrains.com/issue/CMP-9832)

## Release Notes
N/A