### PR TITLE
Add `createWindowsDefaultKeyMapping` and handle alt-backspace in it

### DIFF
--- a/compose/foundation/foundation/src/darwinMain/kotlin/androidx/compose/foundation/text/KeyMapping.darwin.kt
+++ b/compose/foundation/foundation/src/darwinMain/kotlin/androidx/compose/foundation/text/KeyMapping.darwin.kt
@@ -16,4 +16,4 @@
 
 package androidx.compose.foundation.text
 
-internal actual val platformDefaultKeyMapping: KeyMapping = createMacosDefaultKeyMapping()
+internal actual val platformDefaultKeyMapping: KeyMapping = createMacOsDefaultKeyMapping()

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/KeyMapping.desktop.kt
@@ -19,18 +19,19 @@ package androidx.compose.foundation.text
 import androidx.compose.foundation.DesktopPlatform
 
 internal actual val platformDefaultKeyMapping: KeyMapping
-    get() = overriddenDefaultKeyMapping ?: _platformDefaultKeyMapping
+    get() = keyMappingOverride ?: _platformDefaultKeyMapping
 
 /**
  * Used for testing purposes only
  */
-internal var overriddenDefaultKeyMapping: KeyMapping? = null
+internal var keyMappingOverride: KeyMapping? = null
 private val _platformDefaultKeyMapping: KeyMapping =
     createPlatformDefaultKeyMapping(DesktopPlatform.Current)
 
 internal fun createPlatformDefaultKeyMapping(platform: DesktopPlatform): KeyMapping {
     return when (platform) {
-        DesktopPlatform.MacOS -> createMacosDefaultKeyMapping()
+        DesktopPlatform.MacOS -> createMacOsDefaultKeyMapping()
+        DesktopPlatform.Windows -> createWindowsDefaultKeyMapping()
         else -> DefaultSkikoKeyMapping
     }
 }

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
@@ -23,8 +23,9 @@ import androidx.compose.foundation.isEqualTo
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.DefaultSkikoKeyMapping
 import androidx.compose.foundation.text.KeyMapping
-import androidx.compose.foundation.text.createMacosDefaultKeyMapping
-import androidx.compose.foundation.text.overriddenDefaultKeyMapping
+import androidx.compose.foundation.text.createMacOsDefaultKeyMapping
+import androidx.compose.foundation.text.createWindowsDefaultKeyMapping
+import androidx.compose.foundation.text.keyMappingOverride
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -487,6 +488,20 @@ class TextFieldKeyEventTest {
             expectedSelection = TextRange(4),
         )
 
