### PR TITLE
pin androidx.savedstate:savedstate-compose to 1.4.0 in compose-ui

### DIFF
--- a/compose/ui/ui/build.gradle
+++ b/compose/ui/ui/build.gradle
@@ -71,8 +71,6 @@ androidXMultiplatform {
 
     sourceSets {
         def composeVersion = project.findProperty('artifactRedirection.version.androidx.compose')
-        def savedstateVersion =
-                project.findProperty('artifactRedirection.version.androidx.savedstate')
         commonMain.dependencies {
             implementation(libs.kotlinCoroutinesCore)
             api("androidx.annotation:annotation:1.9.1")
@@ -89,7 +87,7 @@ androidXMultiplatform {
             api(project(":compose:ui:ui-util"))
 
             api("org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose:2.9.6")
-            api("androidx.savedstate:savedstate-compose:$savedstateVersion")
+            api("androidx.savedstate:savedstate-compose:1.4.0")
 
             implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel:2.9.6")
             implementation("org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate:2.9.6")


### PR DESCRIPTION
using the latest artifactRedirection version is not correct as it can be of different stability level (e.g. alpha)



## Testing
N/A

## Release Notes
N/A
