### PR TITLE
[Cherry-pick] Remove display link conditions when force-render frame (#2957)

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalRedrawer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/window/SurfaceMetalRedrawer.ios.kt
@@ -303,9 +303,7 @@ internal class SurfaceMetalRedrawer(
         if (caDisplayLink == null) {
             return
         }
-        displayLinkConditions.onDisplayLinkTick {
-            draw(waitUntilCompletion, CACurrentMediaTime())
-        }
+        draw(waitUntilCompletion, CACurrentMediaTime())
     }
 
     private var currentFrameRate: Float = Float.NaN


### PR DESCRIPTION
Fixes
https://youtrack.jetbrains.com/issue/CMP-9890/iOS.-View-stuck-in-the-middle-of-rendering-process-during-rotation

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix an issue where Compose content may become stretched after screen rotation