### PR TITLE
add non-blocking awaitIdle calls in scrollable_nestedDiagonalScroll_mouseWheel_triggersOnAngle test to fix the test on web

### DIFF
--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -707,9 +707,6 @@ class ScrollableTest {
     }
 
     @Test
-    // FIXME: Chrome was not killed in 2000 ms, sending SIGKILL.
-    @IgnoreJsTarget
-    @IgnoreWasmTarget
     fun scrollable_nestedDiagonalScroll_mouseWheel_triggersOnAngle() = runComposeUiTest {
         var totalVerticalScroll = 0f
         var totalHorizontalScroll = 0f
@@ -749,6 +746,7 @@ class ScrollableTest {
         // mostly horizontal event triggered horizontal scrollable
         onRoot().performMouseInput { this.scroll(Offset(-100f, -50f)) }
 
+        awaitIdle()
         runOnIdle {
             assertThat(totalHorizontalScroll).isGreaterThan(0)
             assertThat(totalVerticalScroll).isZero()
@@ -760,6 +758,7 @@ class ScrollableTest {
         // mostly vertical event triggered vertical scrollable
         onRoot().performMouseInput { this.scroll(Offset(-10f, -50f)) }
 
+        awaitIdle()
         runOnIdle {
             assertThat(totalVerticalScroll).isGreaterThan(0)
             assertThat(totalHorizontalScroll).isZero()
@@ -775,6 +774,7 @@ class ScrollableTest {
             this.scroll(Offset(-50f, -10f))
         }
 
+        awaitIdle()
         runOnIdle {
             assertThat(totalVerticalScroll).isGreaterThan(0)
             assertThat(totalHorizontalScroll).isZero()
@@ -786,10 +786,11 @@ class ScrollableTest {
         // started vertical, waited, changed to horizontal means we have a new scrolling direction.
         onRoot().performMouseInput { this.scroll(Offset(-10f, -50f)) }
 
-        waitForIdle()
+        awaitIdle()
 
         onRoot().performMouseInput { this.scroll(Offset(-50f, -10f)) }
 
+        awaitIdle()
         runOnIdle {
             assertThat(totalVerticalScroll).isGreaterThan(0)
             assertThat(totalHorizontalScroll).isGreaterThan(0)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/ScrollableTest.kt
@@ -746,6 +746,8 @@ class ScrollableTest {
         // mostly horizontal event triggered horizontal scrollable
         onRoot().performMouseInput { this.scroll(Offset(-100f, -50f)) }
 
+        // Here and below we call awaitIdle() before runOnIdle to avoid event loop blocking in the web.
+        // awaitIdle waits for idleness co-operatively, unlike waitForIdle (called inside runOnIdle)
         awaitIdle()
         runOnIdle {
             assertThat(totalHorizontalScroll).isGreaterThan(0)


### PR DESCRIPTION

runOnIdle calls the blocking waitForIdle method. Since it's blocking, it doesn't let the event loop  process other coroutines (indirectly) affecting idleness. Calling non-blocking awaitIdle before it fixes the problem.

Fixes https://youtrack.jetbrains.com/issue/CMP-8783/Fix-scrollablenestedDiagonalScrollmouseWheeltriggersOnAngle-on-Web-after-1.10.0-alpha01-merge

## Testing
N/A

## Release Notes
N/A
