### PR TITLE
[Web] Ignore all copy/paste/cut-generating key events, not just ctrl/cmd-c/v/x

### DIFF
--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/KeyMapping.web.kt
@@ -16,11 +16,7 @@
 
 package androidx.compose.foundation.text
 
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.key
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 
@@ -32,15 +28,12 @@ internal fun createPlatformDefaultKeyMapping(platform: OS): KeyMapping {
         else -> DefaultSkikoKeyMapping
     }
     return object : KeyMapping {
-        private val clipboardKeys = setOf(Key.C, Key.V, Key.X)
-
         override fun map(event: KeyEvent): KeyCommand? {
-            val isCtrlOrCmd = if (hostOs.isMacOS) event.isMetaPressed else event.isCtrlPressed
-            if (isCtrlOrCmd && event.key in clipboardKeys) {
+            return when (val command = keyMapping.map(event)) {
                 // we let a browser dispatch a clipboard event
-                return null
+                KeyCommand.COPY, KeyCommand.CUT, KeyCommand.PASTE -> null
+                else -> command
             }
-            return keyMapping.map(event)
         }
     }
 }


### PR DESCRIPTION
Ignore all copy/paste/cut-generating key events, not just ctrl/cmd-c/v/x

Fixes https://youtrack.jetbrains.com/issue/CMP-9937/Web-Ignore-all-copy-paste-cut-commands-not-just-ctrl-cmd-c-v-x

## Testing
N/A

This should be tested by QA

## Release Notes
### Fixes - Web
- The browser now handles additional cut, copy, and paste keyboard shortcuts, such as `Shift+Insert`
