### PR TITLE
Remove lastKnownPointerPosition of ComposeScene and other optimizations

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -144,7 +144,12 @@ internal class ComposeSceneMediator(
 
     private val platformComponent = DesktopPlatformComponent()
     private val textInputService = DesktopTextInputService(platformComponent)
-    private val textInputService2 = DesktopTextInputService2(platformComponent)
+
+    private var _textInputService2: DesktopTextInputService2? = null
+    private val textInputService2
+        get() = _textInputService2 ?: DesktopTextInputService2(platformComponent).also {
+            _textInputService2 = it
+        }
     private val _platformContext = DesktopPlatformContext()
     val platformContext: PlatformContext get() = _platformContext
 

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/window/DesktopPopup.desktop.kt
@@ -21,9 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.scene.BaseComposeScene
-import androidx.compose.ui.scene.LocalComposeScene
-import androidx.compose.ui.scene.lastKnownPointerPosition
+import androidx.compose.ui.scene.LocalComposeSceneContext
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
@@ -32,6 +30,8 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.round
+import androidx.compose.ui.unit.toOffset
+import java.awt.MouseInfo
 import kotlin.math.roundToInt
 
 /**
@@ -39,10 +39,14 @@ import kotlin.math.roundToInt
  */
 @Composable
 private fun rememberCursorPosition(): Offset? {
-    // TODO: Migrate to [LocalComposeSceneContext]
-    @Suppress("DEPRECATION")
-    val scene = LocalComposeScene.current
-    return remember { scene?.lastKnownPointerPosition }
+    val density = LocalDensity.current
+    val composeSceneContext = LocalComposeSceneContext.current
+    return remember {
+        val mouseLocation = MouseInfo.getPointerInfo().location
+        composeSceneContext?.platformContext?.convertScreenToLocalPosition(
+            mouseLocation.asDpOffset().toOffset(density)
+        )
+    }
 }
 
 /**

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -45,9 +45,6 @@ import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.scene.ComposeScene
-import androidx.compose.ui.scene.LocalComposeScene
-import androidx.compose.ui.scene.lastKnownPointerPosition
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Constraints

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -63,7 +63,6 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.util.concurrent.Executors
 import kotlin.random.Random
-import kotlin.test.assertNull
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.yield
@@ -717,23 +716,6 @@ class MouseMoveTest {
         collector.assertCounts(enter = 1, exit = 1, move = 1, press = 1)
     }
 
-    @Test
-    fun `window exit clears lastKnownPointerPosition`() = ImageComposeScene(
-        width = 100,
-        height = 100,
-    ).useInUiThread { scene ->
-        lateinit var composeScene: ComposeScene
-        scene.setContent {
-            composeScene = LocalComposeScene.current!!
-            Box(Modifier.size(100.dp))
-        }
-
-        scene.sendPointerEvent(PointerEventType.Enter, Offset(10f, 20f))
-        // Deliberately send an exit event with coordinates still inside the box
-        scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
-
-        assertNull(composeScene.lastKnownPointerPosition)
-    }
 }
 
 private fun Modifier.collectPointerEvents(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -88,7 +88,6 @@ internal class DesktopCursorPositionTest {
         // so we need to convert it back to Dp and then to pixels again to compare with the original IntOffset
         val pxPointerPosition = pointerPosition?.toDpOffset(window?.density ?: Density(1f))
         assertThat(pxPointerPosition).isEqualTo(pxTargetOffset)
-        exitTestApplication()
     }
 
     private fun IntOffset.toDpOffset(density: Density): IntOffset {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -24,18 +24,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposeWindow
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.toDpOffset
 import androidx.compose.ui.unit.toOffset
 import com.google.common.truth.Truth.assertThat
+import java.awt.MouseInfo
 import java.awt.Robot
 import org.junit.Test
 
@@ -51,9 +49,9 @@ internal class DesktopCursorPositionTest {
     fun `pointer position with single component`(): Unit = runApplicationTest {
         var pointerPosition: IntOffset? = null
         var window: ComposeWindow? = null
-        val robot = Robot()
         val pxTargetOffset = IntOffset(84, 58)
         var pointerMoved by mutableStateOf(false)
+        val initialMouseLocation = MouseInfo.getPointerInfo().location
         launchTestWindowApplication(
             WindowState(WindowPlacement.Maximized),
         ) {
@@ -88,6 +86,10 @@ internal class DesktopCursorPositionTest {
         // so we need to convert it back to Dp and then to pixels again to compare with the original IntOffset
         val pxPointerPosition = pointerPosition?.toDpOffset(window?.density ?: Density(1f))
         assertThat(pxPointerPosition).isEqualTo(pxTargetOffset)
+
+        // Move mouse back to the initial position to avoid interference with other tests
+        moveMouse(initialMouseLocation.x, initialMouseLocation.y)
+        awaitIdle()
     }
 
     private fun IntOffset.toDpOffset(density: Density): IntOffset {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -20,55 +20,50 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.onPointerEvent
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toDpOffset
+import androidx.compose.ui.unit.toOffset
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import org.junit.Rule
+import java.awt.Robot
 import org.junit.Test
 
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTestApi::class)
 internal class DesktopCursorPositionTest {
-    @get:Rule
-    val rule = createComposeRule()
 
     private val windowSize = IntSize(200, 200)
     private val anchorPosition = IntOffset(0, 0)
     private val anchorSize = IntSize(100, 100)
     private val popupSize = IntSize(20, 20)
 
-    // https://github.com/JetBrains/compose-jb/issues/2821
     @Test
-    fun `pointer position with single component`(): Unit = runBlocking(Dispatchers.Main) {
+    fun `pointer position with single component`(): Unit = runApplicationTest {
         var pointerPosition: IntOffset? = null
+        var window: ComposeWindow? = null
+        val robot = Robot()
+        val pxTargetOffset = IntOffset(84, 58)
+        var pointerMoved by mutableStateOf(false)
+        launchTestWindowApplication(
+            WindowState(WindowPlacement.Maximized),
+        ) {
+            window = this.window
 
-        rule.setContent {
-            var savePointerPosition by remember { mutableStateOf(false) }
             Box(
                 modifier = Modifier
                     .size(200.dp, 200.dp)
-                    .testTag("testBox")
-                    .onPointerEvent(PointerEventType.Enter, onEvent = {
-                        savePointerPosition = true
-                    })
-            ) {
-                if (savePointerPosition) {
+            ){
+                if (pointerMoved) {
                     pointerPosition = rememberCursorPositionProvider().calculatePosition(
                         IntRect(anchorPosition, anchorSize),
                         windowSize,
@@ -78,11 +73,25 @@ internal class DesktopCursorPositionTest {
                 }
             }
         }
+        awaitIdle()
 
-        rule.onNodeWithTag("testBox").performMouseInput {
-            moveTo(Offset(30f, 40f))
-        }
-        rule.waitForIdle()
-        assertThat(pointerPosition).isEqualTo(IntOffset(30, 40))
+        val contentLocation = window?.contentPane?.locationOnScreen ?: java.awt.Point(0, 0)
+        robot.mouseMove(
+            contentLocation.x + pxTargetOffset.x,
+            contentLocation.y + pxTargetOffset.y
+        )
+        awaitIdle()
+        pointerMoved = true
+        awaitIdle()
+
+        //calculatePosition returns an IntOffset but that includes the density factor,
+        // so we need to convert it back to Dp and then to pixels again to compare with the original IntOffset
+        val pxPointerPosition = pointerPosition?.toDpOffset(window?.density ?: Density(1f))
+        assertThat(pxPointerPosition).isEqualTo(pxTargetOffset)
+        exitTestApplication()
+    }
+
+    private fun IntOffset.toDpOffset(density: Density): IntOffset {
+        return with(density) { IntOffset(x.toDp().value.toInt(), y.toDp().value.toInt()) }
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopCursorPositionTest.kt
@@ -76,7 +76,7 @@ internal class DesktopCursorPositionTest {
         awaitIdle()
 
         val contentLocation = window?.contentPane?.locationOnScreen ?: java.awt.Point(0, 0)
-        robot.mouseMove(
+        moveMouse(
             contentLocation.x + pxTargetOffset.x,
             contentLocation.y + pxTargetOffset.y
         )

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -191,6 +191,9 @@ internal class WindowTestScope(
         exceptionHandler.throwIfCaught()
     }
 
+    /**
+     * Moves mouse pointer to given screen coordinates.
+     */
     internal fun moveMouse(x: Int, y: Int) = robot.mouseMove(x, y)
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -190,6 +190,8 @@ internal class WindowTestScope(
 
         exceptionHandler.throwIfCaught()
     }
+
+    internal fun moveMouse(x: Int, y: Int) = robot::mouseMove
 }
 
 suspend fun Window.waitForFocusGain() {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/TestUtils.kt
@@ -191,7 +191,7 @@ internal class WindowTestScope(
         exceptionHandler.throwIfCaught()
     }
 
-    internal fun moveMouse(x: Int, y: Int) = robot::mouseMove
+    internal fun moveMouse(x: Int, y: Int) = robot.mouseMove(x, y)
 }
 
 suspend fun Window.waitForFocusGain() {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.toConstraints
 import androidx.compose.ui.unit.toDpSize
 import androidx.compose.ui.unit.toSize
 import kotlin.coroutines.CoroutineContext
@@ -392,5 +393,3 @@ private fun Constraints.toIntSize() =
     } else {
         null
     }
