### PR TITLE
Fixed context menu appearing and disappearing in some cases on iOS

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -480,6 +480,9 @@ internal class UIKitTextInputService(
                 attachIntermediateTextInputView()
                 updateView()
             }
+
+            textUIView?.isFirstResponder()?.let { if (!(it)) { return } }
+
             showMenuOrUpdatePosition = {
                 textUIView?.let { textUIView ->
                     val density = view.density
@@ -620,6 +623,7 @@ internal class UIKitTextInputService(
         } else {
             showMenuOrUpdatePosition = {}
             textUIView?.let { view ->
+                view.hideTextMenu()
                 view.setFrame(outOfBoundsFrame)
 
                 view.resetOnKeyboardPressesCallback()


### PR DESCRIPTION
Fixes: 
[CMP-7769](https://youtrack.jetbrains.com/issue/CMP-7769) [iOS] TextField. Сontext menu appears when selecting an option in ExposedDropdownMenu
[CMP-9316](https://youtrack.jetbrains.com/issue/CMP-9316) [ios]. context menu doesn't hide after backNavigation

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- Fixed the context menu dismissal after back swipe navigation on iOS.
- Fixed the context menu appearing in a text field inside `ExposedDropdownMenu` on iOS.
