### PR TITLE
Support fastDeleteWord on mobile devices

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/BackingDomInput.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.platform
 
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeOptions
 import androidx.compose.ui.text.input.TextFieldValue
@@ -29,7 +30,9 @@ internal interface ComposeCommandCommunicator {
     fun sendEditCommand(commands: List<EditCommand>)
     fun sendEditCommand(command: EditCommand) = sendEditCommand(listOf(command))
 
-    fun sendKeyboardEvent(keyboardEvent: KeyEvent)
+    fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean
+
+    fun currentTextLayoutResult(): TextLayoutResult?
 }
 
 private fun setBackingInputBox(container: HTMLElement, left: Float, top: Float, width: Float, height: Float) { js("""

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -138,7 +138,7 @@ internal abstract class NativeInputEventsProcessor(
         val editCommands = when (inputExt.inputType) {
             "deleteContentBackward" -> buildList {
                 // this means "deleteContentBackward" happened because of an earlier "keydown" event, so skipping it here
-                if (lastProcessedKeydown.isBackspace()) return@buildList
+                if (lastProcessedKeydown?.isBackspace() == true) return@buildList
 
                 if (!currentTextFieldValue.selection.collapsed) {
                     // Likely it's on mobile, where the Backspace has Unidentified key value.
@@ -164,7 +164,7 @@ internal abstract class NativeInputEventsProcessor(
             }
 
             "deleteWordBackward" -> buildList {
-                if (!lastProcessedKeydown.isBackspace()) return@buildList
+                if (lastProcessedKeydown?.isBackspace() != true) return@buildList
 
                 // This would mean event was triggered by long press on mobile device (iOS)
                 if (lastProcessedKeydown?.altKey == false) {
@@ -223,4 +223,4 @@ internal abstract class NativeInputEventsProcessor(
     internal fun getCollectedEvents() = collectedEvents
 }
 
-private fun KeyboardEvent?.isBackspace(): Boolean = this?.key == "Backspace"
+private fun KeyboardEvent.isBackspace(): Boolean = key == "Backspace"

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -52,7 +52,7 @@ internal abstract class NativeInputEventsProcessor(
     internal var isCheckpointScheduled = false
 
     internal var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
-    var lastProcessedEventIsBackspace: Boolean = false
+    private var lastKeydownStatus: ComposeKeyDownStatus? = null
 
     /**
      * Schedules a checkpoint for processing input events.
@@ -95,7 +95,7 @@ internal abstract class NativeInputEventsProcessor(
                     if (isTypedEvent(evt)) {
                         // we need to reset this each time we consider something to be typed
                         // see  https://youtrack.jetbrains.com/issue/CMP-8773
-                        lastProcessedEventIsBackspace = evt.key == "Backspace"
+                        lastKeydownStatus = null
                         return@fastForEach
                     }
 
@@ -110,8 +110,7 @@ internal abstract class NativeInputEventsProcessor(
                     val shouldBeProcessed = timestamp == 0.0 || !isFromLastComposition
 
                     if (shouldBeProcessed) {
-                        lastProcessedEventIsBackspace = evt.key == "Backspace"
-                        composeSender.sendKeyboardEvent(evt.toComposeEvent())
+                        lastKeydownStatus = ComposeKeyDownStatus(evt, composeSender.sendKeyboardEvent(evt.toComposeEvent()))
                     }
                 }
 
@@ -122,7 +121,6 @@ internal abstract class NativeInputEventsProcessor(
 
                 "beforeinput" -> {
                     (evt as InputEvent).process(
-                        lastProcessedEventIsBackspace = lastProcessedEventIsBackspace,
                         currentTextFieldValue = currentTextFieldValue
                     )
                 }
@@ -132,12 +130,12 @@ internal abstract class NativeInputEventsProcessor(
         collectedEvents.clear()
     }
 
-    private fun InputEvent.process(lastProcessedEventIsBackspace: Boolean, currentTextFieldValue: TextFieldValue) {
+    private fun InputEvent.process(currentTextFieldValue: TextFieldValue) {
         val inputExt = this.asInputEventExt()
         val editCommands = when (inputExt.inputType) {
             "deleteContentBackward" -> buildList {
                 // this means "deleteContentBackward" happened because of an earlier "keydown" event, so skipping it here
-                if (lastProcessedEventIsBackspace) return@buildList
+                if (lastKeydownStatus?.getProcessedEvent()?.isBackspace() == true) return@buildList
 
                 if (!currentTextFieldValue.selection.collapsed) {
                     // Likely it's on mobile, where the Backspace has Unidentified key value.
@@ -161,6 +159,22 @@ internal abstract class NativeInputEventsProcessor(
                     }
                 }
             }
+
+            "deleteWordBackward" -> buildList {
+                val lastProcessedEvent = lastKeydownStatus?.getProcessedEvent()
+                if (lastProcessedEvent?.isBackspace() != true) return@buildList
+
+                // This would mean event was triggerd by long press on mobile device (iOS)
+                if (!lastProcessedEvent.altKey) {
+                    val layoutResult = composeSender.currentTextLayoutResult() ?: return@buildList
+                    val text = layoutResult.layoutInput.text
+                    val wordBoundary = layoutResult.getWordBoundary(inputExt.textRangeStart.coerceIn(0, text.length - 1))
+
+                    add(SetSelectionCommand(wordBoundary.start, wordBoundary.end))
+                    add(BackspaceCommand())
+                }
+            }
+
 
             "insertReplacementText" -> buildList {
                 if (data == null) return@buildList
@@ -206,3 +220,14 @@ internal abstract class NativeInputEventsProcessor(
     @TestOnly
     internal fun getCollectedEvents() = collectedEvents
 }
+
+private class ComposeKeyDownStatus(
+    val event: KeyboardEvent,
+    val processed: Boolean
+)
+
+private fun ComposeKeyDownStatus.getProcessedEvent(): KeyboardEvent? {
+    return if (processed) event else null
+}
+
+private fun KeyboardEvent.isBackspace(): Boolean = key == "Backspace"

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -52,7 +52,7 @@ internal abstract class NativeInputEventsProcessor(
     internal var isCheckpointScheduled = false
 
     internal var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
-    private var lastKeydownStatus: ComposeKeyDownStatus? = null
+    private var lastProcessedKeydown: KeyboardEvent? = null
 
     /**
      * Schedules a checkpoint for processing input events.
@@ -95,7 +95,7 @@ internal abstract class NativeInputEventsProcessor(
                     if (isTypedEvent(evt)) {
                         // we need to reset this each time we consider something to be typed
                         // see  https://youtrack.jetbrains.com/issue/CMP-8773
-                        lastKeydownStatus = null
+                        lastProcessedKeydown = null
                         return@fastForEach
                     }
 
@@ -110,7 +110,10 @@ internal abstract class NativeInputEventsProcessor(
                     val shouldBeProcessed = timestamp == 0.0 || !isFromLastComposition
 
                     if (shouldBeProcessed) {
-                        lastKeydownStatus = ComposeKeyDownStatus(evt, composeSender.sendKeyboardEvent(evt.toComposeEvent()))
+                        val isProcessed = composeSender.sendKeyboardEvent(evt.toComposeEvent())
+                        if (isProcessed) {
+                            lastProcessedKeydown = evt
+                        }
                     }
                 }
 
@@ -135,7 +138,7 @@ internal abstract class NativeInputEventsProcessor(
         val editCommands = when (inputExt.inputType) {
             "deleteContentBackward" -> buildList {
                 // this means "deleteContentBackward" happened because of an earlier "keydown" event, so skipping it here
-                if (lastKeydownStatus?.getProcessedEvent()?.isBackspace() == true) return@buildList
+                if (lastProcessedKeydown.isBackspace()) return@buildList
 
                 if (!currentTextFieldValue.selection.collapsed) {
                     // Likely it's on mobile, where the Backspace has Unidentified key value.
@@ -161,11 +164,10 @@ internal abstract class NativeInputEventsProcessor(
             }
 
             "deleteWordBackward" -> buildList {
-                val lastProcessedEvent = lastKeydownStatus?.getProcessedEvent()
-                if (lastProcessedEvent?.isBackspace() != true) return@buildList
+                if (!lastProcessedKeydown.isBackspace()) return@buildList
 
-                // This would mean event was triggerd by long press on mobile device (iOS)
-                if (!lastProcessedEvent.altKey) {
+                // This would mean event was triggered by long press on mobile device (iOS)
+                if (lastProcessedKeydown?.altKey == false) {
                     val layoutResult = composeSender.currentTextLayoutResult() ?: return@buildList
                     val text = layoutResult.layoutInput.text
                     val wordBoundary = layoutResult.getWordBoundary(inputExt.textRangeStart.coerceIn(0, text.length - 1))
@@ -221,13 +223,4 @@ internal abstract class NativeInputEventsProcessor(
     internal fun getCollectedEvents() = collectedEvents
 }
 
-private class ComposeKeyDownStatus(
-    val event: KeyboardEvent,
-    val processed: Boolean
-)
-
-private fun ComposeKeyDownStatus.getProcessedEvent(): KeyboardEvent? {
-    return if (processed) event else null
-}
-
-private fun KeyboardEvent.isBackspace(): Boolean = key == "Backspace"
+private fun KeyboardEvent?.isBackspace(): Boolean = this?.key == "Backspace"

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -65,39 +65,6 @@ internal abstract class WebTextInputService :
      */
     abstract val backingDomInputContainer: HTMLElement
 
-//    override fun startInput(
-//        value: TextFieldValue,
-//        imeOptions: ImeOptions,
-//        onEditCommand: (List<EditCommand>) -> Unit,
-//        onImeActionPerformed: (ImeAction) -> Unit
-//    ) {
-//        backingDomInput = BackingDomInput(
-//            imeOptions = imeOptions,
-//            composeCommunicator = object : ComposeCommandCommunicator {
-//                override fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean {
-//                    return this@WebTextInputService.processKeyboardEvent(keyboardEvent)
-//                }
-//
-//                override fun sendEditCommand(commands: List<EditCommand>) {
-//                    onEditCommand(commands)
-//                }
-//
-//                override fun currentTextLayoutResult(): TextLayoutResult? = null
-//            },
-//            inputContainer = backingDomInputContainer,
-//        )
-//        backingDomInput?.register()
-//
-//        if (currentTouchOffset != null) {
-//            // We don't know the real position yet, but it's reasonable to assume that
-//            // if startInput is caused by a touch event,
-//            // then the TextField is positioned around the touch coordinates.
-//            // See the currentTouchOffset KDoc for the details.
-//            notifyFocusedRect(Rect(currentTouchOffset!!, Size(1f, 1f)))
-//        }
-//        showSoftwareKeyboard()
-//    }
-
     fun startInput(
         request: PlatformTextInputMethodRequest,
         onEditCommand: (List<EditCommand>) -> Unit,

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/WebTextInputService.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.input.EditCommand
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.ImeOptions
@@ -64,22 +65,55 @@ internal abstract class WebTextInputService :
      */
     abstract val backingDomInputContainer: HTMLElement
 
-    override fun startInput(
-        value: TextFieldValue,
-        imeOptions: ImeOptions,
+//    override fun startInput(
+//        value: TextFieldValue,
+//        imeOptions: ImeOptions,
+//        onEditCommand: (List<EditCommand>) -> Unit,
+//        onImeActionPerformed: (ImeAction) -> Unit
+//    ) {
+//        backingDomInput = BackingDomInput(
+//            imeOptions = imeOptions,
+//            composeCommunicator = object : ComposeCommandCommunicator {
+//                override fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean {
+//                    return this@WebTextInputService.processKeyboardEvent(keyboardEvent)
+//                }
+//
+//                override fun sendEditCommand(commands: List<EditCommand>) {
+//                    onEditCommand(commands)
+//                }
+//
+//                override fun currentTextLayoutResult(): TextLayoutResult? = null
+//            },
+//            inputContainer = backingDomInputContainer,
+//        )
+//        backingDomInput?.register()
+//
+//        if (currentTouchOffset != null) {
+//            // We don't know the real position yet, but it's reasonable to assume that
+//            // if startInput is caused by a touch event,
+//            // then the TextField is positioned around the touch coordinates.
+//            // See the currentTouchOffset KDoc for the details.
+//            notifyFocusedRect(Rect(currentTouchOffset!!, Size(1f, 1f)))
+//        }
+//        showSoftwareKeyboard()
+//    }
+
+    fun startInput(
+        request: PlatformTextInputMethodRequest,
         onEditCommand: (List<EditCommand>) -> Unit,
-        onImeActionPerformed: (ImeAction) -> Unit
     ) {
         backingDomInput = BackingDomInput(
-            imeOptions = imeOptions,
+            imeOptions = request.imeOptions,
             composeCommunicator = object : ComposeCommandCommunicator {
-                override fun sendKeyboardEvent(keyboardEvent: KeyEvent) {
-                    this@WebTextInputService.processKeyboardEvent(keyboardEvent)
+                override fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean {
+                    return this@WebTextInputService.processKeyboardEvent(keyboardEvent)
                 }
 
                 override fun sendEditCommand(commands: List<EditCommand>) {
                     onEditCommand(commands)
                 }
+
+                override fun currentTextLayoutResult() = request.textLayoutResult()
             },
             inputContainer = backingDomInputContainer,
         )
@@ -93,6 +127,16 @@ internal abstract class WebTextInputService :
             notifyFocusedRect(Rect(currentTouchOffset!!, Size(1f, 1f)))
         }
         showSoftwareKeyboard()
+    }
+
+    override fun startInput(
+        value: TextFieldValue,
+        imeOptions: ImeOptions,
+        onEditCommand: (List<EditCommand>) -> Unit,
+        onImeActionPerformed: (ImeAction) -> Unit
+    ) {
+        // This method is called from the common code.
+        // It's not used in the new API, but we keep it for backward compatibility.
     }
 
     fun getBackingInput(): HTMLElement? {

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/WebTextInputSession.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/WebTextInputSession.kt
@@ -51,10 +51,8 @@ internal class WebTextInputSession(
         }
         suspendCancellableCoroutine<Nothing> { continuation ->
             webTextInputService.startInput(
-                value = request.value(),
-                imeOptions = request.imeOptions,
-                onEditCommand = request.onEditCommand,
-                onImeActionPerformed = request.onImeAction ?: {}
+                request,
+                onEditCommand = request.onEditCommand
             )
 
             continuation.invokeOnCancellation {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -16,14 +16,13 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.ui.events.beforeInput
-import androidx.compose.ui.events.compositionEnd
-import androidx.compose.ui.events.compositionStart
-import androidx.compose.ui.events.keyEvent
-import androidx.compose.ui.input.key.InternalKeyEvent
-import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.MultiParagraph
+import androidx.compose.ui.text.TextLayoutInput
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.createFontFamilyResolver
 import androidx.compose.ui.text.input.BackspaceCommand
 import androidx.compose.ui.text.input.CommitTextCommand
 import androidx.compose.ui.text.input.EditCommand
@@ -31,6 +30,17 @@ import androidx.compose.ui.text.input.EditingBuffer
 import androidx.compose.ui.text.input.SetComposingTextCommand
 import androidx.compose.ui.text.input.SetSelectionCommand
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.input.key.InternalKeyEvent
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.events.beforeInput
+import androidx.compose.ui.events.compositionEnd
+import androidx.compose.ui.events.compositionStart
+import androidx.compose.ui.events.keyEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -49,7 +59,7 @@ class NativeInputEventsProcessorTest {
     /**
      * A mock implementation of ComposeCommandCommunicator for testing
      */
-    private class MockComposeCommandCommunicator(
+    private open class MockComposeCommandCommunicator(
         startingTextFieldValue: TextFieldValue = TextFieldValue("")
     ) : ComposeCommandCommunicator {
 
@@ -61,6 +71,8 @@ class NativeInputEventsProcessorTest {
         val editCommands = mutableListOf<EditCommand>()
         val keyboardEvents = mutableListOf<KeyEvent>()
 
+        private val fontFamilyResolver = createFontFamilyResolver()
+
         override fun sendEditCommand(commands: List<EditCommand>) {
             editCommands.addAll(commands)
             commands.forEach { it.applyTo(editingBuffer) }
@@ -71,7 +83,36 @@ class NativeInputEventsProcessorTest {
             return true
         }
 
-        override fun currentTextLayoutResult(): TextLayoutResult? = null
+        override fun currentTextLayoutResult(): TextLayoutResult? {
+            val text = editingBuffer.toString()
+            val annotatedString = AnnotatedString(text)
+            val density = Density(1f)
+            val constraints = Constraints()
+            val style = TextStyle.Default
+
+            return TextLayoutResult(
+                layoutInput = TextLayoutInput(
+                    text = annotatedString,
+                    style = style,
+                    placeholders = emptyList(),
+                    maxLines = Int.MAX_VALUE,
+                    softWrap = true,
+                    overflow = TextOverflow.Clip,
+                    density = density,
+                    layoutDirection = LayoutDirection.Ltr,
+                    fontFamilyResolver = fontFamilyResolver,
+                    constraints = constraints
+                ),
+                multiParagraph = MultiParagraph(
+                    annotatedString = annotatedString,
+                    style = style,
+                    constraints = constraints,
+                    density = density,
+                    fontFamilyResolver = fontFamilyResolver
+                ),
+                size = IntSize(0, 0)
+            )
+        }
 
         @Suppress("INVISIBLE_REFERENCE")
         fun currentTextFieldValue(): TextFieldValue {
@@ -253,7 +294,6 @@ class NativeInputEventsProcessorTest {
         )
         processor.registerEvent(backspaceEvent)
 
-        // Add deleteContentBackward event
         processor.registerEvent(
             (beforeInput("deleteContentBackward", null) as InputEvent).apply {
                 this.asInputEventExt().apply {
@@ -273,6 +313,103 @@ class NativeInputEventsProcessorTest {
             ((sentKeyEvent.nativeKeyEvent as InternalKeyEvent).nativeEvent as KeyboardEvent).key
         )
     }
+
+    @Test
+    fun `when Backspace was pressed without modifiers deleteWordBackward is processed`() {
+        val communicator = MockComposeCommandCommunicator(TextFieldValue("here we go again!!!"))
+        val processor = TestNativeInputEventsProcessor(communicator)
+
+        val backspaceEvent = keyEvent(
+            key = "Backspace",
+            code = "Backspace",
+            type = "keydown"
+        )
+        processor.registerEvent(backspaceEvent)
+
+        processor.registerEvent(
+            (beforeInput("deleteWordBackward", null) as InputEvent).apply {
+                this.asInputEventExt().apply {
+                    textRangeStart = 5
+                    textRangeEnd = 5
+                }
+            }
+        )
+        processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
+
+        assertEquals("here  go again!!!", communicator.currentTextFieldValue().text)
+    }
+
+    @Test
+    fun `deleteWordBackward is if TextLayoutResult is not resolved`() {
+        val communicator = object : MockComposeCommandCommunicator() {
+            override fun currentTextLayoutResult(): TextLayoutResult? = null
+        }
+
+        val processor = TestNativeInputEventsProcessor(communicator)
+
+        val backspaceEvent = keyEvent(
+            key = "Backspace",
+            code = "Backspace",
+            type = "keydown",
+            altKey = true
+        )
+        processor.registerEvent(backspaceEvent)
+
+        processor.registerEvent(
+            (beforeInput("deleteWordBackward", null) as InputEvent).apply {
+                this.asInputEventExt().apply {
+                    textRangeStart = 3
+                    textRangeEnd = 4
+                }
+            }
+        )
+        processor.manuallyRunCheckpoint(TextFieldValue("test"))
+
+        assertEquals(1, communicator.keyboardEvents.size)
+        assertEquals(0, communicator.editCommands.size)
+
+        val sentKeyEvent = communicator.keyboardEvents[0]
+        assertEquals(
+            "Backspace",
+            ((sentKeyEvent.nativeKeyEvent as InternalKeyEvent).nativeEvent as KeyboardEvent).key
+        )
+    }
+
+
+    @Test
+    fun `when Backspace was pressed with alt modifier deleteWordBackward is ignored`() {
+        val communicator = MockComposeCommandCommunicator()
+        val processor = TestNativeInputEventsProcessor(communicator)
+
+        val backspaceEvent = keyEvent(
+            key = "Backspace",
+            code = "Backspace",
+            type = "keydown",
+            altKey = true
+        )
+        processor.registerEvent(backspaceEvent)
+
+        processor.registerEvent(
+            (beforeInput("deleteWordBackward", null) as InputEvent).apply {
+                this.asInputEventExt().apply {
+                    textRangeStart = 3
+                    textRangeEnd = 4
+                }
+            }
+        )
+        processor.manuallyRunCheckpoint(TextFieldValue("test"))
+
+        assertEquals(1, communicator.keyboardEvents.size)
+        assertEquals(0, communicator.editCommands.size)
+
+        val sentKeyEvent = communicator.keyboardEvents[0]
+        assertEquals(
+            "Backspace",
+            ((sentKeyEvent.nativeKeyEvent as InternalKeyEvent).nativeEvent as KeyboardEvent).key
+        )
+    }
+
+
 
     @Test
     fun testInsertReplacementText() {

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.events.compositionStart
 import androidx.compose.ui.events.keyEvent
 import androidx.compose.ui.input.key.InternalKeyEvent
 import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.BackspaceCommand
 import androidx.compose.ui.text.input.CommitTextCommand
@@ -65,9 +66,12 @@ class NativeInputEventsProcessorTest {
             commands.forEach { it.applyTo(editingBuffer) }
         }
 
-        override fun sendKeyboardEvent(keyboardEvent: KeyEvent) {
+        override fun sendKeyboardEvent(keyboardEvent: KeyEvent): Boolean {
             keyboardEvents.add(keyboardEvent)
+            return true
         }
+
+        override fun currentTextLayoutResult(): TextLayoutResult? = null
 
         @Suppress("INVISIBLE_REFERENCE")
         fun currentTextFieldValue(): TextFieldValue {


### PR DESCRIPTION
Fixes [CMP-8262](https://youtrack.jetbrains.com/issue/CMP-8262) 

## Testing
`gradlew testWeb`

## Release Notes
### Fixes - Web
- Fix an issue where "fast delete" action removed characters one by one instead of deleting whole words in text fields on iOS
