### PR TITLE
Fix missing mouse release event scenario with magic mouse

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.desktop.kt
@@ -8,12 +8,14 @@ import androidx.compose.ui.input.pointer.PointerEvent
  * The original raw native event from AWT.
  *
  * Null if:
- * - the native event is sent by another framework (when Compose UI is embed into it)
- * - there is no native event (in tests, for example)
- * - there was a synthetic move event sent by compose on re-layout
- * - there was a synthetic move event sent by compose when move is missing between two non-move events
+ * - The native event is sent by another framework (when Compose UI is embed into it)
+ * - There is no native event (in tests, for example)
+ * - The event is a synthetic move event sent by Compose on re-layout
+ * - The event is a synthetic event sent by Compose to maintain a logically consistent stream of
+ *   events. For example, if a native press event is received without a corresponding move event,
+ *   Compose will synthesize a move event. That move event will have a null [awtEventOrNull].
  *
- * Always check for null when you want to handle the native event.
+ * It is therefore recommended to always check for `null` when using this property.
  */
 val PointerEvent.awtEventOrNull: java.awt.event.MouseEvent? get() {
     return nativeEvent as? java.awt.event.MouseEvent?
@@ -23,10 +25,10 @@ val PointerEvent.awtEventOrNull: java.awt.event.MouseEvent? get() {
  * The original raw native event from AWT.
  *
  * Null if:
- * - the native event is sent by another framework (when Compose UI is embed into it)
- * - there is no native event (in tests, for example)
+ * - The native event is sent by another framework (when Compose UI is embed into it)
+ * - There is no native event (in tests, for example)
  *
- * Always check for null when you want to handle the native event.
+ * It is therefore recommended to always check for `null` when using this property.
  */
 val KeyEvent.awtEventOrNull: java.awt.event.KeyEvent? get() {
     return internal.nativeEvent as? java.awt.event.KeyEvent?

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -808,7 +808,10 @@ class SyntheticEventSenderTest {
     private fun SyntheticEventSenderConsumingAllMovements(send: (PointerInputEvent) -> Unit) =
         SyntheticEventSender {
             send(it)
-            PointerEventResult(anyMovementConsumed = true)
+            PointerEventResult(
+                dispatchedToAPointerInputModifier = true,
+                anyMovementConsumed = true
+            )
         }
 
     private fun eventsSentBy(

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -756,16 +756,19 @@ class SyntheticEventSenderTest {
             received.add(it)
         }
 
-        sender.send(mouseEvent(Press, 10f, 10f, pressed = true))
-        sender.send(mouseEvent(Move, 10f, 10f, pressed = true))
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true, nativeEvent = 1))
+        sender.send(mouseEvent(Move, 10f, 10f, pressed = true, nativeEvent = 2))
         assertEquals(0, received.count { it.eventType == Release })
 
-        sender.send(mouseEvent(Move, 10f, 10f, pressed = false))
+        sender.send(mouseEvent(Move, 10f, 10f, pressed = false, nativeEvent = 3))
         assertEquals(1, received.count { it.eventType == Release }, "Release event not sent")
 
         // Also, make sure we don't send an extra release event afterward
-        sender.send(mouseEvent(Release, 10f, 10f, pressed = false))
+        sender.send(mouseEvent(Release, 10f, 10f, pressed = false, nativeEvent = 4))
         assertEquals(1, received.count { it.eventType == Release }, "Extra release event sent")
+
+        // But it should be sent as an `Unknown` event
+        assertEquals(4, received.count { it.nativeEvent != null }, "Missing native event")
     }
 
     @Test
@@ -775,10 +778,13 @@ class SyntheticEventSenderTest {
             received.add(it)
         }
 
-        sender.send(mouseEvent(Press, 10f, 10f, pressed = true))
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true, nativeEvent = 1))
         assertEquals(1, received.count { it.eventType == Press }, "Press event not sent!?")
-        sender.send(mouseEvent(Press, 20f, 20f, pressed = true))
+        sender.send(mouseEvent(Press, 20f, 20f, pressed = true, nativeEvent = 2))
         assertEquals(1, received.count { it.eventType == Press }, "Extra press event sent")
