### PR TITLE
Fix memory spikes caused by Metal texture capturing

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDrawable.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDrawable.h
@@ -1,4 +1,4 @@
- /*
+/*
  * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDrawable.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDrawable.h
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright 2026 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,7 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
 #import <IOSurface/IOSurfaceRef.h>
+#import "CMPMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,8 +27,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface CMPDrawable : NSObject
 
-/// Metal texture for rendering.
-@property (nonatomic, readonly) id<MTLTexture> texture;
+/// Size of the drawable texture
+@property (readonly) CGSize textureSize;
 
 /// Backing IOSurface displayed by the layer.
 @property (nonatomic, readonly) IOSurfaceRef surface;
@@ -41,7 +42,16 @@ NS_ASSUME_NONNULL_BEGIN
 /// Reference to the reusable associated skia surface.
 @property (nonatomic, weak, nullable) id associatedSkiaSurface;
 
-- (instancetype)initWithTexture:(id<MTLTexture>)texture surface:(IOSurfaceRef)surface;
+- (instancetype)initWithTexture:(id<MTLTexture>)texture size:(CGSize)textureSize surface:(IOSurfaceRef)surface;
+
+/// Get metal texture for rendering.
+- (void * CMP_BORROWED)drawableTexture;
+
+/**
+ * Eagerly releases the Metal texture and IOSurface backing this drawable.
+ * Safe to call multiple times (idempotent). Called automatically from -dealloc.
+ */
+- (void)dispose;
 
 @end
 

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDrawable.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPDrawable.m
@@ -15,10 +15,19 @@
  */
 
 #import "CMPDrawable.h"
+#import <UIKit/UIKit.h>
+
+@interface CMPDrawable() {
+    /// Metal texture for rendering.
+    id<MTLTexture> _texture;
+}
+
+@end
+
 
 @implementation CMPDrawable
 
-- (instancetype)initWithTexture:(id<MTLTexture>)texture surface:(IOSurfaceRef)surface {
+- (instancetype)initWithTexture:(id<MTLTexture>)texture size:(CGSize)textureSize surface:(IOSurfaceRef)surface {
     self = [super init];
     if (self) {
         _texture = texture;
@@ -26,15 +35,27 @@
         CFRetain(_surface);
         _presentedTime = 0;
         _isWaitingForCommandBufferCompletion = NO;
+        _textureSize = textureSize;
     }
     return self;
 }
 
-- (void)dealloc {
+- (void)dispose {
+    _texture = nil;
     if (_surface != NULL) {
         CFRelease(_surface);
         _surface = NULL;
     }
+}
+
+- (void * CMP_BORROWED)drawableTexture {
+    assert(_texture != NULL);
+    void *texturePtr = (__bridge void *)_texture;
+    return texturePtr;
+}
+
+- (void)dealloc {
+    [self dispose];
 }
 
 @end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalLayer.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalLayer.h
@@ -66,6 +66,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)releaseDrawable:(CMPDrawable *)drawable;
 
+/**
+ * Disposes and removes all drawables currently held in the pool.
+ * Thread-safe; may be called from any thread.
+ */
+- (void)drainDrawables;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalLayer.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPMetalLayer.m
@@ -54,10 +54,7 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
     if (!CGSizeEqualToSize(_drawableSize, size)) {
         [_drawablesLock lock];
         _drawableSize = size;
-        [_availableDrawables removeAllObjects];
-        _lastPresentedDrawable = nil;
-        _totalDrawables = 0;
-        _drawablesGeneration++;
+        [self drainDrawablesUnsafe];
         [_drawablesLock unlock];
     }
 }
@@ -104,15 +101,15 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
         IOSurfaceRef surface = [self IOSurface];
         if (surface != NULL) {
             MTLTextureDescriptor *descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm
-                                                                                                   width:(NSUInteger)_drawableSize.width
-                                                                                                  height:(NSUInteger)_drawableSize.height
-                                                                                               mipmapped:NO];
+                                                                                                  width:(NSUInteger)_drawableSize.width
+                                                                                                 height:(NSUInteger)_drawableSize.height
+                                                                                              mipmapped:NO];
             descriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead | MTLTextureUsageShaderWrite;
 
             id<MTLTexture> texture = [_device newTextureWithDescriptor:descriptor iosurface:surface plane:0];
 
             if (texture != nil) {
-                result = [[CMPDrawable alloc] initWithTexture:texture surface:surface];
+                result = [[CMPDrawable alloc] initWithTexture:texture size:_drawableSize surface:surface];
                 _totalDrawables++;
             }
 
