### PR TITLE
Support not-blocking pointer inputs outside of focusable Popups

### DIFF
--- a/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/popup/ConfigurablePopup.kt
+++ b/compose/mpp/demo/src/commonMain/kotlin/androidx/compose/mpp/demo/components/popup/ConfigurablePopup.kt
@@ -148,13 +148,15 @@ private fun EditPopupProperties(): PopupProperties {
         val clippingEnabled = EditBooleanSetting("clippingEnabled", true)
         val usePlatformDefaultWidth = EditBooleanSetting("usePlatformDefaultWidth", false)
         val usePlatformInsets = EditBooleanSetting("usePlatformInsets", true)
+        val consumePointerInputOutside = EditBooleanSetting("consumePointerInputOutside", false)
         popupProperties = PopupProperties(
             focusable = focusable,
             dismissOnBackPress = dismissOnBackPress,
             dismissOnClickOutside = dismissOnClickOutside,
             clippingEnabled = clippingEnabled,
             usePlatformDefaultWidth = usePlatformDefaultWidth,
-            usePlatformInsets = usePlatformInsets
+            usePlatformInsets = usePlatformInsets,
+            consumePointerInputOutside = consumePointerInputOutside,
         )
     }
     return popupProperties

--- a/compose/ui/ui/api/desktop/ui.api
+++ b/compose/ui/ui/api/desktop/ui.api
@@ -4611,7 +4611,6 @@ public abstract interface class androidx/compose/ui/window/PopupPositionProvider
 
 public final class androidx/compose/ui/window/PopupProperties {
 	public static final field $stable I
-	public fun <init> ()V
 	public synthetic fun <init> (ZZZZ)V
 	public synthetic fun <init> (ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (ZZZZZ)V

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeContainer.desktop.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.scene.skia.SkiaLayerComponent
 import androidx.compose.ui.skiko.OverlayRenderDecorator
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.util.fastAll
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.util.fastForEachReversed
 import androidx.compose.ui.window.Dialog
@@ -138,7 +137,7 @@ internal class ComposeContainer(
         },
         eventListener = AwtEventListeners(
             DetectEventOutsideLayer(),
-            FocusableLayerEventFilter()
+            BlockingInputLayerEventFilter()
         ),
         architectureComponentsOwner = architectureComponentsOwner,
         coroutineContext = coroutineContext + MainUIDispatcher + DesktopCoroutineExceptionHandler(),
@@ -402,29 +401,31 @@ internal class ComposeContainer(
     }
 
     private fun createPlatformLayer(
+        compositionContext: CompositionContext,
         density: Density,
         layoutDirection: LayoutDirection,
         focusable: Boolean,
-        compositionContext: CompositionContext
+        consumePointerInputOutside: Boolean,
     ): ComposeSceneLayer {
         return when (layerType) {
             LayerType.OnWindow -> WindowComposeSceneLayer(
                 composeContainer = this,
                 skiaLayerAnalytics = skiaLayerAnalytics,
+                renderSettings = renderSettings,
                 transparent = true, // TODO: Consider allowing opaque window layers
+                compositionContext = compositionContext,
                 density = density,
                 layoutDirection = layoutDirection,
                 focusable = focusable,
-                compositionContext = compositionContext,
-                renderSettings = renderSettings
             )
             LayerType.OnComponent -> SwingComposeSceneLayer(
                 composeContainer = this,
                 skiaLayerAnalytics = skiaLayerAnalytics,
+                compositionContext = compositionContext,
                 density = density,
                 layoutDirection = layoutDirection,
                 focusable = focusable,
-                compositionContext = compositionContext
+                consumePointerInputOutside = consumePointerInputOutside,
             )
             else -> error("Unexpected LayerType")
         }
@@ -499,15 +500,17 @@ internal class ComposeContainer(
         override val platformContext: PlatformContext,
     ) : ComposeSceneContext {
         override fun createLayer(
+            compositionContext: CompositionContext,
             density: Density,
             layoutDirection: LayoutDirection,
             focusable: Boolean,
-            compositionContext: CompositionContext
+            consumePointerInputOutside: Boolean,
         ): ComposeSceneLayer = createPlatformLayer(
+            compositionContext = compositionContext,
             density = density,
             layoutDirection = layoutDirection,
             focusable = focusable,
-            compositionContext = compositionContext
+            consumePointerInputOutside = consumePointerInputOutside,
         )
     }
 
@@ -520,13 +523,13 @@ internal class ComposeContainer(
 
     /**
      * Detect and trigger [DesktopComposeSceneLayer.onMouseEventOutside] if event happened below
-     * focused layer.
+     * a layer that blocks pointer input outside of its bounds.
      */
     private inner class DetectEventOutsideLayer : AwtEventListener {
         override fun onMouseEvent(event: AwtMouseEvent): Boolean {
             layers.fastForEachReversed {
                 it.onMouseEventOutside(event)
-                if (it.focusable) {
+                if (it.consumePointerInputOutside) {
                     return false
                 }
             }
@@ -534,10 +537,10 @@ internal class ComposeContainer(
         }
     }
 
-    private inner class FocusableLayerEventFilter : AwtEventFilter() {
-        private val noFocusableLayers get() = layers.fastAll { !it.focusable }
+    private inner class BlockingInputLayerEventFilter : AwtEventFilter() {
+        private val noBlockingInputLayers get() = layers.all { !it.consumePointerInputOutside }
 
-        override fun shouldSendMouseEvent(event: AwtMouseEvent): Boolean = noFocusableLayers
-        override fun shouldSendKeyEvent(event: AwtKeyEvent): Boolean = noFocusableLayers
+        override fun shouldSendMouseEvent(event: AwtMouseEvent): Boolean = noBlockingInputLayers
+        override fun shouldSendKeyEvent(event: AwtKeyEvent): Boolean = noBlockingInputLayers
     }
 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -531,7 +531,7 @@ internal class ComposeSceneMediator(
      * AWT/Swing, however, interprets listening to mouse events as "interest" in them and sends them
      * only to the "interested" component "under" the mouse pointer.
      */
-    private fun redispatchUnconsumedMouseEvent(event: MouseEvent) {
+    private fun redispatchUnconsumedMouseEvent(event: MouseEvent, target: Component? = null) {
         // Redispatch the event to the heavyweight ancestor, which in turn will try to find the
         // correct target component and send the event to it. Unregistering from mouse events
         // during this call allows the event to be sent to the component it would've been sent to
@@ -543,11 +543,11 @@ internal class ComposeSceneMediator(
         // With that approach, there would probably also be a need to add a flag (or multiple flags)
         // to ComposePanel that would control which types of events should be listened to.
         val source = event.component ?: return  // Should be contentComponent
-        val target = source.heavyWeightAncestorOrNull() ?: return
+        val resolvedTarget = target ?: source.heavyWeightAncestorOrNull() ?: return
         try {
             unsubscribeFromInputEvents()
-            val retargetedEvent = SwingUtilities.convertMouseEvent(source, event, target)
-            target.dispatchEvent(retargetedEvent)
+            val retargetedEvent = SwingUtilities.convertMouseEvent(source, event, resolvedTarget)
+            resolvedTarget.dispatchEvent(retargetedEvent)
         } finally {
             subscribeToInputEvents()
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/ComposeSceneMediator.desktop.kt
@@ -531,7 +531,7 @@ internal class ComposeSceneMediator(
      * AWT/Swing, however, interprets listening to mouse events as "interest" in them and sends them
      * only to the "interested" component "under" the mouse pointer.
      */
-    private fun redispatchUnconsumedMouseEvent(event: MouseEvent, target: Component? = null) {
+    private fun redispatchUnconsumedMouseEvent(event: MouseEvent) {
         // Redispatch the event to the heavyweight ancestor, which in turn will try to find the
         // correct target component and send the event to it. Unregistering from mouse events
         // during this call allows the event to be sent to the component it would've been sent to
@@ -543,11 +543,11 @@ internal class ComposeSceneMediator(
         // With that approach, there would probably also be a need to add a flag (or multiple flags)
         // to ComposePanel that would control which types of events should be listened to.
         val source = event.component ?: return  // Should be contentComponent
-        val resolvedTarget = target ?: source.heavyWeightAncestorOrNull() ?: return
+        val target = source.heavyWeightAncestorOrNull() ?: return
         try {
             unsubscribeFromInputEvents()
-            val retargetedEvent = SwingUtilities.convertMouseEvent(source, event, resolvedTarget)
-            resolvedTarget.dispatchEvent(retargetedEvent)
+            val retargetedEvent = SwingUtilities.convertMouseEvent(source, event, target)
+            target.dispatchEvent(retargetedEvent)
         } finally {
             subscribeToInputEvents()
         }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -56,7 +56,7 @@ internal abstract class DesktopComposeSceneLayer(
     protected val eventListener get() = AwtEventListeners(
         DetectEventOutsideLayer(),
         boundsEventFilter,
-        FocusableLayerEventFilter()
+        BlockingInputLayerEventFilter()
     )
     private val boundsEventFilter = BoundsEventFilter(
         bounds = Rectangle(windowContainer.size)
@@ -107,6 +107,11 @@ internal abstract class DesktopComposeSceneLayer(
     final override var compositionLocalContext: CompositionLocalContext?
         get() = mediator?.compositionLocalContext
         set(value) { mediator?.compositionLocalContext = value }
+
+    // Blocking pointer input outside is not supported
+    override var consumePointerInputOutside: Boolean
+        get() = false
+        set(_) {}
 
     @CallSuper
     override fun close() {
@@ -228,7 +233,7 @@ internal abstract class DesktopComposeSceneLayer(
 
     /**
      * Detect and trigger [DesktopComposeSceneLayer.onMouseEventOutside] if event happened below
-     * focused layer.
+     * a layer that blocks pointer input outside of its bounds.
      */
     private inner class DetectEventOutsideLayer : AwtEventListener {
         override fun onMouseEvent(event: MouseEvent): Boolean {
@@ -236,7 +241,7 @@ internal abstract class DesktopComposeSceneLayer(
                 if (!inBounds(event)) {
                     it.onMouseEventOutside(event)
                 }
-                if (it.focusable) {
+                if (it.consumePointerInputOutside) {
                     return false
                 }
             }
@@ -244,12 +249,12 @@ internal abstract class DesktopComposeSceneLayer(
         }
     }
 
-    private inner class FocusableLayerEventFilter : AwtEventFilter() {
-        private val noFocusableLayersAbove: Boolean
-            get() = layersAbove.all { !it.focusable }
+    private inner class BlockingInputLayerEventFilter : AwtEventFilter() {
+        private val noBlockingInputLayers: Boolean
+            get() = layersAbove.all { !it.consumePointerInputOutside }
 
-        override fun shouldSendMouseEvent(event: MouseEvent): Boolean = noFocusableLayersAbove
-        override fun shouldSendKeyEvent(event: KeyEvent): Boolean = focusable && noFocusableLayersAbove
+        override fun shouldSendMouseEvent(event: MouseEvent): Boolean = noBlockingInputLayers
+        override fun shouldSendKeyEvent(event: KeyEvent): Boolean = focusable && noBlockingInputLayers
     }
 
     private inner class BoundsEventFilter(

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -246,7 +246,7 @@ internal abstract class DesktopComposeSceneLayer(
 
     private inner class BlockingInputLayerEventFilter : AwtEventFilter() {
         private val noBlockingInputLayers: Boolean
-            get() = layersAbove.all { !it.consumePointerInputOutside }
+            get() = layersAbove.none { it.consumePointerInputOutside }
 
         override fun shouldSendMouseEvent(event: MouseEvent): Boolean = noBlockingInputLayers
         override fun shouldSendKeyEvent(event: KeyEvent): Boolean = focusable && noBlockingInputLayers

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/DesktopComposeSceneLayer.desktop.kt
@@ -108,11 +108,6 @@ internal abstract class DesktopComposeSceneLayer(
         get() = mediator?.compositionLocalContext
         set(value) { mediator?.compositionLocalContext = value }
 
-    // Blocking pointer input outside is not supported
-    override var consumePointerInputOutside: Boolean
-        get() = false
-        set(_) {}
-
     @CallSuper
     override fun close() {
         isClosed = true

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/SwingComposeSceneLayer.desktop.kt
@@ -40,10 +40,11 @@ import org.jetbrains.skiko.SkiaLayerAnalytics
 internal class SwingComposeSceneLayer(
     composeContainer: ComposeContainer,
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
+    compositionContext: CompositionContext,
     density: Density,
     layoutDirection: LayoutDirection,
     focusable: Boolean,
-    compositionContext: CompositionContext
+    override var consumePointerInputOutside: Boolean = focusable,
 ) : DesktopComposeSceneLayer(composeContainer, density, layoutDirection) {
     private val backgroundMouseListener = object : MouseAdapter() {
         override fun mousePressed(event: MouseEvent) = onMouseEventOutside(event)
@@ -156,7 +157,7 @@ internal class SwingComposeSceneLayer(
             val contentComponent = mediator?.contentComponent ?: return
             val localDrawBounds = drawBounds.toAwtRectangle(density)
 
-            if (focusable) {
+            if (consumePointerInputOutside) {
                 container.setBounds(0, 0, windowContainer.width, windowContainer.height)
                 contentComponent.bounds = localDrawBounds
                 mediator?.sceneBoundsInPx = null

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -49,12 +49,12 @@ import org.jetbrains.skiko.transparentWindowBackgroundHack
 internal class WindowComposeSceneLayer(
     composeContainer: ComposeContainer,
     private val skiaLayerAnalytics: SkiaLayerAnalytics,
+    private val renderSettings: RenderSettings,
     private val transparent: Boolean,
+    compositionContext: CompositionContext,
     density: Density,
     layoutDirection: LayoutDirection,
     focusable: Boolean,
-    compositionContext: CompositionContext,
-    private val renderSettings: RenderSettings
 ) : DesktopComposeSceneLayer(composeContainer, density, layoutDirection) {
     // WindowComposeSceneLayer is tied to the window it was created with
     private val parentWindow = requireNotNull(composeContainer.window)

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/scene/WindowComposeSceneLayer.desktop.kt
@@ -113,6 +113,11 @@ internal class WindowComposeSceneLayer(
 
     override var scrimColor: Color? = null
 
+    // Blocking pointer input outside is not supported for window-based popup layers.
+    override var consumePointerInputOutside: Boolean
+        get() = false
+        set(_) {}
+
     init {
         val boundsInPx = windowContainer.sizeInPx.toRect()
         drawBounds = boundsInPx.roundToIntRect()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -16,6 +16,7 @@
 package androidx.compose.ui.awt
 
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -612,6 +613,66 @@ class ComposePanelTest {
                         awaitIdle()
                         assertTrue(keyEventsOnParent.isEmpty())
                         assertTrue(dismissPopupRequested)
+                    }
+                } finally {
+                    window.dispose()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun focusableNonBlockingPopup_withComponentLayerType_passesClicksThrough() {
+        ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
+            ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {
+                val window = JFrame()
+                try {
+                    runApplicationTest {
+                        var showPopup by mutableStateOf(false)
+                        var backgroundClickCount = 0
+
+                        val composePanel = ComposePanel()
+                        composePanel.setContent {
+                            Box(
+                                Modifier
+                                    .size(200.dp)
+                                    .background(Color.Yellow)
+                                    .clickable { backgroundClickCount++ }
+                            )
+
+                            if (showPopup) {
+                                Popup(
+                                    properties = PopupProperties(
+                                        focusable = true,
+                                        dismissOnClickOutside = false,
+                                        consumePointerInputOutside = false,
+                                    ),
+                                ) {
+                                    Box(
+                                        Modifier
+                                            .size(50.dp)
+                                            .background(Color.Blue)
+                                    )
+                                }
+                            }
+                        }
+
+                        composePanel.windowContainer = window.layeredPane
+
+                        window.contentPane.add(composePanel, BorderLayout.CENTER)
+                        window.pack()
+                        window.isVisible = true
+
+                        awaitIdle()
+
+                        showPopup = true
+                        awaitIdle()
+
+                        window.layeredPane.sendMousePress(x = 100, y = 100)
+                        window.layeredPane.sendMouseRelease(x = 100, y = 100)
+                        awaitIdle()
+
+                        assertEquals(1, backgroundClickCount)
                     }
                 } finally {
                     window.dispose()

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/awt/ComposePanelTest.kt
@@ -622,66 +622,6 @@ class ComposePanelTest {
     }
 
     @Test
-    fun focusableNonBlockingPopup_withComponentLayerType_passesClicksThrough() {
-        ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
-            ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {
-                val window = JFrame()
-                try {
-                    runApplicationTest {
-                        var showPopup by mutableStateOf(false)
-                        var backgroundClickCount = 0
-
-                        val composePanel = ComposePanel()
-                        composePanel.setContent {
-                            Box(
-                                Modifier
-                                    .size(200.dp)
-                                    .background(Color.Yellow)
-                                    .clickable { backgroundClickCount++ }
-                            )
-
-                            if (showPopup) {
-                                Popup(
-                                    properties = PopupProperties(
-                                        focusable = true,
-                                        dismissOnClickOutside = false,
-                                        consumePointerInputOutside = false,
-                                    ),
-                                ) {
-                                    Box(
-                                        Modifier
-                                            .size(50.dp)
-                                            .background(Color.Blue)
-                                    )
-                                }
-                            }
-                        }
-
-                        composePanel.windowContainer = window.layeredPane
-
-                        window.contentPane.add(composePanel, BorderLayout.CENTER)
-                        window.pack()
-                        window.isVisible = true
-
-                        awaitIdle()
-
-                        showPopup = true
-                        awaitIdle()
-
-                        window.layeredPane.sendMousePress(x = 100, y = 100)
-                        window.layeredPane.sendMouseRelease(x = 100, y = 100)
-                        awaitIdle()
-
-                        assertEquals(1, backgroundClickCount)
-                    }
-                } finally {
-                    window.dispose()
-                }
-            }
-        }
-    }
-
-    @Test
     fun unfocusablePopupLayer_withComponentLayerType_inComposePanel_isSizedCorrectly() {
         ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
             ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {

--- a/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
+++ b/compose/ui/ui/src/desktopTest/kotlin/androidx/compose/ui/window/DesktopPopupTest.kt
@@ -17,6 +17,8 @@
 package androidx.compose.ui.window
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -31,18 +33,25 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.ComposeFeatureFlags
 import androidx.compose.ui.LayerType
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.sendMousePress
+import androidx.compose.ui.sendMouseRelease
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.performKeyPress
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigationevent.DirectNavigationEventInput
 import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
 import com.google.common.truth.Truth.assertThat
+import java.awt.BorderLayout
 import java.awt.Window
+import javax.swing.JFrame
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -262,6 +271,66 @@ class DesktopPopupTest {
         rule.waitForIdle()
         assertThat(onDismissRequestCallCount).isEqualTo(0)
         assertThat(onKeyEventCallCount).isEqualTo(2)
+    }
+
+    @Test
+    fun focusableNonBlockingPopup_withComponentLayerType_passesClicksThrough() {
+        ComposeFeatureFlags.layerType.withOverride(LayerType.OnComponent) {
+            ComposeFeatureFlags.useSwingGraphicsInComposePanel.withOverride(true) {
+                val window = JFrame()
+                try {
+                    runApplicationTest {
+                        var showPopup by mutableStateOf(false)
+                        var backgroundClickCount = 0
+
+                        val composePanel = ComposePanel()
+                        composePanel.setContent {
+                            Box(
+                                Modifier
+                                    .size(200.dp)
+                                    .background(Color.Yellow)
+                                    .clickable { backgroundClickCount++ }
+                            )
+
+                            if (showPopup) {
+                                Popup(
+                                    properties = PopupProperties(
+                                        focusable = true,
+                                        dismissOnClickOutside = false,
+                                        consumePointerInputOutside = false,
+                                    ),
+                                ) {
+                                    Box(
+                                        Modifier
+                                            .size(50.dp)
+                                            .background(Color.Blue)
+                                    )
+                                }
+                            }
+                        }
+
+                        composePanel.windowContainer = window.layeredPane
+
+                        window.contentPane.add(composePanel, BorderLayout.CENTER)
+                        window.pack()
+                        window.isVisible = true
+
+                        awaitIdle()
+
+                        showPopup = true
+                        awaitIdle()
+
+                        window.layeredPane.sendMousePress(x = 100, y = 100)
+                        window.layeredPane.sendMouseRelease(x = 100, y = 100)
+                        awaitIdle()
+
+                        assertEquals(1, backgroundClickCount)
+                    }
+                } finally {
+                    window.dispose()
+                }
+            }
+        }
     }
 
     @Test

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/ComposeContainer.ios.kt
@@ -297,10 +297,11 @@ internal class ComposeContainer(
             override val platformContext: PlatformContext = platformContext
 
             override fun createLayer(
+                compositionContext: CompositionContext,
                 density: Density,
                 layoutDirection: LayoutDirection,
                 focusable: Boolean,
-                compositionContext: CompositionContext
+                consumePointerInputOutside: Boolean,
             ): ComposeSceneLayer {
                 val layer = UIKitComposeSceneLayer(
                     onClosed = {
@@ -314,6 +315,7 @@ internal class ComposeContainer(
                     configuration = configuration,
                     onAccessibilityChanged = ::onAccessibilityChanged,
                     focusedViewsList = if (focusable) focusedViewsList.childFocusedViewsList() else null,
+                    consumePointerInputOutside = consumePointerInputOutside,
                     parentCoroutineContext = compositionContext.effectCoroutineContext,
                     ownerProvider = architectureComponentsOwner,
                     interfaceOrientationState = interfaceOrientationState,

--- a/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.ios.kt
+++ b/compose/ui/ui/src/iosMain/kotlin/androidx/compose/ui/scene/UIKitComposeSceneLayer.ios.kt
@@ -58,6 +58,7 @@ internal class UIKitComposeSceneLayer(
     private val onAccessibilityChanged: () -> Unit,
     configuration: ComposeContainerConfiguration,
     private var focusedViewsList: FocusedViewsList?,
+    consumePointerInputOutside: Boolean = focusedViewsList != null,
     parentCoroutineContext: CoroutineContext,
     private val ownerProvider: PlatformArchitectureComponentsOwner,
     private val interfaceOrientationState: State<InterfaceOrientation>,
@@ -66,6 +67,14 @@ internal class UIKitComposeSceneLayer(
     private val layerCoroutineContext = parentCoroutineContext + layerJob
 
     override var focusable: Boolean = focusedViewsList != null
+        set(value) {
+            if (field != value) {
+                field = value
+                onAccessibilityChanged()
+            }
+        }
+
+    override var consumePointerInputOutside: Boolean = consumePointerInputOutside
         set(value) {
             if (field != value) {
                 field = value
@@ -102,7 +111,7 @@ internal class UIKitComposeSceneLayer(
         interfaceOrientationState = interfaceOrientationState
     ).also {
         interactionView.embedSubview(it.backgroundView)
-        it.isInterceptingOutsideEvents = focusable
+        it.isInterceptingOutsideEvents = consumePointerInputOutside
     }
 
     private fun createComposeScene(

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/CanvasLayersComposeScene.skiko.kt
@@ -227,7 +227,7 @@ private class CanvasLayersComposeSceneImpl(
         forEachLayerReversed { layer ->
             if (layer.contains(position)) {
                 return layer.owner.hitTestInteropView(position)
-            } else if (layer == focusedLayer) {
+            } else if (layer.consumePointerInputOutside) {
                 return null
             }
         }
@@ -299,9 +299,26 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     /**
-     * Check if [focusedLayer] blocks input for this owner.
+     * Check if any layer blocks input for this owner.
      */
     private fun isInteractive(owner: RootNodeOwner?): Boolean {
+        if (owner == null) {
+            return true
+        }
+        layers.fastForEachReversed { layer ->
+            if (layer.owner == owner) {
+                return true
+            } else if (layer.consumePointerInputOutside) {
+                return false
+            }
+        }
+        return true
+    }
+
+    /**
+     * Check if there is [focusedLayer] above.
+     */
+    private fun isUnderFocusedLayer(owner: RootNodeOwner?): Boolean {
         if (owner == null || focusedLayer == null) {
             return true
         }
@@ -339,8 +356,8 @@ private class CanvasLayersComposeSceneImpl(
             // Input event is out of bounds - send click outside notification
             layer.onOutsidePointerEvent(event)
 
-            // if the owner is in focus, do not pass the event to underlying owners
-            if (layer == focusedLayer) {
+            // if the layer blocks input, do not pass the event to underlying owners
+            if (layer.consumePointerInputOutside) {
                 return PointerEventResult(anyMovementConsumed = false)
             }
         }
@@ -445,15 +462,17 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     override fun createLayer(
+        compositionContext: CompositionContext,
         density: Density,
         layoutDirection: LayoutDirection,
         focusable: Boolean,
-        compositionContext: CompositionContext,
+        consumePointerInputOutside: Boolean,
     ): ComposeSceneLayer = AttachedComposeSceneLayer(
+        compositionContext = compositionContext,
         density = density,
         layoutDirection = layoutDirection,
         focusable = focusable,
-        compositionContext = compositionContext,
+        consumePointerInputOutside = consumePointerInputOutside,
     )
 
     private fun onOwnerAppended(owner: RootNodeOwner) {
@@ -495,7 +514,7 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     private fun requestFocus(layer: AttachedComposeSceneLayer) {
-        if (isInteractive(layer.owner)) {
+        if (isUnderFocusedLayer(layer.owner)) {
             focusedLayer = layer
 
             // Exit event to lastHoverOwner will be sent via synthetic event on next frame
@@ -511,10 +530,11 @@ private class CanvasLayersComposeSceneImpl(
     }
 
     private inner class AttachedComposeSceneLayer(
+        private val compositionContext: CompositionContext,
         density: Density,
         layoutDirection: LayoutDirection,
         focusable: Boolean,
-        private val compositionContext: CompositionContext,
+        override var consumePointerInputOutside: Boolean,
     ) : ComposeSceneLayer {
         val owner = RootNodeOwner(
             density = density,

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneContext.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneContext.skiko.kt
@@ -55,19 +55,22 @@ interface ComposeSceneContext {
     /**
      * Creates a scene layer to display content as a new [LayoutNode] tree.
      *
+     * @param compositionContext The composition context for the layer.
      * @param density The density of the layer.
      * @param layoutDirection The layout direction of the layer.
      * @param focusable Indicates whether the layer is focusable.
-     * @param compositionContext The composition context for the layer.
+     * @param consumePointerInputOutside Indicates whether the pointer input events outside the
+     *  layer should be blocked.
      * @return The created [ComposeSceneLayer] representing the scene layer.
      *
      * @see ComposeSceneLayer
      */
     fun createLayer(
+        compositionContext: CompositionContext,
         density: Density,
         layoutDirection: LayoutDirection,
         focusable: Boolean,
-        compositionContext: CompositionContext,
+        consumePointerInputOutside: Boolean = focusable,
     ) : ComposeSceneLayer {
         throw IllegalStateException()
     }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -104,6 +104,13 @@ interface ComposeSceneLayer {
     var focusable: Boolean
 
     /**
+     * Indicates if pointer input events outside of this layer's bounds should be blocked.
+     * When set to true, touch events outside of this layer's bounds are not propagated to
+     * the content layered below this one.
+     */
+    var consumePointerInputOutside: Boolean
+
+    /**
      * Close all resources and subscriptions. It's anticipated that the platform implementation
      * will automatically close all layers along with the parent scene.
      * Once this method has been called, invoking any other method of this [ComposeSceneLayer]
@@ -174,7 +181,8 @@ interface ComposeSceneLayer {
  */
 @Composable
 internal fun rememberComposeSceneLayer(
-    focusable: Boolean = false
+    focusable: Boolean = false,
+    consumePointerInputOutside: Boolean = focusable,
 ): ComposeSceneLayer {
     val sceneContext = LocalComposeSceneContext.requireCurrent()
     val density = LocalDensity.current
@@ -183,16 +191,18 @@ internal fun rememberComposeSceneLayer(
     val compositionLocalContext = currentCompositionLocalContext
     val layer = remember {
         sceneContext.createLayer(
+            compositionContext = parentComposition,
             density = density,
             layoutDirection = layoutDirection,
             focusable = focusable,
-            compositionContext = parentComposition,
+            consumePointerInputOutside = consumePointerInputOutside,
         )
     }
-    layer.focusable = focusable
-    layer.compositionLocalContext = compositionLocalContext
     layer.density = density
     layer.layoutDirection = layoutDirection
+    layer.compositionLocalContext = compositionLocalContext
+    layer.focusable = focusable
+    layer.consumePointerInputOutside = consumePointerInputOutside
 
     return layer
 }

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/scene/ComposeSceneLayer.skiko.kt
@@ -96,7 +96,7 @@ interface ComposeSceneLayer {
      * for example, the pressing of the back button.
      *
      * This flag also influences the expected behavior of [setOutsidePointerEventListener]:
-     * when [focusable] is true, touch events outside of this layer's bounds are not propagated to
+     * when [focusable] is true, pointer events outside of this layer's bounds are not propagated to
      * the content layered below this one.
      *
      * @see PopupProperties.focusable
@@ -105,7 +105,7 @@ interface ComposeSceneLayer {
 
     /**
      * Indicates if pointer input events outside of this layer's bounds should be blocked.
-     * When set to true, touch events outside of this layer's bounds are not propagated to
+     * When set to true, pointer events outside of this layer's bounds are not propagated to
      * the content layered below this one.
      */
     var consumePointerInputOutside: Boolean

--- a/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
+++ b/compose/ui/ui/src/skikoMain/kotlin/androidx/compose/ui/window/Popup.skiko.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.pointer.PointerButton
@@ -76,14 +77,32 @@ import androidx.navigationevent.compose.LocalNavigationEventDispatcherOwner
  * platform insets.
  */
 @Immutable
-actual class PopupProperties constructor(
+actual class PopupProperties @ExperimentalComposeUiApi constructor(
     actual val focusable: Boolean = false,
     actual val dismissOnBackPress: Boolean = true,
     actual val dismissOnClickOutside: Boolean = true,
     actual val clippingEnabled: Boolean = true,
     actual val usePlatformDefaultWidth: Boolean = false,
     val usePlatformInsets: Boolean = true,
+    @property:ExperimentalComposeUiApi
+    val consumePointerInputOutside: Boolean = focusable,
 ) {
+    constructor(
+        focusable: Boolean = false,
+        dismissOnBackPress: Boolean = true,
+        dismissOnClickOutside: Boolean = true,
+        clippingEnabled: Boolean = true,
+        usePlatformDefaultWidth: Boolean = false,
+        usePlatformInsets: Boolean = true,
+    ): this(
+        focusable = focusable,
+        dismissOnBackPress = dismissOnBackPress,
+        dismissOnClickOutside = dismissOnClickOutside,
+        clippingEnabled = clippingEnabled,
+        usePlatformDefaultWidth = usePlatformDefaultWidth,
+        usePlatformInsets = usePlatformInsets,
+        consumePointerInputOutside = focusable,
+    )
 
     actual constructor(
         focusable: Boolean,
@@ -97,7 +116,8 @@ actual class PopupProperties constructor(
         dismissOnClickOutside = dismissOnClickOutside,
         clippingEnabled = clippingEnabled,
         usePlatformDefaultWidth = usePlatformDefaultWidth,
-        usePlatformInsets = true
+        usePlatformInsets = true,
+        consumePointerInputOutside = focusable,
     )
 
     @Deprecated("Maintained for binary compatibility", level = DeprecationLevel.HIDDEN)
@@ -113,6 +133,7 @@ actual class PopupProperties constructor(
         clippingEnabled = clippingEnabled,
         usePlatformDefaultWidth = false,
         usePlatformInsets = true,
+        consumePointerInputOutside = focusable,
     )
 
     override fun equals(other: Any?): Boolean {
@@ -125,6 +146,7 @@ actual class PopupProperties constructor(
         if (clippingEnabled != other.clippingEnabled) return false
         if (usePlatformDefaultWidth != other.usePlatformDefaultWidth) return false
         if (usePlatformInsets != other.usePlatformInsets) return false
+        if (consumePointerInputOutside != other.consumePointerInputOutside) return false
 
         return true
     }
@@ -136,6 +158,7 @@ actual class PopupProperties constructor(
         result = 31 * result + clippingEnabled.hashCode()
         result = 31 * result + usePlatformDefaultWidth.hashCode()
         result = 31 * result + usePlatformInsets.hashCode()
+        result = 31 * result + consumePointerInputOutside.hashCode()
         return result
     }
 }
@@ -464,7 +487,8 @@ private fun PopupLayout(
 
     val currentContent by rememberUpdatedState(content)
     val layer = rememberComposeSceneLayer(
-        focusable = properties.focusable
+        focusable = properties.focusable,
+        consumePointerInputOutside = properties.consumePointerInputOutside,
     )
     layer.setKeyEventListener(onPreviewKeyEvent, onKeyEvent)
     layer.setOutsidePointerEventListener(onOutsidePointerEvent)

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/EventTestUtils.kt
@@ -132,6 +132,7 @@ class FillBox(
 class PopupState(
     val bounds: IntRect,
     private val focusable: Boolean = false,
+    private val consumePointerInputOutside: Boolean = focusable,
     private val dismissOnClickOutside: Boolean = focusable,
     private val onDismissRequest: () -> Unit = {}
 ) {
@@ -141,6 +142,7 @@ class PopupState(
 
     @Composable
     fun Content() {
+        @OptIn(ExperimentalComposeUiApi::class)
         Popup(
             popupPositionProvider = object : PopupPositionProvider {
                 override fun calculatePosition(
@@ -154,7 +156,8 @@ class PopupState(
             properties = PopupProperties(
                 focusable = focusable,
                 dismissOnClickOutside = dismissOnClickOutside,
-                clippingEnabled = false
+                clippingEnabled = false,
+                consumePointerInputOutside = consumePointerInputOutside,
             )
         ) {
             with(LocalDensity.current) {

--- a/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
+++ b/compose/ui/ui/src/skikoTest/kotlin/androidx/compose/ui/window/PopupTest.kt
@@ -415,6 +415,50 @@ class PopupTest {
     }
 
     @Test
+    fun passEventIfClickedOutsideOfNonBlockingFocusablePopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val popup = PopupState(
+            IntRect(20, 20, 60, 60),
+            focusable = true,
+            consumePointerInputOutside = false,
+            dismissOnClickOutside = false
+        )
+
+        setContent {
+            background.Content()
+            popup.Content()
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Press, Offset(10f, 10f))
+        background.events.assertReceived(PointerEventType.Release, Offset(10f, 10f))
+    }
+
+    @Test
+    fun doNotPassEventIfClickedOutsideOfBlockingNonFocusablePopup() = runSkikoComposeUiTest(
+        size = Size(100f, 100f)
+    ) {
+        val background = FillBox()
+        val popup = PopupState(
+            IntRect(20, 20, 60, 60),
+            focusable = false,
+            consumePointerInputOutside = true
+        )
+
+        setContent {
+            background.Content()
+            popup.Content()
+        }
+
+        scene.sendPointerEvent(PointerEventType.Press, Offset(10f, 10f))
+        scene.sendPointerEvent(PointerEventType.Release, Offset(10f, 10f))
+        background.events.assertReceivedNoEvents()
+    }
+
+    @Test
     fun canScrollOutsideOfNonFocusablePopup() = runSkikoComposeUiTest(
         size = Size(100f, 100f)
     ) {

--- a/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/PopupInteractionTest.kt
+++ b/compose/ui/ui/src/uikitInstrumentedTest/kotlin/androidx/compose/ui/layers/PopupInteractionTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.background
@@ -259,6 +260,73 @@ class PopupInteractionTest {
         assertTrue(popupButtonClicked)
 
         findNodeWithLabel("Content Button").tap()
+        waitForIdle()
+        assertTrue(contentButtonClicked)
+    }
+
+    @Test
+    fun testBlockingNonFocusablePopupBlocksContentInteraction() = runUIKitInstrumentedTest {
+        var contentButtonClicked = false
+        var popupButtonClicked = false
+        setContent {
+            Button(
+                onClick = { contentButtonClicked = true },
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Text("Content Button")
+            }
+            @OptIn(ExperimentalComposeUiApi::class)
+            Popup(
+                properties = PopupProperties(
+                    dismissOnClickOutside = false,
+                    focusable = false,
+                    consumePointerInputOutside = true,
+                )
+            ) {
+                Button({ popupButtonClicked = true }) {
+                    Text("Popup Button")
+                }
+            }
+        }
+
+        findNodeWithLabel("Popup Button").tap()
+        waitForIdle()
+        assertTrue(popupButtonClicked)
+
+        tap(outOfPopupBoundsPoint)
+        waitForIdle()
+        assertFalse(contentButtonClicked)
+    }
+
+    @Test
+    fun testNonBlockingFocusablePopupAllowsContentInteraction() = runUIKitInstrumentedTest {
+        var contentButtonClicked = false
+        var popupButtonClicked = false
+        setContent {
+            Button(
+                onClick = { contentButtonClicked = true },
+                modifier = Modifier.fillMaxSize()
+            ) {
+                Text("Content Button")
+            }
+            Popup(
+                properties = PopupProperties(
+                    dismissOnClickOutside = false,
+                    focusable = true,
+                    consumePointerInputOutside = false,
+                )
+            ) {
+                Button({ popupButtonClicked = true }) {
+                    Text("Popup Button")
+                }
+            }
+        }
+
+        findNodeWithLabel("Popup Button").tap()
+        waitForIdle()
+        assertTrue(popupButtonClicked)
+
+        tap(outOfPopupBoundsPoint)
         waitForIdle()
         assertTrue(contentButtonClicked)
     }


### PR DESCRIPTION
[CMP-8852](https://youtrack.jetbrains.com/issue/CMP-8852) Support not-blocking pointer inputs outside of focusable Popups

## Release Notes
### Features - Multiple Platforms
- Add `blockPointerInputOutside` flag to `PopupProperties` to support not-blocking pointer inputs outside of focusable `Popup`s