### PR TITLE
Correctly initialize focusManager and inputModeManager in DefaultOpenContextMenu

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/ContextMenuTest.kt
@@ -17,6 +17,7 @@
 package androidx.compose.foundation
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.BasicTextField
@@ -30,11 +31,13 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.Clipboard
@@ -46,16 +49,20 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.MouseButton
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performMouseInput
 import androidx.compose.ui.test.performTextInputSelection
+import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.rightClick
-import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.v2.runComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -320,7 +327,59 @@ class ContextMenuTest {
             onNode(ContextMenuMatcher).assertDoesNotExist()
         }
 
-    private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = runComposeUiTest {
+    // https://youtrack.jetbrains.com/issue/CMP-10043
+    @Test
+    fun `press up and down in context menu`() = runComposeUiTest {
+        var clickedItem: String? = null
+        setContent {
+            val state = remember { ContextMenuState() }
+            ContextMenuArea(
+                items = {
+                    listOf(
+                        ContextMenuItem("Item 1") { clickedItem = "Item 1" },
+                        ContextMenuItem("Item 2") { clickedItem = "Item 2" },
+                    )
+                },
+                state = state,
+                content = {
+                    Box(Modifier.fillMaxSize().testTag("content"))
+                }
+            )
+        }
+
+        fun showContextMenu() {
+            onNodeWithTag("content").performMouseInput {
+                click(button = MouseButton.Secondary)
+            }
+        }
+
+        showContextMenu()
+        onNodeWithText("Item 1").assertExists()
+        onNode(isPopup()).performKeyInput {
+            pressKey(Key.DirectionDown)
+            pressKey(Key.Enter)
+        }
+        assertEquals("Item 1", clickedItem)
+
+        showContextMenu()
+        onNode(isPopup()).performKeyInput {
+            pressKey(Key.DirectionDown)
+            pressKey(Key.DirectionDown)
+            pressKey(Key.Enter)
+        }
+        assertEquals("Item 2", clickedItem)
+
+        showContextMenu()
+        onNode(isPopup()).performKeyInput {
+            pressKey(Key.DirectionDown)
+            pressKey(Key.DirectionDown)
+            pressKey(Key.DirectionUp)
+            pressKey(Key.Enter)
+        }
+        assertEquals("Item 1", clickedItem)
+    }
+
+    private fun runContextMenuTest(block: ComposeUiTest.() -> Unit) = androidx.compose.ui.test.runComposeUiTest {
         DesktopPlatform.withOverriddenCurrent(DesktopPlatform.Unknown) {
             block()
         }

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/BasicContextMenuRepresentation.skiko.kt
@@ -52,10 +52,11 @@ import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
@@ -71,8 +72,8 @@ internal fun DefaultOpenContextMenu(
     popupPositionProvider: PopupPositionProvider,
     colors: ContextMenuColors = DefaultContextMenuColors,
 ) {
-    var focusManager: FocusManager? by mutableStateOf(null)
-    var inputModeManager: InputModeManager? by mutableStateOf(null)
+    var focusManager: FocusManager? by remember { mutableStateOf(null) }
+    var inputModeManager: InputModeManager? by remember { mutableStateOf(null) }
 
     Popup(
         properties = PopupProperties(focusable = true),
@@ -82,13 +83,13 @@ internal fun DefaultOpenContextMenu(
             if (it.type == KeyEventType.KeyDown) {
                 when (it.key) {
                     Key.DirectionDown, Key.NumPadDirectionUp  -> {
-                        inputModeManager!!.requestInputMode(InputMode.Keyboard)
-                        focusManager!!.moveFocus(FocusDirection.Next)
+                        inputModeManager?.requestInputMode(InputMode.Keyboard)
+                        focusManager?.moveFocus(FocusDirection.Next)
                         true
                     }
                     Key.DirectionUp, Key.NumPadDirectionDown -> {
-                        inputModeManager!!.requestInputMode(InputMode.Keyboard)
-                        focusManager!!.moveFocus(FocusDirection.Previous)
+                        inputModeManager?.requestInputMode(InputMode.Keyboard)
+                        focusManager?.moveFocus(FocusDirection.Previous)
                         true
                     }
                     else -> false
@@ -98,6 +99,8 @@ internal fun DefaultOpenContextMenu(
             }
         },
     ) {
+        focusManager = LocalFocusManager.current
+        inputModeManager = LocalInputModeManager.current
         Column(
             modifier = Modifier
                 .shadow(8.dp)
@@ -106,7 +109,7 @@ internal fun DefaultOpenContextMenu(
                 .width(IntrinsicSize.Max)
                 .verticalScroll(rememberScrollState())
         ) {
-            components.fastForEach { component ->
+            components.forEach { component ->
                 when (component) {
                     is TextContextMenuSeparator ->
                         MenuSeparator(colors.textColor)

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/Menu.skiko.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import kotlin.jvm.JvmName
 
 /**
  * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
@@ -112,8 +111,8 @@ actual fun DropdownMenu(
             transformOriginState.value = calculateTransformOrigin(parentBounds, menuBounds)
         }
 
-        var focusManager: FocusManager? by mutableStateOf(null)
-        var inputModeManager: InputModeManager? by mutableStateOf(null)
+        var focusManager: FocusManager? by remember { mutableStateOf(null) }
+        var inputModeManager: InputModeManager? by remember { mutableStateOf(null) }
         Popup(
             onDismissRequest = onDismissRequest,
             popupPositionProvider = popupPositionProvider,

--- a/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/internal/ExposedDropdownMenuPopup.skiko.kt
+++ b/compose/material/material/src/skikoMain/kotlin/androidx/compose/material/internal/ExposedDropdownMenuPopup.skiko.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.handlePopupOnKeyEvent
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.InputModeManager
@@ -35,15 +36,16 @@ internal actual fun ExposedDropdownMenuPopup(
     popupPositionProvider: PopupPositionProvider,
     content: @Composable () -> Unit
 ) {
-    var focusManager: FocusManager? by mutableStateOf(null)
-    var inputModeManager: InputModeManager? by mutableStateOf(null)
+    var focusManager: FocusManager? by remember { mutableStateOf(null) }
+    var inputModeManager: InputModeManager? by remember { mutableStateOf(null) }
     Popup(
         popupPositionProvider = popupPositionProvider,
         onDismissRequest = onDismissRequest,
-        properties =  PopupProperties(),
+        properties = PopupProperties(),
         onKeyEvent = {
             handlePopupOnKeyEvent(it, focusManager, inputModeManager)
-        }) {
+        }
+    ) {
         focusManager = LocalFocusManager.current
         inputModeManager = LocalInputModeManager.current
         content()


### PR DESCRIPTION
Correctly initialize focusManager and inputModeManager in DefaultOpenContextMenu

This is a cherry-pick of https://github.com/jetbrains/compose-multiplatform-core/pull/2945

## Testing
N/A

## Release Notes
### Fixes - Multiple Platforms
- Fix crash when pressing up/down keys in an open context menu
