### PR TITLE
[web] Add --no-parallel flag for building web demos

### DIFF
--- a/.run/mpp/demo/js-Demo.run.xml
+++ b/.run/mpp/demo/js-Demo.run.xml
@@ -20,7 +20,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/compose/mpp/demo" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-Porg.gradle.parallel=false" />
+      <option name="scriptParameters" value="--no-parallel" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/mpp/demo/js-Demo.run.xml
+++ b/.run/mpp/demo/js-Demo.run.xml
@@ -20,7 +20,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/compose/mpp/demo" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value="-Porg.gradle.parallel=false" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/mpp/demo/wasm-Demo.run.xml
+++ b/.run/mpp/demo/wasm-Demo.run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/compose/mpp/demo" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value="-Porg.gradle.parallel=false" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/mpp/demo/wasm-Demo.run.xml
+++ b/.run/mpp/demo/wasm-Demo.run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$/compose/mpp/demo" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-Porg.gradle.parallel=false" />
+      <option name="scriptParameters" value="--no-parallel" />
       <option name="taskDescriptions">
         <list />
       </option>


### PR DESCRIPTION
This is minimal temporary fix for circumventing troubles with

```
Configuration cache state could not be cached: field `__packageJsonFiles__` of task `:wasmRootPackageJson` of type `org.jetbrains.kotlin.gradle.targets.js.npm.tasks.RootPackageJsonTask`: error writing value of type 'org.gradle.api.internal.provider.DefaultListProperty'
> Resolution of the configuration ':compose:runtime:runtime-test-utils:wasmJsTestNpmAggregated' was attempted without an exclusive lock. This is unsafe and not allowed.
```


## Testing
Run "wasm Demo" or "js Demo" configuration

## Release Notes
N/A