+    @Test
+    fun textField_altBackspace_windows() =  // Performs "undo"
+        keysSequenceTest(
+            namedKeyMapping = WindowsKeyMapping,
+            initText = "hello",
+            initSelection = TextRange(5),
+        ) {
+            // Can't currently send typed key events on the desktop, so test undoing deletion
+            pressKey(Key.Backspace)
+            expectedText("hell")
+            press(Key.AltLeft + Key.Backspace)
+            expectedText("hello")
+        }
+
     private class SequenceScope(
         private val state: TextFieldState,
         private val clipboard: FakeClipboard,
@@ -521,41 +536,50 @@ class TextFieldKeyEventTest {
 
     @OptIn(InternalComposeUiApi::class, InternalTestApi::class)
     private fun keysSequenceTest(
+        namedKeyMapping: NamedKeyMapping,
         initText: String = DEFAULT_TEST_STRING,
         initSelection: TextRange = TextRange.Zero,
         initClipboardText: String? = null,
         sequence: suspend SequenceScope.() -> Unit,
     ) {
-        runInternalSkikoComposeUiTest(coroutineDispatcher = StandardTestDispatcher()) {
-            val tag = "TextFieldTestTag"
-            val state = TextFieldState(initText, initSelection)
-            val clipboard = FakeClipboard(initClipboardText)
-            val focusRequester = FocusRequester()
-            setContent {
-                CompositionLocalProvider(LocalClipboard provides clipboard) {
-                    BasicTextField(
-                        state = state,
-                        modifier = Modifier.focusRequester(focusRequester).testTag(tag),
-                        decorator = { it() },
-                    )
-                }
-            }
-
-            runOnIdle { focusRequester.requestFocus() }
-            waitForIdle()
-
-            onNodeWithTag(tag).performKeyInput {
-                runBlocking {
-                    val scope =
-                        SequenceScope(
+        keyMappingOverride = namedKeyMapping.keyMapping
+        try {
+            runInternalSkikoComposeUiTest(coroutineDispatcher = StandardTestDispatcher()) {
+                val tag = "TextFieldTestTag"
+                val state = TextFieldState(initText, initSelection)
+                val clipboard = FakeClipboard(initClipboardText)
+                val focusRequester = FocusRequester()
+                setContent {
+                    CompositionLocalProvider(LocalClipboard provides clipboard) {
+                        BasicTextField(
                             state = state,
-                            clipboard = clipboard,
-                            uiTest = this@runInternalSkikoComposeUiTest,
-                            keyInjectionScope = this@performKeyInput,
+                            modifier = Modifier.focusRequester(focusRequester).testTag(tag),
+                            decorator = { it() },
                         )
-                    scope.sequence()
+                    }
+                }
+
+                runOnIdle { focusRequester.requestFocus() }
+                waitForIdle()
+
+                onNodeWithTag(tag).performKeyInput {
+                    runBlocking {
+                        val scope =
+                            SequenceScope(
+                                state = state,
+                                clipboard = clipboard,
+                                uiTest = this@runInternalSkikoComposeUiTest,
+                                keyInjectionScope = this@performKeyInput,
+                            )
+                        scope.sequence()
+                    }
                 }
             }
+        } catch (e: Throwable) {
+            System.err.println("Failed with key mapping: ${namedKeyMapping.name}")
+            throw e
+        } finally {
+            keyMappingOverride = null
         }
     }
 
@@ -564,7 +588,8 @@ class TextFieldKeyEventTest {
     }
 
     private fun singleKeyStrokeTest(
-        keyMappings: List<NamedKeyMapping> = listOf(NonMacOsKeyMapping, MacOsKeyMapping),
+        keyMappings: List<NamedKeyMapping> =
+            listOf(NonMacOsKeyMapping, MacOsKeyMapping, WindowsKeyMapping),
         initText: String = DEFAULT_TEST_STRING,
         initSelection: TextRange,
         initClipboardText: String? = null,
@@ -574,29 +599,22 @@ class TextFieldKeyEventTest {
         expectedClipboardText: String? = null,
     ) {
         for (namedKeyMapping in keyMappings) {
-            overriddenDefaultKeyMapping = namedKeyMapping.keyMapping
-            try {
-                keysSequenceTest(
-                    initText = initText,
-                    initSelection = initSelection,
-                    initClipboardText = initClipboardText,
-                ) {
-                    press(keys)
-                    if (expectedText != null) {
-                        expectedText(expectedText)
-                    }
-                    if (expectedSelection != null) {
-                        expectedSelection(expectedSelection)
-                    }
-                    if (expectedClipboardText != null) {
-                        expectedClipboardText(expectedClipboardText)
-                    }
+            keysSequenceTest(
+                namedKeyMapping = namedKeyMapping,
+                initText = initText,
+                initSelection = initSelection,
+                initClipboardText = initClipboardText,
+            ) {
+                press(keys)
+                if (expectedText != null) {
+                    expectedText(expectedText)
                 }
-            } catch (e: Throwable) {
-                System.err.println("Failed with key mapping: ${namedKeyMapping.name}")
-                throw e
-            } finally {
-                overriddenDefaultKeyMapping = null
+                if (expectedSelection != null) {
+                    expectedSelection(expectedSelection)
+                }
+                if (expectedClipboardText != null) {
+                    expectedClipboardText(expectedClipboardText)
+                }
             }
         }
     }
@@ -624,7 +642,8 @@ class TextFieldKeyEventTest {
     private companion object {
         const val DEFAULT_TEST_STRING = "Hello"
 
-        val MacOsKeyMapping = NamedKeyMapping("macOS", createMacosDefaultKeyMapping())
+        val MacOsKeyMapping = NamedKeyMapping("macOS", createMacOsDefaultKeyMapping())
+        val WindowsKeyMapping = NamedKeyMapping("Windows", createWindowsDefaultKeyMapping())
         val NonMacOsKeyMapping = NamedKeyMapping("Default (non-macOS)", DefaultSkikoKeyMapping)
     }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/TextSelectionTests.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.CoreTextField
 import androidx.compose.foundation.text.KeyMapping
 import androidx.compose.foundation.text.createPlatformDefaultKeyMapping
-import androidx.compose.foundation.text.overriddenDefaultKeyMapping
+import androidx.compose.foundation.text.keyMappingOverride
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -57,11 +57,11 @@ class TextSelectionTests {
 
     @After
     fun restoreRealDesktopPlatform() {
-        overriddenDefaultKeyMapping = null
+        keyMappingOverride = null
     }
 
     private fun setPlatformDefaultKeyMapping(value: KeyMapping) {
-        overriddenDefaultKeyMapping = value
+        keyMappingOverride = value
     }
 
     private fun SemanticsNodeInteraction.waitAndCheck(check: () -> Unit): SemanticsNodeInteraction {

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
@@ -37,7 +37,7 @@ internal object DefaultSkikoKeyMapping : KeyMapping {
     }
 }
 
-internal fun createMacosDefaultKeyMapping(): KeyMapping {
+internal fun createMacOsDefaultKeyMapping(): KeyMapping {
     val common = commonKeyMapping(KeyModifiers.Meta)
     return object : KeyMapping {
         override fun map(event: KeyEvent): KeyCommand? {
@@ -201,6 +201,20 @@ internal fun createMacosDefaultKeyMapping(): KeyMapping {
 
                 else -> null
             } ?: common.map(event)
+        }
+    }
+}
+
+internal fun createWindowsDefaultKeyMapping(): KeyMapping {
+    return object : KeyMapping {
+        override fun map(event: KeyEvent): KeyCommand? {
+            val keyModifiers = event.modifiers
+
+            if ((keyModifiers == KeyModifiers.Alt) && (event.key == Key.Backspace)) {
+                return KeyCommand.UNDO
+            }
+
+            return DefaultSkikoKeyMapping.map(event)
         }
     }
 }

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
@@ -28,7 +28,8 @@ internal actual val platformDefaultKeyMapping: KeyMapping = createPlatformDefaul
 
 internal fun createPlatformDefaultKeyMapping(platform: OS): KeyMapping {
     val keyMapping = when (platform) {
-        OS.MacOS -> createMacosDefaultKeyMapping()
+        OS.MacOS -> createMacOsDefaultKeyMapping()
+        OS.Windows -> createWindowsDefaultKeyMapping()
         else -> DefaultSkikoKeyMapping
     }
     return object : KeyMapping {


### PR DESCRIPTION
Add `createWindowsDefaultKeyMapping` and handle alt-backspace in it

Fixes https://youtrack.jetbrains.com/issue/CMP-9936

## Testing
Added a unit test

This should be tested by QA

## Release Notes
### Fixes - Desktop
- [Windows] `Alt-backspace` now correctly performs undo action.
