### PR TITLE
Add missing overscroll parameter to CoreTextField scroll modifier

### DIFF
--- a/compose/foundation/foundation/src/androidDeviceTest/kotlin/androidx/compose/foundation/textfield/TextFieldScrollTest.kt
+++ b/compose/foundation/foundation/src/androidDeviceTest/kotlin/androidx/compose/foundation/textfield/TextFieldScrollTest.kt
@@ -46,6 +46,7 @@ import androidx.compose.testutils.assertPixels
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
@@ -54,6 +55,7 @@ import androidx.compose.ui.layout.Measurable
 import androidx.compose.ui.layout.MeasurePolicy
 import androidx.compose.ui.layout.MeasureResult
 import androidx.compose.ui.layout.MeasureScope
+import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.node.Ref
 import androidx.compose.ui.platform.InspectableValue
 import androidx.compose.ui.platform.LocalDensity
@@ -436,6 +438,7 @@ class TextFieldScrollTest : FocusedWindowTest {
                         remember { scrollerPosition },
                         TextFieldValue(text),
                         VisualTransformation.None,
+                        null,
                     ) {
                         textLayoutResultRef.value
                     },
@@ -486,6 +489,7 @@ class TextFieldScrollTest : FocusedWindowTest {
                         remember { scrollerPosition },
                         TextFieldValue(text),
                         VisualTransformation.None,
+                        null,
                     ) {
                         textLayoutResultRef.value
                     },
@@ -622,6 +626,7 @@ class TextFieldScrollTest : FocusedWindowTest {
 
         rule.onNodeWithTag(TextfieldTag).performTouchInput { swipeRight() }
         rule.runOnIdle {
+            assertThat(overscrollEffect.drawCallsCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToScrollCallCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToFlingCallCount).isGreaterThan(0)
         }
@@ -641,6 +646,7 @@ class TextFieldScrollTest : FocusedWindowTest {
 
         rule.onNodeWithTag(TextfieldTag).performTouchInput { swipeDown() }
         rule.runOnIdle {
+            assertThat(overscrollEffect.drawCallsCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToScrollCallCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToFlingCallCount).isGreaterThan(0)
         }
@@ -715,6 +721,7 @@ class TextFieldScrollTest : FocusedWindowTest {
                         remember { scrollerPosition },
                         TextFieldValue(text),
                         VisualTransformation.None,
+                        overscrollEffect,
                         { textLayoutResultRef.value },
                     ),
         )
@@ -722,8 +729,16 @@ class TextFieldScrollTest : FocusedWindowTest {
 }
 
 private class CustomEffect : OverscrollEffect {
+    inner class OverscrollNode : Modifier.Node(), DrawModifierNode {
+        override fun ContentDrawScope.draw() {
+            drawCallsCount++
+            drawContent()
+        }
+    }
+
     override val isInProgress = false
-    override val node = object : Modifier.Node() {}
+    override val node = OverscrollNode()
+    var drawCallsCount = 0
     var applyToScrollCallCount = 0
     var applyToFlingCallCount = 0
 

--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.android.kt
@@ -26,12 +26,14 @@ internal actual fun Modifier.textFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?,
 ): Modifier =
     defaultTextFieldScroll(
         scrollerPosition,
         textFieldValue,
         visualTransformation,
+        overscrollEffect,
         textLayoutResultProvider,
     )
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -562,7 +562,6 @@ internal fun CoreTextField(
                         maxLines = maxLines,
                         softWrap = softWrap,
                     )
-                    .overscroll(overscrollEffect)
                     .textFieldScroll(
                         scrollerPosition = scrollerPosition,
                         textFieldValue = value,

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/CoreTextField.kt
@@ -567,6 +567,7 @@ internal fun CoreTextField(
                         scrollerPosition = scrollerPosition,
                         textFieldValue = value,
                         visualTransformation = visualTransformation,
+                        overscrollEffect = overscrollEffect,
                         textLayoutResultProvider = { state.layoutResult },
                     )
                     .then(cursorModifier)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.kt
@@ -22,7 +22,7 @@ import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.overscroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.derivedStateOf
@@ -119,6 +119,7 @@ internal expect fun Modifier.textFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?,
 ): Modifier
 
@@ -126,6 +127,7 @@ internal fun Modifier.defaultTextFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?,
 ): Modifier {
     val orientation = scrollerPosition.orientation
@@ -151,7 +153,7 @@ internal fun Modifier.defaultTextFieldScroll(
                     textLayoutResultProvider,
                 )
         }