+
+        // But it should be sent as an `Unknown` event
+        assertEquals(2, received.count { it.nativeEvent != null }, "Missing native event")
     }
 
     @Test
@@ -788,12 +794,15 @@ class SyntheticEventSenderTest {
             received.add(it)
         }
 
-        sender.send(mouseEvent(Press, 10f, 10f, pressed = true))
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true, nativeEvent = 1))
         assertEquals(1, received.count { it.eventType == Press }, "Press event not sent!?")
-        sender.send(mouseEvent(Release, 10f, 10f, pressed = false))
+        sender.send(mouseEvent(Release, 10f, 10f, pressed = false, nativeEvent = 2))
         assertEquals(1, received.count { it.eventType == Release }, "Release event not sent!?")
-        sender.send(mouseEvent(Release, 20f, 20f, pressed = false))
+        sender.send(mouseEvent(Release, 20f, 20f, pressed = false, nativeEvent = 3))
         assertEquals(1, received.count { it.eventType == Release }, "Extra release event sent")
+
+        // But it should be sent as an `Unknown` event
+        assertEquals(3, received.count { it.nativeEvent != null }, "Missing native event")
     }
 
     private fun SyntheticEventSenderConsumingAllMovements(send: (PointerInputEvent) -> Unit) =

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -388,8 +388,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should update pointer position with move event after hover event`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(mouseEvent(Enter, 10f, 20f, pressed = false))
 
@@ -416,8 +416,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should update pointer position with move event after pressed event`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(mouseEvent(Press, 10f, 20f, pressed = true))
 
@@ -444,8 +444,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should not update pointer position with move event after touch event`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(event(Press, 1 to touch(10f, 20f, pressed = true)))
 
@@ -470,8 +470,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should not re-enter after mouse exit`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(mouseEvent(Move, 10f, 20f, pressed = false))
         sender.send(mouseEvent(Exit, 10f, 20f, pressed = false))
