### PR TITLE
Fix `DisposableEffect` to correctly dispose of `SaveableStateRegistry`

### DIFF
--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/CompositionLocals.skiko.kt
@@ -88,7 +88,11 @@ internal fun ProvidePlatformCompositionLocals(
             savedStateRegistryOwner = platformContext.architectureComponentsOwner.savedStateRegistryOwner
         )
     }
-    DisposableEffect(platformContext) { onDispose { saveableStateRegistry.dispose() } }
+    DisposableEffect(platformContext) {
+        //save a reference to dispose of a right object
+        val registry = saveableStateRegistry
+        onDispose { registry.dispose() }
+    }
 
     // TODO: https://youtrack.jetbrains.com/issue/CMP-9752/Properly-implement-HostDefaultProvider-and-LocalHostDefaultProvider-for-CMP
     val hostDefaultProvider = remember(platformContext) {


### PR DESCRIPTION
- Ensure a proper reference is used for disposal within `DisposableEffect`.

## Release Notes
N/A