### PR TITLE
Fixed autofill for non-NITI textfields on iOS

### DIFF
--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -21,6 +21,7 @@
 @interface CMPEditMenuView : CMPTextInputView
 
 @property (readonly) BOOL isEditMenuShown;
+@property (readonly) BOOL shouldUseNativeTextMenuActions;
 
 - (void)showEditMenuAtRect:(CGRect)targetRect
                       copy:(void (^)(void))copyBlock
@@ -47,6 +48,4 @@
 
 - (void)deactivateTextInputInteractionIfNeeded;
 
-- (BOOL)canPerformComposeAction:(SEL)action
-                     withSender:(id)sender;
 @end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -47,4 +47,6 @@
 
 - (void)deactivateTextInputInteractionIfNeeded;
 
+- (BOOL)canPerformComposeAction:(SEL)action
+                     withSender:(id)sender;
 @end

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.h
@@ -21,7 +21,7 @@
 @interface CMPEditMenuView : CMPTextInputView
 
 @property (readonly) BOOL isEditMenuShown;
-@property (readonly) BOOL shouldUseNativeTextMenuActions;
+@property (readonly) BOOL shouldUseNonComposeMenuActions;
 
 - (void)showEditMenuAtRect:(CGRect)targetRect
                       copy:(void (^)(void))copyBlock

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -300,6 +300,15 @@ id _editInteraction;
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
+    BOOL composeActionHandled = [self canPerformComposeAction:action withSender:sender];
+    if (composeActionHandled) {
+        return composeActionHandled;
+    } else {
+        return [super canPerformAction:action withSender:sender];
+    }
+}
+
+- (BOOL)canPerformComposeAction:(SEL)action withSender:(id)sender {
     if (@selector(copy:) == action) {
         return self.copyBlock != nil;
     }
@@ -324,7 +333,7 @@ id _editInteraction;
     if (@selector(customAction8:) == action) return self.customActions.count > 8;
     if (@selector(customAction9:) == action) return self.customActions.count > 9;
 
-    return [super canPerformAction:action withSender:sender];
+    return NO;
 }
 
 - (void)copy:(id)sender {

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -74,6 +74,7 @@
 
 @property (assign, nonatomic) CGRect targetRect;
 @property (assign, nonatomic) BOOL isEditMenuShown;
+@property (assign, nonatomic) BOOL shouldUseNativeTextMenuActions;
 
 @property (readwrite) UIEditMenuInteraction* editInteraction API_AVAILABLE(ios(16.0));
 
@@ -300,13 +301,6 @@ id _editInteraction;
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
-    if ([self canPerformComposeAction:action withSender:sender]) {
-        return YES;
-    }
-    return [super canPerformAction:action withSender:sender];
-}
-
-- (BOOL)canPerformComposeAction:(SEL)action withSender:(id)sender {
     if (@selector(copy:) == action) {
         return self.copyBlock != nil;
     }
@@ -331,7 +325,9 @@ id _editInteraction;
     if (@selector(customAction8:) == action) return self.customActions.count > 8;
     if (@selector(customAction9:) == action) return self.customActions.count > 9;
 
-    return NO;
+    if (self.shouldUseNativeTextMenuActions) {
+        return [super canPerformAction:action withSender:sender];
+    } else { return NO; }
 }
 
 - (void)copy:(id)sender {

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -300,12 +300,10 @@ id _editInteraction;
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
-    BOOL composeActionHandled = [self canPerformComposeAction:action withSender:sender];
-    if (composeActionHandled) {
-        return composeActionHandled;
-    } else {
-        return [super canPerformAction:action withSender:sender];
+    if ([self canPerformComposeAction:action withSender:sender]) {
+        return YES;
     }
+    return [super canPerformAction:action withSender:sender];
 }
 
 - (BOOL)canPerformComposeAction:(SEL)action withSender:(id)sender {

--- a/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
+++ b/compose/ui/ui-uikit/src/iosMain/objc/CMPUIKitUtils/CMPUIKitUtils/CMPEditMenuView.m
@@ -74,7 +74,7 @@
 
 @property (assign, nonatomic) CGRect targetRect;
 @property (assign, nonatomic) BOOL isEditMenuShown;
-@property (assign, nonatomic) BOOL shouldUseNativeTextMenuActions;
+@property (assign, nonatomic) BOOL shouldUseNonComposeMenuActions;
 
 @property (readwrite) UIEditMenuInteraction* editInteraction API_AVAILABLE(ios(16.0));
 
@@ -325,7 +325,7 @@ id _editInteraction;
     if (@selector(customAction8:) == action) return self.customActions.count > 8;
     if (@selector(customAction9:) == action) return self.customActions.count > 9;
 
-    if (self.shouldUseNativeTextMenuActions) {
+    if (self.shouldUseNonComposeMenuActions) {
         return [super canPerformAction:action withSender:sender];
     } else { return NO; }
 }

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
@@ -732,7 +732,7 @@ internal class IntermediateTextInputUIView(
                 else -> super.canPerformAction(action, withSender)
             }
         } else {
-            return super.canPerformAction(action, withSender)
+            return super.canPerformComposeAction(action,withSender)
         }
     }
 

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
@@ -681,7 +681,7 @@ internal class IntermediateTextInputUIView(
     fun hideTextMenu() = this.hideEditMenu()
 
     fun isTextMenuShown() = isEditMenuShown
-    override fun shouldUseNativeTextMenuActions() = usingNativeTextInput
+    override fun shouldUseNonComposeMenuActions() = usingNativeTextInput
 
     private var onCopy: (() -> Unit)? = null
     private var onPaste: (() -> Unit)? = null

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/IntermediateTextInputUIView.ios.kt
@@ -681,6 +681,7 @@ internal class IntermediateTextInputUIView(
     fun hideTextMenu() = this.hideEditMenu()
 
     fun isTextMenuShown() = isEditMenuShown
+    override fun shouldUseNativeTextMenuActions() = usingNativeTextInput
 
     private var onCopy: (() -> Unit)? = null
     private var onPaste: (() -> Unit)? = null
@@ -732,7 +733,7 @@ internal class IntermediateTextInputUIView(
                 else -> super.canPerformAction(action, withSender)
             }
         } else {
-            return super.canPerformComposeAction(action,withSender)
+            return super.canPerformAction(action, withSender)
         }
     }
 


### PR DESCRIPTION
Fixed the regression with appeared autofill in non-native textfields on iOS

Fixes:
[CMP-9993](https://youtrack.jetbrains.com/issue/CMP-9993) [iOS] TextField. The new Autofill context menu item is available in the current implementation

## Testing
This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix incorrect appearance of `Autofill` context menu item in the `BasicTextField(TextFieldValue)` and `BasicTextField(TextFieldState)`

