### PR TITLE
Support v2 Compose UI Tests APIs on non-android targets

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.test.MainTestClock
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -391,7 +391,7 @@ internal class TooltipAreaTest {
     @OptIn(InternalComposeUiApi::class, InternalTestApi::class)
     private fun runComposeUiTestWithStandardTestDispatcher(
         block: suspend ComposeUiTest.() -> Unit
-    ) = runInternalSkikoComposeUiTest(useStandardTestDispatcherForComposition = true) {
+    ) = runInternalSkikoComposeUiTest {
         block()
     }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/TooltipAreaTest.kt
@@ -391,7 +391,7 @@ internal class TooltipAreaTest {
     @OptIn(InternalComposeUiApi::class, InternalTestApi::class)
     private fun runComposeUiTestWithStandardTestDispatcher(
         block: suspend ComposeUiTest.() -> Unit
-    ) = runInternalSkikoComposeUiTest(coroutineDispatcher = StandardTestDispatcher()) {
+    ) = runInternalSkikoComposeUiTest(useStandardTestDispatcherForComposition = true) {
         block()
     }
 

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
@@ -544,7 +544,7 @@ class TextFieldKeyEventTest {
     ) {
         keyMappingOverride = namedKeyMapping.keyMapping
         try {
-            runInternalSkikoComposeUiTest(coroutineDispatcher = StandardTestDispatcher()) {
+            runInternalSkikoComposeUiTest(useStandardTestDispatcherForComposition = true) {
                 val tag = "TextFieldTestTag"
                 val state = TextFieldState(initText, initSelection)
                 val clipboard = FakeClipboard(initClipboardText)

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
@@ -44,14 +44,13 @@ import androidx.compose.ui.test.KeyInjectionScope
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.pressKey
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.test.withKeysDown
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextRange
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.StandardTestDispatcher
 
 // Adapted from CommonTextFieldKeyEventTest.kt in AOSP
 @OptIn(ExperimentalTestApi::class)

--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
@@ -544,7 +544,7 @@ class TextFieldKeyEventTest {
     ) {
         keyMappingOverride = namedKeyMapping.keyMapping
         try {
-            runInternalSkikoComposeUiTest(useStandardTestDispatcherForComposition = true) {
+            runInternalSkikoComposeUiTest {
                 val tag = "TextFieldTestTag"
                 val state = TextFieldState(initText, initSelection)
                 val clipboard = FakeClipboard(initClipboardText)

--- a/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopComposeTestRule.desktop.kt
+++ b/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/DesktopComposeTestRule.desktop.kt
@@ -37,26 +37,44 @@ import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
-@OptIn(InternalTestApi::class)
-actual fun createComposeRule(): ComposeContentTestRule = DesktopComposeTestRule()
+@Deprecated(
+    message =
+        "Use `androidx.compose.ui.test.junit4.v2.createComposeRule` instead. The v2 APIs use " +
+            "`StandardTestDispatcher` by default to better simulate production behavior where " +
+            "coroutines are queued rather than executed immediately.",
+    level = DeprecationLevel.WARNING,
+)
+@OptIn(InternalTestApi::class, ExperimentalTestApi::class)
+actual fun createComposeRule(): ComposeContentTestRule =
+    DesktopComposeTestRule(
+        DesktopComposeUiTest(
+            effectContext = EmptyCoroutineContext,
+            useStandardTestDispatcherForComposition = false
+        )
+    )
 
+@Deprecated(
+    message =
+        "Use `androidx.compose.ui.test.junit4.v2.createComposeRule` instead. The v2 APIs use " +
+            "`StandardTestDispatcher` by default to better simulate production behavior where " +
+            "coroutines are queued rather than executed immediately.",
+    level = DeprecationLevel.WARNING,
+)
 @ExperimentalTestApi
 @OptIn(InternalTestApi::class)
 actual fun createComposeRule(effectContext: CoroutineContext): ComposeContentTestRule =
-    DesktopComposeTestRule(effectContext)
+    DesktopComposeTestRule(
+        DesktopComposeUiTest(
+            effectContext = effectContext,
+            useStandardTestDispatcherForComposition = false
+        )
+    )
 
 @InternalTestApi
 @OptIn(ExperimentalTestApi::class)
-class DesktopComposeTestRule private constructor(
+class DesktopComposeTestRule internal constructor(
     private val composeTest: DesktopComposeUiTest
 ) : ComposeContentTestRule {
-
-    constructor() : this(DesktopComposeUiTest())
-
-    @ExperimentalTestApi
-    constructor(
-        effectContext: CoroutineContext = EmptyCoroutineContext
-    ) : this(DesktopComposeUiTest(effectContext = effectContext))
 
     @InternalComposeUiApi
     var scene: ComposeScene

--- a/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/v2/ComposeTestRule.desktop.kt
+++ b/compose/ui/ui-test-junit4/src/desktopMain/kotlin/androidx/compose/ui/test/junit4/v2/ComposeTestRule.desktop.kt
@@ -16,10 +16,18 @@
 
 package androidx.compose.ui.test.junit4.v2
 
+import androidx.compose.ui.test.DesktopComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.DesktopComposeTestRule
 import kotlin.coroutines.CoroutineContext
 
-actual fun createComposeRule(effectContext: CoroutineContext): ComposeContentTestRule {
-    // TODO: https://youtrack.jetbrains.com/issue/CMP-9519/Implement-ComposeUiTest-v2-APIs-and-migrate-the-tests
-    TODO("createComposeRule v2 - Not yet implemented")
-}
+@OptIn(ExperimentalTestApi::class, InternalTestApi::class)
+actual fun createComposeRule(effectContext: CoroutineContext): ComposeContentTestRule =
+    DesktopComposeTestRule(
+        DesktopComposeUiTest(
+            effectContext = effectContext,
+            useStandardTestDispatcherForComposition = true
+        )
+    )

--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/ComposeUiTest.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/ComposeUiTest.desktop.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.Density
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
  * Variant of [runComposeUiTest] that allows you to specify the size of the surface.
@@ -29,11 +30,17 @@ import kotlin.time.Duration
  * @param effectContext The [CoroutineContext] used to run the composition. The context for
  * `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context.
  */
+@Deprecated(
+    message =
+        "Use `androidx.compose.ui.test.v2.runDesktopComposeUiTest` instead. The v2 APIs use " +
+            "`StandardTestDispatcher` by default to better simulate production behavior where " +
+            "coroutines are queued rather than executed immediately.",
+    level = DeprecationLevel.WARNING,
+)
 @ExperimentalTestApi
 fun runDesktopComposeUiTest(
     width: Int = 1024,
     height: Int = 768,
-    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
     effectContext: CoroutineContext = EmptyCoroutineContext,
     runTestContext: CoroutineContext = EmptyCoroutineContext,
     testTimeout: Duration = Duration.INFINITE,
@@ -46,7 +53,8 @@ fun runDesktopComposeUiTest(
                 height = height,
                 effectContext = effectContext,
                 runTestContext = runTestContext,
-                testTimeout = testTimeout
+                testTimeout = testTimeout,
+                useStandardTestDispatcherForComposition = false
             )
         ) {
             runTest { block() }
@@ -54,6 +62,7 @@ fun runDesktopComposeUiTest(
     }
 }
 
+@OptIn(ExperimentalCoroutinesApi::class, InternalTestApi::class)
 @ExperimentalTestApi
 class DesktopComposeUiTest(
     width: Int = 1024,
@@ -62,6 +71,7 @@ class DesktopComposeUiTest(
     runTestContext: CoroutineContext = EmptyCoroutineContext,
     testTimeout: Duration = Duration.INFINITE,
     density: Density = Density(1f),
+    useStandardTestDispatcherForComposition: Boolean,
 ) : SkikoComposeUiTest(
     width = width,
     height = height,
@@ -69,8 +79,10 @@ class DesktopComposeUiTest(
     runTestContext = runTestContext,
     testTimeout = testTimeout,
     density = density,
+    semanticsOwnerListener = null,
+    windowInsets = null,
+    useStandardTestDispatcherForComposition = useStandardTestDispatcherForComposition
 ) {
-
     private val idlingResources = mutableSetOf<IdlingResource>()
 
     override fun areAllResourcesIdle(): Boolean {

--- a/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.desktop.kt
+++ b/compose/ui/ui-test/src/desktopMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.desktop.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test.v2
+
+import androidx.compose.ui.test.DesktopComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.Duration
+import kotlinx.coroutines.test.TestCoroutineScheduler
+
+/**
+ * Variant of [runComposeUiTest] that allows you to specify the size of the surface.
+ *
+ * This implementation uses [kotlinx.coroutines.test.StandardTestDispatcher] by default for running
+ * composition. This ensures that the test behavior is consistent with
+ * [kotlinx.coroutines.test.runTest] and provides explicit control over coroutine execution order.
+ * This means you may need to explicitly advance time or run current coroutines when testing complex
+ * coroutine logic, as tasks are queued on the scheduler rather than running eagerly.
+ *
+ * @param width the desired width of the surface
+ * @param height the desired height of the surface
+ * @param effectContext The [CoroutineContext] used to run the composition. The context for
+ * `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context.
+ * @param runTestContext The [CoroutineContext] used to create the context to run the test [block].
+ *   By default [block] will run using [kotlinx.coroutines.test.StandardTestDispatcher].
+ *   [runTestContext] and [effectContext] must not share [TestCoroutineScheduler].
+ * @param testTimeout The [Duration] within which the test is expected to complete, otherwise a
+ *   platform specific timeout exception will be thrown.
+ * @param block The suspendable test body.
+ */
+@ExperimentalTestApi
+fun runDesktopComposeUiTest(
+    width: Int = 1024,
+    height: Int = 768,
+    effectContext: CoroutineContext = EmptyCoroutineContext,
+    runTestContext: CoroutineContext = EmptyCoroutineContext,
+    testTimeout: Duration = Duration.INFINITE,
+    block: suspend DesktopComposeUiTest.() -> Unit
+) {
+    kotlinx.coroutines.test.runTest {
+        with(
+            DesktopComposeUiTest(
+                width = width,
+                height = height,
+                effectContext = effectContext,
+                runTestContext = runTestContext,
+                testTimeout = testTimeout,
+                useStandardTestDispatcherForComposition = true,
+            )
+        ) {
+            runTest { block() }
+        }
+    }
+}

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.toSize
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.enableSavedStateHandles
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
@@ -60,13 +61,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.jetbrains.skia.Color
-import org.jetbrains.skia.IRect
 import org.jetbrains.skia.Surface
 import org.jetbrains.skiko.currentNanoTime
 
@@ -93,11 +94,18 @@ actual fun runComposeUiTest(
     }
 }
 
+@OptIn(InternalComposeUiApi::class, InternalTestApi::class)
+@Deprecated(
+    message =
+        "Use `androidx.compose.ui.test.v2.runSkikoComposeUiTest` instead. The v2 APIs use " +
+            "`StandardTestDispatcher` by default to better simulate production behavior where " +
+            "coroutines are queued rather than executed immediately.",
+    level = DeprecationLevel.WARNING,
+)
 @ExperimentalTestApi
 fun runSkikoComposeUiTest(
     size: Size = Size(1024.0f, 768.0f),
     density: Density = Density(1f),
-    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
     effectContext: CoroutineContext = EmptyCoroutineContext,
     runTestContext: CoroutineContext = EmptyCoroutineContext,
     testTimeout: Duration = Duration.INFINITE,
@@ -109,12 +117,15 @@ fun runSkikoComposeUiTest(
         effectContext = effectContext,
         testTimeout = testTimeout,
         runTestContext = runTestContext,
-        density = density
+        density = density,
+        semanticsOwnerListener = null,
+        windowInsets = null,
+        useStandardTestDispatcherForComposition = false,
     ).runTest(block)
 }
 
 @InternalTestApi
-@OptIn(InternalComposeUiApi::class, ExperimentalTestApi::class)
+@OptIn(InternalComposeUiApi::class, ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
 fun runInternalSkikoComposeUiTest(
     width: Int = 1024,
     height: Int = 768,
@@ -124,7 +135,6 @@ fun runInternalSkikoComposeUiTest(
     testTimeout: Duration = Duration.INFINITE,
     semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
     windowInsets: PlatformWindowInsets? = null,
-    coroutineDispatcher: TestDispatcher = defaultTestDispatcher(),
     block: suspend SkikoComposeUiTest.() -> Unit
 ): TestResult {
     return runTest {
@@ -137,7 +147,7 @@ fun runInternalSkikoComposeUiTest(
             density = density,
             semanticsOwnerListener = semanticsOwnerListener,
             windowInsets = windowInsets,
-            coroutineDispatcher = coroutineDispatcher,
+            useStandardTestDispatcherForComposition = false,
         ).runTest(block)
     }
 }
@@ -149,13 +159,6 @@ fun runInternalSkikoComposeUiTest(
 private const val IDLING_RESOURCES_CHECK_INTERVAL_MS = 20L
 
 /**
- * Returns the default [TestDispatcher] to use in tests.
- */
-@OptIn(ExperimentalCoroutinesApi::class)
-@InternalTestApi
-fun defaultTestDispatcher(): TestDispatcher = UnconfinedTestDispatcher()
-
-/**
  * @param effectContext The [CoroutineContext] used to run the composition. The context for
  * `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context.
  */
@@ -164,34 +167,27 @@ fun defaultTestDispatcher(): TestDispatcher = UnconfinedTestDispatcher()
 open class SkikoComposeUiTest @InternalTestApi constructor(
     width: Int = 1024,
     height: Int = 768,
-    // TODO(https://github.com/JetBrains/compose-multiplatform/issues/2960) Support effectContext
-    effectContext: CoroutineContext = EmptyCoroutineContext,
+    private val effectContext: CoroutineContext = EmptyCoroutineContext,
     private val runTestContext: CoroutineContext = EmptyCoroutineContext,
     private val testTimeout: Duration = Duration.INFINITE,
     override val density: Density = Density(1f),
     private val semanticsOwnerListener: PlatformContext.SemanticsOwnerListener?,
     private val windowInsets: PlatformWindowInsets?,
-    private val coroutineDispatcher: TestDispatcher = defaultTestDispatcher(),
+    private val useStandardTestDispatcherForComposition: Boolean,
 ) : ComposeUiTest {
-    init {
-        require(effectContext == EmptyCoroutineContext) {
-            "The argument effectContext isn't supported yet. " +
-                "Follow https://github.com/JetBrains/compose-multiplatform/issues/2960"
-        }
-    }
-
     constructor(
         width: Int = 1024,
         height: Int = 768,
         effectContext: CoroutineContext = EmptyCoroutineContext,
         density: Density = Density(1f),
-    ) : this (
+    ) : this(
         width = width,
         height = height,
         effectContext = effectContext,
         density = density,
         semanticsOwnerListener = null,
         windowInsets = null,
+        useStandardTestDispatcherForComposition = true,
     )
 
     constructor(
@@ -210,17 +206,27 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         density = density,
         semanticsOwnerListener = null,
         windowInsets = null,
+        useStandardTestDispatcherForComposition = true,
     )
 
     private val composeRootRegistry = ComposeRootRegistry()
 
+    private val customTestDispatcher: TestDispatcher? =
+        effectContext[ContinuationInterceptor] as? TestDispatcher
+
+    /**
+     * We can only accept a TestDispatcher here because we need to access its scheduler. Use the
+     * TestDispatcher if it is provided in the effectContext Otherwise, use the
+     * TestCoroutineScheduler if it is provided
+     */
+    private val compositionCoroutineDispatcher: TestDispatcher =
+        customTestDispatcher
+            ?: effectContext.createDefaultTestDispatcher(useStandardTestDispatcherForComposition)
+
     private val mainClockImpl = MainTestClockImpl(
-        scheduler = coroutineDispatcher.scheduler,
+        scheduler = compositionCoroutineDispatcher.scheduler,
         frameDelayMillis = FRAME_DELAY_MILLIS,
-        // TODO: https://youtrack.jetbrains.com/issue/CMP-9519/Implement-ComposeUiTest-v2-APIs-and-migrate-the-tests
-        // It used to be ComposeUiTestFlags.isStandardTestDispatcherSupportEnabled which was true by default
-        // Now it's removed.
-        isStandardTestDispatcherSupportEnabled = true
+        isStandardTestDispatcherSupportEnabled = useStandardTestDispatcherForComposition
     )
     override val mainClock: MainTestClock
         get() = mainClockImpl
@@ -235,7 +241,7 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         }
     }
     private val coroutineContext =
-        coroutineDispatcher + uncaughtExceptionHandler + infiniteAnimationPolicy
+        compositionCoroutineDispatcher + uncaughtExceptionHandler + infiniteAnimationPolicy
 
     private val surface = Surface.makeRasterN32Premul(width, height)
     private val size = IntSize(width, height)
@@ -290,7 +296,7 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
             runOnUiThread(::closeScene)
             // After the scene is closed, run all left foreground TestDispatchEvent.
             // They might've been added outside the runTest call, using the provided coroutineDispatcher:
-            coroutineDispatcher.scheduler.advanceUntilIdle()
+            compositionCoroutineDispatcher.scheduler.advanceUntilIdle()
             uncaughtExceptionHandler.throwUncaught()
         }
     }
@@ -577,3 +583,13 @@ actual sealed interface ComposeUiTest : SemanticsNodeInteractionsProvider {
 }
 
 private const val FRAME_DELAY_MILLIS = 16L
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun CoroutineContext.createDefaultTestDispatcher(
+    useStandardTestDispatcher: Boolean
+): TestDispatcher {
+    if (useStandardTestDispatcher) {
+        return StandardTestDispatcher(this[TestCoroutineScheduler])
+    }
+    return UnconfinedTestDispatcher(this[TestCoroutineScheduler])
+}

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -135,7 +135,8 @@ fun runInternalSkikoComposeUiTest(
     testTimeout: Duration = Duration.INFINITE,
     semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
     windowInsets: PlatformWindowInsets? = null,
-    block: suspend SkikoComposeUiTest.() -> Unit
+    useStandardTestDispatcherForComposition: Boolean = false,
+    block: suspend SkikoComposeUiTest.() -> Unit,
 ): TestResult {
     return runTest {
         SkikoComposeUiTest(
@@ -147,7 +148,7 @@ fun runInternalSkikoComposeUiTest(
             density = density,
             semanticsOwnerListener = semanticsOwnerListener,
             windowInsets = windowInsets,
-            useStandardTestDispatcherForComposition = false,
+            useStandardTestDispatcherForComposition = useStandardTestDispatcherForComposition,
         ).runTest(block)
     }
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -137,7 +137,6 @@ fun runInternalSkikoComposeUiTest(
     testTimeout: Duration = Duration.INFINITE,
     semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
     windowInsets: PlatformWindowInsets? = null,
-    useStandardTestDispatcherForComposition: Boolean = false,
     block: suspend SkikoComposeUiTest.() -> Unit,
 ): TestResult {
     return runTest {
@@ -150,7 +149,7 @@ fun runInternalSkikoComposeUiTest(
             density = density,
             semanticsOwnerListener = semanticsOwnerListener,
             windowInsets = windowInsets,
-            useStandardTestDispatcherForComposition = useStandardTestDispatcherForComposition,
+            useStandardTestDispatcherForComposition = true,
         ).runTest(block)
     }
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -126,34 +126,6 @@ fun runSkikoComposeUiTest(
     ).runTest(block)
 }
 
-@InternalTestApi
-@OptIn(InternalComposeUiApi::class, ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
-fun runInternalSkikoComposeUiTest(
-    width: Int = 1024,
-    height: Int = 768,
-    density: Density = Density(1f),
-    effectContext: CoroutineContext = EmptyCoroutineContext,
-    runTestContext: CoroutineContext = EmptyCoroutineContext,
-    testTimeout: Duration = Duration.INFINITE,
-    semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
-    windowInsets: PlatformWindowInsets? = null,
-    block: suspend SkikoComposeUiTest.() -> Unit,
-): TestResult {
-    return runTest {
-        SkikoComposeUiTest(
-            width = width,
-            height = height,
-            effectContext = effectContext,
-            runTestContext = runTestContext,
-            testTimeout = testTimeout,
-            density = density,
-            semanticsOwnerListener = semanticsOwnerListener,
-            windowInsets = windowInsets,
-            useStandardTestDispatcherForComposition = true,
-        ).runTest(block)
-    }
-}
-
 /**
  * How often to check idling resources.
  * Empirically checked that Android (espresso, really) tests approximately at this rate.

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/ComposeUiTest.skiko.kt
@@ -53,8 +53,10 @@ import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
@@ -232,7 +234,9 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
     override val mainClock: MainTestClock
         get() = mainClockImpl
 
-    private val uncaughtExceptionHandler = UncaughtExceptionHandler()
+    private val uncaughtExceptionHandler = UncaughtExceptionHandler(
+        effectContext[CoroutineExceptionHandler]
+    )
     private val infiniteAnimationPolicy = object : InfiniteAnimationPolicy {
         override suspend fun <R> onInfiniteOperation(block: suspend () -> R): R {
             if (mainClock.autoAdvance) {
@@ -241,8 +245,14 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
             return block()
         }
     }
-    private val coroutineContext =
-        compositionCoroutineDispatcher + uncaughtExceptionHandler + infiniteAnimationPolicy
+
+    private val recomposerCoroutineScope = CoroutineScope(
+        effectContext +
+            compositionCoroutineDispatcher +
+            infiniteAnimationPolicy +
+            uncaughtExceptionHandler +
+            Job()
+    )
 
     private val surface = Surface.makeRasterN32Premul(width, height)
     private val size = IntSize(width, height)
@@ -252,7 +262,8 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         @InternalTestApi
         set
 
-    private val architectureComponentsOwner = DefaultArchitectureComponentsOwner(enforceMainThread = false)
+    private val architectureComponentsOwner =
+        DefaultArchitectureComponentsOwner(enforceMainThread = false)
     private val testOwner = SkikoTestOwner()
     private val testContext = TestContext(testOwner)
 
@@ -267,10 +278,18 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         val testDispatcher: CoroutineDispatcher =
             runTestContext[CoroutineDispatcher] ?: StandardTestDispatcher()
 
+        val combinedRunTestCoroutineContext =
+            recomposerCoroutineScope.coroutineContext
+                .minusKey(CoroutineExceptionHandler.Key)
+                .minusKey(Job.Key)
+                .minusKey(TestCoroutineScheduler.Key)
+                .plus(runTestContext)
+                .plus(testDispatcher)
+
         // Note: on web this call returns immediately (it returns a Promise),
         return runTest(
             timeout = testTimeout,
-            context = runTestContext.plus(testDispatcher)
+            context = combinedRunTestCoroutineContext
         ) {
             composeRootRegistry.withRegistry {
                 withScene {
@@ -303,7 +322,7 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
     }
 
     private inline fun <R> withRenderLoop(block: () -> R): R {
-        val scope = CoroutineScope(coroutineContext)
+        val scope = recomposerCoroutineScope
         return try {
             scope.launch {
                 while (isActive) {
@@ -334,7 +353,7 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         scene = CanvasLayersComposeScene(
             density = density,
             size = size,
-            coroutineContext = coroutineContext,
+            coroutineContext = recomposerCoroutineScope.coroutineContext,
             platformContext = TestContext(),
             invalidate = { }
         )
@@ -369,9 +388,9 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
         }
 
         return !Snapshot.current.hasPendingChanges()
-                && !Snapshot.isApplyObserverNotificationPending
-                && !scene.hasInvalidations()
-                && areAllResourcesIdle()
+            && !Snapshot.isApplyObserverNotificationPending
+            && !scene.hasInvalidations()
+            && areAllResourcesIdle()
     }
 
     override fun waitForIdle() {
@@ -476,10 +495,10 @@ open class SkikoComposeUiTest @InternalTestApi constructor(
     fun captureToImage(semanticsNode: SemanticsNode): ImageBitmap {
         val rect = semanticsNode.boundsInWindow
         val image = surface.makeImageSnapshot(
-                rect.left.toInt(),
-                rect.top.toInt(),
-                rect.right.toInt(),
-                rect.bottom.toInt()
+            rect.left.toInt(),
+            rect.top.toInt(),
+            rect.right.toInt(),
+            rect.bottom.toInt()
         )
         return image!!.toComposeImageBitmap()
     }
@@ -580,6 +599,7 @@ actual sealed interface ComposeUiTest : SemanticsNodeInteractionsProvider {
         timeoutMillis: Long,
         condition: () -> Boolean
     )
+
     actual fun setContent(composable: @Composable () -> Unit)
 }
 

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.skiko.kt
@@ -136,3 +136,31 @@ fun runSkikoComposeUiTest(
         useStandardTestDispatcherForComposition = true,
     ).runTest(block)
 }
+
+@InternalTestApi
+@OptIn(InternalComposeUiApi::class, ExperimentalTestApi::class, ExperimentalCoroutinesApi::class)
+fun runInternalSkikoComposeUiTest(
+    width: Int = 1024,
+    height: Int = 768,
+    density: Density = Density(1f),
+    effectContext: CoroutineContext = EmptyCoroutineContext,
+    runTestContext: CoroutineContext = EmptyCoroutineContext,
+    testTimeout: Duration = Duration.INFINITE,
+    semanticsOwnerListener: PlatformContext.SemanticsOwnerListener? = null,
+    windowInsets: PlatformWindowInsets? = null,
+    block: suspend SkikoComposeUiTest.() -> Unit,
+): TestResult {
+    return runTest {
+        SkikoComposeUiTest(
+            width = width,
+            height = height,
+            effectContext = effectContext,
+            runTestContext = runTestContext,
+            testTimeout = testTimeout,
+            density = density,
+            semanticsOwnerListener = semanticsOwnerListener,
+            windowInsets = windowInsets,
+            useStandardTestDispatcherForComposition = true,
+        ).runTest(block)
+    }
+}

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.skiko.kt
@@ -16,12 +16,60 @@
 
 package androidx.compose.ui.test.v2
 
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.InternalTestApi
+import androidx.compose.ui.test.MainTestClock
+import androidx.compose.ui.test.SkikoComposeUiTest
+import androidx.compose.ui.unit.Density
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.math.roundToInt
 import kotlin.time.Duration
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestResult
 
+/**
+ * Sets up the test environment, runs the given [test][block] and then tears down the test
+ * environment. Use the methods on [ComposeUiTest] in the test to find Compose content and make
+ * assertions on it. If you need access to platform specific elements (such as the Activity on
+ * Android), use one of the platform specific variants of this method, e.g.
+ * [runAndroidComposeUiTest] on Android.
+ *
+ * Implementations of this method will launch a Compose host (such as an Activity on Android) for
+ * you. If your test needs to launch its own host, use a platform specific variant that doesn't
+ * launch anything for you (if available), e.g. [runEmptyComposeUiTest] on Android. Always make sure
+ * that the Compose content is set during execution of the [test lambda][block] so the test
+ * framework is aware of the content. Whether you need to launch the host from within the test
+ * lambda as well depends on the platform.
+ *
+ * This implementation uses [kotlinx.coroutines.test.StandardTestDispatcher] by default for running
+ * composition. This ensures that the test behavior is consistent with
+ * [kotlinx.coroutines.test.runTest] and provides explicit control over coroutine execution order.
+ * This means you may need to explicitly advance time or run current coroutines when testing complex
+ * coroutine logic, as tasks are queued on the scheduler rather than running eagerly.
+ *
+ * Keeping a reference to the [ComposeUiTest] outside of this function is an error. Also avoid using
+ * [androidx.compose.ui.test.junit4.ComposeTestRule] (e.g., createComposeRule) inside
+ * [runComposeUiTest][block] or any of their respective variants. Since these APIs independently
+ * manage the test environment, mixing them may lead to unexpected behavior.
+ *
+ * @sample androidx.compose.ui.test.samples.RunComposeUiTestSample
+ * @param effectContext The [CoroutineContext] used to run the composition. The context for
+ *   `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context. If this
+ *   context contains a [TestDispatcher], it is used for composition and the [MainTestClock].
+ *   Otherwise, a [kotlinx.coroutines.test.StandardTestDispatcher] is created and used. This new
+ *   dispatcher will share the [TestCoroutineScheduler] from [effectContext] if one is present.
+ * @param runTestContext The [CoroutineContext] used to create the context to run the test [block].
+ *   By default [block] will run using [kotlinx.coroutines.test.StandardTestDispatcher].
+ *   [runTestContext] and [effectContext] must not share [TestCoroutineScheduler].
+ * @param testTimeout The [Duration] within which the test is expected to complete, otherwise a
+ *   platform specific timeout exception will be thrown.
+ * @param block The suspendable test body.
+ */
 @ExperimentalTestApi
 actual fun runComposeUiTest(
     effectContext: CoroutineContext,
@@ -29,6 +77,58 @@ actual fun runComposeUiTest(
     testTimeout: Duration,
     block: suspend ComposeUiTest.() -> Unit
 ): TestResult {
-    // TODO: https://youtrack.jetbrains.com/issue/CMP-9519/Implement-ComposeUiTest-v2-APIs-and-migrate-the-tests
-    TODO("runComposeUiTest v2 - Not yet implemented")
+    return runSkikoComposeUiTest(
+        effectContext = effectContext,
+        runTestContext = runTestContext,
+        testTimeout = testTimeout,
+    ) {
+        block()
+    }
+}
+
+/**
+ * Runs a Skiko-based Compose UI test within the specified configuration and test execution context.
+ *
+ * This implementation uses [kotlinx.coroutines.test.StandardTestDispatcher] by default for running
+ * composition. This ensures that the test behavior is consistent with
+ * [kotlinx.coroutines.test.runTest] and provides explicit control over coroutine execution order.
+ * This means you may need to explicitly advance time or run current coroutines when testing complex
+ * coroutine logic, as tasks are queued on the scheduler rather than running eagerly.
+ *
+ * @param size The dimensions of the test's virtual display, defaults to 1024x768 pixels.
+ * @param density The screen density used in the test, defaults to a density of 1f.
+ * @param effectContext The [CoroutineContext] used to run the composition. The context for
+ *   `LaunchedEffect`s and `rememberCoroutineScope` will be derived from this context. If this
+ *   context contains a [TestDispatcher], it is used for composition and the [MainTestClock].
+ *   Otherwise, a [kotlinx.coroutines.test.StandardTestDispatcher] is created and used. This new
+ *   dispatcher will share the [TestCoroutineScheduler] from [effectContext] if one is present.
+ * @param runTestContext The [CoroutineContext] used to create the context to run the test [block].
+ *   By default [block] will run using [kotlinx.coroutines.test.StandardTestDispatcher].
+ *   [runTestContext] and [effectContext] must not share [TestCoroutineScheduler].
+ * @param testTimeout The [Duration] within which the test is expected to complete, otherwise a
+ *   platform specific timeout exception will be thrown.
+ * @param block The suspendable test body.
+ * @return A `TestResult` representing the outcome of the test execution.
+ */
+@OptIn(InternalTestApi::class, InternalComposeUiApi::class)
+@ExperimentalTestApi
+fun runSkikoComposeUiTest(
+    size: Size = Size(1024.0f, 768.0f),
+    density: Density = Density(1f),
+    effectContext: CoroutineContext = EmptyCoroutineContext,
+    runTestContext: CoroutineContext = EmptyCoroutineContext,
+    testTimeout: Duration = Duration.INFINITE,
+    block: suspend SkikoComposeUiTest.() -> Unit
+): TestResult {
+    return SkikoComposeUiTest(
+        width = size.width.roundToInt(),
+        height = size.height.roundToInt(),
+        effectContext = effectContext,
+        testTimeout = testTimeout,
+        runTestContext = runTestContext,
+        density = density,
+        semanticsOwnerListener = null,
+        windowInsets = null,
+        useStandardTestDispatcherForComposition = true,
+    ).runTest(block)
 }

--- a/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.skiko.kt
+++ b/compose/ui/ui-test/src/skikoMain/kotlin/androidx/compose/ui/test/v2/ComposeUiTest.skiko.kt
@@ -18,6 +18,8 @@ package androidx.compose.ui.test.v2
 
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.platform.PlatformContext
+import androidx.compose.ui.platform.PlatformWindowInsets
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
@@ -28,9 +30,11 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.roundToInt
 import kotlin.time.Duration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
 
 /**
  * Sets up the test environment, runs the given [test][block] and then tears down the test

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CustomEffectContextTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CustomEffectContextTest.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.compose.ui.test.v2.runSkikoComposeUiTest
 import androidx.kruth.assertThat
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
@@ -29,7 +30,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 
 /**
  * Tests for passing a custom CoroutineContext when [running a ComposeUiTest][runComposeUiTest].
@@ -113,53 +116,47 @@ class CustomEffectContextTest {
         }
     }
 
-//    @Test
-//    fun customDispatcher_StandardTestDispatcher() {
-//        val counter = TestCounter()
-//
-//        runAndroidComposeUiTest<ComponentActivity>(effectContext = StandardTestDispatcher()) {
-//            // b/328299124: sometimes the timing of window focus can change the order or execution
-//            waitForWindowFocus()
-//
-//            // With a StandardTestDispatcher, both launched effects and the launched coroutine are
-//            // dispatched, meaning they are added to the queue of tasks after all pending tasks.
-//            // Thus, the launched effects run first, and the launched coroutine comes last.
-//
-//            setContent {
-//                LaunchedEffect(Unit) {
-//                    counter.expect(1)
-//                    launch { counter.expect(3) }
-//                }
-//                LaunchedEffect(Unit) { counter.expect(2) }
-//            }
-//            runOnIdle { counter.expect(4) }
-//        }
-//    }
-//
-//    @Test
-//    @OptIn(ExperimentalCoroutinesApi::class)
-//    fun customDispatcher_UnconfinedTestDispatcher() {
-//        val counter = TestCounter()
-//
-//        runAndroidComposeUiTest<ComponentActivity>(effectContext = UnconfinedTestDispatcher()) {
-//            // b/328299124: sometimes the timing of window focus can change the order or execution
-//            waitForWindowFocus()
-//
-//            // With a UnconfinedTestDispatcher, both launched effects and the launched coroutine are
-//            // running unconfined, meaning they are executed immediately, regardless if there are
-//            // pending tasks.
-//            // Thus, the launched coroutine comes before the second launched effect.
-//
-//            setContent {
-//                LaunchedEffect(Unit) {
-//                    counter.expect(1)
-//                    launch { counter.expect(2) }
-//                }
-//                LaunchedEffect(Unit) { counter.expect(3) }
-//            }
-//            runOnIdle { counter.expect(4) }
-//        }
-//    }
+    @Test
+    fun customDispatcher_StandardTestDispatcher() {
+        val counter = TestCounter()
+
+        runSkikoComposeUiTest(effectContext = StandardTestDispatcher()) {
+            // With a StandardTestDispatcher, both launched effects and the launched coroutine are
+            // dispatched, meaning they are added to the queue of tasks after all pending tasks.
+            // Thus, the launched effects run first, and the launched coroutine comes last.
+
+            setContent {
+                LaunchedEffect(Unit) {
+                    counter.expect(1)
+                    launch { counter.expect(3) }
+                }
+                LaunchedEffect(Unit) { counter.expect(2) }
+            }
+            runOnIdle { counter.expect(4) }
+        }
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun customDispatcher_UnconfinedTestDispatcher() {
+        val counter = TestCounter()
+
+        runSkikoComposeUiTest(effectContext = UnconfinedTestDispatcher()) {
+            // With a UnconfinedTestDispatcher, both launched effects and the launched coroutine are
+            // running unconfined, meaning they are executed immediately, regardless if there are
+            // pending tasks.
+            // Thus, the launched coroutine comes before the second launched effect.
+
+            setContent {
+                LaunchedEffect(Unit) {
+                    counter.expect(1)
+                    launch { counter.expect(2) }
+                }
+                LaunchedEffect(Unit) { counter.expect(3) }
+            }
+            runOnIdle { counter.expect(4) }
+        }
+    }
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CustomEffectContextTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/CustomEffectContextTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.withFrameNanos
+import androidx.compose.ui.MotionDurationScale
+import androidx.compose.ui.test.v2.runComposeUiTest
+import androidx.kruth.assertThat
+import kotlin.coroutines.CoroutineContext
+import kotlin.test.Test
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Runnable
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+
+/**
+ * Tests for passing a custom CoroutineContext when [running a ComposeUiTest][runComposeUiTest].
+ * Similar tests are available for ComposeTestRule in compose:ui:ui-test-junit4
+ */
+@OptIn(ExperimentalTestApi::class)
+class CustomEffectContextTest {
+
+    @Test
+    fun effectContextPropagatedToComposition_runComposeUiTest() {
+        val testElement = TestCoroutineContextElement()
+        runComposeUiTest(effectContext = testElement) {
+            lateinit var compositionScope: CoroutineScope
+            setContent { compositionScope = rememberCoroutineScope() }
+
+            runOnIdle {
+                val elementFromComposition =
+                    compositionScope.coroutineContext[TestCoroutineContextElement]
+                assertThat(elementFromComposition).isSameInstanceAs(testElement)
+            }
+        }
+    }
+
+    @Test
+    fun motionDurationScale_defaultValue() = runComposeUiTest {
+        var lastRecordedMotionDurationScale: Float? = null
+        setContent {
+            val context = rememberCoroutineScope().coroutineContext
+            lastRecordedMotionDurationScale = context[MotionDurationScale]?.scaleFactor
+        }
+
+        runOnIdle { assertThat(lastRecordedMotionDurationScale).isNull() }
+    }
+
+    @Test
+    fun motionDurationScale_propagatedToCoroutines() {
+        val motionDurationScale =
+            object : MotionDurationScale {
+                override val scaleFactor: Float
+                    get() = 0f
+            }
+        runComposeUiTest(effectContext = motionDurationScale) {
+            var lastRecordedMotionDurationScale: Float? = null
+            setContent {
+                val context = rememberCoroutineScope().coroutineContext
+                lastRecordedMotionDurationScale = context[MotionDurationScale]?.scaleFactor
+            }
+
+            runOnIdle { assertThat(lastRecordedMotionDurationScale).isEqualTo(0f) }
+        }
+    }
+
+    @Test
+    fun customDispatcher_ignoredWhenNotSubclassOfTestDispatcher() {
+        val notATestDispatcher =
+            object : CoroutineDispatcher() {
+                override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+                    throw AssertionError("This dispatcher should be unused")
+                }
+
+                override fun dispatch(context: CoroutineContext, block: Runnable) {
+                    throw AssertionError("This dispatcher should be unused")
+                }
+
+                @OptIn(ExperimentalCoroutinesApi::class)
+                @Deprecated("override")
+                override fun limitedParallelism(parallelism: Int): CoroutineDispatcher {
+                    throw AssertionError("This dispatcher should be unused")
+                }
+            }
+
+        // The custom dispatcher is not a TestDispatcher, so should be completely discarded.
+        // The custom dispatcher throws when it is used, so running the below is enough
+        runComposeUiTest(effectContext = notATestDispatcher) {
+            setContent {
+                LaunchedEffect(Unit) {
+                    withFrameNanos {}
+                    launch {}
+                }
+            }
+        }
+    }
+
+//    @Test
+//    fun customDispatcher_StandardTestDispatcher() {
+//        val counter = TestCounter()
+//
+//        runAndroidComposeUiTest<ComponentActivity>(effectContext = StandardTestDispatcher()) {
+//            // b/328299124: sometimes the timing of window focus can change the order or execution
+//            waitForWindowFocus()
+//
+//            // With a StandardTestDispatcher, both launched effects and the launched coroutine are
+//            // dispatched, meaning they are added to the queue of tasks after all pending tasks.
+//            // Thus, the launched effects run first, and the launched coroutine comes last.
+//
+//            setContent {
+//                LaunchedEffect(Unit) {
+//                    counter.expect(1)
+//                    launch { counter.expect(3) }
+//                }
+//                LaunchedEffect(Unit) { counter.expect(2) }
+//            }
+//            runOnIdle { counter.expect(4) }
+//        }
+//    }
+//
+//    @Test
+//    @OptIn(ExperimentalCoroutinesApi::class)
+//    fun customDispatcher_UnconfinedTestDispatcher() {
+//        val counter = TestCounter()
+//
+//        runAndroidComposeUiTest<ComponentActivity>(effectContext = UnconfinedTestDispatcher()) {
+//            // b/328299124: sometimes the timing of window focus can change the order or execution
+//            waitForWindowFocus()
+//
+//            // With a UnconfinedTestDispatcher, both launched effects and the launched coroutine are
+//            // running unconfined, meaning they are executed immediately, regardless if there are
+//            // pending tasks.
+//            // Thus, the launched coroutine comes before the second launched effect.
+//
+//            setContent {
+//                LaunchedEffect(Unit) {
+//                    counter.expect(1)
+//                    launch { counter.expect(2) }
+//                }
+//                LaunchedEffect(Unit) { counter.expect(3) }
+//            }
+//            runOnIdle { counter.expect(4) }
+//        }
+//    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun scheduler_usedWhenPresent() {
+        val scheduler = TestCoroutineScheduler()
+        val startTime = scheduler.currentTime
+
+        // We don't need any content, we only need to trigger the scheduler
+        runComposeUiTest(scheduler) {
+            setContent { rememberCoroutineScope().launch { withFrameNanos {} } }
+        }
+
+        // Only if it is used will the scheduler's time be changed
+        assertThat(scheduler.currentTime).isNotEqualTo(startTime)
+    }
+
+    private class TestCoroutineContextElement : CoroutineContext.Element {
+        override val key: CoroutineContext.Key<*>
+            get() = Key
+
+        companion object Key : CoroutineContext.Key<TestCoroutineContextElement>
+    }
+}

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestBasicsTest.kt
@@ -44,19 +44,31 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 
+@OptIn(ExperimentalTestApi::class)
+class TestBasicsTest : AbstractTestBasicsTest(
+    runUiTest = { runComposeUiTest(block = it) }
+)
+
+@OptIn(ExperimentalTestApi::class)
+class TestBasicsTestV2 : AbstractTestBasicsTest(
+    runUiTest = { androidx.compose.ui.test.v2.runComposeUiTest(block = it) }
+)
 
 /**
  * Basic tests of the testing framework itself.
  */
 @OptIn(ExperimentalTestApi::class)
-class TestBasicsTest {
+abstract class AbstractTestBasicsTest(
+    private val runUiTest: (ComposeUiTest.() -> Unit) -> TestResult
+) {
 
     // See https://github.com/JetBains/compose-multiplatform/issues/3117
     @Test
     fun recompositionCompletesBeforeSetContentReturns() = repeat(100) {
-        runComposeUiTest {
+        runUiTest {
             var globalValue by atomic(0)
             setContent {
                 var localValue by remember { mutableStateOf(0) }
@@ -80,7 +92,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun inputEventAdvancesClock() = runComposeUiTest {
+    fun inputEventAdvancesClock() = runUiTest {
         setContent {
             Box(Modifier.testTag("box").size(100.dp))
         }
@@ -92,7 +104,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun obtainingSemanticsNodeInteractionWaitsUntilIdle() = runComposeUiTest {
+    fun obtainingSemanticsNodeInteractionWaitsUntilIdle() = runUiTest {
         var text by mutableStateOf("1")
 
         setContent {
@@ -105,7 +117,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun testCaptureToImage() = runComposeUiTest {
+    fun testCaptureToImage() = runUiTest {
         val color = Color.Green
         setContent {
             Box(Modifier.testTag("box").size(20.dp).background(color))
@@ -126,7 +138,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun infiniteDelayLoopInLaunchedEffectDoesNotHang() = runComposeUiTest {
+    fun infiniteDelayLoopInLaunchedEffectDoesNotHang() = runUiTest {
         runTest(timeout = 500.milliseconds) {
             var runDelayLoop by mutableStateOf(false)
             var effectLaunched = false
@@ -152,7 +164,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun delayInLaunchedEffectIsExecutedAfterAdvancingClock() = runComposeUiTest {
+    fun delayInLaunchedEffectIsExecutedAfterAdvancingClock() = runUiTest {
         var value = 0
         mainClock.autoAdvance = false
         setContent {
@@ -174,7 +186,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun advancingClockCausesRecompositions() = runComposeUiTest {
+    fun advancingClockCausesRecompositions() = runUiTest {
         var value by mutableStateOf(0)
         val compositionValues = mutableListOf<Int>()
         setContent {
@@ -192,7 +204,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun advancingClockByLessThanFrameDoesNotRecompose() = runComposeUiTest {
+    fun advancingClockByLessThanFrameDoesNotRecompose() = runUiTest {
         mainClock.autoAdvance = false
         var value by mutableIntStateOf(1)
         var compositionValue = 0
@@ -208,7 +220,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun launchedEffectsRunAfterComposition() = runComposeUiTest {
+    fun launchedEffectsRunAfterComposition() = runUiTest {
         val actions = mutableListOf<String>()
         setContent {
             LaunchedEffect(Unit) {
@@ -221,7 +233,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun waitForIdleDoesNotAdvanceClockIfAlreadyIdle() = runComposeUiTest {
+    fun waitForIdleDoesNotAdvanceClockIfAlreadyIdle() = runUiTest {
         setContent { }
 
         val initialTime = mainClock.currentTime
@@ -231,7 +243,7 @@ class TestBasicsTest {
 
     @Test
     @IgnoreWebTest
-    fun runOnIdleExecutesOnUiThread() = runComposeUiTest {
+    fun runOnIdleExecutesOnUiThread() = runUiTest {
         setContent { }
         runOnIdle {
             assertTrue(isOnUiThread())
@@ -239,7 +251,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun runOnIdleExecutesWhenIdle() = runComposeUiTest {
+    fun runOnIdleExecutesWhenIdle() = runUiTest {
         var sourceValue by mutableIntStateOf(0)
         var targetValue = 0
         setContent {
@@ -254,7 +266,7 @@ class TestBasicsTest {
     }
 
     @Test
-    fun runOnIdleDoesNotWaitForIdleAfterward() = runComposeUiTest {
+    fun runOnIdleDoesNotWaitForIdleAfterward() = runUiTest {
         var sourceValue by mutableIntStateOf(0)
         var targetValue = 0
         setContent {
@@ -271,7 +283,7 @@ class TestBasicsTest {
     @Test
     fun emptyTestPerformance() = runTest(timeout = 6.seconds) {
         repeat(100) {
-            runComposeUiTest {
+            runUiTest {
                 setContent { }
             }
         }
@@ -279,16 +291,17 @@ class TestBasicsTest {
 
     // The two tests below work together to make sure that the initial input is reset between tests
     @Test
-    fun inputModeResetBetweenTests1() = runComposeUiTest {
+    fun inputModeResetBetweenTests1() = runUiTest {
         var initialInputMode: InputMode? = null
         var inputModeAfterwards: InputMode? = null
         setContent {
-            initialInputMode = LocalInputModeManager.current.inputMode
-            LocalInputModeManager.current.apply {
-                requestInputMode(
+            val inputModeManager = LocalInputModeManager.current
+            initialInputMode = inputModeManager.inputMode
+            LaunchedEffect(Unit) {
+                inputModeManager.requestInputMode(
                     if (initialInputMode == InputMode.Touch) InputMode.Keyboard else InputMode.Touch
                 )
-                inputModeAfterwards = inputMode
+                inputModeAfterwards = inputModeManager.inputMode
             }
         }
 
@@ -303,16 +316,17 @@ class TestBasicsTest {
     }
 
     @Test
-    fun inputModeResetBetweenTests2() = runComposeUiTest {
+    fun inputModeResetBetweenTests2() = runUiTest {
         var initialInputMode: InputMode? = null
         var inputModeAfterwards: InputMode? = null
         setContent {
-            initialInputMode = LocalInputModeManager.current.inputMode
-            LocalInputModeManager.current.apply {
-                requestInputMode(
+            val inputModeManager = LocalInputModeManager.current
+            initialInputMode = inputModeManager.inputMode
+            LaunchedEffect(Unit) {
+                inputModeManager.requestInputMode(
                     if (initialInputMode == InputMode.Touch) InputMode.Keyboard else InputMode.Touch
                 )
-                inputModeAfterwards = inputMode
+                inputModeAfterwards = inputModeManager.inputMode
             }
         }
 

--- a/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestCounter.kt
+++ b/compose/ui/ui-test/src/skikoTest/kotlin/androidx/compose/ui/test/TestCounter.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.test
+
+import kotlin.test.fail
+
+/**
+ * Asserts that [expect] calls occur in a specific order. Useful for coroutine dispatching tests.
+ */
+internal class TestCounter {
+    private var count = 0
+
+    fun expect(checkpoint: Int, message: String = "(no message)") {
+        // `checkpoint` is the "expected", but keeping the name for API clarity
+        val actual = count + 1
+        if (checkpoint != actual) {
+            fail("events out of order: expected=$checkpoint, actual=$actual, $message")
+        }
+        count = actual
+    }
+}

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -60,7 +60,7 @@ import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInputSelection
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.toDpSize
 import androidx.compose.ui.unit.DpOffset

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/platform/AccessibilityTest.kt
@@ -622,7 +622,7 @@ private fun runDesktopA11yTest(block: suspend ComposeA11yTestScope.() -> Unit) {
 
     runInternalSkikoComposeUiTest(
         semanticsOwnerListener = sceneAccessibility,
-        coroutineDispatcher = testDispatcher
+        effectContext = testDispatcher
     ) {
         block(
             ComposeA11yTestScope(

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
@@ -235,7 +235,7 @@ class GraphicsLayerRegressionTest {
     @OptIn(InternalTestApi::class)
     private fun runLayerTest(body: suspend SkikoComposeUiTest.() -> Unit) {
         runInternalSkikoComposeUiTest(
-            coroutineDispatcher = StandardTestDispatcher()
+            useStandardTestDispatcherForComposition = true
         ) {
             runOnUiThread {
                 runTest(timeout = 10.seconds) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.SkikoComposeUiTest
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/graphics/GraphicsLayerRegressionTest.kt
@@ -234,9 +234,7 @@ class GraphicsLayerRegressionTest {
 
     @OptIn(InternalTestApi::class)
     private fun runLayerTest(body: suspend SkikoComposeUiTest.() -> Unit) {
-        runInternalSkikoComposeUiTest(
-            useStandardTestDispatcherForComposition = true
-        ) {
+        runInternalSkikoComposeUiTest {
             runOnUiThread {
                 runTest(timeout = 10.seconds) {
                     body()

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/WindowInsetsTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/layout/WindowInsetsTest.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.platform.PlatformInsets
 import androidx.compose.ui.platform.PlatformWindowInsets
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -83,7 +83,7 @@ class RenderPhasesTest {
      */
     @Test
     fun testBasicOrder() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         mainClock.autoAdvance = false
 
@@ -146,7 +146,7 @@ class RenderPhasesTest {
      */
     @Test
     fun syntheticEventsDispatchedAfterEffects() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         val phases = mutableListOf<String>()
         var showNewBox by mutableStateOf(false)
@@ -186,7 +186,7 @@ class RenderPhasesTest {
      */
     @Test
     fun coroutinesDispatchedAfterDraw() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         mainClock.autoAdvance = false
 
@@ -239,7 +239,7 @@ class RenderPhasesTest {
 
     @Test
     fun layoutScopeInvalidationDoesNotCauseRemeasure() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         var measureCount = 0
         var layoutCount = 0
@@ -273,7 +273,7 @@ class RenderPhasesTest {
     @Test
     fun readingStateInLayoutModifiedByMeasureDoesNotCauseInfiniteRemeasureAndLayout() {
         // https://github.com/JetBrains/compose-multiplatform/issues/4760
-        runInternalSkikoComposeUiTest(coroutineDispatcher = StandardTestDispatcher()) {
+        runInternalSkikoComposeUiTest(useStandardTestDispatcherForComposition = true) {
             mainClock.autoAdvance = false
             val state = mutableStateOf(0)
             // Don't read the state initially so that the test fails rather than getting stuck
@@ -312,7 +312,7 @@ class RenderPhasesTest {
 
     @Test
     fun measureAndLayoutRunsAgainBeforeDraw() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         // Android runs measureAndLayout again right before drawing; validate this behavior.
         val state = mutableStateOf(0)
@@ -343,7 +343,7 @@ class RenderPhasesTest {
 
     @Test
     fun dragPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         val scrollState = ScrollState(0)
         setContent {
@@ -373,7 +373,7 @@ class RenderPhasesTest {
 
     @Test
     fun scrollPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         val scrollState = ScrollState(0)
         setContent {
@@ -397,7 +397,7 @@ class RenderPhasesTest {
 
     @Test
     fun panPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         val scrollState = ScrollState(0)
         setContent {
@@ -421,7 +421,7 @@ class RenderPhasesTest {
 
     @Test
     fun scalePointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         var scale = 1f
         setContent {
@@ -449,7 +449,7 @@ class RenderPhasesTest {
 
     @Test
     fun pointerPressEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         var pointerHandledAfterDelay by mutableStateOf(false)
         setContent {
@@ -482,7 +482,7 @@ class RenderPhasesTest {
 
     @Test
     fun pointerScrollEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         var pointerHandledAfterDelay by mutableStateOf(false)
         setContent {
@@ -514,7 +514,7 @@ class RenderPhasesTest {
 
     @Test
     fun keyEventsProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         var keyHandledAfterDelay by mutableStateOf(false)
         setContent {
@@ -556,7 +556,7 @@ class RenderPhasesTest {
 
     @Test
     fun rotaryEventsProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         var eventHandledAfterDelay by mutableStateOf(false)
         setContent {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -58,7 +58,6 @@ import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.runInternalSkikoComposeUiTest
 import androidx.compose.ui.touch
 import androidx.compose.ui.unit.dp
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -66,7 +65,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.StandardTestDispatcher
 
 /**
  * Tests the ordering of the phases of the [BaseComposeScene.render] loop.
@@ -82,9 +80,7 @@ class RenderPhasesTest {
      * 5. Effects launched in the composition.
      */
     @Test
-    fun testBasicOrder() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun testBasicOrder() = runInternalSkikoComposeUiTest {
         mainClock.autoAdvance = false
 
         val phases = mutableListOf<String>()
@@ -93,7 +89,7 @@ class RenderPhasesTest {
         setContent {
             LaunchedEffect(Unit) {
                 var stop = false
-                while(!stop) {
+                while (!stop) {
                     withFrameNanos {
                         if (logPhases) {
                             phases.add("frame")
@@ -145,9 +141,7 @@ class RenderPhasesTest {
      * Test that synthetic events are delivered after effects have run.
      */
     @Test
-    fun syntheticEventsDispatchedAfterEffects() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun syntheticEventsDispatchedAfterEffects() = runInternalSkikoComposeUiTest {
         val phases = mutableListOf<String>()
         var showNewBox by mutableStateOf(false)
 
@@ -185,9 +179,7 @@ class RenderPhasesTest {
      * correct order, and only after the draw phase.
      */
     @Test
-    fun coroutinesDispatchedAfterDraw() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun coroutinesDispatchedAfterDraw() = runInternalSkikoComposeUiTest {
         mainClock.autoAdvance = false
 
         val phases = mutableListOf<String>()
@@ -196,7 +188,7 @@ class RenderPhasesTest {
             val coroutineScope = rememberCoroutineScope()
 
             LaunchedEffect(Unit) {
-                while(true) {
+                while (true) {
                     withFrameMillis {
                         if (startTest) {
                             coroutineScope.launch {
@@ -232,15 +224,18 @@ class RenderPhasesTest {
         startTest = true
         mainClock.advanceTimeByFrame()
         assertContentEquals(
-            expected = listOf("draw", "launchedWithFrame", "launchedFromComposition", "launchedFromEffect"),
+            expected = listOf(
+                "draw",
+                "launchedWithFrame",
+                "launchedFromComposition",
+                "launchedFromEffect"
+            ),
             actual = phases
         )
     }
 
     @Test
-    fun layoutScopeInvalidationDoesNotCauseRemeasure() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun layoutScopeInvalidationDoesNotCauseRemeasure() = runInternalSkikoComposeUiTest {
         var measureCount = 0
         var layoutCount = 0
 
@@ -273,7 +268,7 @@ class RenderPhasesTest {
     @Test
     fun readingStateInLayoutModifiedByMeasureDoesNotCauseInfiniteRemeasureAndLayout() {
         // https://github.com/JetBrains/compose-multiplatform/issues/4760
-        runInternalSkikoComposeUiTest(useStandardTestDispatcherForComposition = true) {
+        runInternalSkikoComposeUiTest {
             mainClock.autoAdvance = false
             val state = mutableStateOf(0)
             // Don't read the state initially so that the test fails rather than getting stuck
@@ -285,7 +280,7 @@ class RenderPhasesTest {
                         val prevValue = Snapshot.withoutReadObservation {
                             state.value
                         }
-                        state.value = prevValue+1
+                        state.value = prevValue + 1
                         layout(100, 100) {
                             if (readStateInLayout) {
                                 state.value  // Read the state value!
@@ -311,9 +306,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun measureAndLayoutRunsAgainBeforeDraw() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun measureAndLayoutRunsAgainBeforeDraw() = runInternalSkikoComposeUiTest {
         // Android runs measureAndLayout again right before drawing; validate this behavior.
         val state = mutableStateOf(0)
         val events = mutableListOf<String>()
@@ -342,9 +335,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun dragPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun dragPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest {
         val scrollState = ScrollState(0)
         setContent {
             Box(modifier = Modifier.size(100.dp).verticalScroll(scrollState)) {
@@ -372,9 +363,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun scrollPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun scrollPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest {
         val scrollState = ScrollState(0)
         setContent {
             Box(modifier = Modifier.size(100.dp).verticalScroll(scrollState)) {
@@ -396,9 +385,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun panPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun panPointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest {
         val scrollState = ScrollState(0)
         setContent {
             Box(modifier = Modifier.size(100.dp).verticalScroll(scrollState)) {
@@ -420,9 +407,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun scalePointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun scalePointerEventHandlesScrollUpdatesSynchronously() = runInternalSkikoComposeUiTest {
         var scale = 1f
         setContent {
             Box(modifier = Modifier.size(100.dp).onPointerEvent(PointerEventType.ScaleChange) {
@@ -448,9 +433,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun pointerPressEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun pointerPressEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest {
         var pointerHandledAfterDelay by mutableStateOf(false)
         setContent {
             val coroutineScope = rememberCoroutineScope()
@@ -481,9 +464,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun pointerScrollEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun pointerScrollEventProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest {
         var pointerHandledAfterDelay by mutableStateOf(false)
         setContent {
             val coroutineScope = rememberCoroutineScope()
@@ -513,9 +494,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun keyEventsProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun keyEventsProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest {
         var keyHandledAfterDelay by mutableStateOf(false)
         setContent {
             val coroutineScope = rememberCoroutineScope()
@@ -555,9 +534,7 @@ class RenderPhasesTest {
     }
 
     @Test
-    fun rotaryEventsProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun rotaryEventsProcessesScheduledCoroutines() = runInternalSkikoComposeUiTest {
         var eventHandledAfterDelay by mutableStateOf(false)
         setContent {
             val coroutineScope = rememberCoroutineScope()

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/platform/RenderPhasesTest.kt
@@ -55,7 +55,7 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performMouseInput
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.touch
 import androidx.compose.ui.unit.dp
 import kotlin.test.Test

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -241,9 +241,7 @@ class DialogTest {
 
     @OptIn(InternalTestApi::class)
     @Test
-    fun dialogCompositionSubscribesToStateChangesImmediately() = runInternalSkikoComposeUiTest(
-        useStandardTestDispatcherForComposition = true
-    ) {
+    fun dialogCompositionSubscribesToStateChangesImmediately() = runInternalSkikoComposeUiTest {
         // https://github.com/JetBrains/compose-multiplatform/issues/4609
         var showDialog by mutableStateOf(false)
         var lastValueInComposition: Int? = null

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -242,7 +242,7 @@ class DialogTest {
     @OptIn(InternalTestApi::class)
     @Test
     fun dialogCompositionSubscribesToStateChangesImmediately() = runInternalSkikoComposeUiTest(
-        coroutineDispatcher = StandardTestDispatcher()
+        useStandardTestDispatcherForComposition = true
     ) {
         // https://github.com/JetBrains/compose-multiplatform/issues/4609
         var showDialog by mutableStateOf(false)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/DialogTest.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.test.InternalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertPositionInRootIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.touch
 import androidx.compose.ui.unit.IntSize

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -61,7 +61,7 @@ import androidx.compose.ui.test.assertPositionInRootIsEqualTo
 import androidx.compose.ui.test.assertWidthIsEqualTo
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.runComposeUiTest
-import androidx.compose.ui.test.runInternalSkikoComposeUiTest
+import androidx.compose.ui.test.v2.runInternalSkikoComposeUiTest
 import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.touch
 import androidx.compose.ui.unit.Density


### PR DESCRIPTION
Standardizing the testing infrastructure around StandardTestDispatcher and introducing "v2" test APIs to improve composition and coroutine handling in tests. It also includes refactoring of the recomposerCoroutineScope and adds validation for custom effect contexts.

Fixes:
[CMP-9519](https://youtrack.jetbrains.com/issue/CMP-9519) Implement ComposeUiTest v2 APIs and migrate the tests
[CMP-2960](https://youtrack.jetbrains.com/issue/CMP-2960) Support runComposeUiTest.effectContext argument
[CMP-8849](https://youtrack.jetbrains.com/issue/CMP-8849) Support to run on a StandardTestDispatcher

## Release Notes
### Features - Multiple Platforms
- Support v2 Compose UI Tests APIs on non-android targets which uses `StandardTestDispatcher` by default instead of `UnconfinedTestDispatcher`
- Support a customization of `effectContext` in Compose UI tests

### Migration Notes - Multiple Platforms
- `runComposeUiTest`, `runSkikoComposeUiTest`, `runDesktopComposeUiTest` are deprecated in favor v2 versions
