### PR TITLE
Update `NativeInputEventsProcessor` to handle `deleteContentBackward` when a browser performs 'Fast Delete' (#2985)

### DIFF
--- a/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
+++ b/compose/ui/ui/src/webMain/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessor.kt
@@ -161,26 +161,29 @@ internal abstract class NativeInputEventsProcessor(
     private fun InputEventExt.process(currentTextFieldValue: TextFieldValue) {
         val editCommands = when (inputType) {
             "deleteContentBackward" -> buildList {
-                // this means "deleteContentBackward" happened because of an earlier "keydown" event, so skipping it here
-                if (lastProcessedKeydown?.isBackspace() == true) return@buildList
-
                 if (!currentTextFieldValue.selection.collapsed) {
-                    // Likely it's on mobile, where the Backspace has Unidentified key value.
-                    // When Compose TextField shows text selection,
-                    // a good UX for deleteContentBackward would be to emulate Backspace
-                    add(BackspaceCommand())
-                } else {
+                    // If the lastProcessedKeydown was Backspace, then Compose must have already processed this.
+                    if (lastProcessedKeydown?.isBackspace() != true) {
+                        // If we got here, then it's likely one of the mobile browsers, where the Backspace has Unidentified key value.
+                        // Compose doesn't handle Unidentified keys - it does not have any context about them.
+                        // And here in `deleteContentBackward` we have this context.
+                        // When Compose TextField has text selection, a good UX for deleteContentBackward would be to emulate Backspace.
+                        add(BackspaceCommand())
+                    }
+                } else { // Empty selection case.
                     // This happens when an autocorrection is applied on mobile:
                     // The system first tells us to delete the old text,
                     // and then it would send the "insertText" event.
                     if (textRangeSize > 0) {
-                        // deleteContentBackward can happen under very non-trivial circumstances,
-                        // for instance; when an input suggestion on Android Chrome is accepted,
-                        // the browser then deletes space after the word just to add space again
+                        // deleteContentBackward can happen under very non-trivial circumstances:
+                        // - for instance, when an input suggestion on Android Chrome is accepted,
+                        // the browser then deletes space after the word just to add space again;
+                        // - or when a browser performs Fast Delete;
                         add(SetSelectionCommand(textRangeStart, textRangeEnd))
                         add(BackspaceCommand())
-                    } else if (textRangeSize == 0) {
-                        // under specific circumstance previous symbol can be deleted while inputing new one
+                    } else if (textRangeSize == 0 && lastProcessedKeydown?.isBackspace() != true) {
+                        // We skip this branch if the lastProcessedKeydown is Backspace, because Compose must have already processed this.
+                        // Otherwise, under specific circumstance previous symbol can be deleted while inputting the new one
                         // see https://youtrack.jetbrains.com/issue/CMP-8773
                         add(BackspaceCommand())
                     }

--- a/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
+++ b/compose/ui/ui/src/webTest/kotlin/androidx/compose/ui/platform/NativeInputEventsProcessorTest.kt
@@ -279,7 +279,7 @@ class NativeInputEventsProcessorTest {
     }
 
     @Test
-    fun when_Backspace_Pressed_deleteContentBackward_is_ignored() {
+    fun when_NonCollapsedSelection_And_Backspace_Pressed_then_deleteContentBackward_is_ignored() {
         val communicator = MockComposeCommandCommunicator()
         val processor = TestNativeInputEventsProcessor(communicator)
 
@@ -296,15 +296,16 @@ class NativeInputEventsProcessorTest {
                 textRangeEnd = 4
             }
         )
-        processor.manuallyRunCheckpoint(TextFieldValue("test"))
+        processor.manuallyRunCheckpoint(TextFieldValue("test", selection = TextRange(3, 4)))
 
-        assertEquals(1, communicator.keyboardEvents.size)
-        assertEquals(0, communicator.editCommands.size)
+        assertEquals(1, communicator.keyboardEvents.size, "exactly one key event should be sent")
+        assertEquals(0, communicator.editCommands.size, "editCommands should not be sent")
 
         val sentKeyEvent = communicator.keyboardEvents[0]
         assertEquals(
             "Backspace",
-            ((sentKeyEvent.nativeKeyEvent as InternalKeyEvent).nativeEvent as KeyboardEvent).key
+            ((sentKeyEvent.nativeKeyEvent as InternalKeyEvent).nativeEvent as KeyboardEvent).key,
+            "keyboardEvent for Backspace should be sent"
         )
     }
 
@@ -673,6 +674,43 @@ class NativeInputEventsProcessorTest {
         // The deleteContentBackward event should be ignored since Backspace key was pressed
         assertEquals(1, communicator.keyboardEvents.size)
         assertEquals(0, communicator.editCommands.size)
+    }
+
+    @Test
+    fun testDeleteContentBackward_with_collapsed_selection_and_Backspace_key_pressed_same_frame() {
+        val textFieldValue = TextFieldValue(
+            text = "example text",
+            selection = TextRange(12) // collapsed selection at the very end
+        )
+
+        val communicator = MockComposeCommandCommunicator(textFieldValue)
+        val processor = TestNativeInputEventsProcessor(communicator)
+
+        val backspaceEvent = keyEvent(
+            key = "Backspace",
+            code = "Backspace",
+            type = "keydown"
+        )
+        processor.registerEvent(backspaceEvent)
+
+        processor.registerEvent(
+            beforeInput("deleteContentBackward", "").asInputEventExt().apply {
+                textRangeStart = 8
+                textRangeEnd = 12
+            },
+        )
+
+        processor.manuallyRunCheckpoint(communicator.currentTextFieldValue())
+
+        assertEquals(1, communicator.keyboardEvents.size)
+        assertEquals(2, communicator.editCommands.size)
+
+        val selectionCommand = communicator.editCommands[0]
+        assertTrue(selectionCommand is SetSelectionCommand)
+        assertEquals(8, selectionCommand.start)
+        assertEquals(12, selectionCommand.end)
+
+        assertEquals("example ", communicator.currentTextFieldValue().text)
     }
 
     @Test


### PR DESCRIPTION

Adjusted the logic: The browsers can perform 'Fast Delete' via deleteContentBackward with textRangeSize > 0. (For example, Chrome on Samsung A25)

Fixes https://youtrack.jetbrains.com/issue/CMP-9966

(cherry picked from commit 6fd60fff3503312865c548c88a3d0a8f17ef9277)

## Testing
- Added a new test
- This should be tested by QA

## Release Notes
### Fixes - Web
- _(prerelease fix)_ Fix handling Fast Delete in mobile browsers