### PR TITLE
[Cherry-pick] Fix unchecked cast issue in UndoManager restore function

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/undo/UndoManager.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/input/internal/undo/UndoManager.kt
@@ -136,10 +136,11 @@ internal class UndoManager<T>(
                     value.redoStack.fastForEach { with(itemSaver) { add(save(it)) } }
                 }
 
-                @Suppress("UNCHECKED_CAST")
                 override fun restore(value: Any): UndoManager<T> {
-                    val list = value as List<Any>
-                    val (capacity, undoSize, redoSize) = (list as List<Int>)
+                    @Suppress("UNCHECKED_CAST") val list = value as List<Any>
+                    val capacity = list[0] as Int
+                    val undoSize = list[1] as Int
+                    val redoSize = list[2] as Int
                     var i = 3
                     val undoStackItems = buildList {
                         while (i < undoSize + 3) {


### PR DESCRIPTION
CL: https://android-review.googlesource.com/c/platform/frameworks/support/+/4000634

Due to Kotlin issue KT-85140, accessing an element that cannot be cast to the Int type after an unchecked cast (list as List<Int>) causes a ClassCastException. The solution is to avoid unchecked casting to a list if it is assumed that not all of its elements can be cast to the target type.

Fixes: https://youtrack.jetbrains.com/issue/CMP-9960/Crash-when-restoring-TextFieldState-on-iOS

Testing:
- Clone the project's https://github.com/HarukeyUA/kmp-architecture-template text-field-state-restoration-crash branch
- Run the iOS app, click login, tap on the "Search" in the bottom navigation and enter any text in the text field
- Dismiss the app from the resents and relaunch the app. The app crashes when trying to restore the field's state
- Apply the fix, build CMP with the fix, point the test app to the maven local version and retest the scenario - app no longer crashes and state is correctly restored

## Release Notes
N/A