@@ -488,8 +488,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `synthetic events should not duplicate scrollDelta`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -513,8 +513,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `synthetic events should not duplicate panGestureOffset`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -538,8 +538,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `synthetic events should not duplicate scaleGestureFactor`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -715,8 +715,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `scale synthetic events should not duplicate scaleGestureFactor`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -733,8 +733,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `pan synthetic events should not duplicate panGestureOffset`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -747,6 +747,60 @@ class SyntheticEventSenderTest {
         }
         assertEquals(Offset(5f, 0f), totalOffset)
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9964
+    @Test
+    fun `mouse move unpressing buttons sends release event`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
+        }
+
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true))
+        sender.send(mouseEvent(Move, 10f, 10f, pressed = true))
+        assertEquals(0, received.count { it.eventType == Release })
+
+        sender.send(mouseEvent(Move, 10f, 10f, pressed = false))
+        assertEquals(1, received.count { it.eventType == Release }, "Release event not sent")
+
+        // Also, make sure we don't send an extra release event afterward
+        sender.send(mouseEvent(Release, 10f, 10f, pressed = false))
+        assertEquals(1, received.count { it.eventType == Release }, "Extra release event sent")
+    }
+
+    @Test
+    fun `extra mouse press events are not sent`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
+        }
+
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true))
+        assertEquals(1, received.count { it.eventType == Press }, "Press event not sent!?")
+        sender.send(mouseEvent(Press, 20f, 20f, pressed = true))
+        assertEquals(1, received.count { it.eventType == Press }, "Extra press event sent")
+    }
+
+    @Test
+    fun `extra mouse release events are not sent`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
+        }
+
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true))
+        assertEquals(1, received.count { it.eventType == Press }, "Press event not sent!?")
+        sender.send(mouseEvent(Release, 10f, 10f, pressed = false))
+        assertEquals(1, received.count { it.eventType == Release }, "Release event not sent!?")
+        sender.send(mouseEvent(Release, 20f, 20f, pressed = false))
+        assertEquals(1, received.count { it.eventType == Release }, "Extra release event sent")
+    }
+
+    private fun SyntheticEventSenderConsumingAllMovements(send: (PointerInputEvent) -> Unit) =
+        SyntheticEventSender {
+            send(it)
+            PointerEventResult(anyMovementConsumed = true)
+        }
 
     private fun eventsSentBy(
         vararg inputEvents: PointerInputEvent

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Enter
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Exit
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Move
@@ -769,6 +770,7 @@ class SyntheticEventSenderTest {
 
         // But it should be sent as an `Unknown` event
         assertEquals(4, received.count { it.nativeEvent != null }, "Missing native event")
+        assertEquals(PointerEventType.Unknown, received.last { it.nativeEvent != null }.eventType)
     }
 
     @Test
@@ -785,6 +787,7 @@ class SyntheticEventSenderTest {
 
         // But it should be sent as an `Unknown` event
         assertEquals(2, received.count { it.nativeEvent != null }, "Missing native event")
+        assertEquals(PointerEventType.Unknown, received.last { it.nativeEvent != null }.eventType)
     }
 
     @Test
@@ -803,6 +806,7 @@ class SyntheticEventSenderTest {
 
         // But it should be sent as an `Unknown` event
         assertEquals(3, received.count { it.nativeEvent != null }, "Missing native event")
+        assertEquals(PointerEventType.Unknown, received.last { it.nativeEvent != null }.eventType)
     }
 
     private fun SyntheticEventSenderConsumingAllMovements(send: (PointerInputEvent) -> Unit) =

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -19,9 +19,11 @@
 package androidx.compose.ui.input.mouse
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -41,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
@@ -63,6 +66,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.util.concurrent.Executors
 import kotlin.random.Random
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
@@ -733,6 +737,37 @@ class MouseMoveTest {
         scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
 
         assertNull(composeScene.lastKnownPointerPosition)
+    }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9964
+    @Test
+    fun magicMouseScenario() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        var clicksCount = 0
+        scene.setContent {
+            Box(modifier = Modifier
+                .fillMaxSize()
+                .clickable {
+                    clicksCount++
+                }
+            )
+        }
+
+        // The bug in this scenario is that no mouse-release event was generated
+        // - SyntheticEventSender.sendMissingReleases didn't include the last released pointer
+        //   when receiving the 3rd event.
+        // - HitPathTracker ignores the 3rd event because it's a Move event at the same
+        //   coordinates as the previous (2nd) event.
+        // - CanvasLayersComposeScene.processPointerInputEvent clears `gestureOwner` after
+        //   receiving the 3rd event, so when it receives the 4th event, it doesn't send it.
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true))
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true))
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = false))
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f))
+
+        assertEquals(1, clicksCount)
     }
 }
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
@@ -66,6 +67,7 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.util.concurrent.Executors
 import kotlin.random.Random
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -768,6 +770,34 @@ class MouseMoveTest {
         scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f))
 
         assertEquals(1, clicksCount)