@@ -189,9 +186,9 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
               onDisplay:(void (^)(void))displayHandler {
     [_drawablesLock lock];
 
-    if (drawable.texture.width != (NSUInteger)_drawableSize.width ||
-        drawable.texture.height != (NSUInteger)_drawableSize.height) {
+    if (!CGSizeEqualToSize(drawable.textureSize, _drawableSize)) {
         // Invalid drawable size. Ignoring.
+        [drawable dispose];
         [_drawablesLock unlock];
         return;
     }
@@ -222,8 +219,7 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
         // Drop drawable that was scheduled before the already presented one
         return;
     }
-    if (drawable.texture.width != (NSUInteger)_drawableSize.width ||
-        drawable.texture.height != (NSUInteger)_drawableSize.height) {
+    if (!CGSizeEqualToSize(drawable.textureSize, _drawableSize)) {
         // Invalid drawable size. Ignoring.
         return;
     }
@@ -243,6 +239,23 @@ static const NSUInteger kBGRA32ColorFormatBytesPerPixel = 4;
 - (void)releaseDrawable:(CMPDrawable *)drawable {
     [_drawablesLock lock];
     [_availableDrawables addObject:drawable];
+    [_drawablesLock unlock];
+}
+
+- (void)drainDrawablesUnsafe {
+    for (CMPDrawable *drawable in _availableDrawables) {
+        [drawable dispose];
+    }
+    [_availableDrawables removeAllObjects];
+    [_lastPresentedDrawable dispose];
+    _lastPresentedDrawable = nil;
+    _totalDrawables = 0;
+    _drawablesGeneration++;
+}
+
+- (void)drainDrawables {
+    [_drawablesLock lock];
+    [self drainDrawablesUnsafe];
     [_drawablesLock unlock];
 }
 

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPMetalLayerTests.swift
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtilsTests/CMPMetalLayerTests.swift
@@ -52,9 +52,9 @@ final class CMPMetalLayerTests: XCTestCase {
 
         let drawable = layer.nextDrawable()
         XCTAssertNotNil(drawable, "Should get a drawable with valid size")
-        XCTAssertNotNil(drawable?.texture, "Drawable should have a texture")
-        XCTAssertEqual(drawable?.texture.width, 100, "Texture width should match")
-        XCTAssertEqual(drawable?.texture.height, 100, "Texture height should match")
+        XCTAssertNotNil(drawable?.surface, "Drawable should have a surface")
+        XCTAssertEqual(drawable?.textureSize.width, 100, "Texture width should match")
+        XCTAssertEqual(drawable?.textureSize.height, 100, "Texture height should match")
     }
 
     func testNextDrawableWithZeroSize() {
@@ -86,12 +86,12 @@ final class CMPMetalLayerTests: XCTestCase {
 
         // Verify they are different objects by comparing texture pointers
         XCTAssertTrue(
-            drawable1?.texture !== drawable2?.texture,
-            "Drawables should have different textures"
+            drawable1?.surface !== drawable2?.surface,
+            "Drawables should have different surfaces"
         )
         XCTAssertTrue(
-            drawable2?.texture !== drawable3?.texture,
-            "Drawables should have different textures"
+            drawable2?.surface !== drawable3?.surface,
+            "Drawables should have different surfaces"
         )
     }
 
@@ -163,16 +163,16 @@ final class CMPMetalLayerTests: XCTestCase {
 
         let drawable1 = layer.nextDrawable()
         XCTAssertNotNil(drawable1)
-        XCTAssertEqual(drawable1?.texture.width, 100)
-        XCTAssertEqual(drawable1?.texture.height, 100)
+        XCTAssertEqual(drawable1?.textureSize.width, 100)
+        XCTAssertEqual(drawable1?.textureSize.height, 100)
 
         // Change size - should invalidate pool
         layer.drawableSize = CGSize(width: 200, height: 200)
 
         let drawable2 = layer.nextDrawable()
         XCTAssertNotNil(drawable2)
-        XCTAssertEqual(drawable2?.texture.width, 200, "New drawable should have new size")
-        XCTAssertEqual(drawable2?.texture.height, 200, "New drawable should have new size")
+        XCTAssertEqual(drawable2?.textureSize.width, 200, "New drawable should have new size")
+        XCTAssertEqual(drawable2?.textureSize.height, 200, "New drawable should have new size")
     }
 
     func testPresentingWrongSizeDrawableIsIgnored() {
@@ -354,8 +354,8 @@ final class CMPMetalLayerTests: XCTestCase {
             layer.drawableSize = size
             let drawable = layer.nextDrawable()
             XCTAssertNotNil(drawable, "Should get drawable for size \(size)")
-            XCTAssertEqual(drawable?.texture.width, Int(size.width))
-            XCTAssertEqual(drawable?.texture.height, Int(size.height))
+            XCTAssertEqual(drawable?.textureSize.width, size.width)
+            XCTAssertEqual(drawable?.textureSize.height, size.height)
         }
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalRedrawer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalRedrawer.ios.kt
@@ -255,6 +255,16 @@ internal class SurfaceMetalRedrawer(
             }
         }
 
+    /**
+     * Closes all Skia surfaces and render targets that are currently associated with drawables.
+     */
+    fun drainSkiaSurfaces() {
+        check(NSThread.isMainThread) { "SurfaceMetalRedrawer.drainSkiaSurfaces() must be called on main thread" }
+        awaitRenderingQueueTasksCompletion()
+        metalLayer.drainDrawables()
+        disposeDrawableAssociatedResources(metalLayer.drawablesGeneration.toInt())
+    }
+
     override fun dispose() {
         check(caDisplayLink != null) { "MetalRedrawer.dispose() was called more than once" }
 
@@ -471,7 +481,7 @@ internal class SurfaceMetalRedrawer(
         val renderTarget = BackendRenderTarget.makeMetal(
             width = IOSurfaceGetWidth(drawable.surface).toInt(),
             height = IOSurfaceGetHeight(drawable.surface).toInt(),
-            texturePtr = drawable.texture.objcPtr()
+            texturePtr = drawable.drawableTexture().rawValue,
         )
 
         val surface = Surface.makeFromBackendRenderTarget(

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalView.ios.kt
@@ -24,6 +24,10 @@ import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ObjCClass
 import kotlinx.cinterop.readValue
 import kotlinx.cinterop.useContents
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Color
 import platform.CoreGraphics.CGRect
@@ -93,11 +97,35 @@ internal class SurfaceMetalView(
     }
 
     fun dispose() {
+        cancelPendingDrawableDrain()
         redrawer.dispose()
+    }
+
+    private var drainJob: Job? = null
+
+    private fun scheduleDrawableDrain() {
+        drainJob?.cancel()
+        drainJob = MainScope().launch {
+            delay(500)
+            if (window == null) {
+                redrawer.drainSkiaSurfaces()
+            }
+        }
+    }
+
+    private fun cancelPendingDrawableDrain() {
+        drainJob?.cancel()
     }
 
     override fun didMoveToWindow() {
         super.didMoveToWindow()
+
+        if (window == null) {
+            scheduleDrawableDrain()
+            return
+        }
+
+        cancelPendingDrawableDrain()
 
         val screen = window?.screen ?: return
         redrawer.maximumFramesPerSecond = screen.maximumFramesPerSecond

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalView.ios.kt
@@ -106,6 +106,7 @@ internal class SurfaceMetalView(
     private fun scheduleDrawableDrain() {
         drainJob?.cancel()
         drainJob = MainScope().launch {
+            // Await a safe time to ensure the metal view won't be displayed again soon
             delay(500)
             if (window == null) {
                 redrawer.drainSkiaSurfaces()


### PR DESCRIPTION
Dispose resources captured by the unused CMPDrawable.
Prevent GCD from capturing metal texture.

Fixes https://youtrack.jetbrains.com/issue/CMP-9939/Compose-Multiplatform-sheet-resizing-causes-excessive-IOSurface-memory-growth-on-iOS
Fixes: https://youtrack.jetbrains.com/issue/CMP-9918/Clear-metal-buffers-when-ComposeUIViewController-goes-out-of-window

### Tests
Since the issue reproduces only on the real device there is no way to write proper tests now.

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix high memory consumption caused by the Compose container resizing when `parallelRendering` is enabled
