### PR TITLE
[Cherry-pick] Combine multiple UIView sources to get window insets (#2946)

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitWindowInsetsManager.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/platform/UIKitWindowInsetsManager.ios.kt
@@ -16,7 +16,6 @@
 
 package androidx.compose.ui.platform
 
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.geometry.Rect
@@ -33,7 +32,7 @@ import platform.UIKit.UIUserInterfaceIdiomPad
 import platform.UIKit.UIView
 
 internal class UIKitWindowInsetsManager(
-    val windowInsetsView: () -> UIView?,
+    val windowInsetsViews: List<() -> UIView?>,
     val interfaceOrientation: State<InterfaceOrientation>,
     userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.currentDevice.userInterfaceIdiom
 ) {
@@ -84,11 +83,10 @@ internal class UIKitWindowInsetsManager(
         )
     }
 
-    private fun CMPLayoutRegion.toPlatformInsets(): PlatformInsets {
-        val view = windowInsetsView() ?: return PlatformInsets.Zero
-
-        return edgeInsetsInView(view).toPlatformInsets(view.density)
-    }
+    private fun CMPLayoutRegion.toPlatformInsets() = windowInsetsViews
+        .mapNotNull { it() }
+        .map { edgeInsetsInView(it).toPlatformInsets(it.density) }
+        .union()
 
     internal class UIKitWindowInsetsSnapshot(
         val layoutMargins: PlatformInsets,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.ios.kt
@@ -323,7 +323,10 @@ internal class ComposeSceneMediator(
     )
 
     private val windowInsetsManager = UIKitWindowInsetsManager(
-        windowInsetsView = { windowContext.window?.rootViewController?.view },
+        windowInsetsViews = listOf(
+            { _overlayView },
+            { windowContext.window?.rootViewController?.view },
+        ),
         interfaceOrientation = interfaceOrientationState
     )
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformWindowInsets.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/platform/PlatformWindowInsets.skiko.kt
@@ -161,6 +161,12 @@ internal fun PlatformInsets.union(insets: PlatformInsets) = PlatformInsets(
     getBottom = { maxOf(bottom, insets.bottom) }
 )
 
+internal fun List<PlatformInsets>.union(): PlatformInsets = if (isEmpty()) {
+    PlatformInsets.Zero
+} else {
+    reduce { acc, insets -> acc.union(insets) }
+}
+
 private class DynamicPlatformInsets(
     private val getLeft: () -> Int = { 0 },
     private val getTop: () -> Int = { 0 },

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsPaddingTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layout/WindowInsetsPaddingTest.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.systemGesturesPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Text
@@ -36,6 +38,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -47,6 +50,8 @@ import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toDpRect
+import androidx.compose.ui.viewinterop.UIKitView
+import androidx.compose.ui.window.ComposeUIView
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -58,6 +63,7 @@ import platform.UIKit.UIDevice
 import platform.UIKit.UIInterfaceOrientationMaskLandscapeLeft
 import platform.UIKit.UIInterfaceOrientationMaskLandscapeRight
 import platform.UIKit.UIUserInterfaceIdiomPad
+import platform.UIKit.UIColor
 
 class WindowInsetsPaddingTest {
     @Test
@@ -163,6 +169,101 @@ class WindowInsetsPaddingTest {
         waitForIdle()
 
         assertEquals(false, recomposed.value)
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testWindowInsetsPaddingAppliedToNonFullscreenContent() = runUIKitInstrumentedTest {
+        var innerBoxRect = DpRectZero()
+        var outerBoxRect = DpRectZero()
+
+        setContent {
+            Box(modifier = Modifier.background(Color.Red).fillMaxSize()) {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .background(Color.Blue)
+                        .size(200.dp, 200.dp)
+                        .onGloballyPositioned {
+                            outerBoxRect = it.boundsInWindow().toDpRect(density)
+                        },
+                ) {
+                    Box(modifier = Modifier
+                        .windowInsetsPadding(WindowInsets.statusBars)
+                        .background(Color.Green)
+                        .fillMaxSize()
+                        .onGloballyPositioned {
+                            innerBoxRect = it.boundsInWindow().toDpRect(density)
+                        }
+                    )
+                }
+            }
+        }
+
+        // WindowInsets.statusBars should only represent the insets at the top in portrait orientation
+        val topSafeAreaInsetsDp = viewController.view.safeAreaInsets.useContents { top }.dp
+
+        assertEquals(
+            DpRect(
+                left = outerBoxRect.left,
+                top = outerBoxRect.top + topSafeAreaInsetsDp,
+                right = outerBoxRect.right,
+                bottom = outerBoxRect.bottom
+            ),
+            innerBoxRect
+        )
+    }
+
+    @OptIn(ExperimentalForeignApi::class)
+    @Test
+    fun testWindowInsetsPaddingAppliedToNonFullscreenComposeUIViewContent() = runUIKitInstrumentedTest {
+        var innerBoxRect = DpRectZero()
+        var outerBoxRect = DpRectZero()
+
+        setContent {
+            Box(modifier = Modifier.background(Color.Red).fillMaxSize()) {
+                UIKitView(
+                    factory = {
+                        ComposeUIView(
+                            configure = {
+                                enforceStrictPlistSanityCheck = false
+                                opaque = false
+                            }
+                        ) {
+                            Box(modifier = Modifier
+                                .windowInsetsPadding(WindowInsets.statusBars)
+                                .background(Color.Green)
+                                .fillMaxSize()
+                                .onGloballyPositioned {
+                                    innerBoxRect = it.boundsInWindow().toDpRect(density)
+                                }
+                            )
+                        }.apply {
+                            backgroundColor = UIColor.blueColor
+                        }
+                    },
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(200.dp, 200.dp)
+                        .onGloballyPositioned {
+                            outerBoxRect = it.boundsInWindow().toDpRect(density)
+                        }
+                )
+            }
+        }
+
+        // WindowInsets.statusBars should only represent the insets at the top in portrait orientation
+        val topSafeAreaInsetsDp = viewController.view.safeAreaInsets.useContents { top }.dp
+
+        assertEquals(
+            DpRect(
+                left = outerBoxRect.left,
+                top = outerBoxRect.top + topSafeAreaInsetsDp,
+                right = outerBoxRect.right,
+                bottom = outerBoxRect.bottom
+            ),
+            innerBoxRect
+        )
     }
 }
 

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/test/UIKitInstrumentedTest.kt
@@ -43,7 +43,7 @@ import androidx.compose.ui.unit.asDpOffset
 import androidx.compose.ui.unit.asDpRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.lerp
-import androidx.compose.ui.unit.toOffset
+import androidx.compose.ui.unit.size
 import androidx.compose.ui.window.KeyboardVisibilityListener
 import androidx.compose.ui.window.MetalRedrawer
 import kotlin.coroutines.cancellation.CancellationException
@@ -212,8 +212,9 @@ internal class UIKitInstrumentedTest(
     val appDelegate = MockAppDelegate()
     val keyboardHeight: Dp get() =
         KeyboardVisibilityListener.keyboardFrame.useContents { size.height.dp }
-    val screenSize: DpSize get() = screen.bounds().useContents { DpSize(size.width.dp, size.height.dp) }
-    val safeDrawingRect: DpRect get() = screen.bounds().asDpRect().let { rect ->
+    val screenBounds: DpRect get() = screen.bounds().asDpRect()
+    val screenSize: DpSize get() = screenBounds.size
+    val safeDrawingRect: DpRect get() = screenBounds.let { rect ->
         viewController.view.safeAreaInsets.useContents {
             DpRect(
                 left = rect.left + Dp(this.left.toFloat()),


### PR DESCRIPTION
Combine multiple UIView sources to get correct window insets. Fixes support for embedding compose views in UIKit navigation view with UIKit navigation bar and iPad insets for traffic light controls.

Fixes [CMP-9931](https://youtrack.jetbrains.com/issue/CMP-9931) iOS: WindowInsets.safeDrawing does not include UINavigationBar safe area insets (regression in 1.11.0-alpha04)

## Testing

Test [CMP-8922](https://youtrack.jetbrains.com/issue/CMP-8922) on iPad in combination with sample provided in [CMP-9931](https://youtrack.jetbrains.com/issue/CMP-9931)

This should be tested by QA

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix `UINavigationBar` safe area insets not included in `WindowInsets.safeDrawing`