### PR TITLE
Lazily materialize `SkPath` after edits

### DIFF
--- a/compose/ui/ui-graphics/src/desktopTest/kotlin/androidx/compose/ui/graphics/DesktopPathTest.kt
+++ b/compose/ui/ui-graphics/src/desktopTest/kotlin/androidx/compose/ui/graphics/DesktopPathTest.kt
@@ -20,8 +20,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
 import androidx.compose.ui.test.InternalTestApi
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 @OptIn(InternalTestApi::class)
@@ -162,68 +160,6 @@ class DesktopPathTest : DesktopGraphicsTest() {
         )
 
         screenshotRule.snap(surface)
-    }
-
-    @Test
-    fun isEmpty() {
-        val path = Path()
-        assertEquals(true, path.isEmpty)
-
-        path.addRect(Rect(0f, 0f, 16f, 16f))
-        assertEquals(false, path.isEmpty)
-    }
-
-    @Test
-    fun isConvex() {
-        val path = Path()
-        assertEquals(true, path.isConvex)
-
-        path.addRect(Rect(0f, 0f, 8f, 8f))
-        assertEquals(true, path.isConvex)
-
-        path.addRect(Rect(8f, 8f, 16f, 16f))
-        assertEquals(false, path.isConvex)
-    }
-
-    @Test
-    fun getBounds() {
-        val path = Path()
-        assertEquals(Rect(0f, 0f, 0f, 0f), path.getBounds())
-
-        path.addRect(Rect(0f, 0f, 8f, 8f))
-        assertEquals(Rect(0f, 0f, 8f, 8f), path.getBounds())
-
-        path.addRect(Rect(8f, 8f, 16f, 16f))
-        assertEquals(Rect(0f, 0f, 16f, 16f), path.getBounds())
-    }
-
-    @Test
-    fun `initial parameters`() {
-        val path = Path()
-
-        assertEquals(PathFillType.NonZero, path.fillType)
-    }
-
-    @Test
-    fun `reset should preserve fillType`() {
-        val path = Path()
-
-        path.fillType = PathFillType.EvenOdd
-        path.reset()
-
-        assertEquals(PathFillType.EvenOdd, path.fillType)
-    }
-
-    @Test
-    fun testRewind() {
-        val path = Path().apply {
-            addRect(Rect(0f, 0f, 100f, 200f))
-        }
-        assertFalse(path.isEmpty)
-
-        path.rewind()
-
-        assertTrue(path.isEmpty)
     }
 
     @Test

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedCanvas.skiko.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui.graphics
 
 import androidx.compose.runtime.InternalComposeApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.IntOffset
@@ -148,9 +149,10 @@ internal class SkiaBackedCanvas(
         )
     }
 
+    @OptIn(InternalComposeUiApi::class)
     override fun clipPath(path: Path, clipOp: ClipOp) {
         val antiAlias = true
-        internalSkiaCanvas.clipPath(path.asSkiaPath(), clipOp.toSkia(), antiAlias)
+        internalSkiaCanvas.clipPath(path.materializeSkiaPath(), clipOp.toSkia(), antiAlias)
     }
 
     override fun drawLine(p1: Offset, p2: Offset, paint: Paint) {
@@ -233,9 +235,10 @@ internal class SkiaBackedCanvas(
         )
     }
 
+    @OptIn(InternalComposeUiApi::class)
     override fun drawPath(path: Path, paint: Paint) {
         internalSkiaCanvas.drawPath(
-            path = path.asSkiaPath(),
+            path = path.materializeSkiaPath(),
             paint = paint.asSkiaPaintWithAppliedAlphaMultiplier(),
         )
     }

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPath.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPath.skiko.kt
@@ -16,10 +16,10 @@
 
 package androidx.compose.ui.graphics
 
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
-import org.jetbrains.skia.Matrix33
 import org.jetbrains.skia.Path as SkPath
 import org.jetbrains.skia.PathDirection
 import org.jetbrains.skia.PathBuilder
@@ -31,7 +31,11 @@ actual fun Path(): Path = SkiaBackedPath()
 /**
  * Convert the [org.jetbrains.skia.Path] instance into a Compose-compatible Path
  */
