### PR TITLE
Fixed autocorrection crash with usingNativeTextInput enabled

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -908,6 +908,10 @@ internal class UIKitTextInputService(
             }
             val currentTextLayoutResult = textLayoutResult ?: return emptyList()
 
+            // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+            // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+            if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return emptyList()
+
             val startSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.start)
             val endSelectionHandleRect = currentTextLayoutResult.getCursorRect(range.end)
 
@@ -996,6 +1000,10 @@ internal class UIKitTextInputService(
             }
             val currentTextLayoutResult = textLayoutResult ?: return null
 
+            // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+            // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+            if (range.end > currentTextLayoutResult.multiParagraph.intrinsics.annotatedString.length) return null
+
             val startHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.start)
             val endHandleLineNumber = currentTextLayoutResult.getLineForOffset(range.end)
 
@@ -1074,12 +1082,7 @@ internal class UIKitTextInputService(
         }
 
         private fun isIncorrect(range: TextRange): Boolean {
-            return range.start < 0 ||
-                range.end > endOfDocument() ||
-                range.start > range.end ||
-                // Layout in native text input mode may be outdated, so not checking this may cause OOB error
-                // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
-                range.end > (textLayoutResult?.multiParagraph?.intrinsics?.annotatedString?.length ?: 0)
+            return range.start < 0 || range.end > endOfDocument() || range.start > range.end
         }
     }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitTextInputService.ios.kt
@@ -1074,7 +1074,12 @@ internal class UIKitTextInputService(
         }
 
         private fun isIncorrect(range: TextRange): Boolean {
-            return range.start < 0 || range.end > endOfDocument() || range.start > range.end
+            return range.start < 0 ||
+                range.end > endOfDocument() ||
+                range.start > range.end ||
+                // Layout in native text input mode may be outdated, so not checking this may cause OOB error
+                // This workaround should be deleted after https://youtrack.jetbrains.com/issue/CMP-9767/
+                range.end > (textLayoutResult?.multiParagraph?.intrinsics?.annotatedString?.length ?: 0)
         }
     }
 }


### PR DESCRIPTION
Workaround for the crash with iOS autocorrection caused by abundant calls of `selectionRects` with bad `range` parameter

Fixes: 
[CMP-9882](https://youtrack.jetbrains.com/issue/CMP-9882) [ios]. niti. crash after unknown actions with flag enabled

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix crash after applying autocorrection change or keyboard suggestion in `TextField` when `usingNativeTextInput` flag is enabled