### PR TITLE
Expose `ComposeScene.measurableContent` to allow querying the scene for its size properties

### DIFF
--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -344,12 +344,11 @@ internal class ComposeSceneMediator(
         ComposeFeatureFlags.redispatchUnconsumedMouseWheelEvents.value
 
     /**
-     * Provides the size of ComposeScene content inside infinity constraints
+     * Provides the size of the scene content in infinity constraints.
      *
-     * This is needed for the bridge between Compose and Swing since
-     * in some cases, Swing's LayoutManagers need
-     * to calculate the preferred size of the content without max/min constraints
-     * to properly lay it out.
+     * This is needed for the bridge between Compose and Swing since in some cases, Swing's
+     * LayoutManagers need to calculate the preferred size of the content without max/min
+     * constraints to properly lay it out.
      *
      * Example: Compose content inside Popup without a preferred size.
      * Swing will calculate the preferred size of the Compose content and set Popup's side for that.
@@ -358,7 +357,7 @@ internal class ComposeSceneMediator(
      */
     val preferredSize: Dimension
         get() {
-            val contentSize = scene.calculateContentSize()
+            val contentSize = scene.unconstrainedSize()
             val scale = scene.density.density
             return Dimension(
                 (contentSize.width / scale).toInt(),

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/ImageComposeScene.skiko.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.platform.WindowInfoImpl
 import androidx.compose.ui.scene.CanvasLayersComposeScene
 import androidx.compose.ui.scene.ComposeScene
 import androidx.compose.ui.scene.ComposeScenePointer
+import androidx.compose.ui.scene.unconstrainedSize
 import androidx.compose.ui.semantics.SemanticsOwner
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
@@ -258,7 +259,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      */
     @Deprecated("Use calculateContentSize() instead", replaceWith = ReplaceWith("calculateContentSize()"))
     val contentSize: IntSize
-        get() = scene.calculateContentSize()
+        get() = scene.unconstrainedSize()
 
     /**
      * Returns the current content size in infinity constraints.
@@ -268,7 +269,7 @@ class ImageComposeScene @ExperimentalComposeUiApi constructor(
      */
     @ExperimentalComposeUiApi
     fun calculateContentSize(): IntSize {
-        return scene.calculateContentSize()
+        return scene.unconstrainedSize()
     }
 
     /**

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/MeasurableRootContent.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/MeasurableRootContent.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.ui.layout
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.unit.Constraints
+
+/**
+ * The interface through which composable content can be queried for its size preferences, such as
+ * its intrinsic size.
+ */
+@ExperimentalComposeUiApi
+interface MeasurableRootContent : IntrinsicMeasurable {
+    /**
+     * Measures the content with the given constraints and calls [block] on the resulting
+     * [Measured].
+     *
+     * Returns the result of [block].
+     *
+     * It is recommended to not hold onto the [Measured] instance beyond the lifetime of the call
+     * to [block].
+     */
+    fun <T> measuringIn(constraints: Constraints, block: (Measured) -> T): T
+}

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/MeasurableRootContent.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/layout/MeasurableRootContent.kt
@@ -16,14 +16,14 @@
 
 package androidx.compose.ui.layout
 
-import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.unit.Constraints
 
 /**
  * The interface through which composable content can be queried for its size preferences, such as
  * its intrinsic size.
  */
-@ExperimentalComposeUiApi
+@InternalComposeUiApi
 interface MeasurableRootContent : IntrinsicMeasurable {
     /**
      * Measures the content with the given constraints and calls [block] on the resulting

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/node/RootNodeOwner.skiko.kt
@@ -62,6 +62,8 @@ import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.pointer.PositionCalculator
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.layout.MeasurableRootContent
+import androidx.compose.ui.layout.Measured
 import androidx.compose.ui.layout.RootMeasurePolicy
 import androidx.compose.ui.layout.RulerProviderModifierElement
 import androidx.compose.ui.modifier.ModifierLocalManager
@@ -204,22 +206,58 @@ internal class RootNodeOwner(
         }
     }
 
+    val measurableRootContent: MeasurableRootContent = object : MeasurableRootContent {
+        override val parentData
+            get() = null
+
+        override fun minIntrinsicWidth(height: Int): Int {
+            // RootMeasurePolicy has LayoutNode.NoIntrinsicsMeasurePolicy, so we ask the children
+            return owner.root.children.fastMaxOfOrDefault(0) {
+                it.outerCoordinator.minIntrinsicWidth(height)
+            }
+        }
+
+        override fun minIntrinsicHeight(width: Int): Int {
+            // RootMeasurePolicy has LayoutNode.NoIntrinsicsMeasurePolicy, so we ask the children
+            return owner.root.children.fastMaxOfOrDefault(0) {
+                it.outerCoordinator.minIntrinsicHeight(width)
+            }
+        }
+
+        override fun maxIntrinsicWidth(height: Int): Int {
+            // RootMeasurePolicy has LayoutNode.NoIntrinsicsMeasurePolicy, so we ask the children
+            return owner.root.children.fastMaxOfOrDefault(0) {
+                it.outerCoordinator.maxIntrinsicWidth(height)
+            }
+        }
+
+        override fun maxIntrinsicHeight(width: Int): Int {
+            // RootMeasurePolicy has LayoutNode.NoIntrinsicsMeasurePolicy, so we ask the children
+            return owner.root.children.fastMaxOfOrDefault(0) {
+                it.outerCoordinator.maxIntrinsicHeight(width)
+            }
+        }
+
+        override fun <T> measuringIn(constraints: Constraints, block: (Measured) -> T): T {
+            return measuringRootWithConstraints(constraints) {
+                block(it.outerCoordinator)
+            }
+        }
+    }
+
     /**
      * Provides a way to measure Owner's content in given [constraints]
      * Draw/pointer and other callbacks won't be called here like in [measureAndLayout] functions
      */
-    fun measureInConstraints(constraints: Constraints): IntSize {
-        try {
+    private fun <T> measuringRootWithConstraints(
+        constraints: Constraints,
+        block: (LayoutNode) -> T
+    ): T {
+        return try {
             // TODO: is it possible to measure without reassigning root constraints?
             measureAndLayoutDelegate.updateRootConstraintsWithInfinityCheck(constraints)
             measureAndLayoutDelegate.measureOnly()
-
-            // Don't use mainOwner.root.width here, as it strictly coerced by [constraints]
-            val children = owner.root.children
-            return IntSize(
-                width = children.fastMaxOfOrDefault(0) { it.outerCoordinator.measuredWidth },
-                height = children.fastMaxOfOrDefault(0) { it.outerCoordinator.measuredHeight },
-            )
+            block(owner.root)
         } finally {
             measureAndLayoutDelegate.updateRootConstraintsWithInfinityCheck(size?.toConstraints())
         }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -38,11 +38,11 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.layout.MeasurableRootContent
 import androidx.compose.ui.node.InternalCoreApi
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.setContent
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -199,10 +199,11 @@ private class CanvasLayersComposeSceneImpl(
         super.close()
     }
 
-    override fun calculateContentSize(): IntSize {
-        check(!isClosed) { "calculateContentSize called after ComposeScene is closed" }
-        return mainOwner.measureInConstraints(Constraints())
-    }
+    override val measurableContent: MeasurableRootContent
+        get() {
+            check(!isClosed) { "measurableContent requested after ComposeScene is closed" }
+            return mainOwner.measurableRootContent
+        }
 
     override fun invalidatePositionInWindow() {
         check(!isClosed) { "invalidatePositionInWindow called after ComposeScene is closed" }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeScene.skiko.kt
@@ -37,11 +37,13 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
 import androidx.compose.ui.input.pointer.PointerType
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.layout.MeasurableRootContent
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.PlatformContext
 import androidx.compose.ui.platform.PlatformDragAndDropManager
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
@@ -133,12 +135,10 @@ sealed interface ComposeScene : AutoCloseable {
     override fun close()
 
     /**
-     * Returns the current content size (in pixels) in infinity constraints.
-     *
-     * @throws IllegalStateException when [ComposeScene] content has lazy layouts without maximum
-     * size bounds (e.g. LazyColumn without maximum height).
+     * An object through which the composable content of the scene can be queried for its size
+     * properties.
      */
-    fun calculateContentSize(): IntSize
+    val measurableContent: MeasurableRootContent
 
     /**
      * Invalidates position of [ComposeScene] in window. It will trigger callbacks like
@@ -308,4 +308,17 @@ sealed interface ComposeScene : AutoCloseable {
      * Set the visual debug option that shows bounds for all nodes in the hierarchy.
      */
     var showLayoutBounds: Boolean
+}
+
+/**
+ * Returns the current content size (in pixels) in infinity constraints.
+ *
+ * @throws IllegalStateException when [ComposeScene] content has lazy layouts without maximum
+ * size bounds (e.g., LazyColumn without maximum height).
+ */
+@InternalComposeUiApi
+fun ComposeScene.unconstrainedSize(): IntSize {
+    return measurableContent.measuringIn(Constraints()) {
+        IntSize(it.measuredWidth, it.measuredHeight)
+    }
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/PlatformLayersComposeScene.skiko.kt
@@ -26,11 +26,11 @@ import androidx.compose.ui.graphics.Canvas
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerInputEvent
 import androidx.compose.ui.input.rotary.RotaryScrollEvent
+import androidx.compose.ui.layout.MeasurableRootContent
 import androidx.compose.ui.node.InternalCoreApi
 import androidx.compose.ui.node.LayoutNode
 import androidx.compose.ui.node.RootNodeOwner
 import androidx.compose.ui.platform.setContent
-import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
@@ -145,10 +145,11 @@ private class PlatformLayersComposeSceneImpl(
         super.close()
     }
 
-    override fun calculateContentSize(): IntSize {
-        check(!isClosed) { "calculateContentSize called after ComposeScene is closed" }
-        return mainOwner.measureInConstraints(Constraints())
-    }
+    override val measurableContent: MeasurableRootContent
+        get() {
+            check(!isClosed) { "measurableContent requested after ComposeScene is closed" }
+            return mainOwner.measurableRootContent
+        }
 
     override fun invalidatePositionInWindow() {
         check(!isClosed) { "invalidatePositionInWindow called after ComposeScene is closed" }


### PR DESCRIPTION
I've extracted this part from the new [Window State API PR](https://github.com/JetBrains/compose-multiplatform-core/pull/2938) because it's also needed by [Support sizing of Compose hosting views on iOS](https://github.com/JetBrains/compose-multiplatform-core/pull/2984).

It's now possible to measure the scene in various constraints, as well as query it for its min/max intrinsic sizes, via `ComposeScene.measurableContent`.

## Testing
N/A

## Release Notes
N/A