### PR TITLE
Implement drag-to-scroll in `SelectionContainer`

### DIFF
--- a/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.desktop.kt
+++ b/compose/foundation/foundation/src/desktopMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.desktop.kt
@@ -23,4 +23,4 @@ import androidx.compose.ui.layout.LayoutCoordinates
 internal actual fun SelectionRegistrar.makeSelectionModifier(
     selectableId: Long,
     layoutCoordinates: () -> LayoutCoordinates?
-): Modifier = makeDefaultSelectionModifier(selectableId, layoutCoordinates)
+): Modifier = makeSkikoSelectionModifier(selectableId, layoutCoordinates)

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.ios.kt
@@ -27,6 +27,8 @@ import androidx.compose.foundation.text.selection.hasSelection
 import androidx.compose.foundation.text.selection.isMouseOrTouchPad
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.AwaitPointerEventScope
@@ -44,9 +46,12 @@ import androidx.compose.ui.node.ModifierNodeElement
 import androidx.compose.ui.node.currentValueOf
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.relocation.bringIntoView
 import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastForEach
 import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
 
 private interface CupertinoTextDragObserver {
     fun onStart(startPoint: Offset, selectionAdjustment: SelectionAdjustment)
@@ -59,16 +64,95 @@ internal actual fun SelectionRegistrar.makeSelectionModifier(
     selectableId: Long,
     layoutCoordinates: () -> LayoutCoordinates?
 ): Modifier {
-    val longPressDragObserver = object : CupertinoTextDragObserver {
+    return CupertinoSelectionModifierElement(
+        selectionRegistrar = this,
+        selectableId = selectableId,
+        layoutCoordinates = layoutCoordinates,
+    )
+}
+
+internal class CupertinoSelectionModifierElement(
+    private val selectionRegistrar: SelectionRegistrar,
+    private val selectableId: Long,
+    private val layoutCoordinates: () -> LayoutCoordinates?,
+) : ModifierNodeElement<CupertinoSelectionModifierNode>() {
+
+    override fun create() =
+        CupertinoSelectionModifierNode(
+            selectionRegistrar = selectionRegistrar,
+            selectableId = selectableId,
+            layoutCoordinates = layoutCoordinates,
+        )
+
+    override fun update(node: CupertinoSelectionModifierNode) {
+        node.update(
+            selectionRegistrar = selectionRegistrar,
+            selectableId = selectableId,
+            layoutCoordinates = layoutCoordinates,
+        )
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "selection"
+        properties["selectableId"] = selectableId
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CupertinoSelectionModifierElement) return false
+
+        if (selectionRegistrar != other.selectionRegistrar) return false
+        if (selectableId != other.selectableId) return false
+        if (layoutCoordinates != other.layoutCoordinates) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = selectableId.hashCode()
+        result = 31 * result + selectionRegistrar.hashCode()
+        result = 31 * result + layoutCoordinates.hashCode()
+        return result
+    }
+}
+
+internal class CupertinoSelectionModifierNode(
+    private var selectionRegistrar: SelectionRegistrar,
+    private var selectableId: Long,
+    private var layoutCoordinates: () -> LayoutCoordinates?,
+) : DelegatingNode(), CompositionLocalConsumerModifierNode {
+
+    private val pointerInputNode = delegate(
+        SuspendingPointerInputModifierNode {
+            val hapticFeedback = currentValueOf(LocalHapticFeedback)
+            val clicksCounter = ClicksCounter(viewConfiguration)
+
+            awaitEachGesture {
+                val down = awaitDown()
+
+                if (
+                    down.isMouseOrTouchPad() &&
+                    down.buttons.isPrimaryPressed &&
+                    down.changes.fastAll { !it.isConsumed }
+                ) {
+                    mouseSelection(mouseSelectionObserver, clicksCounter, down)
+                } else if (!down.isMouseOrTouchPad()) {
+                    touchSelection(longPressDragObserver, clicksCounter, down, hapticFeedback)
+                }
+            }
+        }
+    )
+
+    private val longPressDragObserver = object : CupertinoTextDragObserver {
         /**
-         * The beginning position of the drag gesture. Every time a new drag gesture starts, it wil be
-         * recalculated.
+         * The beginning position of the drag gesture. Every time a new drag gesture starts, it will
+         * be recalculated.
          */
         var lastPosition = Offset.Zero
 
         /**
-         * The total distance being dragged of the drag gesture. Every time a new drag gesture starts,
-         * it will be zeroed out.
+         * The total distance being dragged of the drag gesture. Every time a new drag gesture
+         * starts, it will be zeroed out.
          */
         var dragTotalDistance = Offset.Zero
 
@@ -76,7 +160,7 @@ internal actual fun SelectionRegistrar.makeSelectionModifier(
             layoutCoordinates()?.let {
                 if (!it.isAttached) return
 
-                notifySelectionUpdateStart(
+                selectionRegistrar.notifySelectionUpdateStart(
                     layoutCoordinates = it,
                     startPosition = startPoint,
                     adjustment = selectionAdjustment,
@@ -86,7 +170,7 @@ internal actual fun SelectionRegistrar.makeSelectionModifier(
                 lastPosition = startPoint
             }
             // selection never started
-            if (!hasSelection(selectableId)) return
+            if (!selectionRegistrar.hasSelection(selectableId)) return
             // Zero out the total distance that being dragged.
             dragTotalDistance = Offset.Zero
         }
@@ -95,7 +179,7 @@ internal actual fun SelectionRegistrar.makeSelectionModifier(
             layoutCoordinates()?.let {
                 if (!it.isAttached) return
                 // selection never started, did not consume any drag
-                if (!hasSelection(selectableId)) return
+                if (!selectionRegistrar.hasSelection(selectableId)) return
 
                 dragTotalDistance += delta
                 val newPosition = lastPosition + dragTotalDistance
@@ -105,7 +189,7 @@ internal actual fun SelectionRegistrar.makeSelectionModifier(
                 // long-press is using SelectionAdjustment.WORD or
                 // SelectionAdjustment.PARAGRAPH that updates the start handle position from
                 // the dragBeginPosition.
-                val consumed = notifySelectionUpdate(
+                val consumed = selectionRegistrar.notifySelectionUpdate(
                     layoutCoordinates = it,
                     previousPosition = lastPosition,
                     newPosition = delta,
@@ -121,193 +205,45 @@ internal actual fun SelectionRegistrar.makeSelectionModifier(
         }
 
         override fun onStop() {
-            if (hasSelection(selectableId)) {
-                notifySelectionUpdateEnd()
+            if (selectionRegistrar.hasSelection(selectableId)) {
+                selectionRegistrar.notifySelectionUpdateEnd()
             }
         }
 
         override fun onCancel() {
-            if (hasSelection(selectableId)) {
-                notifySelectionUpdateEnd()
+            if (selectionRegistrar.hasSelection(selectableId)) {
+                selectionRegistrar.notifySelectionUpdateEnd()
             }
         }
     }
 
-    // The rest of that method copied from SelectionController.kt
-    val mouseSelectionObserver = object : MouseSelectionObserver {
-        var lastPosition = Offset.Zero
+    private fun createMouseSelectionObserver() = selectionRegistrar.skikoMouseSelectionObserver(
+        selectableId = selectableId,
+        layoutCoordinates = layoutCoordinates,
+        bringIntoView = ::bringIntoView
+    )
 
-        override fun onExtend(downPosition: Offset): Boolean {
-            layoutCoordinates()?.let { layoutCoordinates ->
-                if (!layoutCoordinates.isAttached) return false
-                val consumed = notifySelectionUpdate(
-                    layoutCoordinates = layoutCoordinates,
-                    newPosition = downPosition,
-                    previousPosition = lastPosition,
-                    isStartHandle = false,
-                    adjustment = SelectionAdjustment.None,
-                    isInTouchMode = false
-                )
-                if (consumed) {
-                    lastPosition = downPosition
-                }
-                return hasSelection(selectableId)
+    private var mouseSelectionObserver = createMouseSelectionObserver()
+
+    private fun bringIntoView(offset: Offset) {
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bringIntoView {
+                Rect(offset = offset, size = Size.Zero)
             }
-            return false
-        }
-
-        override fun onExtendDrag(dragPosition: Offset): Boolean {
-            layoutCoordinates()?.let { layoutCoordinates ->
-                if (!layoutCoordinates.isAttached) return false
-                if (!hasSelection(selectableId)) return false
-
-                val consumed = notifySelectionUpdate(
-                    layoutCoordinates = layoutCoordinates,
-                    newPosition = dragPosition,
-                    previousPosition = lastPosition,
-                    isStartHandle = false,
-                    adjustment = SelectionAdjustment.None,
-                    isInTouchMode = false
-                )
-
-                if (consumed) {
-                    lastPosition = dragPosition
-                }
-            }
-            return true
-        }
-
-        override fun onStart(
-            downPosition: Offset,
-            adjustment: SelectionAdjustment,
-            clickCount: Int,
-        ): Boolean {
-            layoutCoordinates()?.let {
-                if (!it.isAttached) return false
-
-                notifySelectionUpdateStart(
-                    layoutCoordinates = it,
-                    startPosition = downPosition,
-                    adjustment = adjustment,
-                    isInTouchMode = false
-                )
-
-                lastPosition = downPosition
-                return hasSelection(selectableId)
-            }
-
-            return false
-        }
-
-        override fun onDrag(
-            dragPosition: Offset,
-            adjustment: SelectionAdjustment
-        ): Boolean {
-            layoutCoordinates()?.let {
-                if (!it.isAttached) return false
-                if (!hasSelection(selectableId)) return false
-
-                val consumed = notifySelectionUpdate(
-                    layoutCoordinates = it,
-                    previousPosition = lastPosition,
-                    newPosition = dragPosition,
-                    isStartHandle = false,
-                    adjustment = adjustment,
-                    isInTouchMode = false
-                )
-                if (consumed) {
-                    lastPosition = dragPosition
-                }
-            }
-            return true
-        }
-
-        override fun onDragDone() {
-            notifySelectionUpdateEnd()
         }
     }
-
-    return Modifier.selectionGestureInput(mouseSelectionObserver, longPressDragObserver)
-}
-
-private fun Modifier.selectionGestureInput(
-    mouseSelectionObserver: MouseSelectionObserver,
-    textDragObserver: CupertinoTextDragObserver,
-): Modifier = this.then(
-    SelectionGestureInputElement(
-        mouseSelectionObserver = mouseSelectionObserver,
-        textDragObserver = textDragObserver,
-    )
-)
-
-private class SelectionGestureInputElement(
-    private val mouseSelectionObserver: MouseSelectionObserver,
-    private val textDragObserver: CupertinoTextDragObserver,
-) : ModifierNodeElement<SelectionGestureInputNode>() {
-
-    override fun create(): SelectionGestureInputNode = SelectionGestureInputNode(
-        mouseSelectionObserver = mouseSelectionObserver,
-        textDragObserver = textDragObserver,
-    )
-
-    override fun update(node: SelectionGestureInputNode) = node.update(
-        mouseSelectionObserver = mouseSelectionObserver,
-        textDragObserver = textDragObserver,
-    )
-
-    override fun InspectorInfo.inspectableProperties() {
-        name = "selectionGestureInput"
-        properties["mouseSelectionObserver"] = mouseSelectionObserver
-        properties["textDragObserver"] = textDragObserver
-    }
-
-    override fun equals(other: Any?): Boolean =
-        other is SelectionGestureInputElement &&
-        other !== this &&
-        mouseSelectionObserver == other.mouseSelectionObserver &&
-        textDragObserver == other.textDragObserver
-
-    override fun hashCode(): Int {
-        var result = mouseSelectionObserver.hashCode()
-        result = 31 * result + textDragObserver.hashCode()
-        return result
-    }
-}
-
-private class SelectionGestureInputNode(
-    private var mouseSelectionObserver: MouseSelectionObserver,
-    private var textDragObserver: CupertinoTextDragObserver,
-): DelegatingNode(), CompositionLocalConsumerModifierNode {
-
-    private val pointerInputNode = delegate(
-        SuspendingPointerInputModifierNode(
-            pointerInputEventHandler = {
-                val hapticFeedback = currentValueOf(LocalHapticFeedback)
-                val clicksCounter = ClicksCounter(viewConfiguration)
-
-                awaitEachGesture {
-                    val down = awaitDown()
-
-                    if (
-                        down.isMouseOrTouchPad() &&
-                        down.buttons.isPrimaryPressed &&
-                        down.changes.fastAll { !it.isConsumed }
-                    ) {
-                        mouseSelection(mouseSelectionObserver, clicksCounter, down)
-                    } else if (!down.isMouseOrTouchPad()) {
-                        touchSelection(textDragObserver, clicksCounter, down, hapticFeedback)
-                    }
-                }
-            }
-        )
-    )
 
     fun update(
-        mouseSelectionObserver: MouseSelectionObserver,
-        textDragObserver: CupertinoTextDragObserver,
+        selectionRegistrar: SelectionRegistrar,
+        selectableId: Long,
+        layoutCoordinates: () -> LayoutCoordinates?,
     ) {
-        this.mouseSelectionObserver = mouseSelectionObserver
-        this.textDragObserver = textDragObserver
+        this.selectionRegistrar = selectionRegistrar
+        this.selectableId = selectableId
+        this.layoutCoordinates = layoutCoordinates
+
+        mouseSelectionObserver = createMouseSelectionObserver()
+        pointerInputNode.resetPointerInputHandler()
     }
 }
 

--- a/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.macos.kt
+++ b/compose/foundation/foundation/src/macosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.macos.kt
@@ -23,4 +23,4 @@ import androidx.compose.ui.layout.LayoutCoordinates
 internal actual fun SelectionRegistrar.makeSelectionModifier(
     selectableId: Long,
     layoutCoordinates: () -> LayoutCoordinates?
-): Modifier = makeDefaultSelectionModifier(selectableId, layoutCoordinates)
+): Modifier = makeSkikoSelectionModifier(selectableId, layoutCoordinates)

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.skiko.kt
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.modifiers
+
+import androidx.compose.foundation.text.TextDragObserver
+import androidx.compose.foundation.text.selection.MouseSelectionObserver
+import androidx.compose.foundation.text.selection.SelectionAdjustment
+import androidx.compose.foundation.text.selection.SelectionRegistrar
+import androidx.compose.foundation.text.selection.awaitSelectionGestures
+import androidx.compose.foundation.text.selection.hasSelection
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.SuspendingPointerInputModifierNode
+import androidx.compose.ui.layout.LayoutCoordinates
+import androidx.compose.ui.node.DelegatingNode
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.relocation.bringIntoView
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.launch
+
+@Suppress("ModifierFactoryExtensionFunction")
+internal fun SelectionRegistrar.makeSkikoSelectionModifier(
+    selectableId: Long,
+    layoutCoordinates: () -> LayoutCoordinates?,
+): Modifier {
+    return SkikoSelectionModifierElement(
+        selectionRegistrar = this,
+        selectableId = selectableId,
+        layoutCoordinates = layoutCoordinates,
+    )
+}
+
+internal class SkikoSelectionModifierElement(
+    private val selectionRegistrar: SelectionRegistrar,
+    private val selectableId: Long,
+    private val layoutCoordinates: () -> LayoutCoordinates?,
+) : ModifierNodeElement<SkikoSelectionModifierNode>() {
+
+    override fun create() =
+        SkikoSelectionModifierNode(
+            selectionRegistrar = selectionRegistrar,
+            selectableId = selectableId,
+            layoutCoordinates = layoutCoordinates,
+        )
+
+    override fun update(node: SkikoSelectionModifierNode) {
+        node.update(
+            selectionRegistrar = selectionRegistrar,
+            selectableId = selectableId,
+            layoutCoordinates = layoutCoordinates,
+        )
+    }
+
+    override fun InspectorInfo.inspectableProperties() {
+        name = "selection"
+        properties["selectableId"] = selectableId
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SkikoSelectionModifierElement) return false
+
+        if (selectionRegistrar != other.selectionRegistrar) return false
+        if (selectableId != other.selectableId) return false
+        if (layoutCoordinates != other.layoutCoordinates) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = selectableId.hashCode()
+        result = 31 * result + selectionRegistrar.hashCode()
+        result = 31 * result + layoutCoordinates.hashCode()
+        return result
+    }
+}
+
+internal class SkikoSelectionModifierNode(
+    private var selectionRegistrar: SelectionRegistrar,
+    private var selectableId: Long,
+    private var layoutCoordinates: () -> LayoutCoordinates?,
+) : DelegatingNode() {
+
+    private var pointerInputNode = delegate(
+        SuspendingPointerInputModifierNode {
+            awaitSelectionGestures(mouseSelectionObserver, longPressDragObserver)
+        }
+    )
+
+    private val longPressDragObserver = object : TextDragObserver {
+        /**
+         * The beginning position of the drag gesture. Every time a new drag gesture starts, it
+         * will be recalculated.
+         */
+        var lastPosition = Offset.Zero
+
+        /**
+         * The total distance being dragged of the drag gesture. Every time a new drag gesture
+         * starts, it will be zeroed out.
+         */
+        var dragTotalDistance = Offset.Zero
+
+        var selectionAdjustmentMode = SelectionAdjustment.None
+
+        override fun onDown(point: Offset) {
+            // Not supported for long-press-drag.
+        }
+
+        override fun onUp() {
+            // Nothing to do.
+        }
+
+        override fun onStart(startPoint: Offset, selectionAdjustment: SelectionAdjustment) {
+            selectionAdjustmentMode = selectionAdjustment
+            layoutCoordinates()?.let {
+                if (!it.isAttached) return
+
+                selectionRegistrar.notifySelectionUpdateStart(
+                    layoutCoordinates = it,
+                    startPosition = startPoint,
+                    adjustment = selectionAdjustmentMode,
+                    isInTouchMode = true,
+                )
+
+                lastPosition = startPoint
+            }
+            // selection never started
+            if (!selectionRegistrar.hasSelection(selectableId)) return
+            // Zero out the total distance that being dragged.
+            dragTotalDistance = Offset.Zero
+        }
+
+        override fun onDrag(delta: Offset) {
+            layoutCoordinates()?.let {
+                if (!it.isAttached) return
+                // selection never started, did not consume any drag
+                if (!selectionRegistrar.hasSelection(selectableId)) return
+
+                dragTotalDistance += delta
+                val newPosition = lastPosition + dragTotalDistance
+
+                // Notice that only the end position needs to be updated here.
+                // Start position is left unchanged. This is typically important when
+                // long-press is using SelectionAdjustment.WORD or
+                // SelectionAdjustment.PARAGRAPH that updates the start handle position from
+                // the dragBeginPosition.
+                val consumed =
+                    selectionRegistrar.notifySelectionUpdate(
+                        layoutCoordinates = it,
+                        previousPosition = lastPosition,
+                        newPosition = newPosition,
+                        isStartHandle = false,
+                        adjustment = selectionAdjustmentMode,
+                        isInTouchMode = true,
+                    )
+                if (consumed) {
+                    lastPosition = newPosition
+                    dragTotalDistance = Offset.Zero
+                }
+            }
+        }
+
+        override fun onStop() {
+            if (selectionRegistrar.hasSelection(selectableId)) {
+                selectionRegistrar.notifySelectionUpdateEnd()
+            }
+        }
+
+        override fun onCancel() {
+            if (selectionRegistrar.hasSelection(selectableId)) {
+                selectionRegistrar.notifySelectionUpdateEnd()
+            }
+        }
+    }
+
+    private fun createMouseSelectionObserver() = selectionRegistrar.skikoMouseSelectionObserver(
+        selectableId = selectableId,
+        layoutCoordinates = layoutCoordinates,
+        bringIntoView = ::bringIntoView
+    )
+
+    private var mouseSelectionObserver = createMouseSelectionObserver()
+
+    private fun bringIntoView(offset: Offset) {
+        coroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            bringIntoView {
+                Rect(offset = offset, size = Size.Zero)
+            }
+        }
+    }
+
+    fun update(
+        selectionRegistrar: SelectionRegistrar,
+        selectableId: Long,
+        layoutCoordinates: () -> LayoutCoordinates?,
+    ) {
+        this.selectionRegistrar = selectionRegistrar
+        this.selectableId = selectableId
+        this.layoutCoordinates = layoutCoordinates
+
+        mouseSelectionObserver = createMouseSelectionObserver()
+        pointerInputNode.resetPointerInputHandler()
+    }
+}
+
+internal fun SelectionRegistrar.skikoMouseSelectionObserver(
+    selectableId: Long,
+    layoutCoordinates: () -> LayoutCoordinates?,
+    bringIntoView: (Offset) -> Unit,
+) : MouseSelectionObserver {
+    return object : MouseSelectionObserver {
+        var lastPosition = Offset.Zero
+
+        override fun onExtend(downPosition: Offset): Boolean {
+            layoutCoordinates()?.let { layoutCoordinates ->
+                if (!layoutCoordinates.isAttached) return false
+                val consumed =
+                    notifySelectionUpdate(
+                        layoutCoordinates = layoutCoordinates,
+                        newPosition = downPosition,
+                        previousPosition = lastPosition,
+                        isStartHandle = false,
+                        adjustment = SelectionAdjustment.None,
+                        isInTouchMode = false,
+                    )
+                if (consumed) {
+                    lastPosition = downPosition
+                }
+
+                bringIntoView(downPosition)
+
+                return hasSelection(selectableId)
+            }
+            return false
+        }
+
+        override fun onExtendDrag(dragPosition: Offset): Boolean {
+            layoutCoordinates()?.let { layoutCoordinates ->
+                if (!layoutCoordinates.isAttached) return false
+                if (!hasSelection(selectableId)) return false
+
+                val consumed =
+                    notifySelectionUpdate(
+                        layoutCoordinates = layoutCoordinates,
+                        newPosition = dragPosition,
+                        previousPosition = lastPosition,
+                        isStartHandle = false,
+                        adjustment = SelectionAdjustment.None,
+                        isInTouchMode = false,
+                    )
+                if (consumed) {
+                    lastPosition = dragPosition
+                }
+
+                bringIntoView(dragPosition)
+            }
+            return true
+        }
+
+        override fun onStart(
+            downPosition: Offset,
+            adjustment: SelectionAdjustment,
+            clickCount: Int,
+        ): Boolean {
+            layoutCoordinates()?.let {
+                if (!it.isAttached) return false
+
+                notifySelectionUpdateStart(
+                    layoutCoordinates = it,
+                    startPosition = downPosition,
+                    adjustment = adjustment,
+                    isInTouchMode = false,
+                )
+
+                lastPosition = downPosition
+
+                bringIntoView(downPosition)
+
+                return hasSelection(selectableId)
+            }
+
+            return false
+        }
+
+        override fun onDrag(dragPosition: Offset, adjustment: SelectionAdjustment): Boolean {
+            layoutCoordinates()?.let {
+                if (!it.isAttached) return false
+                if (!hasSelection(selectableId)) return false
+
+                val consumed =
+                    notifySelectionUpdate(
+                        layoutCoordinates = it,
+                        previousPosition = lastPosition,
+                        newPosition = dragPosition,
+                        isStartHandle = false,
+                        adjustment = adjustment,
+                        isInTouchMode = false,
+                    )
+                if (consumed) {
+                    lastPosition = dragPosition
+                }
+
+                bringIntoView(dragPosition)
+            }
+            return true
+        }
+
+        override fun onDragDone() {
+            notifySelectionUpdateEnd()
+        }
+    }
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionContainerTest.kt
@@ -16,10 +16,13 @@
 
 package androidx.compose.foundation.text.selection
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -40,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
@@ -149,6 +153,46 @@ class SelectionContainerTest {
     fun selectionMagnifierShouldNotCrash() {
         val sm = SelectionManager(SelectionRegistrarImpl())
         Modifier.selectionMagnifier(sm)
+    }
+
+    @Test
+    fun dragOutsideScrollsAndSelects() = androidx.compose.ui.test.v2.runComposeUiTest {
+        val scrollState by mutableStateOf(ScrollState(0))
+        var selection by mutableStateOf<Selection?>(null)
+        setContent {
+            Box(Modifier.testTag("container").size(200.dp).verticalScroll(scrollState)) {
+                SelectionContainer(
+                    selection = selection,
+                    onSelectionChange = { selection = it },
+                ) {
+                    Column(Modifier.testTag("content")) {
+                        repeat(50) { BasicText("Line $it", Modifier.testTag("tag$it")) }
+                    }
+                }
+            }
+        }
+
+        onNodeWithTag("content").performMouseInput {
+            dragAndDrop(
+                start = Offset(0f, 0f),
+                end =  Offset(width.toFloat(), height + 100f),
+                durationMillis = 10_000
+            )
+        }
+
+        // Verify that it was scrolled to the bottom
+        val contentSize = onNodeWithTag("content").fetchSemanticsNode().size
+        assertTrue(scrollState.value > 0)
+        assertEquals(contentSize.height, scrollState.value + scrollState.viewportSize)
+
+        // Verify that the selection is the entire content
+        selection.let {
+            assertNotNull(it)
+            assertEquals(1, it.start.selectableId)
+            assertEquals(0, it.start.offset)
+            assertEquals(50, it.end.selectableId)
+            assertEquals(7, it.end.offset)
+        }
     }
 }
 

--- a/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.web.kt
+++ b/compose/foundation/foundation/src/webMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.web.kt
@@ -23,4 +23,4 @@ import androidx.compose.ui.layout.LayoutCoordinates
 internal actual fun SelectionRegistrar.makeSelectionModifier(
     selectableId: Long,
     layoutCoordinates: () -> LayoutCoordinates?
-): Modifier = makeDefaultSelectionModifier(selectableId, layoutCoordinates)
+): Modifier = makeSkikoSelectionModifier(selectableId, layoutCoordinates)


### PR DESCRIPTION
Implement scrolling the selection container when the user selects text and drags the mouse outside the text element.

This is a cherry-pick of https://github.com/JetBrains/compose-multiplatform-core/pull/2966

## Testing
N/A

## Release Notes
### Features - Multiple Platforms
- Implement drag-to-scroll in `SelectionContainer`. When the mouse pointer is dragged outside the element while selecting text, the text element will be scrolled accordingly. Note that this requires wrapping the content in a scrolling container/modifier, e.g. `Modifier.verticalScroll`.