### PR TITLE
Add ctrl/cmd-home/end key mappings for text fields

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/input/TextFieldKeyEventTest.kt
@@ -502,6 +502,46 @@ class TextFieldKeyEventTest {
             expectedText("hello")
         }
 
+    @Test
+    fun textField_ctrlHome_nonMacOs() =
+        singleKeyStrokeTest(
+            keyMappings = listOf(NonMacOsKeyMapping),
+            initText = "aaa\nbbb\nccc\nddd",
+            initSelection = TextRange(7),
+            keys = Key.CtrlLeft + Key.MoveHome,
+            expectedSelection = TextRange(0),
+        )
+
+    @Test
+    fun textField_ctrlEnd_nonMacOs() =
+        singleKeyStrokeTest(
+            keyMappings = listOf(NonMacOsKeyMapping),
+            initText = "aaa\nbbb\nccc\nddd",
+            initSelection = TextRange(7),
+            keys = Key.CtrlLeft + Key.MoveEnd,
+            expectedSelection = TextRange("aaa\nbbb\nccc\nddd".length),
+        )
+
+    @Test
+    fun textField_cmdHome_macOs() =
+        singleKeyStrokeTest(
+            keyMappings = listOf(MacOsKeyMapping),
+            initText = "aaa\nbbb\nccc\nddd",
+            initSelection = TextRange(7),
+            keys = Key.MetaLeft + Key.MoveHome,
+            expectedSelection = TextRange(0),
+        )
+
+    @Test
+    fun textField_cmdEnd_macOs() =
+        singleKeyStrokeTest(
+            keyMappings = listOf(MacOsKeyMapping),
+            initText = "aaa\nbbb\nccc\nddd",
+            initSelection = TextRange(7),
+            keys = Key.MetaLeft + Key.MoveEnd,
+            expectedSelection = TextRange("aaa\nbbb\nccc\nddd".length),
+        )
+
     private class SequenceScope(
         private val state: TextFieldState,
         private val clipboard: FakeClipboard,

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/KeyMapping.skiko.kt
@@ -22,13 +22,18 @@ import androidx.compose.ui.input.key.key
 
 internal object DefaultSkikoKeyMapping : KeyMapping {
     override fun map(event: KeyEvent): KeyCommand? {
-        return when (event.modifiers) {
-            KeyModifiers.CtrlShift -> {
-                when (event.key) {
-                    Key.MoveHome,
-                    Key.NumPadMoveHome -> KeyCommand.SELECT_HOME
-                    Key.MoveEnd,
-                    Key.NumPadMoveEnd -> KeyCommand.SELECT_END
+        return when (event.key) {
+            Key.MoveHome, Key.NumPadMoveHome -> {
+                when (event.modifiers) {
+                    KeyModifiers.Ctrl -> KeyCommand.HOME
+                    KeyModifiers.CtrlShift -> KeyCommand.SELECT_HOME
+                    else -> null
+                }
+            }
+            Key.MoveEnd, Key.NumPadMoveEnd -> {
+                when (event.modifiers) {
+                    KeyModifiers.Ctrl -> KeyCommand.END
+                    KeyModifiers.CtrlShift -> KeyCommand.SELECT_END
                     else -> null
                 }
             }
@@ -73,6 +78,20 @@ internal fun createMacOsDefaultKeyMapping(): KeyMapping {
                         KeyModifiers.Alt,
                         KeyModifiers.Shift,
                         KeyModifiers.AltShift -> KeyCommand.NEW_LINE
+                        else -> null
+                    }
+                }
+                Key.MoveHome, Key.NumPadMoveHome -> {
+                    when (event.modifiers) {
+                        KeyModifiers.Meta -> KeyCommand.HOME
+                        KeyModifiers.ShiftMeta -> KeyCommand.SELECT_HOME
+                        else -> null
+                    }
+                }
+                Key.MoveEnd, Key.NumPadMoveEnd -> {
+                    when (event.modifiers) {
+                        KeyModifiers.Meta -> KeyCommand.END
+                        KeyModifiers.ShiftMeta -> KeyCommand.SELECT_END
                         else -> null
                     }
                 }


### PR DESCRIPTION
Add ctrl/cmd-home/end key mappings for text fields.

Fixes https://youtrack.jetbrains.com/issue/CMP-9989

## Testing
Tested manually and added unit tests.

## Release Notes
### Fixes - Multiple Platforms
- `Ctrl+Home`/`Ctrl+End` or `Cmd+Home`/`Cmd+End` shortcuts should now work correctly in text fields
