### PR TITLE
[CMP-7202] Introduce `Modifier.onPointerClick` for commonMain with full pointer metadata

### DIFF
--- a/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/mouseclicks/PointerClicks.jvm.kt
+++ b/compose/desktop/desktop/samples/src/jvmMain/kotlin/androidx/compose/desktop/examples/mouseclicks/PointerClicks.jvm.kt
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.desktop.examples.mouseclicks
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.onPointerClick
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.Card
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.input.pointer.isTertiaryPressed
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.WindowState
+import androidx.compose.ui.window.singleWindowApplication
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+/**
+ * A comprehensive showcase of the [onPointerClick] modifier.
+ * Demonstrates hardware button routing, keyboard modifier combinations,
+ * coordinate tracking, and selective ripple indications.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+fun main() = singleWindowApplication(
+    title = "Advanced Pointer Click Showcase",
+    state = WindowState(width = 900.dp, height = 650.dp)
+) {
+    MaterialTheme {
+        var logs by remember { mutableStateOf(listOf<String>()) }
+        val gridSize = 5
+
+        // Track the color of each cell
+        val cellColors = remember { mutableStateListOf<Color>().apply {
+            repeat(gridSize * gridSize) { add(Color(0xFFE0E0E0)) }
+        }}
+
+        // Track if a cell has a "Right-Click Flag"
+        val cellFlags = remember { mutableStateListOf<Boolean>().apply {
+            repeat(gridSize * gridSize) { add(false) }
+        }}
+
+        fun logEvent(message: String) {
+            val time = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss.SSS"))
+            logs = (listOf("[$time] $message") + logs).take(50) // Keep last 50
+        }
+
+        Row(Modifier.fillMaxSize().background(Color(0xFFF5F5F5)).padding(16.dp)) {
+            // LEFT PANEL: The Interactive Grid
+            Column(
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    "Interactive Canvas",
+                    style = MaterialTheme.typography.h5,
+                    fontWeight = FontWeight.Bold
+                )
+                Text("Test different mouse buttons and keyboard modifiers.", color = Color.Gray)
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Column(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.White)
+                        .border(1.dp, Color.LightGray, RoundedCornerShape(8.dp))
+                        .padding(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    for (row in 0 until gridSize) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                            for (col in 0 until gridSize) {
+                                val index = row * gridSize + col
+                                Box(
+                                    contentAlignment = Alignment.Center,
+                                    modifier = Modifier
+                                        .size(70.dp)
+                                        .clip(RoundedCornerShape(4.dp))
+                                        .background(cellColors[index])
+                                        .border(
+                                            width = if (cellFlags[index]) 3.dp else 1.dp,
+                                            color = if (cellFlags[index]) Color.Red else Color.Transparent,
+                                            shape = RoundedCornerShape(4.dp)
+                                        )
+                                        .onPointerClick(
+                                            triggerPressIndication = {
+                                                it.buttons.isPrimaryPressed || it.buttons.isTertiaryPressed
+                                            }
+                                        ) { event ->
+                                            val x = event.position.x.toInt()
+                                            val y = event.position.y.toInt()
+                                            val isShift = event.keyboardModifiers.isShiftPressed
+                                            val buttons = event.buttons
+
+                                            when {
+                                                // Shift + Left Click
+                                                isShift && buttons?.isPrimaryPressed == true -> {
+                                                    cellColors[index] = Color(0xFFFFD54F) // Yellow Highlight
+                                                    logEvent("Cell [$row,$col]: Shift + Left Click at ($x, $y)")
+                                                }
+                                                // Standard Left Click
+                                                buttons?.isPrimaryPressed == true -> {
+                                                    cellColors[index] = Color(0xFF4FC3F7) // Blue Paint
+                                                    logEvent("Cell [$row,$col]: Left Click at ($x, $y)")
+                                                }
+                                                // Right Click
+                                                buttons?.isSecondaryPressed == true -> {
+                                                    cellFlags[index] = !cellFlags[index] // Toggle Flag
+                                                    logEvent("Cell [$row,$col]: Right Click at ($x, $y)")
+                                                }
+                                                // Middle Click
+                                                buttons?.isTertiaryPressed == true -> {
+                                                    cellColors[index] = Color(0xFFE0E0E0) // Reset Paint
+                                                    cellFlags[index] = false              // Reset Flag
+                                                    logEvent("Cell [$row,$col]: Middle Click (Cleared)")
+                                                }
+                                            }
+                                        }
+                                ) {
+                                    if (cellFlags[index]) {
+                                        Text("🚩", fontSize = 24.sp)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+                Button(onClick = {
+                    cellColors.fill(Color(0xFFE0E0E0))
+                    cellFlags.fill(false)
+                    logEvent("Canvas Reset")
+                }) {
+                    Text("Reset Canvas")
+                }
+            }
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            // RIGHT PANEL: The Event Inspector
+            Card(
+                modifier = Modifier.weight(0.8f).fillMaxHeight(),
+                elevation = 4.dp
+            ) {
+                Column(Modifier.padding(16.dp)) {
+                    Text("Event Inspector", style = MaterialTheme.typography.h6)
+                    Divider(Modifier.padding(vertical = 8.dp))
+
+                    Text("Legend:", fontWeight = FontWeight.Bold, fontSize = 14.sp)
+                    Text("• Left Click: Paint Blue (Shows Ripple)", fontSize = 12.sp)
+                    Text("• Shift + Left Click: Highlight Yellow (Shows Ripple)", fontSize = 12.sp)
+                    Text("• Right Click: Toggle Flag (No Ripple)", fontSize = 12.sp)
+                    Text("• Middle Click: Clear Cell (Shows Ripple)", fontSize = 12.sp)
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Box(Modifier.fillMaxSize().background(Color(0xFF2B2B2B), RoundedCornerShape(4.dp)).padding(8.dp)) {
+                        LazyColumn(Modifier.fillMaxSize()) {
+                            items(logs) { log ->
+                                Text(
+                                    text = log,
+                                    color = Color(0xFFA9B7C6),
+                                    fontFamily = FontFamily.Monospace,
+                                    fontSize = 13.sp,
+                                    modifier = Modifier.padding(vertical = 2.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
@@ -65,12 +65,15 @@ import kotlinx.coroutines.launch
 
 
 /**
- * A data structure representing a pointer click with hardware metadata.
+ * Represents a pointer click event, encapsulating hardware-specific metadata.
  *
- * @property position The exact coordinate of the click relative to the component's bounds.
- * @property buttons The pointer buttons active during the click (e.g., Primary/Left, Secondary/Right).
- * This is `null` if the click was synthesized via keyboard or accessibility services.
- * @property keyboardModifiers The keyboard modifiers active during the click (e.g., Shift, Ctrl, Alt).
+ * This payload provides rich context about the interaction, enabling advanced multiplatform
+ * behaviors such as secondary clicks (context menus) or keyboard-modified clicks (shift-click selection).
+ *
+ * @property position The coordinate of the click, relative to the bounds of the component.
+ * @property buttons The state of the pointer buttons (e.g., Primary/Left, Secondary/Right) active during the click.
+ * This value is `null` if the click was synthesized via software (such as a keyboard action or accessibility service).
+ * @property keyboardModifiers The state of the keyboard modifiers (e.g., Shift, Ctrl, Alt) active during the click.
  */
 @ExperimentalFoundationApi
 class PointerClickEvent(
@@ -80,28 +83,26 @@ class PointerClickEvent(
 )
 
 /**
- * Configures a component to receive pointer clicks (mouse, touch, stylus) alongside hardware metadata.
+ * Configures a component to receive pointer click events alongside hardware-specific metadata.
  *
- * Unlike the standard [clickable] modifier, `onPointerClick` routes raw [PointerButtons] and
- * [PointerKeyboardModifiers] into the callback. This is essential for building complex, desktop-grade
- * multiplatform interactions such as Shift+Clicking to multi-select, or Right-Clicking for context menus.
+ * Unlike standard [clickable], `onPointerClick` exposes raw [PointerButtons] and [PointerKeyboardModifiers]
+ * to the callback. This is essential for supporting complex, multiplatform interactions, such as alternative
+ * button clicks or modifier-key chords.
  *
- * By default, this modifier provides Material Design UX: it listens to all mouse buttons, but only
- * emits visual ripples on Primary actions (Touch or Left-Click). This behavior can be overridden
- * via the [triggerPressIndication] parameter.
+ * By default, this modifier follows Material Design guidelines: it responds to all pointer interactions
+ * but only triggers visual ripple effects on primary actions (e.g., touch or left-click). This behavior
+ * can be customized via the [triggerPressInteraction] parameter.
  *
- * @param enabled Controls the enabled state. When `false`, [onClick] will not be invoked, and
- * the element will appear disabled to accessibility services.
- * @param onClickLabel Semantic/accessibility label for the click action.
- * @param role The type of user interface element (e.g., [Role.Button]).
+ * @param enabled Controls the enabled state of the component. When `false`, [onClick] will not be invoked,
+ * and the element will be exposed as disabled to accessibility services.
+ * @param onClickLabel Semantic label for the click action, used by accessibility services.
+ * @param role The semantic purpose of the user interface element (e.g., [Role.Button]).
  * @param interactionSource The [MutableInteractionSource] used to dispatch [PressInteraction]s.
- * If `null`, a default source is remembered automatically.
- * @param indication The visual effect to draw when the element is pressed. Defaults to [LocalIndication].
- * Set this to `null` to entirely disable visual feedback.
- * @param triggerPressIndication A lambda that evaluates a raw [PointerEvent] and returns `true` if
- * the event should transition the component into a "Pressed" state (triggering ripples). By default,
- * only Primary clicks trigger this state.
- * @param onClick Invoked when the element is successfully clicked, providing hardware metadata.
+ * If `null`, a default source is created and remembered internally.
+ * @param triggerPressInteraction A predicate evaluating a raw [PointerEvent] to determine if the interaction
+ * should transition the component into a pressed state (triggering visual indications). By default, this is
+ * restricted to primary clicks.
+ * @param onClick Invoked when a successful click is recognized, providing the [PointerClickEvent] metadata.
  */
 @ExperimentalFoundationApi
 fun Modifier.onPointerClick(
@@ -109,8 +110,59 @@ fun Modifier.onPointerClick(
     onClickLabel: String? = null,
     role: Role? = null,
     interactionSource: MutableInteractionSource? = null,
-    indication: Indication? = null,
-    triggerPressIndication: (PointerEvent) -> Boolean = { it.buttons.isPrimaryPressed },
+    triggerPressInteraction: (PointerEvent) -> Boolean = { it.buttons.isPrimaryPressed },
+    onClick: (PointerClickEvent) -> Unit
+): Modifier = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "onPointerClick"
+        properties["enabled"] = enabled
+        properties["onClickLabel"] = onClickLabel
+        properties["role"] = role
+        properties["interactionSource"] = interactionSource
+        properties["indication"] = "LocalIndication.current"
+        properties["triggerPressInteraction"] = triggerPressInteraction
+        properties["onClick"] = onClick
+    }
+) {
+    val defaultIndication = LocalIndication.current
+    onPointerClick(
+        interactionSource = interactionSource,
+        indication = defaultIndication,
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        role = role,
+        triggerPressInteraction = triggerPressInteraction,
+        onClick = onClick
+    )
+}
+
+/**
+ * Configures a component to receive pointer click events with precise control over visual indications.
+ *
+ * Use this overload when you need strict control over the [Indication] behavior:
+ * - Pass a custom [Indication] (such as `LocalIndication.current`) to enable visual feedback.
+ * - Pass `null` to disable press effects entirely.
+ *
+ * @param interactionSource The [MutableInteractionSource] used to dispatch [PressInteraction] events.
+ * If `null`, a default source is created and remembered internally.
+ * @param indication The visual effect applied when the element transitions to a pressed state.
+ * Pass `null` to disable standard visual indication.
+ * @param enabled Controls the enabled state of the component. When `false`, input is ignored,
+ * and the element is exposed as disabled to accessibility services.
+ * @param onClickLabel Semantic label for the click action, used by accessibility services.
+ * @param role The semantic purpose of the user interface element (e.g., [Role.Button]).
+ * @param triggerPressInteraction A predicate evaluating a raw [PointerEvent] to determine if the down event
+ * should trigger a pressed state.
+ * @param onClick Invoked when a successful click is recognized, providing the [PointerClickEvent] metadata.
+ */
+@ExperimentalFoundationApi
+fun Modifier.onPointerClick(
+    interactionSource: MutableInteractionSource?,
+    indication: Indication?,
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    triggerPressInteraction: (PointerEvent) -> Boolean = { it.buttons.isPrimaryPressed },
     onClick: (PointerClickEvent) -> Unit
 ): Modifier = composed(
     inspectorInfo = debugInspectorInfo {
@@ -120,12 +172,11 @@ fun Modifier.onPointerClick(
         properties["role"] = role
         properties["interactionSource"] = interactionSource
         properties["indication"] = indication
-        properties["triggerPressIndication"] = triggerPressIndication
+        properties["triggerPressInteraction"] = triggerPressInteraction
         properties["onClick"] = onClick
     }
 ) {
     val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
-    val resolvedIndication = indication ?: LocalIndication.current
 
     this.then(
         PointerClickElement(
@@ -133,12 +184,12 @@ fun Modifier.onPointerClick(
             onClickLabel = onClickLabel,
             role = role,
             interactionSource = resolvedInteractionSource,
-            triggerPressIndication = triggerPressIndication,
+            triggerPressInteraction = triggerPressInteraction,
             onClick = onClick
         )
     ).indication(
         interactionSource = resolvedInteractionSource,
-        indication = resolvedIndication
+        indication = indication
     )
 }
 
@@ -148,7 +199,7 @@ private class PointerClickElement(
     private val onClickLabel: String?,
     private val role: Role?,
     private val interactionSource: MutableInteractionSource,
-    private val triggerPressIndication: (PointerEvent) -> Boolean,
+    private val triggerPressInteraction: (PointerEvent) -> Boolean,
     private val onClick: (PointerClickEvent) -> Unit
 ) : ModifierNodeElement<PointerClickNode>() {
 
@@ -157,7 +208,7 @@ private class PointerClickElement(
         onClickLabel = onClickLabel,
         role = role,
         interactionSource = interactionSource,
-        triggerPressIndication = triggerPressIndication,
+        triggerPressInteraction = triggerPressInteraction,
         onClick = onClick
     )
 
@@ -167,7 +218,7 @@ private class PointerClickElement(
             onClickLabel = onClickLabel,
             role = role,
             interactionSource = interactionSource,
-            triggerPressIndication = triggerPressIndication,
+            triggerPressInteraction = triggerPressInteraction,
             onClick = onClick
         )
     }
@@ -179,7 +230,7 @@ private class PointerClickElement(
         if (onClickLabel != other.onClickLabel) return false
         if (role != other.role) return false
         if (interactionSource != other.interactionSource) return false
-        if (triggerPressIndication !== other.triggerPressIndication) return false
+        if (triggerPressInteraction !== other.triggerPressInteraction) return false
         if (onClick !== other.onClick) return false
         return true
     }
@@ -189,7 +240,7 @@ private class PointerClickElement(
         result = 31 * result + (onClickLabel?.hashCode() ?: 0)
         result = 31 * result + (role?.hashCode() ?: 0)
         result = 31 * result + interactionSource.hashCode()
-        result = 31 * result + triggerPressIndication.hashCode()
+        result = 31 * result + triggerPressInteraction.hashCode()
         result = 31 * result + onClick.hashCode()
         return result
     }
@@ -201,7 +252,7 @@ private class PointerClickNode(
     private var onClickLabel: String?,
     private var role: Role?,
     private var interactionSource: MutableInteractionSource,
-    private var triggerPressIndication: (PointerEvent) -> Boolean,
+    private var triggerPressInteraction: (PointerEvent) -> Boolean,
     private var onClick: (PointerClickEvent) -> Unit
 ) : DelegatingNode(),
     PointerInputModifierNode,
@@ -285,7 +336,7 @@ private class PointerClickNode(
             requestFocusWhenInMouseInputMode()
 
             // Consult the developer's logic to see if this raw event warrants a visual ripple
-            if (triggerPressIndication(pointerEvent)) {
+            if (triggerPressInteraction(pointerEvent)) {
                 handlePressInteractionStart(down.position)
             }
         }
@@ -413,7 +464,7 @@ private class PointerClickNode(
         onClickLabel: String?,
         role: Role?,
         interactionSource: MutableInteractionSource,
-        triggerPressIndication: (PointerEvent) -> Boolean,
+        triggerPressInteraction: (PointerEvent) -> Boolean,
         onClick: (PointerClickEvent) -> Unit
     ) {
         if (this.enabled != enabled) {
@@ -429,9 +480,9 @@ private class PointerClickNode(
         if (this.interactionSource != interactionSource) {
             cancelInput()
             this.interactionSource = interactionSource
-            focusableNode.update(interactionSource)
+            focusableNode?.update(interactionSource)
         }
-        this.triggerPressIndication = triggerPressIndication
+        this.triggerPressInteraction = triggerPressInteraction
         this.onClick = onClick
     }
 
@@ -439,26 +490,26 @@ private class PointerClickNode(
         if (this@PointerClickNode.role != null) {
             role = this@PointerClickNode.role!!
         }
+        onClick(
+            action = {
+                // Fetch window modifiers dynamically to support screen-readers triggering
+                // clicks while the user holds a physical key (e.g. Switch Access).
+                val currentModifiers = currentValueOf(LocalWindowInfo).keyboardModifiers
+                val synthesizedEvent = PointerClickEvent(
+                    position = centerOffset,
+                    buttons = null, // Synthesized clicks lack hardware pointers
+                    keyboardModifiers = currentModifiers
+                )
+                onClick(synthesizedEvent)
+                true
+            },
+            label = onClickLabel
+        )
         if (enabled) {
             // When enabled, expose focus semantics from the delegated focusableNode
-            with(focusableNode) {
+            focusableNode?.apply {
                 applySemantics()
             }
-            onClick(
-                action = {
-                    // Fetch window modifiers dynamically to support screen-readers triggering
-                    // clicks while the user holds a physical key (e.g. Switch Access).
-                    val currentModifiers = currentValueOf(LocalWindowInfo).keyboardModifiers
-                    val synthesizedEvent = PointerClickEvent(
-                        position = centerOffset,
-                        buttons = null, // Synthesized clicks lack hardware pointers
-                        keyboardModifiers = currentModifiers
-                    )
-                    onClick(synthesizedEvent)
-                    true
-                },
-                label = onClickLabel
-            )
         } else {
             // When disabled, suppress focus and click semantics and mark as disabled
             disabled()

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
@@ -1,0 +1,408 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.gestures.ScrollableContainerNode
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequesterModifierNode
+import androidx.compose.ui.focus.requestFocus
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.changedToDown
+import androidx.compose.ui.input.pointer.changedToUp
+import androidx.compose.ui.input.pointer.isOutOfBounds
+import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.LayoutAwareModifierNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.PointerInputModifierNode
+import androidx.compose.ui.node.SemanticsModifierNode
+import androidx.compose.ui.node.currentValueOf
+import androidx.compose.ui.node.invalidateSemantics
+import androidx.compose.ui.node.requireDensity
+import androidx.compose.ui.node.traverseAncestors
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.center
+import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.util.fastAll
+import androidx.compose.ui.util.fastAny
+import kotlin.math.max
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * A data structure representing a pointer click with hardware metadata.
+ *
+ * @property position The pointer position relative to the containing element.
+ * @property buttons The pointer buttons that were active during the click (e.g., Primary, Secondary).
+ * This is `null` if the click was synthesized by accessibility services or keyboard actions.
+ * @property keyboardModifiers The keyboard modifiers that were active during the click (e.g., Shift, Ctrl).
+ */
+@ExperimentalFoundationApi
+class PointerClickEvent(
+    val position: Offset,
+    val buttons: PointerButtons?,
+    val keyboardModifiers: PointerKeyboardModifiers
+)
+
+/**
+ * Configures a component to receive pointer clicks (mouse, touch, stylus) alongside hardware metadata.
+ *
+ * Unlike standard [clickable], this modifier exposes the specific [PointerButtons] and
+ * [PointerKeyboardModifiers] present at the time of the click, making it suitable for complex
+ * desktop-style interactions (e.g., Shift+Click to multi-select, Right-Click for context menus).
+ *
+ * ***Note:*** Any removal operations on Android Views from [onPointerClick] should wrap the
+ * [onClick] lambda in a `post { }` block to guarantee the event dispatch completes before
+ * executing the removal.
+ *
+ * @param enabled Controls the enabled state. When `false`, [onClick] will not be invoked, and
+ * this modifier will appear disabled to accessibility services.
+ * @param onClickLabel Semantic / accessibility label for the [onClick] action.
+ * @param role The type of user interface element. Accessibility services might use this to describe
+ * the element or do customizations.
+ * @param interactionSource [MutableInteractionSource] that will be used to dispatch
+ * [PressInteraction.Press] when this element is pressed.
+ * @param onClick Will be called when the user clicks on the element, providing hardware metadata.
+ */
+@ExperimentalFoundationApi
+fun Modifier.onPointerClick(
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    interactionSource: MutableInteractionSource? = null,
+    onClick: (PointerClickEvent) -> Unit
+): Modifier = this.then(
+    PointerClickElement(
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        role = role,
+        interactionSource = interactionSource,
+        onClick = onClick
+    )
+)
+
+@OptIn(ExperimentalFoundationApi::class)
+private class PointerClickElement(
+    private val enabled: Boolean,
+    private val onClickLabel: String?,
+    private val role: Role?,
+    private val interactionSource: MutableInteractionSource?,
+    private val onClick: (PointerClickEvent) -> Unit
+) : ModifierNodeElement<PointerClickNode>() {
+
+    override fun create() = PointerClickNode(
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        role = role,
+        interactionSource = interactionSource,
+        onClick = onClick
+    )
+
+    override fun update(node: PointerClickNode) {
+        node.update(
+            enabled = enabled,
+            onClickLabel = onClickLabel,
+            role = role,
+            interactionSource = interactionSource,
+            onClick = onClick
+        )
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "onPointerClick"
+        properties["enabled"] = enabled
+        properties["onClickLabel"] = onClickLabel
+        properties["role"] = role
+        properties["interactionSource"] = interactionSource
+        properties["onClick"] = onClick
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PointerClickElement) return false
+        if (enabled != other.enabled) return false
+        if (onClickLabel != other.onClickLabel) return false
+        if (role != other.role) return false
+        if (interactionSource != other.interactionSource) return false
+        if (onClick !== other.onClick) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = enabled.hashCode()
+        result = 31 * result + (onClickLabel?.hashCode() ?: 0)
+        result = 31 * result + (role?.hashCode() ?: 0)
+        result = 31 * result + (interactionSource?.hashCode() ?: 0)
+        result = 31 * result + onClick.hashCode()
+        return result
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+private class PointerClickNode(
+    private var enabled: Boolean,
+    private var onClickLabel: String?,
+    private var role: Role?,
+    private var interactionSource: MutableInteractionSource?,
+    private var onClick: (PointerClickEvent) -> Unit
+) : DelegatingNode(),
+    PointerInputModifierNode,
+    SemanticsModifierNode,
+    FocusRequesterModifierNode,
+    LayoutAwareModifierNode,
+    CompositionLocalConsumerModifierNode {
+
+    private var downEvent: PointerInputChange? = null
+    private var downButtons: PointerButtons? = null
+    private var downKeyboardModifiers: PointerKeyboardModifiers? = null
+
+    private var pressInteraction: PressInteraction.Press? = null
+    private var delayJob: Job? = null
+
+    private var componentSize: IntSize = IntSize.Zero
+    private var centerOffset: Offset = Offset.Zero
+
+    private val focusableNode = delegate(
+        FocusableNode(interactionSource)
+    )
+
+    override fun onRemeasured(size: IntSize) {
+        componentSize = size
+        centerOffset = size.center.toOffset()
+    }
+
+    override fun onPointerEvent(
+        pointerEvent: PointerEvent,
+        pass: PointerEventPass,
+        bounds: IntSize
+    ) {
+        if (pass == PointerEventPass.Main) {
+            if (downEvent == null) {
+                // Listen for ANY button pressing down, not just primary
+                val downChange =
+                    pointerEvent.changes.firstOrNull { it.changedToDown() && !it.isConsumed }
+                if (downChange != null) {
+                    handleDownEvent(downChange, pointerEvent)
+                }
+            } else {
+                // To support multitouch accurately, a click is only resolved
+                // when all active pointers are lifted from the component.
+                if (pointerEvent.changes.fastAll { it.changedToUp() }) {
+                    handleUpEvent(pointerEvent)
+                } else {
+                    handleNonUpEventIfNeeded(pointerEvent)
+                }
+            }
+        } else if (pass == PointerEventPass.Final) {
+            checkForCancellation(pointerEvent)
+        }
+    }
+
+    private fun handleDownEvent(down: PointerInputChange, pointerEvent: PointerEvent) {
+        down.consume()
+        this.downEvent = down
+        this.downButtons = pointerEvent.buttons
+        this.downKeyboardModifiers = pointerEvent.keyboardModifiers
+
+        if (enabled) {
+            requestFocusWhenInMouseInputMode()
+            handlePressInteractionStart(down.position)
+        }
+    }
+
+    private fun handleUpEvent(pointerEvent: PointerEvent) {
+        val upChange = pointerEvent.changes[0]
+        upChange.consume()
+
+        if (enabled) {
+            handlePressInteractionRelease(downEvent!!.position)
+            val event = PointerClickEvent(
+                position = upChange.position,
+                buttons = downButtons,
+                keyboardModifiers = downKeyboardModifiers ?: pointerEvent.keyboardModifiers
+            )
+            onClick(event)
+        }
+        cancelInput()
+    }
+
+    private fun handleNonUpEventIfNeeded(pointerEvent: PointerEvent) {
+        val minimumTouchTargetSizeDp = currentValueOf(LocalViewConfiguration).minimumTouchTargetSize
+        val minimumTouchTargetSize = with(requireDensity()) { minimumTouchTargetSizeDp.toSize() }
+        val horizontal = max(0f, minimumTouchTargetSize.width - componentSize.width) / 2f
+        val vertical = max(0f, minimumTouchTargetSize.height - componentSize.height) / 2f
+        val touchPadding = Size(horizontal, vertical)
+
+        if (pointerEvent.changes.fastAny { it.isConsumed || it.isOutOfBounds(componentSize, touchPadding) }) {
+            cancelInput()
+        }
+    }
+
+    private fun checkForCancellation(pointerEvent: PointerEvent) {
+        if (downEvent != null) {
+            // Relies on identical object references ( !== ) within the same pointer frame
+            // to differentiate between self-consumption and foreign consumption (e.g. scroll parents).
+            if (pointerEvent.changes.fastAny { it.isConsumed && it !== downEvent }) {
+                cancelInput()
+            }
+        }
+    }
+
+    override fun onCancelPointerInput() {
+        cancelInput()
+    }
+
+    private fun cancelInput() {
+        downEvent = null
+        downButtons = null
+        downKeyboardModifiers = null
+        handlePressInteractionCancel()
+    }
+
+    private fun handlePressInteractionStart(offset: Offset) {
+        interactionSource?.let { source ->
+            val press = PressInteraction.Press(offset)
+            val shouldDelayPress = hasScrollableContainer()
+
+            if (shouldDelayPress) {
+                delayJob = coroutineScope.launch {
+                    delay(TapIndicationDelay)
+                    source.emit(press)
+                    pressInteraction = press
+                }
+            } else {
+                pressInteraction = press
+                coroutineScope.launch { source.emit(press) }
+            }
+        }
+    }
+
+    private fun handlePressInteractionRelease(offset: Offset) {
+        interactionSource?.let { source ->
+            val job = delayJob
+            if (job?.isActive == true) {
+                job.cancel()
+                coroutineScope.launch {
+                    // Prevents interaction emission race conditions (b/414319919)
+                    // where rapid clicks resolve before the cancellation completes.
+                    job.join()
+                    val press = PressInteraction.Press(offset)
+                    val release = PressInteraction.Release(press)
+                    source.emit(press)
+                    source.emit(release)
+                }
+            } else {
+                pressInteraction?.let {
+                    coroutineScope.launch { source.emit(PressInteraction.Release(it)) }
+                }
+            }
+            pressInteraction = null
+        }
+    }
+
+    private fun handlePressInteractionCancel() {
+        interactionSource?.let { source ->
+            if (delayJob?.isActive == true) {
+                delayJob?.cancel()
+            } else {
+                pressInteraction?.let {
+                    coroutineScope.launch { source.emit(PressInteraction.Cancel(it)) }
+                }
+            }
+            pressInteraction = null
+        }
+    }
+
+    private fun requestFocusWhenInMouseInputMode() {
+        if (isRequestFocusOnClickEnabled()) {
+            requestFocus()
+        }
+    }
+
+    private fun hasScrollableContainer(): Boolean {
+        var hasScrollable = false
+        traverseAncestors(ScrollableContainerNode.TraverseKey) { node ->
+            hasScrollable = hasScrollable || (node as ScrollableContainerNode).enabled
+            !hasScrollable
+        }
+        return hasScrollable
+    }
+
+    fun update(
+        enabled: Boolean,
+        onClickLabel: String?,
+        role: Role?,
+        interactionSource: MutableInteractionSource?,
+        onClick: (PointerClickEvent) -> Unit
+    ) {
+        if (this.enabled != enabled) {
+            if (!enabled) cancelInput()
+            this.enabled = enabled
+            invalidateSemantics()
+        }
+        if (this.onClickLabel != onClickLabel || this.role != role) {
+            this.onClickLabel = onClickLabel
+            this.role = role
+            invalidateSemantics()
+        }
+        if (this.interactionSource != interactionSource) {
+            cancelInput()
+            this.interactionSource = interactionSource
+            focusableNode.update(interactionSource)
+        }
+        this.onClick = onClick
+    }
+
+    override fun SemanticsPropertyReceiver.applySemantics() {
+        if (this@PointerClickNode.role != null) {
+            role = this@PointerClickNode.role!!
+        }
+        onClick(
+            action = {
+                val currentModifiers = currentValueOf(LocalWindowInfo).keyboardModifiers
+                val synthesizedEvent = PointerClickEvent(
+                    position = centerOffset,
+                    buttons = null,
+                    keyboardModifiers = currentModifiers
+                )
+                onClick(synthesizedEvent)
+                true
+            },
+            label = onClickLabel
+        )
+        if (!enabled) {
+            disabled()
+        }
+    }
+}

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -32,6 +32,7 @@ import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.changedToDown
 import androidx.compose.ui.input.pointer.changedToUp
 import androidx.compose.ui.input.pointer.isOutOfBounds
+import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.node.CompositionLocalConsumerModifierNode
 import androidx.compose.ui.node.DelegatingNode
 import androidx.compose.ui.node.LayoutAwareModifierNode
@@ -93,6 +94,8 @@ class PointerClickEvent(
  * the element or do customizations.
  * @param interactionSource [MutableInteractionSource] that will be used to dispatch
  * [PressInteraction.Press] when this element is pressed.
+ * @param requestIndication A lambda that determines whether a given [PointerEvent] should trigger
+ * visual feedback (like a ripple). By default, only Primary clicks (touch or left-click) trigger indication.
  * @param onClick Will be called when the user clicks on the element, providing hardware metadata.
  */
 @ExperimentalFoundationApi
@@ -101,6 +104,7 @@ fun Modifier.onPointerClick(
     onClickLabel: String? = null,
     role: Role? = null,
     interactionSource: MutableInteractionSource? = null,
+    requestIndication: (PointerEvent) -> Boolean = { it.buttons.isPrimaryPressed },
     onClick: (PointerClickEvent) -> Unit
 ): Modifier = this.then(
     PointerClickElement(
@@ -108,6 +112,7 @@ fun Modifier.onPointerClick(
         onClickLabel = onClickLabel,
         role = role,
         interactionSource = interactionSource,
+        requestIndication = requestIndication,
         onClick = onClick
     )
 )
@@ -118,6 +123,7 @@ private class PointerClickElement(
     private val onClickLabel: String?,
     private val role: Role?,
     private val interactionSource: MutableInteractionSource?,
+    private val requestIndication: (PointerEvent) -> Boolean,
     private val onClick: (PointerClickEvent) -> Unit
 ) : ModifierNodeElement<PointerClickNode>() {
 
@@ -126,6 +132,7 @@ private class PointerClickElement(
         onClickLabel = onClickLabel,
         role = role,
         interactionSource = interactionSource,
+        requestIndication = requestIndication,
         onClick = onClick
     )
 
@@ -135,6 +142,7 @@ private class PointerClickElement(
             onClickLabel = onClickLabel,
             role = role,
             interactionSource = interactionSource,
+            requestIndication = requestIndication,
             onClick = onClick
         )
     }
@@ -145,6 +153,7 @@ private class PointerClickElement(
         properties["onClickLabel"] = onClickLabel
         properties["role"] = role
         properties["interactionSource"] = interactionSource
+        properties["requestIndication"] = requestIndication
         properties["onClick"] = onClick
     }
 
@@ -155,6 +164,7 @@ private class PointerClickElement(
         if (onClickLabel != other.onClickLabel) return false
         if (role != other.role) return false
         if (interactionSource != other.interactionSource) return false
+        if (requestIndication !== other.requestIndication) return false
         if (onClick !== other.onClick) return false
         return true
     }
@@ -164,6 +174,7 @@ private class PointerClickElement(
         result = 31 * result + (onClickLabel?.hashCode() ?: 0)
         result = 31 * result + (role?.hashCode() ?: 0)
         result = 31 * result + (interactionSource?.hashCode() ?: 0)
+        result = 31 * result + requestIndication.hashCode()
         result = 31 * result + onClick.hashCode()
         return result
     }
@@ -175,6 +186,7 @@ private class PointerClickNode(
     private var onClickLabel: String?,
     private var role: Role?,
     private var interactionSource: MutableInteractionSource?,
+    private var requestIndication: (PointerEvent) -> Boolean,
     private var onClick: (PointerClickEvent) -> Unit
 ) : DelegatingNode(),
     PointerInputModifierNode,
@@ -237,12 +249,19 @@ private class PointerClickNode(
 
         if (enabled) {
             requestFocusWhenInMouseInputMode()
-            handlePressInteractionStart(down.position)
+
+            // Allow the developer (or default logic) to decide if this event warrants a visual ripple
+            if (requestIndication(pointerEvent)) {
+                handlePressInteractionStart(down.position)
+            }
         }
     }
 
     private fun handleUpEvent(pointerEvent: PointerEvent) {
-        val upChange = pointerEvent.changes[0]
+        // Ensure we retrieve the change corresponding to the original pointer if possible
+        val upChange = pointerEvent.changes.firstOrNull { it.id == downEvent?.id }
+            ?: pointerEvent.changes.first()
+
         upChange.consume()
 
         if (enabled) {
@@ -364,6 +383,7 @@ private class PointerClickNode(
         onClickLabel: String?,
         role: Role?,
         interactionSource: MutableInteractionSource?,
+        requestIndication: (PointerEvent) -> Boolean,
         onClick: (PointerClickEvent) -> Unit
     ) {
         if (this.enabled != enabled) {
@@ -381,6 +401,7 @@ private class PointerClickNode(
             this.interactionSource = interactionSource
             focusableNode.update(interactionSource)
         }
+        this.requestIndication = requestIndication
         this.onClick = onClick
     }
 

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
@@ -19,7 +19,9 @@ package androidx.compose.foundation
 import androidx.compose.foundation.gestures.ScrollableContainerNode
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.focus.FocusRequesterModifierNode
 import androidx.compose.ui.focus.requestFocus
 import androidx.compose.ui.geometry.Offset
@@ -43,9 +45,9 @@ import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.node.invalidateSemantics
 import androidx.compose.ui.node.requireDensity
 import androidx.compose.ui.node.traverseAncestors
-import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.disabled
@@ -61,13 +63,14 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
+
 /**
  * A data structure representing a pointer click with hardware metadata.
  *
- * @property position The pointer position relative to the containing element.
- * @property buttons The pointer buttons that were active during the click (e.g., Primary, Secondary).
- * This is `null` if the click was synthesized by accessibility services or keyboard actions.
- * @property keyboardModifiers The keyboard modifiers that were active during the click (e.g., Shift, Ctrl).
+ * @property position The exact coordinate of the click relative to the component's bounds.
+ * @property buttons The pointer buttons active during the click (e.g., Primary/Left, Secondary/Right).
+ * This is `null` if the click was synthesized via keyboard or accessibility services.
+ * @property keyboardModifiers The keyboard modifiers active during the click (e.g., Shift, Ctrl, Alt).
  */
 @ExperimentalFoundationApi
 class PointerClickEvent(
@@ -79,24 +82,26 @@ class PointerClickEvent(
 /**
  * Configures a component to receive pointer clicks (mouse, touch, stylus) alongside hardware metadata.
  *
- * Unlike standard [clickable], this modifier exposes the specific [PointerButtons] and
- * [PointerKeyboardModifiers] present at the time of the click, making it suitable for complex
- * desktop-style interactions (e.g., Shift+Click to multi-select, Right-Click for context menus).
+ * Unlike the standard [clickable] modifier, `onPointerClick` routes raw [PointerButtons] and
+ * [PointerKeyboardModifiers] into the callback. This is essential for building complex, desktop-grade
+ * multiplatform interactions such as Shift+Clicking to multi-select, or Right-Clicking for context menus.
  *
- * ***Note:*** Any removal operations on Android Views from [onPointerClick] should wrap the
- * [onClick] lambda in a `post { }` block to guarantee the event dispatch completes before
- * executing the removal.
+ * By default, this modifier provides Material Design UX: it listens to all mouse buttons, but only
+ * emits visual ripples on Primary actions (Touch or Left-Click). This behavior can be overridden
+ * via the [triggerPressIndication] parameter.
  *
  * @param enabled Controls the enabled state. When `false`, [onClick] will not be invoked, and
- * this modifier will appear disabled to accessibility services.
- * @param onClickLabel Semantic / accessibility label for the [onClick] action.
- * @param role The type of user interface element. Accessibility services might use this to describe
- * the element or do customizations.
- * @param interactionSource [MutableInteractionSource] that will be used to dispatch
- * [PressInteraction.Press] when this element is pressed.
- * @param requestIndication A lambda that determines whether a given [PointerEvent] should trigger
- * visual feedback (like a ripple). By default, only Primary clicks (touch or left-click) trigger indication.
- * @param onClick Will be called when the user clicks on the element, providing hardware metadata.
+ * the element will appear disabled to accessibility services.
+ * @param onClickLabel Semantic/accessibility label for the click action.
+ * @param role The type of user interface element (e.g., [Role.Button]).
+ * @param interactionSource The [MutableInteractionSource] used to dispatch [PressInteraction]s.
+ * If `null`, a default source is remembered automatically.
+ * @param indication The visual effect to draw when the element is pressed. Defaults to [LocalIndication].
+ * Set this to `null` to entirely disable visual feedback.
+ * @param triggerPressIndication A lambda that evaluates a raw [PointerEvent] and returns `true` if
+ * the event should transition the component into a "Pressed" state (triggering ripples). By default,
+ * only Primary clicks trigger this state.
+ * @param onClick Invoked when the element is successfully clicked, providing hardware metadata.
  */
 @ExperimentalFoundationApi
 fun Modifier.onPointerClick(
@@ -104,26 +109,46 @@ fun Modifier.onPointerClick(
     onClickLabel: String? = null,
     role: Role? = null,
     interactionSource: MutableInteractionSource? = null,
-    requestIndication: (PointerEvent) -> Boolean = { it.buttons.isPrimaryPressed },
+    indication: Indication? = null,
+    triggerPressIndication: (PointerEvent) -> Boolean = { it.buttons.isPrimaryPressed },
     onClick: (PointerClickEvent) -> Unit
-): Modifier = this.then(
-    PointerClickElement(
-        enabled = enabled,
-        onClickLabel = onClickLabel,
-        role = role,
-        interactionSource = interactionSource,
-        requestIndication = requestIndication,
-        onClick = onClick
+): Modifier = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "onPointerClick"
+        properties["enabled"] = enabled
+        properties["onClickLabel"] = onClickLabel
+        properties["role"] = role
+        properties["interactionSource"] = interactionSource
+        properties["indication"] = indication
+        properties["triggerPressIndication"] = triggerPressIndication
+        properties["onClick"] = onClick
+    }
+) {
+    val resolvedInteractionSource = interactionSource ?: remember { MutableInteractionSource() }
+    val resolvedIndication = indication ?: LocalIndication.current
+
+    this.then(
+        PointerClickElement(
+            enabled = enabled,
+            onClickLabel = onClickLabel,
+            role = role,
+            interactionSource = resolvedInteractionSource,
+            triggerPressIndication = triggerPressIndication,
+            onClick = onClick
+        )
+    ).indication(
+        interactionSource = resolvedInteractionSource,
+        indication = resolvedIndication
     )
-)
+}
 
 @OptIn(ExperimentalFoundationApi::class)
 private class PointerClickElement(
     private val enabled: Boolean,
     private val onClickLabel: String?,
     private val role: Role?,
-    private val interactionSource: MutableInteractionSource?,
-    private val requestIndication: (PointerEvent) -> Boolean,
+    private val interactionSource: MutableInteractionSource,
+    private val triggerPressIndication: (PointerEvent) -> Boolean,
     private val onClick: (PointerClickEvent) -> Unit
 ) : ModifierNodeElement<PointerClickNode>() {
 
@@ -132,7 +157,7 @@ private class PointerClickElement(
         onClickLabel = onClickLabel,
         role = role,
         interactionSource = interactionSource,
-        requestIndication = requestIndication,
+        triggerPressIndication = triggerPressIndication,
         onClick = onClick
     )
 
@@ -142,19 +167,9 @@ private class PointerClickElement(
             onClickLabel = onClickLabel,
             role = role,
             interactionSource = interactionSource,
-            requestIndication = requestIndication,
+            triggerPressIndication = triggerPressIndication,
             onClick = onClick
         )
-    }
-
-    override fun InspectorInfo.inspectableProperties() {
-        name = "onPointerClick"
-        properties["enabled"] = enabled
-        properties["onClickLabel"] = onClickLabel
-        properties["role"] = role
-        properties["interactionSource"] = interactionSource
-        properties["requestIndication"] = requestIndication
-        properties["onClick"] = onClick
     }
 
     override fun equals(other: Any?): Boolean {
@@ -164,7 +179,7 @@ private class PointerClickElement(
         if (onClickLabel != other.onClickLabel) return false
         if (role != other.role) return false
         if (interactionSource != other.interactionSource) return false
-        if (requestIndication !== other.requestIndication) return false
+        if (triggerPressIndication !== other.triggerPressIndication) return false
         if (onClick !== other.onClick) return false
         return true
     }
@@ -173,8 +188,8 @@ private class PointerClickElement(
         var result = enabled.hashCode()
         result = 31 * result + (onClickLabel?.hashCode() ?: 0)
         result = 31 * result + (role?.hashCode() ?: 0)
-        result = 31 * result + (interactionSource?.hashCode() ?: 0)
-        result = 31 * result + requestIndication.hashCode()
+        result = 31 * result + interactionSource.hashCode()
+        result = 31 * result + triggerPressIndication.hashCode()
         result = 31 * result + onClick.hashCode()
         return result
     }
@@ -185,8 +200,8 @@ private class PointerClickNode(
     private var enabled: Boolean,
     private var onClickLabel: String?,
     private var role: Role?,
-    private var interactionSource: MutableInteractionSource?,
-    private var requestIndication: (PointerEvent) -> Boolean,
+    private var interactionSource: MutableInteractionSource,
+    private var triggerPressIndication: (PointerEvent) -> Boolean,
     private var onClick: (PointerClickEvent) -> Unit
 ) : DelegatingNode(),
     PointerInputModifierNode,
@@ -195,19 +210,20 @@ private class PointerClickNode(
     LayoutAwareModifierNode,
     CompositionLocalConsumerModifierNode {
 
+    // Hardware State Caching
     private var downEvent: PointerInputChange? = null
     private var downButtons: PointerButtons? = null
     private var downKeyboardModifiers: PointerKeyboardModifiers? = null
 
+    // Interaction Lifecycle
     private var pressInteraction: PressInteraction.Press? = null
     private var delayJob: Job? = null
 
+    // Layout Metrics
     private var componentSize: IntSize = IntSize.Zero
     private var centerOffset: Offset = Offset.Zero
 
-    private val focusableNode = delegate(
-        FocusableNode(interactionSource)
-    )
+    private val focusableNode = delegate(FocusableNode(interactionSource))
 
     override fun onRemeasured(size: IntSize) {
         componentSize = size
@@ -221,15 +237,12 @@ private class PointerClickNode(
     ) {
         if (pass == PointerEventPass.Main) {
             if (downEvent == null) {
-                // Listen for ANY button pressing down, not just primary
-                val downChange =
-                    pointerEvent.changes.firstOrNull { it.changedToDown() && !it.isConsumed }
+                val downChange = pointerEvent.changes.firstOrNull { it.changedToDown() && !it.isConsumed }
                 if (downChange != null) {
                     handleDownEvent(downChange, pointerEvent)
                 }
             } else {
-                // To support multitouch accurately, a click is only resolved
-                // when all active pointers are lifted from the component.
+                // Multi-touch constraint: A click resolves only when ALL active pointers lift.
                 if (pointerEvent.changes.fastAll { it.changedToUp() }) {
                     handleUpEvent(pointerEvent)
                 } else {
@@ -244,21 +257,23 @@ private class PointerClickNode(
     private fun handleDownEvent(down: PointerInputChange, pointerEvent: PointerEvent) {
         down.consume()
         this.downEvent = down
+
+        // Cache the hardware state exactly as it was during the initial 'Down' frame
         this.downButtons = pointerEvent.buttons
         this.downKeyboardModifiers = pointerEvent.keyboardModifiers
 
         if (enabled) {
             requestFocusWhenInMouseInputMode()
 
-            // Allow the developer (or default logic) to decide if this event warrants a visual ripple
-            if (requestIndication(pointerEvent)) {
+            // Consult the developer's logic to see if this raw event warrants a visual ripple
+            if (triggerPressIndication(pointerEvent)) {
                 handlePressInteractionStart(down.position)
             }
         }
     }
 
     private fun handleUpEvent(pointerEvent: PointerEvent) {
-        // Ensure we retrieve the change corresponding to the original pointer if possible
+        // Map the up event back to the original pointer to handle multitouch displacement safely
         val upChange = pointerEvent.changes.firstOrNull { it.id == downEvent?.id }
             ?: pointerEvent.changes.first()
 
@@ -310,60 +325,56 @@ private class PointerClickNode(
     }
 
     private fun handlePressInteractionStart(offset: Offset) {
-        interactionSource?.let { source ->
-            val press = PressInteraction.Press(offset)
-            val shouldDelayPress = hasScrollableContainer()
+        val press = PressInteraction.Press(offset)
 
-            if (shouldDelayPress) {
-                delayJob = coroutineScope.launch {
-                    delay(TapIndicationDelay)
-                    source.emit(press)
-                    pressInteraction = press
-                }
-            } else {
+        // Parent scroll containers intercept touches. Delay the visual ripple
+        // to prevent UI flickering if the user is just scrolling past this component.
+        if (hasScrollableContainer()) {
+            delayJob = coroutineScope.launch {
+                delay(TapIndicationDelay)
+                interactionSource.emit(press)
                 pressInteraction = press
-                coroutineScope.launch { source.emit(press) }
             }
+        } else {
+            pressInteraction = press
+            coroutineScope.launch { interactionSource.emit(press) }
         }
     }
 
     private fun handlePressInteractionRelease(offset: Offset) {
-        interactionSource?.let { source ->
-            val job = delayJob
-            if (job?.isActive == true) {
-                job.cancel()
-                coroutineScope.launch {
-                    // Prevents interaction emission race conditions (b/414319919)
-                    // where rapid clicks resolve before the cancellation completes.
-                    job.join()
-                    val press = PressInteraction.Press(offset)
-                    val release = PressInteraction.Release(press)
-                    source.emit(press)
-                    source.emit(release)
-                }
-            } else {
-                pressInteraction?.let {
-                    coroutineScope.launch { source.emit(PressInteraction.Release(it)) }
-                }
+        val job = delayJob
+        if (job?.isActive == true) {
+            job.cancel()
+            coroutineScope.launch {
+                // Prevents interaction emission race conditions (b/414319919)
+                // Ensures a rapid "lightning click" still briefly flashes the ripple.
+                job.join()
+                val press = PressInteraction.Press(offset)
+                val release = PressInteraction.Release(press)
+                interactionSource.emit(press)
+                interactionSource.emit(release)
             }
-            pressInteraction = null
+        } else {
+            pressInteraction?.let {
+                coroutineScope.launch { interactionSource.emit(PressInteraction.Release(it)) }
+            }
         }
+        pressInteraction = null
     }
 
     private fun handlePressInteractionCancel() {
-        interactionSource?.let { source ->
-            if (delayJob?.isActive == true) {
-                delayJob?.cancel()
-            } else {
-                pressInteraction?.let {
-                    coroutineScope.launch { source.emit(PressInteraction.Cancel(it)) }
-                }
+        if (delayJob?.isActive == true) {
+            delayJob?.cancel()
+        } else {
+            pressInteraction?.let {
+                coroutineScope.launch { interactionSource.emit(PressInteraction.Cancel(it)) }
             }
-            pressInteraction = null
         }
+        pressInteraction = null
     }
 
     private fun requestFocusWhenInMouseInputMode() {
+        // Implementation delegates to Compose internals to avoid focusing on touch devices
         if (isRequestFocusOnClickEnabled()) {
             requestFocus()
         }
@@ -382,8 +393,8 @@ private class PointerClickNode(
         enabled: Boolean,
         onClickLabel: String?,
         role: Role?,
-        interactionSource: MutableInteractionSource?,
-        requestIndication: (PointerEvent) -> Boolean,
+        interactionSource: MutableInteractionSource,
+        triggerPressIndication: (PointerEvent) -> Boolean,
         onClick: (PointerClickEvent) -> Unit
     ) {
         if (this.enabled != enabled) {
@@ -401,7 +412,7 @@ private class PointerClickNode(
             this.interactionSource = interactionSource
             focusableNode.update(interactionSource)
         }
-        this.requestIndication = requestIndication
+        this.triggerPressIndication = triggerPressIndication
         this.onClick = onClick
     }
 
@@ -411,10 +422,12 @@ private class PointerClickNode(
         }
         onClick(
             action = {
+                // Fetch window modifiers dynamically to support screen-readers triggering
+                // clicks while the user holds a physical key (e.g. Switch Access).
                 val currentModifiers = currentValueOf(LocalWindowInfo).keyboardModifiers
                 val synthesizedEvent = PointerClickEvent(
                     position = centerOffset,
-                    buttons = null,
+                    buttons = null, // Synthesized clicks lack hardware pointers
                     keyboardModifiers = currentModifiers
                 )
                 onClick(synthesizedEvent)

--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/PointerClickable.kt
@@ -223,8 +223,27 @@ private class PointerClickNode(
     private var componentSize: IntSize = IntSize.Zero
     private var centerOffset: Offset = Offset.Zero
 
-    private val focusableNode = delegate(FocusableNode(interactionSource))
+    private var focusableNode: FocusableNode? = null
 
+    private fun updateFocusableNode() {
+        if (enabled && focusableNode == null) {
+            focusableNode = delegate(FocusableNode(interactionSource))
+        } else if (!enabled && focusableNode != null) {
+            focusableNode?.let { undelegate(it) }
+            focusableNode = null
+        }
+    }
+
+    override fun onAttach() {
+        super.onAttach()
+        updateFocusableNode()
+    }
+
+    override fun onDetach() {
+        focusableNode?.let { undelegate(it) }
+        focusableNode = null
+        super.onDetach()
+    }
     override fun onRemeasured(size: IntSize) {
         componentSize = size
         centerOffset = size.center.toOffset()
@@ -420,22 +439,28 @@ private class PointerClickNode(
         if (this@PointerClickNode.role != null) {
             role = this@PointerClickNode.role!!
         }
-        onClick(
-            action = {
-                // Fetch window modifiers dynamically to support screen-readers triggering
-                // clicks while the user holds a physical key (e.g. Switch Access).
-                val currentModifiers = currentValueOf(LocalWindowInfo).keyboardModifiers
-                val synthesizedEvent = PointerClickEvent(
-                    position = centerOffset,
-                    buttons = null, // Synthesized clicks lack hardware pointers
-                    keyboardModifiers = currentModifiers
-                )
-                onClick(synthesizedEvent)
-                true
-            },
-            label = onClickLabel
-        )
-        if (!enabled) {
+        if (enabled) {
+            // When enabled, expose focus semantics from the delegated focusableNode
+            with(focusableNode) {
+                applySemantics()
+            }
+            onClick(
+                action = {
+                    // Fetch window modifiers dynamically to support screen-readers triggering
+                    // clicks while the user holds a physical key (e.g. Switch Access).
+                    val currentModifiers = currentValueOf(LocalWindowInfo).keyboardModifiers
+                    val synthesizedEvent = PointerClickEvent(
+                        position = centerOffset,
+                        buttons = null, // Synthesized clicks lack hardware pointers
+                        keyboardModifiers = currentModifiers
+                    )
+                    onClick(synthesizedEvent)
+                    true
+                },
+                label = onClickLabel
+            )
+        } else {
+            // When disabled, suppress focus and click semantics and mark as disabled
             disabled()
         }
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
@@ -460,7 +460,7 @@ class PointerClickableTest {
                     .onPointerClick(
                         interactionSource = interactionSource,
                         // Custom logic: Only ripple on Right Click (Secondary)
-                        triggerPressIndication = { it.buttons.isSecondaryPressed }
+                        triggerPressInteraction = { it.buttons.isSecondaryPressed }
                     ) {}
             )
         }
@@ -580,7 +580,7 @@ class PointerClickableTest {
                     .size(40.dp)
                     .onPointerClick(
                         interactionSource = interactionSource,
-                        triggerPressIndication = { if (onlyRippleOnShift) it.keyboardModifiers.isShiftPressed else true }
+                        triggerPressInteraction = { if (onlyRippleOnShift) it.keyboardModifiers.isShiftPressed else true }
                     ) {
                         if (onlyRippleOnShift) clickCount2++ else clickCount1++
                     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.isAltPressed
+import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isMetaPressed
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.isShiftPressed
+import androidx.compose.ui.input.pointer.isTertiaryPressed
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.runSkikoComposeUiTest
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalTestApi::class, InternalComposeUiApi::class)
+class PointerClickableTest {
+
+    @Test
+    fun semantics_defaultAndDisabledAndRole() = runSkikoComposeUiTest {
+        var enabled by mutableStateOf(true)
+        var role by mutableStateOf<Role?>(Role.Button)
+
+        setContent {
+            Box(
+                Modifier
+                    .testTag("target")
+                    .size(40.dp)
+                    .onPointerClick(enabled = enabled, role = role) {}
+            )
+        }
+
+        onNodeWithTag("target")
+            .assertIsEnabled()
+            .assertHasClickAction()
+            .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+
+        role = null
+        waitForIdle()
+
+        onNodeWithTag("target")
+            .assertIsEnabled()
+            .assertHasClickAction()
+            .assert(SemanticsMatcher.keyNotDefined(SemanticsProperties.Role))
+
+        enabled = false
+        waitForIdle()
+        onNodeWithTag("target").assertIsNotEnabled().assertHasClickAction()
+    }
+
+    @Test
+    fun primaryClick_providesPrimaryButtonMetadata() = runSkikoComposeUiTest {
+        var event: PointerClickEvent? = null
+
+        setContent {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .onPointerClick { clickEvent -> event = clickEvent }
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f))
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = Offset(10f, 10f),
+            button = PointerButton.Primary
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(10f, 10f),
+            button = PointerButton.Primary
+        )
+
+        waitForIdle()
+        val clickEvent = assertNotNull(event)
+        assertNotNull(clickEvent.buttons)
+        assertThat(clickEvent.buttons.isPrimaryPressed).isTrue()
+    }
+
+    @Test
+    fun secondaryAndTertiaryClicks_reportCorrectButtonMask() = runSkikoComposeUiTest {
+        val events = mutableListOf<PointerClickEvent>()
+
+        setContent {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .onPointerClick { clickEvent -> events += clickEvent }
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f))
+
+        // Let Skiko implicitly manage the bitmask by passing the event button type
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = Offset(10f, 10f),
+            button = PointerButton.Secondary
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(10f, 10f),
+            button = PointerButton.Secondary
+        )
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = Offset(20f, 20f),
+            button = PointerButton.Tertiary
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(20f, 20f),
+            button = PointerButton.Tertiary
+        )
+
+        waitForIdle()
+
+        assertThat(events).hasSize(2)
+        assertThat(events[0].buttons?.isSecondaryPressed).isTrue()
+        assertThat(events[1].buttons?.isTertiaryPressed).isTrue()
+    }
+
+    @Test
+    fun keyboardModifiers_areCapturedFromPointerEvent() = runSkikoComposeUiTest {
+        val events = mutableListOf<PointerClickEvent>()
+
+        setContent {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .onPointerClick { clickEvent -> events += clickEvent }
+            )
+        }
+
+        clickWithModifiers(PointerKeyboardModifiers(isShiftPressed = true))
+        clickWithModifiers(PointerKeyboardModifiers(isCtrlPressed = true))
+        clickWithModifiers(PointerKeyboardModifiers(isAltPressed = true))
+        clickWithModifiers(PointerKeyboardModifiers(isMetaPressed = true))
+
+        waitForIdle()
+
+        assertThat(events).hasSize(4)
+        assertThat(events[0].keyboardModifiers.isShiftPressed).isTrue()
+        assertThat(events[1].keyboardModifiers.isCtrlPressed).isTrue()
+        assertThat(events[2].keyboardModifiers.isAltPressed).isTrue()
+        assertThat(events[3].keyboardModifiers.isMetaPressed).isTrue()
+    }
+
+    @Test
+    fun positionTracking_usesLocalCoordinatesWhenNodeMovesMidGesture() = runSkikoComposeUiTest {
+        var xOffset by mutableStateOf(0)
+        var event: PointerClickEvent? = null
+
+        setContent {
+            Box(
+                Modifier
+                    .offset { IntOffset(xOffset, 0) }
+                    .size(100.dp)
+                    .onPointerClick { clickEvent -> event = clickEvent }
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(50f, 50f))
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = Offset(50f, 50f),
+            button = PointerButton.Primary
+        )
+
+        xOffset = 20
+        waitForIdle()
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(50f, 50f),
+            button = PointerButton.Primary
+        )
+
+        waitForIdle()
+
+        val clickEvent = assertNotNull(event)
+        assertThat(clickEvent.position).isEqualTo(Offset(30f, 50f))
+    }
+
+    @Test
+    fun touchSlopCancellation_dragFarOutsideCancelsClick() = runSkikoComposeUiTest {
+        var clicks = 0
+
+        setContent {
+            Box(Modifier.size(40.dp).onPointerClick { clicks++ })
+        }
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(-100f, -100f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(-100f, -100f), type = PointerType.Touch)
+
+        waitForIdle()
+        assertThat(clicks).isEqualTo(0)
+    }
+
+    @Test
+    fun boundaryRelease_onExactEdge_isStillInside() = runSkikoComposeUiTest {
+        var event: PointerClickEvent? = null
+
+        setContent {
+            Box(Modifier.size(40.dp).onPointerClick { clickEvent -> event = clickEvent })
+        }
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = Offset(1f, 20f),
+            button = PointerButton.Primary
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(40f, 20f),
+            button = PointerButton.Primary
+        )
+
+        waitForIdle()
+        assertThat(assertNotNull(event).position).isEqualTo(Offset(40f, 20f))
+    }
+
+    @Test
+    fun multiPointer_sequentialLifting_clickFiresAfterLastPointerUp() = runSkikoComposeUiTest {
+        var clicks = 0
+
+        setContent {
+            Box(Modifier.size(60.dp).onPointerClick { clicks++ })
+        }
+
+        val pointerA = PointerId(1)
+        val pointerB = PointerId(2)
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            pointers = listOf(pointer(pointerA, 10f, 10f, pressed = true, type = PointerType.Touch))
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            pointers = listOf(
+                pointer(pointerA, 10f, 10f, pressed = true, type = PointerType.Touch),
+                pointer(pointerB, 20f, 20f, pressed = true, type = PointerType.Touch)
+            )
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            pointers = listOf(
+                pointer(pointerA, 10f, 10f, pressed = false, type = PointerType.Touch),
+                pointer(pointerB, 20f, 20f, pressed = true, type = PointerType.Touch)
+            )
+        )
+
+        waitForIdle()
+        assertThat(clicks).isEqualTo(0)
+
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            pointers = listOf(pointer(pointerB, 20f, 20f, pressed = false, type = PointerType.Touch))
+        )
+
+        waitForIdle()
+        assertThat(clicks).isEqualTo(1)
+    }
+
+    @Test
+    fun parentScrolling_cancelsClickAndEmitsPressCancel() = runSkikoComposeUiTest {
+        val interactionSource = MutableInteractionSource()
+        val interactions = mutableListOf<Interaction>()
+        var clicks = 0
+
+        this.mainClock.autoAdvance = false
+
+        setContent {
+            LaunchedEffect(interactionSource) {
+                interactionSource.interactions.collect { interactions += it }
+            }
+            Box(Modifier.size(120.dp).verticalScroll(rememberScrollState())) {
+                Box(
+                    Modifier
+                        .size(80.dp)
+                        .onPointerClick(interactionSource = interactionSource) { clicks++ }
+                )
+            }
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f), type = PointerType.Touch)
+        this.mainClock.advanceTimeBy(TapIndicationDelay)
+        waitForIdle()
+
+        scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 100f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 100f), type = PointerType.Touch)
+
+        waitForIdle()
+
+        val pressInteractions = interactions.filterIsInstance<PressInteraction>()
+        assertThat(pressInteractions).hasSize(2)
+        val press = assertIs<PressInteraction.Press>(pressInteractions[0])
+        val cancel = assertIs<PressInteraction.Cancel>(pressInteractions[1])
+        assertEquals(press, cancel.press)
+        assertThat(clicks).isEqualTo(0)
+    }
+
+    @Test
+    fun midGestureDisable_preventsClick() = runSkikoComposeUiTest {
+        var enabled by mutableStateOf(true)
+        var clicks = 0
+
+        setContent {
+            Box(Modifier.size(40.dp).onPointerClick(enabled = enabled) { clicks++ })
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), type = PointerType.Touch)
+
+        enabled = false
+        waitForIdle() // Force recomposition down to the Node layer
+
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), type = PointerType.Touch)
+
+        waitForIdle()
+        assertThat(clicks).isEqualTo(0)
+    }
+
+    @Test
+    fun semanticTrigger_invokesCallbackWithNullButtons() = runSkikoComposeUiTest {
+        var event: PointerClickEvent? = null
+
+        setContent {
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .testTag("target")
+                    .onPointerClick { clickEvent -> event = clickEvent }
+            )
+        }
+
+        onNodeWithTag("target").performSemanticsAction(SemanticsActions.OnClick)
+
+        waitForIdle()
+        val clickEvent = assertNotNull(event)
+        assertNull(clickEvent.buttons)
+    }
+
+    @Test
+    fun rippleLifecycle_successAndCancel_emitExpectedInteractions() = runSkikoComposeUiTest {
+        val sourceSuccess = MutableInteractionSource()
+        val sourceCancel = MutableInteractionSource()
+        val successInteractions = mutableListOf<Interaction>()
+        val cancelInteractions = mutableListOf<Interaction>()
+
+        setContent {
+            LaunchedEffect(sourceSuccess) {
+                sourceSuccess.interactions.collect { successInteractions += it }
+            }
+            LaunchedEffect(sourceCancel) {
+                sourceCancel.interactions.collect { cancelInteractions += it }
+            }
+            Box {
+                Box(
+                    Modifier
+                        .size(40.dp)
+                        .onPointerClick(interactionSource = sourceSuccess) {}
+                )
+                Box(
+                    Modifier
+                        .offset { IntOffset(50, 0) }
+                        .size(40.dp)
+                        .onPointerClick(interactionSource = sourceCancel) {}
+                )
+            }
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), type = PointerType.Touch)
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(60f, 10f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(150f, 10f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(150f, 10f), type = PointerType.Touch)
+
+        waitForIdle()
+
+        val successPresses = successInteractions.filterIsInstance<PressInteraction>()
+        assertThat(successPresses).hasSize(2)
+        val successPress = assertIs<PressInteraction.Press>(successPresses[0])
+        val successRelease = assertIs<PressInteraction.Release>(successPresses[1])
+        assertEquals(successPress, successRelease.press)
+
+        val cancelPresses = cancelInteractions.filterIsInstance<PressInteraction>()
+        assertThat(cancelPresses).hasSize(2)
+        val cancelPress = assertIs<PressInteraction.Press>(cancelPresses[0])
+        val cancelEvent = assertIs<PressInteraction.Cancel>(cancelPresses[1])
+        assertEquals(cancelPress, cancelEvent.press)
+    }
+
+    @Test
+    fun lightningClick_inScrollableContainerStillEmitsPressThenRelease() = runSkikoComposeUiTest {
+        val interactionSource = MutableInteractionSource()
+        val interactions = mutableListOf<Interaction>()
+
+        this.mainClock.autoAdvance = false
+
+        setContent {
+            LaunchedEffect(interactionSource) {
+                interactionSource.interactions.collect { interactions += it }
+            }
+            Box(Modifier.size(120.dp).verticalScroll(rememberScrollState())) {
+                Box(
+                    Modifier
+                        .size(80.dp)
+                        .onPointerClick(interactionSource = interactionSource) {}
+                )
+            }
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f), type = PointerType.Touch)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(20f, 20f), type = PointerType.Touch)
+
+        waitForIdle()
+
+        val pressInteractions = interactions.filterIsInstance<PressInteraction>()
+        assertThat(pressInteractions).hasSize(2)
+        val press = assertIs<PressInteraction.Press>(pressInteractions[0])
+        val release = assertIs<PressInteraction.Release>(pressInteractions[1])
+        assertEquals(press, release.press)
+    }
+
+    @Test
+    fun modifierIsPure() {
+        val sharedLambda: (PointerClickEvent) -> Unit = {}
+        val modifier1 = Modifier.onPointerClick(enabled = true, onClick = sharedLambda)
+        val modifier2 = Modifier.onPointerClick(enabled = true, onClick = sharedLambda)
+
+        assertThat(modifier1).isEqualTo(modifier2)
+    }
+
+    private fun pointer(
+        id: PointerId,
+        x: Float,
+        y: Float,
+        pressed: Boolean,
+        type: PointerType
+    ): ComposeScenePointer = ComposeScenePointer(
+        id = id,
+        position = Offset(x, y),
+        pressed = pressed,
+        type = type
+    )
+
+    private fun androidx.compose.ui.test.SkikoComposeUiTest.clickWithModifiers(
+        modifiers: PointerKeyboardModifiers
+    ) {
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            position = Offset(10f, 10f),
+            keyboardModifiers = modifiers,
+            button = PointerButton.Primary
+        )
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            position = Offset(10f, 10f),
+            keyboardModifiers = modifiers,
+            button = PointerButton.Primary
+        )
+    }
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -317,6 +318,57 @@ class PointerClickableTest {
     }
 
     @Test
+    fun multiPointer_clickResolvesWithOriginalPointerPosition() = runSkikoComposeUiTest {
+        var clickEvent: PointerClickEvent? = null
+
+        setContent {
+            Box(
+                Modifier
+                    .size(100.dp)
+                    .onPointerClick { clickEvent = it }
+            )
+        }
+
+        val p1 = PointerId(1)
+        val p2 = PointerId(2)
+
+        // Press P1
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            pointers = listOf(pointer(p1, 10f, 10f, pressed = true, type = PointerType.Touch))
+        )
+        // Press P2 elsewhere
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Press,
+            pointers = listOf(
+                pointer(p1, 10f, 10f, pressed = true, type = PointerType.Touch),
+                pointer(p2, 50f, 50f, pressed = true, type = PointerType.Touch)
+            )
+        )
+        // Release P2
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            pointers = listOf(
+                pointer(p1, 10f, 10f, pressed = true, type = PointerType.Touch),
+                pointer(p2, 50f, 50f, pressed = false, type = PointerType.Touch)
+            )
+        )
+        // Release P1
+        scene.sendPointerEvent(
+            eventType = PointerEventType.Release,
+            pointers = listOf(
+                pointer(p1, 10f, 10f, pressed = false, type = PointerType.Touch)
+            )
+        )
+
+        waitForIdle()
+
+        // Ensure the click event corresponds to the original down event (P1)
+        assertNotNull(clickEvent)
+        assertThat(clickEvent.position).isEqualTo(Offset(10f, 10f))
+    }
+
+    @Test
     fun parentScrolling_cancelsClickAndEmitsPressCancel() = runSkikoComposeUiTest {
         val interactionSource = MutableInteractionSource()
         val interactions = mutableListOf<Interaction>()
@@ -338,7 +390,7 @@ class PointerClickableTest {
         }
 
         scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f), type = PointerType.Touch)
-        this.mainClock.advanceTimeBy(TapIndicationDelay)
+        this.mainClock.advanceTimeBy(100L) // Advance past tap delay
         waitForIdle()
 
         scene.sendPointerEvent(PointerEventType.Move, Offset(20f, 100f), type = PointerType.Touch)
@@ -392,6 +444,41 @@ class PointerClickableTest {
         waitForIdle()
         val clickEvent = assertNotNull(event)
         assertNull(clickEvent.buttons)
+    }
+
+    @Test
+    fun requestIndication_controlsRippleEmission() = runSkikoComposeUiTest {
+        val interactions = mutableListOf<Interaction>()
+        val interactionSource = MutableInteractionSource()
+
+        setContent {
+            LaunchedEffect(interactionSource) {
+                interactionSource.interactions.collect { interactions += it }
+            }
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .onPointerClick(
+                        interactionSource = interactionSource,
+                        // Custom logic: Only ripple on Right Click (Secondary)
+                        requestIndication = { it.buttons.isSecondaryPressed }
+                    ) {}
+            )
+        }
+
+        // Left Click -> Should NOT ripple
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), button = PointerButton.Primary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+
+        waitForIdle()
+        assertThat(interactions.filterIsInstance<PressInteraction>()).isEmpty()
+
+        // Right Click -> SHOULD ripple
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), button = PointerButton.Secondary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Secondary)
+
+        waitForIdle()
+        assertThat(interactions.filterIsInstance<PressInteraction>()).hasSize(2)
     }
 
     @Test
@@ -478,10 +565,72 @@ class PointerClickableTest {
     }
 
     @Test
+    fun nodeReuse_updatesRequestIndicationAndOnClickLambda() = runSkikoComposeUiTest {
+        var onlyRippleOnShift by mutableStateOf(false)
+        var clickCount1 = 0
+        var clickCount2 = 0
+        val interactionSource = MutableInteractionSource()
+        val interactions = mutableListOf<Interaction>()
+
+        setContent {
+            LaunchedEffect(interactionSource) {
+                interactionSource.interactions.collect { interactions += it }
+            }
+            Box(
+                Modifier
+                    .size(40.dp)
+                    .onPointerClick(
+                        interactionSource = interactionSource,
+                        requestIndication = { if (onlyRippleOnShift) it.keyboardModifiers.isShiftPressed else true }
+                    ) {
+                        if (onlyRippleOnShift) clickCount2++ else clickCount1++
+                    }
+            )
+        }
+
+        // 1. Initial state: ripple on anything.
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), button = PointerButton.Primary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+        waitForIdle()
+
+        assertThat(clickCount1).isEqualTo(1)
+        assertThat(interactions.filterIsInstance<PressInteraction>()).hasSize(2)
+        interactions.clear()
+
+        // 2. Recompose: swap the behavior logic
+        onlyRippleOnShift = true
+        waitForIdle()
+
+        // 3. Click WITHOUT shift -> Callback fires, NO ripple
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), button = PointerButton.Primary)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), button = PointerButton.Primary)
+        waitForIdle()
+
+        assertThat(clickCount2).isEqualTo(1)
+        assertThat(interactions.filterIsInstance<PressInteraction>()).isEmpty()
+
+        // 4. Click WITH shift -> Callback fires, YES ripple
+        clickWithModifiers(PointerKeyboardModifiers(isShiftPressed = true))
+        waitForIdle()
+
+        assertThat(clickCount2).isEqualTo(2)
+        assertThat(interactions.filterIsInstance<PressInteraction>()).hasSize(2)
+    }
+
+    @Test
     fun modifierIsPure() {
         val sharedLambda: (PointerClickEvent) -> Unit = {}
-        val modifier1 = Modifier.onPointerClick(enabled = true, onClick = sharedLambda)
-        val modifier2 = Modifier.onPointerClick(enabled = true, onClick = sharedLambda)
+        val sharedFilter: (PointerEvent) -> Boolean = { true }
+        val modifier1 = Modifier.onPointerClick(
+            enabled = true,
+            requestIndication = sharedFilter,
+            onClick = sharedLambda
+        )
+        val modifier2 = Modifier.onPointerClick(
+            enabled = true,
+            requestIndication = sharedFilter,
+            onClick = sharedLambda
+        )
 
         assertThat(modifier1).isEqualTo(modifier2)
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/PointerClickableTest.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerButton
-import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerId
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
@@ -461,7 +460,7 @@ class PointerClickableTest {
                     .onPointerClick(
                         interactionSource = interactionSource,
                         // Custom logic: Only ripple on Right Click (Secondary)
-                        requestIndication = { it.buttons.isSecondaryPressed }
+                        triggerPressIndication = { it.buttons.isSecondaryPressed }
                     ) {}
             )
         }
@@ -581,7 +580,7 @@ class PointerClickableTest {
                     .size(40.dp)
                     .onPointerClick(
                         interactionSource = interactionSource,
-                        requestIndication = { if (onlyRippleOnShift) it.keyboardModifiers.isShiftPressed else true }
+                        triggerPressIndication = { if (onlyRippleOnShift) it.keyboardModifiers.isShiftPressed else true }
                     ) {
                         if (onlyRippleOnShift) clickCount2++ else clickCount1++
                     }
@@ -615,24 +614,6 @@ class PointerClickableTest {
 
         assertThat(clickCount2).isEqualTo(2)
         assertThat(interactions.filterIsInstance<PressInteraction>()).hasSize(2)
-    }
-
-    @Test
-    fun modifierIsPure() {
-        val sharedLambda: (PointerClickEvent) -> Unit = {}
-        val sharedFilter: (PointerEvent) -> Boolean = { true }
-        val modifier1 = Modifier.onPointerClick(
-            enabled = true,
-            requestIndication = sharedFilter,
-            onClick = sharedLambda
-        )
-        val modifier2 = Modifier.onPointerClick(
-            enabled = true,
-            requestIndication = sharedFilter,
-            onClick = sharedLambda
-        )
-
-        assertThat(modifier1).isEqualTo(modifier2)
     }
 
     private fun pointer(


### PR DESCRIPTION
# Introduce `Modifier.onPointerClick` for `commonMain`  

## Summary  

Adds a new `Modifier.onPointerClick` to `androidx.compose.foundation` (`commonMain`), providing a unified and extensible API for pointer click handling with full access to hardware metadata.  

This change addresses the request in [CMP-7202](https://youtrack.jetbrains.com/issue/CMP-7202) by making `onClick`-like functionality available in `commonMain`, while also offering an alternative API for handling multiple mouse buttons and keyboard modifiers.  

Currently, `Modifier.onClick` is only available on Desktop/Web/iOS. The alternative (`commonMain` clickable) does not support certain desktop use cases and has opinionated behavior that is not always compatible with user customization. Having `onClick` only for some platforms complicates writing cross-platform applications.  

---

## Problem  

### 1. Missing common API  

`Modifier.onClick` is not available in `commonMain`, making it difficult to write consistent cross-platform code. Developers were forced to rely on `Modifier.clickable`, which:  

- Does not expose pointer buttons (right/middle click)  
- Does not expose keyboard modifiers  

### 2. Limitations of the existing API  

Even where available, `onClick` had structural issues:  

- Required **modifier stacking** to handle multiple buttons (e.g., left + right click)  
- Created **multiple independent gesture detectors**, leading to:  
  - Redundant state machines  
  - Higher overhead  
  - Hard-to-reason-about interactions  

---

## Solution  

Instead of promoting the existing `onClick` API to `commonMain`, this introduces a **new, more general primitive**:  

### `Modifier.onPointerClick`  

This API:  

- Works in `commonMain`  
- Unifies all pointer click handling into a **single modifier**  
- Exposes full hardware context via `PointerClickEvent`  
- Eliminates the need for modifier stacking  
- Provides a foundation for advanced and customizable interaction patterns  

---

### `PointerClickEvent`  

Provides:  

- Click position  
- `PointerButtons` bitmask  
- `PointerKeyboardModifiers`  

---

### Implementation  

Implemented as a `DelegatingNode` combining:  

- `PointerInputModifierNode`  
- `SemanticsModifierNode`  
- `FocusRequesterModifierNode`  

Pointer input is processed in the **final pass** to:  

- Detect gesture interception by parent containers (e.g., scrollables)  
- Ensure consistent and predictable behavior in complex hierarchies  

---

## Testing  

Adds `PointerClickableTest` covering:  

- Pointer button bitmask handling  
- Keyboard modifier propagation  
- Multi-pointer gesture resolution  
- `InteractionSource` emission and filtering  
- Coordinate correctness during layout changes  
- Semantics integration  

---

## Related Feature Request  

- YouTrack: [CMP-7202](https://youtrack.jetbrains.com/issue/CMP-7202)