### PR TITLE
Fix `RecordDrawRectRenderDecorator` closing

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -78,6 +78,7 @@ internal abstract class DesktopComposeSceneLayer(
         eventType: PointerEventType,
         button: PointerButton?
     ) -> Unit)? = null
+    private var drawBoundsRecorder: RecordDrawRectRenderDecorator? = null
     private var isClosed = false
 
     final override var density: Density = density
@@ -109,6 +110,8 @@ internal abstract class DesktopComposeSceneLayer(
 
     @CallSuper
     override fun close() {
+        drawBoundsRecorder?.close()
+        drawBoundsRecorder = null
         isClosed = true
     }
 
@@ -147,6 +150,9 @@ internal abstract class DesktopComposeSceneLayer(
                 bottom = boundsInWindow.bottom + maxDrawInflate.bottom
             )
             onDrawBoundsChanged()
+        }.also {
+            drawBoundsRecorder?.close()
+            drawBoundsRecorder = it
         }
 
     /**

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -63,7 +63,7 @@ internal abstract class DesktopComposeSceneLayer(
     )
 
     protected abstract val mediator: ComposeSceneMediator?
-    private val closeables = mutableSetOf<AutoCloseable>()
+    private var drawBoundsRecorder: RecordDrawRectRenderDecorator? = null
 
     /**
      * Bounds of real drawings based on previous renders.
@@ -111,8 +111,8 @@ internal abstract class DesktopComposeSceneLayer(
     @CallSuper
     override fun close() {
         isClosed = true
-        closeables.forEach { it.close() }
-        closeables.clear()
+        drawBoundsRecorder?.close()
+        drawBoundsRecorder = null
     }
 
     final override fun setContent(content: @Composable () -> Unit) {
@@ -138,8 +138,11 @@ internal abstract class DesktopComposeSceneLayer(
     override fun calculateLocalPosition(positionInWindow: IntOffset) =
         positionInWindow // [ComposeScene] is equal to [windowContainer] for the layer.
 
-    protected fun recordDrawBounds(renderDelegate: SkikoRenderDelegate) =
-        RecordDrawRectRenderDecorator(renderDelegate) { canvasBoundsInPx ->
+    protected fun recordDrawBounds(renderDelegate: SkikoRenderDelegate): RecordDrawRectRenderDecorator {
+        check(drawBoundsRecorder == null) {
+            "recordDrawBounds cannot be called multiple times."
+        }
+        return RecordDrawRectRenderDecorator(renderDelegate) { canvasBoundsInPx ->
             val currentCanvasOffset = drawBounds.topLeft
             val drawBoundsInWindow = canvasBoundsInPx.roundToIntRect().translate(currentCanvasOffset)
             maxDrawInflate = maxInflate(boundsInWindow, drawBoundsInWindow, maxDrawInflate)
@@ -150,7 +153,8 @@ internal abstract class DesktopComposeSceneLayer(
                 bottom = boundsInWindow.bottom + maxDrawInflate.bottom
             )
             onDrawBoundsChanged()
-        }.also { closeables.add(it) }
+        }.also { drawBoundsRecorder = it }
+    }
 
     /**
      * Called when the focus of the window containing main Compose view has changed.

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -139,6 +139,9 @@ internal abstract class DesktopComposeSceneLayer(
         positionInWindow // [ComposeScene] is equal to [windowContainer] for the layer.
 
     protected fun recordDrawBounds(renderDelegate: SkikoRenderDelegate): RecordDrawRectRenderDecorator {
+        check(!isClosed) {
+            "recordDrawBounds called after layer is closed"
+        }
         check(drawBoundsRecorder == null) {
             "recordDrawBounds cannot be called multiple times."
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -63,6 +63,7 @@ internal abstract class DesktopComposeSceneLayer(
     )
 
     protected abstract val mediator: ComposeSceneMediator?
+    private val closeables = mutableSetOf<AutoCloseable>()
 
     /**
      * Bounds of real drawings based on previous renders.
@@ -78,7 +79,6 @@ internal abstract class DesktopComposeSceneLayer(
         eventType: PointerEventType,
         button: PointerButton?
     ) -> Unit)? = null
-    private var drawBoundsRecorder: RecordDrawRectRenderDecorator? = null
     private var isClosed = false
 
     final override var density: Density = density
@@ -110,9 +110,9 @@ internal abstract class DesktopComposeSceneLayer(
 
     @CallSuper
     override fun close() {
-        drawBoundsRecorder?.close()
-        drawBoundsRecorder = null
         isClosed = true
+        closeables.forEach { it.close() }
+        closeables.clear()
     }
 
     final override fun setContent(content: @Composable () -> Unit) {
@@ -150,10 +150,7 @@ internal abstract class DesktopComposeSceneLayer(
                 bottom = boundsInWindow.bottom + maxDrawInflate.bottom
             )
             onDrawBoundsChanged()
-        }.also {
-            drawBoundsRecorder?.close()
-            drawBoundsRecorder = it
-        }
+        }.also { closeables.add(it) }
 
     /**
      * Called when the focus of the window containing main Compose view has changed.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
@@ -51,6 +51,7 @@ internal class RecordDrawRectRenderDecorator(
 
     override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
         if (isClosed) {
+            decorated.onRender(canvas, width, height, nanoTime)
             return
         }
         drawRect = canvas.recordCullRect {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
@@ -28,7 +28,7 @@ import org.jetbrains.skiko.SkikoRenderDelegate
 internal class RecordDrawRectRenderDecorator(
     private val decorated: SkikoRenderDelegate,
     private val onDrawRectChange: (Rect) -> Unit
-) : SkikoRenderDelegate by decorated, AutoCloseable {
+) : SkikoRenderDelegate, AutoCloseable {
     private val pictureRecorder = PictureRecorder()
     private val bbhFactory = RTreeFactory()
     private var isClosed = false

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/skiko/RecordDrawRectRenderDecorator.skiko.kt
@@ -28,9 +28,10 @@ import org.jetbrains.skiko.SkikoRenderDelegate
 internal class RecordDrawRectRenderDecorator(
     private val decorated: SkikoRenderDelegate,
     private val onDrawRectChange: (Rect) -> Unit
-) : SkikoRenderDelegate by decorated {
+) : SkikoRenderDelegate by decorated, AutoCloseable {
     private val pictureRecorder = PictureRecorder()
     private val bbhFactory = RTreeFactory()
+    private var isClosed = false
     private var drawRect = Rect.Zero
         set(value) {
             if (value != field) {
@@ -39,13 +40,19 @@ internal class RecordDrawRectRenderDecorator(
             }
         }
 
-    // TODO(@MatkovIvan): nobody calls it
-    fun close() {
+    override fun close() {
+        if (isClosed) {
+            return
+        }
+        isClosed = true
         pictureRecorder.close()
         bbhFactory.close()
     }
 
     override fun onRender(canvas: Canvas, width: Int, height: Int, nanoTime: Long) {
+        if (isClosed) {
+            return
+        }
         drawRect = canvas.recordCullRect {
             decorated.onRender(it, width, height, nanoTime)
         }?.toComposeRect() ?: Rect.Zero
@@ -87,11 +94,3 @@ internal class RecordDrawRectRenderDecorator(
  * so temporary applying some offset is required to get right measurement in negative area.
  */
 private const val MeasureOffset = (1 shl 14).toFloat()
-
-private val SkRect.Companion.Unconstrained: SkRect
-    get() = makeLTRB(
-        l = Float.MIN_VALUE,
-        t = Float.MIN_VALUE,
-        r = Float.MAX_VALUE,
-        b = Float.MAX_VALUE
-    )


### PR DESCRIPTION
[CMP-6590](https://youtrack.jetbrains.com/issue/CMP-6590) Memory leak: `RecordDrawRectRenderDecorator` is not closed

## Release Notes
### Fixes - Desktop
- Fix memory leak in dialogs with non-default `compose.layers.type` setting
