### PR TITLE
IntropWrappingView clipToBounds

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/viewinterop/InteropWrappingView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/viewinterop/InteropWrappingView.ios.kt
@@ -64,10 +64,7 @@ internal class InteropWrappingView(
         }
 
     init {
-        // required to properly clip the content of the wrapping view in case interop unclipped
-        // bounds are larger than clipped bounds
         userInteractionEnabled = interactionMode != null
-        clipsToBounds = true
     }
 
     private fun updateAccessibilityElements() {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/viewinterop/UIKitInteropElementHolder.ios.kt
@@ -199,6 +199,9 @@ internal abstract class UIKitInteropElementHolder<T : InteropView>(
 
     private fun onPropertiesChanged() {
         interopWrappingView.interactionMode = properties.interactionMode
+        // required to properly clip the content of the wrapping view in case interop unclipped
+        // bounds are larger than clipped bounds
+        interopWrappingView.clipsToBounds = !properties.placedAsOverlay
 
         platformModifier = Modifier
             .pointerInteropFilter(


### PR DESCRIPTION
Avoid clipping overlay interop views (for example views with applied shadows), while still enabling clipping when needed for offset/clipped positioning.

Fixes [CMP-9728](https://youtrack.jetbrains.com/issue/CMP-9728) Interop view with placedAsOverlay clip their bounds

## Release Notes
N/A