### PR TITLE
Fix the regression with keyboard autosuggestions during typing in the non-niti TextFields

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
@@ -568,17 +568,6 @@ internal class IntermediateTextInputUIView(
             )
             val rects = input?.selectionDpRectsForRange(textRange) ?: return fallbackList
 
-            // HACK: On iOS 17+, selection changes are not submitted during selection interaction.
-            if (available(OS.Ios to OSVersion(major = 17)) &&
-                touchesTrackerGestureRecognizer.isTrackingTouches
-            ) {
-                shouldPerformSelectionNotifications = false
-                if (input?.getSelectedTextRange() != textRange) {
-                    input?.setSelectedTextRange(textRange)
-                }
-                shouldPerformSelectionNotifications = true
-            }
-
             return rects.fastMap { IntermediateTextSelectionRect(it) }
         } else {
             return listOf<UITextSelectionRect>()
@@ -663,24 +652,18 @@ internal class IntermediateTextInputUIView(
         _inputDelegate?.textDidChange(this)
     }
 
-    private var shouldPerformSelectionNotifications: Boolean = usingNativeTextInput
-
     /**
      * Call when something changes in text data
      */
     fun selectionWillChange() {
-        if (shouldPerformSelectionNotifications) {
-            _inputDelegate?.selectionWillChange(this)
-        }
+        _inputDelegate?.selectionWillChange(this)
     }
 
     /**
      * Call when something changes in text data
      */
     fun selectionDidChange() {
-        if (shouldPerformSelectionNotifications) {
-            _inputDelegate?.selectionDidChange(this)
-        }
+        _inputDelegate?.selectionDidChange(this)
     }
 
     override fun isUserInteractionEnabled(): Boolean = usingNativeTextInput


### PR DESCRIPTION
The bug was due to not calling Text Input Delegate `selectionWillChange` and `selectionDidChange` calls, because they were wrongly hidden under `usingNativeTextInput` flag (they shouldn't)
Deleted hack with Text Input Delegate calls (should be not required anymore), restored the original behavior.

Fixes:
[CMP-9991 [iOS] TextField. Autocorrect doesn't work correctly](https://youtrack.jetbrains.com/issue/CMP-9991)

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix regression with the outdated and wrongly inserted keyboard suggestions in `BasicTextField(TextFieldValue)` and `BasicTextField(TextFieldState)`
