### PR TITLE
[Cherry-pick] Restore deleted haptic feedbacks handling (#2958)

### DIFF
--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/hapticfeedback/HapticFeedback.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/hapticfeedback/HapticFeedback.ios.kt
@@ -29,6 +29,7 @@ internal class CupertinoHapticFeedback : HapticFeedback {
 
     private val mediumImpactGenerator = UIImpactFeedbackGenerator()
     private val lightImpactGenerator = UIImpactFeedbackGenerator(UIImpactFeedbackStyle.UIImpactFeedbackStyleLight)
+    private val selectionGenerator = UISelectionFeedbackGenerator()
     private val notificationGenerator = UINotificationFeedbackGenerator()
 
     override fun performHapticFeedback(hapticFeedbackType: HapticFeedbackType) {
@@ -45,7 +46,7 @@ internal class CupertinoHapticFeedback : HapticFeedback {
             HapticFeedbackType.ToggleOn,
             HapticFeedbackType.VirtualKey -> lightImpactGenerator.impactOccurred()
             HapticFeedbackType.SegmentFrequentTick,
-            HapticFeedbackType.SegmentTick,
+            HapticFeedbackType.SegmentTick -> selectionGenerator.selectionChanged()
             HapticFeedbackType.TextHandleMove -> {
                 // iOS does not produce haptic feedback for these types
                 return


### PR DESCRIPTION
Deleted by accident here:
https://github.com/JetBrains/compose-multiplatform-core/pull/2786

Fixes
https://youtrack.jetbrains.com/issue/CMP-10050/iOS-HapticFeedbackType.SegmentTick-and-SegmentFrequentTick-produce-no-haptic-feedback-on-iOS-regression-in-1.11.0-alpha04

## Release Notes
### Fixes - iOS
- _(prerelease fix)_ Fix `SegmentFrequentTick` and `SegmentTick` haptic feedbacks.