### PR TITLE
Use `TextRange.min/max` instead of start/end in TextEditingScope

### DIFF
--- a/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
+++ b/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/input/internal/TextInputSession.skiko.kt
@@ -155,6 +155,9 @@ private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScop
             setSelectionCoerced(value, value)
         }
 
+    // Be careful about using TextRange.start/end, as the selection can be reversed (start > end).
+    // Prefer to use TextRange.min/max.
+
     override fun deleteSurroundingTextInCodePoints(
         lengthBeforeCursor: Int,
         lengthAfterCursor: Int
@@ -162,26 +165,26 @@ private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScop
         val charSequence = buffer.asCharSequence()
         val selection = buffer.selection
         buffer.delete(
-            start = selection.end,
+            start = selection.max,
             end = charSequence.offsetByCodePoints(
-                index = selection.end,
+                index = selection.max,
                 offset = lengthAfterCursor
             )
         )
         buffer.delete(
             start = charSequence.offsetByCodePoints(
-                index = selection.start,
+                index = selection.min,
                 offset = -lengthBeforeCursor
             ),
-            end = selection.start
+            end = selection.min
         )
     }
 
     override fun commitText(text: CharSequence, newCursorPosition: Int) {
         // API description says replace ongoing composition text if there. Then, if there is no
-        // composition text, insert text into cursor position or replace selection.
+        // composition text, insert text into the cursor position or replace selection.
         val replacementRange = buffer.composition ?: buffer.selection
-        buffer.replace(replacementRange.start, replacementRange.end, text)
+        buffer.replace(replacementRange.min, replacementRange.max, text)
 
         // After replace function is called, the editing buffer places the cursor at the end of the
         // modified range.
@@ -200,11 +203,11 @@ private fun TextEditingScope(buffer: TextFieldBuffer) = object : TextEditingScop
     override fun setComposingText(text: CharSequence, newCursorPosition: Int) {
         val replacementRange = buffer.composition ?: buffer.selection
         // API doc says, if there is ongoing composing text, replace it with new text.
-        // If there is no composing text, insert composing text into cursor position with
+        // If there is no composing text, insert composing text into the cursor position with
         // removing selected text if any.
-        buffer.replace(replacementRange.start, replacementRange.end, text)
+        buffer.replace(replacementRange.min, replacementRange.max, text)
         if (text.isNotEmpty()) {
-            buffer.setComposition(replacementRange.start, replacementRange.start + text.length)
+            buffer.setComposition(replacementRange.min, replacementRange.max + text.length)
         }
 
         // After replace function is called, the editing buffer places the cursor at the end of the

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/TestUtils.kt
@@ -91,6 +91,16 @@ fun Window.sendKeyEvent(
     return event.isConsumed
 }
 
+fun Window.sendPressAndReleaseKeyEvents(
+    code: Int,
+    char: Char = code.toChar(),
+    location: Int = KeyEvent.KEY_LOCATION_STANDARD,
+    modifiers: Int = 0
+) {
+    sendKeyEvent(code, char, id = KeyEvent.KEY_PRESSED, location, modifiers)
+    sendKeyEvent(code, char, id = KeyEvent.KEY_RELEASED, location, modifiers)
+}
+
 fun Window.focusedInputMethodRequests(): InputMethodRequests? =
     mostRecentFocusOwner!!.inputMethodRequests
 

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/BaseWindowTextFieldTest.kt
@@ -63,6 +63,8 @@ open class BaseWindowTextFieldTest {
     internal fun <S: TextFieldTestScope> runTextFieldTest(
         textFieldKind: TextFieldKind<S>,
         name: String,
+        initialText: String = "",
+        initialSelection: TextRange = TextRange.Zero,
         body: suspend S.() -> Unit
     ) = runApplicationTest {
         var scope: S? = null
@@ -75,7 +77,12 @@ open class BaseWindowTextFieldTest {
                 modifier = Modifier.fillMaxSize()
             ) {
                 if (scope == null) {
-                    scope = textFieldKind.createScope(this@runApplicationTest, window)
+                    scope = textFieldKind.createScope(
+                        windowTestScope = this@runApplicationTest,
+                        window = window,
+                        initialText = initialText,
+                        initialSelection = initialSelection
+                    )
                 }
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text("$name ($scope)")
@@ -153,10 +160,17 @@ open class BaseWindowTextFieldTest {
 
     internal abstract class TextField1Scope(
         windowTestScope: WindowTestScope,
-        window: ComposeWindow
+        window: ComposeWindow,
+        initialText: String,
+        initialSelection: TextRange,
     ): TextFieldTestScope(windowTestScope, window) {
 
-        protected var textFieldValue by mutableStateOf(TextFieldValue())
+        protected var textFieldValue by mutableStateOf(
+            TextFieldValue(
+                text = initialText,
+                selection = initialSelection,
+            )
+        )
 
         override val text: String
             get() = textFieldValue.text
@@ -175,9 +189,14 @@ open class BaseWindowTextFieldTest {
 
     internal abstract class TextField2Scope(
         windowTestScope: WindowTestScope,
-        window: ComposeWindow
+        window: ComposeWindow,
+        initialText: String,
+        initialSelection: TextRange,
     ): TextFieldTestScope(windowTestScope, window) {
-        protected val textFieldState = TextFieldState()
+        protected val textFieldState = TextFieldState(
+            initialText = initialText,
+            initialSelection = initialSelection,
+        )
         var inputTransformation: InputTransformation? by mutableStateOf(null)
 
         override val text: String
@@ -198,99 +217,115 @@ open class BaseWindowTextFieldTest {
         windowTestScope: WindowTestScope,
         window: ComposeWindow,
         textObfuscationMode: TextObfuscationMode,
-    ): TextField2Scope(windowTestScope, window) {
+        initialText: String = "",
+        initialSelection: TextRange = TextRange.Zero,
+    ): TextField2Scope(windowTestScope, window, initialText, initialSelection) {
 
         var textObfuscationMode by mutableStateOf(textObfuscationMode)
 
     }
 
     internal fun interface TextFieldKind<S: TextFieldTestScope> {
-        fun createScope(windowTestScope: WindowTestScope, window: ComposeWindow): S
+        fun createScope(
+            windowTestScope: WindowTestScope,
+            window: ComposeWindow,
+            initialText: String,
+            initialSelection: TextRange,
+        ): S
     }
 
     companion object {
         @JvmField
         @DataPoint
-        internal val TextField1 = TextFieldKind<TextField1Scope> { windowTestScope, window ->
-            object : TextField1Scope(windowTestScope, window) {
-                @Composable
-                override fun TextField() {
-                    val focusRequester = remember { FocusRequester() }
-                    BasicTextField(
-                        value = textFieldValue,
-                        onValueChange = {
-                            textFieldValue = it
-                        },
-                        onTextLayout = { textLayoutResult = it },
-                        modifier = Modifier
-                            .focusRequester(focusRequester)
-                            .onPlaced {
-                                textBoundingBox = it.boundsInWindow()
-                            }
-                    )
+        internal val TextField1 = TextFieldKind<TextField1Scope> {
+            windowTestScope, window, initialText, initialSelection ->
+                object : TextField1Scope(windowTestScope, window, initialText, initialSelection) {
+                    @Composable
+                    override fun TextField() {
+                        val focusRequester = remember { FocusRequester() }
+                        BasicTextField(
+                            value = textFieldValue,
+                            onValueChange = {
+                                textFieldValue = it
+                            },
+                            onTextLayout = { textLayoutResult = it },
+                            modifier = Modifier
+                                .focusRequester(focusRequester)
+                                .onPlaced {
+                                    textBoundingBox = it.boundsInWindow()
+                                }
+                        )
 
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
+                        LaunchedEffect(focusRequester) {
+                            focusRequester.requestFocus()
+                        }
                     }
-                }
 
-                override fun toString() = "TextField1"
-            }
+                    override fun toString() = "TextField1"
+                }
         }
 
         @JvmField
         @DataPoint
-        internal val TextField2 = TextFieldKind<TextField2Scope> { windowTestScope, window ->
-            object : TextField2Scope(windowTestScope, window) {
-                @Composable
-                override fun TextField() {
-                    val focusRequester = remember { FocusRequester() }
-                    BasicTextField(
-                        state = textFieldState,
-                        inputTransformation = inputTransformation,
-                        onTextLayout = { textLayoutResultGetter = it },
-                        modifier = Modifier
-                            .focusRequester(focusRequester)
-                            .onPlaced {
-                                textBoundingBox = it.boundsInWindow()
-                            }
-                    )
+        internal val TextField2 = TextFieldKind<TextField2Scope> {
+            windowTestScope, window, initialText, initialSelection ->
+                object : TextField2Scope(windowTestScope, window, initialText, initialSelection) {
+                    @Composable
+                    override fun TextField() {
+                        val focusRequester = remember { FocusRequester() }
+                        BasicTextField(
+                            state = textFieldState,
+                            inputTransformation = inputTransformation,
+                            onTextLayout = { textLayoutResultGetter = it },
+                            modifier = Modifier
+                                .focusRequester(focusRequester)
+                                .onPlaced {
+                                    textBoundingBox = it.boundsInWindow()
+                                }
+                        )
 
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
+                        LaunchedEffect(focusRequester) {
+                            focusRequester.requestFocus()
+                        }
                     }
-                }
 
-                override fun toString() = "TextField2"
-            }
+                    override fun toString() = "TextField2"
+                }
         }
 
         @JvmField
         @DataPoint
-        internal val SecureTextField = TextFieldKind<SecureTextFieldScope> { windowTestScope, window ->
-            object : SecureTextFieldScope(windowTestScope, window, TextObfuscationMode.Hidden) {
-                @Composable
-                override fun TextField() {
-                    val focusRequester = remember { FocusRequester() }
+        internal val SecureTextField = TextFieldKind<SecureTextFieldScope> {
+            windowTestScope, window, initialText, initialSelection ->
+                object : SecureTextFieldScope(
+                    windowTestScope,
+                    window,
+                    TextObfuscationMode.Hidden,
+                    initialText,
+                    initialSelection
+                ) {
+                    @Composable
+                    override fun TextField() {
+                        val focusRequester = remember { FocusRequester() }
 
-                    BasicSecureTextField(
-                        state = textFieldState,
-                        textObfuscationMode = textObfuscationMode,
-                        onTextLayout = { textLayoutResultGetter = it },
-                        modifier = Modifier
-                            .focusRequester(focusRequester)
-                            .onPlaced {
-                                textBoundingBox = it.boundsInWindow()
-                            }
-                    )
+                        BasicSecureTextField(
+                            state = textFieldState,
+                            textObfuscationMode = textObfuscationMode,
+                            onTextLayout = { textLayoutResultGetter = it },
+                            modifier = Modifier
+                                .focusRequester(focusRequester)
+                                .onPlaced {
+                                    textBoundingBox = it.boundsInWindow()
+                                }
+                        )
 
-                    LaunchedEffect(focusRequester) {
-                        focusRequester.requestFocus()
+                        LaunchedEffect(focusRequester) {
+                            focusRequester.requestFocus()
+                        }
                     }
-                }
 
-                override fun toString() = "SecureTextField"
-            }
+                    override fun toString() = "SecureTextField"
+                }
         }
     }
 }

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/window/WindowTypeTest.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.sendCharTypedEvents
 import androidx.compose.ui.sendInputMethodEvent
 import androidx.compose.ui.sendKeyEvent
 import androidx.compose.ui.sendKeyTypedEvent
+import androidx.compose.ui.sendPressAndReleaseKeyEvents
 import androidx.compose.ui.text.TextRange
+import java.awt.event.KeyEvent
 import java.awt.event.KeyEvent.KEY_PRESSED
 import java.awt.event.KeyEvent.KEY_RELEASED
 import kotlin.test.Test
@@ -903,4 +905,29 @@ class WindowTypeTest : BaseWindowTextFieldTest() {
             window.sendInputMethodEvent("·", committedCharacterCount = 1)
             assertStateEquals("·", selection = TextRange(1), composition = null)
         }
+
+    @Theory
+    internal fun `select text backwards, then input via IME`(
+        textFieldKind: TextFieldKind<*>
+    ) = runTextFieldTest(
+        textFieldKind = textFieldKind,
+        name = "Select text backwards, then input via IME",
+        initialText = "abcdef",
+        initialSelection = TextRange(6)
+    ) {
+        // Select "def"
+        window.sendKeyEvent(KeyEvent.VK_SHIFT, id = KEY_PRESSED)
+        repeat(3) {
+            window.sendPressAndReleaseKeyEvents(KeyEvent.VK_LEFT, modifiers = KeyEvent.SHIFT_DOWN_MASK)
+            awaitIdle()
+        }
+
+        assertStateEquals("abcdef", selection = TextRange(6, 3), composition = null)
+
+        // Insert character via IME
+        window.sendInputMethodEvent("ㅂ", 0)
+        window.sendKeyEvent(81, 'q', KEY_RELEASED)
+
+        assertStateEquals("abcㅂ", selection = TextRange(4, 4), composition = TextRange(3, 4))
+    }
 }


### PR DESCRIPTION
Replace usage of TextRange.start/end in favor of min/max in TextEditingScope for BTF2, which caused a crash when start > end.

This is a cherry-pick of https://github.com/JetBrains/compose-multiplatform-core/pull/2982

## Testing
N/A

## Release Notes
### Fixes - Multiple Platforms
- Fix crash when selecting text right-to-left and then typing a character via IME.
