### PR TITLE
Replace internal platform-specific helpers with unified `HostDefaultProviderImpl`

### DIFF
--- a/compose/foundation/foundation/build.gradle
+++ b/compose/foundation/foundation/build.gradle
@@ -54,6 +54,7 @@ androidXMultiplatform {
     configureDarwinFlags()
 
     sourceSets {
+        def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
         commonMain.dependencies {
             api("androidx.collection:collection:1.5.0")
             api(project(":compose:animation:animation"))
@@ -67,9 +68,9 @@ androidXMultiplatform {
         commonTest.dependencies {
             implementation(libs.kotlinTest)
             implementation(libs.kotlinCoroutinesTest)
-            implementation("androidx.navigationevent:navigationevent:1.0.1")
-            implementation("androidx.navigationevent:navigationevent-testing:1.0.1")
-            implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
+            implementation("androidx.navigationevent:navigationevent:$navigationEventVersion")
+            implementation("androidx.navigationevent:navigationevent-testing:$navigationEventVersion")
+            implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
         }
 
         androidMain.dependencies {

--- a/compose/material/material/build.gradle
+++ b/compose/material/material/build.gradle
@@ -66,7 +66,7 @@ androidXMultiplatform {
             implementation(libs.kotlinTest)
             implementation(project(":compose:ui:ui-test"))
             implementation("androidx.navigationevent:navigationevent-testing:$navigationEventVersion")
-            implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
+            implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
         }
 
         androidMain.dependencies {

--- a/compose/material3/adaptive/adaptive-navigation3/build.gradle
+++ b/compose/material3/adaptive/adaptive-navigation3/build.gradle
@@ -47,11 +47,12 @@ androidXMultiplatform {
     defaultPlatform(PlatformIdentifier.ANDROID)
 
     sourceSets {
+        def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
         commonMain.dependencies {
             api(project(":compose:material3:adaptive:adaptive-navigation"))
             api(project(":navigation3:navigation3-ui"))
             implementation("androidx.collection:collection:1.5.0")
-            implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
+            implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
         }
 
         androidMain.dependencies {

--- a/compose/material3/material3/build.gradle
+++ b/compose/material3/material3/build.gradle
@@ -122,7 +122,7 @@ androidXMultiplatform {
                 implementation(project(":compose:runtime:runtime"))
                 def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
                 implementation("androidx.navigationevent:navigationevent-testing:$navigationEventVersion")
-                implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
+                implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
             }
         }
 

--- a/compose/ui/ui-backhandler/build.gradle
+++ b/compose/ui/ui-backhandler/build.gradle
@@ -58,11 +58,13 @@ androidXMultiplatform {
             }
         }
 
+        def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
+
         // TODO: Align naming: nonAndroidMain
         jbMain {
             dependsOn(commonMain)
             dependencies {
-                implementation("androidx.navigationevent:navigationevent:1.0.1")
+                implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
             }
         }
 

--- a/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
+++ b/compose/ui/ui-backhandler/src/jbMain/kotlin/androidx/compose/ui/backhandler/BackHandler.jb.kt
@@ -23,15 +23,10 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.currentCompositeKeyHashCode
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.navigationevent.NavigationEventDispatcherOwner
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import kotlinx.coroutines.flow.Flow
-
-@InternalComposeUiApi
-val LocalCompatNavigationEventDispatcherOwner =
-    staticCompositionLocalOf<NavigationEventDispatcherOwner?> { null }
 
 @OptIn(InternalComposeUiApi::class)
 @Deprecated("Use NavigationEventHandler instead")
@@ -41,8 +36,8 @@ actual fun PredictiveBackHandler(
     enabled: Boolean,
     onBack: suspend (progress: Flow<BackEventCompat>) -> Unit
 ) {
-    val owner = LocalCompatNavigationEventDispatcherOwner.current ?: error(
-        "No NavigationEventDispatcher was provided via LocalCompatNavigationEventDispatcherOwner"
+    val owner = LocalNavigationEventDispatcherOwner.current ?: error(
+        "No NavigationEventDispatcher was provided via LocalNavigationEventDispatcherOwner"
     )
     val dispatcher = owner.navigationEventDispatcher
     val coroutineScope = rememberCoroutineScope()
@@ -63,8 +58,8 @@ actual fun PredictiveBackHandler(
 @ExperimentalComposeUiApi
 @Composable
 actual fun BackHandler(enabled: Boolean, onBack: () -> Unit) {
-    val owner = LocalCompatNavigationEventDispatcherOwner.current ?: error(
-        "No NavigationEventDispatcher was provided via LocalCompatNavigationEventDispatcherOwner"
+    val owner = LocalNavigationEventDispatcherOwner.current ?: error(
+        "No NavigationEventDispatcher was provided via LocalNavigationEventDispatcherOwner"
     )
     val dispatcher = owner.navigationEventDispatcher
     val compositeKey = currentCompositeKeyHashCode

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -3744,7 +3744,7 @@ public final class androidx/compose/ui/platform/CompositionLocalsKt {
 }
 
 public final class androidx/compose/ui/platform/CompositionLocals_skikoKt {
-	public static final fun getLocalLifecycleOwner ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final synthetic fun getLocalLifecycleOwner ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
 public final class androidx/compose/ui/platform/DefaultViewConfiguration : androidx/compose/ui/platform/ViewConfiguration {

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -197,6 +197,7 @@ androidXMultiplatform {
             implementation(project(":compose:test-utils"))
         }
 
+        def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
         // TODO: Align naming: nonAndroidMain
         skikoMain {
             dependsOn(commonMain)
@@ -206,15 +207,8 @@ androidXMultiplatform {
                 api(libs.skiko)
                 implementation(libs.atomicFu)
 
-                // Keep this dependency for compatibility due to https://youtrack.jetbrains.com/issue/KT-60874
                 implementation(project(":compose:ui:ui-backhandler"))
-
-                // Use direct dependency to AOSP's artifact instead of using project reference
-                // because this module supports all KMP platforms from the beginning.
-                // Project dependency (commented out version) is required for `integration` branch setup
-                // implementation(project(":navigationevent:navigationevent"))
-                def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
-                implementation("androidx.navigationevent:navigationevent:$navigationEventVersion")
+                implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
             }
         }
 
@@ -225,7 +219,6 @@ androidXMultiplatform {
                 implementation(project(":compose:material:material"))
                 implementation(project(":compose:foundation:foundation"))
                 implementation(project(":compose:ui:ui-test"))
-                implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
             }
         }
 

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -207,6 +207,7 @@ androidXMultiplatform {
                 api(libs.skiko)
                 implementation(libs.atomicFu)
 
+                // Keep this dependency for compatibility due to https://youtrack.jetbrains.com/issue/KT-60874
                 implementation(project(":compose:ui:ui-backhandler"))
                 implementation("androidx.navigationevent:navigationevent-compose:$navigationEventVersion")
             }

--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -89,8 +89,8 @@ androidXMultiplatform {
             api("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.6")
             api("androidx.savedstate:savedstate-compose:1.4.0")
 
-            implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.6")
-            implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.6")
+            implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose:2.11.0-alpha01")
+            implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.11.0-alpha01")
         }
 
         commonTest.dependencies {
@@ -213,7 +213,8 @@ androidXMultiplatform {
                 // because this module supports all KMP platforms from the beginning.
                 // Project dependency (commented out version) is required for `integration` branch setup
                 // implementation(project(":navigationevent:navigationevent"))
-                implementation("androidx.navigationevent:navigationevent:1.0.1")
+                def navigationEventVersion = project.findProperty('artifactRedirection.version.androidx.navigationevent')
+                implementation("androidx.navigationevent:navigationevent:$navigationEventVersion")
             }
         }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
@@ -19,19 +19,13 @@ package androidx.compose.ui.platform
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.HostDefaultKey
-import androidx.compose.runtime.HostDefaultProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.LocalHostDefaultProvider
 import androidx.compose.runtime.ProvidedValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.retain.LocalRetainedValuesStore
 import androidx.compose.runtime.saveable.LocalSaveableStateRegistry
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.InternalComposeUiApi
-import androidx.compose.ui.backhandler.LocalCompatNavigationEventDispatcherOwner
-import androidx.compose.ui.node.Owner
 import androidx.lifecycle.LifecycleOwner
 import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 
@@ -41,6 +35,7 @@ import androidx.savedstate.compose.LocalSavedStateRegistryOwner
 @Deprecated(
     "Moved to lifecycle-runtime-compose library in androidx.lifecycle.compose package.",
     ReplaceWith("androidx.lifecycle.compose.LocalLifecycleOwner"),
+    level = DeprecationLevel.HIDDEN
 )
 actual val LocalLifecycleOwner get() = androidx.lifecycle.compose.LocalLifecycleOwner
 
@@ -63,18 +58,6 @@ val LocalPlatformWindowInsets = staticCompositionLocalOf<PlatformWindowInsets> {
     error("CompositionLocal LocalPlatformWindowInsets not present")
 }
 
-private val PlatformArchitectureComponentsOwner.values: Array<ProvidedValue<*>>
-    get() {
-        val providedValues = mutableListOf(
-            androidx.lifecycle.compose.LocalLifecycleOwner provides lifecycleOwner,
-            LocalInternalNavigationEventDispatcherOwner provides navigationEventDispatcherOwner,
-            LocalCompatNavigationEventDispatcherOwner provides navigationEventDispatcherOwner,
-            LocalSavedStateRegistryOwner provides savedStateRegistryOwner,
-        )
-        viewModelStoreOwner?.let { providedValues.add(LocalInternalViewModelStoreOwner provides it) }
-        return providedValues.toTypedArray()
-    }
-
 @OptIn(InternalComposeApi::class)
 @Composable
 internal fun ProvidePlatformCompositionLocals(
@@ -94,21 +77,16 @@ internal fun ProvidePlatformCompositionLocals(
         onDispose { registry.dispose() }
     }
 
-    // TODO: https://youtrack.jetbrains.com/issue/CMP-9752/Properly-implement-HostDefaultProvider-and-LocalHostDefaultProvider-for-CMP
     val hostDefaultProvider = remember(platformContext) {
-        object : HostDefaultProvider {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T> getHostDefault(key: HostDefaultKey<T>): T {
-                return platformContext.architectureComponentsOwner as T
-            }
-        }
+        HostDefaultProviderImpl(platformContext)
     }
 
     CompositionLocalProvider(
         *values,
         LocalPlatformScreenReader provides platformContext.screenReader,
         LocalPlatformWindowInsets provides platformContext.windowInsets,
-        *platformContext.architectureComponentsOwner.values,
+        androidx.lifecycle.compose.LocalLifecycleOwner provides platformContext.architectureComponentsOwner.lifecycleOwner,
+        LocalSavedStateRegistryOwner provides platformContext.architectureComponentsOwner.savedStateRegistryOwner,
         LocalSaveableStateRegistry provides saveableStateRegistry,
         LocalHostDefaultProvider provides hostDefaultProvider,
         content = content,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultNavigationEventDispatcherOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultNavigationEventDispatcherOwner.skiko.kt
@@ -18,22 +18,15 @@ package androidx.compose.ui.platform
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.InternalComposeApi
-import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.backhandler.LocalCompatNavigationEventDispatcherOwner
 import androidx.navigationevent.NavigationEventDispatcherOwner
-
-/**
- * Internal helper to provide [NavigationEventDispatcherOwner] from Compose UI module.
- * In applications please use [androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner].
- *
- * @hide
- */
-internal val LocalInternalNavigationEventDispatcherOwner =
-    staticCompositionLocalOf<NavigationEventDispatcherOwner?> { null }
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 
 
+@Deprecated(
+    "Moved to navigation-event-compose library in androidx.navigationevent.compose package.",
+    level = DeprecationLevel.HIDDEN
+)
 @InternalComposeApi
 @Composable
 fun findDefaultNavigationEventDispatcherOwner(): NavigationEventDispatcherOwner? =
-    LocalInternalNavigationEventDispatcherOwner.current
-        ?: LocalCompatNavigationEventDispatcherOwner.current
+    LocalNavigationEventDispatcherOwner.current

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Android Open Source Project
+ * Copyright 2024 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/DefaultViewModelOwnerStore.skiko.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,18 +20,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 
-/**
- * Internal helper to provide [ViewModelStoreOwner] from Compose UI module.
- * In applications please use [androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner].
- *
- * @hide
- */
-internal val LocalInternalViewModelStoreOwner = staticCompositionLocalOf<ViewModelStoreOwner?> {
-    null
-}
-
+@Deprecated(
+    "Moved to lifecycle-viewmodel-compose library in androidx.lifecycle.viewmodel.compose package.",
+    level = DeprecationLevel.HIDDEN
+)
 @InternalComposeApi
 @Composable
 fun findComposeDefaultViewModelStoreOwner(): ViewModelStoreOwner? =
-    LocalInternalViewModelStoreOwner.current
+    LocalViewModelStoreOwner.current

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/HostDefaultProviderImpl.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/HostDefaultProviderImpl.kt
@@ -24,6 +24,9 @@ import androidx.navigationevent.compose.NavigationEventDispatcherOwnerHostDefaul
 internal class HostDefaultProviderImpl(
     private val platformContext: PlatformContext
 ) : HostDefaultProvider {
+    // Note: https://youtrack.jetbrains.com/issue/KT-85051
+    // Potentially unsafe casts are intentional here.
+    @Suppress("UNCHECKED_CAST")
     override fun <T> getHostDefault(key: HostDefaultKey<T>): T = when (key) {
         NavigationEventDispatcherOwnerHostDefaultKey ->
             platformContext.architectureComponentsOwner.navigationEventDispatcherOwner

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/HostDefaultProviderImpl.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/HostDefaultProviderImpl.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.runtime.HostDefaultKey
+import androidx.compose.runtime.HostDefaultProvider
+import androidx.lifecycle.viewmodel.compose.ViewModelStoreOwnerHostDefaultKey
+import androidx.navigationevent.compose.NavigationEventDispatcherOwnerHostDefaultKey
+
+internal class HostDefaultProviderImpl(
+    private val platformContext: PlatformContext
+) : HostDefaultProvider {
+    override fun <T> getHostDefault(key: HostDefaultKey<T>): T = when (key) {
+        NavigationEventDispatcherOwnerHostDefaultKey ->
+            platformContext.architectureComponentsOwner.navigationEventDispatcherOwner
+        ViewModelStoreOwnerHostDefaultKey ->
+            platformContext.architectureComponentsOwner.viewModelStoreOwner
+        else -> null
+    } as T
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Dialog.skiko.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.Snapshot
-import androidx.compose.runtime.toLong
 import androidx.compose.ui.ComposeUiFlags
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -54,7 +53,6 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.exclude
 import androidx.compose.ui.platform.excludeWindowInsets
-import androidx.compose.ui.platform.findDefaultNavigationEventDispatcherOwner
 import androidx.compose.ui.platform.union
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.scene.Content
@@ -64,6 +62,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.center
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
@@ -182,7 +181,7 @@ actual fun Dialog(
         onBackHandler.backClickIsEnabled = properties.dismissOnBackPress
     }
     val navigationEventDispatcher =
-        requireNotNull(findDefaultNavigationEventDispatcherOwner()) {
+        requireNotNull(LocalNavigationEventDispatcherOwner.current) {
             error("NavigationEventDispatcherOwner not found")
         }.navigationEventDispatcher
     DisposableEffect(navigationEventDispatcher, onBackHandler) {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.exclude
 import androidx.compose.ui.platform.excludeWindowInsets
-import androidx.compose.ui.platform.findDefaultNavigationEventDispatcherOwner
 import androidx.compose.ui.scene.ComposeSceneLayer
 import androidx.compose.ui.scene.Content
 import androidx.compose.ui.scene.rememberComposeSceneLayer
@@ -53,6 +52,7 @@ import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.round
+import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 
 /**
  * Properties used to customize the behavior of a [Popup].
@@ -406,7 +406,7 @@ fun Popup(
             onBackHandler.backClickIsEnabled = properties.dismissOnBackPress
         }
         val navigationEventDispatcher =
-            requireNotNull(findDefaultNavigationEventDispatcherOwner()) {
+            requireNotNull(LocalNavigationEventDispatcherOwner.current) {
                 error("NavigationEventDispatcherOwner not found")
             }.navigationEventDispatcher
         DisposableEffect(navigationEventDispatcher, onBackHandler) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/HostDefaultProviderTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/HostDefaultProviderTest.kt
@@ -21,22 +21,17 @@ import androidx.compose.runtime.compositionLocalWithHostDefaultOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.lifecycle.ViewModelStoreOwner
-import kotlin.test.Ignore
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import kotlin.test.Test
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class HostDefaultProviderTest {
 
     @Test
     fun testHostDefaultProviderGetLocalViewModelStoreOwner() = runSkikoComposeUiTest {
-        val ViewModelStoreOwnerHostDefaultKey = object : HostDefaultKey<ViewModelStoreOwner?> {}
-        val LocalViewModelStoreOwner =
-            compositionLocalWithHostDefaultOf(ViewModelStoreOwnerHostDefaultKey)
-
         var owner: ViewModelStoreOwner? = null
         setContent {
             owner = LocalViewModelStoreOwner.current
@@ -46,32 +41,18 @@ class HostDefaultProviderTest {
         assertIs<ViewModelStoreOwner>(owner)
     }
 
-    interface TestRegistry { fun foo() }
+    interface TestRegistry
     val TestRegistryKey = object : HostDefaultKey<TestRegistry?> {}
 
-    //iOS: Child process terminated with signal 11: Segmentation fault
-    //web: unhandled Promise rejection RuntimeError: array element access out of bounds
-    @Ignore
     @Test
-    fun testHostDefaultProviderError() = runSkikoComposeUiTest {
+    fun testHostDefaultProviderNull() = runSkikoComposeUiTest {
         val LocalTestRegistry = compositionLocalWithHostDefaultOf(TestRegistryKey)
 
-        var exception: Exception? = null
-        try {
-            setContent {
-                val registry = LocalTestRegistry.current
-                registry?.foo()
-            }
-        } catch (e: Exception) {
-            exception = e
+        var registry: TestRegistry? = null
+        setContent {
+            registry = LocalTestRegistry.current
         }
 
-        assertIs<ClassCastException>(exception)
-        assertTrue(
-            exception.message!!.contains(
-                "class androidx.compose.ui.platform.DefaultArchitectureComponentsOwner " +
-                    "cannot be cast to class androidx.compose.ui.platform.HostDefaultProviderTest\$TestRegistry"
-            )
-        )
+        assertNull(registry)
     }
 }


### PR DESCRIPTION
- Removed `findDefaultNavigationEventDispatcherOwner` and `findComposeDefaultViewModelStoreOwner`.
- Deprecated and replaced obsolete CompositionLocals with lifecycle-runtime-compose equivalents.
- Updated dependencies to align with `navigationevent-compose` and `lifecycle-viewmodel-compose`.
- Simplified host default provider initialization through `HostDefaultProviderImpl`.

Describe proposed changes and the issue being fixed

Fixes https://youtrack.jetbrains.com/issue/CMP-9752

## Release Notes
N/A