### PR TITLE
Fix `SkikoSelectionModifierElement.equals` to compare `layoutCoordinates` via reference comparison

### DIFF
--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.ios.kt
@@ -101,11 +101,9 @@ internal class CupertinoSelectionModifierElement(
         if (this === other) return true
         if (other !is CupertinoSelectionModifierElement) return false
 
-        if (selectionRegistrar != other.selectionRegistrar) return false
-        if (selectableId != other.selectableId) return false
-        if (layoutCoordinates != other.layoutCoordinates) return false
-
-        return true
+        return selectionRegistrar == other.selectionRegistrar &&
+            selectableId == other.selectableId &&
+            layoutCoordinates === other.layoutCoordinates
     }
 
     override fun hashCode(): Int {

--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/modifiers/SelectionController.skiko.kt
@@ -77,11 +77,9 @@ internal class SkikoSelectionModifierElement(
         if (this === other) return true
         if (other !is SkikoSelectionModifierElement) return false
 
-        if (selectionRegistrar != other.selectionRegistrar) return false
-        if (selectableId != other.selectableId) return false
-        if (layoutCoordinates != other.layoutCoordinates) return false
-
-        return true
+        return selectionRegistrar == other.selectionRegistrar &&
+            selectableId == other.selectableId &&
+            layoutCoordinates === other.layoutCoordinates
     }
 
     override fun hashCode(): Int {


### PR DESCRIPTION
Fix the implementation of `SkikoSelectionModifierElement.equals` to compare the `layoutCoordinates` lambda via reference comparison.

It turns out that it does need to be compared via `===`.
Android Studio has this lint:

> Checking lambdas for structural equality, instead of checking for referential equality Toggle info (⌘F1)
> Inspection info: Checking structural equality on lambdas can lead to issues, as function references (::lambda) do not consider their capture scope in their equals implementation. This means that structural equality can return true, even if the lambdas are different references with a different capture scope. Instead, lambdas should becompared referentially (`===` or `!==`) to avoid this issue.

## Testing
N/A

## Release Notes
N/A