### PR TITLE
[web] limit preventDefault-ing of processed pointer events only for touchscreens

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/window/ComposeWindowInternal.web.kt
@@ -644,6 +644,16 @@ internal class ComposeWindow(
             if (eventType == PointerEventType.Release) {
                 activeTouchPointers.remove(event.pointerId)
             }
+
+            if (result != null && result.anyChangeConsumed && event.cancelable) {
+                event.preventDefault()
+
+                // Since we call preventDefault, the browser will not focus the canvas automatically,
+                // but it should be focused to receive key events.
+                if (!canvasFocused && !isTouchEvent && eventType == PointerEventType.Press) {
+                    canvas.focus()
+                }
+            }
         } else {
             keyboardModeState = KeyboardModeState.Hardware
 
@@ -679,16 +689,6 @@ internal class ComposeWindow(
                 nativeEvent = event,
                 button = event.composeButton,
             )
-        }
-
-        if (result != null && result.anyChangeConsumed && event.cancelable) {
-            event.preventDefault()
-
-            // Since we call preventDefault, the browser will not focus the canvas automatically,
-            // but it should be focused to receive key events.
-            if (!canvasFocused && !isTouchEvent && eventType == PointerEventType.Press) {
-                canvas.focus()
-            }
         }
     }
 


### PR DESCRIPTION
We fight the undesired toggling of Virtual Keyboard view (caused by input losing it's focus) by prevent defaulting the pointer event if we know that compose processed it. Unfortunately this cancels out the drag-n-drop behaviour for nodes with both `clickable` and `dragAndDropSource` modifiers.  

The smallest, safest and quickest fix is just to revert to limiting this behaviour to touchscreens. This means that the DnD logic still won't work on mobile devices but this should be addressed separately

## Testing
manual + `./gradlew testWeb`

## Release Notes
### Fixes - Web

[CMP-10035](https://youtrack.jetbrains.com/issue/CMP-10035) dragAndDropSource combined with clickable doesn't allow to start drag