-fun SkPath.asComposePath(): Path = SkiaBackedPath(this)
+// TODO: Multiple calls will NOT return the same instance,
+//  consider to replace to `fun Path(skiaPath: org.jetbrains.skia.Path)`
+fun SkPath.asComposePath(): Path = SkiaBackedPath(this).also {
+    it.isSkiaPathObserved = true
+}
 
 /**
  * Obtain a reference to the underlying [org.jetbrains.skia.Path] instance.
@@ -42,36 +46,81 @@ fun Path.asSkiaPath(): SkPath {
     requirePrecondition(this is SkiaBackedPath) {
         "Extracting skia path reference is only supported from androidx.compose.ui.graphics.SkiaBackedPath instances but received ${this::class}"
     }
+    isSkiaPathObserved = true
+    synchronizeSkiaPathIfNeeded()
     return internalSkiaPath
 }
 
-@Suppress("OVERRIDE_DEPRECATION")
-internal class SkiaBackedPath(
-    internalSkiaPath: SkPath = SkPath()
+/**
+ * Obtain a reference to the underlying [org.jetbrains.skia.Path] instance without marking
+ * that native path as externally observed.
+ *
+ * This is intended for internal, one-shot interop where the Skia API reads or copies the path
+ * immediately. Callers must not retain or mutate the returned [org.jetbrains.skia.Path].
+ *
+ * It throws an exception if accessed on unsupported types.
+ */
+@InternalComposeUiApi
+fun Path.materializeSkiaPath(): SkPath {
+    requirePrecondition(this is SkiaBackedPath) {
+        "Materializing skia path snapshot is only supported from androidx.compose.ui.graphics.SkiaBackedPath instances but received ${this::class}"
+    }
+    synchronizeSkiaPathIfNeeded()
+    return internalSkiaPath
+}
+
+/**
+ * Marks that a path has Compose-side mutations in its [PathBuilder] that are not yet
+ * reflected in the stable native [SkPath]. Skia's public path generation IDs are always non-zero,
+ * so `0` remains reserved for this local pending-state marker.
+ */
+private const val PendingGenerationId = 0
+
+@OptIn(InternalComposeUiApi::class)
+private class SkiaBackedPath(
+    internal val internalSkiaPath: SkPath = SkPath()
 ) : Path {
-    internal var internalSkiaPath = internalSkiaPath
-        private set
     private var pathBuilder = PathBuilder(internalSkiaPath)
     private var materializedGenerationId = internalSkiaPath.generationId
     private var currentFillMode = internalSkiaPath.fillMode
 
+    /**
+     * Indicates if [internalSkiaPath] is externally observable.
+     */
+    internal var isSkiaPathObserved = false
+
     private inline fun mutatePath(block: PathBuilder.() -> Unit) {
         synchronizeBuilderIfNeeded()
         pathBuilder.apply(block)
-        replacePath(pathBuilder.snapshot())
-        pathBuilder = PathBuilder(internalSkiaPath)
+        materializedGenerationId = PendingGenerationId
+        if (isSkiaPathObserved) {
+            synchronizeSkiaPathIfNeeded()
+        }
     }
+
+    private fun hasPendingChanges(): Boolean = materializedGenerationId == PendingGenerationId
 
     private fun synchronizeBuilderIfNeeded() {
         // Skia's generationId does not change when only the fill mode changes. Compare both
         // so a native/external fill type update still rebuilds the cached PathBuilder before
-        // its next snapshot overwrites internalSkiaPath with stale state.
-        if (internalSkiaPath.generationId != materializedGenerationId ||
-            internalSkiaPath.fillMode != currentFillMode
+        // the next Compose-side mutation would otherwise overwrite internalSkiaPath with stale
+        // builder state.
+        if (!hasPendingChanges() &&
+            (internalSkiaPath.generationId != materializedGenerationId ||
+                internalSkiaPath.fillMode != currentFillMode)
         ) {
+            pathBuilder.close()
             pathBuilder = PathBuilder(internalSkiaPath)
             materializedGenerationId = internalSkiaPath.generationId
             currentFillMode = internalSkiaPath.fillMode
+        }
+    }
+
+    internal fun synchronizeSkiaPathIfNeeded() {
+        if (hasPendingChanges()) {
+            replacePath(pathBuilder.snapshot())
+        } else {
+            synchronizeBuilderIfNeeded()
         }
     }
 
@@ -80,6 +129,8 @@ internal class SkiaBackedPath(
         internalSkiaPath.swap(path)
         materializedGenerationId = internalSkiaPath.generationId
         currentFillMode = internalSkiaPath.fillMode
+        pathBuilder.close()
+        pathBuilder = PathBuilder(internalSkiaPath)
     }
 
     override var fillType: PathFillType
@@ -93,6 +144,7 @@ internal class SkiaBackedPath(
             mutatePath {
                 setFillType(fillMode)
             }
+            currentFillMode = fillMode
         }
 
     override fun moveTo(x: Float, y: Float) = mutatePath {
@@ -200,6 +252,11 @@ internal class SkiaBackedPath(
         )
     }
 
+    @Deprecated(
+        "Prefer usage of addOval() with a winding direction",
+        replaceWith = ReplaceWith("addOval(oval)"),
+        level = DeprecationLevel.HIDDEN
+    )
     override fun addOval(oval: Rect) = mutatePath {
         addOval(
             oval.left,
@@ -220,6 +277,11 @@ internal class SkiaBackedPath(
         )
     }
 
+    @Deprecated(
+        "Prefer usage of addRoundRect() with a winding direction",
+        replaceWith = ReplaceWith("addRoundRect(roundRect)"),
+        level = DeprecationLevel.HIDDEN
+    )
     override fun addRoundRect(roundRect: RoundRect) = mutatePath {
         addRRect(
             roundRect.left,
@@ -276,7 +338,7 @@ internal class SkiaBackedPath(
     }
 
     override fun addPath(path: Path, offset: Offset) =
-        mutatePath { addPath(path.asSkiaPath(), offset.x, offset.y) }
+        mutatePath { addPath(path.materializeSkiaPath(), offset.x, offset.y) }
 
     override fun close() = mutatePath {
         closePath()
@@ -299,6 +361,7 @@ internal class SkiaBackedPath(
     }
 
     override fun getBounds(): Rect {
+        synchronizeSkiaPathIfNeeded()
         val bounds = internalSkiaPath.bounds
         return Rect(
             bounds.left,
@@ -313,19 +376,24 @@ internal class SkiaBackedPath(
         path2: Path,
         operation: PathOperation
     ): Boolean = SkPath.makeCombining(
-        path1.asSkiaPath(),
-        path2.asSkiaPath(),
+        path1.materializeSkiaPath(),
+        path2.materializeSkiaPath(),
         operation.toSkiaOperation()
     )?.also {
         replacePath(it)
-        pathBuilder = PathBuilder(internalSkiaPath)
     } != null
 
     override val isConvex: Boolean
-        get() = internalSkiaPath.isConvex
+        get() {
+            synchronizeSkiaPathIfNeeded()
+            return internalSkiaPath.isConvex
+        }
 
     override val isEmpty: Boolean
-        get() = internalSkiaPath.isEmpty
+        get() {
+            synchronizeSkiaPathIfNeeded()
+            return internalSkiaPath.isEmpty
+        }
 }
 
 private fun PathOperation.toSkiaOperation() = when (this) {

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathEffect.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathEffect.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.graphics
 
+import androidx.compose.ui.InternalComposeUiApi
 import org.jetbrains.skia.PathEffect as SkPathEffect
 
 internal class SkiaBackedPathEffect(
@@ -50,6 +51,7 @@ internal actual fun actualDashPathEffect(
 internal actual fun actualChainPathEffect(outer: PathEffect, inner: PathEffect): PathEffect =
     SkiaBackedPathEffect(outer.asSkiaPathEffect().makeCompose(inner.asSkiaPathEffect()))
 
+@OptIn(InternalComposeUiApi::class)
 internal actual fun actualStampedPathEffect(
     shape: Path,
     advance: Float,
@@ -58,7 +60,7 @@ internal actual fun actualStampedPathEffect(
 ): PathEffect =
     SkiaBackedPathEffect(
         SkPathEffect.makePath1D(
-            shape.asSkiaPath(),
+            shape.materializeSkiaPath(),
             advance,
             phase,
             style.toSkiaStampedPathEffectStyle()

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathMeasure.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPathMeasure.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.graphics
 
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.Offset
 import org.jetbrains.skia.PathMeasure as SkPathMeasure
 
@@ -40,8 +41,9 @@ internal class SkiaBackedPathMeasure(
     internal val internalSkiaPathMeasure: SkPathMeasure = SkPathMeasure()
 ) : PathMeasure {
 
+    @OptIn(InternalComposeUiApi::class)
     override fun setPath(path: Path?, forceClosed: Boolean) {
-        internalSkiaPathMeasure.setPath(path?.asSkiaPath(), forceClosed)
+        internalSkiaPathMeasure.setPath(path?.materializeSkiaPath(), forceClosed)
     }
 
     override fun getSegment(

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaPathIterator.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaPathIterator.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.graphics
 
+import androidx.compose.ui.InternalComposeUiApi
 import org.jetbrains.skia.PathVerb
 
 actual fun PathIterator(
@@ -66,12 +67,13 @@ actual fun PathIterator(
 //     return subdivisions
 // }
 
+@OptIn(InternalComposeUiApi::class)
 private class SkiaPathIterator(
     override val path: Path,
     override val conicEvaluation: PathIterator.ConicEvaluation,
     override val tolerance: Float
 ) : PathIterator {
-    private val skiaPath = path.asSkiaPath()
+    private val skiaPath = path.materializeSkiaPath()
     private val iterator = skiaPath.iterator()
 
     // TODO: Handle conversion from conics to quadratics

--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/layer/SkiaGraphicsLayer.skiko.kt
@@ -16,6 +16,7 @@
 
 package androidx.compose.ui.graphics.layer
 
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -33,12 +34,12 @@ import androidx.compose.ui.graphics.RenderEffect
 import androidx.compose.ui.graphics.SkiaBackedCanvas
 import androidx.compose.ui.graphics.asComposeCanvas
 import androidx.compose.ui.graphics.asSkiaColorFilter
-import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.draw
 import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.graphics.skiaImageFilter
+import androidx.compose.ui.graphics.materializeSkiaPath
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toSkia
 import androidx.compose.ui.unit.Density
@@ -366,6 +367,7 @@ actual class GraphicsLayer internal constructor(
         discardContentIfReleasedAndHaveNoParentLayerUsages()
     }
 
+    @OptIn(InternalComposeUiApi::class)
     private fun configureOutlineAndClip() {
         if (!outlineDirty) return
         val renderNode = renderNode ?: return
@@ -400,7 +402,7 @@ actual class GraphicsLayer internal constructor(
                     ),
                     antiAlias = true
                 )
-                is Outline.Generic -> renderNode.setClipPath(tmpOutline.path.asSkiaPath(), antiAlias = true)
+                is Outline.Generic -> renderNode.setClipPath(tmpOutline.path.materializeSkiaPath(), antiAlias = true)
             }
         }
         outlineDirty = false

--- a/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/SkikoPathTest.kt
+++ b/compose/ui/ui-graphics/src/skikoTest/kotlin/androidx/compose/ui/graphics/SkikoPathTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.graphics
+
+import androidx.compose.ui.geometry.Rect
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.jetbrains.skia.PathBuilder as SkPathBuilder
+
+class SkikoPathTest {
+
+    @Test
+    fun asSkiaPath_observesSubsequentComposeMutations() {
+        val path = Path().apply {
+            moveTo(10f, 20f)
+            lineTo(30f, 40f)
+        }
+
+        val retainedPath = path.asSkiaPath()
+
+        path.lineTo(50f, 60f)
+
+        val expected = Path().apply {
+            moveTo(10f, 20f)
+            lineTo(30f, 40f)
+            lineTo(50f, 60f)
+        }
+
+        assertEquals(expected.toSvg(), path.toSvg())
+        assertContentEquals(expected.asSkiaPath().serializeToBytes(), retainedPath.serializeToBytes())
+    }
+
+    @Test
+    fun asComposePath_marksOriginalSkiaPathAsObserved() {
+        val skiaPath = SkPathBuilder()
+            .moveTo(10f, 20f)
+            .lineTo(30f, 40f)
+            .snapshot()
+        val composePath = skiaPath.asComposePath()
+
+        composePath.lineTo(50f, 60f)
+
+        val expected = Path().apply {
+            moveTo(10f, 20f)
+            lineTo(30f, 40f)
+            lineTo(50f, 60f)
+        }
+
+        assertEquals(expected.toSvg(), composePath.toSvg())
+        assertContentEquals(expected.asSkiaPath().serializeToBytes(), skiaPath.serializeToBytes())
+    }
+
+    @Test
+    fun isEmpty() {
+        val path = Path()
+        assertTrue(path.isEmpty)
+
+        path.addRect(Rect(0f, 0f, 16f, 16f))
+
+        assertFalse(path.isEmpty)
+    }
+
+    @Test
+    fun isConvex() {
+        val path = Path()
+        assertTrue(path.isConvex)
+
+        path.addRect(Rect(0f, 0f, 8f, 8f))
+        assertTrue(path.isConvex)
+
+        path.addRect(Rect(8f, 8f, 16f, 16f))
+        assertFalse(path.isConvex)
+    }
+
+    @Test
+    fun getBounds() {
+        val path = Path()
+        assertEquals(Rect(0f, 0f, 0f, 0f), path.getBounds())
+
+        path.addRect(Rect(0f, 0f, 8f, 8f))
+        assertEquals(Rect(0f, 0f, 8f, 8f), path.getBounds())
+
+        path.addRect(Rect(8f, 8f, 16f, 16f))
+        assertEquals(Rect(0f, 0f, 16f, 16f), path.getBounds())
+    }
+
+    @Test
+    fun initialParameters() {
+        val path = Path()
+
+        assertEquals(PathFillType.NonZero, path.fillType)
+    }
+
+    @Test
+    fun resetPreservesFillType() {
+        val path = Path()
+
+        path.fillType = PathFillType.EvenOdd
+        path.reset()
+
+        assertEquals(PathFillType.EvenOdd, path.fillType)
+    }
+
+    @Test
+    fun rewindClearsPath() {
+        val path = Path().apply {
+            addRect(Rect(0f, 0f, 100f, 200f))
+        }
+        assertFalse(path.isEmpty)
+
+        path.rewind()
+
+        assertTrue(path.isEmpty)
+    }
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/LegacyRenderNodeLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/LegacyRenderNodeLayer.skiko.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.SnapshotMutationPolicy
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.FrameRateCategory
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.geometry.MutableRect
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -38,12 +39,12 @@ import androidx.compose.ui.graphics.ReusableGraphicsLayerScope
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.alphaMultiplier
 import androidx.compose.ui.graphics.asComposeCanvas
-import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.skiaCanvas
 import androidx.compose.ui.graphics.skiaPaint
 import androidx.compose.ui.graphics.prepareTransformationMatrix
 import androidx.compose.ui.graphics.skiaImageFilter
+import androidx.compose.ui.graphics.materializeSkiaPath
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.node.OwnedLayer
 import androidx.compose.ui.unit.Density
@@ -51,7 +52,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toRect
-import kotlin.math.abs
 import kotlin.math.max
 import org.jetbrains.skia.ClipMode
 import org.jetbrains.skia.Picture
@@ -355,6 +355,7 @@ internal class LegacyRenderNodeLayer(
 
     override fun updateDisplayList() = Unit
 
+    @OptIn(InternalComposeUiApi::class)
     fun drawShadow(canvas: Canvas) = with(density) {
         val path = when (val outline = outline) {
             is Outline.Rectangle -> Path().apply { addRect(outline.rect) }
@@ -373,7 +374,7 @@ internal class LegacyRenderNodeLayer(
         val spotColor = spotShadowColor.copy(alpha = spotAlpha)
 
         ShadowUtils.drawShadow(
-            canvas.skiaCanvas, path.asSkiaPath(), zParams, lightPos,
+            canvas.skiaCanvas, path.materializeSkiaPath(), zParams, lightPos,
             lightRad,
             ambientColor.toArgb(),
             spotColor.toArgb(), alpha < 1f, false


### PR DESCRIPTION
Fixes [CMP-10003](https://youtrack.jetbrains.com/issue/CMP-10003) Performance degradation of CanvasDrawing benchmark

Instead of snapshotting a new skia path on every mutating call, pending changes in `PathBuilder` and materialize them only when native skia state is actually needed. At the same time, retained native `SkPath` references obtained through `asSkiaPath()` still stay synchronized, so existing interop behavior remains correct. It's done via separating observing and non-observing native access: `asSkiaPath()` keeps the "retained native path" contract, while internal one-shot consumers use `materializeSkiaPath()` to avoid unnecessary eager synchronization.

## Testing
`SkikoPathTest` + existing pipelines

## Release Notes
N/A
