### PR TITLE
Implemented isCopyKeyEvent for the hardware keyboard on the iOS

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
@@ -18,6 +18,8 @@ package androidx.compose.foundation.text.selection
 
 import androidx.compose.foundation.SelectionMagnifierElement
 import androidx.compose.foundation.isPlatformMagnifierSupported
+import androidx.compose.foundation.magnifier
+import androidx.compose.foundation.text.KeyCommand
 import androidx.compose.foundation.text.addTextContextMenuComponents
 import androidx.compose.foundation.text.contextmenu.builder.TextContextMenuBuilderScope
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItemWithComposableLeadingIcon
@@ -28,7 +30,7 @@ import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.platform.inspectable
 
 internal actual fun isCopyKeyEvent(keyEvent: KeyEvent): Boolean =
-    false //TODO implement copy key event for iPad
+    platformDefaultKeyMapping.map(keyEvent) == KeyCommand.COPY
 
 internal actual fun Modifier.selectionMagnifier(manager: SelectionManager): Modifier = if (isPlatformMagnifierSupported()) {
     this.then(

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionManager.ios.kt
@@ -18,12 +18,12 @@ package androidx.compose.foundation.text.selection
 
 import androidx.compose.foundation.SelectionMagnifierElement
 import androidx.compose.foundation.isPlatformMagnifierSupported
-import androidx.compose.foundation.magnifier
 import androidx.compose.foundation.text.KeyCommand
 import androidx.compose.foundation.text.addTextContextMenuComponents
 import androidx.compose.foundation.text.contextmenu.builder.TextContextMenuBuilderScope
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuItemWithComposableLeadingIcon
 import androidx.compose.foundation.text.contextmenu.data.TextContextMenuKeys
+import androidx.compose.foundation.text.platformDefaultKeyMapping
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.platform.debugInspectorInfo


### PR DESCRIPTION
Fixes: [CMP-7655](https://youtrack.jetbrains.com/issue/CMP-7655) iOS. Implement isCopyKeyEvent for hardware keyboard

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- Fix `Cmd + C` (copy) event handling for the selected text wrapped in `SelectionContainer` when using a hardware keyboard

