### PR TITLE
Fix accessibility focus

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -64,6 +64,7 @@ import androidx.compose.ui.window.DisplayLinkListener
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.native.ref.WeakReference
 import kotlin.time.measureTime
 import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.CValue
@@ -990,7 +991,9 @@ private class AccessibilityNotification(
         } else {
             UIAccessibilityLayoutChangedNotification
         }
-        AccessibilityMediator.lastFocusedElementForTests = newElementToFocus
+        AccessibilityMediator.lastFocusedElementForTests = newElementToFocus?.let {
+            WeakReference(it)
+        }
         UIAccessibilityPostNotification(notificationName, newElementToFocus)
     }
 }
@@ -1055,7 +1058,7 @@ internal class AccessibilityMediator(
 ) {
     companion object {
         // For testing purposes only
-        var lastFocusedElementForTests: Any? = null
+        var lastFocusedElementForTests: WeakReference<Any>? = null
     }
 
     private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -131,7 +131,6 @@ import platform.UIKit.UIFocusItemProtocol
 import platform.UIKit.UIFocusItemScrollableContainerProtocol
 import platform.UIKit.UIFocusSystem
 import platform.UIKit.UIFocusUpdateContext
-import platform.UIKit.UIPressesEvent
 import platform.UIKit.UIView
 import platform.UIKit.accessibilityElementAtIndex
 import platform.UIKit.accessibilityElementCount
@@ -314,7 +313,7 @@ private sealed interface AccessibilityNode {
 
         override fun accessibilityPerformEscape(): Boolean {
             if (mediator.performEscape()) {
-                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, null)
+                AccessibilityNotification(newElementToFocus = null, isScreenChange = true).postNotification()
                 return true
             } else {
                 return false
@@ -981,10 +980,20 @@ private class AccessibilityElement(
     }
 }
 
-private class NodesSyncResult(
+private class AccessibilityNotification(
     val newElementToFocus: Any?,
     val isScreenChange: Boolean
-)
+) {
+    fun postNotification() {
+        val notificationName = if (isScreenChange) {
+            UIAccessibilityScreenChangedNotification
+        } else {
+            UIAccessibilityLayoutChangedNotification
+        }
+        AccessibilityMediator.lastFocusedElementForTests = newElementToFocus
+        UIAccessibilityPostNotification(notificationName, newElementToFocus)
+    }
+}
 
 /**
  * An interface for logging accessibility debug messages.
@@ -1044,6 +1053,11 @@ internal class AccessibilityMediator(
     val performEscape: () -> Boolean,
     val onScreenReaderActive: (Boolean) -> Unit,
 ) {
+    companion object {
+        // For testing purposes only
+        var lastFocusedElementForTests: Any? = null
+    }
+
     private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
 
     var focusedNodesScrollableParentsIds: Set<Int> = setOf()
@@ -1095,7 +1109,7 @@ internal class AccessibilityMediator(
                 field = value
                 onSemanticsChange()
 
-                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, null)
+                AccessibilityNotification(newElementToFocus = null, isScreenChange = true).postNotification()
 
                 updateFocusOnAccessibilityElementsLoaded = value
             }
@@ -1228,7 +1242,7 @@ internal class AccessibilityMediator(
                 } else if (root.element != null) {
                     refocusKeyboardElementIfNeeded()
                     root.element = null
-                    UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, null)
+                    AccessibilityNotification(newElementToFocus = null, isScreenChange = false).postNotification()
                 }
 
                 if (keyboardFocusedElementKey != null) {
@@ -1322,7 +1336,7 @@ internal class AccessibilityMediator(
                     focusMode = AccessibilityElementFocusMode.KeepFocus(element.key)
                 }
 
-                UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, element)
+                AccessibilityNotification(element, isScreenChange = false).postNotification()
             }
         }
     }
@@ -1489,7 +1503,7 @@ internal class AccessibilityMediator(
                         semanticsChildren,
                         beforeBeyondBoundsChildren,
                         afterBeyondBoundsChildren,
-                        collectOnlyAccessibilityElements || canBeAccessibilityElement,
+                        collectOnlyAccessibilityElements || child.unmergedConfig.isMergingSemanticsOfDescendants,
                         flatten
                     )
                 }
@@ -1598,7 +1612,7 @@ internal class AccessibilityMediator(
     /**
      * Performs a complete sync of the accessibility tree with the current semantics tree.
      */
-    private fun sync(): NodesSyncResult {
+    private fun sync(): AccessibilityNotification {
         val rootSemanticsNode = owner.unmergedRootSemanticsNode
 
         check(!view.isAccessibilityElement) {
@@ -1633,19 +1647,21 @@ internal class AccessibilityMediator(
         return updateFocusedElement()
     }
 
-    private fun updateFocusedElement(): NodesSyncResult {
+    private fun updateFocusedElement(): AccessibilityNotification {
         return when (val mode = focusMode) {
             AccessibilityElementFocusMode.None -> {
-                NodesSyncResult(newElementToFocus = null, isScreenChange = false)
+                AccessibilityNotification(newElementToFocus = null, isScreenChange = false)
             }
 
             is AccessibilityElementFocusMode.KeepFocus -> {
                 val focusedElement = UIAccessibilityFocusedElement(null)
-                val element = accessibilityElementsMap[mode.key]
+                val element = accessibilityElementsMap[mode.key]?.let {
+                    findAccessibilityElementInSemanticsHierarchy(it.node.semanticsNode)
+                }
                 if (element != null && !CGRectIsEmpty(element.accessibilityFrame())) {
-                    NodesSyncResult(element.takeIf { it !== focusedElement }, isScreenChange = false)
+                    AccessibilityNotification(element.takeIf { it !== focusedElement }, isScreenChange = false)
                 } else if (focusedElement is AccessibilityElement) {
-                    val newFocusedElement = root.element?.let { findFocusableElement(it) }
+                    val newFocusedElement = root.element?.let { findChildAccessibilityElement(it) }
 
                     focusMode = if (newFocusedElement is AccessibilityElement) {
                         AccessibilityElementFocusMode.KeepFocus(newFocusedElement.key)
@@ -1653,20 +1669,22 @@ internal class AccessibilityMediator(
                         AccessibilityElementFocusMode.None
                     }
 
-                    NodesSyncResult(newFocusedElement, isScreenChange = true)
+                    AccessibilityNotification(newFocusedElement, isScreenChange = true)
                 } else {
-                    NodesSyncResult(null, isScreenChange = false)
+                    AccessibilityNotification(null, isScreenChange = false)
                 }
             }
 
             is AccessibilityElementFocusMode.Focus -> {
-                val element = accessibilityElementsMap[mode.key]
+                val element = accessibilityElementsMap[mode.key]?.let {
+                    findAccessibilityElementInSemanticsHierarchy(it.node.semanticsNode)
+                }
                 if (element != null && !CGRectIsEmpty(element.accessibilityFrame())) {
                     focusMode = AccessibilityElementFocusMode.KeepFocus(mode.key)
-                    NodesSyncResult(element, isScreenChange = false)
+                    AccessibilityNotification(element, isScreenChange = false)
                 } else {
                     focusMode = AccessibilityElementFocusMode.None
-                    NodesSyncResult(null, isScreenChange = false)
+                    AccessibilityNotification(null, isScreenChange = false)
                 }
             }
         }
@@ -1736,28 +1754,42 @@ internal class AccessibilityMediator(
         }
     }
 
-    private fun findFocusableElement(node: Any): Any? {
+    /**
+     * Because the AccessibilityElement tree is mostly flattened, we need to traverse the original
+     * semantics nodes hierarchy to find the corresponding element to focus inside the focused
+     * semantics node.
+     */
+    private fun findAccessibilityElementInSemanticsHierarchy(semanticsNode: SemanticsNode): NSObject? {
+        accessibilityElementsMap[semanticsNode.semanticsKey]
+            ?.let { findChildAccessibilityElement(it) }
+            ?.let { return it }
+
+        semanticsNode.children.forEach { child ->
+            findAccessibilityElementInSemanticsHierarchy(semanticsNode = child)?.let { return it }
+        }
+
+        return null
+    }
+
+    private fun findChildAccessibilityElement(node: Any): NSObject? {
         val nsNode = node as NSObject
         if (nsNode.isAccessibilityElement) {
             return nsNode
         }
-        nsNode.accessibilityElements?.takeIf { it.isNotEmpty() }?.forEach {
-            findFocusableElement(it as Any)
-        } ?: repeat(node.accessibilityElementCount().toInt()) { index ->
+        nsNode.accessibilityElements?.takeIf { it.isNotEmpty() }?.firstNotNullOfOrNull {
+            findChildAccessibilityElement(it as Any)
+        }?.let {
+            return it
+        }
+
+        repeat(node.accessibilityElementCount().toInt()) { index ->
             node.accessibilityElementAtIndex(index.toLong())?.let {
-                findFocusableElement(it)
+                findChildAccessibilityElement(it)
+            }?.let {
+                return it
             }
         }
         return null
-    }
-
-    private fun NodesSyncResult.postNotification() {
-        val notificationName = if (isScreenChange) {
-            UIAccessibilityScreenChangedNotification
-        } else {
-            UIAccessibilityLayoutChangedNotification
-        }
-        UIAccessibilityPostNotification(notificationName, newElementToFocus)
     }
 
     private fun refocusKeyboardElementIfNeeded() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -107,7 +107,6 @@ import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
 import platform.QuartzCore.CACurrentMediaTime
 import platform.UIKit.NSStringFromCGRect
-import platform.UIKit.UIAccessibilityAnnouncementNotification
 import platform.UIKit.UIAccessibilityContainerType
 import platform.UIKit.UIAccessibilityContainerTypeNone
 import platform.UIKit.UIAccessibilityContainerTypeSemanticGroup
@@ -991,6 +990,12 @@ internal class AccessibilityNotification private constructor(
     companion object {
         // For testing purposes only
         var lastPostedNotificationForTests: AccessibilityNotification? = null
+            private set
+
+        private val notificationsWithFocusedElement = setOf(
+            UIAccessibilityScreenChangedNotification,
+            UIAccessibilityLayoutChangedNotification
+        )
     }
 
     constructor(
@@ -1000,14 +1005,11 @@ internal class AccessibilityNotification private constructor(
     ) : this(notification, elementToFocus?.let { WeakReference(it) }, message)
 
     fun postNotification() {
-        val focusNotification = notification in listOf(
-            UIAccessibilityScreenChangedNotification,
-            UIAccessibilityLayoutChangedNotification
-        )
+        val focusNotification = notification in notificationsWithFocusedElement
         lastPostedNotificationForTests = this
         UIAccessibilityPostNotification(
             notification,
-            argument = if (focusNotification) elementToFocus else message
+            argument = if (focusNotification) elementToFocus?.value else message
         )
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -107,6 +107,7 @@ import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
 import platform.QuartzCore.CACurrentMediaTime
 import platform.UIKit.NSStringFromCGRect
+import platform.UIKit.UIAccessibilityAnnouncementNotification
 import platform.UIKit.UIAccessibilityContainerType
 import platform.UIKit.UIAccessibilityContainerTypeNone
 import platform.UIKit.UIAccessibilityContainerTypeSemanticGroup
@@ -116,6 +117,7 @@ import platform.UIKit.UIAccessibilityElementFocusedNotification
 import platform.UIKit.UIAccessibilityFocusedElement
 import platform.UIKit.UIAccessibilityFocusedElementKey
 import platform.UIKit.UIAccessibilityLayoutChangedNotification
+import platform.UIKit.UIAccessibilityNotifications
 import platform.UIKit.UIAccessibilityPageScrolledNotification
 import platform.UIKit.UIAccessibilityPostNotification
 import platform.UIKit.UIAccessibilityScreenChangedNotification
@@ -314,7 +316,7 @@ private sealed interface AccessibilityNode {
 
         override fun accessibilityPerformEscape(): Boolean {
             if (mediator.performEscape()) {
-                AccessibilityNotification(newElementToFocus = null, isScreenChange = true).postNotification()
+                AccessibilityNotification(UIAccessibilityScreenChangedNotification).postNotification()
                 return true
             } else {
                 return false
@@ -981,20 +983,32 @@ private class AccessibilityElement(
     }
 }
 
-private class AccessibilityNotification(
-    val newElementToFocus: Any?,
-    val isScreenChange: Boolean
+internal class AccessibilityNotification private constructor(
+    val notification: UIAccessibilityNotifications,
+    val elementToFocus: WeakReference<Any>?,
+    val message: String?
 ) {
+    companion object {
+        // For testing purposes only
+        var lastPostedNotificationForTests: AccessibilityNotification? = null
+    }
+
+    constructor(
+        notification: UIAccessibilityNotifications,
+        elementToFocus: Any? = null,
+        message: String? = null
+    ) : this(notification, elementToFocus?.let { WeakReference(it) }, message)
+
     fun postNotification() {
-        val notificationName = if (isScreenChange) {
-            UIAccessibilityScreenChangedNotification
-        } else {
+        val focusNotification = notification in listOf(
+            UIAccessibilityScreenChangedNotification,
             UIAccessibilityLayoutChangedNotification
-        }
-        AccessibilityMediator.lastFocusedElementForTests = newElementToFocus?.let {
-            WeakReference(it)
-        }
-        UIAccessibilityPostNotification(notificationName, newElementToFocus)
+        )
+        lastPostedNotificationForTests = this
+        UIAccessibilityPostNotification(
+            notification,
+            argument = if (focusNotification) elementToFocus else message
+        )
     }
 }
 
@@ -1056,11 +1070,6 @@ internal class AccessibilityMediator(
     val performEscape: () -> Boolean,
     val onScreenReaderActive: (Boolean) -> Unit,
 ) {
-    companion object {
-        // For testing purposes only
-        var lastFocusedElementForTests: WeakReference<Any>? = null
-    }
-
     private var focusMode: AccessibilityElementFocusMode = AccessibilityElementFocusMode.None
 
     var focusedNodesScrollableParentsIds: Set<Int> = setOf()
@@ -1072,7 +1081,7 @@ internal class AccessibilityMediator(
                 if (value.isNotEmpty()) {
                     // Hack to fix an issue where iOS accessibility only reads the items visible
                     // at the moment of the beginning of the "Speak Screen" command.
-                    UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, null)
+                    AccessibilityNotification(UIAccessibilityPageScrolledNotification).postNotification()
                 }
             }
         }
@@ -1112,7 +1121,7 @@ internal class AccessibilityMediator(
                 field = value
                 onSemanticsChange()
 
-                AccessibilityNotification(newElementToFocus = null, isScreenChange = true).postNotification()
+                AccessibilityNotification(UIAccessibilityScreenChangedNotification).postNotification()
 
                 updateFocusOnAccessibilityElementsLoaded = value
             }
@@ -1245,7 +1254,7 @@ internal class AccessibilityMediator(
                 } else if (root.element != null) {
                     refocusKeyboardElementIfNeeded()
                     root.element = null
-                    AccessibilityNotification(newElementToFocus = null, isScreenChange = false).postNotification()
+                    AccessibilityNotification(UIAccessibilityLayoutChangedNotification).postNotification()
                 }
 
                 if (keyboardFocusedElementKey != null) {
@@ -1324,10 +1333,10 @@ internal class AccessibilityMediator(
         coroutineScope.launch {
             delay(delay)
 
-            UIAccessibilityPostNotification(
+            AccessibilityNotification(
                 UIAccessibilityPageScrolledNotification,
-                scrollResult.announceMessage()
-            )
+                message = scrollResult.announceMessage()
+            ).postNotification()
 
             accessibilityDebugLogger?.log("PageScrolled")
 
@@ -1339,7 +1348,7 @@ internal class AccessibilityMediator(
                     focusMode = AccessibilityElementFocusMode.KeepFocus(element.key)
                 }
 
-                AccessibilityNotification(element, isScreenChange = false).postNotification()
+                AccessibilityNotification(UIAccessibilityLayoutChangedNotification, elementToFocus = element).postNotification()
             }
         }
     }
@@ -1653,7 +1662,7 @@ internal class AccessibilityMediator(
     private fun updateFocusedElement(): AccessibilityNotification {
         return when (val mode = focusMode) {
             AccessibilityElementFocusMode.None -> {
-                AccessibilityNotification(newElementToFocus = null, isScreenChange = false)
+                AccessibilityNotification(UIAccessibilityLayoutChangedNotification)
             }
 
             is AccessibilityElementFocusMode.KeepFocus -> {
@@ -1662,7 +1671,10 @@ internal class AccessibilityMediator(
                     findAccessibilityElementInSemanticsHierarchy(it.node.semanticsNode)
                 }
                 if (element != null && !CGRectIsEmpty(element.accessibilityFrame())) {
-                    AccessibilityNotification(element.takeIf { it !== focusedElement }, isScreenChange = false)
+                    AccessibilityNotification(
+                        UIAccessibilityLayoutChangedNotification,
+                        elementToFocus = element.takeIf { it !== focusedElement }
+                    )
                 } else if (focusedElement is AccessibilityElement) {
                     val newFocusedElement = root.element?.let { findChildAccessibilityElement(it) }
 
@@ -1672,9 +1684,12 @@ internal class AccessibilityMediator(
                         AccessibilityElementFocusMode.None
                     }
 
-                    AccessibilityNotification(newFocusedElement, isScreenChange = true)
+                    AccessibilityNotification(
+                        UIAccessibilityScreenChangedNotification,
+                        elementToFocus = newFocusedElement
+                    )
                 } else {
-                    AccessibilityNotification(null, isScreenChange = false)
+                    AccessibilityNotification(UIAccessibilityLayoutChangedNotification)
                 }
             }
 
@@ -1684,10 +1699,13 @@ internal class AccessibilityMediator(
                 }
                 if (element != null && !CGRectIsEmpty(element.accessibilityFrame())) {
                     focusMode = AccessibilityElementFocusMode.KeepFocus(mode.key)
-                    AccessibilityNotification(element, isScreenChange = false)
+                    AccessibilityNotification(
+                        UIAccessibilityLayoutChangedNotification,
+                        elementToFocus = element
+                    )
                 } else {
                     focusMode = AccessibilityElementFocusMode.None
-                    AccessibilityNotification(null, isScreenChange = false)
+                    AccessibilityNotification(UIAccessibilityLayoutChangedNotification)
                 }
             }
         }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -289,13 +289,12 @@ private fun LinkAnnotation.getTag(): String? =
 
 internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
     return !isHiddenFromAccessibility &&
-        (unmergedConfig.isMergingSemanticsOfDescendants ||
-            isUnmergedNode && unmergedConfig.isSpeakingNode)
+        (unmergedConfig.isMergingSemanticsOfDescendants || isUnmergedSpeakingNode)
 }
 
-internal val SemanticsNode.isUnmergedNode: Boolean get() {
-    if (unmergedConfig.isMergingSemanticsOfDescendants) return true
+internal val SemanticsNode.isUnmergedSpeakingNode: Boolean get() {
     if (isFake) return false
+    if (!unmergedConfig.isSpeakingNode) return false
     if (unmergedConfig.isActionableNode) return true
 
     val hasReplacedChildren = replacedChildren.isNotEmpty()

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/accessibility/SemanticsNodeUtils.ios.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.platform.getString
 import androidx.compose.ui.semantics.AccessibilityAction
 import androidx.compose.ui.semantics.ScrollAxisRange
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.SemanticsProperties.HideFromAccessibility
@@ -289,22 +290,58 @@ private fun LinkAnnotation.getTag(): String? =
 internal fun SemanticsNode.canBeAccessibilityElement(): Boolean {
     return !isHiddenFromAccessibility &&
         (unmergedConfig.isMergingSemanticsOfDescendants ||
-            isUnmergedNode && isSpeakingNode)
+            isUnmergedNode && unmergedConfig.isSpeakingNode)
 }
 
-private val SemanticsNode.isUnmergedNode get() =
-    !isFake && layoutNode.findClosestParentNode {
-        it.semanticsConfiguration?.isMergingSemanticsOfDescendants == true
-    } == null
+internal val SemanticsNode.isUnmergedNode: Boolean get() {
+    if (unmergedConfig.isMergingSemanticsOfDescendants) return true
+    if (isFake) return false
+    if (unmergedConfig.isActionableNode) return true
 
-private val SemanticsNode.isSpeakingNode: Boolean get() {
-    return unmergedConfig.contains(SemanticsProperties.ContentDescription) ||
-        unmergedConfig.contains(SemanticsProperties.EditableText) ||
-        unmergedConfig.contains(SemanticsProperties.Text) ||
-        unmergedConfig.contains(SemanticsProperties.StateDescription) ||
-        unmergedConfig.contains(SemanticsProperties.ToggleableState) ||
-        unmergedConfig.contains(SemanticsProperties.Selected) ||
-        unmergedConfig.contains(SemanticsProperties.ProgressBarRangeInfo)
+    val hasReplacedChildren = replacedChildren.isNotEmpty()
+
+    var currentNode = layoutNode.parent
+    while (currentNode != null) {
+        if (currentNode.semanticsConfiguration?.isMergingSemanticsOfDescendants == true) {
+            return false
+        }
+        if (hasReplacedChildren && currentNode.semanticsConfiguration?.isSpeakingNode == true) {
+            return false
+        }
+        if (currentNode.semanticsConfiguration?.getOrNull(SemanticsProperties.IsTraversalGroup) == true) {
+            return true
+        }
+        currentNode = currentNode.parent
+    }
+
+    return replacedChildren.isEmpty()
+}
+
+internal val SemanticsConfiguration.isActionableNode: Boolean
+    get() = (contains(SemanticsActions.RequestFocus) ||
+        contains(SemanticsActions.OnClick) ||
+        contains(SemanticsActions.OnLongClick) ||
+        contains(SemanticsActions.SetProgress) ||
+        contains(SemanticsActions.SetText) ||
+        contains(SemanticsActions.InsertTextAtCursor) ||
+        contains(SemanticsActions.SetSelection) ||
+        contains(SemanticsActions.OnImeAction) ||
+        contains(SemanticsActions.CopyText) ||
+        contains(SemanticsActions.CutText) ||
+        contains(SemanticsActions.PasteText) ||
+        contains(SemanticsActions.Expand) ||
+        contains(SemanticsActions.Collapse) ||
+        contains(SemanticsActions.Dismiss) ||
+        contains(SemanticsActions.CustomActions))
+
+internal val SemanticsConfiguration.isSpeakingNode: Boolean get() {
+    return contains(SemanticsProperties.ContentDescription) ||
+        contains(SemanticsProperties.EditableText) ||
+        contains(SemanticsProperties.Text) ||
+        contains(SemanticsProperties.StateDescription) ||
+        contains(SemanticsProperties.ToggleableState) ||
+        contains(SemanticsProperties.Selected) ||
+        contains(SemanticsProperties.ProgressBarRangeInfo)
 }
 
 @Suppress("DEPRECATION")

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
@@ -28,9 +28,11 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.findNodeWithLabel
 import androidx.compose.ui.test.getAccessibilityTree
 import androidx.compose.ui.test.runUIKitInstrumentedTest
+import kotlin.experimental.ExperimentalNativeApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalNativeApi::class)
 class AccessibilityFocusRequesterTest {
     @Test
     fun testFocusRequesterMovesAccessibilityFocus() = runUIKitInstrumentedTest {
@@ -39,12 +41,16 @@ class AccessibilityFocusRequesterTest {
 
         setContent {
             Column {
-                Text("Text A", modifier =  Modifier
-                    .focusRequester(focusRequesterA)
-                    .focusable())
-                Text("Text B", modifier =  Modifier
-                    .focusRequester(focusRequesterB)
-                    .focusable())
+                Text(
+                    "Text A", modifier = Modifier
+                        .focusRequester(focusRequesterA)
+                        .focusable()
+                )
+                Text(
+                    "Text B", modifier = Modifier
+                        .focusRequester(focusRequesterB)
+                        .focusable()
+                )
             }
         }
 
@@ -56,13 +62,19 @@ class AccessibilityFocusRequesterTest {
         waitForIdle()
 
         val buttonBElement = findNodeWithLabel("Text B").element
-        assertEquals(buttonBElement, AccessibilityMediator.lastFocusedElementForTests)
+        assertEquals(
+            expected = buttonBElement,
+            actual = AccessibilityMediator.lastFocusedElementForTests?.value
+        )
 
         focusRequesterA.requestFocus()
         waitForIdle()
 
         val buttonAElement = findNodeWithLabel("Text A").element
-        assertEquals(buttonAElement, AccessibilityMediator.lastFocusedElementForTests)
+        assertEquals(
+            expected = buttonAElement,
+            actual = AccessibilityMediator.lastFocusedElementForTests?.value
+        )
     }
 
     @Test
@@ -91,6 +103,9 @@ class AccessibilityFocusRequesterTest {
         waitForIdle()
 
         val content1Element = findNodeWithLabel("Content 1").element
-        assertEquals(content1Element, AccessibilityMediator.lastFocusedElementForTests)
+        assertEquals(
+            expected = content1Element,
+            actual = AccessibilityMediator.lastFocusedElementForTests?.value
+        )
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.accessibility
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.AccessibilityMediator
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.findNodeWithLabel
+import androidx.compose.ui.test.getAccessibilityTree
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AccessibilityFocusRequesterTest {
+    @Test
+    fun testFocusRequesterMovesAccessibilityFocus() = runUIKitInstrumentedTest {
+        val focusRequesterA = FocusRequester()
+        val focusRequesterB = FocusRequester()
+
+        setContent {
+            Column {
+                Text("Text A", modifier =  Modifier
+                    .focusRequester(focusRequesterA)
+                    .focusable())
+                Text("Text B", modifier =  Modifier
+                    .focusRequester(focusRequesterB)
+                    .focusable())
+            }
+        }
+
+        // Trigger accessibility.
+        getAccessibilityTree()
+        waitForIdle()
+
+        focusRequesterB.requestFocus()
+        waitForIdle()
+
+        val buttonBElement = findNodeWithLabel("Text B").element
+        assertEquals(buttonBElement, AccessibilityMediator.lastFocusedElementForTests)
+
+        focusRequesterA.requestFocus()
+        waitForIdle()
+
+        val buttonAElement = findNodeWithLabel("Text A").element
+        assertEquals(buttonAElement, AccessibilityMediator.lastFocusedElementForTests)
+    }
+
+    @Test
+    fun testFocusRequesterSelectsFirstFocusableElement() = runUIKitInstrumentedTest {
+        val focusRequester = FocusRequester()
+
+        setContent {
+            Column(
+                modifier = Modifier
+                    .testTag("ContentBox")
+                    .focusRequester(focusRequester)
+                    .focusable()
+            ) {
+                Box {
+                    Text("Content 1")
+                }
+                Text("Content 2")
+            }
+        }
+
+        // Trigger accessibility.
+        getAccessibilityTree()
+        waitForIdle()
+
+        focusRequester.requestFocus()
+        waitForIdle()
+
+        val content1Element = findNodeWithLabel("Content 1").element
+        assertEquals(content1Element, AccessibilityMediator.lastFocusedElementForTests)
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
@@ -61,18 +61,16 @@ class AccessibilityFocusRequesterTest {
         focusRequesterB.requestFocus()
         waitForIdle()
 
-        val buttonBElement = findNodeWithLabel("Text B").element
         assertEquals(
-            expected = buttonBElement,
+            expected = findNodeWithLabel("Text B").element,
             actual = AccessibilityNotification.lastPostedNotificationForTests?.elementToFocus?.value
         )
 
         focusRequesterA.requestFocus()
         waitForIdle()
 
-        val buttonAElement = findNodeWithLabel("Text A").element
         assertEquals(
-            expected = buttonAElement,
+            expected = findNodeWithLabel("Text A").element,
             actual = AccessibilityNotification.lastPostedNotificationForTests?.elementToFocus?.value
         )
     }
@@ -89,9 +87,9 @@ class AccessibilityFocusRequesterTest {
                     .focusable()
             ) {
                 Box {
-                    Text("Content 1")
+                    Text("Text 1")
                 }
-                Text("Content 2")
+                Text("Text 2")
             }
         }
 
@@ -102,9 +100,8 @@ class AccessibilityFocusRequesterTest {
         focusRequester.requestFocus()
         waitForIdle()
 
-        val content1Element = findNodeWithLabel("Content 1").element
         assertEquals(
-            expected = content1Element,
+            expected = findNodeWithLabel("Text 1").element,
             actual = AccessibilityNotification.lastPostedNotificationForTests?.elementToFocus?.value
         )
     }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityFocusRequesterTest.kt
@@ -23,7 +23,7 @@ import androidx.compose.material.Text
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.platform.AccessibilityMediator
+import androidx.compose.ui.platform.AccessibilityNotification
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.findNodeWithLabel
 import androidx.compose.ui.test.getAccessibilityTree
@@ -64,7 +64,7 @@ class AccessibilityFocusRequesterTest {
         val buttonBElement = findNodeWithLabel("Text B").element
         assertEquals(
             expected = buttonBElement,
-            actual = AccessibilityMediator.lastFocusedElementForTests?.value
+            actual = AccessibilityNotification.lastPostedNotificationForTests?.elementToFocus?.value
         )
 
         focusRequesterA.requestFocus()
@@ -73,7 +73,7 @@ class AccessibilityFocusRequesterTest {
         val buttonAElement = findNodeWithLabel("Text A").element
         assertEquals(
             expected = buttonAElement,
-            actual = AccessibilityMediator.lastFocusedElementForTests?.value
+            actual = AccessibilityNotification.lastPostedNotificationForTests?.elementToFocus?.value
         )
     }
 
@@ -105,7 +105,7 @@ class AccessibilityFocusRequesterTest {
         val content1Element = findNodeWithLabel("Content 1").element
         assertEquals(
             expected = content1Element,
-            actual = AccessibilityMediator.lastFocusedElementForTests?.value
+            actual = AccessibilityNotification.lastPostedNotificationForTests?.elementToFocus?.value
         )
     }
 }

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/ComponentsAccessibilitySemanticTest.kt
@@ -18,6 +18,7 @@ package androidx.compose.ui.accessibility
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -26,6 +27,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Button
 import androidx.compose.material.Checkbox
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.RadioButton
@@ -956,7 +958,9 @@ class ComponentsAccessibilitySemanticTest {
         setContent {
             Box(modifier = Modifier.semantics { contentDescription = "Box 1" }) {
                 Box(modifier = Modifier.semantics { contentDescription = "Box 2" }) {
-                    Column(modifier = Modifier.padding(1.dp).semantics { contentDescription = "Column 3" }) {
+                    Column(
+                        modifier = Modifier.padding(1.dp)
+                            .semantics { contentDescription = "Column 3" }) {
                         Text("Text 1")
                         Text("Text 2")
                     }
@@ -971,11 +975,11 @@ class ComponentsAccessibilitySemanticTest {
             }
             node {
                 label = "Box 2"
-                isAccessibilityElement = true
+                isAccessibilityElement = false
             }
             node {
                 label = "Column 3"
-                isAccessibilityElement = true
+                isAccessibilityElement = false
             }
             node {
                 label = "Text 1"
@@ -1235,6 +1239,136 @@ class ComponentsAccessibilitySemanticTest {
                 isAccessibilityElement = true
                 label = "link"
                 traits = listOf(UIAccessibilityTraitButton)
+            }
+        }
+    }
+
+    @Test
+    fun testSemanticsMergingWithFocusableNodes() = runUIKitInstrumentedTest {
+        setContent {
+            Column(modifier = Modifier.clickable {}) {
+                Text("Line 1")
+                Text("Line 2")
+                Text("Line 3", modifier = Modifier.focusable())
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                label = "Line 1, Line 2"
+                traits(UIAccessibilityTraitButton)
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 1"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 2"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Line 3"
+                traits(UIAccessibilityTraitStaticText)
+            }
+        }
+    }
+
+    @Test
+    fun testSemanticsMergingWithProgressIndicators() = runUIKitInstrumentedTest {
+        setContent {
+            Column(modifier = Modifier.semantics(mergeDescendants = true) {}) {
+                Row {
+                    Text("Circular")
+                    CircularProgressIndicator()
+                }
+
+                Row {
+                    Text("Linear")
+                    LinearProgressIndicator(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                label = "Circular, Linear"
+                node {
+                    isAccessibilityElement = false
+                    label = "Circular"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+                node {
+                    isAccessibilityElement = false
+                    label = "Linear"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+            }
+            node {
+                isAccessibilityElement = true
+            }
+            node {
+                isAccessibilityElement = true
+            }
+        }
+    }
+
+    @Test
+    fun testSemanticsMergingWithComplexHierarchy() = runUIKitInstrumentedTest {
+        setContent {
+            Column(
+                modifier = Modifier.clickable {}
+            ) {
+                Text("Line 1")
+                Column(
+                    modifier = Modifier.clickable {}
+                ) {
+                    Text("Line 3")
+                    Button(onClick = {}) { Text("Button") }
+                }
+                Text("Line 2")
+            }
+        }
+
+        assertAccessibilityTree {
+            node {
+                isAccessibilityElement = true
+                label = "Line 1, Line 2"
+                traits(UIAccessibilityTraitButton)
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 1"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 2"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Line 3"
+                traits(UIAccessibilityTraitButton)
+                node {
+                    isAccessibilityElement = false
+                    label = "Line 3"
+                    traits(UIAccessibilityTraitStaticText)
+                }
+            }
+            node {
+                isAccessibilityElement = true
+                label = "Button"
+                traits(UIAccessibilityTraitButton)
+                node {
+                    isAccessibilityElement = false
+                    label = "Button"
+                    traits(UIAccessibilityTraitStaticText)
+                }
             }
         }
     }


### PR DESCRIPTION
Fix accessibility elements hierarchy by including to non-merging elements nodes with the specific semantic actions.
Improve search for force-focused accessibility elements.

Fixes: https://youtrack.jetbrains.com/issue/CMP-9677/iOS-VoiceOver-Incorrect-reading-of-component-current-state

## Release Notes
### Fixes - iOS
- The structure of accessibility elements is now better aligned with Android semantic nodes.
- Fix issues with accessibility elements not focusing at runtime.