### PR TITLE
Fix missing mouse release event scenario with magic mouse

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/awt/AwtEvents.desktop.kt
@@ -8,12 +8,14 @@ import androidx.compose.ui.input.pointer.PointerEvent
  * The original raw native event from AWT.
  *
  * Null if:
- * - the native event is sent by another framework (when Compose UI is embed into it)
- * - there is no native event (in tests, for example)
- * - there was a synthetic move event sent by compose on re-layout
- * - there was a synthetic move event sent by compose when move is missing between two non-move events
+ * - The native event is sent by another framework (when Compose UI is embed into it)
+ * - There is no native event (in tests, for example)
+ * - The event is a synthetic move event sent by Compose on re-layout
+ * - The event is a synthetic event sent by Compose to maintain a logically consistent stream of
+ *   events. For example, if a native press event is received without a corresponding move event,
+ *   Compose will synthesize a move event. That move event will have a null [awtEventOrNull].
  *
- * Always check for null when you want to handle the native event.
+ * It is therefore recommended to always check for `null` when using this property.
  */
 val PointerEvent.awtEventOrNull: java.awt.event.MouseEvent? get() {
     return nativeEvent as? java.awt.event.MouseEvent?
@@ -23,10 +25,10 @@ val PointerEvent.awtEventOrNull: java.awt.event.MouseEvent? get() {
  * The original raw native event from AWT.
  *
  * Null if:
- * - the native event is sent by another framework (when Compose UI is embed into it)
- * - there is no native event (in tests, for example)
+ * - The native event is sent by another framework (when Compose UI is embed into it)
+ * - There is no native event (in tests, for example)
  *
- * Always check for null when you want to handle the native event.
+ * It is therefore recommended to always check for `null` when using this property.
  */
 val KeyEvent.awtEventOrNull: java.awt.event.KeyEvent? get() {
     return internal.nativeEvent as? java.awt.event.KeyEvent?

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/SyntheticEventSenderTest.kt
@@ -17,6 +17,7 @@
 package androidx.compose.ui
 
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Enter
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Exit
 import androidx.compose.ui.input.pointer.PointerEventType.Companion.Move
@@ -388,8 +389,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should update pointer position with move event after hover event`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(mouseEvent(Enter, 10f, 20f, pressed = false))
 
@@ -416,8 +417,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should update pointer position with move event after pressed event`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(mouseEvent(Press, 10f, 20f, pressed = true))
 
@@ -444,8 +445,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should not update pointer position with move event after touch event`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(event(Press, 1 to touch(10f, 20f, pressed = true)))
 
@@ -470,8 +471,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `should not re-enter after mouse exit`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
         sender.send(mouseEvent(Move, 10f, 20f, pressed = false))
         sender.send(mouseEvent(Exit, 10f, 20f, pressed = false))
@@ -488,8 +489,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `synthetic events should not duplicate scrollDelta`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -513,8 +514,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `synthetic events should not duplicate panGestureOffset`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -538,8 +539,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `synthetic events should not duplicate scaleGestureFactor`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -715,8 +716,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `scale synthetic events should not duplicate scaleGestureFactor`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -733,8 +734,8 @@ class SyntheticEventSenderTest {
     @Test
     fun `pan synthetic events should not duplicate panGestureOffset`() {
         val received = mutableListOf<PointerInputEvent>()
-        val sender = SyntheticEventSender {
-            PointerEventResult(received.add(it))
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
         }
 
         sender.send(
@@ -747,6 +748,75 @@ class SyntheticEventSenderTest {
         }
         assertEquals(Offset(5f, 0f), totalOffset)
     }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9964
+    @Test
+    fun `mouse move unpressing buttons sends release event`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
+        }
+
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true, nativeEvent = 1))
+        sender.send(mouseEvent(Move, 10f, 10f, pressed = true, nativeEvent = 2))
+        assertEquals(0, received.count { it.eventType == Release })
+
+        sender.send(mouseEvent(Move, 10f, 10f, pressed = false, nativeEvent = 3))
+        assertEquals(1, received.count { it.eventType == Release }, "Release event not sent")
+
+        // Also, make sure we don't send an extra release event afterward
+        sender.send(mouseEvent(Release, 10f, 10f, pressed = false, nativeEvent = 4))
+        assertEquals(1, received.count { it.eventType == Release }, "Extra release event sent")
+
+        // But it should be sent as an `Unknown` event
+        assertEquals(4, received.count { it.nativeEvent != null }, "Missing native event")
+        assertEquals(PointerEventType.Unknown, received.last { it.nativeEvent != null }.eventType)
+    }
+
+    @Test
+    fun `extra mouse press events are not sent`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
+        }
+
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true, nativeEvent = 1))
+        assertEquals(1, received.count { it.eventType == Press }, "Press event not sent!?")
+        sender.send(mouseEvent(Press, 20f, 20f, pressed = true, nativeEvent = 2))
+        assertEquals(1, received.count { it.eventType == Press }, "Extra press event sent")
+
+        // But it should be sent as an `Unknown` event
+        assertEquals(2, received.count { it.nativeEvent != null }, "Missing native event")
+        assertEquals(PointerEventType.Unknown, received.last { it.nativeEvent != null }.eventType)
+    }
+
+    @Test
+    fun `extra mouse release events are not sent`() {
+        val received = mutableListOf<PointerInputEvent>()
+        val sender = SyntheticEventSenderConsumingAllMovements {
+            received.add(it)
+        }
+
+        sender.send(mouseEvent(Press, 10f, 10f, pressed = true, nativeEvent = 1))
+        assertEquals(1, received.count { it.eventType == Press }, "Press event not sent!?")
+        sender.send(mouseEvent(Release, 10f, 10f, pressed = false, nativeEvent = 2))
+        assertEquals(1, received.count { it.eventType == Release }, "Release event not sent!?")
+        sender.send(mouseEvent(Release, 20f, 20f, pressed = false, nativeEvent = 3))
+        assertEquals(1, received.count { it.eventType == Release }, "Extra release event sent")
+
+        // But it should be sent as an `Unknown` event
+        assertEquals(3, received.count { it.nativeEvent != null }, "Missing native event")
+        assertEquals(PointerEventType.Unknown, received.last { it.nativeEvent != null }.eventType)
+    }
+
+    private fun SyntheticEventSenderConsumingAllMovements(send: (PointerInputEvent) -> Unit) =
+        SyntheticEventSender {
+            send(it)
+            PointerEventResult(
+                dispatchedToAPointerInputModifier = true,
+                anyMovementConsumed = true
+            )
+        }
 
     private fun eventsSentBy(
         vararg inputEvents: PointerInputEvent

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/input/mouse/MouseMoveTest.kt
@@ -19,9 +19,11 @@
 package androidx.compose.ui.input.mouse
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -41,7 +43,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.input.pointer.pointerInput
@@ -63,6 +67,8 @@ import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import java.util.concurrent.Executors
 import kotlin.random.Random
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
@@ -733,6 +739,65 @@ class MouseMoveTest {
         scene.sendPointerEvent(PointerEventType.Exit, Offset(0f, 50f))
 
         assertNull(composeScene.lastKnownPointerPosition)
+    }
+
+    // https://youtrack.jetbrains.com/issue/CMP-9964
+    @Test
+    fun magicMouseScenario() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        var clicksCount = 0
+        scene.setContent {
+            Box(modifier = Modifier
+                .fillMaxSize()
+                .clickable {
+                    clicksCount++
+                }
+            )
+        }
+
+        // The bug in this scenario is that no mouse-release event was generated
+        // - SyntheticEventSender.sendMissingReleases didn't include the last released pointer
+        //   when receiving the 3rd event.
+        // - HitPathTracker ignores the 3rd event because it's a Move event at the same
+        //   coordinates as the previous (2nd) event.
+        // - CanvasLayersComposeScene.processPointerInputEvent clears `gestureOwner` after
+        //   receiving the 3rd event, so when it receives the 4th event, it doesn't send it.
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true))
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true))
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = false))
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f))
+
+        assertEquals(1, clicksCount)
+    }
+
+    @Test
+    fun allNativeMouseEventsAreSent1() = ImageComposeScene(
+        width = 100,
+        height = 100,
+    ).useInUiThread { scene ->
+        val nativeEventsReceived = mutableListOf<Any>()
+        scene.setContent {
+            Box(modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Main)
+                            event.nativeEvent?.let { nativeEventsReceived.add(it) }
+                        }
+                    }
+                }
+            )
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true), nativeEvent = 1)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = true), nativeEvent = 2)
+        scene.sendPointerEvent(PointerEventType.Move, Offset(10f, 10f), buttons = PointerButtons(isPrimaryPressed = false), nativeEvent = 3)
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f), nativeEvent = 4)
+
+        assertContentEquals(listOf(1, 2, 3, 4), nativeEventsReceived)
     }
 }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/input/pointer/SyntheticEventSender.skiko.kt
@@ -92,7 +92,7 @@ internal class SyntheticEventSender(
         val syntheticScaleStartResult = sendMissingScaleStart(event)
         val syntheticPanEndResult = sendMissingPanEnd(event)
         val syntheticPanStartResult = sendMissingPanStart(event)
-        val eventResult = sendInternal(event)
+        val eventResult = if (shouldSend(event)) sendInternal(event) else sendNativeEventOnly(event)
         return syntheticMoveForHoverResult.merging(
             syntheticReleasesResult,
             syntheticPressesResult,
@@ -126,8 +126,46 @@ internal class SyntheticEventSender(
         }
     }
 
+    /**
+     * Returns whether the given event should be sent.
+     *
+     * An event could be filtered out if, for example, it is a duplicate of the previous event.
+     */
+    private fun shouldSend(event: PointerInputEvent): Boolean {
+        // Filter out press/release events with the same pressed pointers, buttons and keyboard
+        // modifiers as the previous event.
+        // Note that missing move events for this event should have already been sent
+        fun areSameParams(e1: PointerInputEvent, e2: PointerInputEvent): Boolean {
+            if (e1.pressedIds().toSet() != e2.pressedIds().toSet()) return false
+            if (e1.buttons != e2.buttons) return false
+            if (e1.keyboardModifiers != e2.keyboardModifiers) return false
+            return true
+        }
+        if (event.eventType == PointerEventType.Press) {
+            val prevEvent = previousEvent
+            if ((prevEvent != null) && areSameParams(event, prevEvent)) return false
+        }
+        if (event.eventType == PointerEventType.Release) {
+            val prevEvent = previousEvent ?: return false
+            if (areSameParams(event, prevEvent)) return false
+        }
+
+        return true
+    }
+
+    /**
+     * When an event generated as a result of a native event is filtered out (see [shouldSend]),
+     * we nevertheless want listeners to native events to receive them.
+     * This method sends an event with a type of [PointerEventType.Unknown] so that listeners can
+     * still receive it.
+     */
+    private fun sendNativeEventOnly(event: PointerInputEvent): PointerEventResult {
+        if (event.nativeEvent == null) return UnconsumedEventResult
+        return _send(event.copy(eventType = PointerEventType.Unknown))
+    }
+
     fun updatePointerPosition(): PointerEventResult {
-        val nothingConsumed = PointerEventResult(anyMovementConsumed = false)
+        val nothingConsumed = UnconsumedEventResult
 
         if (!needUpdatePointerPosition) return nothingConsumed
         needUpdatePointerPosition = false
@@ -152,7 +190,7 @@ internal class SyntheticEventSender(
     private fun sendSyntheticMove(
         pointersSourceEvent: PointerInputEvent
     ): PointerEventResult {
-        val previousEvent = previousEvent ?: return PointerEventResult(anyMovementConsumed = false)
+        val previousEvent = previousEvent ?: return UnconsumedEventResult
         val idToPosition = pointersSourceEvent.pointers.associate { it.id to it.position }
         return sendInternal(
             previousEvent.copySynthetic(
@@ -171,22 +209,24 @@ internal class SyntheticEventSender(
             isMoveEventMissing(previousEvent, currentEvent)) {
             sendSyntheticMove(currentEvent)
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
     private fun sendMissingReleases(currentEvent: PointerInputEvent): PointerEventResult {
-        val previousEvent = previousEvent ?: return PointerEventResult(anyMovementConsumed = false)
+        val previousEvent = previousEvent ?: return UnconsumedEventResult
         val previousPressed = previousEvent.pressedIds()
         val currentPressed = currentEvent.pressedIds()
         val newReleased = (previousPressed - currentPressed.toSet()).toList()
         val sendingAsUp = HashSet<PointerId>(newReleased.size)
 
-        var result = PointerEventResult(anyMovementConsumed = false)
-        // Don't send the first released pointer
-        // It will be sent as a real event. Here we only need to send synthetic events
-        // before a real one.
-        for (i in newReleased.size - 2 downTo 0) {
+        var result = UnconsumedEventResult
+        val lastIndex = when (currentEvent.eventType) {
+            // The "real" event itself will be the last one
+            PointerEventType.Release -> newReleased.lastIndex - 1
+            else -> newReleased.lastIndex
+        }
+        for (i in lastIndex downTo 0) {
             sendingAsUp.add(newReleased[i])
 
             sendInternal(
@@ -211,11 +251,13 @@ internal class SyntheticEventSender(
         val newPressed = (currentPressed - previousPressed).toList()
         val sendingAsDown = HashSet<PointerId>(newPressed.size)
 
-        var result = PointerEventResult(anyMovementConsumed = false)
-        // Don't send the last pressed pointer (newPressed.size - 1)
-        // It will be sent as a real event. Here we only need to send synthetic events
-        // before a real one.
-        for (i in 0..newPressed.size - 2) {
+        var result = UnconsumedEventResult
+        val lastIndex = when (currentEvent.eventType) {
+            // The "real" event itself will be the last one
+            PointerEventType.Press -> newPressed.lastIndex - 1
+            else -> newPressed.lastIndex
+        }
+        for (i in 0..lastIndex) {
             sendingAsDown.add(newPressed[i])
 
             sendInternal(
@@ -246,11 +288,23 @@ internal class SyntheticEventSender(
             PointerEventType.PanEnd -> isPanGestureInProgress = false
             else -> {}
         }
-        val anyMovementConsumed = _send(event)
+        val result = _send(event)
+        if (!result.dispatchedToAPointerInputModifier) {
+            // What we want to do here is to make sure to dispatch the native event if the Compose
+            // event has been filtered out by HitPathTracker. Unfortunately, there's no
+            // `PointerEventResult.eventIgnored` flag, but `dispatchedToAPointerInputModifier`
+            // seems adequate for now. It will be false also in the case of no `PointerInput` nodes,
+            // but that's ok because then our native event will also not be delivered to anyone.
+            sendNativeEventOnly(event)
+        }
         // We don't send nativeEvent for synthetic events.
         // Nullify to avoid memory leaks (native events can point to native views).
-        previousEvent = event.copy(nativeEvent = null)
-        return anyMovementConsumed
+        // Copy the pointers list because the original list may be reused
+        previousEvent = event.copy(
+            nativeEvent = null,
+            pointers = event.pointers.toList()
+        )
+        return result
     }
 
     private fun sendMissingScaleStart(event: PointerInputEvent): PointerEventResult {
@@ -258,7 +312,7 @@ internal class SyntheticEventSender(
             (event.eventType == PointerEventType.ScaleChange || event.eventType == PointerEventType.ScaleEnd)) {
             sendInternal(event.copySynthetic(PointerEventType.ScaleStart) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -266,7 +320,7 @@ internal class SyntheticEventSender(
         return if (isScaleGestureInProgress && event.eventType == PointerEventType.ScaleStart) {
             sendInternal(event.copySynthetic(PointerEventType.ScaleEnd) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -275,7 +329,7 @@ internal class SyntheticEventSender(
             (event.eventType == PointerEventType.PanMove || event.eventType == PointerEventType.PanEnd)) {
             sendInternal(event.copySynthetic(PointerEventType.PanStart) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -283,7 +337,7 @@ internal class SyntheticEventSender(
         return if (isPanGestureInProgress && event.eventType == PointerEventType.PanStart) {
             sendInternal(event.copySynthetic(PointerEventType.PanEnd) { it.copySynthetic() })
         } else {
-            PointerEventResult(anyMovementConsumed = false)
+            UnconsumedEventResult
         }
     }
 
@@ -339,3 +393,5 @@ internal class SyntheticEventSender(
         originalEventPosition = position,
     )
 }
+
+private val UnconsumedEventResult = PointerEventResult(anyMovementConsumed = false)

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -247,6 +247,8 @@ private class CanvasLayersComposeSceneImpl(
             PointerEventType.ScaleStart,
             PointerEventType.ScaleChange,
             PointerEventType.ScaleEnd -> processHoveredEvent(event)
+            PointerEventType.Unknown ->
+                return processUnknownEvent(event)  // We don't want any side effects from it
             else -> PointerEventResult(anyMovementConsumed = false)
         }
 
@@ -428,6 +430,16 @@ private class CanvasLayersComposeSceneImpl(
             owner.onPointerInput(event)
         } else {
             PointerEventResult(anyMovementConsumed = false)
+        }
+    }
+
+    private fun processUnknownEvent(event: PointerInputEvent): PointerEventResult {
+        val gestureOwner = gestureOwner
+        @Suppress("IfThenToElvis")
+        return if (gestureOwner != null) {
+            gestureOwner.onPointerInput(event)
+        } else {
+            processHoveredEvent(event)
         }
     }
 

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScenePointer.skiko.kt
@@ -158,11 +158,17 @@ value class PointerEventResult internal constructor(internal val value: Int) {
 
     constructor(
         anyMovementConsumed: Boolean = false,
-        anyChangeConsumed: Boolean = false
+        anyChangeConsumed: Boolean = false,
+        dispatchedToAPointerInputModifier: Boolean = false,
     ) : this(
-        value = (anyMovementConsumed.toInt() shl 1) or
+        value =
+            dispatchedToAPointerInputModifier.toInt() or
+            (anyMovementConsumed.toInt() shl 1) or
             (anyChangeConsumed.toInt() shl 2)
     )
+
+    internal val dispatchedToAPointerInputModifier
+        inline get() = (value and 0x1) != 0
 
     /** It's true when [PointerInputChange] was consumed and Pointer's position was changed */
     internal val anyMovementConsumed

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -247,6 +247,7 @@ internal fun mouseEvent(
     scrollDelta: Offset = Offset.Zero,
     scaleGestureFactor: Float = 1f,
     panGestureOffset:Offset = Offset.Zero,
+    nativeEvent: Any? = null
 ) = PointerInputEvent(
     type,
     0,
@@ -266,7 +267,8 @@ internal fun mouseEvent(
             panGestureOffset = panGestureOffset,
         )
     ),
-    buttons = PointerButtons(isPrimaryPressed = pressed)
+    buttons = PointerButtons(isPrimaryPressed = pressed),
+    nativeEvent = nativeEvent
 )
 
 internal infix fun List<PointerInputEvent>.positionAndDownShouldEqual(


### PR DESCRIPTION
Fix SyntheticEventSender's sendMissingPresses and sendMissingReleases to send all missing presses/releases.

This is a cherry-pick of https://github.com/jetbrains/compose-multiplatform-core/pull/2909

## Testing
N/A

## Release Notes
### Fixes - Multiple Platforms
- Fix mouse-clicks being missed occasionally (typically when using Apple's Magic Mouse).
