### PR TITLE
[build] Fix logging for libs resolution when SKIKO_VERSION is set

### DIFF
--- a/buildSrc/settingsScripts/skiko-setup.groovy
+++ b/buildSrc/settingsScripts/skiko-setup.groovy
@@ -29,7 +29,7 @@ class SkikoSetup {
                 libs {
                     def skikoOverride = System.getenv("SKIKO_VERSION")
                     if (skikoOverride != null) {
-                        org.gradle.api.logging.Logging.getLogger(settings.class).warn("Using custom version ${skikoOverride} of SKIKO due to " +
+                        org.gradle.api.logging.Logging.getLogger(SkikoSetup.class).warn("Using custom version ${skikoOverride} of SKIKO due to " +
                                 "SKIKO_VERSION being set.")
                         version('skiko', skikoOverride)
                     }

--- a/buildSrc/settingsScripts/skiko-setup.groovy
+++ b/buildSrc/settingsScripts/skiko-setup.groovy
@@ -16,6 +16,7 @@
 
 import org.gradle.api.GradleException
 import org.gradle.api.initialization.Settings
+import org.gradle.api.logging.Logging.getLogger
 
 class SkikoSetup {
     /**
@@ -29,7 +30,7 @@ class SkikoSetup {
                 libs {
                     def skikoOverride = System.getenv("SKIKO_VERSION")
                     if (skikoOverride != null) {
-                        logger.warn("Using custom version ${skikoOverride} of SKIKO due to " +
+                        getLogger(settings.class).warn("Using custom version ${skikoOverride} of SKIKO due to " +
                                 "SKIKO_VERSION being set.")
                         version('skiko', skikoOverride)
                     }

--- a/buildSrc/settingsScripts/skiko-setup.groovy
+++ b/buildSrc/settingsScripts/skiko-setup.groovy
@@ -16,7 +16,6 @@
 
 import org.gradle.api.GradleException
 import org.gradle.api.initialization.Settings
-import org.gradle.api.logging.Logging.getLogger
 
 class SkikoSetup {
     /**
@@ -30,7 +29,7 @@ class SkikoSetup {
                 libs {
                     def skikoOverride = System.getenv("SKIKO_VERSION")
                     if (skikoOverride != null) {
-                        getLogger(settings.class).warn("Using custom version ${skikoOverride} of SKIKO due to " +
+                        org.gradle.api.logging.Logging.getLogger(settings.class).warn("Using custom version ${skikoOverride} of SKIKO due to " +
                                 "SKIKO_VERSION being set.")
                         version('skiko', skikoOverride)
                     }


### PR DESCRIPTION
This is a fix for  the
```
Could not get unknown property 'logger' for object of type org.gradle.api.internal.catalog.DefaultVersionCatalogBuilder.
```
which occurs when one tries to run any configuration with SKIKO_VERSION env variable explicitely set

## Testing
` SKIKO_VERSION=2.2.20-SHAGEN ./gradlew --no-parallel testWebJs`

## Release Notes
N/A