+    }
+
+    @Test
+    fun allNativeMouseEventsAreSent1() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        val nativeEventsReceived = mutableListOf<Any>()
+        scene.setContent {
+            Box(modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Main)
+                            event.nativeEvent?.let { nativeEventsReceived.add(it) }
+                        }
+                    }
+                }
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true), nativeEvent = 1)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true), nativeEvent = 2)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = false), nativeEvent = 3)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), nativeEvent = 4)
+
+        assertContentEquals(listOf(1, 2, 3, 4), nativeEventsReceived)
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -127,21 +127,22 @@ internal class SyntheticEventSender(
     }
 
     private fun shouldSend(event: PointerInputEvent): Boolean {
-        // Filter out press/release events with the same pressed pointers and buttons as the
-        // previous event.
+        // Filter out press/release events with the same pressed pointers, buttons and keyboard
+        // modifiers as the previous event.
         // Note that missing move events for this event should have already been sent
-        fun areSamePointersAndButtons(e1: PointerInputEvent, e2: PointerInputEvent): Boolean {
+        fun areSameParams(e1: PointerInputEvent, e2: PointerInputEvent): Boolean {
             if (e1.pressedIds().toSet() != e2.pressedIds().toSet()) return false
             if (e1.buttons != e2.buttons) return false
+            if (e1.keyboardModifiers != e2.keyboardModifiers) return false
             return true
         }
         if (event.eventType == PointerEventType.Press) {
             val prevEvent = previousEvent
-            if ((prevEvent != null) && areSamePointersAndButtons(event, prevEvent)) return false
+            if ((prevEvent != null) && areSameParams(event, prevEvent)) return false
         }
         if (event.eventType == PointerEventType.Release) {
             val prevEvent = previousEvent ?: return false
-            if (areSamePointersAndButtons(event, prevEvent)) return false
+            if (areSameParams(event, prevEvent)) return false
         }
 
         return true

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -92,7 +92,7 @@ internal class SyntheticEventSender(
         val syntheticScaleStartResult = sendMissingScaleStart(event)
         val syntheticPanEndResult = sendMissingPanEnd(event)
         val syntheticPanStartResult = sendMissingPanStart(event)
-        val eventResult = if (shouldSend(event)) sendInternal(event) else UnconsumedEventResult
+        val eventResult = if (shouldSend(event)) sendInternal(event) else sendNativeEventOnly(event)
         return syntheticMoveForHoverResult.merging(
             syntheticReleasesResult,
             syntheticPressesResult,
@@ -126,6 +126,11 @@ internal class SyntheticEventSender(
         }
     }
 
+    /**
+     * Returns whether the given event should be sent.
+     *
+     * An event could be filtered out if, for example, it is a duplicate of the previous event.
+     */
     private fun shouldSend(event: PointerInputEvent): Boolean {
         // Filter out press/release events with the same pressed pointers, buttons and keyboard
         // modifiers as the previous event.
@@ -146,6 +151,17 @@ internal class SyntheticEventSender(
         }
 
         return true
+    }
+
+    /**
+     * When an event generated as a result of a native event is filtered out (see [shouldSend]),
+     * we nevertheless want listeners to native events to receive them.
+     * This method sends an event with a type of [PointerEventType.Unknown] so that listeners can
+     * still receive it.
+     */
+    private fun sendNativeEventOnly(event: PointerInputEvent): PointerEventResult {
+        if (event.nativeEvent == null) return UnconsumedEventResult
+        return _send(event.copy(eventType = PointerEventType.Unknown))
     }
 
     fun updatePointerPosition(): PointerEventResult {
@@ -272,7 +288,15 @@ internal class SyntheticEventSender(
             PointerEventType.PanEnd -> isPanGestureInProgress = false
             else -> {}
         }
-        val anyMovementConsumed = _send(event)
+        val result = _send(event)
+        if (!result.dispatchedToAPointerInputModifier) {
+            // What we want to do here is to make sure to dispatch the native event if the Compose
+            // event has been filtered out by HitPathTracker. Unfortunately, there's no
+            // `PointerEventResult.eventIgnored` flag, but `dispatchedToAPointerInputModifier`
+            // seems adequate for now. It will be false also in the case of no `PointerInput` nodes,
+            // but that's ok because then our native event will also not be delivered to anyone.
+            sendNativeEventOnly(event)
+        }
         // We don't send nativeEvent for synthetic events.
         // Nullify to avoid memory leaks (native events can point to native views).
         // Copy the pointers list because the original list may be reused
@@ -280,7 +304,7 @@ internal class SyntheticEventSender(
             nativeEvent = null,
             pointers = event.pointers.toList()
         )
-        return anyMovementConsumed
+        return result
     }
 
     private fun sendMissingScaleStart(event: PointerInputEvent): PointerEventResult {

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -127,14 +127,21 @@ internal class SyntheticEventSender(
     }
 
     private fun shouldSend(event: PointerInputEvent): Boolean {
+        // Filter out press/release events with the same pressed pointers and buttons as the
+        // previous event.
+        // Note that missing move events for this event should have already been sent
+        fun areSamePointersAndButtons(e1: PointerInputEvent, e2: PointerInputEvent): Boolean {
+            if (e1.pressedIds().toSet() != e2.pressedIds().toSet()) return false
+            if (e1.buttons != e2.buttons) return false
+            return true
+        }
         if (event.eventType == PointerEventType.Press) {
-            // Filter out press events with the same pressed pointers as the previous event
-            if (event.pressedIds().toSet() == previousEvent?.pressedIds()?.toSet()) return false
+            val prevEvent = previousEvent
+            if ((prevEvent != null) && areSamePointersAndButtons(event, prevEvent)) return false
         }
         if (event.eventType == PointerEventType.Release) {
             val prevEvent = previousEvent ?: return false
-            // Filter out release events with the same pressed pointers as the previous event
-            if (event.pressedIds().toSet() == prevEvent.pressedIds().toSet()) return false
+            if (areSamePointersAndButtons(event, prevEvent)) return false
         }
 
         return true
@@ -267,7 +274,11 @@ internal class SyntheticEventSender(
         val anyMovementConsumed = _send(event)
         // We don't send nativeEvent for synthetic events.
         // Nullify to avoid memory leaks (native events can point to native views).
-        previousEvent = event.copy(nativeEvent = null)
+        // Copy the pointers list because the original list may be reused
+        previousEvent = event.copy(
+            nativeEvent = null,
+            pointers = event.pointers.toList()
+        )
         return anyMovementConsumed
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -92,7 +92,7 @@ internal class SyntheticEventSender(
         val syntheticScaleStartResult = sendMissingScaleStart(event)
         val syntheticPanEndResult = sendMissingPanEnd(event)
         val syntheticPanStartResult = sendMissingPanStart(event)
-        val eventResult = sendInternal(event)
+        val eventResult = if (shouldSend(event)) sendInternal(event) else UnconsumedEventResult
         return syntheticMoveForHoverResult.merging(
             syntheticReleasesResult,
             syntheticPressesResult,
@@ -126,8 +126,22 @@ internal class SyntheticEventSender(
         }
     }
 
+    private fun shouldSend(event: PointerInputEvent): Boolean {
+        if (event.eventType == PointerEventType.Press) {
+            // Filter out press events with the same pressed pointers as the previous event
+            if (event.pressedIds().toSet() == previousEvent?.pressedIds()?.toSet()) return false
+        }
+        if (event.eventType == PointerEventType.Release) {
+            val prevEvent = previousEvent ?: return false
+            // Filter out release events with the same pressed pointers as the previous event
+            if (event.pressedIds().toSet() == prevEvent.pressedIds().toSet()) return false
+        }
+
+        return true
+    }
+
     fun updatePointerPosition(): PointerEventResult {
-        val nothingConsumed = PointerEventResult(anyMovementConsumed = false)
+        val nothingConsumed = UnconsumedEventResult
 
         if (!needUpdatePointerPosition) return nothingConsumed
         needUpdatePointerPosition = false
@@ -152,7 +166,7 @@ internal class SyntheticEventSender(
     private fun sendSyntheticMove(
         pointersSourceEvent: PointerInputEvent
     ): PointerEventResult {
-        val previousEvent = previousEvent ?: return PointerEventResult(anyMovementConsumed = false)
+        val previousEvent = previousEvent ?: return UnconsumedEventResult
         val idToPosition = pointersSourceEvent.pointers.associate { it.id to it.position }
         return sendInternal(
             previousEvent.copySynthetic(
@@ -171,22 +185,24 @@ internal class SyntheticEventSender(
             isMoveEventMissing(previousEvent, currentEvent)) {
             sendSyntheticMove(currentEvent)
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
     private fun sendMissingReleases(currentEvent: PointerInputEvent): PointerEventResult {
-        val previousEvent = previousEvent ?: return PointerEventResult(anyMovementConsumed = false)
+        val previousEvent = previousEvent ?: return UnconsumedEventResult
         val previousPressed = previousEvent.pressedIds()
         val currentPressed = currentEvent.pressedIds()
         val newReleased = (previousPressed - currentPressed.toSet()).toList()
         val sendingAsUp = HashSet<PointerId>(newReleased.size)
 
-        var result = PointerEventResult(anyMovementConsumed = false)
-        // Don't send the first released pointer
-        // It will be sent as a real event. Here we only need to send synthetic events
-        // before a real one.
-        for (i in newReleased.size - 2 downTo 0) {
+        var result = UnconsumedEventResult
+        val lastIndex = when (currentEvent.eventType) {
+            // The "real" event itself will be the last one
+            PointerEventType.Release -> newReleased.lastIndex - 1
+            else -> newReleased.lastIndex
+        }
+        for (i in lastIndex downTo 0) {
             sendingAsUp.add(newReleased[i])
 
             sendInternal(
@@ -211,11 +227,13 @@ internal class SyntheticEventSender(
         val newPressed = (currentPressed - previousPressed).toList()
         val sendingAsDown = HashSet<PointerId>(newPressed.size)
 
-        var result = PointerEventResult(anyMovementConsumed = false)
-        // Don't send the last pressed pointer (newPressed.size - 1)
-        // It will be sent as a real event. Here we only need to send synthetic events
-        // before a real one.
-        for (i in 0..newPressed.size - 2) {
+        var result = UnconsumedEventResult
+        val lastIndex = when (currentEvent.eventType) {
+            // The "real" event itself will be the last one
+            PointerEventType.Press -> newPressed.lastIndex - 1
+            else -> newPressed.lastIndex
+        }
+        for (i in 0..lastIndex) {
             sendingAsDown.add(newPressed[i])
 
             sendInternal(
@@ -258,7 +276,7 @@ internal class SyntheticEventSender(
             (event.eventType == PointerEventType.ScaleChange || event.eventType == PointerEventType.ScaleEnd)) {
             sendInternal(event.copySynthetic(PointerEventType.ScaleStart) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -266,7 +284,7 @@ internal class SyntheticEventSender(
         return if (isScaleGestureInProgress && event.eventType == PointerEventType.ScaleStart) {
             sendInternal(event.copySynthetic(PointerEventType.ScaleEnd) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -275,7 +293,7 @@ internal class SyntheticEventSender(
             (event.eventType == PointerEventType.PanMove || event.eventType == PointerEventType.PanEnd)) {
             sendInternal(event.copySynthetic(PointerEventType.PanStart) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -283,7 +301,7 @@ internal class SyntheticEventSender(
         return if (isPanGestureInProgress && event.eventType == PointerEventType.PanStart) {
             sendInternal(event.copySynthetic(PointerEventType.PanEnd) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -339,3 +357,5 @@ internal class SyntheticEventSender(
         originalEventPosition = position,
     )
 }
+
+private val UnconsumedEventResult = PointerEventResult(anyMovementConsumed = false)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -434,8 +434,13 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     private fun processUnknownEvent(event: PointerInputEvent): PointerEventResult {
-        gestureOwner?.let { return it.onPointerInput(event) }
-        return processHoveredEvent(event)
+        val gestureOwner = gestureOwner
+        @Suppress("IfThenToElvis")
+        return if (gestureOwner != null) {
+            gestureOwner.onPointerInput(event)
+        } else {
+            processHoveredEvent(event)
+        }
     }
 
     override fun createLayer(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -247,6 +247,8 @@ private class CanvasLayersComposeSceneImpl(
             PointerEventType.ScaleStart,
             PointerEventType.ScaleChange,
             PointerEventType.ScaleEnd -> processHoveredEvent(event)
+            PointerEventType.Unknown ->
+                return processUnknownEvent(event)  // We don't want any side effects from it
             else -> PointerEventResult(anyMovementConsumed = false)
         }
 
@@ -429,6 +431,11 @@ private class CanvasLayersComposeSceneImpl(
         } else {
             PointerEventResult(anyMovementConsumed = false)
         }
+    }
+
+    private fun processUnknownEvent(event: PointerInputEvent): PointerEventResult {
+        gestureOwner?.let { return it.onPointerInput(event) }
+        return processHoveredEvent(event)
     }
 
     override fun createLayer(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -158,11 +158,17 @@ value class PointerEventResult internal constructor(internal val value: Int) {
 
     constructor(
         anyMovementConsumed: Boolean = false,
-        anyChangeConsumed: Boolean = false
+        anyChangeConsumed: Boolean = false,
+        dispatchedToAPointerInputModifier: Boolean = false,
     ) : this(
-        value = (anyMovementConsumed.toInt() shl 1) or
+        value =
+            dispatchedToAPointerInputModifier.toInt() or
+            (anyMovementConsumed.toInt() shl 1) or
             (anyChangeConsumed.toInt() shl 2)
     )
+
+    internal val dispatchedToAPointerInputModifier
+        inline get() = (value and 0x1) != 0
 
     /** It's true when [PointerInputChange] was consumed and Pointer's position was changed */
     internal val anyMovementConsumed

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -247,6 +247,7 @@ internal fun mouseEvent(
     scrollDelta: Offset = Offset.Zero,
     scaleGestureFactor: Float = 1f,
     panGestureOffset:Offset = Offset.Zero,
+    nativeEvent: Any? = null
 ) = PointerInputEvent(
     type,
     0,
@@ -266,7 +267,8 @@ internal fun mouseEvent(
             panGestureOffset = panGestureOffset,
         )
     ),
-    buttons = PointerButtons(isPrimaryPressed = pressed)
+    buttons = PointerButtons(isPrimaryPressed = pressed),
+    nativeEvent = nativeEvent
 )
 
 internal infix fun List<PointerInputEvent>.positionAndDownShouldEqual(


### PR DESCRIPTION
Fix `SyntheticEventSender`'s `sendMissingPresses` and `sendMissingReleases` to send all missing presses/releases.

Fixes https://youtrack.jetbrains.com/issue/CMP-9964

Follow-up task: [CMP-10029](https://youtrack.jetbrains.com/issue/CMP-10029) Rework native events access in `PointerInputEvent`

## Testing
Added unit tests and tested manually on Amazon Corretto 21.0.10 with:
```
fun Modifier.myClickable(onClick: () -> Unit): Modifier =
    pointerInput(Unit) {
        awaitEachGesture {
            val down = awaitFirstDown()
            println("DOWN: $down")
            down.consume()

            while (true) {
                val event = awaitPointerEvent()

                if (event.changes.fastAny { it.changedToUp() }) {
                    println("UP: $event")
                    onClick()
                    break
                } else {
                    println("event: $event")
                }
            }
        }
    }

@Composable
fun ClickTestWindow(onCloseRequest: () -> Unit) {
    Window(
        onCloseRequest = onCloseRequest,
        state = rememberWindowState(size = DpSize.Unspecified),
        title = "Click test",
    ) {
        var clickCount by remember { mutableStateOf(0) }

        DisposableEffect(Unit) {
            val mouseListener =  object : MouseAdapter() {
                override fun mousePressed(e: MouseEvent) = println("AWT: Mouse pressed: $e")
                override fun mouseReleased(e: MouseEvent) = println("AWT: Mouse released: $e")
                override fun mouseMoved(e: MouseEvent) = println("AWT: Mouse moved: $e")
                override fun mouseDragged(e: MouseEvent?) = println("AWT: Mouse dragged: $e")
            }

            window.addMouseListener(mouseListener)
            window.addMouseMotionListener(mouseListener)
            onDispose {
                window.removeMouseListener(mouseListener)
                window.removeMouseMotionListener(mouseListener)
            }
        }

        Column(
            modifier = Modifier.padding(16.dp),
            verticalArrangement = Arrangement.spacedBy(16.dp),
        ) {
            Text(text = "Click count: $clickCount")
            Box(
                modifier =
                    Modifier
                        .requiredSize(400.dp)
                        .background(Color.Red)
                        .myClickable {
                            println("--- Increase click count to: ${++clickCount} ---")
                        },
            )
        }
    }
}

fun main() = application {
    ClickTestWindow(
        onCloseRequest = ::exitApplication
    )
}
```

This should be tested by QA

## Release Notes
### Fixes - Multiple Platforms
- Fixed occasional mouse-clicks being missed (typically when using Apple's Magic Mouse).
