### PR TITLE
Support LiveRegion

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -107,6 +107,7 @@ import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSSelectorFromString
 import platform.QuartzCore.CACurrentMediaTime
 import platform.UIKit.NSStringFromCGRect
+import platform.UIKit.UIAccessibilityAnnouncementNotification
 import platform.UIKit.UIAccessibilityContainerType
 import platform.UIKit.UIAccessibilityContainerTypeNone
 import platform.UIKit.UIAccessibilityContainerTypeSemanticGroup
@@ -1249,7 +1250,7 @@ internal class AccessibilityMediator(
                     if (isAccessibilityActive) {
                         scheduleAccessibilityDisablingAndCleanup()
                         val time = measureTime {
-                            sync().postNotification()
+                            sync()
                         }
                         accessibilityDebugLogger?.log("AccessibilityMediator.sync took $time")
                     }
@@ -1314,7 +1315,7 @@ internal class AccessibilityMediator(
     fun activateAccessibilityIfNeeded() {
         isAccessibilityActive = true
         if (root.element == null) {
-            sync().postNotification()
+            sync()
         }
         cancelAccessibilityDisabling()
     }
@@ -1460,7 +1461,7 @@ internal class AccessibilityMediator(
      */
     private fun traverseSemanticsTree(
         rootNode: SemanticsNode
-    ): Pair<AccessibilityElement, AccessibilityElementKey?> {
+    ): Triple<AccessibilityElement, AccessibilityElementKey?, AccessibilityNotification?> {
         val presentIds = MutableIntSet()
         presentIds.add(rootNode.id)
         val nodes = owner.getAllUncoveredSemanticsNodesToIntObjectMap(
@@ -1475,6 +1476,7 @@ internal class AccessibilityMediator(
             }
         }
         var focusedKey: AccessibilityElementKey? = null
+        var lastLiveRegionAnnouncement: AccessibilityNotification? = null
 
         // 1. Get accessibility elements and traversal groups.
         // Flattening of accessibility elements is used to:
@@ -1536,8 +1538,14 @@ internal class AccessibilityMediator(
                 focusedKey = node.semanticsKey
             }
 
-            fun makeSemanticsNode(children: List<AccessibilityElement>) =
-                createOrUpdateAccessibilityElement(
+            fun makeSemanticsNode(children: List<AccessibilityElement>): AccessibilityElement {
+                val isLiveRegion = node.unmergedConfig.contains(SemanticsProperties.LiveRegion)
+                val (oldLabel, oldValue) = isLiveRegion.takeIf { it }
+                    ?.let { accessibilityElementsMap[node.semanticsKey] }
+                    ?.let { it.accessibilityLabel() to it.accessibilityValue() }
+                    ?: Pair(null, null)
+
+                val element = createOrUpdateAccessibilityElement(
                     node = AccessibilityNode.Semantics(
                         semanticsNode = node,
                         mediator = this,
@@ -1547,6 +1555,23 @@ internal class AccessibilityMediator(
                     children = children,
                     frame = frame
                 )
+
+                if (isLiveRegion) {
+                    val newLabel = element.accessibilityLabel()
+                    val newValue = element.accessibilityValue()
+
+                    if ((newLabel != null || newValue != null) &&
+                        (oldLabel != newLabel || oldValue != newValue)
+                    ) {
+                        val announcement = listOfNotNull(newValue, newLabel).joinToString(", ")
+                        lastLiveRegionAnnouncement = AccessibilityNotification(
+                            UIAccessibilityAnnouncementNotification,
+                            message = announcement
+                        )
+                    }
+                }
+                return element
+            }
 
             val flattenChildren = flatten && !node.canBeAccessibilityElement()
             return if (node.isTraversalGroup || node.id == rootNode.id || !flattenChildren) {
@@ -1620,20 +1645,20 @@ internal class AccessibilityMediator(
             isPresent
         }
 
-        return rootAccessibilityElement to focusedKey
+        return Triple(rootAccessibilityElement, focusedKey, lastLiveRegionAnnouncement)
     }
 
     /**
      * Performs a complete sync of the accessibility tree with the current semantics tree.
      */
-    private fun sync(): AccessibilityNotification {
+    private fun sync() {
         val rootSemanticsNode = owner.unmergedRootSemanticsNode
 
         check(!view.isAccessibilityElement) {
             "Root view must not be an accessibility element"
         }
 
-        val (element, focusedElementKey) = traverseSemanticsTree(rootSemanticsNode)
+        val (element, focusedElementKey, liveRegionAnnouncement) = traverseSemanticsTree(rootSemanticsNode)
         root.element = element
 
         if (displayLinkListener == null) {
@@ -1658,7 +1683,10 @@ internal class AccessibilityMediator(
             updateFocusOnAccessibilityElementsLoaded = false
         }
 
-        return updateFocusedElement()
+        // Post layout notification first, then the live region announcement (if any) so that
+        // the announcement is the last posted notification, as iOS VoiceOver expects.
+        updateFocusedElement().postNotification()
+        liveRegionAnnouncement?.postNotification()
     }
 
     private fun updateFocusedElement(): AccessibilityNotification {

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/Accessibility.ios.kt
@@ -1540,10 +1540,12 @@ internal class AccessibilityMediator(
 
             fun makeSemanticsNode(children: List<AccessibilityElement>): AccessibilityElement {
                 val isLiveRegion = node.unmergedConfig.contains(SemanticsProperties.LiveRegion)
-                val (oldLabel, oldValue) = isLiveRegion.takeIf { it }
-                    ?.let { accessibilityElementsMap[node.semanticsKey] }
-                    ?.let { it.accessibilityLabel() to it.accessibilityValue() }
-                    ?: Pair(null, null)
+                val (oldLabel, oldValue) = if (isLiveRegion) {
+                    val element = accessibilityElementsMap[node.semanticsKey]
+                    element?.accessibilityLabel() to element?.accessibilityValue()
+                } else {
+                    Pair(null, null)
+                }
 
                 val element = createOrUpdateAccessibilityElement(
                     node = AccessibilityNode.Semantics(
@@ -1563,7 +1565,7 @@ internal class AccessibilityMediator(
                     if ((newLabel != null || newValue != null) &&
                         (oldLabel != newLabel || oldValue != newValue)
                     ) {
-                        val announcement = listOfNotNull(newValue, newLabel).joinToString(", ")
+                        val announcement = listOfNotNull(newLabel, newValue).joinToString(", ")
                         lastLiveRegionAnnouncement = AccessibilityNotification(
                             UIAccessibilityAnnouncementNotification,
                             message = announcement

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityLiveRegionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityLiveRegionTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.accessibility
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.AccessibilityNotification
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.test.getAccessibilityTree
+import androidx.compose.ui.test.runUIKitInstrumentedTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import platform.UIKit.UIAccessibilityAnnouncementNotification
+
+class AccessibilityLiveRegionTest {
+
+    @Test
+    fun testLiveRegionPoliteAnnouncesOnContentChange() = runUIKitInstrumentedTest {
+        var text by mutableStateOf("Initial")
+
+        setContent {
+            Text(text, modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Polite
+            })
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        text = "Updated"
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Updated", last?.message)
+    }
+
+    @Test
+    fun testLiveRegionAssertiveAnnouncesOnContentChange() = runUIKitInstrumentedTest {
+        var text by mutableStateOf("Initial")
+
+        setContent {
+            Text(text, modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Assertive
+            })
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        text = "Urgent update"
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Urgent update", last?.message)
+    }
+
+    @Test
+    fun testLiveRegionAnnouncesWhenNodeAppearsWithContent() = runUIKitInstrumentedTest {
+        var showLiveRegion by mutableStateOf(false)
+
+        setContent {
+            Column {
+                Text("Static text")
+                if (showLiveRegion) {
+                    Text("Live content appeared", modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    })
+                }
+            }
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        showLiveRegion = true
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Live content appeared", last?.message)
+    }
+
+    @Test
+    fun testLiveRegionDoesNotAnnounceWhenContentDoesNotChange() = runUIKitInstrumentedTest {
+        var unrelatedState by mutableStateOf(0)
+
+        setContent {
+            Column {
+                Text("Live region text", modifier = Modifier.semantics {
+                    liveRegion = LiveRegionMode.Polite
+                })
+                Text("Counter: $unrelatedState")
+            }
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        unrelatedState = 1
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertNotEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+    }
+
+    @Test
+    fun testLiveRegionAnnouncesMultipleUpdates() = runUIKitInstrumentedTest {
+        var text by mutableStateOf("First")
+
+        setContent {
+            Text(text, modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Polite
+            })
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        text = "Second"
+        waitForIdle()
+
+        var last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Second", last?.message)
+
+        text = "Third"
+        waitForIdle()
+
+        last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Third", last?.message)
+    }
+
+    @Test
+    fun testNoAnnouncementWithoutLiveRegion() = runUIKitInstrumentedTest {
+        var text by mutableStateOf("Initial")
+
+        setContent {
+            Text(text)
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        text = "Updated"
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertNotEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+    }
+
+    @Test
+    fun testLiveRegionNoAnnouncementWhenNodeDisappears() = runUIKitInstrumentedTest {
+        var showLiveRegion by mutableStateOf(true)
+
+        setContent {
+            Column {
+                Text("Static text")
+                if (showLiveRegion) {
+                    Text("Live content", modifier = Modifier.semantics {
+                        liveRegion = LiveRegionMode.Polite
+                    })
+                }
+            }
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        showLiveRegion = false
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertNotEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+    }
+
+    @Test
+    fun testLiveRegionAnnouncesOnInitialTreeBuild() = runUIKitInstrumentedTest {
+        setContent {
+            Text("Live content", modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Polite
+            })
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        val last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Live content", last?.message)
+    }
+}

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityLiveRegionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/accessibility/AccessibilityLiveRegionTest.kt
@@ -24,8 +24,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.AccessibilityNotification
 import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.test.getAccessibilityTree
 import androidx.compose.ui.test.runUIKitInstrumentedTest
 import kotlin.test.Test
@@ -211,5 +213,34 @@ class AccessibilityLiveRegionTest {
         val last = AccessibilityNotification.lastPostedNotificationForTests
         assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
         assertEquals("Live content", last?.message)
+    }
+
+    @Test
+    fun testLiveRegionAnnouncementContainsLabelBeforeValue() = runUIKitInstrumentedTest {
+        var label by mutableStateOf("Label")
+        var value by mutableStateOf("Value")
+
+        setContent {
+            Text("placeholder", modifier = Modifier.semantics {
+                liveRegion = LiveRegionMode.Polite
+                contentDescription = label
+                stateDescription = value
+            })
+        }
+
+        getAccessibilityTree()
+        waitForIdle()
+
+        var last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("Label, Value", last?.message)
+
+        label = "New Label"
+        value = "New Value"
+        waitForIdle()
+
+        last = AccessibilityNotification.lastPostedNotificationForTests
+        assertEquals(UIAccessibilityAnnouncementNotification, last?.notification)
+        assertEquals("New Label, New Value", last?.message)
     }
 }


### PR DESCRIPTION
Post notifications for noes with the `LiveRegion` semantics when either the new node appears or existing node changed its label or value.

Fixes https://youtrack.jetbrains.com/issue/CMP-7602/Support-live-regions
Fixes https://youtrack.jetbrains.com/issue/CMP-9046/iOS-VoiceOver-Snackbar-message-is-not-announced-read

## Testing
(Optional) Describe how you tested your changes (provide a snippet or/and steps)

(Optional) This should be tested by QA

## Release Notes
### Features - iOS
- Support `LiveRegion` semantics in Accessibility.