-    return this.clipToBounds().then(layout)
+    return this.overscroll(overscrollEffect).clipToBounds().then(layout)
 }
 
 private data class VerticalScrollLayoutModifier(

--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.desktop.kt
@@ -13,10 +13,12 @@ internal actual fun Modifier.textFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?
 ): Modifier = defaultTextFieldScroll(
     scrollerPosition,
     textFieldValue,
     visualTransformation,
+    overscrollEffect,
     textLayoutResultProvider,
 )

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.ios.kt
@@ -19,6 +19,7 @@ package androidx.compose.foundation.text
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.OverscrollEffect
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.overscroll
 import androidx.compose.foundation.rememberOverscrollEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -47,6 +48,7 @@ internal actual fun Modifier.textFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?
 ): Modifier {
     val orientation = scrollerPosition.orientation
@@ -72,7 +74,7 @@ internal actual fun Modifier.textFieldScroll(
                 textLayoutResultProvider
             )
     }
-    return this.clipToBounds().then(layout)
+    return this.overscroll(overscrollEffect).clipToBounds().then(layout)
 }
 
 private data class IOSVerticalScrollLayoutModifier(

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.macos.kt
@@ -31,10 +31,12 @@ internal actual fun Modifier.textFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?
 ): Modifier = defaultTextFieldScroll(
     scrollerPosition,
     textFieldValue,
     visualTransformation,
+    overscrollEffect,
     textLayoutResultProvider,
 )

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldScrollTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/copyPasteAndroidTests/textfield/TextFieldScrollTest.kt
@@ -46,7 +46,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.layout.IntrinsicMeasurable
 import androidx.compose.ui.layout.IntrinsicMeasureScope
 import androidx.compose.ui.layout.Layout
@@ -333,6 +335,7 @@ class TextFieldScrollTest : FocusedWindowTest {
                         remember { scrollerPosition },
                         TextFieldValue(text),
                         VisualTransformation.None,
+                        null,
                     ) {
                         textLayoutResultRef.value
                     },
@@ -383,6 +386,7 @@ class TextFieldScrollTest : FocusedWindowTest {
                         remember { scrollerPosition },
                         TextFieldValue(text),
                         VisualTransformation.None,
+                        null,
                     ) {
                         textLayoutResultRef.value
                     },
@@ -520,6 +524,7 @@ class TextFieldScrollTest : FocusedWindowTest {
 
         onNodeWithTag(TextfieldTag).performTouchInput { swipeRight() }
         runOnIdle {
+            assertThat(overscrollEffect.drawCallsCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToScrollCallCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToFlingCallCount).isGreaterThan(0)
         }
@@ -539,6 +544,7 @@ class TextFieldScrollTest : FocusedWindowTest {
 
         onNodeWithTag(TextfieldTag).performTouchInput { swipeDown() }
         runOnIdle {
+            assertThat(overscrollEffect.drawCallsCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToScrollCallCount).isGreaterThan(0)
             assertThat(overscrollEffect.applyToFlingCallCount).isGreaterThan(0)
         }
@@ -609,6 +615,7 @@ class TextFieldScrollTest : FocusedWindowTest {
                         remember { scrollerPosition },
                         TextFieldValue(text),
                         VisualTransformation.None,
+                        overscrollEffect,
                         { textLayoutResultRef.value },
                     ),
         )
@@ -616,8 +623,16 @@ class TextFieldScrollTest : FocusedWindowTest {
 }
 
 private class CustomEffect : OverscrollEffect {
+    inner class OverscrollNode : Modifier.Node(), DrawModifierNode {
+        override fun ContentDrawScope.draw() {
+            drawCallsCount++
+            drawContent()
+        }
+    }
+
     override val isInProgress = false
-    override val node = object : Modifier.Node() {}
+    override val node = OverscrollNode()
+    var drawCallsCount = 0
     var applyToScrollCallCount = 0
     var applyToFlingCallCount = 0
 

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/TextFieldScroll.web.kt
@@ -31,10 +31,12 @@ internal actual fun Modifier.textFieldScroll(
     scrollerPosition: TextFieldScrollerPosition,
     textFieldValue: TextFieldValue,
     visualTransformation: VisualTransformation,
+    overscrollEffect: OverscrollEffect?,
     textLayoutResultProvider: () -> TextLayoutResultProxy?
 ): Modifier = defaultTextFieldScroll(
     scrollerPosition,
     textFieldValue,
     visualTransformation,
+    overscrollEffect,
     textLayoutResultProvider,
 )


### PR DESCRIPTION
Pass the overscroll effect to the `Modifier.textFieldScroll` to add the corresponding overscroll effect node to the hierarchy.

Test: TextFieldScrollTest
Change-Id: [Iddf048257ae9ae8fbe10e2e1a2b411c6517c80e3](https://android-review.googlesource.com/q/Iddf048257ae9ae8fbe10e2e1a2b411c6517c80e3)

## Release Notes
N/A