### PR TITLE
Revert "Make canvas focused when Compose handles pointer events (#2796)"

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -116,7 +116,6 @@ import org.w3c.dom.MediaQueryListEvent
 import org.w3c.dom.Node
 import org.w3c.dom.events.Event
 import org.w3c.dom.events.EventTarget
-import org.w3c.dom.events.FocusEvent
 import org.w3c.dom.events.KeyboardEvent
 import org.w3c.dom.events.MouseEvent
 import org.w3c.dom.events.WheelEvent
@@ -370,8 +369,6 @@ internal class ComposeWindow(
 
     private val isMacOS = hostOs.isMacOS
 
-    private var canvasFocused = false
-
     private fun processClipKeyDown(keyEvent: KeyEvent) {
         val mod = if (isMacOS) keyEvent.isMetaPressed else keyEvent.isCtrlPressed
         if (!mod) return
@@ -411,14 +408,6 @@ internal class ComposeWindow(
 
         addTypedEvent<KeyboardEvent>("keyup") { event ->
             processKeyboardEvent(event)
-        }
-
-        addTypedEvent<FocusEvent>("focus") { event ->
-            canvasFocused = true
-        }
-
-        addTypedEvent<FocusEvent>("blur") { event ->
-            canvasFocused = false
         }
 
         state.globalEvents.addDisposableEvent("focus") {
@@ -682,12 +671,6 @@ internal class ComposeWindow(
 
         if (result != null && result.anyChangeConsumed && event.cancelable) {
             event.preventDefault()
-
-            // Since we call preventDefault, the browser will not focus the canvas automatically,
-            // but it should be focused to receive key events
-            if (!canvasFocused && eventType == PointerEventType.Press) {
-                canvas.focus()
-            }
         }
     }
 


### PR DESCRIPTION
This reverts commit c31fceb6

## Release Notes
N/A