### PR TITLE
Make the iOS selection handles match the system style.

### DIFF
--- a/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.desktop.kt
+++ b/compose/foundation/foundation/src/desktopTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.desktop.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.Density
+
+internal actual fun PlatformSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+): SelectionHandleShape = DefaultSelectionHandleShape(density, cursor, isStartHandler)

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.ios.kt
@@ -46,14 +46,14 @@ import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.OSVersion
 import org.jetbrains.skiko.available
 
-private data class HandleStyle(
+internal data class HandleStyle(
     val dotDiameter: Dp,
     val stemWidth: Dp,
     val shadowRadius: Dp,
     val shadowAlpha: Float,
 )
 
-private val iosHandleStyle: HandleStyle by lazy {
+internal val iosHandleStyle: HandleStyle by lazy {
     if (available(OS.Ios to OSVersion(major = 17))) {
         HandleStyle(
             dotDiameter = 16.7.dp,

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.ios.kt
@@ -16,12 +16,61 @@
 
 package androidx.compose.foundation.text.selection
 
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.Handle
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.InternalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.isSpecified
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Paint
+import androidx.compose.ui.graphics.skiaPaint
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.ResolvedTextDirection
 import androidx.compose.ui.uikit.LocalNativeTextInputContext
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import org.jetbrains.skia.FilterBlurMode
+import org.jetbrains.skia.MaskFilter
+import org.jetbrains.skiko.OS
+import org.jetbrains.skiko.OSVersion
+import org.jetbrains.skiko.available
+
+private data class HandleStyle(
+    val dotDiameter: Dp,
+    val stemWidth: Dp,
+    val shadowRadius: Dp,
+    val shadowAlpha: Float,
+)
+
+private val iosHandleStyle: HandleStyle by lazy {
+    if (available(OS.Ios to OSVersion(major = 17))) {
+        HandleStyle(
+            dotDiameter = 16.7.dp,
+            stemWidth = 2.dp,
+            shadowRadius = 13.dp,
+            shadowAlpha = 0.3f,
+        )
+    } else {
+        HandleStyle(
+            dotDiameter = 11.dp,
+            stemWidth = 2.dp,
+            shadowRadius = 0.dp,
+            shadowAlpha = 0f,
+        )
+    }
+}
+
+// Clickable padding around the visible handle.
+private val PADDING = 5.dp
 
 @OptIn(InternalComposeUiApi::class)
 @Composable
@@ -38,5 +87,111 @@ internal actual fun SelectionHandle(
     if (nativeInputProvider.usingNativeTextInput()) {
         return // iOS draws selection handles itself.
     }
-    SkikoSelectionHandle(offsetProvider, isStartHandle, direction, handlesCrossed, minTouchTargetSize, lineHeight, modifier)
+    val style = iosHandleStyle
+    val isLeft = isLeftSelectionHandle(isStartHandle, direction, handlesCrossed)
+    val handleReferencePoint = if (isLeft) Alignment.BottomCenter else Alignment.TopCenter
+
+    HandlePopup(
+        positionProvider = {
+            var offset = offsetProvider.provide()
+            if (offset.isSpecified && !isLeft) {
+                offset += Offset(0f, -lineHeight)
+            }
+            offset
+        },
+        handleReferencePoint = handleReferencePoint
+    ) {
+        IosSelectionHandleIcon(
+            modifier = modifier.semantics {
+                val position = offsetProvider.provide()
+                this[SelectionHandleInfoKey] = SelectionHandleInfo(
+                    handle = if (isStartHandle) Handle.SelectionStart else Handle.SelectionEnd,
+                    position = position,
+                    anchor = if (isLeft) SelectionHandleAnchor.Left else SelectionHandleAnchor.Right,
+                    visible = position.isSpecified,
+                )
+            },
+            iconVisible = { offsetProvider.provide().isSpecified },
+            lineHeight = lineHeight,
+            isLeft = isLeft,
+            style = style,
+        )
+    }
+}
+
+@Composable
+private fun IosSelectionHandleIcon(
+    modifier: Modifier,
+    iconVisible: () -> Boolean,
+    lineHeight: Float,
+    isLeft: Boolean,
+    style: HandleStyle,
+) {
+    val density = LocalDensity.current
+    val handleColor = LocalTextSelectionColors.current.handleColor
+    val lineHeightDp = with(density) { lineHeight.toDp() }
+    val dotRadius = style.dotDiameter / 2
+    Spacer(
+        modifier
+            .size(
+                width = (PADDING + dotRadius) * 2,
+                height = dotRadius * 2 + PADDING + lineHeightDp
+            )
+            .drawIosSelectionHandle(iconVisible, lineHeight, isLeft, handleColor, density, style)
+    )
+}
+
+private fun Modifier.drawIosSelectionHandle(
+    iconVisible: () -> Boolean,
+    lineHeight: Float,
+    isLeft: Boolean,
+    handleColor: Color,
+    density: Density,
+    style: HandleStyle,
+): Modifier = drawWithCache {
+    val paddingPx = with(density) { PADDING.toPx() }
+    val dotRadiusPx = with(density) { (style.dotDiameter / 2).toPx() }
+    val stemWidthPx = with(density) { style.stemWidth.toPx() }
+    val shadowRadiusPx = with(density) { style.shadowRadius.toPx() }
+    val shadowPaint = if (style.shadowRadius > 0.dp && style.shadowAlpha > 0f) {
+        Paint().apply {
+            color = Color.Black.copy(alpha = style.shadowAlpha)
+            isAntiAlias = true
+            // Skia gaussian-blur sigma matching androidx.compose.ui.graphics.BlurEffect.
+            val sigma = 0.57735f * shadowRadiusPx + 0.5f
+            skiaPaint.maskFilter = MaskFilter.makeBlur(FilterBlurMode.NORMAL, sigma)
+        }
+    } else null
+
+    onDrawWithContent {
+        drawContent()
+        if (!iconVisible()) return@onDrawWithContent
+
+        val cx = size.width / 2
+        val dotCenterY = if (isLeft) paddingPx + dotRadiusPx else lineHeight + dotRadiusPx
+
+        if (shadowPaint != null) {
+            drawContext.canvas.drawCircle(
+                center = Offset(cx, dotCenterY),
+                radius = dotRadiusPx,
+                paint = shadowPaint,
+            )
+        }
+
+        // Vertical stem
+        drawRect(
+            color = handleColor,
+            topLeft = Offset(
+                x = cx - stemWidthPx / 2,
+                y = if (isLeft) paddingPx + dotRadiusPx else 0f
+            ),
+            size = Size(stemWidthPx, lineHeight + dotRadiusPx)
+        )
+        // Dot
+        drawCircle(
+            color = handleColor,
+            radius = dotRadiusPx,
+            center = Offset(cx, dotCenterY)
+        )
+    }
 }

--- a/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.ios.kt
+++ b/compose/foundation/foundation/src/iosMain/kotlin/androidx/compose/foundation/text/selection/SelectionHandles.ios.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import kotlin.math.floor
+import kotlin.math.roundToInt
 import org.jetbrains.skia.FilterBlurMode
 import org.jetbrains.skia.MaskFilter
 import org.jetbrains.skiko.OS
@@ -167,12 +169,24 @@ private fun Modifier.drawIosSelectionHandle(
         drawContent()
         if (!iconVisible()) return@onDrawWithContent
 
-        val cx = size.width / 2
+        val stemWidthInt = stemWidthPx.roundToInt().toFloat()
+        val stemLeftX = floor((size.width - stemWidthInt) / 2f)
+        val stemCenterX = stemLeftX + stemWidthInt / 2f
         val dotCenterY = if (isLeft) paddingPx + dotRadiusPx else lineHeight + dotRadiusPx
+
+        val stemTopY: Float
+        val stemBottomY: Float
+        if (isLeft) {
+            stemTopY = dotCenterY
+            stemBottomY = size.height
+        } else {
+            stemTopY = 0f
+            stemBottomY = dotCenterY
+        }
 
         if (shadowPaint != null) {
             drawContext.canvas.drawCircle(
-                center = Offset(cx, dotCenterY),
+                center = Offset(stemCenterX, dotCenterY),
                 radius = dotRadiusPx,
                 paint = shadowPaint,
             )
@@ -181,17 +195,14 @@ private fun Modifier.drawIosSelectionHandle(
         // Vertical stem
         drawRect(
             color = handleColor,
-            topLeft = Offset(
-                x = cx - stemWidthPx / 2,
-                y = if (isLeft) paddingPx + dotRadiusPx else 0f
-            ),
-            size = Size(stemWidthPx, lineHeight + dotRadiusPx)
+            topLeft = Offset(stemLeftX, stemTopY),
+            size = Size(stemWidthInt, stemBottomY - stemTopY)
         )
         // Dot
         drawCircle(
             color = handleColor,
             radius = dotRadiusPx,
-            center = Offset(cx, dotCenterY)
+            center = Offset(stemCenterX, dotCenterY)
         )
     }
 }

--- a/compose/foundation/foundation/src/iosTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.ios.kt
+++ b/compose/foundation/foundation/src/iosTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.ios.kt
@@ -26,17 +26,11 @@ internal actual fun PlatformSelectionHandleShape(
     cursor: Rect,
     isStartHandler: Boolean,
 ): SelectionHandleShape {
-    val majorVersion = UIDevice.currentDevice.systemVersion
-        .substringBefore('.')
-        .toIntOrNull() ?: 0
-    val isModern = majorVersion >= 17
-    val lineWidth = 2.dp
-    val circleRadius = if (isModern) (16.7 / 2).dp else (11.0 / 2).dp
     return DefaultSelectionHandleShape(
         density = density,
         cursor = cursor,
         isStartHandler = isStartHandler,
-        lineWidth = lineWidth,
-        circleRadius = circleRadius,
+        lineWidth = iosHandleStyle.stemWidth,
+        circleRadius = iosHandleStyle.dotDiameter / 2,
     )
 }

--- a/compose/foundation/foundation/src/iosTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.ios.kt
+++ b/compose/foundation/foundation/src/iosTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.ios.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import platform.UIKit.UIDevice
+
+internal actual fun PlatformSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+): SelectionHandleShape {
+    val majorVersion = UIDevice.currentDevice.systemVersion
+        .substringBefore('.')
+        .toIntOrNull() ?: 0
+    val isModern = majorVersion >= 17
+    val lineWidth = 2.dp
+    val circleRadius = if (isModern) (16.7 / 2).dp else (11.0 / 2).dp
+    return DefaultSelectionHandleShape(
+        density = density,
+        cursor = cursor,
+        isStartHandler = isStartHandler,
+        lineWidth = lineWidth,
+        circleRadius = circleRadius,
+    )
+}

--- a/compose/foundation/foundation/src/jsTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.js.kt
+++ b/compose/foundation/foundation/src/jsTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.js.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.Density
+
+internal actual fun PlatformSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+): SelectionHandleShape = DefaultSelectionHandleShape(density, cursor, isStartHandler)

--- a/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.macos.kt
+++ b/compose/foundation/foundation/src/macosTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.macos.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.Density
+
+internal actual fun PlatformSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+): SelectionHandleShape = DefaultSelectionHandleShape(density, cursor, isStartHandler)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ImageAssertions.skiko.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/ImageAssertions.skiko.kt
@@ -72,6 +72,24 @@ fun ImageBitmap.assertPixels(
 }
 
 /**
+ * Iterates over each pixel in the ImageBitmap and invokes the provided function for every pixel.
+ *
+ * @param handlePixel A function that is invoked for each pixel. It receives the color of the pixel
+ * and its position as parameters. The color is represented as a [Color] object, and the position
+ * is specified as an [IntOffset].
+ */
+fun ImageBitmap.forEachPixel(
+    handlePixel: (color: Color, position: IntOffset) -> Unit
+) {
+    val pixel = toPixelMap()
+    for (x in 0 until width) {
+        for (y in 0 until height) {
+            handlePixel(pixel[x, y], IntOffset(x, y))
+        }
+    }
+}
+
+/**
  * Asserts that the color at a specific pixel in the bitmap at ([x], [y]) is [expected].
  */
 fun PixelMap.assertPixelColor(

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.roundToIntRect
+import kotlin.math.pow
+
+internal data class SelectionHandleShape(
+    val lineRect: Rect,
+    val circleRect: Rect,
+) {
+    fun containsInner(point: IntOffset): Boolean =
+        lineRect.roundToIntRect().contains(point) ||
+            circleRect.roundToIntRect().deflate(1).containsInOval(point)
+
+    fun containsOuter(point: IntOffset): Boolean =
+        lineRect.roundToIntRect().contains(point) ||
+            circleRect.roundToIntRect().inflate(1).containsInOval(point)
+
+    private fun IntRect.containsInOval(point: IntOffset): Boolean {
+        val normX = (point.x + 0.5 - center.x) / (width / 2)
+        val normY = (point.y + 0.5 - center.y) / (height / 2)
+        return normX.pow(2) + normY.pow(2) <= 1.0
+    }
+}
+
+internal expect fun PlatformSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+): SelectionHandleShape
+
+internal fun DefaultSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+    lineWidth: Dp = 2.dp,
+    circleRadius: Dp = 6.dp,
+): SelectionHandleShape = with(density) {
+    val lineRect = cursor.copy(
+        left = cursor.bottomCenter.x - lineWidth.toPx() / 2,
+        right = cursor.bottomCenter.x + lineWidth.toPx() / 2,
+    )
+    val circleCenter = Offset(
+        x = cursor.bottomCenter.x,
+        y = if (isStartHandler) {
+            cursor.top - circleRadius.toPx()
+        } else {
+            cursor.bottom + circleRadius.toPx()
+        }
+    )
+    val circleRect = Rect(center = circleCenter, radius = circleRadius.toPx())
+
+    SelectionHandleShape(lineRect, circleRect)
+}

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.kt
@@ -30,13 +30,13 @@ internal data class SelectionHandleShape(
     val lineRect: Rect,
     val circleRect: Rect,
 ) {
-    fun containsInner(point: IntOffset): Boolean =
+    fun isInside(point: IntOffset): Boolean =
         lineRect.roundToIntRect().contains(point) ||
             circleRect.roundToIntRect().deflate(1).containsInOval(point)
 
-    fun containsOuter(point: IntOffset): Boolean =
-        lineRect.roundToIntRect().contains(point) ||
-            circleRect.roundToIntRect().inflate(1).containsInOval(point)
+    fun isOutside(point: IntOffset): Boolean =
+        !lineRect.roundToIntRect().contains(point) &&
+            !circleRect.roundToIntRect().inflate(1).containsInOval(point)
 
     private fun IntRect.containsInOval(point: IntOffset): Boolean {
         val normX = (point.x + 0.5 - center.x) / (width / 2)

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
@@ -16,8 +16,8 @@
 
 package androidx.compose.foundation.text.selection
 
-import androidx.compose.foundation.assertPixels
 import androidx.compose.foundation.background
+import androidx.compose.foundation.forEachPixel
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
@@ -48,6 +48,8 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlinx.test.IgnoreJsTarget
 import kotlinx.test.IgnoreWasmTarget
 
@@ -72,7 +74,7 @@ class BasicTextFieldSelectionHandleTest {
 
     @Test
     fun basicTextFieldSelectionHandles() = runSkikoComposeUiTest(size = Size(100f, 100f)) {
-        val textState = TextFieldState(initialText = "Text")
+        val textState = TextFieldState(initialText = "TextText")
 
         var selectionStart: Rect = Rect.Zero
         var selectionEnd: Rect = Rect.Zero
@@ -100,7 +102,7 @@ class BasicTextFieldSelectionHandleTest {
             up()
         }
         textState.edit {
-            selection = TextRange(start = 1, end = 3)
+            selection = TextRange(start = 1, end = 6)
         }
         waitForIdle()
 
@@ -128,10 +130,10 @@ class BasicTextFieldSelectionHandleTest {
     @IgnoreJsTarget
     @IgnoreWasmTarget
     fun coreTextFieldSelectionHandles() = runSkikoComposeUiTest(size = Size(100f, 100f)) {
-        val selection = TextRange(1, 3)
+        val selection = TextRange(1, 6)
         var selectionStart: Rect = Rect.Zero
         var selectionEnd: Rect = Rect.Zero
-        val textFieldValue = mutableStateOf(TextFieldValue(text = "Text", selection = selection))
+        val textFieldValue = mutableStateOf(TextFieldValue(text = "Text Text", selection = selection))
 
         setContent {
             SetInitialTouchInputMode()
@@ -160,7 +162,7 @@ class BasicTextFieldSelectionHandleTest {
             move(1000)
             up()
         }
-        textFieldValue.value = TextFieldValue(text = "Text", selection = selection)
+        textFieldValue.value = TextFieldValue(text = "TextText", selection = selection)
 
         waitForIdle()
 
@@ -201,13 +203,11 @@ class BasicTextFieldSelectionHandleTest {
         right: SelectionHandleShape,
     ) {
         val shapes = listOf(left, right)
-        assertPixels { offset ->
-            if (shapes.any { it.containsInner(offset) }) {
-                Color.Red
-            } else if (shapes.any { it.containsOuter(offset) }) {
-                null
-            } else {
-                Color.White
+        forEachPixel { color, offset ->
+            if (shapes.any { it.isInside(offset) }) {
+                assertEquals(Color.Red, color, "Expected $offset to be red, but was $color")
+            } else if (shapes.all { it.isOutside(offset) }) {
+                assertNotEquals(Color.Red, color, "Expected $offset to be not red, but was $color")
             }
         }
     }

--- a/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
+++ b/compose/foundation/foundation/src/skikoTest/kotlin/androidx/compose/foundation/text/selection/TextFieldSelectionHandleTest.kt
@@ -45,20 +45,16 @@ import androidx.compose.ui.test.runSkikoComposeUiTest
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.roundToIntRect
 import androidx.compose.ui.unit.sp
-import kotlin.math.pow
 import kotlin.test.Test
 import kotlinx.test.IgnoreJsTarget
 import kotlinx.test.IgnoreWasmTarget
 
+@Suppress("DEPRECATION")
 @OptIn(ExperimentalTestApi::class)
 class BasicTextFieldSelectionHandleTest {
-    private val textPadding = 14.dp
+    private val textPadding = 30.dp
     private val selectionColor = TextSelectionColors(
         handleColor = Color.Red,
         backgroundColor = Color.White
@@ -198,44 +194,7 @@ class BasicTextFieldSelectionHandleTest {
     private fun SkikoComposeUiTest.TestHandleShape(
         cursor: Rect,
         isStartHandler: Boolean,
-        lineWidth: Dp = 2.dp,
-        circleRadius: Dp = 6.dp,
-    ) = density.run {
-        val lineRect = cursor.copy(
-            left = cursor.bottomCenter.x - lineWidth.toPx() / 2,
-            right = cursor.bottomCenter.x + lineWidth.toPx() / 2,
-        )
-        val circleCenter = Offset(
-            x = cursor.bottomCenter.x,
-            y = if (isStartHandler) {
-                cursor.top - circleRadius.toPx()
-            } else {
-                cursor.bottom + circleRadius.toPx()
-            }
-        )
-        val circleRect = Rect(center = circleCenter, radius = circleRadius.toPx())
-
-        SelectionHandleShape(lineRect, circleRect)
-    }
-
-    private data class SelectionHandleShape(
-        val lineRect: Rect,
-        val circleRect: Rect
-    ) {
-        fun containsInner(point: IntOffset): Boolean =
-            lineRect.roundToIntRect().contains(point) ||
-                circleRect.roundToIntRect().deflate(1).containsInOval(point)
-
-        fun containsOuter(point: IntOffset): Boolean =
-            lineRect.roundToIntRect().contains(point) ||
-                circleRect.roundToIntRect().inflate(1).containsInOval(point)
-
-        private fun IntRect.containsInOval(point: IntOffset): Boolean {
-            val normX = (point.x + 0.5 - center.x) / (width / 2)
-            val normY = (point.y + 0.5 - center.y) / (height / 2)
-            return normX.pow(2) + normY.pow(2) <= 1.0
-        }
-    }
+    ) = PlatformSelectionHandleShape(density, cursor, isStartHandler)
 
     private fun ImageBitmap.assertHandlers(
         left: SelectionHandleShape,

--- a/compose/foundation/foundation/src/wasmJsTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.wasmJs.kt
+++ b/compose/foundation/foundation/src/wasmJsTest/kotlin/androidx/compose/foundation/text/selection/SelectionHandleShape.wasmJs.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.compose.foundation.text.selection
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.unit.Density
+
+internal actual fun PlatformSelectionHandleShape(
+    density: Density,
+    cursor: Rect,
+    isStartHandler: Boolean,
+): SelectionHandleShape = DefaultSelectionHandleShape(density, cursor, isStartHandler)


### PR DESCRIPTION
Fixes https://youtrack.jetbrains.com/issue/CMP-10036/Adjust-selection-handles-size-to-iOS-26

## Release Notes
### Features - iOS
- The selection handles now match the style of iOS.
