### PR TITLE
Fix the exceptions thrown on attempting fast delete in empty strings

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -57,16 +57,19 @@ internal abstract class NativeInputEventsProcessor(
     internal var lastCompositionEndTimestamp = 0.0 // Double because of k/wasm where Number.toLong() leads to a compilation error
     private var lastProcessedKeydown: KeyboardEvent? = null
 
-    private tailrec fun TextLayoutResult.getPrevWordOffset(currentOffset: Int): Int {
+    private tailrec fun TextLayoutResult.getPrevWordOffset(
+        currentOffset: Int,
+        offsetMapping: OffsetMapping = OffsetMapping.Identity
+    ): Int {
         if (currentOffset <= 0) {
             return 0
         }
         val text = layoutInput.text
-        val currentWord = getWordBoundary(currentOffset.coerceIn(0, text.length - 1))
+        val currentWord = getWordBoundary(currentOffset.coerceAtMost(text.length - 1))
         return if (currentWord.start >= currentOffset) {
             getPrevWordOffset(currentOffset - 1)
         } else {
-            OffsetMapping.Identity.transformedToOriginal(currentWord.start)
+            offsetMapping.transformedToOriginal(currentWord.start)
         }
     }
 

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -189,7 +189,7 @@ internal abstract class NativeInputEventsProcessor(
                     val layoutResult = composeSender.currentTextLayoutResult() ?: return@buildList
 
 
-                    val offset = layoutResult.getPrevWordOffset(textRangeStart)
+                    val offset = layoutResult.getPrevWordOffset(textRangeEnd)
                     val deleteCommand = DeleteSurroundingTextCommand((textRangeEnd - offset).coerceAtLeast(0), 0)
                     add(deleteCommand)
                 }

--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -65,7 +65,13 @@ internal abstract class NativeInputEventsProcessor(
             return 0
         }
         val text = layoutInput.text
-        val currentWord = getWordBoundary(currentOffset.coerceAtMost(text.length - 1))
+
+        val offset = currentOffset.coerceAtMost(text.length - 1)
+        if (offset <= 0) {
+            return 0
+        }
+
+        val currentWord = getWordBoundary(offset)
         return if (currentWord.start >= currentOffset) {
             getPrevWordOffset(currentOffset - 1)
         } else {


### PR DESCRIPTION

This is minimal version of the [PR-2954](https://github.com/JetBrains/compose-multiplatform-core/pull/2954)

## Testing
manual and `./gradlew testWeb`

## Release Notes
### Fixes - Web
- [CMP-9971](https://youtrack.jetbrains.com/issue/CMP-9971) [Web] Mobile. iOS. Crash when using 'Fast delete'. Cannot coerce value to an empty range: maximum -1 is less than minimum 0