-
-private fun IntSize.toConstraints() = Constraints(maxWidth = width, maxHeight = height)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -163,7 +163,11 @@ internal class RootNodeOwner(
             owner.root.layoutDirection = value
         }
 
-    private val rootForTest = PlatformRootForTestImpl()
+    private var _rootForTest: PlatformRootForTest? = null
+    private val rootForTest
+        get() = _rootForTest ?: PlatformRootForTestImpl().also {
+            _rootForTest = it
+        }
     private val ownedLayerManager = OwnedLayerManagerImpl()
     private val pointerInputEventProcessor = PointerInputEventProcessor(owner.root)
     private val measureAndLayoutDelegate = MeasureAndLayoutDelegate(owner.root)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -98,9 +98,11 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.round
+import androidx.compose.ui.unit.toConstraints
 import androidx.compose.ui.unit.toRect
 import androidx.compose.ui.useLegacyRenderNodeLayers
 import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastMaxOfOrDefault
 import androidx.compose.ui.util.trace
 import androidx.compose.ui.viewinterop.InteropPointerInputModifier
@@ -925,8 +927,7 @@ internal class RootNodeOwner(
             // So, we applying it before drawing to reflect the changes from previous phases.
             // Changes that requires another round of invalidation will be scheduled to next frame.
             if (dirtyLayers.isNotEmpty()) {
-                for (i in 0 until dirtyLayers.size) {
-                    val layer = dirtyLayers[i]
+                dirtyLayers.fastForEach { layer ->
                     layer.updateDisplayList()
                 }
             }
@@ -1005,8 +1006,6 @@ private fun MeasureAndLayoutDelegate.updateRootConstraintsWithInfinityCheck(
         )
     )
 }
