### PR TITLE
Pin navigation3-ui dependency to 1.1.0 in adaptive-navigation3 module

### DIFF
--- a/compose/material3/adaptive/adaptive-navigation3/build.gradle
+++ b/compose/material3/adaptive/adaptive-navigation3/build.gradle
@@ -48,7 +48,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain.dependencies {
             api(project(":compose:material3:adaptive:adaptive-navigation"))
-            api("org.jetbrains.androidx.navigation3:navigation3-ui:1.0.0-alpha06")
+            api("org.jetbrains.androidx.navigation3:navigation3-ui:1.1.0")
             implementation("androidx.collection:collection:1.5.0")
             implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
         }

--- a/compose/material3/adaptive/adaptive-navigation3/build.gradle
+++ b/compose/material3/adaptive/adaptive-navigation3/build.gradle
@@ -48,7 +48,7 @@ androidXMultiplatform {
     sourceSets {
         commonMain.dependencies {
             api(project(":compose:material3:adaptive:adaptive-navigation"))
-            api(project(":navigation3:navigation3-ui"))
+            api("org.jetbrains.androidx.navigation3:navigation3-ui:1.0.0-alpha06")
             implementation("androidx.collection:collection:1.5.0")
             implementation("org.jetbrains.androidx.navigationevent:navigationevent-compose:1.0.1")
         }


### PR DESCRIPTION

Note: we haven't published a stable nav3-ui:1.0.0, but alpha is okay since m3-adaptive is alpha too.

___

UPD: as @MatkovIvan suggested, I changed the pin to 1.1.0 stable


## Release Notes
N/A
