### PR TITLE
Fixed incorrect resizing of IntermediateTextInputUIView when usingNativeTextInput = true

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -69,7 +69,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.CoreGraphics.CGRectMake
-import platform.UIKit.UIColor
 import platform.UIKit.UIPress
 import platform.UIKit.UIView
 import platform.UIKit.UIViewAutoresizingFlexibleHeight
@@ -288,10 +287,12 @@ internal class UIKitTextInputService(
         this.clippingTextFrame = clippingTextFrame
         this.unclippedTextPosition = unclippedTextPosition
 
-        recalculateTextViewPosition()
+        updateTextViewPosition()
+
+        showMenuOrUpdatePosition()
     }
 
-    private fun recalculateTextViewPosition() {
+    private fun updateTextViewPosition() {
         val rect = textFieldFrameInRoot ?: return
 
         if (usingNativeTextInput) {
@@ -319,8 +320,6 @@ internal class UIKitTextInputService(
         } else {
             textUIView?.setFrame(rect.toDpRect(view.density).asCGRect())
         }
-
-        showMenuOrUpdatePosition()
     }
 
     fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.skia.BreakIterator
 import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIColor
 import platform.UIKit.UIPress
 import platform.UIKit.UIView
 import platform.UIKit.UIViewAutoresizingFlexibleHeight
@@ -250,15 +251,6 @@ internal class UIKitTextInputService(
         }
     }
 
-    fun updateTextFrame(rect: Rect) {
-        if (usingNativeTextInput) {
-            textFieldFrameInRoot = rect
-        } else {
-            textUIView?.setFrame(rect.toDpRect(view.density).asCGRect())
-        }
-        showMenuOrUpdatePosition()
-    }
-
     private fun calculateContentBounds(textLayoutResult: TextLayoutResult, textFieldFrame: Rect, unclippedTextPosition: Offset): Rect {
         val textSize = textLayoutResult.size.toSize()
         val contentBounds = Rect(
@@ -285,23 +277,36 @@ internal class UIKitTextInputService(
     private var clippingTextFrame: Rect? = null
     private var currentContentBounds: Rect? = null
     private var currentContentInsets: DpInsets? = null
-    fun updateClippingTextFrame(rect: Rect) {
-        clippingTextFrame = rect
+    private var unclippedTextPosition: Offset? = null
+
+    fun updateTextFieldGeometry(
+        textFieldFrame: Rect,
+        clippingTextFrame: Rect,
+        unclippedTextPosition: Offset
+    ) {
+        textFieldFrameInRoot = textFieldFrame
+        this.clippingTextFrame = clippingTextFrame
+        this.unclippedTextPosition = unclippedTextPosition
+
+        recalculateTextViewPosition()
     }
 
-    fun updateUnclippedTextPosition(offset: Offset) {
+    private fun recalculateTextViewPosition() {
+        val rect = textFieldFrameInRoot ?: return
+
         if (usingNativeTextInput) {
             // Since Compose content is rendered on a MetalView and the UITextInput-implementing
             // view is overlayed on top of it, we need to synchronize the Compose text
             // field with the IntermediateTextScrollView (which contains IntermediateUITextView)
             // to ensure native iOS text input controls
             // align correctly with the rendered text.
-            val rect = textFieldFrameInRoot ?: return
             val layoutResult = textLayoutResult ?: return
+            val unclippedTextPosition = unclippedTextPosition ?: return
+
             val contentBounds = calculateContentBounds(
                 layoutResult,
                 rect,
-                offset
+                unclippedTextPosition
             )
             currentContentBounds = contentBounds
             val contentInsets = calculateContentInsets(rect, contentBounds)
@@ -311,7 +316,11 @@ internal class UIKitTextInputService(
                 contentBounds.toDpRect(view.density),
                 contentInsets
             )
+        } else {
+            textUIView?.setFrame(rect.toDpRect(view.density).asCGRect())
         }
+
+        showMenuOrUpdatePosition()
     }
 
     fun updateTextLayoutResult(textLayoutResult: TextLayoutResult) {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -758,23 +758,25 @@ internal class ComposeSceneMediator(
                     }
                 }
                 launch {
-                    snapshotFlow { request.textClippingRectInRoot() }.filterNotNull().collect {
-                        textInputService.updateClippingTextFrame(it)
-                    }
-                }
-                launch {
-                    snapshotFlow { request.textFieldRectInRoot() }.filterNotNull().collect {
-                        textInputService.updateTextFrame(it)
+                    snapshotFlow {
+                        Triple(
+                            request.textFieldRectInRoot(),
+                            request.textClippingRectInRoot(),
+                            request.unclippedTextOffsetInRoot()
+                        )
+                    }.collect { (textFieldRect, clippingRect, unclippedTextOffset) ->
+                        if (textFieldRect != null && clippingRect != null && unclippedTextOffset != null) {
+                            textInputService.updateTextFieldGeometry(
+                                textFieldFrame = textFieldRect,
+                                clippingTextFrame = clippingRect,
+                                unclippedTextPosition = unclippedTextOffset
+                            )
+                        }
                     }
                 }
                 launch {
                     snapshotFlow { request.focusedRectInRoot() }.filterNotNull().collect {
                         textInputService.updateFocusedRect(it)
-                    }
-                }
-                launch {
-                    snapshotFlow { request.unclippedTextOffsetInRoot() }.filterNotNull().collect {
-                        textInputService.updateUnclippedTextPosition(it)
                     }
                 }
                 suspendCancellableCoroutine<Nothing> { continuation ->


### PR DESCRIPTION
Fixed incorrect resizing of IntermediateTextInputUIView when usingNativeTextInput = true

Fixes: 
[CMP-9988](https://youtrack.jetbrains.com/issue/CMP-9988) [iOS] NITI - Text View isn't resizing after changing the text
Partially - [CMP-9982](https://youtrack.jetbrains.com/issue/CMP-9982) [iOS] NITI. Sometimes Selection handles aren't displayed on top of TextField

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix missing handles and caret in `TextField` on new line at the end of the text when `usingNativeTextInput` flag is enabled

