### PR TITLE
Migrate Modifier.magnifier from Modifier.composed to Modifier.Node

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.foundation
 
+import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -29,6 +30,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.GlobalPositionAwareModifierNode
 import androidx.compose.ui.node.ModifierNodeElement
@@ -38,14 +40,13 @@ import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.node.observeReads
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.platform.inspectable
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.uikit.LocalUIViewController
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.roundToIntSize
 import androidx.compose.ui.unit.toSize
 import kotlinx.cinterop.useContents
 import kotlinx.coroutines.launch
@@ -61,34 +62,6 @@ import platform.UIKit.UIView
  */
 internal val MagnifierPositionInWindow =
     SemanticsPropertyKey<() -> Offset>("MagnifierPositionInWindow")
-
-internal fun Modifier.magnifier(
-    sourceCenter: Density.() -> Offset,
-    onSizeChanged: ((DpSize) -> Unit)?,
-    color: Color = Color.Unspecified,
-    hapticFeedback: HapticFeedback?,
-): Modifier {
-    return if (isPlatformMagnifierSupported()) {
-        then(
-            MagnifierElement(
-                sourceCenter = sourceCenter,
-                onSizeChanged = onSizeChanged,
-                color = color,
-                platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform(),
-                hapticFeedback = hapticFeedback,
-            )
-        )
-    } else {
-        inspectable(
-            // Publish inspector info even if magnification isn't supported.
-            inspectorInfo = debugInspectorInfo {
-                name = "magnifier (not supported)"
-                properties["sourceCenter"] = sourceCenter
-                properties["color"] = color
-            }
-        ) { this }
-    }
-}
 
 internal class MagnifierElement(
     private val sourceCenter: Density.() -> Offset,
@@ -338,3 +311,101 @@ internal class MagnifierNode(
 
 internal fun isPlatformMagnifierSupported() =
     available(OS.Ios to OSVersion(major = 17))
+
+internal class SelectionMagnifierElement<M>(
+    private val manager: M,
+    private val hapticFeedback: M.() -> HapticFeedback?,
+    private val calculateCenter: Density.(IntSize) -> Offset,
+) : ModifierNodeElement<SelectionMagnifierNode<M>>() {
+
+    override fun create() = SelectionMagnifierNode(
+        manager = manager,
+        hapticFeedback = hapticFeedback,
+        calculateCenter = calculateCenter,
+    )
+
+    override fun update(node: SelectionMagnifierNode<M>) = node.update(
+        manager = manager,
+        hapticFeedback = hapticFeedback,
+        calculateCenter = calculateCenter,
+    )
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "magnifier"
+        properties["manager"] = manager
+        properties["calculateCenter"] = calculateCenter
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SelectionMagnifierElement<*>) return false
+        return manager == other.manager &&
+            hapticFeedback === other.hapticFeedback &&
+            calculateCenter === other.calculateCenter
+    }
+
+    override fun hashCode(): Int {
+        var result = manager.hashCode()
+        result = 31 * result + hapticFeedback.hashCode()
+        result = 31 * result + calculateCenter.hashCode()
+        return result
+    }
+}
+
+internal class SelectionMagnifierNode<M>(
+    private var manager: M,
+    private var hapticFeedback: M.() -> HapticFeedback?,
+    private var calculateCenter: Density.(IntSize) -> Offset,
+) : DelegatingNode(),
+    ObserverModifierNode,
+    CompositionLocalConsumerModifierNode {
+
+    private var magnifierSizeDp by mutableStateOf(DpSize.Zero)
+    private val color: Color get() = currentValueOf(LocalTextSelectionColors).handleColor
+
+    private val magnifierNode = delegate(
+        MagnifierNode(
+            sourceCenter = {
+                calculateCenter(magnifierSizeDp.toSize().roundToIntSize())
+            },
+            onSizeChanged = { magnifierSizeDp = it },
+            color = color,
+            hapticFeedback = manager.hapticFeedback(),
+            platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform()
+        )
+    )
+
+    override fun onAttach() {
+        super.onAttach()
+
+        onObservedReadsChanged()
+    }
+
+    override fun onObservedReadsChanged() {
+        observeReads {
+            magnifierNode.update(
+                color = color,
+                hapticFeedback = manager.hapticFeedback(),
+            )
+        }
+    }
+
+    fun update(
+        manager: M,
+        hapticFeedback: M.() -> HapticFeedback?,
+        calculateCenter: Density.(IntSize) -> Offset,
+    ) {
+        val managerChanged = this.manager != manager
+        val hapticFeedbackChanged = this.hapticFeedback !== hapticFeedback
+
+        this.manager = manager
+        this.hapticFeedback = hapticFeedback
+        this.calculateCenter = calculateCenter
+
+        if (managerChanged || hapticFeedbackChanged) {
+            magnifierNode.update(
+                hapticFeedback = manager.hapticFeedback()
+            )
+        }
+    }
+}

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
@@ -338,7 +338,7 @@ internal class SelectionMagnifierElement<M>(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is SelectionMagnifierElement<*>) return false
+        if (other !is SelectionMagnifierElement<M>) return false
         return manager == other.manager &&
             hapticFeedback === other.hapticFeedback &&
             calculateCenter === other.calculateCenter

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/Magnifier.ios.kt
@@ -361,7 +361,6 @@ internal class SelectionMagnifierNode<M>(
     CompositionLocalConsumerModifierNode {
 
     private var magnifierSizeDp by mutableStateOf(DpSize.Zero)
-    private val color: Color get() = currentValueOf(LocalTextSelectionColors).handleColor
 
     private val magnifierNode = delegate(
         MagnifierNode(
@@ -369,7 +368,6 @@ internal class SelectionMagnifierNode<M>(
                 calculateCenter(magnifierSizeDp.toSize().roundToIntSize())
             },
             onSizeChanged = { magnifierSizeDp = it },
-            color = color,
             hapticFeedback = manager.hapticFeedback(),
             platformMagnifierFactory = PlatformMagnifierFactory.getForCurrentPlatform()
         )
@@ -384,7 +382,7 @@ internal class SelectionMagnifierNode<M>(
     override fun onObservedReadsChanged() {
         observeReads {
             magnifierNode.update(
-                color = color,
+                color = currentValueOf(LocalTextSelectionColors).handleColor,
                 hapticFeedback = manager.hapticFeedback(),
             )
         }

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
@@ -16,49 +16,38 @@
 
 package androidx.compose.foundation.text.selection
 
+import androidx.compose.foundation.SelectionMagnifierElement
 import androidx.compose.foundation.isPlatformMagnifierSupported
-import androidx.compose.foundation.magnifier
 import androidx.compose.foundation.text.addTextContextMenuComponents
 import androidx.compose.foundation.text.contextmenu.builder.TextContextMenuBuilderScope
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItemWithComposableLeadingIcon
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuKeys
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.platform.inspectable
 
 internal actual fun isCopyKeyEvent(keyEvent: KeyEvent): Boolean =
     false //TODO implement copy key event for iPad
 
-internal actual fun Modifier.selectionMagnifier(manager: SelectionManager): Modifier {
-    if (!isPlatformMagnifierSupported()) {
-        return this
-    }
-
-    return composed {
-        val density = LocalDensity.current
-        var magnifierSize by remember { mutableStateOf(IntSize.Zero) }
-        val color = LocalTextSelectionColors.current
-
-        magnifier(
-            sourceCenter = {
-                // Don't animate position as it is automatically animated by the framework
-                calculateSelectionMagnifierCenterAndroid(manager, magnifierSize)
-            },
-            onSizeChanged = { size ->
-                magnifierSize = with(density) {
-                    IntSize(size.width.roundToPx(), size.height.roundToPx())
-                }
-            },
-            color = color.handleColor, // align magnifier border color with selection handleColor,
-            hapticFeedback = manager.hapticFeedBack,
+internal actual fun Modifier.selectionMagnifier(manager: SelectionManager): Modifier = if (isPlatformMagnifierSupported()) {
+    this.then(
+        SelectionMagnifierElement(
+            manager = manager,
+            hapticFeedback = { hapticFeedBack },
+            calculateCenter = { size ->
+                calculateSelectionMagnifierCenterAndroid(manager, size)
+            }
         )
-    }
+    )
+} else {
+    inspectable(
+        // Publish inspector info even if magnification isn't supported.
+        inspectorInfo = debugInspectorInfo {
+            name = "selectionMagnifier (not supported)"
+            properties["manager"] = manager
+        }
+    ) { this }
 }
 
 internal actual fun Modifier.addSelectionContainerTextContextMenuComponents(

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionManager.ios.kt
@@ -16,59 +16,43 @@
 
 package androidx.compose.foundation.text.selection
 
-import androidx.compose.foundation.PlatformMagnifierFactory
+import androidx.compose.foundation.SelectionMagnifierElement
 import androidx.compose.foundation.isPlatformMagnifierSupported
-import androidx.compose.foundation.magnifier
 import androidx.compose.foundation.text.Handle
 import androidx.compose.foundation.text.addTextContextMenuComponents
 import androidx.compose.foundation.text.contextmenu.builder.TextContextMenuBuilderScope
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItemWithComposableLeadingIcon
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuKeys
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.composed
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.platform.inspectable
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 
-internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManager): Modifier {
-    if (!isPlatformMagnifierSupported()) {
-        return this
-    }
-
-    return composed {
-        val density = LocalDensity.current
-        var magnifierSize by remember { mutableStateOf(IntSize.Zero) }
-
-        val color = LocalTextSelectionColors.current
-
-        magnifier(
-            sourceCenter = {
-                // Don't animate position as it is automatically animated by the framework
-                calculateSelectionMagnifierCenterIOS(
-                    manager = manager,
-                    magnifierSize = magnifierSize,
-                    density = density.density
-                )
-            },
-            onSizeChanged = { size ->
-                magnifierSize = with(density) {
-                    IntSize(size.width.roundToPx(), size.height.roundToPx())
-                }
-            },
-            color = color.handleColor, // align magnifier border color with selection handleColor
-            hapticFeedback = manager.hapticFeedBack,
+internal actual fun Modifier.textFieldMagnifier(
+    manager: TextFieldSelectionManager
+): Modifier = if (isPlatformMagnifierSupported()) {
+    this.then(
+        SelectionMagnifierElement(
+            manager = manager,
+            hapticFeedback = { hapticFeedBack },
+            calculateCenter = { size -> calculateSelectionMagnifierCenterIOS(manager, size) }
         )
-    }
+    )
+} else {
+    inspectable(
+        // Publish inspector info even if magnification isn't supported.
+        inspectorInfo = debugInspectorInfo {
+            name = "textFieldMagnifier (not supported)"
+            properties["manager"] = manager
+        }
+    ) { this }
 }
-
 
 // similar to calculateSelectionMagnifierCenterAndroid, but magnifier
 // 1) displays even if the text field is empty
@@ -79,10 +63,9 @@ internal actual fun Modifier.textFieldMagnifier(manager: TextFieldSelectionManag
 // But! Compose text selection is a bit different from iOS:
 // when we select multiple lines below the selection start on iOS - we always see the caret / handle.
 // Compose caret in such scenario is always covered by finger so we don't actually see what do we select.
-private fun calculateSelectionMagnifierCenterIOS(
+private fun Density.calculateSelectionMagnifierCenterIOS(
     manager: TextFieldSelectionManager,
     magnifierSize: IntSize,
-    density: Float,
 ): Offset {
 
     // state read of currentDragPosition so that we always recompose on drag position changes
@@ -112,7 +95,7 @@ private fun calculateSelectionMagnifierCenterIOS(
         .translateDecorationToInnerCoordinates(localDragPosition)
 
     // hide magnifier when selection goes below the text field
-    if (innerDragPosition.y > layoutResult.lastBaseline + MagnifierPostTravel.value * density) {
+    if (innerDragPosition.y > layoutResult.lastBaseline + MagnifierPostTravel.toPx()) {
         return Offset.Unspecified
     }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
@@ -22,6 +22,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -41,27 +44,22 @@ import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowScene
 
 class TextFieldMagnifierTest {
+
+    private val params = listOf<TextFieldComposableFactory>(
+        { fr -> BFT(fr) },
+        { fr -> BFT2(fr) }
+    )
+
     @Test
-    fun testMagnifierShownOnTouchAndHold() = runUIKitInstrumentedTest {
+    fun testMagnifierShownOnTouchAndHold() = runUIKitInstrumentedTest(
+        params = params
+    ) { factory ->
         val focusRequester = FocusRequester()
 
         setContent {
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
-                BasicTextField(
-                    "TEXT VALUE",
-                    {},
-                    keyboardOptions = KeyboardOptions(
-                        platformImeOptions = PlatformImeOptions {
-                            usingNativeTextInput(false)
-                        }
-                    ),
-                    modifier = Modifier
-                        .testTag("textField")
-                        .height(40.dp)
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester)
-                )
+                factory(focusRequester)
             }
         }
 
@@ -77,26 +75,15 @@ class TextFieldMagnifierTest {
     }
 
     @Test
-    fun testMagnifierHidesOnLift() = runUIKitInstrumentedTest {
+    fun testMagnifierHidesOnLift() = runUIKitInstrumentedTest(
+        params = params
+    ) { factory ->
         val focusRequester = FocusRequester()
 
         setContent {
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
-                BasicTextField(
-                    "TEXT VALUE",
-                    {},
-                    keyboardOptions = KeyboardOptions(
-                        platformImeOptions = PlatformImeOptions {
-                            usingNativeTextInput(false)
-                        }
-                    ),
-                    modifier = Modifier
-                        .testTag("textField")
-                        .height(40.dp)
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester)
-                )
+                factory(focusRequester)
             }
         }
 
@@ -118,26 +105,15 @@ class TextFieldMagnifierTest {
     }
 
     @Test
-    fun testMagnifierHidesOnDragOutsideTextField() = runUIKitInstrumentedTest {
+    fun testMagnifierHidesOnDragOutsideTextField() = runUIKitInstrumentedTest(
+        params = params
+    ) { factory ->
         val focusRequester = FocusRequester()
 
         setContent {
             Column {
                 Box(Modifier.height(200.dp).fillMaxWidth())
-                BasicTextField(
-                    "TEXT VALUE",
-                    {},
-                    keyboardOptions = KeyboardOptions(
-                        platformImeOptions = PlatformImeOptions {
-                            usingNativeTextInput(false)
-                        }
-                    ),
-                    modifier = Modifier
-                        .testTag("textField")
-                        .height(40.dp)
-                        .fillMaxWidth()
-                        .focusRequester(focusRequester)
-                )
+                factory(focusRequester)
             }
         }
 
@@ -156,6 +132,36 @@ class TextFieldMagnifierTest {
         waitUntil {
             findFirstDescendant { it.isLoupeView } == null
         }
+    }
+
+    private val textValue = "TEXT"
+    private val keyboardOptions = KeyboardOptions(
+        platformImeOptions = PlatformImeOptions {
+            usingNativeTextInput(false)
+        }
+    )
+    private fun modifier(focusRequester: FocusRequester): Modifier = Modifier
+        .testTag("textField")
+        .height(40.dp)
+        .fillMaxWidth()
+        .focusRequester(focusRequester)
+
+    @Composable
+    private fun BFT(
+        focusRequester: FocusRequester
+    ) = BasicTextField(
+        textValue,
+        onValueChange = {},
+        keyboardOptions = keyboardOptions,
+        modifier = modifier(focusRequester)
+    )
+
+    @Composable
+    private fun BFT2(
+        focusRequester: FocusRequester
+    ) {
+        val state = remember { TextFieldState(textValue) }
+        BasicTextField(state, keyboardOptions = keyboardOptions, modifier = modifier(focusRequester))
     }
 }
 
@@ -187,7 +193,9 @@ fun findFirstDescendant(predicate: (UIView) -> Boolean): UIView? {
     return null
 }
 
-private val loupeClassNames = listOf(
+private typealias TextFieldComposableFactory = @Composable (FocusRequester) -> Unit
+
+    private val loupeClassNames = listOf(
     "_UITextMagnifiedLoupeView",
     "_UITextLoupeView",
     "LoupeView"
@@ -195,6 +203,5 @@ private val loupeClassNames = listOf(
 
 private val UIView.isLoupeView: Boolean get() {
     val name = objcClassName(this) ?: return false
-    println("UIView.isLoupeView $name")
     return loupeClassNames.any { name.contains(it) }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
@@ -195,7 +195,7 @@ fun findFirstDescendant(predicate: (UIView) -> Boolean): UIView? {
 
 private typealias TextFieldComposableFactory = @Composable (FocusRequester) -> Unit
 
-    private val loupeClassNames = listOf(
+private val loupeClassNames = listOf(
     "_UITextMagnifiedLoupeView",
     "_UITextLoupeView",
     "LoupeView"

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/interaction/TextFieldMagnifierTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.interaction
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithTag
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import androidx.compose.ui.test.utils.up
+import androidx.compose.ui.text.input.PlatformImeOptions
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.cinterop.BetaInteropApi
+import platform.Foundation.NSStringFromClass
+import platform.UIKit.UIApplication
+import platform.UIKit.UIView
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowScene
+
+class TextFieldMagnifierTest {
+    @Test
+    fun testMagnifierShownOnTouchAndHold() = runUIKitInstrumentedTest {
+        val focusRequester = FocusRequester()
+
+        setContent {
+            Column {
+                Box(Modifier.height(200.dp).fillMaxWidth())
+                BasicTextField(
+                    "TEXT VALUE",
+                    {},
+                    keyboardOptions = KeyboardOptions(
+                        platformImeOptions = PlatformImeOptions {
+                            usingNativeTextInput(false)
+                        }
+                    ),
+                    modifier = Modifier
+                        .testTag("textField")
+                        .height(40.dp)
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+
+        waitForIdle()
+
+        findNodeWithTag("textField").touchDown()
+
+        waitUntil {
+            findFirstDescendant { it.isLoupeView } != null
+        }
+    }
+
+    @Test
+    fun testMagnifierHidesOnLift() = runUIKitInstrumentedTest {
+        val focusRequester = FocusRequester()
+
+        setContent {
+            Column {
+                Box(Modifier.height(200.dp).fillMaxWidth())
+                BasicTextField(
+                    "TEXT VALUE",
+                    {},
+                    keyboardOptions = KeyboardOptions(
+                        platformImeOptions = PlatformImeOptions {
+                            usingNativeTextInput(false)
+                        }
+                    ),
+                    modifier = Modifier
+                        .testTag("textField")
+                        .height(40.dp)
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+
+        waitForIdle()
+
+        val touch = findNodeWithTag("textField").touchDown()
+
+        waitUntil {
+            findFirstDescendant { it.isLoupeView } != null
+        }
+
+        touch.up()
+
+        waitUntil {
+            findFirstDescendant { it.isLoupeView } == null
+        }
+    }
+
+    @Test
+    fun testMagnifierHidesOnDragOutsideTextField() = runUIKitInstrumentedTest {
+        val focusRequester = FocusRequester()
+
+        setContent {
+            Column {
+                Box(Modifier.height(200.dp).fillMaxWidth())
+                BasicTextField(
+                    "TEXT VALUE",
+                    {},
+                    keyboardOptions = KeyboardOptions(
+                        platformImeOptions = PlatformImeOptions {
+                            usingNativeTextInput(false)
+                        }
+                    ),
+                    modifier = Modifier
+                        .testTag("textField")
+                        .height(40.dp)
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester)
+                )
+            }
+        }
+
+        focusRequester.requestFocus()
+
+        waitForIdle()
+
+        val touch = findNodeWithTag("textField").touchDown()
+
+        waitUntil {
+            findFirstDescendant { it.isLoupeView } != null
+        }
+
+        touch.dragBy(dy = 100.dp, duration = 0.1.seconds)
+
+        waitUntil {
+            findFirstDescendant { it.isLoupeView } == null
+        }
+    }
+}
+
+@OptIn(BetaInteropApi::class)
+private fun objcClassName(view: UIView): String? = view.`class`()?.let { NSStringFromClass(it) }
+
+private fun findFirstDescendant(root: UIView, predicate: (UIView) -> Boolean): UIView? {
+    if (predicate(root)) return root
+    root.subviews.forEach { view ->
+        view as UIView
+        val hit = findFirstDescendant(view, predicate)
+        if (hit != null) return hit
+    }
+    return null
+}
+
+fun findFirstDescendant(predicate: (UIView) -> Boolean): UIView? {
+    val app = UIApplication.sharedApplication
+    val scenes = app.connectedScenes
+
+    scenes.forEach { scene ->
+        val scene = scene as? UIWindowScene ?: return@forEach
+        scene.windows.forEach { window ->
+            window as UIWindow
+            val hit = findFirstDescendant(window) { it.isLoupeView }
+            if (hit != null) return hit
+        }
+    }
+    return null
+}
+
+private val loupeClassNames = listOf(
+    "_UITextMagnifiedLoupeView",
+    "_UITextLoupeView",
+    "LoupeView"
+)
+
+private val UIView.isLoupeView: Boolean get() {
+    val name = objcClassName(this) ?: return false
+    println("UIView.isLoupeView $name")
+    return loupeClassNames.any { name.contains(it) }
+}


### PR DESCRIPTION
Migrate Modifier.magnifier from Modifier.composed to Modifier.Node

Fixes [CMP-9914](https://youtrack.jetbrains.com/issue/CMP-9914)
Fixes [CMP-9935](https://youtrack.jetbrains.com/issue/CMP-9935) Add tests for non-NITI magnifier in TextField

## Release Notes
N/A