### PR TITLE
Fix identityHashCode in Wasm

### DIFF
--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/internal/System.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/internal/System.web.kt
@@ -28,7 +28,7 @@ internal actual fun identityHashCode(instance: Any?): Int {
     }
 
     val jsRef = instance.toJsReference()
-    return weakMap.get(jsRef) ?: memoizeIdentityHashCode(jsRef)
+    return weakMap.get(jsRef).takeIf { it != 0 } ?: memoizeIdentityHashCode(jsRef)
 }
 
 private var nextHash = 1

--- a/compose/material/material/src/wasmJsMain/kotlin/androidx/compose/material/internal/System.wasm.kt
+++ b/compose/material/material/src/wasmJsMain/kotlin/androidx/compose/material/internal/System.wasm.kt
@@ -42,5 +42,5 @@ internal actual fun identityHashCode(instance: Any?): Int {
     }
 
     val jsRef = instance.toJsReference()
-    return weakMap.get(jsRef) ?: memoizeIdentityHashCode(jsRef)
+    return weakMap.get(jsRef).takeIf { it != 0 } ?: memoizeIdentityHashCode(jsRef)
 }

--- a/compose/material3/adaptive/adaptive-layout/src/wasmJsMain/kotlin/androidx/compose/material3/adaptive/layout/internal/System.wasm.kt
+++ b/compose/material3/adaptive/adaptive-layout/src/wasmJsMain/kotlin/androidx/compose/material3/adaptive/layout/internal/System.wasm.kt
@@ -42,5 +42,5 @@ internal actual fun identityHashCode(instance: Any?): Int {
     }
 
     val jsRef = instance.toJsReference()
-    return weakMap.get(jsRef) ?: memoizeIdentityHashCode(jsRef)
+    return weakMap.get(jsRef).takeIf { it != 0 } ?: memoizeIdentityHashCode(jsRef)
 }

--- a/compose/material3/material3/src/wasmJsMain/kotlin/androidx/compose/material3/internal/System.wasm.kt
+++ b/compose/material3/material3/src/wasmJsMain/kotlin/androidx/compose/material3/internal/System.wasm.kt
@@ -42,5 +42,5 @@ internal actual fun identityHashCode(instance: Any?): Int {
     }
 
     val jsRef = instance.toJsReference()
-    return weakMap.get(jsRef) ?: memoizeIdentityHashCode(jsRef)
+    return weakMap.get(jsRef).takeIf { it != 0 } ?: memoizeIdentityHashCode(jsRef)
 }

--- a/compose/ui/ui-test/src/wasmJsMain/kotlin/androidx/compose/ui/test/Actuals.wasm.kt
+++ b/compose/ui/ui-test/src/wasmJsMain/kotlin/androidx/compose/ui/test/Actuals.wasm.kt
@@ -42,5 +42,5 @@ internal actual fun identityHashCode(instance: Any?): Int {
     }
 
     val jsRef = instance.toJsReference()
-    return weakMap.get(jsRef) ?: memoizeIdentityHashCode(jsRef)
+    return weakMap.get(jsRef).takeIf { it != 0 } ?: memoizeIdentityHashCode(jsRef)
 }

--- a/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/internal/System.wasm.kt
+++ b/compose/ui/ui/src/wasmJsMain/kotlin/androidx/compose/ui/internal/System.wasm.kt
@@ -42,5 +42,5 @@ internal actual fun identityHashCode(instance: Any?): Int {
     }
 
     val jsRef = instance.toJsReference()
-    return weakMap.get(jsRef) ?: memoizeIdentityHashCode(jsRef)
+    return weakMap.get(jsRef).takeIf { it != 0 } ?: memoizeIdentityHashCode(jsRef)
 }


### PR DESCRIPTION
Fixes issue where WeakMap.get() was returning 0 instead of null when the value for the specified key was not found. In Js target this works correctly but not for Wasm for some reason. This is applying these [changes that where made in the Wasm source set in upstream Compose Runtime](https://android-review.googlesource.com/c/platform/frameworks/support/+/3987016)
It should fix some recompositions for stable types since the indentity is now working correctly if cached. Maybe there are more obscure bugs that are affected by this that should be fixed

## Release Notes
### Fixes - Web
- Fix identity hash code not being correctly cached
