### PR TITLE
[Cherry-pick] Fix memory leak after migrating to `PathBuilder` (#2995)

### DIFF
--- a/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPath.skiko.kt
+++ b/compose/ui/ui-graphics/src/skikoMain/kotlin/androidx/compose/ui/graphics/SkiaBackedPath.skiko.kt
@@ -127,6 +127,7 @@ private class SkiaBackedPath(
     private fun replacePath(path: SkPath) {
         // Keep the same SkPath instance alive so native callers can continue mutating it.
         internalSkiaPath.swap(path)
+        path.close()
         materializedGenerationId = internalSkiaPath.generationId
         currentFillMode = internalSkiaPath.fillMode
         pathBuilder.close()


### PR DESCRIPTION
[CMP-10098](https://youtrack.jetbrains.com/issue/CMP-10098) Fix memory leak after migrating to `PathBuilder`
Found during work on https://github.com/alexzhirkevich/compottie/pull/76

## Testing

Manually 😢 - currently we don't have a way to reliably check this

## Release Notes
### Fixes - Multiple Platforms
- _(prerelease fix)_ Fix memory leak during mutating `Path` after migrating to skia m144