-
-private fun IntSize.toConstraints() = Constraints(maxWidth = width, maxHeight = height)
 
 private object IdentityPositionCalculator: PositionCalculator {
     override fun screenToLocal(positionOnScreen: Offset): Offset = positionOnScreen

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/BaseComposeScene.skiko.kt
@@ -109,12 +109,6 @@ internal abstract class BaseComposeScene(
 
     override var compositionLocalContext: CompositionLocalContext? by mutableStateOf(null)
 
-    /**
-     * The last known position of pointer cursor position or `null` if cursor is not inside a scene.
-     *
-     * TODO: Move it to PlatformContext
-     */
-    val lastKnownPointerPosition by inputHandler::lastKnownPointerPosition
 
     init {
         GlobalSnapshotManager.ensureStarted()
@@ -328,10 +322,3 @@ internal abstract class BaseComposeScene(
 
 internal val BaseComposeScene.semanticsOwnerListener
     get() = composeSceneContext.platformContext.semanticsOwnerListener
-
-// TODO: Remove the cast once there is a way to obtain it from [PlatformContext]
-internal val ComposeScene.lastKnownPointerPosition: Offset?
-    get() {
-        this as BaseComposeScene
-        return lastKnownPointerPosition
-    }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneInputHandler.skiko.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.scene
 
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
@@ -36,8 +35,6 @@ import androidx.compose.ui.input.pointer.SyntheticEventSender
 import androidx.compose.ui.input.pointer.areAnyPressed
 import androidx.compose.ui.input.pointer.copy
 import androidx.compose.ui.node.RootNodeOwner
-import androidx.compose.ui.util.fastFirstOrNull
-import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.trace
 
 /**
@@ -55,15 +52,8 @@ internal class ComposeSceneInputHandler(
     private val processKeyEvent: (KeyEvent) -> Boolean,
 ) {
     private val defaultPointerStateTracker = DefaultPointerStateTracker()
-    private val pointerPositions = mutableStateMapOf<PointerId, Offset>()
     private val syntheticEventSender = SyntheticEventSender(processPointerInputEvent)
 
-    /**
-     * The mouse cursor (also works with touch pointer) position
-     * or `null` if cursor is not inside a scene.
-     */
-    val lastKnownPointerPosition: Offset?
-        get() = pointerPositions.values.firstOrNull()
 
     /**
      * Indicates whether [updatePointerPosition] needs to be called.
@@ -136,7 +126,6 @@ internal class ComposeSceneInputHandler(
         prepareForPointerInputEvent()
         val updatePointerPositionResult = updatePointerPosition()
         val eventResult = syntheticEventSender.send(event)
-        updatePointerPositions(event)
         return updatePointerPositionResult.merging(eventResult)
     }
 
@@ -155,30 +144,6 @@ internal class ComposeSceneInputHandler(
 
     fun onPointerUpdate() {
         syntheticEventSender.needUpdatePointerPosition = true
-    }
-
-    private fun updatePointerPositions(event: PointerInputEvent) {
-        // update positions for pointers that are down + mouse (if it is not Exit event)
-        event.pointers.fastForEach { pointer ->
-            if ((pointer.type == PointerType.Mouse && event.eventType != PointerEventType.Exit) ||
-                pointer.down
-            ) {
-                pointerPositions[pointer.id] = pointer.position
-            }
-        }
-
-        // touches/styluses positions should be removed from [pointerPositions] if they are not down
-        // anymore also, mouse exited ComposeScene should be removed
-        val iterator = pointerPositions.iterator()
-        while (iterator.hasNext()) {
-            val pointerId = iterator.next().key
-            val pointer = event.pointers.fastFirstOrNull { it.id == pointerId } ?: continue
-            if ((pointer.type != PointerType.Mouse && !pointer.down) ||
-                (pointer.type == PointerType.Mouse && event.eventType == PointerEventType.Exit)
-            ) {
-                iterator.remove()
-            }
-        }
     }
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -177,10 +177,26 @@ value class PointerEventResult internal constructor(internal val value: Int) {
 private inline fun Boolean.toInt() = if (this) 1 else 0
 
 // TODO: Rewrite to vararg after https://youtrack.jetbrains.com/issue/KT-33565/Allow-vararg-parameter-of-inline-class-type
-internal fun PointerEventResult.merging(
-    result1: PointerEventResult,
-    result2: PointerEventResult? = null,
-    result3: PointerEventResult? = null
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun PointerEventResult.merging(
+    result1: PointerEventResult
 ) = PointerEventResult(
-    value = this.value or result1.value or (result2?.value ?: 0) or (result3?.value ?: 0)
+    value = this.value or result1.value
+)
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun PointerEventResult.merging(
+    result1: PointerEventResult,
+    result2: PointerEventResult
+) = PointerEventResult(
+    value = this.value or result1.value or result2.value
+)
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun PointerEventResult.merging(
+    result1: PointerEventResult,
+    result2: PointerEventResult,
+    result3: PointerEventResult
+) = PointerEventResult(
+    value = this.value or result1.value or result2.value or result3.value
 )

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/unit/Geometry.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/unit/Geometry.skiko.kt
@@ -87,3 +87,6 @@ internal inline fun DpSize.toSize(density: Density): Size = with(density) {
 internal inline fun IntSize.toRect(): Rect =
     Rect(0f, 0f, width.toFloat(), height.toFloat())
 
+@Stable
+internal inline fun IntSize.toConstraints() = Constraints(maxWidth = width, maxHeight = height)
+

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/PointerEventResultTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/scene/PointerEventResultTest.kt
@@ -139,19 +139,9 @@ class PointerEventResultTest {
             assertEquals(7, result.value)
         }
 
-        // Test with null parameters
-        PointerEventResult(value = 1).merging(
-            result1 = PointerEventResult(value = 2),
-            result2 = null,
-            result3 = null
-        ).let { result ->
-            assertEquals(3, result.value)
-        }
-
         PointerEventResult(value = 1).merging(
             result1 = PointerEventResult(value = 2),
             result2 = PointerEventResult(value = 4),
-            result3 = null
         ).let { result ->
             assertEquals(7, result.value)
         }


### PR DESCRIPTION
Remove lastKnownPointerPosition by migrating CursorDropdownMenu (its only usage) to use Awt’s MouseInfo.getPointerInfo().location. This avoids having to deprecate the component while maintaining functionality. Also, make some classes in RootOwner be lazily loaded to avoid loading unnecessary classes (whether its because it is not initially used or only needed for example only on tests)

Fixes https://youtrack.jetbrains.com/issue/CMP-9926

## Testing
Modified the associated test of CursorDropdown and it correctly passes

## Release Notes
N/A