### PR TITLE
Call renderImmediately() without read observation in SwingWindow.update

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/SwingWindow.desktop.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.KeyEvent
@@ -138,7 +139,9 @@ fun SwingWindow(
             // - Make the window displayable
             // - Size the window and the ComposeLayer correctly, so that we can draw it here
             if (!wasDisplayable && it.isDisplayable) {
-                it.renderImmediately()
+                Snapshot.withoutReadObservation {
+                    it.renderImmediately()
+                }
             }
         },
     )


### PR DESCRIPTION
Call renderImmediately() without read observation in SwingWindow.update
Could speed-up startup.

Fixes https://youtrack.jetbrains.com/issue/CMP-9973

## Testing
N/A

## Release Notes
N/A